### PR TITLE
Validate single Audience in ID Token

### DIFF
--- a/modules/authenticate/src/actions/crypto.ts
+++ b/modules/authenticate/src/actions/crypto.ts
@@ -109,7 +109,7 @@ export const getJWKForTheIdToken = (jwtHeader: string, keys: JWKInterface[]) => 
 export const isValidIdToken = (idToken, jwk, clientID: string) => {
     return KJUR.jws.JWS.verifyJWT(idToken, jwk, {
         alg: getSupportedSignatureAlgorithms(),
-        aud: [clientID],
+        aud: clientID,
         gracePeriod: 3600,
         iss: [SERVICE_RESOURCES.token]
     });


### PR DESCRIPTION
## Purpose
If the audience is passed as an array, validation fails when the ID token has multiple audiences and the submitted array misses some of the audience. 

With this fix, we will only validate the relevant audience we need to check