### PR TITLE
[Dev Portal] Fix IDP authenticator listing & add authenticator visibility toggle capability to authenticator accordion component

### DIFF
--- a/apps/admin-portal/src/components/identity-providers/settings/authenticator-settings.tsx
+++ b/apps/admin-portal/src/components/identity-providers/settings/authenticator-settings.tsx
@@ -16,25 +16,25 @@
  * under the License.
  */
 
-import { CheckboxProps, Grid, Icon } from "semantic-ui-react";
+import { AlertLevels } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
 import { ConfirmationModal, ContentLoader, PrimaryButton } from "@wso2is/react-components";
-import {
-    FederatedAuthenticatorInterface,
-    FederatedAuthenticatorListItemInterface,
-    FederatedAuthenticatorListResponseInterface
-} from "../../../models";
+import React, { FormEvent, FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
+import { CheckboxProps, Grid, Icon } from "semantic-ui-react";
 import {
     getFederatedAuthenticatorDetails,
     getFederatedAuthenticatorMeta,
     updateFederatedAuthenticator
 } from "../../../api";
-import React, { FormEvent, FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
-import { addAlert } from "@wso2is/core/store";
-import { AlertLevels } from "@wso2is/core/models";
+import {
+    FederatedAuthenticatorInterface,
+    FederatedAuthenticatorListItemInterface,
+    FederatedAuthenticatorListResponseInterface
+} from "../../../models";
 import { AuthenticatorAccordion } from "../../shared";
 import { AuthenticatorFormFactory } from "../forms";
 import { FederatedAuthenticators } from "../meta/authenticators";
-import { useDispatch } from "react-redux";
 
 /**
  * Proptypes for the identity providers settings component.
@@ -248,9 +248,30 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         // TODO: Implement deletion logic here.
     };
 
+    /**
+     * Handles Authenticator delete button on click action.
+     *
+     * @param {React.MouseEvent<HTMLDivElement>} e - Click event.
+     * @param {string} id - Id of the authenticator.
+     */
+    const handleAuthenticatorDeleteOnClick = (e: MouseEvent<HTMLDivElement>, id: string): void => {
+        if (!id) {
+            return;
+        }
+
+        const deletingAuthenticator = availableAuthenticators
+            .find((authenticator) => authenticator.id === id);
+
+        if (!deletingAuthenticator) {
+            return;
+        }
+
+        setDeletingAuthenticator(deletingAuthenticator.data);
+        setShowDeleteConfirmationModal(true);
+    };
+
     const handleAddAuthenticator = () => {
         // TODO: Implement method
-        console.log("Add authenticator...")
     };
 
     return (
@@ -267,61 +288,54 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                         </Grid.Row>
                         <Grid.Row>
                             <Grid.Column width={ 16 }>
-                                { availableAuthenticators.map((authenticator) => {
-                                    return (
-                                        <AuthenticatorAccordion
-                                            key={ authenticator.id }
-                                            globalActions={ [
-                                                {
-                                                    icon: "trash alternate",
-                                                    onClick: (e: MouseEvent<HTMLDivElement>, id: string): void => {
-                                                        setShowDeleteConfirmationModal(true);
-                                                        setDeletingAuthenticator(authenticator.data);
+                                <AuthenticatorAccordion
+                                    globalActions={ [
+                                        {
+                                            icon: "trash alternate",
+                                            onClick: handleAuthenticatorDeleteOnClick,
+                                            type: "icon"
+                                        }
+                                    ] }
+                                    authenticators={
+                                        availableAuthenticators.map((authenticator) => {
+                                            return {
+                                                actions: [
+                                                    {
+                                                        defaultChecked: authenticator.data?.isDefault,
+                                                        disabled: (authenticator.data?.isDefault ||
+                                                            !authenticator.data?.isEnabled),
+                                                        label: (authenticator.data?.isDefault ?
+                                                            "Default" : "Make default"),
+                                                        onChange: handleDefaultAuthenticatorChange,
+                                                        type: "checkbox"
                                                     },
-                                                    type: "icon"
-                                                }
-                                            ] }
-                                            authenticators={ [
-                                                {
-                                                    actions: [
-                                                        {
-                                                            defaultChecked: authenticator.data?.isDefault,
-                                                            disabled: (authenticator.data?.isDefault ||
-                                                                !authenticator.data?.isEnabled),
-                                                            label: (authenticator.data?.isDefault ?
-                                                                "Default" : "Make default"),
-                                                            onChange: handleDefaultAuthenticatorChange,
-                                                            type: "checkbox"
-                                                        },
-                                                        {
-                                                            defaultChecked: authenticator.data?.isEnabled,
-                                                            label: (authenticator.data?.isEnabled ?
-                                                                "Enabled" : "Disabled"),
-                                                            onChange: handleAuthenticatorEnableToggle,
-                                                            type: "toggle"
-                                                        }
-                                                    ],
-                                                    content: authenticator && (
-                                                        <AuthenticatorFormFactory
-                                                            metadata={ authenticator.meta }
-                                                            initialValues={ authenticator.data }
-                                                            onSubmit={ handleInboundConfigFormSubmit }
-                                                            type={ authenticator.meta?.name }
-                                                        />
-                                                    ),
-                                                    icon: {
-                                                        icon: authenticator.id &&
-                                                            (FederatedAuthenticators.find((fedAuth) =>
-                                                                (fedAuth.authenticatorId === authenticator.id ))).icon
-                                                    },
-                                                    id: authenticator?.id,
-													title: authenticator.meta?.displayName
-                                                }
-                                            ] }
-                                        />
-                                    )
-                                })}
-
+                                                    {
+                                                        defaultChecked: authenticator.data?.isEnabled,
+                                                        label: (authenticator.data?.isEnabled ?
+                                                            "Enabled" : "Disabled"),
+                                                        onChange: handleAuthenticatorEnableToggle,
+                                                        type: "toggle"
+                                                    }
+                                                ],
+                                                content: authenticator && (
+                                                    <AuthenticatorFormFactory
+                                                        metadata={ authenticator.meta }
+                                                        initialValues={ authenticator.data }
+                                                        onSubmit={ handleInboundConfigFormSubmit }
+                                                        type={ authenticator.meta?.name }
+                                                    />
+                                                ),
+                                                icon: {
+                                                    icon: authenticator.id &&
+                                                        (FederatedAuthenticators.find((fedAuth) =>
+                                                            (fedAuth.authenticatorId === authenticator.id))).icon
+                                                },
+                                                id: authenticator?.id,
+                                                title: authenticator.meta?.displayName
+                                            }
+                                        })
+                                    }
+                                />
                             </Grid.Column>
                         </Grid.Row>
                     </Grid>

--- a/apps/admin-portal/src/components/shared/authenticator-accordion.tsx
+++ b/apps/admin-portal/src/components/shared/authenticator-accordion.tsx
@@ -141,7 +141,7 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
                                     { authenticator.title }
                                 </>
                             ) }
-                            actions={ [ ...authenticator.actions, ...globalActions ] }
+                            actions={ authenticator.actions && [ ...authenticator.actions, ...globalActions ] }
                             hideChevron={ hideChevron }
                         />
                         <SegmentedAccordion.Content

--- a/apps/admin-portal/src/components/shared/authenticator-accordion.tsx
+++ b/apps/admin-portal/src/components/shared/authenticator-accordion.tsx
@@ -65,6 +65,10 @@ export interface AuthenticatorAccordionItemInterface {
      */
     id: string;
     /**
+     * Flag to show/hide the authenticator inside the accordion.
+     */
+    hidden?: boolean;
+    /**
      * Title of the authenticator.
      */
     title: string;
@@ -123,33 +127,37 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
         >
             {
                 _.sortBy(authenticators, orderBy).map((authenticator, index) => (
-                    <>
-                        <SegmentedAccordion.Title
-                            id={ authenticator.id }
-                            active={ accordionActiveIndexes.includes(index) }
-                            index={ index }
-                            onClick={ handleAccordionOnClick }
-                            content={ (
-                                <>
-                                    <GenericIcon
-                                        floated="left"
-                                        size="micro"
-                                        spaced="right"
-                                        transparent
-                                        { ...authenticator.icon }
-                                    />
-                                    { authenticator.title }
-                                </>
-                            ) }
-                            actions={ authenticator.actions && [ ...authenticator.actions, ...globalActions ] }
-                            hideChevron={ hideChevron }
-                        />
-                        <SegmentedAccordion.Content
-                            active={ accordionActiveIndexes.includes(index) }
-                        >
-                            { authenticator.content }
-                        </SegmentedAccordion.Content>
-                    </>
+                    !authenticator.hidden
+                        ? (
+                            <>
+                                <SegmentedAccordion.Title
+                                    id={ authenticator.id }
+                                    active={ accordionActiveIndexes.includes(index) }
+                                    index={ index }
+                                    onClick={ handleAccordionOnClick }
+                                    content={ (
+                                        <>
+                                            <GenericIcon
+                                                floated="left"
+                                                size="micro"
+                                                spaced="right"
+                                                transparent
+                                                { ...authenticator.icon }
+                                            />
+                                            { authenticator.title }
+                                        </>
+                                    ) }
+                                    actions={ authenticator.actions && [ ...authenticator.actions, ...globalActions ] }
+                                    hideChevron={ hideChevron }
+                                />
+                                <SegmentedAccordion.Content
+                                    active={ accordionActiveIndexes.includes(index) }
+                                >
+                                    { authenticator.content }
+                                </SegmentedAccordion.Content>
+                            </>
+                        )
+                        : null
                 ))
             }
         </SegmentedAccordion>

--- a/apps/admin-portal/src/components/shared/authenticator-accordion.tsx
+++ b/apps/admin-portal/src/components/shared/authenticator-accordion.tsx
@@ -17,14 +17,14 @@
  */
 
 import { GenericIcon, GenericIconProps } from "@wso2is/react-components";
+import { SegmentedAccordion, SegmentedAccordionTitlePropsInterface } from "@wso2is/react-components";
+import _ from "lodash";
 import React, {
     FunctionComponent,
     ReactElement,
     SyntheticEvent,
     useState
 } from "react";
-import { SegmentedAccordion, SegmentedAccordionTitlePropsInterface } from "@wso2is/react-components";
-import _ from "lodash";
 
 /**
  * Proptypes for the Authenticator Accordion component.
@@ -42,6 +42,10 @@ export interface AuthenticatorAccordionPropsInterface {
      * Accordion actions.
      */
     globalActions?: SegmentedAccordionTitlePropsInterface["actions"];
+    /**
+     * Hides the chevron icon.
+     */
+    hideChevron?: SegmentedAccordionTitlePropsInterface["hideChevron"];
     /**
      * Attribute to sort the array.
      */
@@ -88,6 +92,7 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
         globalActions,
         authenticators,
         defaultActiveIndexes,
+        hideChevron,
         orderBy
     } = props;
 
@@ -137,6 +142,7 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
                                 </>
                             ) }
                             actions={ [ ...authenticator.actions, ...globalActions ] }
+                            hideChevron={ hideChevron }
                         />
                         <SegmentedAccordion.Content
                             active={ accordionActiveIndexes.includes(index) }
@@ -155,5 +161,6 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
  */
 AuthenticatorAccordion.defaultProps = {
     defaultActiveIndexes: [ -1 ],
+    hideChevron: false,
     orderBy: undefined
 };

--- a/modules/react-components/src/accordion/segmented-accordion/segmented-accordion-title.tsx
+++ b/modules/react-components/src/accordion/segmented-accordion/segmented-accordion-title.tsx
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+import classNames from "classnames";
+import React, { FormEvent, FunctionComponent, MouseEvent, ReactElement } from "react";
 import {
     Accordion,
     AccordionTitleProps,
@@ -28,8 +30,6 @@ import {
     SemanticICONS
 } from "semantic-ui-react";
 import { GenericIcon, GenericIconProps } from "../../icon";
-import React, { FormEvent, FunctionComponent, MouseEvent, ReactElement } from "react";
-import classNames from "classnames";
 
 /**
  * Proptypes for the segmented accordion title component.
@@ -47,6 +47,10 @@ export interface SegmentedAccordionTitlePropsInterface extends AccordionTitlePro
      * Clearing
      */
     clearing?: boolean;
+    /**
+     * Hides the chevron icon.
+     */
+    hideChevron?: boolean;
 }
 
 /**
@@ -110,6 +114,7 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
         className,
         clearing,
         content,
+        hideChevron,
         id,
         ...rest
     } = props;
@@ -253,20 +258,22 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
                         { content || children }
                     </Grid.Column>
                     <Grid.Column computer={ 8 } tablet={ 8 } mobile={ 16 } verticalAlign="middle">
-                        {
-                            actions && actions instanceof Array && actions.length > 0 && (
-                                <div className="flex floated right">
-                                    {
-                                        actions.map((action, index) => (
-                                            <div
-                                                key={ index }
-                                                className="mr-3 m-auto"
-                                                onClick={ (e: MouseEvent<HTMLDivElement>) => e.stopPropagation() }
-                                            >
-                                                { resolveAction(action) }
-                                            </div>
-                                        ))
-                                    }
+                        <div className="flex floated right">
+                            {
+                                (actions && actions instanceof Array && actions.length > 0)
+                                    ? actions.map((action, index) => (
+                                        <div
+                                            key={ index }
+                                            className="mr-3 m-auto"
+                                            onClick={ (e: MouseEvent<HTMLDivElement>) => e.stopPropagation() }
+                                        >
+                                            { resolveAction(action) }
+                                        </div>
+                                    ))
+                                    : null
+                            }
+                            {
+                                !hideChevron && (
                                     <GenericIcon
                                         size="default"
                                         defaultIcon
@@ -275,11 +282,11 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
                                         transparent
                                         verticalAlign="middle"
                                         floated="right"
-                                        icon={ <Icon name="angle right" className="chevron" /> }
+                                        icon={ <Icon name="angle right" className="chevron"/> }
                                     />
-                                </div>
-                            )
-                        }
+                                )
+                            }
+                        </div>
                     </Grid.Column>
                 </Grid.Row>
             </Grid>
@@ -287,7 +294,11 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
     );
 };
 
+/**
+ * Default props for the segmented accordion title component.
+ */
 SegmentedAccordionTitle.defaultProps = {
     attached: true,
-    clearing: false
+    clearing: false,
+    hideChevron: false
 };

--- a/modules/react-components/src/accordion/segmented-accordion/segmented-accordion.tsx
+++ b/modules/react-components/src/accordion/segmented-accordion/segmented-accordion.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import { Accordion, AccordionProps } from "semantic-ui-react";
-import React, { FunctionComponent, ReactElement } from "react";
 import classNames from "classnames";
+import React, { FunctionComponent, ReactElement } from "react";
+import { Accordion, AccordionProps } from "semantic-ui-react";
 import { SegmentedAccordionContent } from "./segmented-accordion-content";
 import { SegmentedAccordionTitle } from "./segmented-accordion-title";
 

--- a/modules/theme/src/themes/default/modules/accordion.overrides
+++ b/modules/theme/src/themes/default/modules/accordion.overrides
@@ -18,8 +18,5 @@
                 }
             }
         }
-        .segmented-accordion-content {
-            margin-bottom: 1em;
-        }
     }
 }

--- a/modules/theme/src/themes/default/modules/accordion.overrides
+++ b/modules/theme/src/themes/default/modules/accordion.overrides
@@ -18,5 +18,8 @@
                 }
             }
         }
+        .segmented-accordion-content {
+            margin-bottom: 1em;
+        }
     }
 }


### PR DESCRIPTION
## Purpose
1. IDP list had multiple instances of `AuthenticatorAccordion` component due to having `AuthenticatorAccordion` declared inside the loop.

<img width="523" alt="Screen Shot 2020-04-22 at 10 26 37 PM" src="https://user-images.githubusercontent.com/25959096/80016790-3f2b2b80-84f1-11ea-8719-8b55677b4833.png">

2. Authenticator listing should allow to toggle the visibility of authenticators based on conditions.

## Goals
1. This PR fixed the IDP list issue.
2. Adds `hidden` prop to the `AuthenticatorAccordion` list item component.
2. Adds `hideChevron` prop to the `AuthenticatorAccordion` component so that the chevron icon can be hidden based on the preference.

## Approach

#### Usage of the `hidden` prop.

```tsx
<AuthenticatorAccordion
  ...
  authenticators={[
    {
      ...
      hidden: "<boolean>",
     ...
    },
  ]}
/>;
```