### PR TITLE
Add expert mode options to add a new authenticator

### DIFF
--- a/apps/admin-portal/src/components/identity-providers/forms/components/common-pluggable-component-form.tsx
+++ b/apps/admin-portal/src/components/identity-providers/forms/components/common-pluggable-component-form.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../../../models";
 import { getPropertyMetadata } from "../../utils";
 import { CommonConstants, FieldType, getFieldType, getPropertyField } from "../helpers";
+import { collectAllDependants } from "ts-loader/dist/utils";
 
 /**
  * Common pluggable connector configurations form.
@@ -78,10 +79,17 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
             });
         });
 
-        return {
-            ...initialValues,
-            properties: [...properties]
-        };
+        if (initialValues?.properties) {
+            return {
+                ...initialValues,
+                properties: [...properties]
+            };
+        } else {
+            return {
+                ...metadata,
+                properties: [...properties]
+            };
+        }
     };
 
     /**

--- a/apps/admin-portal/src/components/identity-providers/forms/factories/authenticator-form-factory.tsx
+++ b/apps/admin-portal/src/components/identity-providers/forms/factories/authenticator-form-factory.tsx
@@ -21,7 +21,7 @@ import { FederatedAuthenticatorListItemInterface, FederatedAuthenticatorMetaInte
 import { CommonAuthenticatorForm } from "../authenticators";
 
 /**
- * Proptypes for the inbound form factory component.
+ * Proptypes for the authenticator form factory component.
  */
 interface AuthenticatorFormFactoryInterface {
     metadata?: FederatedAuthenticatorMetaInterface;

--- a/apps/admin-portal/src/components/identity-providers/meta/authenticators.ts
+++ b/apps/admin-portal/src/components/identity-providers/meta/authenticators.ts
@@ -17,8 +17,9 @@
  */
 
 import { IdPIcons } from "../../../configs";
+import { FederatedAuthenticatorMetaDataInterface } from "../../../models";
 
-export const FederatedAuthenticators = [
+export const FederatedAuthenticators: FederatedAuthenticatorMetaDataInterface[] = [
     {
         authenticatorId: "T2ZmaWNlMzY1QXV0aGVudGljYXRvcg",
         icon: IdPIcons.office365,

--- a/apps/admin-portal/src/components/identity-providers/settings/authenticator-settings.tsx
+++ b/apps/admin-portal/src/components/identity-providers/settings/authenticator-settings.tsx
@@ -24,20 +24,17 @@ import { useDispatch } from "react-redux";
 import { CheckboxProps, Grid, Icon } from "semantic-ui-react";
 import {
     getFederatedAuthenticatorDetails,
-    getFederatedAuthenticatorMeta,
+    getFederatedAuthenticatorMeta, getIdentityProviderTemplate,
     getIdentityProviderTemplateList,
     updateFederatedAuthenticator
 } from "../../../api";
-import { IdPCapabilityIcons } from "../../../configs";
 import {
     FederatedAuthenticatorListItemInterface,
     FederatedAuthenticatorListResponseInterface,
     FederatedAuthenticatorWithMetaInterface,
     IdentityProviderTemplateListItemInterface,
     IdentityProviderTemplateListItemResponseInterface,
-    IdentityProviderTemplateListResponseInterface,
-    SupportedServices,
-    SupportedServicesInterface
+    IdentityProviderTemplateListResponseInterface
 } from "../../../models";
 import { AuthenticatorAccordion } from "../../shared";
 import { AuthenticatorFormFactory } from "../forms";
@@ -138,6 +135,24 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
             });
     };
 
+    const handleIDPTemplateAPICallError = (error) => {
+        if (error.response && error.response.data && error.response.data.description) {
+            dispatch(addAlert({
+                description: error.response.data.description,
+                level: AlertLevels.ERROR,
+                message: "Retrieval error"
+            }));
+
+            return;
+        }
+
+        dispatch(addAlert({
+            description: "An error occurred while retrieving IDP template.",
+            level: AlertLevels.ERROR,
+            message: "Retrieval error"
+        }));
+    };
+
     const handleAuthenticatorAPICallError = (error) => {
         if (error.response && error.response.data && error.response.data.description) {
             dispatch(addAlert({
@@ -150,7 +165,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         }
 
         dispatch(addAlert({
-            description: "An error occurred retrieving the federated authenticator details.",
+            description: "An error occurred while retrieving the federated authenticator details.",
             level: AlertLevels.ERROR,
             message: "Retrieval error"
         }));
@@ -168,7 +183,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         }
 
         dispatch(addAlert({
-            description: "An error occurred retrieving the federated authenticator metadata.",
+            description: "An error occurred while retrieving the federated authenticator metadata.",
             level: AlertLevels.ERROR,
             message: "Retrieval error"
         }));
@@ -202,7 +217,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
     };
 
     /**
-     * Asynchronous function to Loop through federated authenticators, fetch data and metadata and
+     * Asynchronous function to loop through federated authenticators, fetch data and metadata and
      * return an array of available authenticators.
      */
     async function fetchAuthenticators() {
@@ -296,20 +311,32 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         setIsTemplatesLoading(true);
         setShowAddAuthenticatorWizard(false);
 
-        // Load available templates from the server
+        // Get the list of available templates from the server
         getIdentityProviderTemplateList()
             .then((response: IdentityProviderTemplateListResponseInterface) => {
                 if (!response?.totalResults) {
                     return;
                 }
-                // sort templateList based on display Order
-                response?.templates.sort((a, b) => (a.displayOrder > b.displayOrder) ? 1 : -1);
+                // Load each template
+                fetchIDPTemplates(response?.templates)
+                    .then((templates) => {
 
-                const availableTemplates: IdentityProviderTemplateListItemInterface[] = interpretAvailableTemplates(
-                    response?.templates);
+                        // Filter out already added authenticators and templates with federated authenticators.
+                        const availableAuthenticatorIDs = availableAuthenticators.map((a) => {
+                            return a.id;
+                        });
+                        const filteredTemplates = templates.filter((template) =>
+                            (template.idp.federatedAuthenticators.defaultAuthenticatorId &&
+                            !availableAuthenticatorIDs.includes(
+                                template.idp.federatedAuthenticators.defaultAuthenticatorId))
+                        );
 
-                setAvailableTemplates(availableTemplates);
-                setShowAddAuthenticatorWizard(true);
+                        // sort templateList based on display Order
+                        filteredTemplates.sort((a, b) => (a.displayOrder > b.displayOrder) ? 1 : -1);
+
+                        setAvailableTemplates(filteredTemplates);
+                        setShowAddAuthenticatorWizard(true);
+                    });
             })
             .catch((error) => {
                 if (error.response && error.response.data && error.response.data.description) {
@@ -333,49 +360,32 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
     };
 
     /**
-     * Interpret available templates from the response templates.
+     * Asynchronous function to loop through IDP templates list and fetch templates.
      *
-     * @param templates List of response templates.
-     * @return List of templates.
+     * @param templatesList List of templates.
      */
-    const interpretAvailableTemplates = (templates: IdentityProviderTemplateListItemResponseInterface[]):
-        IdentityProviderTemplateListItemInterface[] => {
-        return templates?.map(eachTemplate => {
-            if (eachTemplate.services[0] === "") {
-                return {
-                    ...eachTemplate,
-                    services: []
-                };
-            } else {
-                return {
-                    ...eachTemplate,
-                    services: buildSupportedServices(eachTemplate?.services)
-                };
-            }
-        });
-    };
+    async function fetchIDPTemplates(templatesList: IdentityProviderTemplateListItemResponseInterface[]) {
+        const templates: IdentityProviderTemplateListItemInterface[] = [];
+        for (const template of templatesList) {
+            templates.push(await fetchIDPTemplate(template.id));
+        }
+        return templates;
+    }
 
     /**
-     * Build supported services from the given service identifiers.
+     * Fetch IDP template corresponds to the given tempalte ID.
      *
-     * @param serviceIdentifiers Set of service identifiers.
+     * @param templateId ID of the authenticator.
      */
-    const buildSupportedServices = (serviceIdentifiers: string[]): SupportedServicesInterface[] => {
-        return serviceIdentifiers?.map((serviceIdentifier: string): SupportedServicesInterface => {
-            switch (serviceIdentifier) {
-                case SupportedServices.AUTHENTICATION:
-                    return {
-                        displayName: "Authentication Service",
-                        logo: IdPCapabilityIcons[SupportedServices.AUTHENTICATION],
-                        name: SupportedServices.AUTHENTICATION
-                    };
-                case SupportedServices.PROVISIONING:
-                    return {
-                        displayName: "Provisioning Service",
-                        logo: IdPCapabilityIcons[SupportedServices.PROVISIONING],
-                        name: SupportedServices.PROVISIONING
-                    }
-            }
+    const fetchIDPTemplate = (templateId: string): Promise<IdentityProviderTemplateListItemInterface> => {
+        return new Promise(resolve => {
+            getIdentityProviderTemplate(templateId)
+                .then(response => {
+                    resolve(response)
+                })
+                .catch(error => {
+                    handleIDPTemplateAPICallError(error);
+                });
         });
     };
 

--- a/apps/admin-portal/src/components/identity-providers/wizards/steps/authenticator-create-steps/authenticator-template-selection.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizards/steps/authenticator-create-steps/authenticator-template-selection.tsx
@@ -21,7 +21,11 @@ import { Heading, Hint, SelectionCard } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { Grid } from "semantic-ui-react";
 import { IdPIcons } from "../../../../../configs";
-import { IdentityProviderInterface } from "../../../../../models";
+import {
+    FederatedAuthenticatorMetaDataInterface,
+    IdentityProviderInterface,
+    IdentityProviderTemplateListItemInterface
+} from "../../../../../models";
 
 /**
  * Proptypes for the general settings wizard form component.
@@ -29,8 +33,8 @@ import { IdentityProviderInterface } from "../../../../../models";
 interface AuthenticatorTemplateSelectionWizardFormPropsInterface {
     triggerSubmit: boolean;
     onSubmit: (values: any) => void;
-    defaultTemplates: any;
-    authenticatorTemplates: any;
+    expertModeOptions: FederatedAuthenticatorMetaDataInterface[];
+    authenticatorTemplates: IdentityProviderTemplateListItemInterface[];
 }
 
 /**
@@ -47,62 +51,56 @@ export const AuthenticatorTemplateSelection:
     const {
         triggerSubmit,
         onSubmit,
-        defaultTemplates,
+        expertModeOptions,
         authenticatorTemplates
     } = props;
 
-    const [
-        selectedTemplate,
-        setSelectedTemplate
-    ] = useState<IdentityProviderInterface>(undefined);
+    const [ selectedTemplate, setSelectedTemplate ] = useState<IdentityProviderInterface>(undefined);
+    const [ selectedExpertModeOption, setSelectedExpertModeOption ] = useState<any>(undefined);
 
     /**
-     * Handles inbound protocol selection.
+     * Handles template selection.
      *
      * @param {IdentityProviderInterface} template - Selected protocol.
      */
-    const handleInboundProtocolSelection = (template: IdentityProviderInterface): void => {
+    const handleTemplateSelection = (template: IdentityProviderInterface): void => {
         setSelectedTemplate(template);
+        setSelectedExpertModeOption(undefined);
+    };
+
+    /**
+     * Handles expert mode option selection.
+     *
+     * @param option - Selected expert mode option.
+     */
+    const handleExpertModeOptionSelection = (option): void => {
+        setSelectedExpertModeOption(option);
+        setSelectedTemplate(undefined);
     };
 
     return (
         <Forms
             onSubmit={ (): void => {
-                onSubmit({
-                    templateId: selectedTemplate.id
-                })
+                if (selectedTemplate) {
+                    onSubmit({
+                        templateId: selectedTemplate.id
+                    })
+                } else if (selectedExpertModeOption) {
+                    onSubmit({
+                        expertModeOptionId: selectedExpertModeOption.authenticatorId
+                    })
+                }
             } }
             submitState={ triggerSubmit }
         >
             <Grid>
-                {
-                    (defaultTemplates && defaultTemplates instanceof Array && defaultTemplates.length > 0)
-                    &&
-                    <Grid.Row columns={ 1 }>
-                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                            <Heading as="h4">Inbound protocol</Heading>
-                            <Hint icon={ null }>Select one of the following inbound protocol</Hint>
-                            { defaultTemplates.map((temp, index) => (
-                                <SelectionCard
-                                    inline
-                                    id={ temp.id }
-                                    key={ index }
-                                    header={ temp.name }
-                                    image={ IdPIcons[temp.image] }
-                                    onClick={ (): void => handleInboundProtocolSelection(temp) }
-                                    // selected={ selectedInboundProtocol?.id === protocol.id }
-                                />))
-                            }
-                        </Grid.Column>
-                    </Grid.Row>
-                }
                 {
                     (authenticatorTemplates && authenticatorTemplates instanceof Array &&
                         authenticatorTemplates.length > 0) &&
                     <Grid.Row columns={ 1 }>
                         <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                             <Heading as="h4">Templates</Heading>
-                            <Hint icon={ null }>Get the authenticator settings from already available template</Hint>
+                            <Hint icon={ null }>Get the authenticator settings from an already available template</Hint>
                             { authenticatorTemplates.map((template, index) => (
                                 <SelectionCard
                                     inline
@@ -110,8 +108,29 @@ export const AuthenticatorTemplateSelection:
                                     key={ index }
                                     header={ template.name }
                                     image={ IdPIcons[template.image] }
-                                    onClick={ (): void => handleInboundProtocolSelection(template) }
+                                    onClick={ (): void => handleTemplateSelection(template) }
                                     selected={ selectedTemplate?.id === template.id }
+                                />))
+                            }
+                        </Grid.Column>
+                    </Grid.Row>
+                }
+                {
+                    (expertModeOptions && expertModeOptions instanceof Array && expertModeOptions.length > 0)
+                    &&
+                    <Grid.Row columns={ 1 }>
+                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                            <Heading as="h4">Expert Mode</Heading>
+                            <Hint icon={ null }>Add a new authenticator by manually configuring the settings.</Hint>
+                            { expertModeOptions.map((option, index) => (
+                                <SelectionCard
+                                    inline
+                                    id={ option.authenticatorId }
+                                    key={ index }
+                                    header={ option.name }
+                                    image={ option.icon }
+                                    onClick={ (): void => handleExpertModeOptionSelection(option) }
+                                    selected={ selectedExpertModeOption?.authenticatorId === option.authenticatorId }
                                 />))
                             }
                         </Grid.Column>

--- a/apps/admin-portal/src/components/identity-providers/wizards/steps/shared-steps/authenticator-settings.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizards/steps/shared-steps/authenticator-settings.tsx
@@ -52,35 +52,46 @@ export const AuthenticatorSettings: FunctionComponent<AuthenticatorSettingsWizar
     } = props;
 
     const handleSubmit = (authenticator: FederatedAuthenticatorListItemInterface) => {
-        onSubmit({
-            ...initialValues,
-            federatedAuthenticators: {
-                authenticators: [{
-                    ...authenticator,
-                    isDefault: true,
-                    isEnabled: true
-                }],
-                defaultAuthenticatorId: initialValues?.federatedAuthenticators?.defaultAuthenticatorId
-            }
-        });
+        if (initialValues?.id) {
+            onSubmit({
+                ...initialValues,
+                federatedAuthenticators: {
+                    authenticators: [{
+                        ...authenticator,
+                        isDefault: true,
+                        isEnabled: true
+                    }],
+                    defaultAuthenticatorId: initialValues?.federatedAuthenticators?.defaultAuthenticatorId
+                }
+            });
+        } else {
+            onSubmit({
+                federatedAuthenticators: {
+                    authenticators: [{
+                        authenticatorId: authenticator.authenticatorId,
+                        isDefault: false,
+                        isEnabled: true,
+                        properties: authenticator.properties
+                    }],
+                    defaultAuthenticatorId: authenticator.authenticatorId
+                }
+            });
+        }
     };
 
     const authenticator = initialValues?.federatedAuthenticators?.authenticators.find(authenticator =>
         authenticator.authenticatorId === initialValues?.federatedAuthenticators?.defaultAuthenticatorId);
 
-    if (metadata) {
-        return (
+    return (
+        ( metadata ?
             <AuthenticatorFormFactory
                 metadata={ metadata }
-                initialValues={ authenticator }
+                initialValues={ (authenticator ? authenticator : {}) }
                 onSubmit={ handleSubmit }
-                type={ authenticator.name }
+                type={ authenticator?.name }
                 triggerSubmit={ triggerSubmit }
                 enableSubmitButton={ false }
-            />
+            /> : null
         )
-    }
-    return (
-        <></>
     )
 };

--- a/apps/admin-portal/src/components/identity-providers/wizards/steps/shared-steps/wizard-summary.tsx
+++ b/apps/admin-portal/src/components/identity-providers/wizards/steps/shared-steps/wizard-summary.tsx
@@ -68,11 +68,11 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
         onSubmit(identityProvider);
     }, [triggerSubmit]);
 
-    const authenticatorSummary = identityProvider?.federatedAuthenticators?.authenticators.find(
+    const authenticatorSummary = identityProvider?.federatedAuthenticators?.authenticators?.find(
         authenticator => authenticator.authenticatorId === identityProvider?.federatedAuthenticators?.
             defaultAuthenticatorId);
 
-    const provisioningSummary = identityProvider?.provisioning?.outboundConnectors.connectors?.find(connector =>
+    const provisioningSummary = identityProvider?.provisioning?.outboundConnectors?.connectors?.find(connector =>
         connector.connectorId === identityProvider?.provisioning?.outboundConnectors?.defaultConnectorId);
 
     const getPropertySummary = (properties: any[], metaProperties: any[]) => {
@@ -172,12 +172,14 @@ export const WizardSummary: FunctionComponent<WizardSummaryProps> = (
     };
 
     return (
-        <Grid className="wizard-summary">
-            { getGeneralDetailsComponent() }
+        identityProvider ?
+            <Grid className="wizard-summary">
+                { !isAddAuthenticatorWizard && getGeneralDetailsComponent() }
 
-            { isAuthenticatorSettingsStepAvailable() && getAuthenticatorSettingsComponent() }
+                { isAuthenticatorSettingsStepAvailable() && getAuthenticatorSettingsComponent() }
 
-            { isProvisioningSettingsStepAvailable() && getProvisioningSettingsComponent() }
-        </Grid>
+                { isProvisioningSettingsStepAvailable() && getProvisioningSettingsComponent() }
+            </Grid>
+            : null
     );
 };

--- a/apps/admin-portal/src/models/identity-provider.ts
+++ b/apps/admin-portal/src/models/identity-provider.ts
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+import { IdPIcons } from "../configs";
+
 /**
  * Available Identity Provider list.
  */
@@ -91,6 +93,12 @@ export interface IdentityProviderAdvanceInterface {
 export interface CertificateConfigInterface {
     certificates?: string[];
     jwksUri?: string; // TODO  Check for upload option.
+}
+
+export interface FederatedAuthenticatorMetaDataInterface {
+    authenticatorId: string;
+    icon: any;
+    name: string;
 }
 
 export interface FederatedAuthenticatorListItemInterface extends FederatedAuthenticatorInterface {


### PR DESCRIPTION
## Purpose
> No we can add authenticators to an IDP by expert mode options too. Earlier we only supported available IDP templates.

![image](https://user-images.githubusercontent.com/9441136/80367083-14055b00-88a8-11ea-9fdf-03dd3e52f474.png)

Refers: #354