### PR TITLE
Fix Footer overlap App content

### DIFF
--- a/apps/admin-portal/src/layouts/inner.tsx
+++ b/apps/admin-portal/src/layouts/inner.tsx
@@ -35,6 +35,8 @@ interface InnerPageLayoutProps {
  */
 const DEFAULT_HEADER_HEIGHT = 59;
 
+const DEFAULT_FOOTER_HEIGHT = 60;
+
 /**
  * Inner page layout.
  *
@@ -48,6 +50,7 @@ export const InnerPageLayout: React.FunctionComponent<InnerPageLayoutProps> = (
 
     const [ mobileSidePanelVisibility, setMobileSidePanelVisibility ] = React.useState(false);
     const [ headerHeight, setHeaderHeight ] = React.useState(DEFAULT_HEADER_HEIGHT);
+    const [ footerHeight, setFooterHeight ] = React.useState(DEFAULT_FOOTER_HEIGHT);
 
     React.useEffect(() => {
         if (headerHeight === document.getElementById("app-header").offsetHeight) {
@@ -55,6 +58,13 @@ export const InnerPageLayout: React.FunctionComponent<InnerPageLayoutProps> = (
         }
         setHeaderHeight(document.getElementById("app-header").offsetHeight);
     });
+
+    React.useEffect(() => {
+        if (footerHeight === document.getElementById("app-footer").offsetHeight) {
+            return;
+        }
+        setFooterHeight(document.getElementById("app-footer").offsetHeight);
+    })
 
     const handleSidePanelToggleClick = () => {
         setMobileSidePanelVisibility(!mobileSidePanelVisibility);
@@ -71,7 +81,7 @@ export const InnerPageLayout: React.FunctionComponent<InnerPageLayoutProps> = (
     return (
         <>
             <AppHeader onSidePanelToggleClick={ handleSidePanelToggleClick }/>
-            <div style={ { paddingTop: `${ headerHeight }px` } } className="app-content">
+            <div style={ { paddingTop: `${ headerHeight }px`, paddingBottom: `${ footerHeight }px` } } className="app-content">
                 <SidePanelWrapper
                     headerHeight={ headerHeight }
                     mobileSidePanelVisibility={ mobileSidePanelVisibility }

--- a/apps/admin-portal/src/layouts/inner.tsx
+++ b/apps/admin-portal/src/layouts/inner.tsx
@@ -34,7 +34,6 @@ interface InnerPageLayoutProps {
  * @type {string}
  */
 const DEFAULT_HEADER_HEIGHT = 59;
-
 const DEFAULT_FOOTER_HEIGHT = 60;
 
 /**


### PR DESCRIPTION
## Purpose

Fix: #293

> This PR will fix the Footer overlapping the APP content. The following image shows the issue.

<img width="1142" alt="Screenshot 2020-01-22 at 11 35 55" src="https://user-images.githubusercontent.com/11191791/72869917-ad9ef880-3d0c-11ea-970d-ac1282dcd11f.png">

## Goals
>The issue is fixed by adding a padding equal to the footer to the app-content component.
