### PR TITLE
Remove tenant domain name from the username when querying the consent…

### DIFF
--- a/apps/user-portal/src/api/consents.ts
+++ b/apps/user-portal/src/api/consents.ts
@@ -34,7 +34,10 @@ const httpClient = AxiosHttpClient.getInstance();
  */
 export const fetchConsentedApps = (state: ConsentState): Promise<any> => {
     const userName = AuthenticateSessionUtil.getSessionParameter(AuthenticateUserKeys.USERNAME).split("@");
-    userName.pop();
+
+    if (userName.length > 1) {
+        userName.pop();
+    }
 
     const requestConfig = {
         headers: {

--- a/apps/user-portal/src/api/consents.ts
+++ b/apps/user-portal/src/api/consents.ts
@@ -19,12 +19,7 @@
 import { AuthenticateSessionUtil, AuthenticateUserKeys } from "@wso2is/authentication";
 import { AxiosHttpClient } from "@wso2is/http";
 import { GlobalConfig, ServiceResourcesEndpoint } from "../configs";
-import {
-    ConsentReceiptInterface,
-    ConsentState,
-    HttpMethods,
-    UpdateReceiptInterface
-} from "../models";
+import { ConsentReceiptInterface, ConsentState, HttpMethods, UpdateReceiptInterface } from "../models";
 
 /**
  * Initialize an axios Http client.
@@ -38,6 +33,9 @@ const httpClient = AxiosHttpClient.getInstance();
  * @return {Promise<any>} A promise containing the response.
  */
 export const fetchConsentedApps = (state: ConsentState): Promise<any> => {
+    const userName = AuthenticateSessionUtil.getSessionParameter(AuthenticateUserKeys.USERNAME).split("@");
+    userName.pop();
+
     const requestConfig = {
         headers: {
             "Accept": "application/json",
@@ -46,13 +44,14 @@ export const fetchConsentedApps = (state: ConsentState): Promise<any> => {
         },
         method: HttpMethods.GET,
         params: {
-            piiPrincipalId: AuthenticateSessionUtil.getSessionParameter(AuthenticateUserKeys.USERNAME),
+            piiPrincipalId: userName.join("@"),
             state
         },
         url: ServiceResourcesEndpoint.consents
     };
 
-    return httpClient.request(requestConfig)
+    return httpClient
+        .request(requestConfig)
         .then((response) => {
             return response.data;
         })
@@ -77,7 +76,8 @@ export const fetchConsentReceipt = (receiptId: string): Promise<any> => {
         url: ServiceResourcesEndpoint.receipts + `/${receiptId}`
     };
 
-    return httpClient.request(requestConfig)
+    return httpClient
+        .request(requestConfig)
         .then((response) => {
             return response.data as ConsentReceiptInterface;
         })
@@ -94,13 +94,14 @@ export const fetchConsentReceipt = (receiptId: string): Promise<any> => {
 export const revokeConsentedApp = (appId: string): Promise<any> => {
     const requestConfig = {
         headers: {
-            Accept: "application/json",
+            Accept: "application/json"
         },
         method: HttpMethods.DELETE,
         url: ServiceResourcesEndpoint.receipts + `/${appId}`
     };
 
-    return httpClient.request(requestConfig)
+    return httpClient
+        .request(requestConfig)
         .then((response) => {
             // TODO: change the return type
             return response.data as ConsentReceiptInterface;
@@ -108,7 +109,6 @@ export const revokeConsentedApp = (appId: string): Promise<any> => {
         .catch((error) => {
             return Promise.reject(error);
         });
-
 };
 
 /**
@@ -117,7 +117,7 @@ export const revokeConsentedApp = (appId: string): Promise<any> => {
  * @param {any} dispatch - `dispatch` function from redux.
  * @returns {(next) => (action) => any} Passes the action to the next middleware
  */
-export const updateConsentedClaims = (receipt: ConsentReceiptInterface): Promise<any>  => {
+export const updateConsentedClaims = (receipt: ConsentReceiptInterface): Promise<any> => {
     const body: UpdateReceiptInterface = {
         collectionMethod: "Web Form - User Portal",
         jurisdiction: receipt.jurisdiction,
@@ -154,7 +154,8 @@ export const updateConsentedClaims = (receipt: ConsentReceiptInterface): Promise
         url: ServiceResourcesEndpoint.consents
     };
 
-    return httpClient.request(requestConfig)
+    return httpClient
+        .request(requestConfig)
         .then((response) => {
             return response.data as ConsentReceiptInterface;
         })


### PR DESCRIPTION
This removes the tenant domain name from the username when sending an API request to fetch consents.  