### PR TITLE
Implement Groups for internal roles

### DIFF
--- a/apps/admin-portal/src/components/roles/create-role-wizard/role-basics.tsx
+++ b/apps/admin-portal/src/components/roles/create-role-wizard/role-basics.tsx
@@ -20,6 +20,7 @@ import React, { FunctionComponent, ReactElement } from "react";
 import { Forms, Field } from "@wso2is/forms";
 import { Grid, GridRow, GridColumn } from "semantic-ui-react";
 import { CreateRoleFormData } from "../../../models";
+import { APPLICATION_DOMAIN, INTERNAL_DOMAIN, PRIMARY_DOMAIN } from "../../../constants";
 
 /**
  * Interface to capture role basics props.
@@ -28,6 +29,7 @@ interface RoleBasicProps {
     dummyProp?: string;
     triggerSubmit: boolean;
     initialValues: any;
+    isAddGroup: boolean;
     onSubmit: (values: any) => void;
 }
 
@@ -41,7 +43,8 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
     const {
         onSubmit,
         triggerSubmit,
-        initialValues
+        initialValues,
+        isAddGroup
     } = props;
 
     /**
@@ -53,8 +56,14 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
      * TODO : Discuss and add or remove the Hybrid domains 
      *        to the dropdown.
     */
+    const groupDomains = [{
+        key: -1, text: PRIMARY_DOMAIN, value: PRIMARY_DOMAIN,
+    }];
+
     const roleDomains = [{
-        key: -1, text: "Primary", value: "primary",
+        key: -1, text: APPLICATION_DOMAIN, value: APPLICATION_DOMAIN
+    },{
+        key: 0, text: INTERNAL_DOMAIN, value: INTERNAL_DOMAIN,
     }];
 
     /**
@@ -83,12 +92,16 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
                             type="dropdown"
                             label="Domain"
                             name="domain"
-                            children={ roleDomains }
+                            children={ isAddGroup ? groupDomains : roleDomains }
                             placeholder="Domain"
                             requiredErrorMessage="Select Domain"
                             required={ true }
                             element={ <div></div> }
-                            value={ initialValues?.domain ? initialValues?.domain : roleDomains[0].value }
+                            value={ initialValues?.domain ? 
+                                    initialValues?.domain : 
+                                        isAddGroup ? 
+                                            groupDomains[0].value : roleDomains[0].value 
+                            }
                         />
                     </GridColumn>
                     <GridColumn mobile={ 16 } tablet={ 16 } computer={ 8 }>

--- a/apps/admin-portal/src/components/roles/create-role-wizard/role-wizard.tsx
+++ b/apps/admin-portal/src/components/roles/create-role-wizard/role-wizard.tsx
@@ -41,6 +41,7 @@ import { CreateRoleSummary } from "./role-sumary";
 interface CreateRoleProps {
     closeWizard: () => void;
     updateList: () => void;
+    isAddGroup: boolean;
     initStep?: number;
 }
 
@@ -73,7 +74,8 @@ export const CreateRoleWizard: FunctionComponent<CreateRoleProps> = (props: Crea
     const {
         closeWizard,
         initStep,
-        updateList
+        updateList,
+        isAddGroup
     } = props;
 
     const { t } = useTranslation();
@@ -123,7 +125,7 @@ export const CreateRoleWizard: FunctionComponent<CreateRoleProps> = (props: Crea
             "schemas": [
                 "urn:ietf:params:scim:schemas:core:2.0:Group"
             ],
-            "displayName": basicData.BasicDetails.roleName,
+            "displayName": basicData.BasicDetails.domain + "/" + basicData.BasicDetails.roleName,
             "members" : members
         }
 
@@ -262,6 +264,7 @@ export const CreateRoleWizard: FunctionComponent<CreateRoleProps> = (props: Crea
     const WIZARD_STEPS = [{
         content: (
             <RoleBasics
+                isAddGroup={ isAddGroup }
                 triggerSubmit={ submitGeneralSettings }
                 initialValues={ wizardState && wizardState[ WizardStepsFormTypes.BASIC_DETAILS ] }
                 onSubmit={ (values) => handleWizardSubmit(values, WizardStepsFormTypes.BASIC_DETAILS) }

--- a/apps/admin-portal/src/configs/routes.ts
+++ b/apps/admin-portal/src/configs/routes.ts
@@ -24,6 +24,7 @@ import {
     ApplicationsPage,
     ApplicationTemplateSelectPage,
     CustomizePage,
+    GroupsPage,
     HomePage,
     IdentityProvidersPage,
     IdentityProviderTemplateSelectPage,
@@ -163,6 +164,17 @@ const DASHBOARD_LAYOUT_ROUTES: RouteInterface[] = [
                 level: 2,
                 name: "Roles",
                 path: "/roles",
+                protected: true,
+                showOnSidePanel: true
+            },
+            {
+                component: GroupsPage,
+                exact: true,
+                icon: "childIcon",
+                id: "groups",
+                level: 2,
+                name: "Groups",
+                path: "/groups",
                 protected: true,
                 showOnSidePanel: true
             },

--- a/apps/admin-portal/src/configs/routes.ts
+++ b/apps/admin-portal/src/configs/routes.ts
@@ -157,6 +157,17 @@ const DASHBOARD_LAYOUT_ROUTES: RouteInterface[] = [
                 showOnSidePanel: true
             },
             {
+                component: GroupsPage,
+                exact: true,
+                icon: "childIcon",
+                id: "userGroups",
+                level: 2,
+                name: "User Groups",
+                path: "/groups",
+                protected: true,
+                showOnSidePanel: true
+            },
+            {
                 component: RolesPage,
                 exact: true,
                 icon: "childIcon",
@@ -164,17 +175,6 @@ const DASHBOARD_LAYOUT_ROUTES: RouteInterface[] = [
                 level: 2,
                 name: "Roles",
                 path: "/roles",
-                protected: true,
-                showOnSidePanel: true
-            },
-            {
-                component: GroupsPage,
-                exact: true,
-                icon: "childIcon",
-                id: "groups",
-                level: 2,
-                name: "Groups",
-                path: "/groups",
                 protected: true,
                 showOnSidePanel: true
             },

--- a/apps/admin-portal/src/constants/role-constants.ts
+++ b/apps/admin-portal/src/constants/role-constants.ts
@@ -17,3 +17,7 @@
  */
 
 export const ROLE_VIEW_PATH = "/roles/";
+
+export const APPLICATION_DOMAIN = "Application";
+export const INTERNAL_DOMAIN = "Internal";
+export const PRIMARY_DOMAIN = "Primary";

--- a/apps/admin-portal/src/pages/groups.tsx
+++ b/apps/admin-portal/src/pages/groups.tsx
@@ -23,7 +23,7 @@ import React, { ReactElement, useEffect, useState, SyntheticEvent } from "react"
 import { deleteRoleById, getRolesList, searchRoleList, getUserStoreList } from "../api";
 
 import { CreateRoleWizard } from "../components/roles/create-role-wizard";
-import { DEFAULT_ROLE_LIST_ITEM_LIMIT, APPLICATION_DOMAIN, INTERNAL_DOMAIN } from "../constants";
+import { DEFAULT_ROLE_LIST_ITEM_LIMIT } from "../constants";
 import { PrimaryButton } from "@wso2is/react-components";
 import { RoleList, RoleSearch } from "../components/roles";
 import { addAlert } from "../store/actions";
@@ -54,7 +54,7 @@ const ROLES_SORTING_OPTIONS: DropdownItemProps[] = [
  * 
  * @return {ReactElement}
  */
-export const RolesPage = (): ReactElement => {
+export const GroupsPage = (): ReactElement => {
     const dispatch = useDispatch();
     const { t } = useTranslation();
 
@@ -73,11 +73,11 @@ export const RolesPage = (): ReactElement => {
     }, []);
 
     useEffect(() => {
-        getRoles();
+        getGroups();
     },[ listOffset, listItemLimit ]);
 
     useEffect(() => {
-        getRoles();
+        getGroups();
         setListUpdated(false);
     }, [ isListUpdated ]);
 
@@ -86,17 +86,16 @@ export const RolesPage = (): ReactElement => {
     }, []);
 
     useEffect(() => {
-        getRoles();
+        getGroups();
     }, [ userStore ]);
 
-    const getRoles = () => {
+    const getGroups = () => {
         getRolesList(userStore).then((response)=> {
             if (response.status === 200) {
                 const roleResources = response.data.Resources
                 if (roleResources && roleResources instanceof Array) {
                     const updatedResources = roleResources.filter((role: RolesInterface) => {
-                        return role.displayName.includes(APPLICATION_DOMAIN) || 
-                                role.displayName.includes(INTERNAL_DOMAIN);
+                        return !role.displayName.includes("Application/") && !role.displayName.includes("Internal/");
                     })
                     response.data.Resources = updatedResources;
                 }
@@ -212,7 +211,7 @@ export const RolesPage = (): ReactElement => {
      */
     const handleUserFilter = (query: string): void => {
         if (query === null || query === "displayName sw ") {
-            getRoles();
+            getGroups();
             return;
         }
 
@@ -221,8 +220,8 @@ export const RolesPage = (): ReactElement => {
 
     return (
         <PageLayout
-            title="Roles"
-            description="Create and Manage Roles, Assign Permissions for Roles."
+            title="Groups"
+            description="Create and manage user groups, assign permissions for groups."
             showBottomDivider={ true } 
         >
             <ListLayout
@@ -237,9 +236,18 @@ export const RolesPage = (): ReactElement => {
                     (
                         <PrimaryButton onClick={ () => setShowWizard(true) }>
                             <Icon name="add"/>
-                            Add Role
+                            Add Group
                         </PrimaryButton>
                     )
+                }
+                leftActionPanel={
+                    <Dropdown
+                        selection
+                        options={ userStoreOptions && userStoreOptions }
+                        placeholder="Select User Store"
+                        value={ userStore && userStore }
+                        onChange={ handleDomainChange }
+                    />
                 }
                 showPagination={ true }
                 totalPages={ Math.ceil(roleList?.totalResults / listItemLimit) }
@@ -252,7 +260,7 @@ export const RolesPage = (): ReactElement => {
                 {
                     showWizard && (
                         <CreateRoleWizard
-                            isAddGroup={ false }
+                            isAddGroup
                             closeWizard={ () => setShowWizard(false) }
                             updateList={ () => setListUpdated(true) }
                         />

--- a/apps/admin-portal/src/pages/groups.tsx
+++ b/apps/admin-portal/src/pages/groups.tsx
@@ -50,7 +50,7 @@ const ROLES_SORTING_OPTIONS: DropdownItemProps[] = [
 ];
 
 /**
- * React component to list User Roles.
+ * React component to list User Groups.
  * 
  * @return {ReactElement}
  */

--- a/apps/admin-portal/src/pages/index.ts
+++ b/apps/admin-portal/src/pages/index.ts
@@ -19,6 +19,7 @@
 export * from "./applications";
 export * from "./customize";
 export * from "./errors";
+export * from "./groups";
 export * from "./home";
 export * from "./privacy";
 export * from "./users";

--- a/apps/admin-portal/src/pages/role.tsx
+++ b/apps/admin-portal/src/pages/role.tsx
@@ -93,6 +93,7 @@ export const RolesPage = (): ReactElement => {
         getRolesList(userStore).then((response)=> {
             if (response.status === 200) {
                 const roleResources = response.data.Resources
+
                 if (roleResources && roleResources instanceof Array) {
                     const updatedResources = roleResources.filter((role: RolesInterface) => {
                         return role.displayName.includes(APPLICATION_DOMAIN) || 

--- a/modules/i18n/src/translations/en-US/portals/dev-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/dev-portal.ts
@@ -632,56 +632,56 @@ export const devPortal: DevPortalNS = {
                 deleteRole: {
                     error: {
                         description: "{{description}}",
-                        message: "Error deleting the selected role."
+                        message: "Error Deleting the Selected Role."
                     },
                     genericError: {
-                        description: "Couldn't remove the selected role.",
-                        message: "Something went wrong"
+                        description: "Couldn't Remove the Selected Role.",
+                        message: "Something Went Wrong"
                     },
                     success: {
-                        description: "The selected role was deleted successfully.",
+                        description: "The Selected Role Was Deleted Successfully.",
                         message: "Role deleted successfully"
                     }
                 },
                 updateRole: {
                     error: {
                         description: "{{description}}",
-                        message: "Error updating the selected role."
+                        message: "Error Updating the Selected Role."
                     },
                     genericError: {
-                        description: "Couldn't update the selected role.",
-                        message: "Something went wrong"
+                        description: "Couldn't Update the Selected Role.",
+                        message: "Something Went Wrong"
                     },
                     success: {
-                        description: "The selected role was updated successfully.",
+                        description: "The Selected Role Was Updated Successfully.",
                         message: "Role updated successfully"
                     }
                 },
                 createRole: {
                     error: {
                         description: "{{description}}",
-                        message: "Error occured while creating the role."
+                        message: "Error Occurred While Creating the Role."
                     },
                     genericError: {
-                        description: "Couldn't create the role.",
-                        message: "Something went wrong"
+                        description: "Couldn't Create the Role.",
+                        message: "Something Went Wrong"
                     },
                     success: {
-                        description: "The role was created successfully.",
-                        message: "Role created successfully."
+                        description: "The Role Was Created Successfully.",
+                        message: "Role Created Successfully."
                     }
                 },
                 createPermission: {
                     error: {
                         description: "{{description}}",
-                        message: "Error occured while adding permission to role."
+                        message: "Error Occurred While Adding Permission to Role."
                     },
                     genericError: {
-                        description: "Couldn't add permissions to role.",
-                        message: "Something went wrong"
+                        description: "Couldn't Add Permissions to Role.",
+                        message: "Something Went Wrong"
                     },
                     success: {
-                        description: "Permissions were successfully added to the role.",
+                        description: "Permissions Were Successfully Added to the Role.",
                         message: "Role created successfully."
                     }
                 }
@@ -691,24 +691,24 @@ export const devPortal: DevPortalNS = {
                     searchForm: {
                         inputs: {
                             filerAttribute: {
-                                label: "Filter attribute",
+                                label: "Filter Attribute",
                                 placeholder: "E.g. role name.",
                                 validations: {
-                                    empty: "Filter attribute is a required field"
+                                    empty: "Filter Attribute Is a Required Field"
                                 }
                             },
                             filterCondition: {
-                                label: "Filter condition",
+                                label: "Filter Condition",
                                 placeholder: "E.g. Starts with etc.",
                                 validations: {
-                                    empty: "Filter condition is a required field"
+                                    empty: "Filter Condition Is a Required Field"
                                 }
                             },
                             filterValue: {
-                                label: "Filter value",
-                                placeholder: "Enter value to search",
+                                label: "Filter Value",
+                                placeholder: "Enter Value to Search",
                                 validations: {
-                                    empty: "Filter value is a required field"
+                                    empty: "Filter Value Is a Required Field"
                                 }
                             },
                         }
@@ -717,18 +717,18 @@ export const devPortal: DevPortalNS = {
                 hints: {
                     querySearch: {
                         actionKeys: "Shift + Enter",
-                        label: "To search as a query"
+                        label: "To Search as a Query"
                     }
                 },
                 options: {
-                    header: "Advanced search",
+                    header: "Advanced Search",
                 },
-                placeholder: "Search by role name",
+                placeholder: "Search by Role Name",
                 popups: {
-                    clear: "clear search",
-                    dropdown: "Show options"
+                    clear: "Clear Search",
+                    dropdown: "Show Options"
                 },
-                resultsIndicator: "Showing results for the query \"{{query}}\""
+                resultsIndicator: "Showing Results for the Query \"{{query}}\""
             }
         },
         serverConfigs: {

--- a/modules/i18n/src/translations/en-US/portals/dev-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/dev-portal.ts
@@ -632,56 +632,56 @@ export const devPortal: DevPortalNS = {
                 deleteRole: {
                     error: {
                         description: "{{description}}",
-                        message: "Error Deleting the Selected Role."
+                        message: "Error deleting the selected role."
                     },
                     genericError: {
-                        description: "Couldn't Remove the Selected Role.",
-                        message: "Something Went Wrong"
+                        description: "Couldn't remove the selected role.",
+                        message: "Something went wrong"
                     },
                     success: {
-                        description: "The Selected Role Was Deleted Successfully.",
+                        description: "The selected role was deleted successfully.",
                         message: "Role deleted successfully"
                     }
                 },
                 updateRole: {
                     error: {
                         description: "{{description}}",
-                        message: "Error Updating the Selected Role."
+                        message: "Error updating the selected role."
                     },
                     genericError: {
-                        description: "Couldn't Update the Selected Role.",
-                        message: "Something Went Wrong"
+                        description: "Couldn't update the selected role.",
+                        message: "Something went wrong"
                     },
                     success: {
-                        description: "The Selected Role Was Updated Successfully.",
+                        description: "The selected role was updated successfully.",
                         message: "Role updated successfully"
                     }
                 },
                 createRole: {
                     error: {
                         description: "{{description}}",
-                        message: "Error Occurred While Creating the Role."
+                        message: "Error occurred while creating the role."
                     },
                     genericError: {
-                        description: "Couldn't Create the Role.",
-                        message: "Something Went Wrong"
+                        description: "Couldn't create the role.",
+                        message: "Something went wrong"
                     },
                     success: {
-                        description: "The Role Was Created Successfully.",
-                        message: "Role Created Successfully."
+                        description: "The role was created successfully.",
+                        message: "Role created successfully."
                     }
                 },
                 createPermission: {
                     error: {
                         description: "{{description}}",
-                        message: "Error Occurred While Adding Permission to Role."
+                        message: "Error occurred while adding permission to role."
                     },
                     genericError: {
-                        description: "Couldn't Add Permissions to Role.",
-                        message: "Something Went Wrong"
+                        description: "Couldn't add permissions to role.",
+                        message: "Something went wrong"
                     },
                     success: {
-                        description: "Permissions Were Successfully Added to the Role.",
+                        description: "Permissions were successfully added to the role.",
                         message: "Role created successfully."
                     }
                 }
@@ -694,21 +694,21 @@ export const devPortal: DevPortalNS = {
                                 label: "Filter Attribute",
                                 placeholder: "E.g. role name.",
                                 validations: {
-                                    empty: "Filter Attribute Is a Required Field"
+                                    empty: "Filter attribute is a required field"
                                 }
                             },
                             filterCondition: {
                                 label: "Filter Condition",
                                 placeholder: "E.g. Starts with etc.",
                                 validations: {
-                                    empty: "Filter Condition Is a Required Field"
+                                    empty: "Filter condition is a required field"
                                 }
                             },
                             filterValue: {
                                 label: "Filter Value",
-                                placeholder: "Enter Value to Search",
+                                placeholder: "Enter value to search",
                                 validations: {
-                                    empty: "Filter Value Is a Required Field"
+                                    empty: "Filter value is a required field"
                                 }
                             },
                         }
@@ -717,18 +717,18 @@ export const devPortal: DevPortalNS = {
                 hints: {
                     querySearch: {
                         actionKeys: "Shift + Enter",
-                        label: "To Search as a Query"
+                        label: "To search as a query"
                     }
                 },
                 options: {
                     header: "Advanced Search",
                 },
-                placeholder: "Search by Role Name",
+                placeholder: "Search by role name",
                 popups: {
-                    clear: "Clear Search",
-                    dropdown: "Show Options"
+                    clear: "Clear search",
+                    dropdown: "Show options"
                 },
-                resultsIndicator: "Showing Results for the Query \"{{query}}\""
+                resultsIndicator: "Showing results for the query \"{{query}}\""
             }
         },
         serverConfigs: {


### PR DESCRIPTION
## Purpose
This PR will fix issue #640.

**Feature**
This PR will add a separate menu entry called `Groups` to manage all `Roles` user store roles and the existing `Roles` page will only list down `Internal` and `Application` roles.

<img width="278" alt="Screenshot 2020-03-30 at 18 12 47" src="https://user-images.githubusercontent.com/11191791/77913568-1c22a880-72b2-11ea-82dd-32ec624e89fe.png">
