### PR TITLE
Change tenantDomain param key for JIT provisioning

### DIFF
--- a/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -33,7 +33,7 @@
     boolean isSaaSApp = Boolean.parseBoolean(request.getParameter("isSaaSApp"));
     boolean skipSignUpEnableCheck = Boolean.parseBoolean(request.getParameter("skipsignupenablecheck"));
     String username = request.getParameter("username");
-    String tenantDomain = request.getParameter("tenantDomain");
+    String tenantDomain = request.getParameter("TenantDomain");
     User user = IdentityManagementServiceUtil.getInstance().getUser(username);
     Object errorCodeObj = request.getAttribute("errorCode");
     Object errorMsgObj = request.getAttribute("errorMsg");


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/7889

For JIT provisioning with username we use MultitenantConstants.TENANT_DOMAIN_HEADER_NAME[1] variable as the key to the tenant domain param. It resolves to "TenantDomain"[2]

[1] - https://github.com/wso2/carbon-identity-framework/blob/master/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/JITProvisioningPostAuthenticationHandler.java#L527
[2] - https://github.com/wso2/carbon-kernel/blob/4.6.x/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/multitenancy/MultitenantConstants.java#L38
