### PR TITLE
Fix unnecessary phrase in humanize of date

### DIFF
--- a/apps/admin-portal/src/utils/common-utils.ts
+++ b/apps/admin-portal/src/utils/common-utils.ts
@@ -39,7 +39,7 @@ export class CommonUtils {
     static humanizeDateDifference = (date: string): string => {
         const now = moment(new Date());
         const recievedDate = moment(date);
-        return "last modified " + moment.duration(now.diff(recievedDate)).humanize(true) + " ago";
+        return "last modified " + moment.duration(now.diff(recievedDate)).humanize() + " ago";
     };
     
 }


### PR DESCRIPTION
## Purpose
> This will remove the `in` word in the `last updated in {time} ago` string when humanising the edit string.