### PR TITLE
Fix session storage duplication issue when redirecting user from admin portal to user portal 

### DIFF
--- a/apps/admin-portal/src/layouts/dashboard.tsx
+++ b/apps/admin-portal/src/layouts/dashboard.tsx
@@ -17,6 +17,7 @@
  */
 
 import { getProfileInfo } from "@wso2is/core/api";
+import { AppConstants } from "@wso2is/core/constants";
 import { AuthReducerStateInterface, ChildRouteInterface, RouteInterface } from "@wso2is/core/models";
 import { ContextUtils } from "@wso2is/core/utils";
 import { Footer, Header, Logo, ProductBrand, SidePanel } from "@wso2is/react-components";
@@ -232,7 +233,7 @@ export const DashboardLayout: React.FunctionComponent<DashboardLayoutPropsInterf
                             primary
                             onClick={
                                 () => {
-                                    sessionStorage.setItem("redirected", "true");
+                                    sessionStorage.setItem(AppConstants.REDIRECTED_KEY, AppConstants.REDIRECTED_VALUE);
                                     window.open(
                                         `${GlobalConfig.userPortalClientHost}/${GlobalConfig.userPortalBaseName}`
                                     );

--- a/apps/admin-portal/src/layouts/dashboard.tsx
+++ b/apps/admin-portal/src/layouts/dashboard.tsx
@@ -232,6 +232,7 @@ export const DashboardLayout: React.FunctionComponent<DashboardLayoutPropsInterf
                             primary
                             onClick={
                                 () => {
+                                    sessionStorage.setItem("redirected", "true");
                                     window.open(
                                         `${GlobalConfig.userPortalClientHost}/${GlobalConfig.userPortalBaseName}`
                                     );

--- a/apps/user-portal/src/components/authentication/sign-in.tsx
+++ b/apps/user-portal/src/components/authentication/sign-in.tsx
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { AppConstants } from "@wso2is/core/constants";
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { GlobalConfig } from "../../configs";
@@ -47,7 +48,7 @@ export const SignIn = (props) => {
     };
 
     const checkRedirected = () => {
-        if (sessionStorage.getItem("redirected") === "true") {
+        if (sessionStorage.getItem(AppConstants.REDIRECTED_KEY) === AppConstants.REDIRECTED_VALUE) {
             sessionStorage.removeItem("redirected");
             return true;
         }

--- a/apps/user-portal/src/components/authentication/sign-in.tsx
+++ b/apps/user-portal/src/components/authentication/sign-in.tsx
@@ -49,18 +49,17 @@ export const SignIn = (props) => {
 
     const checkRedirected = () => {
         if (sessionStorage.getItem(AppConstants.REDIRECTED_KEY) === AppConstants.REDIRECTED_VALUE) {
-            sessionStorage.removeItem("redirected");
-            return true;
+            sessionStorage.clear();
+            window.location.replace(GlobalConfig.appHomePath);
         }
-        return false;
     };
 
     const loginSuccessRedirect = () => {
         const AuthenticationCallbackUrl = getAuthenticationCallbackUrl();
+        checkRedirected();
         const location =
             !AuthenticationCallbackUrl
                 || AuthenticationCallbackUrl === GlobalConfig.appLoginPath
-                || checkRedirected()
                 ? GlobalConfig.appHomePath
                 : AuthenticationCallbackUrl;
 

--- a/apps/user-portal/src/components/authentication/sign-in.tsx
+++ b/apps/user-portal/src/components/authentication/sign-in.tsx
@@ -46,10 +46,20 @@ export const SignIn = (props) => {
         return window.sessionStorage.getItem("auth_callback_url");
     };
 
+    const checkRedirected = () => {
+        if (sessionStorage.getItem("redirected") === "true") {
+            sessionStorage.removeItem("redirected");
+            return true;
+        }
+        return false;
+    };
+
     const loginSuccessRedirect = () => {
         const AuthenticationCallbackUrl = getAuthenticationCallbackUrl();
         const location =
-            !AuthenticationCallbackUrl || AuthenticationCallbackUrl === GlobalConfig.appLoginPath
+            !AuthenticationCallbackUrl
+                || AuthenticationCallbackUrl === GlobalConfig.appLoginPath
+                || checkRedirected()
                 ? GlobalConfig.appHomePath
                 : AuthenticationCallbackUrl;
 

--- a/modules/core/src/constants/app-constants.ts
+++ b/modules/core/src/constants/app-constants.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Class containing app constants.
+ */
+export class AppConstants {
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     *
+     * @hideconstructor
+     */
+    private constructor() {}
+
+    /**
+     * Constant that holds the key of the sessionStorage that is used during redirect
+     * @constant
+     * @type {number}
+     */
+    public static readonly REDIRECTED_KEY: string = "redirected";
+
+    /**
+     * Constant that holds the value of the `REDIRECTED_KEY` of the sessionStorage that is used during redirect
+     * @constant
+     * @type {number}
+     */
+    public static readonly REDIRECTED_VALUE: string = "true";
+}

--- a/modules/core/src/constants/index.ts
+++ b/modules/core/src/constants/index.ts
@@ -19,3 +19,4 @@
 export * from "./is-constants";
 export * from "./token-constants";
 export * from "./ui-constants";
+export * from "./app-constants";


### PR DESCRIPTION
## Purpose
> When a user clicks on the My Account button in teh admin portal, a new tab opened with the user portal app. However, the session storage was duplicated and this resulted in the user getting redirected to the auth callback URL of the admin portal. 

## Goals
> Set a sessionStorage item called "redirected" to true when redirecting user, and then prevent redirection on login in the user portal if this key is true. 