### PR TITLE
Fix duplicate token request issue in user portal

### DIFF
--- a/apps/user-portal/src/contexts/auth.tsx
+++ b/apps/user-portal/src/contexts/auth.tsx
@@ -35,13 +35,6 @@ export const AuthProvider = ({ children }) => {
     const signOut = () => { handleSignOut(state, dispatch); };
 
     /**
-     * Update authentication state on app load
-     */
-    useEffect(() => {
-        signIn();
-    }, []);
-
-    /**
      * Render state, dispatch and special case actions
      */
     return (


### PR DESCRIPTION
## Purpose
> Token requests are being sent on app load and on the `login` route resulting in duplicate requests. 