### PR TITLE
Fix UI issue in the header

### DIFF
--- a/modules/theme/src/themes/default/collections/menu.overrides
+++ b/modules/theme/src/themes/default/collections/menu.overrides
@@ -274,6 +274,12 @@
                     }
                 }
             }
+            // Fix for username and avatar in the header being pushed right to the right edge in tablet view
+            &:not(.fluid-header) {
+                .user-dropdown {
+                    padding-right: 0.92857143em;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose
> The username and user avatar in the header are pushed right to the right edge of the screen when the screen size is less than 767px. 
![Screenshot 2020-02-06 at 12 30 24](https://user-images.githubusercontent.com/20745428/73913416-03fb6200-48dd-11ea-935c-32a618610c51.png)
## Goals
> Adds a right-padding when the screen width is less than 767px.
![Screenshot 2020-02-06 at 12 31 44](https://user-images.githubusercontent.com/20745428/73913422-078ee900-48dd-11ea-87fd-f9967b322967.png)
