### PR TITLE
Add indeterminate state for permission tree

### DIFF
--- a/apps/admin-portal/src/components/roles/create-role-wizard/role-permisson.tsx
+++ b/apps/admin-portal/src/components/roles/create-role-wizard/role-permisson.tsx
@@ -76,6 +76,7 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
                                 isChecked: false,
                                 fullPath: permission,
                                 name: permission,
+                                isPartiallyChecked: false,
                                 isExpanded: true
                             })
                         })
@@ -90,6 +91,15 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
             getAllPermissions();
         }
     }, [availablePermissionsInRole.toString()])
+
+    useEffect(() => {
+        const collapsedTree = _.cloneDeep(permissionTree);
+        removeIndeterminateState(collapsedTree);
+        checkedPermissions.forEach((node: Permission) => {
+            markParentAsPartiallyChecked(collapsedTree, node, 0)
+        })
+        setPermissionTree(collapsedTree);
+    }, [checkedPermissions.length])
 
     /**
      * Retrieve all permissions to render permissions tree.
@@ -111,12 +121,18 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
                     //Retrieved permissions of Role in edit mode
                     if (availablePermissionsInRole.length !== 0) {
                         setCheckedPermissions(availablePermissionsInRole);
+                        availablePermissionsInRole.forEach((node: Permission) => {
+                            markParentAsPartiallyChecked(permissionTree, node, 0)
+                        })
                         setCheckedStateForNodesInPermissionTree(availablePermissionsInRole, permissionTree, false);
                     }
 
                     //temporary selected roles in roles create wizard
                     if (initialValues && initialValues.length !== 0) {
                         setCheckedPermissions(initialValues);
+                        initialValues.forEach((node: Permission) => {
+                            markParentAsPartiallyChecked(permissionTree, node, 0)
+                        })
                         setCheckedStateForNodesInPermissionTree(initialValues, permissionTree, false);
                     }
 
@@ -138,6 +154,20 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
     const setTopNodesCollapsed = (permissionNodes: Permission[]): void => {
         permissionNodes[0].children?.forEach((permissionNode: Permission) => {
             permissionNode.isExpanded = false;
+        })
+    }
+
+    /**
+     * Util method to remove indeterminate state.
+     * 
+     * @param nodeTree permission node tree
+     */
+    const removeIndeterminateState = (nodeTree: Permission[]): void => {
+        nodeTree.forEach(permission => {
+            permission.isPartiallyChecked = false;
+            if (permission.children) {
+                removeIndeterminateState(permission.children);
+            }
         })
     }
 
@@ -201,13 +231,33 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
     }
 
     /**
+     * Add indeteminate state for parent node when checked on tree node.
+     * 
+     * @param nodes permission node list
+     * @param checkedNode current checked permission node
+     * @param depth depth of the current checked permission node
+     */
+    const markParentAsPartiallyChecked = (nodes: Permission[], checkedNode: Permission, depth: number): void => {
+        const permissionPath: string[] = checkedNode?.fullPath?.split('/').filter(String);
+        permissionPath.pop();
+        nodes.forEach((node: Permission) => {
+            if (permissionPath[depth] === node.name) {
+                node.isPartiallyChecked = true;
+                if (node.children) {
+                    markParentAsPartiallyChecked(node.children, checkedNode, ++depth);
+                }
+            }
+        });
+    }
+
+    /**
      * Click event handler for the permission tree checkboxes.
      * 
      * @param nodeData - array of checked elements returned.
      */
-    const handlePermssionCheck = (nodeData): void => {
+    const handlePermssionCheck = (nodeData: Permission[]): void => {
         const checkState = nodeData[0].isChecked;
-
+        
         markChildrenAsChecked(nodeData, checkState);
 
         if (nodeData[0].isChecked) {

--- a/apps/admin-portal/src/components/roles/create-role-wizard/role-permisson.tsx
+++ b/apps/admin-portal/src/components/roles/create-role-wizard/role-permisson.tsx
@@ -257,7 +257,7 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
      */
     const handlePermssionCheck = (nodeData: Permission[]): void => {
         const checkState = nodeData[0].isChecked;
-        
+
         markChildrenAsChecked(nodeData, checkState);
 
         if (nodeData[0].isChecked) {

--- a/apps/admin-portal/src/components/roles/role-utils.ts
+++ b/apps/admin-portal/src/components/roles/role-utils.ts
@@ -40,7 +40,8 @@ export const addPath = (permObj: PermissionObject, pathcomponents: string[],
             isExpanded: true,
             isChecked: false,
             name: component,
-            id: permObj.resourcePath
+            id: permObj.resourcePath,
+            isPartiallyChecked: false
         }
         permissionTreeArray.push(comp)
     }

--- a/apps/admin-portal/src/models/permission.ts
+++ b/apps/admin-portal/src/models/permission.ts
@@ -26,6 +26,7 @@ export interface Permission {
     children?: Permission[];
     fullPath?: string;
     isChecked: boolean;
+    isPartiallyChecked: boolean;
     id: string;
 }
 

--- a/modules/react-components/src/tree-view/tree-view.tsx
+++ b/modules/react-components/src/tree-view/tree-view.tsx
@@ -175,7 +175,6 @@ export const TreeView: FunctionComponent<TreeViewProps> = (props: TreeViewProps)
         const nodeText = _.get(node, keywordLabel, "");
 
         if (isCheckable(node, depth)) {
-            console.log(node.isPartiallyChecked);
             return (
                 <label htmlFor={ node.id } className="tree-label">
                     <input

--- a/modules/react-components/src/tree-view/tree-view.tsx
+++ b/modules/react-components/src/tree-view/tree-view.tsx
@@ -59,6 +59,7 @@ interface TreeNode {
     isExpanded: boolean;
     isChecked: boolean;
     children?: TreeNode[];
+    isPartiallyChecked: boolean;
 }
 
 /**
@@ -174,6 +175,7 @@ export const TreeView: FunctionComponent<TreeViewProps> = (props: TreeViewProps)
         const nodeText = _.get(node, keywordLabel, "");
 
         if (isCheckable(node, depth)) {
+            console.log(node.isPartiallyChecked);
             return (
                 <label htmlFor={ node.id } className="tree-label">
                     <input
@@ -186,12 +188,13 @@ export const TreeView: FunctionComponent<TreeViewProps> = (props: TreeViewProps)
                         checked={ !!node.isChecked }
                         id={ node.id }
                     />
-                    <div className="checkbox">
+                    <div className={"checkbox " + (node.isPartiallyChecked ? "indeterminate" : "") }>
                         <svg width="17px" height="17px" viewBox="0 0 20 20">
                             <path d="M3,1 L17,1 L17,1 C18.1045695,1 19,1.8954305 19,3 L19,17 L19,17 C19,
                                 18.1045695 18.1045695,19 17,19 L3,19 L3,19 C1.8954305,19 1,18.1045695 1,17 L1,3 L1,
                                 3 C1,1.8954305 1.8954305,1 3,1 Z"></path>
-                            <polyline points="4 11 8 15 16 6"></polyline>
+                            <polyline className="tick" points="4 11 8 15 16 6" />
+                            <polyline className="dash" points="5 10 15 10 20" />
                         </svg>
                     </div>
                     <span>{ nodeText }</span>

--- a/modules/theme/src/theme-core/definitions/modules/treeview/treeview.less
+++ b/modules/theme/src/theme-core/definitions/modules/treeview/treeview.less
@@ -181,7 +181,7 @@
                             fill: @primaryColor;
                         }
 
-                        polyline {
+                        .tick {
                             stroke-dashoffset: 0;
                         }
                     }
@@ -236,6 +236,19 @@
                         stroke-linejoin: round;
                         stroke-width: 2;
                         stroke: #ffffff;
+                        transition: all 0.3s ease;
+                    }
+                }
+            }
+
+            .indeterminate {
+                svg {
+                    path {
+                        fill: @primaryColor;
+                    }
+
+                    .dash {
+                        stroke-dashoffset: 0;
                         transition: all 0.3s ease;
                     }
                 }


### PR DESCRIPTION
## Purpose
fixes #703 

Adding `indeterminate` state for permission tree view. 

![indeterminate](https://user-images.githubusercontent.com/11191791/79367950-493ab080-7f6c-11ea-9340-a5b62e8e421c.gif)
