### PR TITLE
Fix incorrect check for header.jsp include

### DIFF
--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -118,7 +118,7 @@
 <head>
     <!-- header -->
     <%
-        File headerFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+        File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
     %>
         <jsp:include page="extensions/header.jsp"/>


### PR DESCRIPTION
## Purpose
Seems like there is a small mishap in the logic to decide whether to included header.jsp defined in the extensions folder.

We are checking whether extensions/product-title.jsp exists and then including extensions/header.jsp. This could lead to JSP compiling issue if extensions/header.jsp does not exist.

