### PR TITLE
Fix user portal webapp loading issue

### DIFF
--- a/apps/user-portal/webpack.config.js
+++ b/apps/user-portal/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = (env) => {
                 favicon: faviconImage,
                 title: titleText,
                 publicPath: publicPath,
-                contentType: "<%@ page language=\"java\" contentType=\"text/html; charset=UTF-8\"" + 
+                contentType: "<%@ page language=\"java\" contentType=\"text/html; charset=UTF-8\" " +
                                 "pageEncoding=\"UTF-8\" %>",
                 importUtil: "<%@ page import=\"" + 
                                 "static org.wso2.carbon.identity.core.util.IdentityUtil.getServerURL\" %>",


### PR DESCRIPTION
Charset encoding in the `index.jsp` was missing a space between two attributes which resulted in a parsing issue.