### PR TITLE
Fix footer UI issues in Firefox & Safari browsers

### DIFF
--- a/modules/theme/src/definitions/views/user-portal.less
+++ b/modules/theme/src/definitions/views/user-portal.less
@@ -27,7 +27,7 @@
 *****************************************/
 
 .layout-content {
-    margin-bottom: 4em;
+    padding-bottom: 6em;
 
     &.default-layout {
         margin-top: 7em;


### PR DESCRIPTION
## Purpose
> This PR introduces a fix for the footer content overflowing issue in Safari & Firefox browsers

### Before
**Firefox**

<img width="1913" alt="Screen Shot 2019-11-27 at 12 32 31 PM" src="https://user-images.githubusercontent.com/25959096/69703812-41db4d80-1118-11ea-9e74-22ab2ec747d7.png">

**Safari**

<img width="1912" alt="Screen Shot 2019-11-27 at 12 32 44 PM" src="https://user-images.githubusercontent.com/25959096/69703827-4acc1f00-1118-11ea-8b61-e5eeb104af68.png">

### After
**Firefox**

<img width="1913" alt="Screen Shot 2019-11-27 at 12 30 18 PM" src="https://user-images.githubusercontent.com/25959096/69703848-5ae3fe80-1118-11ea-97ea-5bfefcbb0e18.png">

**Safari**

<img width="1918" alt="Screen Shot 2019-11-27 at 12 29 47 PM" src="https://user-images.githubusercontent.com/25959096/69703866-60d9df80-1118-11ea-8b23-71824c86c589.png">
