### PR TITLE
Improve idp templates

### DIFF
--- a/features/org.wso2.identity.apps.admin.portal.server.feature/resources/templates/identity-providers/Facebook.json
+++ b/features/org.wso2.identity.apps.admin.portal.server.feature/resources/templates/identity-providers/Facebook.json
@@ -9,7 +9,7 @@
   "idp": {
     "name": "Facebook",
     "description": "Identity provider for Facebook Federation",
-    "image": "facebook",
+    "image": "",
     "isPrimary": false,
     "isFederationHub": false,
     "homeRealmIdentifier": "",

--- a/features/org.wso2.identity.apps.admin.portal.server.feature/resources/templates/identity-providers/Google.json
+++ b/features/org.wso2.identity.apps.admin.portal.server.feature/resources/templates/identity-providers/Google.json
@@ -1,15 +1,15 @@
 {
   "id": "8ea23303-49c0-4253-b81f-82c0fe6fb4a0",
   "name": "Google",
-  "description": "Authenticate users with Google.",
+  "description": "Provision users with Google.",
   "image": "google",
   "category": "DEFAULT",
   "displayOrder": 1,
-  "services": ["authentication", "provisioning"],
+  "services": ["provisioning"],
   "idp": {
     "name": "Google",
     "description": "Identity provider for Google Federation",
-    "image": "google",
+    "image": "",
     "isPrimary": false,
     "isFederationHub": false,
     "homeRealmIdentifier": "",
@@ -31,31 +31,8 @@
       "outboundProvisioningRoles": []
     },
     "federatedAuthenticators": {
-      "defaultAuthenticatorId": "R29vZ2xlT0lEQ0F1dGhlbnRpY2F0b3I",
-      "authenticators": [
-        {
-          "authenticatorId": "R29vZ2xlT0lEQ0F1dGhlbnRpY2F0b3I",
-          "isEnabled": true,
-          "properties": [
-            {
-              "key": "AdditionalQueryParameters",
-              "value": ""
-            },
-            {
-              "key": "ClientId",
-              "value": ""
-            },
-            {
-              "key": "ClientSecret",
-              "value": ""
-            },
-            {
-              "key": "callbackUrl",
-              "value": ""
-            }
-          ]
-        }
-      ]
+      "defaultAuthenticatorId": "",
+      "authenticators": []
     },
     "provisioning": {
       "jit": {

--- a/features/org.wso2.identity.apps.admin.portal.server.feature/resources/templates/identity-providers/OIDC Connect.json
+++ b/features/org.wso2.identity.apps.admin.portal.server.feature/resources/templates/identity-providers/OIDC Connect.json
@@ -9,7 +9,7 @@
   "idp": {
     "name": "OpenIdConnect",
     "description": "Identity provider for Federation via OpenId Connect",
-    "image": "oidc",
+    "image": "",
     "isPrimary": false,
     "isFederationHub": false,
     "homeRealmIdentifier": "",


### PR DESCRIPTION
## Purpose
- Use an avatar as the default IdP image.
- Refactor Google IdP to only support provisioning. 