### PR TITLE
Dynamically generate IdP creation wizard from templates 

### DIFF
--- a/apps/admin-portal/src/components/identity-providers/templates/quick-start-identity-provider-templates.tsx
+++ b/apps/admin-portal/src/components/identity-providers/templates/quick-start-identity-provider-templates.tsx
@@ -17,9 +17,9 @@
  */
 
 import { EmptyPlaceholder, IdentityProviderTemplateCard } from "@wso2is/react-components";
+import { EmptyPlaceholderIllustrations, IdPIcons } from "../../../configs";
 import React, { FunctionComponent, SyntheticEvent } from "react";
 import { IdentityProviderTemplateListItemInterface } from "../../../models";
-import { EmptyPlaceholderIllustrations, IdPIcons } from "../../../configs";
 
 /**
  * Proptypes for the quick start templates component.
@@ -49,11 +49,10 @@ const getPredefinedIdpImage = (image) => {
  * Quick start application templates component.
  *
  * @param {QuickStartApplicationTemplatesPropsInterface} props - Props injected to the component.
- * @return {JSX.Element}
+ * @return {FunctionComponent}
  */
-export const QuickStartIdentityProviderTemplates: FunctionComponent<QuickStartIdentityProviderTemplatesPropsInterface> = (
-    props: QuickStartIdentityProviderTemplatesPropsInterface
-): JSX.Element => {
+export const QuickStartIdentityProviderTemplates: FunctionComponent<QuickStartIdentityProviderTemplatesPropsInterface>
+    = (props: QuickStartIdentityProviderTemplatesPropsInterface): JSX.Element => {
 
     const {
         onTemplateSelect,

--- a/apps/admin-portal/src/components/identity-providers/wizard/identity-provider-create-wizard.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizard/identity-provider-create-wizard.tsx
@@ -289,16 +289,11 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
      * Loads the identity provider authenticators on initial component load.
      */
     useEffect(() => {
-        if (!_.isEmpty(availableAuthenticators)) {
-            return;
-        }
-
-        // Call backend APIs to retrieve required data.
-        if (isAuthenticatorStepAvailable()) {
+        if (isAuthenticatorStepAvailable() && _.isEmpty(availableAuthenticators)) {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const authenticators = IdentityProviderManagementUtils.getAuthenticators();
         } else {
-            // If there are no data retrieval to be done, initialize the wizard.
+            // If there are no data retrieval requirements.
             setInitWizard(true);
         }
     }, []);
@@ -334,7 +329,7 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
      * Called when `availableAuthenticators` are changed.
      */
     useEffect(() => {
-        if (availableAuthenticators.find(eachAuthenticator => eachAuthenticator.authenticatorId ===
+        if (availableAuthenticators?.find(eachAuthenticator => eachAuthenticator.authenticatorId ===
             template?.federatedAuthenticators?.defaultAuthenticatorId)) {
             getAuthenticatorMetadata(template?.federatedAuthenticators?.defaultAuthenticatorId);
         }

--- a/apps/admin-portal/src/components/identity-providers/wizard/identity-provider-create-wizard.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizard/identity-provider-create-wizard.tsx
@@ -387,7 +387,6 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
                     title: "Authenticator"
                 }
             ];
-
         }
 
         STEPS = [

--- a/apps/admin-portal/src/components/identity-providers/wizard/identity-provider-create-wizard.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizard/identity-provider-create-wizard.tsx
@@ -59,6 +59,15 @@ enum WizardConstants {
 }
 
 /**
+ * Constants for wizard steps.
+ */
+enum WizardSteps {
+    GENERAL_DETAILS = "GeneralDetails",
+    AUTHENTICATOR = "Authenticator",
+    SUMMARY = "Summary"
+}
+
+/**
  * Interface for the wizard state.
  */
 interface WizardStateInterface {
@@ -73,6 +82,8 @@ interface WizardStepInterface {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     icon: any;
     title: string;
+    submitCallback: any;
+    name: WizardSteps;
 }
 
 /**
@@ -93,13 +104,14 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
         template
     } = props;
 
+    const [initWizard, setInitWizard] = useState<boolean>(false);
     const [wizardSteps, setWizardSteps] = useState<WizardStepInterface[]>(undefined);
     const [isSelectionHidden, setIsSelectionHidden] = useState<boolean>(false);
     const [wizardState, setWizardState] = useState<WizardStateInterface>(undefined);
     const [partiallyCompletedStep, setPartiallyCompletedStep] = useState<number>(undefined);
     const [currentWizardStep, setCurrentWizardStep] = useState<number>(currentStep);
-    const [authenticatorMetadata, setAuthenticatorMetadata] = useState<FederatedAuthenticatorMetaInterface>(
-        undefined);
+    const [defaultAuthenticatorMetadata, setDefaultAuthenticatorMetadata] =
+        useState<FederatedAuthenticatorMetaInterface>(undefined);
 
     const dispatch = useDispatch();
 
@@ -166,14 +178,14 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
             step = currentWizardStep + 1;
         }
 
-        switch (step) {
-            case 0:
+        switch (wizardSteps[step]?.name) {
+            case WizardSteps.GENERAL_DETAILS:
                 setSubmitGeneralSettings();
                 break;
-            case 1:
+            case WizardSteps.AUTHENTICATOR:
                 setSubmitAuthenticator();
                 break;
-            case 2:
+            case WizardSteps.SUMMARY:
                 setFinishSubmit();
                 break;
             default:
@@ -231,15 +243,15 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
      *
      * @return {React.ReactElement} Step content.
      */
-    const resolveStepContent = (): ReactElement => {
-        let step = currentWizardStep;
+    const resolveStepContent = (currentStep: number): ReactElement => {
+        let step = currentStep;
 
         if (isSelectionHidden) {
-            step = currentWizardStep + 1;
+            step = currentStep + 1;
         }
 
-        switch (step) {
-            case 0: {
+        switch (wizardSteps[step]?.name) {
+            case WizardSteps.GENERAL_DETAILS: {
                 return (
                     <GeneralSettings
                         triggerSubmit={ submitGeneralSettings }
@@ -249,10 +261,10 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
                     />
                 );
             }
-            case 1: {
+            case WizardSteps.AUTHENTICATOR: {
                 return (
                     <AuthenticatorSettings
-                        metadata={ authenticatorMetadata }
+                        metadata={ defaultAuthenticatorMetadata }
                         initialValues={ wizardState[WizardConstants.IDENTITY_PROVIDER] }
                         onSubmit={ (values): void => handleWizardFormSubmit(
                             values, WizardConstants.IDENTITY_PROVIDER) }
@@ -260,10 +272,10 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
                     />
                 )
             }
-            case 2: {
+            case WizardSteps.SUMMARY: {
                 return (
                     <WizardSummary
-                        authenticatorMetadata={ authenticatorMetadata }
+                        authenticatorMetadata={ defaultAuthenticatorMetadata }
                         triggerSubmit={ finishSubmit }
                         identityProvider={ generateWizardSummary() }
                         onSubmit={ handleWizardFormFinish }
@@ -273,21 +285,6 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
         }
     };
 
-    const STEPS: WizardStepInterface[] = [
-        {
-            icon: IdentityProviderWizardStepIcons.general,
-            title: "General settings"
-        },
-        {
-            icon: IdentityProviderWizardStepIcons.authenticator,
-            title: "Authenticator"
-        },
-        {
-            icon: IdentityProviderWizardStepIcons.summary,
-            title: "Summary"
-        }
-    ];
-
     /**
      * Loads the identity provider authenticators on initial component load.
      */
@@ -295,7 +292,15 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
         if (!_.isEmpty(availableAuthenticators)) {
             return;
         }
-        IdentityProviderManagementUtils.getAuthenticators();
+
+        // Call backend APIs to retrieve required data.
+        if (isAuthenticatorStepAvailable()) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const authenticators = IdentityProviderManagementUtils.getAuthenticators();
+        } else {
+            // If there are no data retrieval to be done, initialize the wizard.
+            setInitWizard(true);
+        }
     }, []);
 
     /**
@@ -306,7 +311,7 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
     const getAuthenticatorMetadata = (authenticatorId: string): Promise<void> => {
         return getFederatedAuthenticatorMetadata(authenticatorId)
             .then((response) => {
-                setAuthenticatorMetadata(response);
+                setDefaultAuthenticatorMetadata(response);
             })
             .catch((error) => {
                 if (error.response && error.response.data && error.response.data.description) {
@@ -329,49 +334,121 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
      * Called when `availableAuthenticators` are changed.
      */
     useEffect(() => {
-        // todo Handle multiple authenticators in the template.
-        const availableAuthenticator = _.find(availableAuthenticators, {
-            authenticatorId: template
-                .federatedAuthenticators?.authenticators[0]?.authenticatorId
-        });
-        if (availableAuthenticator) {
-            getAuthenticatorMetadata(availableAuthenticator.authenticatorId);
+        if (availableAuthenticators.find(eachAuthenticator => eachAuthenticator.authenticatorId ===
+            template?.federatedAuthenticators?.defaultAuthenticatorId)) {
+            getAuthenticatorMetadata(template?.federatedAuthenticators?.defaultAuthenticatorId);
         }
     }, [availableAuthenticators]);
 
-    const getAuthenticatorProperties = () => {
-        return authenticatorMetadata?.properties.map(
+    /**
+     * Validate and get federate authenticators.
+     */
+    const getValidatedAuthenticators = () => {
+        const defaultAuthenticatorPropertiesFromMetadata = defaultAuthenticatorMetadata?.properties.map(
             (eachProp): AuthenticatorProperty => {
                 return {
                     key: eachProp?.key,
                     value: eachProp?.defaultValue
                 }
             });
+
+        // For the default authenticator, update values of it's properties with the corresponding value from the
+        // template, if any.
+        // todo Need to do the same for rest of the configured authenticators in the template.
+        const authenticatorsInTemplate = template?.federatedAuthenticators.authenticators;
+        return {
+            authenticators: authenticatorsInTemplate.map((authenticator) => {
+                return authenticator.authenticatorId === template.federatedAuthenticators.defaultAuthenticatorId ?
+                    {
+                        ...authenticator,
+                        properties: _.merge(defaultAuthenticatorPropertiesFromMetadata, authenticator.properties)
+                    } : authenticator;
+            }),
+            defaultAuthenticatorId: template.federatedAuthenticators.defaultAuthenticatorId
+        };
+    };
+
+    const isAuthenticatorStepAvailable = () => {
+        return template?.federatedAuthenticators?.defaultAuthenticatorId;
+    };
+
+    const getWizardSteps = () => {
+        let STEPS: WizardStepInterface[] = [
+            {
+                icon: IdentityProviderWizardStepIcons.general,
+                name: WizardSteps.GENERAL_DETAILS,
+                submitCallback: setSubmitGeneralSettings,
+                title: "General settings"
+            }
+        ];
+
+        if (isAuthenticatorStepAvailable()) {
+            STEPS = [
+                ...STEPS,
+                {
+                    icon: IdentityProviderWizardStepIcons.authenticator,
+                    name: WizardSteps.AUTHENTICATOR,
+                    submitCallback: setSubmitAuthenticator,
+                    title: "Authenticator"
+                }
+            ];
+
+        }
+
+        STEPS = [
+            ...STEPS,
+            {
+                icon: IdentityProviderWizardStepIcons.summary,
+                name: WizardSteps.SUMMARY,
+                submitCallback: setFinishSubmit,
+                title: "Summary"
+            }
+        ];
+        return STEPS;
+    };
+
+    const initializeWizard = () => {
+        // Each of the IdP attributes which require validation or any modification prior initializing, are stored in
+        // this object.
+        let validatedIdpAttributes = {};
+
+        if (isAuthenticatorStepAvailable()) {
+            validatedIdpAttributes = {
+                ...validatedIdpAttributes,
+                federatedAuthenticators: getValidatedAuthenticators()
+            };
+        }
+
+        setWizardState(_.merge(wizardState, {
+            [WizardConstants.IDENTITY_PROVIDER]: {
+                ...template,
+                ...validatedIdpAttributes
+            }
+        }));
+        setWizardSteps(getWizardSteps());
     };
 
     /**
-     * Called when `authenticatorMetadata` is changed.
+     * Called when required backend data are gathered.
      */
     useEffect(() => {
-        if (authenticatorMetadata) {
-            const identityProvider: IdentityProviderInterface = {
-                federatedAuthenticators: {
-                    authenticators: [{
-                        authenticatorId: authenticatorMetadata?.authenticatorId,
-                        name: authenticatorMetadata?.name,
-                        properties: getAuthenticatorProperties()
-                    }],
-                    defaultAuthenticatorId: authenticatorMetadata?.authenticatorId
-                }
-            };
-
-            setWizardState(_.merge(wizardState, {
-                [WizardConstants.IDENTITY_PROVIDER]: identityProvider
-            }));
-
-            setWizardSteps(STEPS);
+        if (!initWizard) {
+            return;
         }
-    }, [authenticatorMetadata]);
+
+        initializeWizard();
+
+        setInitWizard(false);
+    }, [initWizard]);
+
+    /**
+     * Called to initialize the wizard, once all the data gathered from the backend.
+     */
+    useEffect(() => {
+        if (defaultAuthenticatorMetadata) {
+            setInitWizard(true);
+        }
+    }, [defaultAuthenticatorMetadata]);
 
     /**
      * Sets the current wizard step to the previous on every `partiallyCompletedStep`
@@ -411,7 +488,7 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
                         ))}
                     </Steps.Group>
                 </Modal.Content>
-                <Modal.Content className="content-container" scrolling>{resolveStepContent()}</Modal.Content>
+                <Modal.Content className="content-container" scrolling>{resolveStepContent(currentWizardStep)}</Modal.Content>
                 <Modal.Actions>
                     <Grid>
                         <Grid.Row column={ 1 }>

--- a/apps/admin-portal/src/components/identity-providers/wizard/steps/general-settings.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizard/steps/general-settings.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, {FunctionComponent, useEffect} from "react";
+import React, { FunctionComponent } from "react";
 import { GeneralDetailsForm } from "../../forms";
 import { IdentityProviderInterface } from "../../../../models";
 

--- a/apps/admin-portal/src/components/identity-providers/wizard/steps/general-settings.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizard/steps/general-settings.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { FunctionComponent } from "react";
+import React, {FunctionComponent, useEffect} from "react";
 import { GeneralDetailsForm } from "../../forms";
 import { IdentityProviderInterface } from "../../../../models";
 

--- a/apps/admin-portal/src/components/identity-providers/wizard/steps/wizard-summary.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizard/steps/wizard-summary.tsx
@@ -82,26 +82,28 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
         });
     };
 
-    return (
-        <Grid className="wizard-summary">
-            <Grid.Row>
-                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } textAlign="center">
-                    <div className="general-details">
-                        <AppAvatar
-                            name={ identityProvider?.name }
-                            image={ identityProvider?.image }
-                            size="tiny"
-                        />
-                        {identityProvider?.name && (
-                            <Heading size="small" className="name">{identityProvider.name}</Heading>
-                        )}
-                        {identityProvider?.description && (
-                            <div className="description">{identityProvider.description}</div>
-                        )}
-                    </div>
-                </Grid.Column>
-            </Grid.Row>
+    const getGeneralDetailsComponent = () => {
+        return <Grid.Row>
+            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } textAlign="center">
+                <div className="general-details">
+                    <AppAvatar
+                        name={ identityProvider?.name }
+                        image={ identityProvider?.image }
+                        size="tiny"
+                    />
+                    {identityProvider?.name && (
+                        <Heading size="small" className="name">{identityProvider.name}</Heading>
+                    )}
+                    {identityProvider?.description && (
+                        <div className="description">{identityProvider.description}</div>
+                    )}
+                </div>
+            </Grid.Column>
+        </Grid.Row>;
+    };
 
+    const getAuthenticatorComponent = () => {
+        return <>
             <Divider horizontal>Authenticator details</Divider>
 
             {authenticatorSummary && (
@@ -117,6 +119,17 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
             {
                 authenticatorSummary?.properties && getAuthenticatorProperties()
             }
+        </>;
+    };
+
+    const isAuthenticatorStepAvailable = () => {
+        return identityProvider?.federatedAuthenticators?.defaultAuthenticatorId;
+    };
+
+    return (
+        <Grid className="wizard-summary">
+            {getGeneralDetailsComponent()}
+            {isAuthenticatorStepAvailable() ? getAuthenticatorComponent() : null}
         </Grid>
     );
 };

--- a/apps/admin-portal/src/components/identity-providers/wizard/steps/wizard-summary.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizard/steps/wizard-summary.tsx
@@ -108,16 +108,18 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
         return <>
             <Divider horizontal>Authenticator details</Divider>
 
-            { authenticatorSummary && (
-                <Grid.Row className="summary-field" columns={ 2 }>
-                    <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">
-                        <div className="label">Name</div>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 8 } textAlign="left">
-                        <div className="value url">{ authenticatorSummary?.name }</div>
-                    </Grid.Column>
-                </Grid.Row>
-            ) }
+            {
+                authenticatorSummary && (
+                    <Grid.Row className="summary-field" columns={ 2 }>
+                        <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">
+                            <div className="label">Name</div>
+                        </Grid.Column>
+                        <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 8 } textAlign="left">
+                            <div className="value url">{authenticatorSummary?.name}</div>
+                        </Grid.Column>
+                    </Grid.Row>
+                )
+            }
             {
                 authenticatorSummary?.properties && getAuthenticatorProperties()
             }

--- a/apps/admin-portal/src/components/identity-providers/wizard/steps/wizard-summary.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizard/steps/wizard-summary.tsx
@@ -83,39 +83,41 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
     };
 
     const getGeneralDetailsComponent = () => {
-        return <Grid.Row>
-            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } textAlign="center">
-                <div className="general-details">
-                    <AppAvatar
-                        name={ identityProvider?.name }
-                        image={ identityProvider?.image }
-                        size="tiny"
-                    />
-                    {identityProvider?.name && (
-                        <Heading size="small" className="name">{identityProvider.name}</Heading>
-                    )}
-                    {identityProvider?.description && (
-                        <div className="description">{identityProvider.description}</div>
-                    )}
-                </div>
-            </Grid.Column>
-        </Grid.Row>;
+        return (
+            <Grid.Row>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } textAlign="center">
+                    <div className="general-details">
+                        <AppAvatar
+                            name={ identityProvider?.name }
+                            image={ identityProvider?.image }
+                            size="tiny"
+                        />
+                        {identityProvider?.name && (
+                            <Heading size="small" className="name">{ identityProvider.name }</Heading>
+                        )}
+                        {identityProvider?.description && (
+                            <div className="description">{ identityProvider.description }</div>
+                        )}
+                    </div>
+                </Grid.Column>
+            </Grid.Row>
+        );
     };
 
     const getAuthenticatorComponent = () => {
         return <>
             <Divider horizontal>Authenticator details</Divider>
 
-            {authenticatorSummary && (
+            { authenticatorSummary && (
                 <Grid.Row className="summary-field" columns={ 2 }>
                     <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">
                         <div className="label">Name</div>
                     </Grid.Column>
                     <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 8 } textAlign="left">
-                        <div className="value url">{authenticatorSummary?.name}</div>
+                        <div className="value url">{ authenticatorSummary?.name }</div>
                     </Grid.Column>
                 </Grid.Row>
-            )}
+            ) }
             {
                 authenticatorSummary?.properties && getAuthenticatorProperties()
             }
@@ -128,8 +130,8 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
 
     return (
         <Grid className="wizard-summary">
-            {getGeneralDetailsComponent()}
-            {isAuthenticatorStepAvailable() ? getAuthenticatorComponent() : null}
+            { getGeneralDetailsComponent() }
+            { isAuthenticatorStepAvailable() ? getAuthenticatorComponent() : null }
         </Grid>
     );
 };

--- a/apps/admin-portal/src/pages/identity-provider-template.tsx
+++ b/apps/admin-portal/src/pages/identity-provider-template.tsx
@@ -23,9 +23,11 @@ import { IdentityProviderTemplateListInterface, IdentityProviderTemplateListItem
 import { IdentityProviderCreateWizard } from "../components/identity-providers/wizard";
 import { QuickStartIdentityProviderTemplates } from "../components/identity-providers/templates";
 import { getIdentityProviderTemplate, getIdentityProviderTemplateList } from "../api";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { addAlert } from "@wso2is/core/store";
 import { AlertLevels } from "@wso2is/core/models";
+import { AppState } from "../store";
+import { setAvailableAuthenticatorsMeta } from "../store/actions/identity-provider";
 
 /**
  * Choose the application template from this page.
@@ -39,6 +41,8 @@ export const IdentityProviderTemplateSelectPage: FunctionComponent<{}> = (): Rea
     const [availableTemplates, setAvailableTemplates] = useState<IdentityProviderTemplateListItemInterface[]>([]);
     
     const dispatch = useDispatch();
+
+    const availableAuthenticators = useSelector((state: AppState) => state.identityProvider.meta.authenticators);
 
     /**
      * Retrieve Identity Provider template list.
@@ -110,6 +114,9 @@ export const IdentityProviderTemplateSelectPage: FunctionComponent<{}> = (): Rea
      * Handles back button click.
      */
     const handleBackButtonClick = (): void => {
+        if (availableAuthenticators) {
+            dispatch(setAvailableAuthenticatorsMeta(undefined));
+        }
         history.push("/identity-providers");
     };
 

--- a/apps/admin-portal/src/utils/identity-provider-management-utils.ts
+++ b/apps/admin-portal/src/utils/identity-provider-management-utils.ts
@@ -45,12 +45,10 @@ export class IdentityProviderManagementUtils {
 
     /**
      * Gets the list of available authenticator list and sets them in the redux store.
-     *
-     * @param {AuthProtocolMetaListItemInterface[]} meta - Meta data to filter.
      */
-    public static getAuthenticators(): Promise<void> {
+     public static getAuthenticators(): Promise<void> {
         return getFederatedAuthenticatorsList()
-            .then((response) => {
+            .then((response): void => {
                 store.dispatch(
                     setAvailableAuthenticatorsMeta(response)
                 );

--- a/apps/admin-portal/src/utils/identity-provider-management-utils.ts
+++ b/apps/admin-portal/src/utils/identity-provider-management-utils.ts
@@ -17,13 +17,7 @@
  *
  */
 
-import {
-    AuthProtocolMetaListItemInterface,
-    FederatedAuthenticatorListItemInterface,
-    FederatedAuthenticatorMetaInterface
-} from "../models";
 import { getFederatedAuthenticatorsList } from "../api";
-import _ from "lodash";
 import { store } from "../store";
 import { addAlert } from "@wso2is/core/store";
 import { AlertLevels } from "@wso2is/core/models";


### PR DESCRIPTION
## Purpose
- Addresses https://github.com/wso2/identity-apps/issues/354.

## Goals
- Generate wizard steps based on the template.

## Approach
- Steps are initialized with the template attributes and values.
![Screenshot from 2020-04-01 19-47-36](https://user-images.githubusercontent.com/22551445/78147886-bec55d80-7451-11ea-8d5a-dd3a2eb267eb.png)
- General settings and Summary steps are common for every template. The rest of the supported steps are generated according to the template. For example, if the Authenticator step is not available in the template, that will be excluded from wizard steps.
![Screenshot from 2020-04-01 19-50-59](https://user-images.githubusercontent.com/22551445/78148159-22e82180-7452-11ea-80a4-6bce42b9c0e0.png)
- And also, the Summary page is rendered accordingly.
![Screenshot from 2020-04-01 19-51-47](https://user-images.githubusercontent.com/22551445/78148218-3e532c80-7452-11ea-9b3c-0f1b09051759.png)
