### PR TITLE
Avoid session termination on 403 response codes

### DIFF
--- a/apps/admin-portal/src/utils/http-utils.ts
+++ b/apps/admin-portal/src/utils/http-utils.ts
@@ -72,9 +72,9 @@ export const onHttpRequestError = (error: any): void => {
     }
 
     // Terminate the session if the requests returns an un-authorized status code (401)
-    // or a forbidden status code (403). NOTE: Axios is unable to handle 401 errors.
-    // `!error.response` will usually catch the `401` error. Check the link in the doc comment.
-    if (!error.response || error.response.status === 403 || error.response.status === 401) {
+    // NOTE: Axios is unable to handle 401 errors. `!error.response` will usually catch
+    // the `401` error. Check the link in the doc comment.
+    if (!error.response || error.response.status === 401) {
         history.push(APP_LOGOUT_PATH);
     }
 };


### PR DESCRIPTION
## Purpose
When the API responds with a 403 response code, the user will be logged out of the portal.

## Goals
This PR will introduce the necessary changes to stop automatic logouts on 403 response codes.