### PR TITLE
Resolve `java.Lang.LinkageError` caused by the accountrecoveryendpoint 

### DIFF
--- a/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
@@ -22,6 +22,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="org.wso2.carbon.identity.oauth2.OAuth2ScopeService" %>
+<%@ page import="org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeException" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.stream.Collectors" %>
@@ -111,14 +112,18 @@
                                 <div class="scopes-list ui list">
                                     <%
                                         for (String scopeID : openIdScopes) {
-                                            String displayName = new OAuth2ScopeService()
-                                                                    .getScope(scopeID)
-                                                                    .getDisplayName();
+                                            String scopeDisplayName = "";
+                                            try {
+                                                scopeDisplayName = new OAuth2ScopeService().getScope(scopeID).getDisplayName();
+                                            } catch(IdentityOAuth2ScopeException exception){
+                                                String redirectURL = "error.do";
+                                                response.sendRedirect(redirectURL);
+                                            }
                                     %>
                                     <div class="item">
                                         <i class="check circle outline icon"></i>
                                         <div class="content">
-                                            <%=Encode.forHtml(displayName)%>
+                                            <%=Encode.forHtml(scopeDisplayName)%>
                                         </div>
                                     </div>
                                     <%

--- a/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
@@ -22,7 +22,6 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="org.wso2.carbon.identity.oauth2.OAuth2ScopeService" %>
-<%@ page import="org.wso2.carbon.identity.oauth2.IdentityOAuth2ScopeException" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.stream.Collectors" %>
@@ -112,18 +111,14 @@
                                 <div class="scopes-list ui list">
                                     <%
                                         for (String scopeID : openIdScopes) {
-                                            String scopeDisplayName = "";
-                                            try {
-                                                scopeDisplayName = new OAuth2ScopeService().getScope(scopeID).getDisplayName();
-                                            } catch(IdentityOAuth2ScopeException exception){
-                                                String redirectURL = "error.do";
-                                                response.sendRedirect(redirectURL);
-                                            }
+                                            String displayName = new OAuth2ScopeService()
+                                                                    .getScope(scopeID)
+                                                                    .getDisplayName();
                                     %>
                                     <div class="item">
                                         <i class="check circle outline icon"></i>
                                         <div class="content">
-                                            <%=Encode.forHtml(scopeDisplayName)%>
+                                            <%=Encode.forHtml(displayName)%>
                                         </div>
                                     </div>
                                     <%

--- a/apps/recovery-portal/pom.xml
+++ b/apps/recovery-portal/pom.xml
@@ -180,11 +180,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents.wso2</groupId>
             <artifactId>httpcore</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
## Purpose
> Resolves the issue of a server error was thrown during self signup when the `Proceed to Self Register` button is clicked. The stack trace produced the following error. 
![image](https://user-images.githubusercontent.com/20745428/73632299-50e2fc80-4681-11ea-9d1d-7ca0a7f45c61.png)

## Goals
> The issue is resolved by removing the `httpclient` artifact from the pom.xml file of the recovery-portal.  
