### PR TITLE
Add a listen prop to Field components and an onChange prop to the Form component

### DIFF
--- a/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
@@ -21,6 +21,7 @@
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.oauth2.OAuth2ScopeService" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.stream.Collectors" %>
@@ -110,11 +111,14 @@
                                 <div class="scopes-list ui list">
                                     <%
                                         for (String scopeID : openIdScopes) {
+                                            String displayName = new OAuth2ScopeService()
+                                                                    .getScope(scopeID)
+                                                                    .getDisplayName();
                                     %>
                                     <div class="item">
                                         <i class="check circle outline icon"></i>
                                         <div class="content">
-                                            <%=Encode.forHtml(scopeID)%>
+                                            <%=Encode.forHtml(displayName)%>
                                         </div>
                                     </div>
                                     <%

--- a/modules/forms/src/components/field.tsx
+++ b/modules/forms/src/components/field.tsx
@@ -29,7 +29,7 @@ import {
     isResetField,
     isSubmitField,
     isTextField
-} from "../helpers/typeguards";
+} from "../helpers";
 import { FormField, FormValue, RadioChild } from "../models";
 import { Password } from "./password";
 

--- a/modules/forms/src/forms.tsx
+++ b/modules/forms/src/forms.tsx
@@ -19,19 +19,15 @@
 import React, { useEffect, useState } from "react";
 import { Form } from "semantic-ui-react";
 import { Field, GroupFields, InnerField, InnerGroupFields } from "./components";
-import { isCheckBoxField, isDropdownField, isInputField, isRadioField, isTextField } from "./helpers/typeguards";
-import {
-    Error,
-    FormField,
-    FormValue,
-    Validation
-} from "./models";
+import { isCheckBoxField, isDropdownField, isInputField, isRadioField, isTextField } from "./helpers";
+import { Error, FormField, FormValue, Validation } from "./models";
 
 /**
  * Prop types for Form component
  */
 interface FormProps {
     onSubmit: (values: Map<string, FormValue>) => void;
+    onChange?: (isPure: boolean, values: Map<string, FormValue>) => void;
     triggerReset?: (reset: () => void) => void;
 
 }
@@ -43,14 +39,34 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormProps>> 
     props: React.PropsWithChildren<FormProps>
 ): JSX.Element => {
 
-    const { onSubmit, triggerReset, children } = props;
+    const { onSubmit, triggerReset, onChange, children } = props;
 
     const [form, setForm] = useState(new Map<string, FormValue>());
+    const [isPure, setIsPure] = useState(true);
     const [validFields, setValidFields] = useState(new Map<string, Validation>());
     const [requiredFields, setRequiredFields] = useState(new Map<string, boolean>());
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     const formFields: FormField[] = [];
+    const flatReactChildren: React.ReactElement[] = [];
+
+    /**
+     * This function calls the listener prop of the field that is calling the `handleChange` function
+     * @param name
+     * @param newForm
+     */
+    const listener = (name: string, newForm: Map<string, FormValue>) => {
+        React.Children.map(flatReactChildren, (element: React.ReactElement) => {
+            if (
+                element.props.name
+                && element.props.name === name
+                && element.props.listen
+                && typeof element.props.listen === "function"
+            ) {
+                element.props.listen(newForm);
+            }
+        });
+    };
 
     /**
      * Handler for the onChange event
@@ -61,7 +77,10 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormProps>> 
         const tempForm: Map<string, FormValue> = new Map(form);
 
         tempForm.set(name, value);
+        listener(name, tempForm);
+        propagateOnChange(tempForm);
         setForm(tempForm);
+        setIsPure(false);
     };
 
     /**
@@ -80,8 +99,12 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormProps>> 
             }
         });
         itemIndex === -1 ? selectedItems.push(value) : selectedItems.splice(itemIndex, 1);
+
         tempForm.set(name, selectedItems);
+        listener(name, tempForm);
+        propagateOnChange(tempForm);
         setForm(tempForm);
+        setIsPure(false);
     };
 
     /**
@@ -140,6 +163,15 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormProps>> 
     };
 
     /**
+     * Calls the onChange prop
+     */
+    const propagateOnChange = (formValue: Map<string, FormValue>) => {
+        if (onChange && typeof onChange === "function") {
+            onChange(isPure, formValue);
+        }
+    };
+
+    /**
      * Handles reset button click
      * @param event
      */
@@ -159,6 +191,7 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormProps>> 
         return React.Children.map(elements, (element: React.ReactElement) => {
             if (element.type === Field) {
                 fields.push(element.props);
+                flatReactChildren.push(element);
                 return React.createElement(InnerField, {
                     formProps: {
                         checkError,

--- a/modules/forms/src/forms.tsx
+++ b/modules/forms/src/forms.tsx
@@ -24,7 +24,6 @@ import {
     Error,
     FormField,
     FormValue,
-    TextField,
     Validation
 } from "./models";
 

--- a/modules/forms/src/models/forms.ts
+++ b/modules/forms/src/models/forms.ts
@@ -53,36 +53,102 @@ export interface Error {
     errorMessages: string[];
 }
 
+interface FormFieldModel {
+    name: string;
+    label: string;
+    listener: () => void;
+}
+
+interface FormRequiredFieldModel extends FormFieldModel {
+    required: boolean;
+    requiredErrorMessage: string;
+
+}
 /**
  * Input field model
  */
-export interface TextField {
-    placeholder: string;
-    name: string;
+export interface TextField extends FormRequiredFieldModel {
     type: "text" | "email" | "textarea" | "number";
-    required: boolean;
-    label: string;
     width?: SemanticWIDTHS;
     validation?: (value: string, validation: Validation, allValues?: Map<string, FormValue>) => void;
-    requiredErrorMessage: string;
     value?: string;
+    placeholder: string;
 }
 
 /**
  * Password field model
  */
-export interface PasswordField {
-    placeholder: string;
-    name: string;
+export interface PasswordField extends FormRequiredFieldModel {
     type: "password";
-    required: boolean;
-    label: string;
     width?: SemanticWIDTHS;
     validation?: (value: string, validation: Validation, allValues?: Map<string, FormValue>) => void;
-    requiredErrorMessage: string;
     value?: string;
     showPassword: string;
     hidePassword: string;
+    placeholder: string;
+}
+
+/**
+ * Radio field child model
+ */
+export interface RadioChild {
+    label: string;
+    value: string;
+}
+
+/**
+ * Radio field model
+ */
+export interface RadioField extends FormFieldModel {
+    type: "radio";
+    default: string;
+    children: RadioChild[];
+    value?: string;
+}
+
+/**
+ * Checkbox field child model
+ */
+export interface CheckboxChild {
+    label: string;
+    value: string;
+}
+
+/**
+ * Checkbox field model
+ */
+export interface CheckboxField extends FormRequiredFieldModel {
+    type: "checkbox";
+    children: CheckboxChild[];
+    value?: string[];
+}
+
+/**
+ * Dropdown field child model
+ */
+export interface DropdownChild {
+    text: string;
+    value: string;
+    key: number;
+}
+
+/**
+ * Dropdown field model
+ */
+export interface DropdownField extends FormRequiredFieldModel {
+    type: "dropdown";
+    default?: string;
+    children: DropdownChild[];
+    placeholder?: string;
+    value?: string;
+}
+
+/**
+ * Custom field model
+ */
+export interface CustomField {
+    type: Type;
+    element: JSX.Element;
 }
 
 /**
@@ -117,79 +183,6 @@ export interface FormButton {
     size?: SemanticSIZES;
     type: "button";
     value: string;
-}
-
-/**
- * Radio field child model
- */
-export interface RadioChild {
-    label: string;
-    value: string;
-}
-
-/**
- * Custom field model
- */
-export interface CustomField {
-    type: Type;
-    element: JSX.Element;
-}
-
-/**
- * Radio field model
- */
-export interface RadioField {
-    type: "radio";
-    label: string;
-    name: string;
-    default: string;
-    children: RadioChild[];
-    value?: string;
-}
-
-/**
- * Checkbox field child model
- */
-export interface CheckboxChild {
-    label: string;
-    value: string;
-}
-
-/**
- * Checkbox field model
- */
-export interface CheckboxField {
-    type: "checkbox";
-    label: string;
-    name: string;
-    children: CheckboxChild[];
-    value?: string[];
-    required: boolean;
-    requiredErrorMessage: string;
-}
-
-/**
- * Dropdown field child model
- */
-export interface DropdownChild {
-    text: string;
-    value: string;
-    key: number;
-}
-
-/**
- * Dropdown field model
- */
-export interface DropdownField {
-    type: "dropdown";
-    label: string;
-    name: string;
-    default?: string;
-    children: DropdownChild[];
-    placeholder?: string;
-    requiredErrorMessage: string;
-    required: boolean;
-    value?: string;
 }
 
 /**

--- a/modules/forms/src/models/forms.ts
+++ b/modules/forms/src/models/forms.ts
@@ -56,13 +56,12 @@ export interface Error {
 interface FormFieldModel {
     name: string;
     label: string;
-    listener: () => void;
+    listen?: (values: Map<string, FormValue>) => void;
 }
 
 interface FormRequiredFieldModel extends FormFieldModel {
     required: boolean;
     requiredErrorMessage: string;
-
 }
 /**
  * Input field model

--- a/modules/forms/src/tests/constants.tsx
+++ b/modules/forms/src/tests/constants.tsx
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import React from "react";
 
 const constants = {
@@ -67,8 +68,9 @@ const constants = {
     TEXT_BOX_VALIDATION_FAILED: "Validation failed",
     TEXT_BOX_VALID_MESSAGE: "Text box Validated",
     TEXT_BOX_VALUE: "Text box value",
+    listen: jest.fn((value) => console.log(value)),
     onClick: jest.fn(),
-    onSubmit: () => jest.fn((value) => value),
+    onSubmit: jest.fn((value) => value)
 };
 
 export default constants;

--- a/modules/forms/src/tests/constants.tsx
+++ b/modules/forms/src/tests/constants.tsx
@@ -68,7 +68,7 @@ const constants = {
     TEXT_BOX_VALIDATION_FAILED: "Validation failed",
     TEXT_BOX_VALID_MESSAGE: "Text box Validated",
     TEXT_BOX_VALUE: "Text box value",
-    listen: jest.fn((value) => console.log(value)),
+    listen: jest.fn((value) => value),
     onClick: jest.fn(),
     onSubmit: jest.fn((value) => value)
 };

--- a/modules/forms/src/tests/forms.test.tsx
+++ b/modules/forms/src/tests/forms.test.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import "@testing-library/jest-dom/extend-expect";
 import { fireEvent, render } from "@testing-library/react";
 import constants from "./constants";
 import getForm from "./test-form";
@@ -57,6 +58,10 @@ describe("Test if the Forms is working fine", () => {
         fireEvent.change(textBox, { target: { value: NEW_VALUE } });
         expect(getByDisplayValue(NEW_VALUE)).toBeInTheDocument();
 
+        // check if the listen function was called
+        expect(constants.listen).toHaveBeenCalledTimes(1);
+        expect(constants.listen.mock.calls[0][0].get(constants.TEXT_BOX_NAME)).toBe(NEW_VALUE);
+
         // check if required error message is correctly displayed
         fireEvent.change(textBox, { target: { value: "" } });
         fireEvent.blur(textBox);
@@ -73,10 +78,10 @@ describe("Test if the Forms is working fine", () => {
         fireEvent.change(textBox, { target: { value: constants.TEXT_BOX_VALID_MESSAGE } });
         fireEvent.blur(textBox);
         fireEvent.click(getByText(constants.SUBMIT));
-        expect(constants.onSubmit()).toHaveBeenCalledTimes(1);
-        expect(constants.onSubmit().mock.calls[0][0].get(constants.TEXT_BOX_NAME))
+        expect(constants.onSubmit).toHaveBeenCalledTimes(1);
+        expect(constants.onSubmit.mock.calls[0][0].get(constants.TEXT_BOX_NAME))
             .toBe(constants.TEXT_BOX_VALID_MESSAGE);
-        constants.onSubmit().mockReset();
+        constants.onSubmit.mockReset();
     });
 
     test("Test if input type text is empty by default when no value is passed", () => {
@@ -159,9 +164,14 @@ describe("Test if the Forms is working fine", () => {
         expect(passwordBox).toBeInTheDocument();
 
         // check if the value of the password box changes
+        constants.listen.mockReset();
         const NEW_VALUE = "new value";
         fireEvent.change(passwordBox, { target: { value: NEW_VALUE } });
         expect(getByDisplayValue(NEW_VALUE)).toBeInTheDocument();
+
+        // check if the listen function was called
+        expect(constants.listen).toHaveBeenCalledTimes(1);
+        expect(constants.listen.mock.calls[0][0].get(constants.PASSWORD_NAME)).toBe(NEW_VALUE);
 
         // check if validation is working fine
         fireEvent.change(passwordBox, { target: { value: "wrong value" } });
@@ -207,13 +217,13 @@ describe("Test if the Forms is working fine", () => {
         expect(getByText(constants.PASSWORD_REQUIRED_MESSAGE)).toBeInTheDocument();
 
         // check if submit is working fine
+        constants.onSubmit.mockReset();
         fireEvent.change(passwordBox, { target: { value: constants.PASSWORD_VALID_MESSAGE } });
         fireEvent.blur(passwordBox);
         fireEvent.click(getByText(constants.SUBMIT));
-        expect(constants.onSubmit()).toHaveBeenCalledTimes(1);
-        expect(constants.onSubmit().mock.calls[0][0].get(constants.PASSWORD_NAME))
+        expect(constants.onSubmit).toHaveBeenCalledTimes(1);
+        expect(constants.onSubmit.mock.calls[0][0].get(constants.PASSWORD_NAME))
             .toBe(constants.PASSWORD_VALID_MESSAGE);
-        constants.onSubmit().mockReset();
     });
 
     test("Test if the basic functions of a checkbox are working fine", () => {
@@ -244,8 +254,15 @@ describe("Test if the Forms is working fine", () => {
         expect(getByDisplayValue(constants.CHECKBOX_VALUE[0]).parentElement).toHaveClass("checked");
 
         // check if the checkbox selection is working fine
+        constants.listen.mockReset();
         fireEvent.click(getByDisplayValue(constants.CHECKBOX_CHILD_1_VALUE));
         expect(getByText(constants.CHECKBOX_CHILD_1_LABEL).parentElement).toHaveClass("checked");
+
+        // check if the listen function was called
+        expect(constants.listen).toHaveBeenCalledTimes(1);
+        expect(constants.listen.mock.calls[0][0].get(constants.CHECKBOX_NAME)[1])
+            .toBe(constants.CHECKBOX_CHILD_1_VALUE);
+
 
         // check if required validation is working fine
         fireEvent.click(getByDisplayValue(constants.CHECKBOX_CHILD_1_VALUE));
@@ -258,10 +275,10 @@ describe("Test if the Forms is working fine", () => {
         fireEvent.click(getByDisplayValue(constants.CHECKBOX_CHILD_1_VALUE));
         fireEvent.click(getByDisplayValue(constants.CHECKBOX_CHILD_2_VALUE));
         fireEvent.blur(getByDisplayValue(constants.CHECKBOX_CHILD_1_VALUE));
+        constants.onSubmit.mockReset();
         fireEvent.click(getByText(constants.SUBMIT));
-        expect(constants.onSubmit()).toHaveBeenCalledTimes(1);
-        expect(constants.onSubmit().mock.calls[0][0].get(constants.CHECKBOX_NAME)).toHaveLength(2);
-        constants.onSubmit().mockReset();
+        expect(constants.onSubmit).toHaveBeenCalledTimes(1);
+        expect(constants.onSubmit.mock.calls[0][0].get(constants.CHECKBOX_NAME)).toHaveLength(2);
 
     });
 
@@ -280,11 +297,11 @@ describe("Test if the Forms is working fine", () => {
                 type: "submit"
             }
         ]));
+        constants.onSubmit.mockReset();
         fireEvent.click(getByText(constants.SUBMIT));
         expect(queryByText(constants.CHECKBOX_REQUIRED_MESSAGE)).not.toBeInTheDocument();
-        expect(constants.onSubmit()).toHaveBeenCalledTimes(1);
-        expect(constants.onSubmit().mock.calls[0][0].get(constants.CHECKBOX_NAME)).toHaveLength(0);
-        constants.onSubmit().mockReset();
+        expect(constants.onSubmit).toHaveBeenCalledTimes(1);
+        expect(constants.onSubmit.mock.calls[0][0].get(constants.CHECKBOX_NAME)).toHaveLength(0);
     });
 
     test("Test if the basic functions of the radio field are working fine", () => {
@@ -314,14 +331,19 @@ describe("Test if the Forms is working fine", () => {
         expect(getByDisplayValue(constants.RADIO_VALUE).parentElement).toHaveClass("checked");
 
         // check if radio selection is working fine
+        constants.listen.mockReset();
         fireEvent.click(getByDisplayValue(constants.RADIO_CHILD_2_VALUE));
         expect(getByDisplayValue(constants.RADIO_CHILD_2_VALUE).parentElement).toHaveClass("checked");
 
+        // check if the listen function was called
+        expect(constants.listen).toHaveBeenCalledTimes(1);
+        expect(constants.listen.mock.calls[0][0].get(constants.RADIO_NAME)).toBe(constants.RADIO_CHILD_2_VALUE);
+
         // check if submission is working fine
+        constants.onSubmit.mockReset();
         fireEvent.click(getByText(constants.SUBMIT));
-        expect(constants.onSubmit()).toHaveBeenCalledTimes(1);
-        expect(constants.onSubmit().mock.calls[0][0].get(constants.RADIO_NAME)).toBe(constants.RADIO_CHILD_2_VALUE);
-        constants.onSubmit().mockReset();
+        expect(constants.onSubmit).toHaveBeenCalledTimes(1);
+        expect(constants.onSubmit.mock.calls[0][0].get(constants.RADIO_NAME)).toBe(constants.RADIO_CHILD_2_VALUE);
 
     });
 
@@ -374,17 +396,23 @@ describe("Test if the Forms is working fine", () => {
         expect(getByText(constants.DROPDOWN_REQUIRED_MESSAGE)).toBeInTheDocument();
 
         // check if selection works properly
+        constants.listen.mockReset();
         fireEvent.click(getByRole("alert"));
         fireEvent.click(getByText(constants.DROPDOWN_CHILD_2_VALUE).parentElement);
         fireEvent.blur(getAllByText(constants.DROPDOWN_CHILD_2_VALUE)[1].parentElement);
         expect(getByRole("alert").firstChild.nodeValue).toBe(constants.DROPDOWN_CHILD_2_VALUE);
 
-        // check if submission works fine
-        fireEvent.click(getByText(constants.SUBMIT));
-        expect(constants.onSubmit()).toHaveBeenCalledTimes(1);
-        expect(constants.onSubmit().mock.calls[0][0].get(constants.DROPDOWN_NAME))
+        // check if the listen function was called
+        expect(constants.listen).toHaveBeenCalledTimes(1);
+        expect(constants.listen.mock.calls[0][0].get(constants.DROPDOWN_NAME))
             .toBe(constants.DROPDOWN_CHILD_2_VALUE);
-        constants.onSubmit().mockReset();
+
+        // check if submission works fine
+        constants.onSubmit.mockReset();
+        fireEvent.click(getByText(constants.SUBMIT));
+        expect(constants.onSubmit).toHaveBeenCalledTimes(1);
+        expect(constants.onSubmit.mock.calls[0][0].get(constants.DROPDOWN_NAME))
+            .toBe(constants.DROPDOWN_CHILD_2_VALUE);
     });
 
     test("Test if the default value is selected in a dropdown", () => {
@@ -443,11 +471,11 @@ describe("Test if the Forms is working fine", () => {
             }
         ]));
 
+        constants.onSubmit.mockReset();
         fireEvent.click(getByText(constants.SUBMIT));
         expect(queryByText(constants.DROPDOWN_REQUIRED_MESSAGE)).not.toBeInTheDocument();
-        expect(constants.onSubmit()).toHaveBeenCalledTimes(1);
-        expect(constants.onSubmit().mock.calls[0][0].get(constants.DROPDOWN_NAME)).toBe("");
-        constants.onSubmit().mockReset();
+        expect(constants.onSubmit).toHaveBeenCalledTimes(1);
+        expect(constants.onSubmit.mock.calls[0][0].get(constants.DROPDOWN_NAME)).toBe("");
     });
 
     test("Test if the reset button is working fine", () => {
@@ -473,7 +501,7 @@ describe("Test if the Forms is working fine", () => {
     });
 
     test("Test if the button works fine", () => {
-        const{ getByText } = render(getForm([
+        const { getByText } = render(getForm([
             {
                 isDefault: false,
                 isRequired: false,
@@ -554,9 +582,14 @@ describe("Test if the Forms is working fine", () => {
         expect(getByDisplayValue(constants.TEXT_BOX_VALUE)).toBeInTheDocument();
 
         // check if the value of the text box changes
+        constants.listen.mockReset();
         const NEW_VALUE = "new value";
         fireEvent.change(textBox, { target: { value: NEW_VALUE } });
         expect(getByDisplayValue(NEW_VALUE)).toBeInTheDocument();
+
+        // check if the listen function was called
+        expect(constants.listen).toHaveBeenCalledTimes(1);
+        expect(constants.listen.mock.calls[0][0].get(constants.TEXT_BOX_NAME)).toBe(NEW_VALUE);
 
         // check if required error message is correctly displayed
         fireEvent.change(textBox, { target: { value: "" } });
@@ -573,11 +606,10 @@ describe("Test if the Forms is working fine", () => {
         // check if submit is working fine
         fireEvent.change(textBox, { target: { value: constants.TEXT_BOX_VALID_MESSAGE } });
         fireEvent.blur(textBox);
+        constants.onSubmit.mockReset();
         fireEvent.click(getByText(constants.SUBMIT));
-        expect(constants.onSubmit()).toHaveBeenCalledTimes(1);
-        expect(constants.onSubmit().mock.calls[0][0].get(constants.TEXT_BOX_NAME))
+        expect(constants.onSubmit).toHaveBeenCalledTimes(1);
+        expect(constants.onSubmit.mock.calls[0][0].get(constants.TEXT_BOX_NAME))
             .toBe(constants.TEXT_BOX_VALID_MESSAGE);
-        constants.onSubmit().mockReset();
     });
-
 });

--- a/modules/forms/src/tests/test-form.tsx
+++ b/modules/forms/src/tests/test-form.tsx
@@ -53,6 +53,7 @@ const getForm = (testFields: FormTestFields[], isGroup?: boolean): JSX.Element =
                 }
             ],
             label: constants.CHECKBOX_LABEL,
+            listen: (value) => { constants.listen(value); },
             name: constants.CHECKBOX_NAME,
             required: true,
             requiredErrorMessage: constants.CHECKBOX_REQUIRED_MESSAGE,
@@ -82,6 +83,7 @@ const getForm = (testFields: FormTestFields[], isGroup?: boolean): JSX.Element =
             ],
             default: constants.DROPDOWN_DEFAULT,
             label: constants.DROPDOWN_LABEL,
+            listen: (value) => { constants.listen(value); },
             name: constants.DROPDOWN_NAME,
             placeholder: constants.DROPDOWN_PLACEHOLDER,
             required: true,
@@ -91,6 +93,7 @@ const getForm = (testFields: FormTestFields[], isGroup?: boolean): JSX.Element =
         password: {
             hidePassword: constants.HIDE_PASSWORD,
             label: constants.PASSWORD_LABEL,
+            listen: (value) => { constants.listen(value); },
             name: constants.PASSWORD_NAME,
             placeholder: constants.PASSWORD_PLACEHOLDER,
             required: true,
@@ -121,6 +124,7 @@ const getForm = (testFields: FormTestFields[], isGroup?: boolean): JSX.Element =
             ],
             default: constants.RADIO_DEFAULT,
             label: constants.RADIO_LABEL,
+            listen: (value) => { constants.listen(value); },
             name: constants.RADIO_NAME,
             type: "radio" as const,
             value: constants.RADIO_VALUE
@@ -135,6 +139,7 @@ const getForm = (testFields: FormTestFields[], isGroup?: boolean): JSX.Element =
         },
         text: {
             label: constants.TEXT_BOX_LABEL,
+            listen: (value) => { constants.listen(value); },
             name: constants.TEXT_BOX_NAME,
             placeholder: constants.TEXT_BOX_PLACEHOLDER,
             required: true,
@@ -169,7 +174,7 @@ const getForm = (testFields: FormTestFields[], isGroup?: boolean): JSX.Element =
     });
 
     return (
-        <Forms onSubmit={ (value) => constants.onSubmit()(value) }>
+        <Forms onSubmit={ (value) => constants.onSubmit(value) }>
             {
                 isGroup
                     ? (


### PR DESCRIPTION
## Purpose
> At present, there is no way a parent component can listen to the changes in the individual Field components of the Forms component. So, it's impossible for a parent component to update its own state based on the state of the Forms component. 
> There should be a way for the parent component to check the purity of the Forms component, i.e. if the Forms' initial state has changed or not since mounting.

## Goals
> A `listen` prop function has been introduced in the Field component so that every time the Field component changes, the listen prop will be called. The values argument carries the whole state of the Forms component just like the submit prop.
```javascript
   <Field
      .
      .
      .
       listen={
           (values)=>{ console.log(values.get("name")) }
       }
   />
```
>An `onChange` prop has been introduced to the Forms component that is called every time the Forms' state changes. Two arguments are passed into this prop method, namely `isPure` and `values`. The `isPure` is a boolean value that denotes the purity of the Forms component while the ` values` carries the whole state of the Forms component.
```javascript
    <Forms
        onChange={
            (isPure,values)=>{}
        }
     />
```