### PR TITLE
Fix issues caused when the child element of the Forms component is undefined

### DIFF
--- a/modules/forms/src/forms.tsx
+++ b/modules/forms/src/forms.tsx
@@ -189,34 +189,36 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
      */
     const parseChildren = (elements: React.ReactNode, fields: FormField[]): React.ReactElement[] => {
         return React.Children.map(elements, (element: React.ReactElement) => {
-            if (element.type === Field) {
-                fields.push(element.props);
-                flatReactChildren.push(element);
-                return React.createElement(InnerField, {
-                    formProps: {
-                        checkError,
-                        form,
-                        handleBlur,
-                        handleChange,
-                        handleChangeCheckBox,
-                        handleReset
-                    },
-                    passedProps: { ...element.props }
-                });
-            } else if (element.type === GroupFields) {
-                return React.createElement(InnerGroupFields, {
-                    ...element.props,
-                    children: parseChildren(element.props.children, fields)
-                });
-            } else if (element.props
-                && element.props.children
-                && React.Children.count(element.props.children) > 0) {
-                return React.createElement(element.type, {
-                    ...element.props,
-                    children: parseChildren(element.props.children, fields)
-                });
-            } else {
-                return element;
+            if (element) {
+                if (element.type === Field) {
+                    fields.push(element.props);
+                    flatReactChildren.push(element);
+                    return React.createElement(InnerField, {
+                        formProps: {
+                            checkError,
+                            form,
+                            handleBlur,
+                            handleChange,
+                            handleChangeCheckBox,
+                            handleReset
+                        },
+                        passedProps: { ...element.props }
+                    });
+                } else if (element.type === GroupFields) {
+                    return React.createElement(InnerGroupFields, {
+                        ...element.props,
+                        children: parseChildren(element.props.children, fields)
+                    });
+                } else if (element.props
+                    && element.props.children
+                    && React.Children.count(element.props.children) > 0) {
+                    return React.createElement(element.type, {
+                        ...element.props,
+                        children: parseChildren(element.props.children, fields)
+                    });
+                } else {
+                    return element;
+                }
             }
         });
     };


### PR DESCRIPTION
## Purpose
>  When a map function of an array doesn't return a value, the returned array has teh corresponding element set to undefined. When the Forms component iterates through its child components, this results in an error. 

## Goals
> The Forms component now checks if the child element is not undefined before proceeding further.   