### PR TITLE
Fix circular dependency issue

### DIFF
--- a/apps/admin-portal/src/components/applications/templates/application-template-card.tsx
+++ b/apps/admin-portal/src/components/applications/templates/application-template-card.tsx
@@ -20,7 +20,9 @@ import classNames from "classnames";
 import React, { FunctionComponent, MouseEvent, ReactElement } from "react";
 import { Card, CardProps, Popup } from "semantic-ui-react";
 import { GenericIcon, GenericIconSizes } from "@wso2is/react-components";
-import { ApplicationTemplateIllustrations, TechnologyLogos } from "../../../configs";
+// Importing the following from the `configs` index causes a circular dependency due to `GlobalConfig` being exported
+// from the index as well. TODO: Revert the import after this issue is fixed.
+import { ApplicationTemplateIllustrations, TechnologyLogos } from "../../../configs/ui";
 
 /**
  * Proptypes for the application template card component.

--- a/apps/admin-portal/src/components/applications/templates/quick-start-application-templates.tsx
+++ b/apps/admin-portal/src/components/applications/templates/quick-start-application-templates.tsx
@@ -18,9 +18,11 @@
 
 import React, { FunctionComponent, SyntheticEvent } from "react";
 import { ApplicationTemplateListItemInterface } from "../../../models";
+// Importing the following from the `configs` index causes a circular dependency due to `GlobalConfig` being exported
+// from the index as well. TODO: Revert the import after this issue is fixed.
+import { EmptyPlaceholderIllustrations } from "../../../configs/ui";
 import { ApplicationTemplateCard } from "./application-template-card";
 import { EmptyPlaceholder } from "@wso2is/react-components";
-import { EmptyPlaceholderIllustrations } from "../../../configs";
 
 /**
  * Proptypes for the quick start templates component.


### PR DESCRIPTION
## Purpose
Importing `GlobalConfig` in multiple places has caused a  circular dependency.

## Goals
Imports have been rearranged to temporary fix the issue.

## TODO
Move the configs to redux store and access from there, rather than importing the `GlobalConfig` object everywhere.