### PR TITLE
Fix URL error message being shown when the modal is reopened.

### DIFF
--- a/apps/user-portal/package.json
+++ b/apps/user-portal/package.json
@@ -19,30 +19,6 @@
         "test": "jest --passWithNoTests",
         "clean": "rm -rf node_modules build npm"
     },
-    "jest": {
-        "globals": {
-            "APP_BASENAME": "user-portal",
-            "SERVER_HOST_DEFAULT": "https://localhost:9443",
-            "APP_HOME_PATH": "/overview",
-            "APP_LOGIN_PATH": "/login",
-            "CLIENT_ID_DEFAULT": "USER_PORTAL",
-            "CLIENT_HOST_DEFAULT": "https://localhost:9000",
-            "LOGIN_CALLBACK_URL": "https://localhost:9000/user-portal/login"
-        },
-        "transform": {
-            "^.+\\.tsx$": "ts-jest",
-            "^.+\\.ts$": "ts-jest",
-            "^.+\\.js$": "babel-jest",
-            "^.+\\.jsx$": "babel-jest"
-        },
-        "moduleNameMapper": {
-            "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test_configs/file_mock.js",
-            "\\.(css|less)$": "<rootDir>/test_configs/style_mock.js"
-        },
-        "setupFilesAfterEnv": [
-            "<rootDir>/test_configs/setup_test.ts"
-        ]
-    },
     "dependencies": {
         "@wso2is/authentication": "^0.1.168",
         "@wso2is/forms": "^0.1.168",

--- a/apps/user-portal/src/components/shared/user-avatar.tsx
+++ b/apps/user-portal/src/components/shared/user-avatar.tsx
@@ -96,15 +96,6 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props: UserAvatar
     }, [image]);
 
     /**
-     * Get the profileUrl from the props and set the url state
-     */
-    useEffect(() => {
-        if (profileUrl) {
-            setUrl(profileUrl);
-        }
-    }, [profileUrl]);
-
-    /**
      * Resolves the top label image.
      *
      * @return {string}
@@ -225,6 +216,23 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props: UserAvatar
     };
 
     /**
+     * This function is called when the modal is closed
+     */
+    const closeModal = () => {
+        setShowEditModal(false);
+        setUrlError(Error.NONE);
+    };
+
+    /**
+     * This function is called when the button inside dimmer is clicked
+     * This shows the modal and sets the profileUrl.
+     */
+    const openModal = () => {
+        setShowEditModal(true);
+        setUrl(profileUrl);
+    };
+
+    /**
      * Show Edit Modal
      */
     const editModal = () => {
@@ -238,7 +246,7 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props: UserAvatar
                 dimmer="blurring"
                 size="tiny"
                 open={ showEditModal }
-                onClose={ () => { setShowEditModal(false); } }
+                onClose={ closeModal }
             >
                 <Modal.Content>
                     <h3>{ t("views:components.userAvatar.urlUpdateHeader") }</h3>
@@ -279,7 +287,7 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props: UserAvatar
                     </Form>
                 </Modal.Content>
                 <Modal.Actions>
-                    <Button className="link-button" onClick={ () => { setShowEditModal(false); } } >
+                    <Button className="link-button" onClick={ closeModal } >
                         { t("common:cancel").toString() }
                     </Button>
                     <Button primary={ true } onClick={ handleSubmit }>
@@ -319,7 +327,7 @@ export const UserAvatar: FunctionComponent<UserAvatarProps> = (props: UserAvatar
                                             circular
                                             basic
                                             className="upload-button"
-                                            onClick={ () => { setShowEditModal(true); } }
+                                            onClick={ openModal }
                                         >
                                             <Icon name="camera" size="large" />
                                         </Button>

--- a/modules/forms/package.json
+++ b/modules/forms/package.json
@@ -22,20 +22,5 @@
         "test": "jest"
     },
     "author": "WSO2",
-    "license": "Apache-2.0",
-    "jest": {
-        "transform": {
-            "^.+\\.tsx$": "ts-jest",
-            "^.+\\.ts$": "ts-jest",
-            "^.+\\.js$": "babel-jest",
-            "^.+\\.jsx$": "babel-jest"
-        },
-        "moduleNameMapper": {
-            "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/test-configs/file-mock.js",
-            "\\.(css|less)$": "<rootDir>/test-configs/style-mock.js"
-        },
-        "setupFilesAfterEnv": [
-            "<rootDir>/test-configs/setup-test.ts"
-        ]
-    }
+    "license": "Apache-2.0"
 }


### PR DESCRIPTION
## Purpose
> In the modal that appears when one clicks on the camera icon on the dimmer that appears over the user avatar in the personal info section, the error message that appears when the URL is invalid or not entered continues to be shown even when the modal is closed and reopened.
> If the URL is deleted and the modal is closed without saving and reopened, the URL textbox remains empty.

## Goals
> The URL error message is not shown when the modal is reopened.
> The textbox shows the saved URL when the modal is reopened. 