### PR TITLE
Generate next IdP name in template

### DIFF
--- a/apps/admin-portal/src/pages/identity-provider-template.tsx
+++ b/apps/admin-portal/src/pages/identity-provider-template.tsx
@@ -156,7 +156,7 @@ export const IdentityProviderTemplateSelectPage: FunctionComponent<{}> = (): Rea
      */
     const generateUniqueIdpName = (initialIdpName: string, idpList: string[]): string => {
         let idpName = initialIdpName;
-        for (let i = 1; ; i++) {
+        for (let i = 2; ; i++) {
             if (!idpList?.includes(idpName)) {
                 break;
             }

--- a/apps/admin-portal/src/pages/identity-provider-template.tsx
+++ b/apps/admin-portal/src/pages/identity-provider-template.tsx
@@ -160,7 +160,7 @@ export const IdentityProviderTemplateSelectPage: FunctionComponent<{}> = (): Rea
             if (!idpList?.includes(idpName)) {
                 break;
             }
-            idpName = idpName + i;
+            idpName = initialIdpName + i;
         }
         return idpName;
     };


### PR DESCRIPTION
## Purpose
- Addresses https://github.com/wso2/identity-apps/issues/354.

## Goals
- When creating an IdP via the wizard, generate a unique name as the template provided value.

## Approach
- Once the template is selected, the default name will be suffixed with the next 2-based index, in order to have a unique name for the IdP, from the already created IdPs in the server. Ex: If the IdP `Google` is already available, the next wizard invoke contains the name `Google2`
![Screenshot from 2020-04-03 00-10-25](https://user-images.githubusercontent.com/22551445/78289290-9025b080-753f-11ea-9296-f99d89b0a62e.png)

