### PR TITLE
Fix encoding issues in jsp

### DIFF
--- a/apps/user-portal/src/index.jsp
+++ b/apps/user-portal/src/index.jsp
@@ -21,6 +21,7 @@
 <!doctype html>
 <html>
     <head>
+        <%= htmlWebpackPlugin.options.contentType %>
         <meta charset="utf-8"/>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
         <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/styles/css/wso2-default.css" rel="stylesheet" type="text/css"/>

--- a/apps/user-portal/webpack.config.js
+++ b/apps/user-portal/webpack.config.js
@@ -166,6 +166,7 @@ module.exports = (env) => {
                 favicon: faviconImage,
                 title: titleText,
                 publicPath: publicPath,
+                contentType: "<%@ page language=\"java\" contentType=\"text/html; charset=UTF-8\" pageEncoding=\"UTF-8\" %>",
                 importUtil: "<%@ page import=\"static org.wso2.carbon.identity.core.util.IdentityUtil.getServerURL\" %>",
                 serverUrl: "<%=getServerURL(\"\", true, true)%>"
             }),


### PR DESCRIPTION
## Purpose
> The default encoding type in jsp is not UTF-8. This causes issues when rendering special characters. This PR introduces a fix which overrides the default content type.

Fixes #210 