### PR TITLE
Handle undefined routes in Developer Portal

### DIFF
--- a/apps/admin-portal/src/app.tsx
+++ b/apps/admin-portal/src/app.tsx
@@ -48,6 +48,7 @@ export const App = (): JSX.Element => {
                                                     component={ route.component }
                                                     path={ route.path }
                                                     key={ index }
+                                                    exact={ route.exact }
                                                 />
                                             )
                                             :
@@ -58,6 +59,7 @@ export const App = (): JSX.Element => {
                                                         (<route.component { ...props } />)
                                                     }
                                                     key={ index }
+                                                    exact={ route.exact }
                                                 />
                                             )
                                     );

--- a/apps/admin-portal/src/components/protected-route.tsx
+++ b/apps/admin-portal/src/components/protected-route.tsx
@@ -18,12 +18,23 @@
 
 import React from "react";
 import { useSelector } from "react-redux";
-import { Redirect, Route } from "react-router-dom";
+import { Redirect, Route, RouteProps } from "react-router-dom";
 import * as ApplicationConstants from "../constants/application-constants";
 import { history } from "../helpers";
 import { updateAuthenticationCallbackUrl } from "../store/actions";
 
-export const ProtectedRoute = ({ component: Component, ...rest }) => {
+/**
+ * Protected route component.
+ *
+ * @return {JSX.Element}
+ */
+export const ProtectedRoute = (props: RouteProps): JSX.Element => {
+
+    const {
+        component: Component,
+        ...rest
+    } = props;
+
     const isAuth = useSelector((state: any) => state.authenticationInformation.isAuth);
 
     /**
@@ -37,10 +48,12 @@ export const ProtectedRoute = ({ component: Component, ...rest }) => {
 
     return (
         <Route
-            render={ (props) =>
-                isAuth ?
-                    <Component { ...props } /> :
-                    <Redirect to={ APP_LOGIN_PATH } />
+            render={ (renderProps) =>
+                isAuth
+                    ? Component
+                        ? <Component { ...renderProps } />
+                        : null
+                    : <Redirect to={ APP_LOGIN_PATH }/>
             }
             { ...rest }
         />

--- a/apps/admin-portal/src/configs/routes.ts
+++ b/apps/admin-portal/src/configs/routes.ts
@@ -18,10 +18,11 @@
 
 import { RouteInterface } from "@wso2is/core/models";
 import { SignIn, SignOut } from "../components/authentication";
-import { AppLayout, AuthLayout, DashboardLayout, DefaultPageLayout } from "../layouts";
+import { AppLayout, AuthLayout, DashboardLayout, DefaultPageLayout, ErrorPageLayout } from "../layouts";
 import {
     ApplicationsPage,
     HomePage,
+    PageNotFound,
     PrivacyPage,
     UsersPage
 } from "../pages";
@@ -61,6 +62,15 @@ const DASHBOARD_LAYOUT_ROUTES: RouteInterface[] = [
         path: "/privacy",
         protected: true,
         showOnSidePanel: false,
+    },
+    {
+        component: null,
+        icon: null,
+        name: "404",
+        path: "*",
+        protected: true,
+        redirectTo: "/404",
+        showOnSidePanel: false,
     }
 ];
 
@@ -73,6 +83,20 @@ const DEFAULT_LAYOUT_ROUTES: RouteInterface[] = [
         icon: null,
         name: "Privacy",
         path: "/privacy",
+        protected: true,
+        showOnSidePanel: false,
+    },
+];
+
+/**
+ * Error page layout routes array.
+ */
+const ERROR_LAYOUT_ROUTES: RouteInterface[] = [
+    {
+        component: PageNotFound,
+        icon: null,
+        name: "404",
+        path: "/404",
         protected: true,
         showOnSidePanel: false,
     }
@@ -129,6 +153,15 @@ const APP_ROUTES: RouteInterface[] = [
         showOnSidePanel: false,
     },
     {
+        component: ErrorPageLayout,
+        exact: true,
+        icon: null,
+        name: "Error",
+        path: "/404",
+        protected: true,
+        showOnSidePanel: false,
+    },
+    {
         component: DashboardLayout,
         icon: null,
         name: "Dashboard",
@@ -157,4 +190,5 @@ export const baseRoutes = BASE_ROUTES;
 export const authLayoutRoutes = AUTH_LAYOUT_ROUTES;
 export const dashboardLayoutRoutes = DASHBOARD_LAYOUT_ROUTES;
 export const defaultLayoutRoutes = DEFAULT_LAYOUT_ROUTES;
-export const routes = [ ...DASHBOARD_LAYOUT_ROUTES, ...DEFAULT_LAYOUT_ROUTES ];
+export const errorLayoutRoutes = ERROR_LAYOUT_ROUTES;
+export const routes = [ ...DASHBOARD_LAYOUT_ROUTES ];

--- a/apps/admin-portal/src/constants/ui-constants.ts
+++ b/apps/admin-portal/src/constants/ui-constants.ts
@@ -30,6 +30,20 @@ export class UIConstants {
     private constructor() { }
 
     /**
+     * Default header height to be used in state initialisations
+     * @constant
+     * @type {number}
+     */
+    public static readonly DEFAULT_HEADER_HEIGHT: number = 59;
+
+    /**
+     * Default footer height to be used in state initialisations
+     * @constant
+     * @type {number}
+     */
+    public static readonly DEFAULT_FOOTER_HEIGHT: number = 60;
+
+    /**
      * Constant to handle dashboard layout's desktop content top spacing.
      * @constant
      * @type {number}

--- a/apps/admin-portal/src/layouts/app.tsx
+++ b/apps/admin-portal/src/layouts/app.tsx
@@ -33,26 +33,29 @@ export const AppLayout: React.FunctionComponent<{}> = (): JSX.Element => {
         <Switch>
             {
                 appRoutes.map((route, index) => (
-                    route.protected ?
-                        (
-                            <ProtectedRoute
-                                component={ route.component }
-                                path={ route.path }
-                                key={ index }
-                                exact={ route.exact }
-                            />
-                        )
-                        :
-                        (
-                            <Route
-                                path={ route.path }
-                                render={ (renderProps) =>
-                                    (<route.component { ...renderProps } />)
-                                }
-                                key={ index }
-                                exact={ route.exact }
-                            />
-                        )
+                    route.redirectTo
+                        ? <Redirect to={ route.redirectTo } />
+                        : route.protected
+                            ? (
+                                <ProtectedRoute
+                                    component={ route.component ? route.component : null }
+                                    path={ route.path }
+                                    key={ index }
+                                    exact={ route.exact }
+                                />
+                            )
+                            : (
+                                <Route
+                                    path={ route.path }
+                                    render={ (renderProps) =>
+                                        route.component
+                                            ? <route.component { ...renderProps } />
+                                            : null
+                                    }
+                                    key={ index }
+                                    exact={ route.exact }
+                                />
+                            )
                 ))
             }
         </Switch>

--- a/apps/admin-portal/src/layouts/auth.tsx
+++ b/apps/admin-portal/src/layouts/auth.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from "react";
-import { Route, Switch } from "react-router-dom";
+import { Redirect, Route, Switch } from "react-router-dom";
 import { ProtectedRoute } from "../components";
 import { authLayoutRoutes } from "../configs";
 
@@ -33,26 +33,29 @@ export const AuthLayout: React.FunctionComponent<{}> = (): JSX.Element => {
         <Switch>
             {
                 authLayoutRoutes.map((route, index) => (
-                    route.protected ?
-                        (
-                            <ProtectedRoute
-                                component={ route.component }
-                                path={ route.path }
-                                key={ index }
-                                exact={ route.exact }
-                            />
-                        )
-                        :
-                        (
-                            <Route
-                                path={ route.path }
-                                render={ (renderProps) =>
-                                    (<route.component { ...renderProps } />)
-                                }
-                                key={ index }
-                                exact={ route.exact }
-                            />
-                        )
+                    route.redirectTo
+                        ? <Redirect to={ route.redirectTo } />
+                        : route.protected
+                            ? (
+                                <ProtectedRoute
+                                    component={ route.component ? route.component : null }
+                                    path={ route.path }
+                                    key={ index }
+                                    exact={ route.exact }
+                                />
+                            )
+                            : (
+                                <Route
+                                    path={ route.path }
+                                    render={ (renderProps) =>
+                                        route.component
+                                            ? <route.component { ...renderProps } />
+                                            : null
+                                    }
+                                    key={ index }
+                                    exact={ route.exact }
+                                />
+                            )
                 ))
             }
         </Switch>

--- a/apps/admin-portal/src/layouts/dashboard.tsx
+++ b/apps/admin-portal/src/layouts/dashboard.tsx
@@ -25,7 +25,7 @@ import _ from "lodash";
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Route, Switch } from "react-router-dom";
+import { Redirect, Route, Switch } from "react-router-dom";
 import { Responsive } from "semantic-ui-react";
 import { ProtectedRoute } from "../components";
 import { dashboardLayoutRoutes, LogoImage, routes, SidePanelIcons, SidePanelMiscIcons } from "../configs";
@@ -116,6 +116,13 @@ export const DashboardLayout: React.FunctionComponent<DashboardLayoutPropsInterf
 
         const recurse = (routesArr: RouteInterface[] | ChildRouteInterface[]) => {
             for (const route of routesArr) {
+
+                // Terminate the evaluation if the route is
+                // not supposed to be displayed on the side panel.
+                if (!route.showOnSidePanel) {
+                    return;
+                }
+
                 activeRoute = route;
 
                 if (isActiveRoute(route)) {
@@ -253,50 +260,56 @@ export const DashboardLayout: React.FunctionComponent<DashboardLayoutPropsInterf
                             if (route.children && route.children.length > 0) {
                                 return route.children.map((child, i) => {
                                     return (
-                                        child.protected ?
-                                            (
-                                                <ProtectedRoute
-                                                    component={ child.component }
-                                                    path={ child.path }
-                                                    key={ i }
-                                                    exact={ child.exact }
-                                                />
-                                            )
-                                            :
-                                            (
-                                                <Route
-                                                    path={ child.path }
-                                                    render={ (renderProps) =>
-                                                        (<child.component { ...renderProps } />)
-                                                    }
-                                                    key={ i }
-                                                    exact={ child.exact }
-                                                />
-                                            )
+                                        child.redirectTo
+                                            ? <Redirect to={ child.redirectTo } />
+                                            : child.protected
+                                                ? (
+                                                    <ProtectedRoute
+                                                        component={ child.component ? child.component : null }
+                                                        path={ child.path }
+                                                        key={ i }
+                                                        exact={ child.exact }
+                                                    />
+                                                )
+                                                : (
+                                                    <Route
+                                                        path={ child.path }
+                                                        render={ (renderProps) =>
+                                                            child.component
+                                                                ? <child.component { ...renderProps } />
+                                                                : null
+                                                        }
+                                                        key={ i }
+                                                        exact={ child.exact }
+                                                    />
+                                                )
                                     );
                                 });
                             }
                             return (
-                                route.protected ?
-                                    (
-                                        <ProtectedRoute
-                                            component={ route.component }
-                                            path={ route.path }
-                                            key={ index }
-                                            exact={ route.exact }
-                                        />
-                                    )
-                                    :
-                                    (
-                                        <Route
-                                            path={ route.path }
-                                            render={ (renderProps) =>
-                                                (<route.component { ...renderProps } />)
-                                            }
-                                            key={ index }
-                                            exact={ route.exact }
-                                        />
-                                    )
+                                route.redirectTo
+                                    ? <Redirect to={ route.redirectTo } />
+                                    : route.protected
+                                        ? (
+                                            <ProtectedRoute
+                                                component={ route.component ? route.component : null }
+                                                path={ route.path }
+                                                key={ index }
+                                                exact={ route.exact }
+                                            />
+                                        )
+                                        : (
+                                            <Route
+                                                path={ route.path }
+                                                render={ (renderProps) =>
+                                                    route.component
+                                                        ? <route.component { ...renderProps } />
+                                                        : null
+                                                }
+                                                key={ index }
+                                                exact={ route.exact }
+                                            />
+                                        )
                             );
                         })
                     }

--- a/apps/admin-portal/src/layouts/dashboard.tsx
+++ b/apps/admin-portal/src/layouts/dashboard.tsx
@@ -34,17 +34,6 @@ import { history } from "../helpers";
 import { AppState } from "../store";
 
 /**
- * Default header height to be used in state initialisations
- * @type {number}
- */
-const DEFAULT_HEADER_HEIGHT: number = 59;
-/**
- * Default footer height to be used in state initialisations
- * @type {number}
- */
-const DEFAULT_FOOTER_HEIGHT: number = 60;
-
-/**
  * Dashboard layout Prop types.
  */
 interface DashboardLayoutPropsInterface {
@@ -54,6 +43,7 @@ interface DashboardLayoutPropsInterface {
 /**
  * Dashboard layout.
  *
+ * @param {DashboardLayoutPropsInterface} props - Props injected to the component.
  * @return {JSX.Element}
  */
 export const DashboardLayout: React.FunctionComponent<DashboardLayoutPropsInterface> = (
@@ -69,8 +59,8 @@ export const DashboardLayout: React.FunctionComponent<DashboardLayoutPropsInterf
 
     const [ selectedRoute, setSelectedRoute ] = useState<RouteInterface | ChildRouteInterface>(routes[0]);
     const [ mobileSidePanelVisibility, setMobileSidePanelVisibility ] = React.useState<boolean>(false);
-    const [ headerHeight, setHeaderHeight ] = React.useState<number>(DEFAULT_HEADER_HEIGHT);
-    const [ footerHeight, setFooterHeight ] = React.useState<number>(DEFAULT_FOOTER_HEIGHT);
+    const [ headerHeight, setHeaderHeight ] = React.useState<number>(UIConstants.DEFAULT_HEADER_HEIGHT);
+    const [ footerHeight, setFooterHeight ] = React.useState<number>(UIConstants.DEFAULT_FOOTER_HEIGHT);
     const [ isMobileViewport, setIsMobileViewport ] = React.useState<boolean>(false);
 
     const classes = classNames(
@@ -188,8 +178,8 @@ export const DashboardLayout: React.FunctionComponent<DashboardLayoutPropsInterf
             return pathname === urlTokens[1];
         } else if (!route.path && route.children && route.children.length > 0) {
             return route.children.some((childRoute) => {
-                return pathname === childRoute.path
-            })
+                return pathname === childRoute.path;
+            });
         }
     };
 

--- a/apps/admin-portal/src/layouts/default.tsx
+++ b/apps/admin-portal/src/layouts/default.tsx
@@ -17,7 +17,7 @@
  */
 
 import React from "react";
-import { Route, Switch } from "react-router-dom";
+import { Redirect, Route, Switch } from "react-router-dom";
 import { ProtectedRoute } from "../components";
 import { defaultLayoutRoutes } from "../configs";
 
@@ -45,26 +45,29 @@ export const DefaultPageLayout: React.FunctionComponent<DefaultPageLayoutPropsIn
         <Switch>
             {
                 defaultLayoutRoutes.map((route, index) => (
-                    route.protected ?
-                        (
-                            <ProtectedRoute
-                                component={ route.component }
-                                path={ route.path }
-                                key={ index }
-                                exact={ route.exact }
-                            />
-                        )
-                        :
-                        (
-                            <Route
-                                path={ route.path }
-                                render={ (renderProps) =>
-                                    (<route.component { ...renderProps } />)
-                                }
-                                key={ index }
-                                exact={ route.exact }
-                            />
-                        )
+                    route.redirectTo
+                        ? <Redirect to={ route.redirectTo } />
+                        : route.protected
+                            ? (
+                                <ProtectedRoute
+                                    component={ route.component ? route.component : null }
+                                    path={ route.path }
+                                    key={ index }
+                                    exact={ route.exact }
+                                />
+                            )
+                            : (
+                                <Route
+                                    path={ route.path }
+                                    render={ (renderProps) =>
+                                        route.component
+                                            ? <route.component { ...renderProps } />
+                                            : null
+                                    }
+                                    key={ index }
+                                    exact={ route.exact }
+                                />
+                            )
                 ))
             }
         </Switch>

--- a/apps/admin-portal/src/layouts/error.tsx
+++ b/apps/admin-portal/src/layouts/error.tsx
@@ -17,7 +17,10 @@
  */
 
 import React, { PropsWithChildren } from "react";
+import { Redirect, Route, Switch } from "react-router-dom";
 import { Container, Divider } from "semantic-ui-react";
+import { ProtectedRoute } from "../components";
+import { errorLayoutRoutes } from "../configs";
 
 /**
  * Error page layout.
@@ -29,12 +32,35 @@ import { Container, Divider } from "semantic-ui-react";
 export const ErrorPageLayout: React.FunctionComponent<PropsWithChildren<{}>> = (
     props: PropsWithChildren<{}>
 ): JSX.Element => {
-    const { children } = props;
 
     return (
         <Container className="layout-content error-page-layout">
             <Divider className="x4" hidden/>
-            { children }
+            <Switch>
+                {
+                    errorLayoutRoutes.map((route, index) => (
+                        route.redirectTo
+                            ? <Redirect to={ route.redirectTo } />
+                            : route.protected
+                                ? (
+                                    <ProtectedRoute
+                                        component={ route.component }
+                                        path={ route.path }
+                                        key={ index }
+                                    />
+                                )
+                                : (
+                                    <Route
+                                        path={ route.path }
+                                        render={ (renderProps) =>
+                                            (<route.component { ...renderProps } />)
+                                        }
+                                        key={ index }
+                                    />
+                                )
+                    ))
+                }
+            </Switch>
             <Divider className="x3" hidden/>
         </Container>
     );

--- a/apps/admin-portal/src/pages/errors/404.tsx
+++ b/apps/admin-portal/src/pages/errors/404.tsx
@@ -16,13 +16,12 @@
  * under the License.
  */
 
-import * as React from "react";
+import React from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Button } from "semantic-ui-react";
 import { EmptyPlaceholder } from "../../components/shared";
 import { EmptyPlaceholderIllustrations, GlobalConfig } from "../../configs";
-import { ErrorPageLayout } from "../../layouts";
 
 /**
  * 404 error page.
@@ -32,25 +31,23 @@ import { ErrorPageLayout } from "../../layouts";
 export const PageNotFound = (): JSX.Element => {
     const { t } = useTranslation();
     return (
-        <ErrorPageLayout>
-            <EmptyPlaceholder
-                action={ (
-                    <Button
-                        className="link-button"
-                        as={ Link }
-                        to={ GlobalConfig.appHomePath }
-                    >
-                        { t("views:placeholders.404.action") }
-                    </Button>
-                ) }
-                image={ EmptyPlaceholderIllustrations.pageNotFound }
-                imageSize="tiny"
-                subtitle={ [
-                    t("views:placeholders.404.subtitles.0"),
-                    t("views:placeholders.404.subtitles.1")
-                ] }
-                title={ t("views:placeholders.404.title") }
-            />
-        </ErrorPageLayout>
+        <EmptyPlaceholder
+            action={ (
+                <Button
+                    className="link-button"
+                    as={ Link }
+                    to={ GlobalConfig.appHomePath }
+                >
+                    { t("views:placeholders.404.action") }
+                </Button>
+            ) }
+            image={ EmptyPlaceholderIllustrations.pageNotFound }
+            imageSize="tiny"
+            subtitle={ [
+                t("views:placeholders.404.subtitles.0"),
+                t("views:placeholders.404.subtitles.1")
+            ] }
+            title={ t("views:placeholders.404.title") }
+        />
     );
 };

--- a/apps/admin-portal/src/pages/errors/index.ts
+++ b/apps/admin-portal/src/pages/errors/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/admin-portal/src/pages/errors/index.ts
+++ b/apps/admin-portal/src/pages/errors/index.ts
@@ -16,8 +16,5 @@
  * under the License.
  */
 
-export * from "./applications";
-export * from "./errors";
-export * from "./home";
-export * from "./privacy";
-export * from "./users";
+export * from "./404";
+export * from "./under-construction";

--- a/modules/core/src/models/route.ts
+++ b/modules/core/src/models/route.ts
@@ -47,6 +47,10 @@ export interface RouteInterface {
      */
     protected: boolean;
     /**
+     * Redirect path.
+     */
+    redirectTo?: string;
+    /**
      * Should the item be displayed on the side panel.
      */
     showOnSidePanel: boolean;

--- a/modules/react-components/src/side-panel/side-panel-item.tsx
+++ b/modules/react-components/src/side-panel/side-panel-item.tsx
@@ -62,8 +62,10 @@ export const SidePanelItem: React.FunctionComponent<SidePanelItemPropsInterface>
                     ? (
                         <Menu.Item
                             name={ route.name }
-                            className={ `side-panel-item ${ selected.path === route.path ? "active" : "" }` }
-                            active={ selected.path === route.path }
+                            className={ `side-panel-item ${
+                                selected && (selected.path === route.path) ? "active" : ""
+                            }` }
+                            active={ selected && (selected.path === route.path) }
                             onClick={ () => onSidePanelItemClick(route) }
                         >
                             <GenericIcon
@@ -106,7 +108,7 @@ export const SidePanelItem: React.FunctionComponent<SidePanelItemPropsInterface>
                             onSidePanelItemClick={ onSidePanelItemClick }
                             selected={ selected }
                             open={ route.open }
-                            sidePanelItemHeight = { sidePanelItemHeight }
+                            sidePanelItemHeight={ sidePanelItemHeight }
                         />
                     )
                     : null


### PR DESCRIPTION
## Purpose
The portal should display a 404 page when a user navigates to an undefined route.

## Goals
This PR brings a 404 page for the dev portal and Fixes #375.

## Approach
A new prop `redirectTo` was added to the `RouteInterface` which can be used to include a redirect URL. When the routes are being resolved by the layout, `redirectTo` prop is being checked and if it is present, user will be routed to the redirect URL.

Using the above strategy, all the undefined routes will be routed to the 404 page.

```ts
{
    component: null,
    icon: null,
    name: "404",
    path: "*",
    protected: true,
    redirectTo: "/404",
    showOnSidePanel: false,
}
```
