### PR TITLE
Fix profile data JSON duplicate download issue

### DIFF
--- a/apps/user-portal/src/components/shared/settings-section.tsx
+++ b/apps/user-portal/src/components/shared/settings-section.tsx
@@ -78,6 +78,7 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
      * @param action - action which is passed in.
      * @param {SemanticICONS} actionIcon - Icon for the action.
      * @param {boolean} actionDisabled - Flag to determine if the action should be disabled.
+     * @param actionOnClick - On Click handler of the action.
      * @param {"primary" | "secondary"} actionType - Type of the action.
      * @return Constructed element.
      */
@@ -85,6 +86,7 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
         action: any,
         actionIcon: SemanticICONS,
         actionDisabled: boolean,
+        actionOnClick: any,
         actionType: "primary" | "secondary"
     ) => {
         // if passed in action is a react component
@@ -106,7 +108,7 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
                     className={ actionDisabled ? "disabled" : "" }
                     floated={ actionType === "secondary" ? "right" : "left" }
                 >
-                    <List.Header className="action-button-text">
+                    <List.Header className="action-button-text" onClick={ actionOnClick }>
                         {
                             actionIcon
                                 ? (<><Icon name={ actionIcon }/>{ " " }</>)
@@ -203,6 +205,9 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
                                                     primaryAction,
                                                     primaryActionIcon,
                                                     primaryActionDisabled,
+                                                    (primaryAction && secondaryAction)
+                                                        ? onPrimaryActionClick
+                                                        : null,
                                                     "primary"
                                                     )
                                                     : null
@@ -213,6 +218,9 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
                                                     secondaryAction,
                                                     secondaryActionIcon,
                                                     secondaryActionDisabled,
+                                                    (primaryAction && secondaryAction)
+                                                        ? onSecondaryActionClick
+                                                        : null,
                                                     "secondary"
                                                     )
                                                     : null

--- a/apps/user-portal/src/components/shared/settings-section.tsx
+++ b/apps/user-portal/src/components/shared/settings-section.tsx
@@ -78,7 +78,6 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
      * @param action - action which is passed in.
      * @param {SemanticICONS} actionIcon - Icon for the action.
      * @param {boolean} actionDisabled - Flag to determine if the action should be disabled.
-     * @param actionOnClick - On Click handler of the action.
      * @param {"primary" | "secondary"} actionType - Type of the action.
      * @return Constructed element.
      */
@@ -86,7 +85,6 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
         action: any,
         actionIcon: SemanticICONS,
         actionDisabled: boolean,
-        actionOnClick: any,
         actionType: "primary" | "secondary"
     ) => {
         // if passed in action is a react component
@@ -108,9 +106,7 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
                     className={ actionDisabled ? "disabled" : "" }
                     floated={ actionType === "secondary" ? "right" : "left" }
                 >
-                    <List.Header
-                        className="action-button-text"
-                        onClick={ actionOnClick }>
+                    <List.Header className="action-button-text">
                         {
                             actionIcon
                                 ? (<><Icon name={ actionIcon }/>{ " " }</>)
@@ -207,7 +203,6 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
                                                     primaryAction,
                                                     primaryActionIcon,
                                                     primaryActionDisabled,
-                                                    onPrimaryActionClick,
                                                     "primary"
                                                     )
                                                     : null
@@ -218,7 +213,6 @@ export const SettingsSection: FunctionComponent<SettingsSectionProps> = (props):
                                                     secondaryAction,
                                                     secondaryActionIcon,
                                                     secondaryActionDisabled,
-                                                    onSecondaryActionClick,
                                                     "secondary"
                                                     )
                                                     : null


### PR DESCRIPTION
The settings section supports primary and secondary actions. And the action passed in is set to the item(bottom bar) and also to the button's onClick action. This causes the callback to be fired twice when clicked on the button area. The code was changed to disable the button on click when just one action type i.e primary or secondary is passed in.

Resolves wso2/identity-apps#98