### PR TITLE
Fix moment.js locale issue when switching the languages

### DIFF
--- a/apps/user-portal/src/components/shared/language-switcher/language-switcher.tsx
+++ b/apps/user-portal/src/components/shared/language-switcher/language-switcher.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { SyntheticEvent } from "react";
-import { i18n, SupportedLanguages } from "../../../configs";
+import { i18n, setMomentJSLocale, SupportedLanguages } from "../../../configs";
 import { LanguageSwitcherDropdown } from "./language-switcher-dropdown";
 
 /**
@@ -48,6 +48,7 @@ export const LanguageSwitcher: React.FunctionComponent<LanguageSwitcherProps> = 
      * @param data - data object returned from the dropdown item.
      */
     const handleLanguageChange = (event: SyntheticEvent, data: any) => {
+        setMomentJSLocale(data.value);
         i18n.changeLanguage(data.value);
     };
 

--- a/apps/user-portal/src/configs/i18n.ts
+++ b/apps/user-portal/src/configs/i18n.ts
@@ -20,6 +20,7 @@ import i18n from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import * as locales from "../locales";
+import * as moment from "moment";
 
 /**
  * Supported language list.
@@ -86,6 +87,16 @@ const defaultLanguageFallback = (): void => {
     }
 };
 
+/**
+ * Sets the moment JS locale.
+ *
+ * @param {string} localeCode - Locale code.
+ */
+export const setMomentJSLocale = (localeCode = i18n.language): void => {
+    moment.locale(localeCode);
+};
+
 defaultLanguageFallback();
+setMomentJSLocale();
 
 export { i18n, SupportedLanguages };


### PR DESCRIPTION
## Purpose
There were inconsistencies in the interchange of languages.

## Goals
This PR fixes #540 

## Approach
Implemented a method to switch Moment JS locale when the user changes the portal language.

**Sinhalese**
![Screen Shot 2020-03-19 at 7 37 38 PM](https://user-images.githubusercontent.com/25959096/77076131-66399d80-6a19-11ea-84cc-f649369da869.png)

**Portuguese**
![Screen Shot 2020-03-19 at 7 48 30 PM](https://user-images.githubusercontent.com/25959096/77077016-ab120400-6a1a-11ea-8852-ad5258f6dd86.png)

**Tamil**
![Screen Shot 2020-03-19 at 7 48 38 PM](https://user-images.githubusercontent.com/25959096/77077027-acdbc780-6a1a-11ea-8418-e1fd9c589cfe.png)
