### PR TITLE
Update the state of the Forms component when the passed value changes

### DIFF
--- a/modules/forms/src/forms.tsx
+++ b/modules/forms/src/forms.tsx
@@ -279,7 +279,7 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
         /**
          * Check if the element is an input element(an element that can hold a value)
          *      -> Then:
-         *          Check if the field has not been touched
+         *          Check if the field has not been touched OR the reset button has been pressed
          *          -> Then:
          *              Check if the element has a value and the reset button has not been clicked
          *                  -> Then:
@@ -297,7 +297,7 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
          *
          */
             if (isInputField(inputField)) {
-                if (!touchedFields.get(inputField.name)) {
+                if (!touchedFields.get(inputField.name) || isReset) {
                     inputField.value && !isReset
                         ? tempForm.set(inputField.name, inputField.value)
                         : (isRadioField(inputField) || isDropdownField(inputField)) && inputField.default

--- a/modules/forms/src/models/forms.ts
+++ b/modules/forms/src/models/forms.ts
@@ -17,7 +17,7 @@
  */
 
 import * as React from "react";
-import { SemanticFLOATS, SemanticICONS, SemanticSIZES, SemanticWIDTHS } from "semantic-ui-react";
+import { SemanticSIZES, SemanticWIDTHS } from "semantic-ui-react";
 
 /**
  * Form Field Types
@@ -53,6 +53,9 @@ export interface Error {
     errorMessages: string[];
 }
 
+/**
+ * The generic interface for all input fields
+ */
 interface FormFieldModel {
     name: string;
     label?: string;
@@ -60,10 +63,14 @@ interface FormFieldModel {
     autoFocus?: boolean;
 }
 
+/**
+ * The generic interface for all input fields but the radio field
+ */
 interface FormRequiredFieldModel extends FormFieldModel {
     required: boolean;
     requiredErrorMessage: string;
 }
+
 /**
  * Input field model
  */


### PR DESCRIPTION
## Purpose
> Right now, the Form component uses the following logic to see if a Form's state should be updated or not: 
- Check if a form field doesn't exist already OR the reset the button has been pressed

>before updating the state of the Form with the passed value. This was done to avoid the Form's state being changed when the parent component re-renders. However, this leads to the side effect of the Form component not receiving the values passed after an API request.  

## Goals
> The logic has been altered so that, 
- First, it will be checked if the field has been modified by the user after the initial render OR the reset button has been clicked.
- If so, the Form's state won't be updated since doing so will result in the user's changes being lost
- If the field has not been modified, then the state will be updated with the new value.
