### PR TITLE
Fix associated accounts getting removed on profile update + Minor fixes

### DIFF
--- a/apps/user-portal/src/api/profile.ts
+++ b/apps/user-portal/src/api/profile.ts
@@ -79,10 +79,12 @@ export const getProfileInfo = (): Promise<BasicProfileInterface> => {
         .request(requestConfig)
         .then(async (response) => {
             let gravatar = "";
+            let profileImage: string;
+
             if (response.status !== 200) {
                 return Promise.reject(new Error(`Failed get user profile info from: ${ServiceResourcesEndpoint.me}`));
             }
-            if (isEmpty(response.data.userImage)) {
+            if (isEmpty(response.data.userImage) && !response.data.profileUrl) {
                 try {
                     gravatar = await getGravatarImage(
                         typeof response.data.emails[0] === "string"
@@ -93,6 +95,9 @@ export const getProfileInfo = (): Promise<BasicProfileInterface> => {
                     gravatar = "";
                 }
             }
+
+            profileImage = response.data.profileUrl ? response.data.profileUrl : gravatar;
+
             const profileResponse: BasicProfileInterface = {
                 emails: response.data.emails || "",
                 name: response.data.name || { givenName: "", familyName: "" },
@@ -102,7 +107,7 @@ export const getProfileInfo = (): Promise<BasicProfileInterface> => {
                 responseStatus: response.status || null,
                 roles: response.data.roles || [],
                 userName: response.data.userName || "",
-                userimage: response.data.userImage || gravatar
+                userimage: response.data.userImage || profileImage
             };
             return Promise.resolve(profileResponse);
         })

--- a/apps/user-portal/src/components/applications/application-list-item.tsx
+++ b/apps/user-portal/src/components/applications/application-list-item.tsx
@@ -44,7 +44,12 @@ export const ApplicationListItem: FunctionComponent<ApplicationListItemProps> = 
         <Item.Group unstackable onClick={ () => onAppNavigate(app.id, app.accessUrl) }>
             <Item className="application-list-item">
                 <List.Content className="icon-container" floated="left">
-                    <AppAvatar spaced="right" size="little" name={ app.name } image={ app.image } />
+                    <AppAvatar
+                        spaced="right"
+                        size={ app.image ? "mini" : "little" }
+                        name={ app.name }
+                        image={ app.image }
+                    />
                 </List.Content>
                 <Item.Content className="text-content-container">
                     <Item.Header as="a">

--- a/apps/user-portal/src/components/header/header.tsx
+++ b/apps/user-portal/src/components/header/header.tsx
@@ -149,7 +149,7 @@ export const Header: React.FunctionComponent<HeaderProps> = (props: HeaderProps)
                                 className="user-dropdown"
                             >
                                 <Dropdown.Menu onClick={ handleUserDropdownClick }>
-                                    <Item.Group unstackable>
+                                    <Item.Group className="authenticated-user" unstackable>
                                         <Item
                                             className="header"
                                             key={ `logged-in-user-${profileDetails.profileInfo.userName}` }

--- a/apps/user-portal/src/components/overview/widgets/user-sessions-widget.tsx
+++ b/apps/user-portal/src/components/overview/widgets/user-sessions-widget.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import _ from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -46,7 +47,15 @@ export const UserSessionsWidget: FunctionComponent<{}> = (): JSX.Element => {
     const getUserSessions = (): void => {
         fetchUserSessions()
             .then((response) => {
-                setUserSessions(response);
+                let sessions = [ ...response.sessions ];
+
+                // Sort the array by last access time
+                sessions = _.reverse(_.sortBy(sessions, (session) => session.lastAccessTime));
+
+                setUserSessions({
+                    ...response,
+                    sessions
+                });
             })
             .catch((error) => {
                 if (error.response && error.response.data && error.response.detail) {

--- a/apps/user-portal/src/components/profile/profile.tsx
+++ b/apps/user-portal/src/components/profile/profile.tsx
@@ -412,10 +412,12 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                                             )
                                             : profileInfo.get(schema.name)
                                             || (
-                                                <a onClick={ () => { showFormEditView(schema.name); } }>
-                                                    { t("views:components.profile.forms.generic.inputs.placeholder",
-                                                        { fieldName: schema.displayName }) }
-                                                </a>
+                                                <div className="placeholder-text">
+                                                    {
+                                                        t("views:components.profile.forms.generic.inputs.placeholder",
+                                                        { fieldName: schema.displayName })
+                                                    }
+                                                </div>
                                             )
                                     }
                                 </List.Description>
@@ -433,7 +435,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                                 { schema.mutability !== "READ_ONLY" && schema.name !== "userName"
                                     ?
                                     (
-                                        < Popup
+                                        <Popup
                                             trigger={
                                                 (
                                                     <Icon
@@ -442,9 +444,11 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                                                         size="small"
                                                         color="grey"
                                                         onClick={ () => showFormEditView(schema.name) }
-                                                        name={ !isEmpty(profileInfo.get(schema.name))
-                                                            ? "pencil alternate"
-                                                            : null }
+                                                        name={
+                                                            !isEmpty(profileInfo.get(schema.name))
+                                                                ? "pencil alternate"
+                                                                : "add"
+                                                        }
                                                     />
                                                 )
                                             }
@@ -464,7 +468,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
     };
 
     return (
-        < SettingsSection
+        <SettingsSection
             description={ t("views:sections.profile.description") }
             header={ t("views:sections.profile.heading") }
             icon={ profileInfoLoader

--- a/apps/user-portal/src/components/shared/app-avatar.tsx
+++ b/apps/user-portal/src/components/shared/app-avatar.tsx
@@ -46,6 +46,8 @@ export const AppAvatar: FunctionComponent<AppAvatarProps> = (props: AppAvatarPro
         return (
             <Avatar
                 avatarType="app"
+                avatar
+                className="with-app-image"
                 image={ image }
                 bordered={ false }
                 { ...props }

--- a/apps/user-portal/src/components/shared/avatar.tsx
+++ b/apps/user-portal/src/components/shared/avatar.tsx
@@ -18,7 +18,7 @@
 
 import classNames from "classnames";
 import * as React from "react";
-import { Image, SemanticSIZES } from "semantic-ui-react";
+import { Image, Placeholder, SemanticSIZES } from "semantic-ui-react";
 import { DefaultAppIcon } from "../../configs";
 import { UserImageDummy } from "./ui";
 
@@ -34,6 +34,7 @@ export interface AvatarProps {
     floated?: "left" | "right";
     image?: React.ReactNode;
     inline?: boolean;
+    isLoading?: boolean;
     label?: string;
     name?: string;
     onMouseOut?: (e: MouseEvent) => void;
@@ -67,6 +68,7 @@ export const Avatar: React.FunctionComponent<AvatarProps> = (props): JSX.Element
         floated,
         image,
         inline,
+        isLoading,
         label,
         name,
         onMouseOver,
@@ -90,6 +92,24 @@ export const Avatar: React.FunctionComponent<AvatarProps> = (props): JSX.Element
         [ `${ avatarType === "user" ? "user-avatar" : "app-avatar" }` ]: avatar,
         [ `${ relaxLevel }` ]: relaxLevel,
     }, className);
+
+    // If loading, show the placeholder.
+    if (isLoading) {
+        return (
+            <Image
+                className={ `${ avatarType === "user" ? "user-image" : "app-image" } ${ classes }` }
+                bordered={ bordered }
+                floated={ floated }
+                circular={ avatarType === "user" }
+                rounded={ avatarType === "app" }
+                style={ style }
+            >
+                <Placeholder>
+                    <Placeholder.Image square />
+                </Placeholder>
+            </Image>
+        );
+    }
 
     /**
      * Generates the initials for the avatar. If the name
@@ -195,6 +215,7 @@ Avatar.defaultProps = {
     bordered: true,
     className: "",
     inline: false,
+    isLoading: false,
     label: null,
     onMouseOut: null,
     onMouseOver: null,

--- a/apps/user-portal/src/components/shared/user-avatar.tsx
+++ b/apps/user-portal/src/components/shared/user-avatar.tsx
@@ -76,7 +76,9 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props: UserAvatar
     const isGravatarURL = (): boolean => {
         return (userImage && userImage.includes(UIConstants.GRAVATAR_URL))
             || (authState && authState.profileInfo && authState.profileInfo.userimage
-                && authState.profileInfo.userimage.includes(UIConstants.GRAVATAR_URL));
+                && authState.profileInfo.userimage.includes(UIConstants.GRAVATAR_URL))
+            || (authState && authState.profileInfo && authState.profileInfo.profileUrl
+                && authState.profileInfo.profileUrl.includes(UIConstants.GRAVATAR_URL));
     };
 
     /**

--- a/apps/user-portal/src/components/shared/user-avatar.tsx
+++ b/apps/user-portal/src/components/shared/user-avatar.tsx
@@ -98,7 +98,7 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props: UserAvatar
     };
 
     // Avatar for the authenticated user.
-    if (authState && authState.profileInfo && authState.profileInfo.userimage) {
+    if (authState && authState.profileInfo && (authState.profileInfo.profileUrl || authState.profileInfo.userimage)) {
         return (
             <Popup
                 content={ gravatarInfoPopoverText }
@@ -113,7 +113,11 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props: UserAvatar
                         { ...props }
                         avatarType="user"
                         bordered={ false }
-                        image={ authState.profileInfo && authState.profileInfo.userimage }
+                        image={
+                            authState.profileInfo.profileUrl
+                                ? authState.profileInfo.profileUrl
+                                : authState.profileInfo.userimage
+                        }
                         label={ showGravatarLabel ? resolveTopLabel() : null }
                         onMouseOver={ handleOnMouseOver }
                         onMouseOut={ handleOnMouseOut }

--- a/apps/user-portal/src/components/user-sessions/user-sessions.tsx
+++ b/apps/user-portal/src/components/user-sessions/user-sessions.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import _ from "lodash";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Container, Menu, Modal } from "semantic-ui-react";
@@ -67,7 +68,15 @@ export const UserSessionsComponent: FunctionComponent<UserSessionsComponentProps
     const getUserSessions = (): void => {
         fetchUserSessions()
             .then((response) => {
-                setUserSessions(response);
+                let sessions = [ ...response.sessions ];
+
+                // Sort the array by last access time
+                sessions = _.reverse(_.sortBy(sessions, (session) => session.lastAccessTime));
+
+                setUserSessions({
+                    ...response,
+                    sessions
+                });
             })
             .catch((error) => {
                 if (error.response && error.response.data && error.response.detail) {

--- a/apps/user-portal/src/store/actions/types/authenticate.ts
+++ b/apps/user-portal/src/store/actions/types/authenticate.ts
@@ -51,12 +51,19 @@ const SET_PROFILE_INFO = "SET_PROFILE_INFO";
 const SET_SCHEMAS = "SET_SCHEMAS";
 
 /**
+ * Action type to set the associated accounts.
+ * @type {string}
+ */
+const SET_ASSOCIATED_ACCOUNTS = "SET_ASSOCIATED_ACCOUNTS";
+
+/**
  * Export action types
  *
  * @type {object}
  */
 export const authenticateActionTypes = {
     RESET_AUTHENTICATION,
+    SET_ASSOCIATED_ACCOUNTS,
     SET_PROFILE_INFO,
     SET_SCHEMAS,
     SET_SIGN_IN,

--- a/apps/user-portal/src/store/reducers/authenticate.ts
+++ b/apps/user-portal/src/store/reducers/authenticate.ts
@@ -73,6 +73,14 @@ const authenticateReducer = (state = authenticateInitialState, action) => {
                 ...state,
                 profileInfo: action.payload
             };
+        case authenticateActionTypes.SET_ASSOCIATED_ACCOUNTS:
+            return {
+                ...state,
+                profileInfo: {
+                    ...state.profileInfo,
+                    associations: action.payload
+                }
+            };
         case authenticateActionTypes.SET_SCHEMAS:
             return {
                 ...state,

--- a/modules/theme/src/themes/default/collections/menu.overrides
+++ b/modules/theme/src/themes/default/collections/menu.overrides
@@ -213,12 +213,12 @@
         &.app-header {
             .user-dropdown {
                 .authenticated-user {
-                    .ui.image.user-image.user-avatar.tiny {
+                    .ui.image.user-image.tiny {
                         width: 80px !important;
                     }
                 }
                 .linked-accounts-list {
-                    .ui.image.user-image.user-avatar.little {
+                    .ui.image.user-image.little {
                         width: @littleWidth !important;
                     }
                 }

--- a/modules/theme/src/themes/default/elements/image.overrides
+++ b/modules/theme/src/themes/default/elements/image.overrides
@@ -123,6 +123,16 @@
         &.app-avatar {
             text-align: center;
 
+            &.with-app-image {
+                img {
+                    position: absolute;
+                    top: 0;
+                    bottom: 0;
+                    left: 0;
+                    right: 0;
+                    margin: auto;
+                }
+            }
             &.bg-image {
                 background-repeat: no-repeat;
 

--- a/modules/theme/src/themes/default/views/card.overrides
+++ b/modules/theme/src/themes/default/views/card.overrides
@@ -129,6 +129,9 @@
                     padding: 0;
 
                     .description {
+                        .placeholder-text {
+                            color: lighten(@black, 40);
+                        }
                         .small-text {
                             font-size: 11px;
                         }

--- a/modules/theme/src/themes/default/views/item.overrides
+++ b/modules/theme/src/themes/default/views/item.overrides
@@ -20,9 +20,14 @@
 .ui.items > .item {
     &.application-list-item {
         margin-bottom: 25px;
+        padding: @applicationListItemPadding;
+        border: @dividedBorder;
+        border-color: transparent;
+        border-radius: @defaultBorderRadius;
 
         &:hover {
             cursor: pointer;
+            border-color: @borderColor;
 
             .app-avatar {
                 &.bg-image {

--- a/modules/theme/src/themes/default/views/item.overrides
+++ b/modules/theme/src/themes/default/views/item.overrides
@@ -47,6 +47,8 @@
             }
         }
         .icon-container {
+            margin: auto 0;
+
             .ui.mini.image {
                 width: @littleWidth; // Make the image larger than the default `mini` size
             }

--- a/modules/theme/src/themes/default/views/item.overrides
+++ b/modules/theme/src/themes/default/views/item.overrides
@@ -41,6 +41,11 @@
                 color: @headerColor;
             }
         }
+        .icon-container {
+            .ui.mini.image {
+                width: @littleWidth; // Make the image larger than the default `mini` size
+            }
+        }
         .text-content-container {
             margin-top: 5px;
             margin-left: 5px;

--- a/modules/theme/src/themes/default/views/item.variables
+++ b/modules/theme/src/themes/default/views/item.variables
@@ -27,6 +27,7 @@ Application List Item
 
 @starColor: #FFB70A;
 @applicationListItemHeaderMaxWidth: 140px;
-@applicationListItemDescMaxWidth: 160px;
+@applicationListItemDescMaxWidth: 150px;
+@applicationListItemPadding: 8px 11px;
 @applicationListItemHeaderColor: @darkTextColor;
 @applicationListItemDescColor: @mutedTextColor;


### PR DESCRIPTION
## Purpose
> The associated accounts state in redux was getting replaced when a profile field is updated. This PR brings a fix to the mentioned issue.
> When a profile URL value is present, It should get prominence over the Gravatar profile image.
> Fix UI issues in applications page.
> Add a loading placeholder to the avatar component.
> Sorted the sessions list by last accessed time.

**Fixed applications page UI issue**

Before

<img width="1000" alt="Screen Shot 2019-12-14 at 8 01 00 AM" src="https://user-images.githubusercontent.com/25959096/70842319-21b1cb00-1e48-11ea-9baf-aad875936541.png">


After

<img width="1027" alt="Screen Shot 2019-12-14 at 7 50 58 AM" src="https://user-images.githubusercontent.com/25959096/70842322-2eceba00-1e48-11ea-81e9-c1fc7870403f.png">

**Modified profile edit UI**

<img width="955" alt="Screen Shot 2019-12-14 at 7 51 51 AM" src="https://user-images.githubusercontent.com/25959096/70842325-3aba7c00-1e48-11ea-81a1-326bb8311dde.png">
