### PR TITLE
Add avatar background to roles feature.

### DIFF
--- a/apps/admin-portal/src/components/claims/claims-list.tsx
+++ b/apps/admin-portal/src/components/claims/claims-list.tsx
@@ -24,7 +24,6 @@ import React, { ReactElement, useContext, useEffect, useRef, useState } from "re
 import { useDispatch } from "react-redux";
 import { Icon, List, Modal, Popup } from "semantic-ui-react";
 import { Image } from "semantic-ui-react";
-import { ClaimsAvatarBackground } from ".";
 import { EditExternalClaim } from "./edit";
 import { deleteAClaim, deleteADialect, deleteAnExternalClaim, getUserStores } from "../../api";
 import { EDIT_EXTERNAL_DIALECT, EDIT_LOCAL_CLAIMS_PATH } from "../../constants";
@@ -38,6 +37,7 @@ import {
     ExternalClaim,
     UserStoreListItem
 } from "../../models";
+import { AvatarBackground } from "../shared";
 
 /**
  * Enum containing the list types.
@@ -443,7 +443,7 @@ export const ClaimsList = (props: ClaimsListPropsInterface): ReactElement => {
                                                 centered
                                                 size="mini"
                                             >
-                                                <ClaimsAvatarBackground />
+                                                <AvatarBackground />
                                                 <span className="claims-letter">
                                                     { generateClaimLetter(claim.claimURI) }
                                                 </span>
@@ -477,7 +477,7 @@ export const ClaimsList = (props: ClaimsListPropsInterface): ReactElement => {
                                                 centered
                                                 size="mini"
                                             >
-                                                <ClaimsAvatarBackground />
+                                                <AvatarBackground />
                                                 <span className="claims-letter">
                                                     { generateDialectLetter(dialect.dialectURI) }
                                                 </span>
@@ -550,7 +550,7 @@ export const ClaimsList = (props: ClaimsListPropsInterface): ReactElement => {
                                                     centered
                                                     size="mini"
                                                 >
-                                                    <ClaimsAvatarBackground />
+                                                    <AvatarBackground />
                                                     <span className="claims-letter">
                                                         { generateClaimLetter(claim.claimURI) }
                                                     </span>
@@ -614,7 +614,7 @@ export const ClaimsList = (props: ClaimsListPropsInterface): ReactElement => {
                                                             centered
                                                             size="mini"
                                                         >
-                                                            <ClaimsAvatarBackground />
+                                                            <AvatarBackground />
                                                             <span className="claims-letter">
                                                                 { generateClaimLetter(claim.claimURI) }
                                                             </span>

--- a/apps/admin-portal/src/components/claims/index.ts
+++ b/apps/admin-portal/src/components/claims/index.ts
@@ -21,4 +21,3 @@ export * from "./add";
 export * from "./edit";
 export * from "./advanced-search";
 export * from "./dynamic-fields";
-export * from "./claims-avatar-background";

--- a/apps/admin-portal/src/components/index.ts
+++ b/apps/admin-portal/src/components/index.ts
@@ -23,6 +23,7 @@ export * from "./notification";
 export * from "./protected-route";
 export * from "./ui";
 export * from "./shared/icon";
+export * from "./shared/avatar-svg-background";
 export * from "./users/users-search";
 export * from "./users/users-list";
 export * from "./claims";

--- a/apps/admin-portal/src/components/roles/role-list.tsx
+++ b/apps/admin-portal/src/components/roles/role-list.tsx
@@ -23,7 +23,7 @@ import { ROLE_VIEW_PATH } from "../../constants";
 import { history } from "../../helpers";
 import { RolesInterface } from "../../models";
 import { CommonUtils } from "../../utils";
-import { ClaimsAvatarBackground } from "../claims";
+import { AvatarBackground } from "../shared";
 
 interface RoleListProps {
     roleList: RolesInterface[];
@@ -80,7 +80,7 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
                                     centered
                                     size="mini"
                                 >
-                                    <ClaimsAvatarBackground />
+                                    <AvatarBackground />
                                     <span className="claims-letter">
                                         { role.displayName[0].toLocaleUpperCase() }
                                     </span>

--- a/apps/admin-portal/src/components/roles/role-list.tsx
+++ b/apps/admin-portal/src/components/roles/role-list.tsx
@@ -16,13 +16,14 @@
  * under the License.
  */
 
-import { Avatar, ConfirmationModal, ResourceList, ResourceListItem } from "@wso2is/react-components";
+import { ConfirmationModal, ResourceList, ResourceListItem } from "@wso2is/react-components";
 import React, { ReactElement, useState } from "react";
-import { Icon } from "semantic-ui-react";
+import { Image } from "semantic-ui-react";
 import { ROLE_VIEW_PATH } from "../../constants";
 import { history } from "../../helpers";
 import { RolesInterface } from "../../models";
 import { CommonUtils } from "../../utils";
+import { ClaimsAvatarBackground } from "../claims";
 
 interface RoleListProps {
     roleList: RolesInterface[];
@@ -72,13 +73,18 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
                                     type: "button"
                             }] }
                             avatar={ (
-                                <Avatar
-                                    name={ role.displayName }
-                                    size="small"
-                                    image={ 
-                                        <Icon size="large" name='users' />
-                                    }
-                                />
+                                <Image
+                                    floated="left"
+                                    verticalAlign="middle"
+                                    rounded
+                                    centered
+                                    size="mini"
+                                >
+                                    <ClaimsAvatarBackground />
+                                    <span className="claims-letter">
+                                        { role.displayName[0].toLocaleUpperCase() }
+                                    </span>
+                                </Image>
                             ) }
                             itemHeader={ role.displayName }
                             metaContent={ CommonUtils.humanizeDateDifference(role.meta.created) }

--- a/apps/admin-portal/src/components/shared/avatar-svg-background.tsx
+++ b/apps/admin-portal/src/components/shared/avatar-svg-background.tsx
@@ -19,9 +19,9 @@
 import React, { ReactElement } from "react";
 
 /**
- * Prop types of `ClaimsAvatarBackground` component
+ * Prop types of `AvataBackground` component
  */
-interface ClaimsAvatarBackgroundPropsInterface {
+interface AvataBackgroundPropsInterface {
     /**
      * Sets if the avatar is of primary color or not
      */
@@ -31,10 +31,10 @@ interface ClaimsAvatarBackgroundPropsInterface {
 /**
  * This component renders the Claim Avatar Background
  * This is a mosaic of 6x6 squares with random opacity values between `0.8` and `1`.
- * @param {ClaimsAvatarBackgroundPropsInterface} props
+ * @param {AvataBackgroundPropsInterface} props
  * @return {ReactElement}
  */
-export const ClaimsAvatarBackground = (props: ClaimsAvatarBackgroundPropsInterface): ReactElement => {
+export const AvatarBackground = (props: AvataBackgroundPropsInterface): ReactElement => {
 
     const { primary } = props;
 

--- a/apps/admin-portal/src/components/shared/index.ts
+++ b/apps/admin-portal/src/components/shared/index.ts
@@ -21,3 +21,4 @@ export * from "./authenticator-accordion";
 export * from "./icon";
 export * from "./empty-placeholder";
 export * from "./modal";
+export * from "./avatar-svg-background";

--- a/apps/admin-portal/src/pages/claim-dialects.tsx
+++ b/apps/admin-portal/src/pages/claim-dialects.tsx
@@ -22,8 +22,8 @@ import React, { ReactElement, useContext, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { Divider, DropdownProps, Grid, Icon, Image, List, PaginationProps, Popup, Segment } from "semantic-ui-react";
 import { getDialects } from "../api";
-import { AddDialect, DialectSearch } from "../components";
-import { ClaimsAvatarBackground, ClaimsList, ListType } from "../components";
+import { AddDialect, DialectSearch, AvatarBackground } from "../components";
+import { ClaimsList, ListType } from "../components";
 import { LOCAL_CLAIMS_PATH, UserConstants } from "../constants";
 import { AppConfig, history } from "../helpers";
 import { ListLayout } from "../layouts";
@@ -190,7 +190,7 @@ export const ClaimDialectsPage = (): ReactElement => {
                                                     centered
                                                     size="mini"
                                                 >
-                                                    <ClaimsAvatarBackground primary />
+                                                    <AvatarBackground primary />
                                                     <span className="claims-letter">
                                                         L
                                                     </span>


### PR DESCRIPTION
## Purpose
> This PR will add `Avatarbackground` as the listing background in roles component. 

<img width="1379" alt="Screenshot 2020-04-23 at 14 35 27" src="https://user-images.githubusercontent.com/11191791/80080774-b1daec00-856f-11ea-9e17-a5881317a64f.png">


Fixes #737