### PR TITLE
Fix issues in the self user registration page (#273,#274,#275)

### DIFF
--- a/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -96,6 +96,7 @@ Start.signing.up=Start Signing Up
 Enter.your.username.here=Enter your username here
 If.you.specify.tenant.domain.you.registered.under.super.tenant=If you do not specify a tenant domain, you will be registered under super tenant
 Proceed.to.self.register=Proceed to Self Register
+Confirm.Privacy.Policy=Please confirm that you have read and understood the Privacy Policy
 For.security.following.characters.restricted=For security measures following characters are restricted < > ` "
 Start.username.recovery=Start Username Recovery
 Start.password.recovery=Start Password Recovery

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -240,7 +240,7 @@
                                         String firstNameValue = request.getParameter(IdentityManagementEndpointConstants.ClaimURIs.FIRST_NAME_CLAIM);
                                 %>
                                 <div class="two fields">
-                                    <div class="field">
+                                    <div class="<% if (firstNamePII.getRequired() || !piisConfigured) {%> required <%}%> field">
                                         <label class="control-label">
                                             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "First.name")%>
                                         </label>
@@ -257,7 +257,7 @@
                                             String lastNameValue =
                                                     request.getParameter(IdentityManagementEndpointConstants.ClaimURIs.LAST_NAME_CLAIM);
                                     %>
-                                    <div class="field">
+                                    <div class="<% if (lastNamePII.getRequired() || !piisConfigured) {%> required <%}%> field">
                                         <label class="control-label">
                                             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Last.name")%>
                                         </label>
@@ -275,14 +275,14 @@
                                            class="form-control required usrName usrNameLength">
                                 </div>
                                 <div class="two fields">
-                                    <div class="field">
+                                    <div class="required field">
                                         <label class="control-label">
                                             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Password")%>
                                         </label>
                                         <input id="password" name="password" type="password"
                                                class="form-control" required>
                                     </div>
-                                    <div class="field">
+                                    <div class="required field">
                                         <label class="control-label">
                                             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Confirm.password")%>
                                         </label>
@@ -297,7 +297,7 @@
                                         String emailValue =
                                                 request.getParameter(IdentityManagementEndpointConstants.ClaimURIs.EMAIL_CLAIM);
                                 %>
-                                <div class="field">
+                                <div class="<% if (emailNamePII.getRequired() || !piisConfigured) {%> required <%}%> field">
                                     <label class="control-label">
                                         <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Email")%>
                                     </label>
@@ -325,7 +325,7 @@
                                             && !StringUtils
                                             .equals(claim, IdentityManagementEndpointConstants.ClaimURIs.EMAIL_CLAIM)) {
                                 %>
-                                <div class="field">
+                                <div class="required field">
                                     <label class="control-label">
                                         <%=IdentityManagementEndpointUtil.i18nBase64(recoveryResourceBundle, claimDisplayName)%>
                                     </label>
@@ -354,7 +354,7 @@
                                             String claimURI = claim.getUri();
                                             String claimValue = request.getParameter(claimURI);
                                 %>
-                                <div class="field">
+                                <div class="<% if (claim.getRequired()) {%> required <%}%>field">
                                     <label <% if (claim.getRequired()) {%> class="control-label" <%}%>>
                                         <%=IdentityManagementEndpointUtil.i18nBase64(recoveryResourceBundle, claim.getDisplayName())%>
                                     </label>
@@ -501,7 +501,7 @@
                                 <div class="ui divider hidden"></div>
                                 <div>
                                     <!--Terms/Privacy Policy-->
-                                    <div class="field">
+                                    <div class="required field">
                                         <div class="ui checkbox">
                                             <input id="termsCheckbox" type="checkbox"/>
                                             <label><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -231,8 +231,8 @@
                             <div class="ui divider hidden"></div>
                             <!-- validation -->
                             <div>
-                                <div id="regFormError" class="alert alert-danger" style="display:none"></div>
-                                <div id="regFormSuc" class="alert alert-success" style="display:none"></div>
+                                <div id="regFormError" class="ui negative message" style="display:none"></div>
+                                <div id="regFormSuc" class="ui positive message" style="display:none"></div>
 
                                 <% Claim firstNamePII =
                                         uniquePIIs.get(IdentityManagementEndpointConstants.ClaimURIs.FIRST_NAME_CLAIM);
@@ -503,7 +503,7 @@
                                     <!--Terms/Privacy Policy-->
                                     <div class="field">
                                         <div class="ui checkbox">
-                                            <input type="checkbox"/>
+                                            <input id="termsCheckbox" type="checkbox"/>
                                             <label><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                                                     "I.confirm.that.read.and.understood")%>
                                                 <a href="/authenticationendpoint/privacy_policy.do" target="policy-pane">
@@ -625,8 +625,8 @@
                     registrationBtn.prop("disabled", true).addClass("disabled");
                 }
             });
-
-            $(".form-info").tooltip();
+            
+            $(".form-info").popup();
 
             $("#register").submit(function (e) {
                 var unsafeCharPattern = /[<>`\"]/;
@@ -652,13 +652,21 @@
 
                 var password = $("#password").val();
                 var password2 = $("#password2").val();
-
-                if (password != password2) {
+                
+                if (password !== password2) {
                     error_msg.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                         "Passwords.did.not.match.please.try.again")%>");
                     error_msg.show();
                     $("html, body").animate({scrollTop: error_msg.offset().top}, 'slow');
                     return false;
+                }
+                
+                if(!$("#termsCheckbox").checked){
+                        error_msg.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
+                            "Confirm.Privacy.Policy")%>");
+                        error_msg.show();
+                        $("html, body").animate({scrollTop: error_msg.offset().top}, 'slow');
+                        return false;
                 }
 
                 <%
@@ -763,7 +771,7 @@
                     '<ul>' +
                     '{{#purposes}}' +
                     '<li data-jstree=\'{"icon":"icon-book"}\' purposeid="{{purposeId}}" mandetorypurpose={{mandatory}}>' +
-                    '{{purpose}}{{#if mandatory}}<span class="required_consent">*</span>{{/if}} {{#if description}}<img src="images/info.png" class="form-info" data-toggle="tooltip" title="{{description}}" data-placement="right"/>{{/if}}<ul>' +
+                    '{{purpose}}{{#if mandatory}}<span class="required_consent">*</span>{{/if}} {{#if description}}<img src="images/info.png" class="form-info" data-toggle="tooltip" data-content="{{description}}" data-placement="right"/>{{/if}}<ul>' +
                     '{{#piiCategories}}' +
                     '<li data-jstree=\'{"icon":"icon-user"}\' piicategoryid="{{piiCategoryId}}" mandetorypiicatergory={{mandatory}}>{{#if displayName}}{{displayName}}{{else}}{{piiCategory}}{{/if}}{{#if mandatory}}<span class="required_consent">*</span>{{/if}}</li>' +
                     '</li>' +
@@ -1049,7 +1057,7 @@
                 var rowTemplate =
                     '{{#purposes}}' +
                     '<div class="consent-container-3 box clearfix"><ul class="consent-ul">' +
-                    '<li><span>{{purpose}} {{#if description}}<img src="images/info.png" class="form-info" data-toggle="tooltip" title="{{description}}" data-placement="right"/>{{/if}}</span></li></ul>' +
+                    '<li><span>{{purpose}} {{#if description}}<img src="images/info.png" class="form-info" data-toggle="tooltip" data-content="{{description}}" data-placement="right"/>{{/if}}</span></li></ul>' +
                     '{{#grouped_each 2 piiCategories}}' +
                     '<div class="row">' +
                     '{{#each this }}' +


### PR DESCRIPTION
## Purpose
>  Resolves #273, #274 and #275 

When there is password mismatch:
<img width="666" alt="Screenshot 2020-01-16 at 16 14 08" src="https://user-images.githubusercontent.com/20745428/72518486-7d260d00-387b-11ea-917a-875741ad432e.png">
When the user hasn't confirmed that they have read and understood the privacy policy
![Screenshot 2020-01-16 at 16 22 55](https://user-images.githubusercontent.com/20745428/72518972-78ae2400-387c-11ea-930a-9faf49b006cf.png)
Asterisk marks are displayed for required fields
![image](https://user-images.githubusercontent.com/20745428/72520339-418d4200-387f-11ea-92e7-ac8510e2e298.png)

