### PR TITLE
Fix undefined issue in application wizard summary

### DIFF
--- a/apps/admin-portal/src/components/applications/wizard/wizard-summary.tsx
+++ b/apps/admin-portal/src/components/applications/wizard/wizard-summary.tsx
@@ -197,7 +197,7 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
                 )
             }
             {
-                summary?.inboundProtocolConfiguration?.passiveSts.realm && (
+                summary?.inboundProtocolConfiguration?.passiveSts?.realm && (
                     <Grid.Row className="summary-field" columns={ 2 }>
                         <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">
                             <div className="label">Realm</div>
@@ -209,7 +209,7 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
                 )
             }
             {
-                summary?.inboundProtocolConfiguration?.passiveSts.replyTo && (
+                summary?.inboundProtocolConfiguration?.passiveSts?.replyTo && (
                     <Grid.Row className="summary-field" columns={ 2 }>
                         <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">
                             <div className="label">Audience</div>


### PR DESCRIPTION
## Purpose
- Undefined values are coming in the application wizard summary because of passive sts config check. 