### PR TITLE
Add consent management page (view only)

### DIFF
--- a/apps/user-portal/src/actions/consents.ts
+++ b/apps/user-portal/src/actions/consents.ts
@@ -19,8 +19,8 @@
 import axios from "axios";
 import log from "log";
 import { ServiceResourcesEndpoint } from "../configs";
+import { ConsentInterface, ConsentReceiptInterface, ConsentState } from "../models/consents";
 import { getLoginSession, isLoggedSession } from "./session";
-import { ConsentInterface, ConsentState, ConsentReceiptInterface } from '../models/consents';
 
 export const getConsents = (state: ConsentState) => {
     if (isLoggedSession()) {
@@ -31,20 +31,20 @@ export const getConsents = (state: ConsentState) => {
             "Access-Control-Allow-Origin": CLIENT_HOST,
             "Authorization": `Bearer ${token}`,
             "Content-Type": "application/json"
-
         };
         const params = {
             piiPrincipalId: getLoginSession("authenticated_user"),
-            state: state
+            state
         };
 
-        return axios.get(consentsUrl, { params, headers })
+        return axios
+            .get(consentsUrl, { params, headers })
             .then((response) => {
                 return response.data as ConsentInterface[];
             })
             .catch((error) => {
                 log.error(error);
-            })
+            });
     }
 };
 
@@ -57,15 +57,15 @@ export const getConsentReceipt = (id: string) => {
             "Access-Control-Allow-Origin": CLIENT_HOST,
             "Authorization": `Bearer ${token}`,
             "Content-Type": "application/json"
-
         };
 
-        return axios.get(receiptsUrl, { headers })
+        return axios
+            .get(receiptsUrl, { headers })
             .then((response) => {
                 return response.data as ConsentReceiptInterface;
             })
             .catch((error) => {
                 log.error(error);
-            })
+            });
     }
-}
+};

--- a/apps/user-portal/src/actions/consents.ts
+++ b/apps/user-portal/src/actions/consents.ts
@@ -22,7 +22,7 @@ import { ServiceResourcesEndpoint } from "../configs";
 import { getLoginSession, isLoggedSession } from "./session";
 import { ConsentInterface, ConsentState, ConsentReceiptInterface } from '../models/consents';
 
-export const getConsents = async (state: ConsentState) => {
+export const getConsents = (state: ConsentState) => {
     if (isLoggedSession()) {
         const consentsUrl = ServiceResourcesEndpoint.consents;
         const token = getLoginSession("access_token");
@@ -38,17 +38,17 @@ export const getConsents = async (state: ConsentState) => {
             state: state
         };
 
-        try {
-            const response = await axios.get(consentsUrl, { params, headers });
-            return response.data as ConsentInterface[];
-        }
-        catch (error) {
-            log.error(error);
-        }
+        return axios.get(consentsUrl, { params, headers })
+            .then((response) => {
+                return response.data as ConsentInterface[];
+            })
+            .catch((error) => {
+                log.error(error);
+            })
     }
 };
 
-export const getConsentReceipt = async (id: string) => {
+export const getConsentReceipt = (id: string) => {
     if (isLoggedSession()) {
         const receiptsUrl = ServiceResourcesEndpoint.receipts + `/${id}`;
         const token = getLoginSession("access_token");
@@ -60,12 +60,12 @@ export const getConsentReceipt = async (id: string) => {
 
         };
 
-        try {
-            const response = await axios.get(receiptsUrl, { headers });
-            return response.data as ConsentReceiptInterface;
-        }
-        catch (error) {
-            log.error(error);
-        }
+        return axios.get(receiptsUrl, { headers })
+            .then((response) => {
+                return response.data as ConsentReceiptInterface;
+            })
+            .catch((error) => {
+                log.error(error);
+            })
     }
 }

--- a/apps/user-portal/src/actions/consents.ts
+++ b/apps/user-portal/src/actions/consents.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import axios from "axios";
+import log from "log";
+import { ServiceResourcesEndpoint } from "../configs";
+import { getLoginSession, isLoggedSession } from "./session";
+import { ConsentInterface, ConsentState, ConsentReceiptInterface } from '../models/consents';
+
+export const getConsents = async (state: ConsentState) => {
+    if (isLoggedSession()) {
+        const consentsUrl = ServiceResourcesEndpoint.consents;
+        const token = getLoginSession("access_token");
+        const headers = {
+            "Accept": "application/json",
+            "Access-Control-Allow-Origin": CLIENT_HOST,
+            "Authorization": `Bearer ${token}`,
+            "Content-Type": "application/json"
+
+        };
+        const params = {
+            piiPrincipalId: getLoginSession("authenticated_user"),
+            state: state
+        };
+
+        try {
+            const response = await axios.get(consentsUrl, { params, headers });
+            return response.data as ConsentInterface[];
+        }
+        catch (error) {
+            log.error(error);
+        }
+    }
+};
+
+export const getConsentReceipt = async (id: string) => {
+    if (isLoggedSession()) {
+        const receiptsUrl = ServiceResourcesEndpoint.receipts + `/${id}`;
+        const token = getLoginSession("access_token");
+        const headers = {
+            "Accept": "application/json",
+            "Access-Control-Allow-Origin": CLIENT_HOST,
+            "Authorization": `Bearer ${token}`,
+            "Content-Type": "application/json"
+
+        };
+
+        try {
+            const response = await axios.get(receiptsUrl, { headers });
+            return response.data as ConsentReceiptInterface;
+        }
+        catch (error) {
+            log.error(error);
+        }
+    }
+}

--- a/apps/user-portal/src/actions/index.ts
+++ b/apps/user-portal/src/actions/index.ts
@@ -19,3 +19,4 @@
 export * from "./login";
 export * from "./session";
 export * from "./user";
+export * from "./consents";

--- a/apps/user-portal/src/app.tsx
+++ b/apps/user-portal/src/app.tsx
@@ -25,7 +25,8 @@ import history from "./helpers/history";
 import {
     HomePage,
     PageNotFound,
-    UserProfilePage
+    UserProfilePage,
+    ConsentsPage
 } from "./pages";
 
 const LoginPage = (props) => {
@@ -55,13 +56,14 @@ class App extends React.Component<any, any> {
                                     <Switch>
                                         <Redirect exact path="/" to="/login" />
                                         <Route path="/login" render={(props) => (
-                                            <LoginPage loginFunction={login} {...props}/>
+                                            <LoginPage loginFunction={login} {...props} />
                                         )} />
                                         <Route path="/logout" render={(props) => (
-                                            <LogoutPage logoutFunction={logout} {...props}/>
+                                            <LogoutPage logoutFunction={logout} {...props} />
                                         )} />
                                         <ProtectedRoute path="/home" component={HomePage} />
-                                        <ProtectedRoute component={UserProfilePage} path="/profile"/>
+                                        <ProtectedRoute component={UserProfilePage} path="/profile" />
+                                        <ProtectedRoute component={ConsentsPage} path="/consent" />
                                         <ProtectedRoute component={PageNotFound} />
                                     </Switch>
                                 </>

--- a/apps/user-portal/src/configs/app.ts
+++ b/apps/user-portal/src/configs/app.ts
@@ -22,6 +22,8 @@ interface ServiceResourcesType {
     logout: string;
     me: string;
     token: string;
+    consents: string;
+    receipts: string,
 }
 
 export const ServiceEndpoint: ServiceEndpointURLType = SERVER_HOST;
@@ -30,5 +32,7 @@ export const ServiceResourcesEndpoint: ServiceResourcesType = {
             `${CLIENT_ID}&redirect_uri=${LOGIN_CALLBACK_URL}&scope=openid&code_challenge_method=S256`,
     logout: `${ServiceEndpoint}/oidc/logout`,
     me: `${ServiceEndpoint}/scim2/Me`,
-    token: `${ServiceEndpoint}/oauth2/token`
+    token: `${ServiceEndpoint}/oauth2/token`,
+    consents: `${ServiceEndpoint}/api/identity/consent-mgt/v1.0/consents`,
+    receipts: `${ServiceEndpoint}/api/identity/consent-mgt/v1.0/consents/receipts`
 };

--- a/apps/user-portal/src/models/consents.ts
+++ b/apps/user-portal/src/models/consents.ts
@@ -55,3 +55,38 @@ export enum ConsentState {
     ACTIVE = "ACTIVE",
     REVOKED = "REVOKED"
 }
+
+export const createEmptyConsent = (): ConsentInterface => ({
+    consentReceiptID: "",
+    language: "",
+    piiPrincipalId: "",
+    spDescription: "",
+    spDisplayName: "",
+    state: ConsentState.ACTIVE,
+    tenantDomain: ""
+});
+
+export const createEmptyConsentReceipt = (): ConsentReceiptInterface => ({
+    version: "",
+    collectionMethod: "",
+    services: [
+        {
+            service: "",
+            serviceDisplayName: "",
+            serviceDescription: "",
+            tenantDomain: "",
+            purposes: [
+                {
+                    purpose: "",
+                    piiCategory: [
+                        {
+                            piiCategoryName: "",
+                            piiCategoryId: 0,
+                            piiCategoryDisplayName: ""
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+});

--- a/apps/user-portal/src/models/consents.ts
+++ b/apps/user-portal/src/models/consents.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface ConsentInterface {
+    consentReceiptID: string;
+    language: string;
+    piiPrincipalId: string;
+    spDescription: string;
+    spDisplayName: string;
+    state: ConsentState;
+    tenantDomain: string;
+}
+
+export interface ConsentReceiptInterface {
+    version: string;
+    collectionMethod: string;
+    services: ServiceInterface[];
+}
+
+interface ServiceInterface {
+    service: string;
+    serviceDisplayName: string;
+    serviceDescription: string;
+    tenantDomain: string;
+    purposes: PurposeInterface[];
+}
+
+interface PurposeInterface {
+    purpose: string;
+    piiCategory: PIICategory[];
+}
+
+interface PIICategory {
+    piiCategoryName: string;
+    piiCategoryId: number;
+    piiCategoryDisplayName: string;
+}
+
+export enum ConsentState {
+    ACTIVE = "ACTIVE",
+    REVOKED = "REVOKED"
+}

--- a/apps/user-portal/src/models/consents.ts
+++ b/apps/user-portal/src/models/consents.ts
@@ -27,28 +27,28 @@ export interface ConsentInterface {
 }
 
 export interface ConsentReceiptInterface {
-    version: string;
     collectionMethod: string;
     services: ServiceInterface[];
+    version: string;
 }
 
 interface ServiceInterface {
-    service: string;
-    serviceDisplayName: string;
-    serviceDescription: string;
-    tenantDomain: string;
     purposes: PurposeInterface[];
+    service: string;
+    serviceDescription: string;
+    serviceDisplayName: string;
+    tenantDomain: string;
 }
 
 interface PurposeInterface {
-    purpose: string;
     piiCategory: PIICategory[];
+    purpose: string;
 }
 
 interface PIICategory {
-    piiCategoryName: string;
-    piiCategoryId: number;
     piiCategoryDisplayName: string;
+    piiCategoryId: number;
+    piiCategoryName: string;
 }
 
 export enum ConsentState {
@@ -67,26 +67,26 @@ export const createEmptyConsent = (): ConsentInterface => ({
 });
 
 export const createEmptyConsentReceipt = (): ConsentReceiptInterface => ({
-    version: "",
     collectionMethod: "",
     services: [
         {
-            service: "",
-            serviceDisplayName: "",
-            serviceDescription: "",
-            tenantDomain: "",
             purposes: [
                 {
-                    purpose: "",
                     piiCategory: [
                         {
-                            piiCategoryName: "",
+                            piiCategoryDisplayName: "",
                             piiCategoryId: 0,
-                            piiCategoryDisplayName: ""
+                            piiCategoryName: ""
                         }
-                    ]
+                    ],
+                    purpose: ""
                 }
-            ]
+            ],
+            service: "",
+            serviceDescription: "",
+            serviceDisplayName: "",
+            tenantDomain: ""
         }
-    ]
+    ],
+    version: ""
 });

--- a/apps/user-portal/src/pages/consents.tsx
+++ b/apps/user-portal/src/pages/consents.tsx
@@ -17,7 +17,7 @@
  */
 
 import * as React from "react";
-import { getConsents, getConsentReceipt, revokeConsent } from "../actions/consents";
+import { getConsents, getConsentReceipt } from "../actions/consents";
 import { InnerPageLayout } from "../layouts";
 import { ConsentState, ConsentInterface } from "../models/consents";
 import { Container, Tab, Button, Card, Image, MenuItem, Label, Modal, Divider, Checkbox, Grid } from 'semantic-ui-react'

--- a/apps/user-portal/src/pages/consents.tsx
+++ b/apps/user-portal/src/pages/consents.tsx
@@ -17,10 +17,22 @@
  */
 
 import * as React from "react";
-import { getConsents, getConsentReceipt } from "../actions/consents";
+import {
+    Button,
+    Card,
+    Checkbox,
+    Container,
+    Divider,
+    Grid,
+    Image,
+    Label,
+    MenuItem,
+    Modal,
+    Tab
+} from "semantic-ui-react";
+import { getConsentReceipt, getConsents } from "../actions";
 import { InnerPageLayout } from "../layouts";
-import { ConsentState, ConsentInterface } from "../models/consents";
-import { Container, Tab, Button, Card, Image, MenuItem, Label, Modal, Divider, Checkbox, Grid } from 'semantic-ui-react'
+import { ConsentInterface, ConsentState, createEmptyConsent, createEmptyConsentReceipt } from "../models/consents";
 
 export class ConsentsPage extends React.Component<any, any> {
     constructor(props) {
@@ -28,22 +40,20 @@ export class ConsentsPage extends React.Component<any, any> {
         this.state = {
             activeIndex: 0,
             consents: [],
-            editingConsent: {},
-            consentReceipt: {},
+            editingConsent: createEmptyConsent(),
+            consentReceipt: createEmptyConsentReceipt(),
             showConsentEditModal: false,
             showConsentRevokeModal: false
-        }
+        };
     }
 
     public componentWillMount() {
-        getConsents(ConsentState.ACTIVE)
-            .then((response) => {
-                this.setState({ consents: response });
-            }
-            );
+        getConsents(ConsentState.ACTIVE).then((response) => {
+            this.setState({ consents: response });
+        });
     }
 
-    handleConsentTabChange = (e, { activeIndex }) => {
+    public handleConsentTabChange = (e, { activeIndex }) => {
         this.setState({ activeIndex }, () => {
             let consentState = ConsentState.ACTIVE;
             switch (activeIndex) {
@@ -58,105 +68,116 @@ export class ConsentsPage extends React.Component<any, any> {
                     break;
             }
 
-            getConsents(consentState)
-                .then((response) => {
-                    this.setState({ consents: response });
-                }
-                );
+            getConsents(consentState).then((response) => {
+                this.setState({ consents: response });
+            });
         });
     }
 
-    handleConsentEditClick = (consent: ConsentInterface) => {
+    public handleConsentEditClick = (consent: ConsentInterface) => {
         const { showConsentEditModal } = this.state;
-        getConsentReceipt(consent.consentReceiptID)
-            .then((response) => {
-                this.setState({
-                    consentReceipt: response,
-                    editingConsent: consent,
-                    showConsentEditModal: !showConsentEditModal
-                })
-            })
+        getConsentReceipt(consent.consentReceiptID).then((response) => {
+            this.setState({
+                consentReceipt: response,
+                editingConsent: consent,
+                showConsentEditModal: !showConsentEditModal
+            });
+        });
     }
 
-    handleConsentRevokeClick = (consent: ConsentInterface) => {
+    public handleConsentRevokeClick = (consent: ConsentInterface) => {
         const { showConsentRevokeModal } = this.state;
         this.setState({
             editingConsent: consent,
             showConsentRevokeModal: !showConsentRevokeModal
-        })
+        });
     }
 
-    handleConsentModalClose = () => {
+    public handleConsentModalClose = () => {
         this.setState({ showConsentEditModal: false });
     }
 
-    handleConsentRevokeModalClose = () => {
+    public handleConsentRevokeModalClose = () => {
         this.setState({ showConsentRevokeModal: false });
     }
 
-    render() {
-
-        const { consents, activeIndex, editingConsent, consentReceipt, showConsentEditModal, showConsentRevokeModal } = this.state;
+    public render() {
+        const {
+            consents,
+            activeIndex,
+            editingConsent,
+            consentReceipt,
+            showConsentEditModal,
+            showConsentRevokeModal
+        } = this.state;
 
         const paneContent = (
             <Card.Group>
-                {
-                    consents ? consents.map((consent, key) => (
-                        <Card key={key}>
-                            <Card.Content>
-                                <Image floated="left" size="tiny" src="https://react.semantic-ui.com/images/wireframe/image.png" />
-                                <Card.Header>{consent.spDisplayName}</Card.Header>
-                            </Card.Content>
-                            {
-                                activeIndex === 0 ?
-                                    <Card.Content extra>
-                                        <div className="ui two buttons">
-                                            <Button basic color="green" onClick={() => this.handleConsentEditClick(consent)}>Edit</Button>
-                                            <Button basic color="red" onClick={() => this.handleConsentRevokeClick(consent)}>Revoke</Button>
-                                        </div>
-                                    </Card.Content> : null
-                            }
-                        </Card>
-                    )) : null
-                }
+                {consents
+                    ? consents.map((consent, key) => (
+                          <Card key={key}>
+                              <Card.Content>
+                                  <Image
+                                      floated="left"
+                                      size="tiny"
+                                      src="https://react.semantic-ui.com/images/wireframe/image.png"
+                                  />
+                                  <Card.Header>{consent.spDisplayName}</Card.Header>
+                              </Card.Content>
+                              {activeIndex === 0 ? (
+                                  <Card.Content extra>
+                                      <div className="ui two buttons">
+                                          <Button
+                                              basic
+                                              color="green"
+                                              onClick={() => this.handleConsentEditClick(consent)}
+                                          >
+                                              Edit
+                                          </Button>
+                                          <Button
+                                              basic
+                                              color="red"
+                                              onClick={() => this.handleConsentRevokeClick(consent)}
+                                          >
+                                              Revoke
+                                          </Button>
+                                      </div>
+                                  </Card.Content>
+                              ) : null}
+                          </Card>
+                      ))
+                    : null}
             </Card.Group>
-        )
+        );
 
         const tabPanes = [
             {
                 menuItem: (
                     <MenuItem>
                         Active
-                        {
-                            activeIndex === 0 ?
-                                (
-                                    <Label circular color="green">
-                                        {consents ? consents.length : 0}
-                                    </Label>
-                                ) : null
-                        }
+                        {activeIndex === 0 ? (
+                            <Label circular color="green">
+                                {consents ? consents.length : 0}
+                            </Label>
+                        ) : null}
                     </MenuItem>
                 ),
                 render: () => <Tab.Pane attached="bottom">{paneContent}</Tab.Pane>
-
             },
             {
                 menuItem: (
                     <MenuItem>
                         Revoked
-                        {
-                            activeIndex === 1 ?
-                                (
-                                    <Label circular color="red">
-                                        {consents ? consents.length : 0}
-                                    </Label>
-                                ) : null
-                        }
+                        {activeIndex === 1 ? (
+                            <Label circular color="red">
+                                {consents ? consents.length : 0}
+                            </Label>
+                        ) : null}
                     </MenuItem>
                 ),
                 render: () => <Tab.Pane attached="bottom">{paneContent}</Tab.Pane>
-            },
-        ]
+            }
+        ];
 
         const EditConsentModal = (
             <Modal open={showConsentEditModal} onClose={this.handleConsentModalClose} size="tiny">
@@ -166,69 +187,95 @@ export class ConsentsPage extends React.Component<any, any> {
                 </Modal.Header>
                 <Modal.Content scrolling>
                     <Modal.Description>
-                        <div><strong>State:</strong> {editingConsent.state}</div>
-                        <div><strong>Collection Method:</strong> {consentReceipt.collectionMethod}</div>
-                        <div><strong>Version: </strong>{consentReceipt.version}</div>
-                        <div><strong>Description: </strong>{editingConsent.spDescription}</div>
+                        <div>
+                            <strong>State:</strong> {editingConsent.state}
+                        </div>
+                        <div>
+                            <strong>Collection Method:</strong> {consentReceipt.collectionMethod}
+                        </div>
+                        <div>
+                            <strong>Version: </strong>
+                            {consentReceipt.version}
+                        </div>
+                        <div>
+                            <strong>Description: </strong>
+                            {editingConsent.spDescription}
+                        </div>
                         <Divider />
                         <p style={{ textTransform: "uppercase", fontWeight: "bold" }}>
                             Deselect consents that you wish to revoke
                         </p>
-                        {
-                            consentReceipt && consentReceipt.services && consentReceipt.services.map(service => (
-                                service && service.purposes && service.purposes.map((purpose) => {
-                                    return (
-                                        <React.Fragment>
-                                            <div style={{ textDecoration: "underline" }}>{purpose.purpose}</div>
-                                            {
-                                                purpose.piiCategory && purpose.piiCategory.map((category, key) => (
-                                                    <Grid key={key}>
-                                                        <Grid.Column floated='left' width={5}>
-                                                            <div style={{ marginTop: "10px" }}>
-                                                                {category.piiCategoryDisplayName}
-                                                            </div>
-                                                        </Grid.Column>
-                                                        <Grid.Column floated='right' width={3}>
-                                                            <Checkbox toggle checked={true} disabled />
-                                                        </Grid.Column>
-                                                    </Grid>
-                                                ))
-                                            }
-                                        </React.Fragment>
-                                    );
-                                })
-                            ))
-                        }
+                        {consentReceipt &&
+                            consentReceipt.services &&
+                            consentReceipt.services.map(
+                                (service) =>
+                                    service &&
+                                    service.purposes &&
+                                    service.purposes.map((purpose) => {
+                                        return (
+                                            <React.Fragment>
+                                                <div style={{ textDecoration: "underline" }}>{purpose.purpose}</div>
+                                                {purpose.piiCategory &&
+                                                    purpose.piiCategory.map((category, key) => (
+                                                        <Grid key={key}>
+                                                            <Grid.Column floated="left" width={5}>
+                                                                <div style={{ marginTop: "10px" }}>
+                                                                    {category.piiCategoryDisplayName}
+                                                                </div>
+                                                            </Grid.Column>
+                                                            <Grid.Column floated="right" width={3}>
+                                                                <Checkbox toggle checked={true} disabled />
+                                                            </Grid.Column>
+                                                        </Grid>
+                                                    ))}
+                                            </React.Fragment>
+                                        );
+                                    })
+                            )}
                     </Modal.Description>
                 </Modal.Content>
                 <Modal.Actions>
-                    <Button primary disabled>Update</Button>
-                    <Button secondary onClick={this.handleConsentModalClose}>Cancel</Button>
+                    <Button primary disabled>
+                        Update
+                    </Button>
+                    <Button secondary onClick={this.handleConsentModalClose}>
+                        Cancel
+                    </Button>
                 </Modal.Actions>
-            </Modal >
-        )
+            </Modal>
+        );
 
         const consentRevokeModal = (
             <Modal size="mini" open={showConsentRevokeModal} onClose={this.handleConsentRevokeModalClose}>
                 <Modal.Content>
-                    <Container textAlign="center"><h3>Revoke {editingConsent.spDisplayName}?</h3></Container>
+                    <Container textAlign="center">
+                        <h3>Revoke {editingConsent.spDisplayName}?</h3>
+                    </Container>
                     <br />
-                    <p style={{ fontSize: "12px" }}>Are you sure you want to revoke this consent? This operation is not reversible.</p>
+                    <p style={{ fontSize: "12px" }}>
+                        Are you sure you want to revoke this consent? This operation is not reversible.
+                    </p>
                 </Modal.Content>
                 <Modal.Actions>
-                    <Button secondary onClick={this.handleConsentRevokeModalClose}>Cancel</Button>
-                    <Button primary disabled>Revoke</Button>
+                    <Button secondary onClick={this.handleConsentRevokeModalClose}>
+                        Cancel
+                    </Button>
+                    <Button primary disabled>
+                        Revoke
+                    </Button>
                 </Modal.Actions>
             </Modal>
-        )
+        );
 
         return (
-            <InnerPageLayout
-                pageTitle="Consents"
-                pageDescription="Manage consented applications"
-            >
+            <InnerPageLayout pageTitle="Consents" pageDescription="Manage consented applications">
                 <Container>
-                    <Tab panes={tabPanes} activeIndex={activeIndex} onTabChange={this.handleConsentTabChange} menu={{ attached: "top" }} />
+                    <Tab
+                        panes={tabPanes}
+                        activeIndex={activeIndex}
+                        onTabChange={this.handleConsentTabChange}
+                        menu={{ attached: "top" }}
+                    />
                     {EditConsentModal}
                     {consentRevokeModal}
                 </Container>

--- a/apps/user-portal/src/pages/consents.tsx
+++ b/apps/user-portal/src/pages/consents.tsx
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from "react";
+import { getConsents, getConsentReceipt, revokeConsent } from "../actions/consents";
+import { InnerPageLayout } from "../layouts";
+import { ConsentState, ConsentInterface } from "../models/consents";
+import { Container, Tab, Button, Card, Image, MenuItem, Label, Modal, Divider, Checkbox, Grid } from 'semantic-ui-react'
+
+export class ConsentsPage extends React.Component<any, any> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            activeIndex: 0,
+            consents: [],
+            editingConsent: {},
+            consentReceipt: {},
+            showConsentEditModal: false,
+            showConsentRevokeModal: false
+        }
+    }
+
+    public componentWillMount() {
+        getConsents(ConsentState.ACTIVE)
+            .then((response) => {
+                this.setState({ consents: response });
+            }
+            );
+    }
+
+    handleConsentTabChange = (e, { activeIndex }) => {
+        this.setState({ activeIndex }, () => {
+            let consentState = ConsentState.ACTIVE;
+            switch (activeIndex) {
+                case 0:
+                    consentState = ConsentState.ACTIVE;
+                    break;
+                case 1:
+                    consentState = ConsentState.REVOKED;
+                    break;
+                default:
+                    consentState = ConsentState.ACTIVE;
+                    break;
+            }
+
+            getConsents(consentState)
+                .then((response) => {
+                    this.setState({ consents: response });
+                }
+                );
+        });
+    }
+
+    handleConsentEditClick = (consent: ConsentInterface) => {
+        const { showConsentEditModal } = this.state;
+        getConsentReceipt(consent.consentReceiptID)
+            .then((response) => {
+                this.setState({
+                    consentReceipt: response,
+                    editingConsent: consent,
+                    showConsentEditModal: !showConsentEditModal
+                })
+            })
+    }
+
+    handleConsentRevokeClick = (consent: ConsentInterface) => {
+        const { showConsentRevokeModal } = this.state;
+        this.setState({
+            editingConsent: consent,
+            showConsentRevokeModal: !showConsentRevokeModal
+        })
+    }
+
+    handleConsentModalClose = () => {
+        this.setState({ showConsentEditModal: false });
+    }
+
+    handleConsentRevokeModalClose = () => {
+        this.setState({ showConsentRevokeModal: false });
+    }
+
+    render() {
+
+        const { consents, activeIndex, editingConsent, consentReceipt, showConsentEditModal, showConsentRevokeModal } = this.state;
+
+        const paneContent = (
+            <Card.Group>
+                {
+                    consents ? consents.map((consent, key) => (
+                        <Card key={key}>
+                            <Card.Content>
+                                <Image floated="left" size="tiny" src="https://react.semantic-ui.com/images/wireframe/image.png" />
+                                <Card.Header>{consent.spDisplayName}</Card.Header>
+                            </Card.Content>
+                            {
+                                activeIndex === 0 ?
+                                    <Card.Content extra>
+                                        <div className="ui two buttons">
+                                            <Button basic color="green" onClick={() => this.handleConsentEditClick(consent)}>Edit</Button>
+                                            <Button basic color="red" onClick={() => this.handleConsentRevokeClick(consent)}>Revoke</Button>
+                                        </div>
+                                    </Card.Content> : null
+                            }
+                        </Card>
+                    )) : null
+                }
+            </Card.Group>
+        )
+
+        const tabPanes = [
+            {
+                menuItem: (
+                    <MenuItem>
+                        Active
+                        {
+                            activeIndex === 0 ?
+                                (
+                                    <Label circular color="green">
+                                        {consents ? consents.length : 0}
+                                    </Label>
+                                ) : null
+                        }
+                    </MenuItem>
+                ),
+                render: () => <Tab.Pane attached="bottom">{paneContent}</Tab.Pane>
+
+            },
+            {
+                menuItem: (
+                    <MenuItem>
+                        Revoked
+                        {
+                            activeIndex === 1 ?
+                                (
+                                    <Label circular color="red">
+                                        {consents ? consents.length : 0}
+                                    </Label>
+                                ) : null
+                        }
+                    </MenuItem>
+                ),
+                render: () => <Tab.Pane attached="bottom">{paneContent}</Tab.Pane>
+            },
+        ]
+
+        const EditConsentModal = (
+            <Modal open={showConsentEditModal} onClose={this.handleConsentModalClose} size="tiny">
+                <Modal.Header>
+                    <Image floated="left" size="mini" src="https://react.semantic-ui.com/images/wireframe/image.png" />
+                    {editingConsent.spDisplayName} ({editingConsent.state})
+                </Modal.Header>
+                <Modal.Content scrolling>
+                    <Modal.Description>
+                        <div><strong>State:</strong> {editingConsent.state}</div>
+                        <div><strong>Collection Method:</strong> {consentReceipt.collectionMethod}</div>
+                        <div><strong>Version: </strong>{consentReceipt.version}</div>
+                        <div><strong>Description: </strong>{editingConsent.spDescription}</div>
+                        <Divider />
+                        <p style={{ textTransform: "uppercase", fontWeight: "bold" }}>
+                            Deselect consents that you wish to revoke
+                        </p>
+                        {
+                            consentReceipt && consentReceipt.services && consentReceipt.services.map(service => (
+                                service && service.purposes && service.purposes.map((purpose) => {
+                                    return (
+                                        <React.Fragment>
+                                            <div style={{ textDecoration: "underline" }}>{purpose.purpose}</div>
+                                            {
+                                                purpose.piiCategory && purpose.piiCategory.map((category, key) => (
+                                                    <Grid key={key}>
+                                                        <Grid.Column floated='left' width={5}>
+                                                            <div style={{ marginTop: "10px" }}>
+                                                                {category.piiCategoryDisplayName}
+                                                            </div>
+                                                        </Grid.Column>
+                                                        <Grid.Column floated='right' width={3}>
+                                                            <Checkbox toggle checked={true} disabled />
+                                                        </Grid.Column>
+                                                    </Grid>
+                                                ))
+                                            }
+                                        </React.Fragment>
+                                    );
+                                })
+                            ))
+                        }
+                    </Modal.Description>
+                </Modal.Content>
+                <Modal.Actions>
+                    <Button primary disabled>Update</Button>
+                    <Button secondary onClick={this.handleConsentModalClose}>Cancel</Button>
+                </Modal.Actions>
+            </Modal >
+        )
+
+        const consentRevokeModal = (
+            <Modal size="mini" open={showConsentRevokeModal} onClose={this.handleConsentRevokeModalClose}>
+                <Modal.Content>
+                    <Container textAlign="center"><h3>Revoke {editingConsent.spDisplayName}?</h3></Container>
+                    <br />
+                    <p style={{ fontSize: "12px" }}>Are you sure you want to revoke this consent? This operation is not reversible.</p>
+                </Modal.Content>
+                <Modal.Actions>
+                    <Button secondary onClick={this.handleConsentRevokeModalClose}>Cancel</Button>
+                    <Button primary disabled>Revoke</Button>
+                </Modal.Actions>
+            </Modal>
+        )
+
+        return (
+            <InnerPageLayout
+                pageTitle="Consents"
+                pageDescription="Manage consented applications"
+            >
+                <Container>
+                    <Tab panes={tabPanes} activeIndex={activeIndex} onTabChange={this.handleConsentTabChange} menu={{ attached: "top" }} />
+                    {EditConsentModal}
+                    {consentRevokeModal}
+                </Container>
+            </InnerPageLayout>
+        );
+    }
+}

--- a/apps/user-portal/src/pages/index.ts
+++ b/apps/user-portal/src/pages/index.ts
@@ -22,3 +22,4 @@ export * from "./home";
 export * from "./theme";
 export * from "./user-listing";
 export * from "./user-profile";
+export * from "./consents";


### PR DESCRIPTION
## Purpose
> Implement basic consent management page layout (view only)
> Add consent and consent receipt endpoints
> Implement actions related to consents

<img width="1487" alt="Screen Shot 2019-08-01 at 1 00 01 AM" src="https://user-images.githubusercontent.com/25959096/62242374-a8658e80-b3f8-11e9-8753-2b941f24f62a.png">
<img width="1368" alt="Screen Shot 2019-08-01 at 1 00 13 AM" src="https://user-images.githubusercontent.com/25959096/62242378-aac7e880-b3f8-11e9-8640-f93a48910d18.png">
<img width="1388" alt="Screen Shot 2019-08-01 at 1 00 29 AM" src="https://user-images.githubusercontent.com/25959096/62242382-adc2d900-b3f8-11e9-9923-8f9d23d3f3c9.png">
<img width="1298" alt="Screen Shot 2019-08-01 at 1 00 43 AM" src="https://user-images.githubusercontent.com/25959096/62242393-b1eef680-b3f8-11e9-810a-bb3379394dc5.png">
