### PR TITLE
Fix undefined error while reloading child pages.

### DIFF
--- a/apps/admin-portal/src/layouts/dashboard.tsx
+++ b/apps/admin-portal/src/layouts/dashboard.tsx
@@ -175,9 +175,15 @@ export const DashboardLayout: React.FunctionComponent<DashboardLayoutPropsInterf
      * @return {boolean} If the route is active or not.
      */
     const isActiveRoute = (route: RouteInterface | ChildRouteInterface): boolean => {
-        const pathname = window.location.pathname;
-        const urlTokens = route.path.split("/");
-        return pathname.indexOf(urlTokens[ 1 ]) > -1;
+        const pathname = window.location.pathname.split("/").pop();
+        if (route.path) {
+            const urlTokens = route.path.split("/");
+            return pathname === urlTokens[1];
+        } else if (!route.path && route.children && route.children.length > 0) {
+            return route.children.some((childRoute) => {
+                return pathname === childRoute.path
+            })
+        }
     };
 
     /**


### PR DESCRIPTION
## Purpose
This PR will fix #364 issue where a child route reload crashes the `admin-portal`.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
When checking for selected route is the same in the routes object, should consider the child routes as well.
