### PR TITLE
Allow connectors/authenticators per template

### DIFF
--- a/apps/admin-portal/src/components/identity-providers/identity-provider-edit.tsx
+++ b/apps/admin-portal/src/components/identity-providers/identity-provider-edit.tsx
@@ -137,31 +137,49 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
         </ResourceTab.Pane>
     );
 
+    const getPanes = () => {
+        const panes = [];
+
+        panes.push({
+            menuItem: "General",
+            render: GeneralIdentityProviderSettingsTabPane
+        });
+
+        panes.push({
+            menuItem: "Attributes",
+            render: AttributeSettingsTabPane
+        });
+
+        // todo Once multiple authenticator support added, this check needs to be removed and edit view should allow
+        //  adding authenticators.
+        if (identityProvider?.federatedAuthenticators?.defaultAuthenticatorId) {
+            panes.push({
+                menuItem: "Authentication",
+                render: AuthenticatorSettingsTabPane
+            });
+        }
+
+        // todo Once multiple connector support added, this check needs to be removed and edit view should allow
+        //  adding connectors.
+        if (identityProvider?.provisioning?.outboundConnectors?.defaultConnectorId) {
+            panes.push({
+                menuItem: "Outbound Provisioning",
+                render: OutboundProvisioningSettingsTabPane
+            });
+        }
+
+        panes.push({
+            menuItem: "Advance",
+            render: AdvancedSettingsTabPane
+        });
+
+        return panes;
+    };
+
     return (
         identityProvider && (
             <ResourceTab
-                panes={ [
-                    {
-                        menuItem: "General",
-                        render: GeneralIdentityProviderSettingsTabPane
-                    },
-                    {
-                        menuItem: "Attributes",
-                        render: AttributeSettingsTabPane
-                    },
-                    {
-                        menuItem: "Authentication",
-                        render: AuthenticatorSettingsTabPane
-                    },
-                    {
-                        menuItem: "Outbound Provisioning",
-                        render: OutboundProvisioningSettingsTabPane
-                    },
-                    {
-                        menuItem: "Advance",
-                        render: AdvancedSettingsTabPane
-                    }
-                ] }
+                panes={ getPanes() }
             />
         )
     );


### PR DESCRIPTION
## Purpose
- Addresses https://github.com/wso2/identity-apps/issues/354.

## Goals
- Since add/remove connectors/authenticators feature is not available yet, an IdP template with only authenticator or connector config will lead to an edit view having an empty panel for the missing type. Until the above-mentioned feature is available, this panel should not be displayed.