### PR TITLE
[Application Management] Add create SAML from metadata file option & UI fixes

### DIFF
--- a/apps/admin-portal/src/components/applications/application-edit.tsx
+++ b/apps/admin-portal/src/components/applications/application-edit.tsx
@@ -207,10 +207,6 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 onDelete={ onDelete }
                 onUpdate={ onUpdate }
                 featureConfig={ featureConfig }
-                // TODO we need check whether application is active or not as well.
-                showRevoke={
-                    inboundProtocolList.some((protocol) => protocol === SupportedAuthProtocolTypes.OIDC)
-                }
                 template={ template }
             />
         </ResourceTab.Pane>

--- a/apps/admin-portal/src/components/applications/forms/inbound-form-factory.tsx
+++ b/apps/admin-portal/src/components/applications/forms/inbound-form-factory.tsx
@@ -17,12 +17,12 @@
  */
 
 import React, { FunctionComponent } from "react";
+import { InboundCustomProtocolForm } from "./inbound-custom-form";
 import { InboundOIDCForm } from "./inbound-oidc-form";
 import { InboundPassiveStsForm } from "./inbound-passive-sts-form";
 import { InboundSAMLForm } from "./inbound-saml-form";
 import { InboundWSTrustForm } from "./inbound-ws-trust-form";
 import { SupportedAuthProtocolTypes } from "../../../models";
-import { InboundCustomProtocolForm } from "./inbound-custom-form";
 
 /**
  * Proptypes for the inbound form factory component.
@@ -32,8 +32,8 @@ interface InboundFormFactoryInterface {
     initialValues: any;
     onSubmit: (values: any) => void;
     type: SupportedAuthProtocolTypes;
-    handleApplicationRegenerate?: () => void;
-    handleApplicationRevoke?: () => void;
+    onApplicationRegenerate?: () => void;
+    onApplicationRevoke?: () => void;
     /**
      * Make the form read only.
      */
@@ -55,8 +55,8 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
         initialValues,
         onSubmit,
         type,
-        handleApplicationRegenerate,
-        handleApplicationRevoke,
+        onApplicationRegenerate,
+        onApplicationRevoke,
         readOnly
     } = props;
 
@@ -67,8 +67,8 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
                     initialValues={ initialValues }
                     metadata={ metadata }
                     onSubmit={ onSubmit }
-                    handleApplicationRegenerate={ handleApplicationRegenerate }
-                    handleApplicationRevoke={ handleApplicationRevoke }
+                    onApplicationRegenerate={ onApplicationRegenerate }
+                    onApplicationRevoke={ onApplicationRevoke }
                     readOnly={ readOnly }
                 />
             );

--- a/apps/admin-portal/src/components/applications/forms/inbound-form-factory.tsx
+++ b/apps/admin-portal/src/components/applications/forms/inbound-form-factory.tsx
@@ -33,6 +33,7 @@ interface InboundFormFactoryInterface {
     onSubmit: (values: any) => void;
     type: SupportedAuthProtocolTypes;
     handleApplicationRegenerate?: () => void;
+    handleApplicationRevoke?: () => void;
     /**
      * Make the form read only.
      */
@@ -55,6 +56,7 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
         onSubmit,
         type,
         handleApplicationRegenerate,
+        handleApplicationRevoke,
         readOnly
     } = props;
 
@@ -66,6 +68,7 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
                     metadata={ metadata }
                     onSubmit={ onSubmit }
                     handleApplicationRegenerate={ handleApplicationRegenerate }
+                    handleApplicationRevoke={ handleApplicationRevoke }
                     readOnly={ readOnly }
                 />
             );

--- a/apps/admin-portal/src/components/applications/forms/inbound-oidc-form.tsx
+++ b/apps/admin-portal/src/components/applications/forms/inbound-oidc-form.tsx
@@ -27,6 +27,7 @@ import {
     OAuth2PKCEConfigurationInterface,
     OIDCDataInterface,
     OIDCMetadataInterface,
+    State,
     emptyOIDCConfig
 } from "../../../models";
 import { URLInputComponent } from "../components";
@@ -39,6 +40,7 @@ interface InboundOIDCFormPropsInterface {
     initialValues: OIDCDataInterface;
     onSubmit: (values: any) => void;
     handleApplicationRegenerate: () => void;
+    handleApplicationRevoke: () => void;
     /**
      * Make the form read only.
      */
@@ -61,6 +63,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         initialValues,
         onSubmit,
         handleApplicationRegenerate,
+        handleApplicationRevoke,
         readOnly
     } = props;
 
@@ -68,6 +71,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const [callBackUrls, setCallBackUrls] = useState("");
     const [showURLError, setShowURLError] = useState(false);
     const [showRegenerateConfirmationModal, setShowRegenerateConfirmationModal] = useState<boolean>(false);
+    const [showRevokeConfirmationModal, setShowRevokeConfirmationModal] = useState<boolean>(false);
 
     /**
      * Add regexp to multiple callbackUrls and update configs.
@@ -192,6 +196,16 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     };
 
     /**
+     * Show Revoke confirmation.
+     *
+     * @param event Button click event.
+     */
+    const handleRevokeButton = (event) => {
+        event.preventDefault();
+        setShowRevokeConfirmationModal(true)
+    };
+
+    /**
      * Prepares form values for submit.
      *
      * @param values - Form values.
@@ -297,45 +311,91 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             readOnly
                                         />
                                     </Grid.Column>
-                                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 4 }>
+                                </Grid.Row>
+                            )
+                        }
+                        {
+                            initialValues.clientSecret && (
+                                <Grid.Row columns={ 2 }>
+                                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
                                         {
                                             !readOnly && (
-                                                <Button
-                                                    color="red"
-                                                    className="oidc-regenerate-button"
-                                                    onClick={ handleRegenerateButton }
-                                                >
-                                                    Regenerate
-                                                </Button>
+                                                <>
+                                                    <Button
+                                                        color="red"
+                                                        className="oidc-regenerate-button"
+                                                        onClick={ handleRegenerateButton }
+                                                    >
+                                                        Regenerate
+                                                    </Button>
+                                                    <Button
+                                                        color="red"
+                                                        className="oidc-revoke-button"
+                                                        onClick={ handleRevokeButton }
+                                                        disabled={ (initialValues?.state === State.REVOKED) }
+                                                    >
+                                                        Revoke
+                                                    </Button>
+                                                </>
+
                                             )
                                         }
-                                        <ConfirmationModal
-                                            onClose={ (): void => setShowRegenerateConfirmationModal(false) }
-                                            type="warning"
-                                            open={ showRegenerateConfirmationModal }
-                                            assertion={ initialValues?.clientId }
-                                            assertionHint={ <p>Please
-                                                type <strong>{ initialValues?.clientId }</strong> to confirm.</p> }
-                                            assertionType="input"
-                                            primaryAction="Confirm"
-                                            secondaryAction="Cancel"
-                                            onSecondaryActionClick={ (): void => setShowRegenerateConfirmationModal(false) }
-                                            onPrimaryActionClick={ (): void => {
-                                                handleApplicationRegenerate();
-                                                setShowRegenerateConfirmationModal(false);
-                                            }
-                                            }
-                                        >
-                                            <ConfirmationModal.Header>Are you sure?</ConfirmationModal.Header>
-                                            <ConfirmationModal.Message attached warning>
-                                                This action is irreversible and permanently change the client secret.
-                                            </ConfirmationModal.Message>
-                                            <ConfirmationModal.Content>
-                                                If you regenerate this application, All the applications
-                                                depending on this also might stop working. Please proceed with caution.
-                                            </ConfirmationModal.Content>
-                                        </ConfirmationModal>
                                     </Grid.Column>
+                                    <ConfirmationModal
+                                        onClose={ (): void => setShowRegenerateConfirmationModal(false) }
+                                        type="warning"
+                                        open={ showRegenerateConfirmationModal }
+                                        assertion={ initialValues?.clientId }
+                                        assertionHint={
+                                            <p>Please type <strong>{ initialValues?.clientId }</strong> to confirm.</p>
+                                        }
+                                        assertionType="input"
+                                        primaryAction="Confirm"
+                                        secondaryAction="Cancel"
+                                        onSecondaryActionClick={ (): void =>
+                                            setShowRegenerateConfirmationModal(false)
+                                        }
+                                        onPrimaryActionClick={ (): void => {
+                                            handleApplicationRegenerate();
+                                            setShowRegenerateConfirmationModal(false);
+                                        }
+                                        }
+                                    >
+                                        <ConfirmationModal.Header>Are you sure?</ConfirmationModal.Header>
+                                        <ConfirmationModal.Message attached warning>
+                                            This action is irreversible and permanently change the client secret.
+                                        </ConfirmationModal.Message>
+                                        <ConfirmationModal.Content>
+                                            If you regenerate this application, All the applications
+                                            depending on this also might stop working. Please proceed with caution.
+                                        </ConfirmationModal.Content>
+                                    </ConfirmationModal>
+                                    <ConfirmationModal
+                                        onClose={ (): void => setShowRevokeConfirmationModal(false) }
+                                        type="warning"
+                                        open={ showRevokeConfirmationModal }
+                                        assertion={ initialValues?.clientId }
+                                        assertionHint={
+                                            <p>Please type <strong>{ initialValues?.clientId }</strong> to confirm.</p>
+                                        }
+                                        assertionType="input"
+                                        primaryAction="Confirm"
+                                        secondaryAction="Cancel"
+                                        onSecondaryActionClick={ (): void => setShowRevokeConfirmationModal(false) }
+                                        onPrimaryActionClick={ (): void => {
+                                            handleApplicationRevoke();
+                                            setShowRevokeConfirmationModal(false);
+                                        } }
+                                    >
+                                        <ConfirmationModal.Header>Are you sure?</ConfirmationModal.Header>
+                                        <ConfirmationModal.Message attached warning>
+                                            This action is can be reversed by regenerating client secret.
+                                        </ConfirmationModal.Message>
+                                        <ConfirmationModal.Content>
+                                            If you Revoke this application, All the applications
+                                            depending on this also might stop working. Please proceed with caution.
+                                        </ConfirmationModal.Content>
+                                    </ConfirmationModal>
                                 </Grid.Row>
                             )
                         }

--- a/apps/admin-portal/src/components/applications/forms/inbound-oidc-form.tsx
+++ b/apps/admin-portal/src/components/applications/forms/inbound-oidc-form.tsx
@@ -20,7 +20,7 @@ import { Field, Forms } from "@wso2is/forms";
 import { ConfirmationModal, CopyInputField, Heading, Hint } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import { isEmpty } from "lodash";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import { Button, Divider, Form, Grid } from "semantic-ui-react";
 import {
     MetadataPropertyInterface,
@@ -39,8 +39,8 @@ interface InboundOIDCFormPropsInterface {
     metadata: OIDCMetadataInterface;
     initialValues: OIDCDataInterface;
     onSubmit: (values: any) => void;
-    handleApplicationRegenerate: () => void;
-    handleApplicationRevoke: () => void;
+    onApplicationRegenerate: () => void;
+    onApplicationRevoke: () => void;
     /**
      * Make the form read only.
      */
@@ -62,8 +62,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         metadata,
         initialValues,
         onSubmit,
-        handleApplicationRegenerate,
-        handleApplicationRevoke,
+        onApplicationRegenerate,
+        onApplicationRevoke,
         readOnly
     } = props;
 
@@ -190,7 +190,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      *
      * @param event Button click event.
      */
-    const handleRegenerateButton = (event) => {
+    const handleRegenerateButton = (event: MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
         setShowRegenerateConfirmationModal(true)
     };
@@ -200,7 +200,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      *
      * @param event Button click event.
      */
-    const handleRevokeButton = (event) => {
+    const handleRevokeButton = (event: MouseEvent<HTMLButtonElement>) => {
         event.preventDefault();
         setShowRevokeConfirmationModal(true)
     };
@@ -356,7 +356,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             setShowRegenerateConfirmationModal(false)
                                         }
                                         onPrimaryActionClick={ (): void => {
-                                            handleApplicationRegenerate();
+                                            onApplicationRegenerate();
                                             setShowRegenerateConfirmationModal(false);
                                         }
                                         }
@@ -383,7 +383,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                         secondaryAction="Cancel"
                                         onSecondaryActionClick={ (): void => setShowRevokeConfirmationModal(false) }
                                         onPrimaryActionClick={ (): void => {
-                                            handleApplicationRevoke();
+                                            onApplicationRevoke();
                                             setShowRevokeConfirmationModal(false);
                                         } }
                                     >

--- a/apps/admin-portal/src/components/applications/general-application-settings.tsx
+++ b/apps/admin-portal/src/components/applications/general-application-settings.tsx
@@ -23,7 +23,7 @@ import { ConfirmationModal, ContentLoader, DangerZone, DangerZoneGroup } from "@
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { GeneralDetailsForm } from "./forms";
-import { deleteApplication, revokeClientSecret, updateApplicationDetails } from "../../api";
+import { deleteApplication, updateApplicationDetails } from "../../api";
 import {
     ApplicationInterface,
     ApplicationTemplateListItemInterface,
@@ -74,14 +74,6 @@ interface GeneralApplicationSettingsInterface extends SBACInterface<FeatureConfi
      */
     onUpdate: (id: string) => void;
     /**
-     * whether to show regenerate in danger zones or not
-     */
-    showRegenerate?: boolean;
-    /**
-     * whether to show revoke in danger zones or not
-     */
-    showRevoke?: boolean;
-    /**
      * Application template.
      */
     template?: ApplicationTemplateListItemInterface;
@@ -108,7 +100,6 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
         isLoading,
         onDelete,
         onUpdate,
-        showRevoke,
         template
     } = props;
 
@@ -116,8 +107,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
 
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
-    const [ showDeleteConfirmationModal, setShowDeleteConfirmationModal ] = useState<boolean>(false);
-    const [ showRevokeConfirmationModal, setShowRevokeConfirmationModal ] = useState<boolean>(false);
+    const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState<boolean>(false);
 
     /**
      * Deletes an application.
@@ -152,41 +142,6 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                 }));
             });
     };
-
-    /**
-     * Revokes application.
-     */
-    const handleApplicationRevoke = (): void => {
-        revokeClientSecret(appId)
-            .then(() => {
-                dispatch(addAlert({
-                    description: "Successfully revoked the application",
-                    level: AlertLevels.SUCCESS,
-                    message: "Revoke successful"
-                }));
-
-                setShowRevokeConfirmationModal(false);
-                onUpdate(appId);
-            })
-            .catch((error) => {
-                if (error.response && error.response.data && error.response.data.description) {
-                    dispatch(addAlert({
-                        description: error.response.data.description,
-                        level: AlertLevels.ERROR,
-                        message: "Application revoke Error"
-                    }));
-
-                    return;
-                }
-
-                dispatch(addAlert({
-                    description: "An error occurred while revoking the application",
-                    level: AlertLevels.ERROR,
-                    message: "Application Revoke Error"
-                }));
-            });
-    };
-
 
     /**
      * Handles form submit action.
@@ -237,20 +192,10 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
             return null;
         }
 
-        if (showRevoke
-            || hasRequiredScopes(featureConfig?.applications, featureConfig?.applications?.scopes?.delete)) {
+        if (hasRequiredScopes(featureConfig?.applications, featureConfig?.applications?.scopes?.delete)) {
 
             return (
                 <DangerZoneGroup sectionHeader="Danger Zone">
-                    { showRevoke && (
-                        <DangerZone
-                            actionTitle="Revoke"
-                            header="Revoke the application"
-                            subheader="This action is reversible but cannot use the same
-                                                    client secret. Please proceed with caution."
-                            onActionClick={ (): void => setShowRevokeConfirmationModal(true) }
-                        />
-                    ) }
                     { hasRequiredScopes(featureConfig?.applications, featureConfig?.applications?.scopes?.delete) && (
                         <DangerZone
                             actionTitle="Delete"
@@ -304,27 +249,6 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                         </ConfirmationModal.Message>
                         <ConfirmationModal.Content>
                             If you delete this application, you will not be able to get it back. All the applications
-                            depending on this also might stop working. Please proceed with caution.
-                        </ConfirmationModal.Content>
-                    </ConfirmationModal>
-                    <ConfirmationModal
-                        onClose={ (): void => setShowRevokeConfirmationModal(false) }
-                        type="warning"
-                        open={ showRevokeConfirmationModal }
-                        assertion={ name }
-                        assertionHint={ <p>Please type <strong>{ name }</strong> to confirm.</p> }
-                        assertionType="input"
-                        primaryAction="Confirm"
-                        secondaryAction="Cancel"
-                        onSecondaryActionClick={ (): void => setShowRevokeConfirmationModal(false) }
-                        onPrimaryActionClick={ (): void => handleApplicationRevoke() }
-                    >
-                        <ConfirmationModal.Header>Are you sure?</ConfirmationModal.Header>
-                        <ConfirmationModal.Message attached warning>
-                            This action is can be reversed by regenerating client secret.
-                        </ConfirmationModal.Message>
-                        <ConfirmationModal.Content>
-                            If you Revoke this application, All the applications
                             depending on this also might stop working. Please proceed with caution.
                         </ConfirmationModal.Content>
                     </ConfirmationModal>

--- a/apps/admin-portal/src/components/applications/general-application-settings.tsx
+++ b/apps/admin-portal/src/components/applications/general-application-settings.tsx
@@ -193,18 +193,20 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
         }
 
         if (hasRequiredScopes(featureConfig?.applications, featureConfig?.applications?.scopes?.delete)) {
-
             return (
                 <DangerZoneGroup sectionHeader="Danger Zone">
-                    { hasRequiredScopes(featureConfig?.applications, featureConfig?.applications?.scopes?.delete) && (
-                        <DangerZone
-                            actionTitle="Delete"
-                            header="Delete application"
-                            subheader={ "Once you delete an application, there is no going back. " +
-                            "Please be certain." }
-                            onActionClick={ (): void => setShowDeleteConfirmationModal(true) }
-                        />
-                    ) }
+                    {
+                        hasRequiredScopes(featureConfig?.applications, featureConfig?.applications?.scopes?.delete) &&
+                        (
+                            <DangerZone
+                                actionTitle="Delete"
+                                header="Delete application"
+                                subheader={ "Once you delete an application, there is no going back. " +
+                                "Please be certain." }
+                                onActionClick={ (): void => setShowDeleteConfirmationModal(true) }
+                            />
+                        )
+                    }
                 </DangerZoneGroup>
             );
         }

--- a/apps/admin-portal/src/components/applications/meta/custom-application-template.meta.ts
+++ b/apps/admin-portal/src/components/applications/meta/custom-application-template.meta.ts
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-import { ApplicationTemplateListItemInterface } from "../../../models";
+import { ApplicationTemplateCategories, ApplicationTemplateListItemInterface } from "../../../models";
 
 export const CustomApplicationTemplate: ApplicationTemplateListItemInterface = {
     authenticationProtocol: "",
-    category: "DEFAULT",
+    category: ApplicationTemplateCategories.DEFAULT_CUSTOM,
     description: "Manually configure the inbound authentication protocol, authentication flow, etc.",
     displayOrder: 0,
     id: "custom-application",

--- a/apps/admin-portal/src/components/applications/settings-application.tsx
+++ b/apps/admin-portal/src/components/applications/settings-application.tsx
@@ -297,8 +297,8 @@ export const ApplicationSettings: FunctionComponent<ApplicationSettingsPropsInte
                                                 protocol)
                                         }
                                         type={ protocol as SupportedAuthProtocolTypes }
-                                        handleApplicationRegenerate={ handleApplicationRegenerate }
-                                        handleApplicationRevoke={ handleApplicationRevoke }
+                                        onApplicationRegenerate={ handleApplicationRegenerate }
+                                        onApplicationRevoke={ handleApplicationRevoke }
                                         readOnly={
                                             !hasRequiredScopes(
                                                 featureConfig?.applications,

--- a/apps/admin-portal/src/components/applications/settings-application.tsx
+++ b/apps/admin-portal/src/components/applications/settings-application.tsx
@@ -33,7 +33,13 @@ import { useDispatch, useSelector } from "react-redux";
 import { Button, Grid, Icon } from "semantic-ui-react";
 import { InboundFormFactory } from "./forms";
 import { ApplicationCreateWizard } from "./wizard";
-import { deleteProtocol, getAuthProtocolMetadata, regenerateClientSecret, updateAuthProtocolConfig } from "../../api";
+import {
+    deleteProtocol,
+    getAuthProtocolMetadata,
+    regenerateClientSecret,
+    revokeClientSecret,
+    updateAuthProtocolConfig
+} from "../../api";
 import { EmptyPlaceholderIllustrations, InboundProtocolLogos } from "../../configs";
 import { FeatureConfigInterface, SupportedAuthProtocolMetaTypes, SupportedAuthProtocolTypes } from "../../models";
 import { AppState } from "../../store";
@@ -205,6 +211,38 @@ export const ApplicationSettings: FunctionComponent<ApplicationSettingsPropsInte
     };
 
     /**
+     * Revokes application.
+     */
+    const handleApplicationRevoke = (): void => {
+        revokeClientSecret(appId)
+            .then(() => {
+                dispatch(addAlert({
+                    description: "Successfully revoked the application",
+                    level: AlertLevels.SUCCESS,
+                    message: "Revoke successful"
+                }));
+                onUpdate(appId);
+            })
+            .catch((error) => {
+                if (error.response && error.response.data && error.response.data.description) {
+                    dispatch(addAlert({
+                        description: error.response.data.description,
+                        level: AlertLevels.ERROR,
+                        message: "Application revoke Error"
+                    }));
+
+                    return;
+                }
+
+                dispatch(addAlert({
+                    description: "An error occurred while revoking the application",
+                    level: AlertLevels.ERROR,
+                    message: "Application Revoke Error"
+                }));
+            });
+    };
+
+    /**
      * Handles Authenticator delete button on click action.
      *
      * @param {React.MouseEvent<HTMLDivElement>} e - Click event.
@@ -260,6 +298,7 @@ export const ApplicationSettings: FunctionComponent<ApplicationSettingsPropsInte
                                         }
                                         type={ protocol as SupportedAuthProtocolTypes }
                                         handleApplicationRegenerate={ handleApplicationRegenerate }
+                                        handleApplicationRevoke={ handleApplicationRevoke }
                                         readOnly={
                                             !hasRequiredScopes(
                                                 featureConfig?.applications,
@@ -295,7 +334,6 @@ export const ApplicationSettings: FunctionComponent<ApplicationSettingsPropsInte
                                                 protocol)
                                         }
                                         type={ SupportedAuthProtocolTypes.CUSTOM }
-                                        handleApplicationRegenerate={ handleApplicationRegenerate }
                                         readOnly={
                                             !hasRequiredScopes(
                                                 featureConfig?.applications,

--- a/apps/admin-portal/src/components/applications/wizard/application-create-wizard.tsx
+++ b/apps/admin-portal/src/components/applications/wizard/application-create-wizard.tsx
@@ -175,6 +175,8 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
     const [triggerProtocolSelectionSubmit, setTriggerProtocolSelectionSubmit] = useState<boolean>(false);
     const [selectedCustomInboundProtocol, setSelectedCustomInboundProtocol] = useState<boolean>(false);
 
+    const [selectedSAMLMetaFile, setSelectedSAMLMetaFile] = useState<boolean>(false);
+
     /**
      *  Retrieve Application template data.
      *
@@ -518,7 +520,7 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
                                 <SAMLProtocolAllSettingsWizardForm
                                     triggerSubmit={ submitOAuth }
                                     initialValues={ wizardState && wizardState[WizardStepsFormTypes.PROTOCOL_SETTINGS] }
-                                    templateValues={ templateSettings }
+                                    updateSelectedSAMLMetaFile={ setSelectedSAMLMetaFile }
                                     onSubmit={ (values): void => handleWizardFormSubmit(values,
                                         WizardStepsFormTypes.PROTOCOL_SETTINGS) }
                                 /> :
@@ -565,6 +567,7 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
                             onSubmit={ HandleApplicationProtocolsUpdate }
                             image={ selectedTemplate.authenticationProtocol }
                             customProtocol={ selectedCustomInboundProtocol }
+                            samlMetaFileSelected={ selectedSAMLMetaFile }
                         />
                     )
                 } else {

--- a/apps/admin-portal/src/components/applications/wizard/protocol-selection-wizard-form.tsx
+++ b/apps/admin-portal/src/components/applications/wizard/protocol-selection-wizard-form.tsx
@@ -24,7 +24,7 @@ import {
     EmptyPlaceholderIllustrations,
     InboundProtocolLogos
 } from "../../../configs";
-import { ApplicationTemplateListItemInterface } from "../../../models";
+import { ApplicationTemplateCategories, ApplicationTemplateListItemInterface } from "../../../models";
 import { AppState } from "../../../store";
 import { ApplicationManagementUtils } from "../../../utils";
 import { EmptyPlaceholder } from "../../shared";
@@ -224,7 +224,10 @@ export const ProtocolSelectionWizardForm: FunctionComponent<ProtocolSelectionWiz
             { !isApplicationTemplateRequestLoading && (
                 <TemplateGrid<ApplicationTemplateListItemInterface>
                     type="application"
-                    templates={ availableTemplates }
+                    templates={
+                        availableTemplates.filter((template) =>
+                            template.category === ApplicationTemplateCategories.DEFAULT)
+                    }
                     templateIcons={ ApplicationTemplateIllustrations }
                     heading="Quick Setup"
                     subHeading={ "Get protocol configuration from a template" }

--- a/apps/admin-portal/src/components/applications/wizard/protocol-wizard-summary.tsx
+++ b/apps/admin-portal/src/components/applications/wizard/protocol-wizard-summary.tsx
@@ -20,13 +20,9 @@ import { EncodeDecodeUtils } from "@wso2is/core/utils";
 import { AppAvatar, UserAvatar } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Grid, Label } from "semantic-ui-react";
-import {
-    MainApplicationInterface,
-    SubmitFormCustomPropertiesInterface,
-    SupportedAuthProtocolTypes
-} from "../../../models";
-import { ApplicationManagementUtils } from "../../../utils/application-management-utils";
 import { InboundProtocolLogos } from "../../../configs/ui";
+import { SubmitFormCustomPropertiesInterface, SupportedAuthProtocolTypes } from "../../../models";
+import { ApplicationManagementUtils } from "../../../utils/application-management-utils";
 
 
 /**
@@ -35,9 +31,10 @@ import { InboundProtocolLogos } from "../../../configs/ui";
 interface ProtocolWizardSummaryPropsInterface {
     summary: any;
     triggerSubmit: boolean;
-    onSubmit: (application: MainApplicationInterface) => void;
+    onSubmit: (values: any) => void;
     customProtocol: boolean;
     image: string;
+    samlMetaFileSelected: boolean;
 }
 
 /**
@@ -55,7 +52,8 @@ export const ProtocolWizardSummary: FunctionComponent<ProtocolWizardSummaryProps
         triggerSubmit,
         onSubmit,
         image,
-        customProtocol
+        customProtocol,
+        samlMetaFileSelected
     } = props;
 
     const [protocolImage, setProtocolImage] = useState<string>("");
@@ -65,6 +63,14 @@ export const ProtocolWizardSummary: FunctionComponent<ProtocolWizardSummaryProps
      */
     useEffect(() => {
         if (!triggerSubmit) {
+            return;
+        }
+
+        if (samlMetaFileSelected) {
+            const newSummary = {
+                metadataFile: summary?.metadataFile
+            };
+            onSubmit(newSummary);
             return;
         }
 
@@ -165,6 +171,18 @@ export const ProtocolWizardSummary: FunctionComponent<ProtocolWizardSummaryProps
                 )
             }
             {
+                summary?.metadataFile && (
+                    <Grid.Row className="summary-field" columns={ 2 }>
+                        <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">
+                            <div className="label">Meta File(Base64Encoded)</div>
+                        </Grid.Column>
+                        <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 8 } textAlign="left">
+                            <div className="value constrain">{ summary?.metadataFile }</div>
+                        </Grid.Column>
+                    </Grid.Row>
+                )
+            }
+            {
                 summary?.callbackURLs && (
                     <Grid.Row className="summary-field" columns={ 2 }>
                         <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">
@@ -249,4 +267,8 @@ export const ProtocolWizardSummary: FunctionComponent<ProtocolWizardSummaryProps
             }
         </Grid>
     );
+};
+
+ProtocolWizardSummary.defaultProps = {
+    samlMetaFileSelected: false
 };

--- a/apps/admin-portal/src/components/shared/index.ts
+++ b/apps/admin-portal/src/components/shared/index.ts
@@ -22,3 +22,4 @@ export * from "./icon";
 export * from "./empty-placeholder";
 export * from "./modal";
 export * from "./avatar-svg-background";
+export * from "./upload-file";

--- a/apps/admin-portal/src/components/shared/upload-file.tsx
+++ b/apps/admin-portal/src/components/shared/upload-file.tsx
@@ -1,0 +1,413 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the 'License'); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import _ from "lodash";
+import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
+import { Button, Divider, Form, Icon, Message, Segment, Tab, TextArea } from "semantic-ui-react";
+import { CertificateIllustrations } from "../../configs";
+
+/**
+ * Component to upload file and read the content.
+ */
+interface UploadFilePropsInterface {
+    /**
+     * Method to update file state in parent component.
+     */
+    updateFile: (file: File) => void;
+    /**
+     * Method to update file name state in parent component.
+     */
+    updateFileName: (name: string) => void;
+    /**
+     * Method to update file content in parent component.
+     */
+    updateContent: (value: string) => void;
+    /**
+     * Method to update paste value in parent component.
+     */
+    updatePasteContent?: (value: string) => void;
+    /**
+     * Encode the file content or not.
+     */
+    encode?: boolean;
+    /**
+     * Initial file name.
+     */
+    initialName?: string;
+    /**
+     * Initial file.
+     */
+    initialFile?: File;
+    /**
+     * Initial paste value.
+     */
+    initialPasteValue?: string;
+    /**
+     * Initial file content.
+     */
+    initialContent?: string;
+    /**
+     * Trigger empty file error.
+     */
+    triggerEmptyFileError?: boolean;
+    /**
+     * File type that can be uploaded.
+     */
+    fileTypeToUpload?: string;
+}
+
+/**
+ * Component to upload file and read the content.
+ *
+ * @param props  {UploadFilePropsInterface} props - Props injected to the component.
+ *
+ * @return {React.ReactElement}.
+ */
+export const UploadFile: FunctionComponent<UploadFilePropsInterface> = (
+    props: UploadFilePropsInterface
+): ReactElement => {
+
+    const {
+        initialName,
+        initialFile,
+        initialPasteValue,
+        initialContent,
+        updateFileName,
+        updateFile,
+        updateContent,
+        updatePasteContent,
+        encode,
+        triggerEmptyFileError,
+        fileTypeToUpload
+    } = props;
+
+    const [name, setName] = useState("");
+    const [file, setFile] = useState<File>(null);
+    const [content, setContent] = useState("");
+    const [pasteContent, setPasteContent] = useState("");
+    const [encodedContent, setEncodedContent] = useState("");
+
+    const [nameError, setNameError] = useState(false);
+    const [fileError, setFileError] = useState(false);
+    const [encodeError, setEncodeError] = useState(false);
+
+    const [dragOver, setDragOver] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(0);
+    const [dark, setDark] = useState(false);
+
+    const fileUpload = useRef(null);
+    const loadedInitValue = useRef(false);
+
+    /**
+     * Set initialValues.
+     */
+    useEffect(() => {
+        if (initialName) {
+            setName(initialName);
+        }
+    }, [initialName]);
+
+    /**
+     * Set initialValues.
+     */
+    useEffect(() => {
+        if (initialFile) {
+            setFile(initialFile);
+        }
+    }, [initialFile]);
+
+    /**
+     * Set initialValues.
+     */
+    useEffect(() => {
+        if (initialName) {
+            setName(initialName)
+        }
+        if (initialFile) {
+            setFile(initialFile)
+        }
+        if (initialPasteValue) {
+            setPasteContent(initialPasteValue)
+        }
+        if (!loadedInitValue.current) {
+            loadedInitValue.current = true;
+        }
+        if (initialContent) {
+            // Check if initial content is not equal to initial  paste content or not
+            if (!(initialPasteValue && (
+                    (encode && ((initialContent) === btoa(initialPasteValue)))
+                    || (!encode && (initialContent === initialPasteValue)))
+            )) {
+                if (encode) {
+                    setEncodedContent(initialContent)
+                    return;
+                }
+                setContent(initialContent);
+            }
+        }
+    }, []);
+
+    /**
+     * Trigger file error.
+     */
+    useEffect(() => {
+        if (triggerEmptyFileError) {
+            setFileError(true);
+        }
+    }, [triggerEmptyFileError]);
+
+    /**
+     * Update file name.
+     */
+    useEffect(() => {
+        if (name || loadedInitValue.current) {
+            if (name) {
+                setNameError(false);
+            }
+            updateFileName(name);
+        }
+    }, [name]);
+
+    /***
+     * Update file.
+     */
+    useEffect(() => {
+        if (file || loadedInitValue.current) {
+            if (file) {
+                setFileError(false);
+            }
+            updateFile(file);
+        }
+    }, [file]);
+
+    /**
+     * Update content if encoded content is updated.
+     */
+    useEffect(() => {
+        if (encode && (encodedContent || (loadedInitValue.current))) {
+            updateContent(encodedContent);
+        }
+    }, [encodedContent]);
+
+    /**
+     * Update content if content is updated.
+     */
+    useEffect(() => {
+        if (!encode && (content || (loadedInitValue.current))) {
+            updateContent(content);
+        }
+    }, [content]);
+
+    /**
+     * Update content if paste content is updated.
+     */
+    useEffect(() => {
+        if (pasteContent) {
+            updatePasteContent(pasteContent);
+            if (encode) {
+                updateContent(btoa(pasteContent));
+                return
+            }
+            updateContent(pasteContent);
+        } else {
+            if (loadedInitValue.current) {
+                updatePasteContent(pasteContent);
+            }
+        }
+    }, [pasteContent]);
+
+    /**
+     * Update contents if paste value or file content removed.
+     */
+    useEffect(() => {
+        const fileContent = encode ? encodedContent : content;
+        const newPasteContent = encode ? btoa(pasteContent) : pasteContent;
+
+        if (_.isEmpty(fileContent) && !_.isEmpty(newPasteContent)) {
+            updateContent(newPasteContent);
+        } else if (!_.isEmpty(fileContent) && _.isEmpty(newPasteContent)) {
+            updateContent(fileContent);
+        } else if (_.isEmpty(fileContent) && _.isEmpty(newPasteContent)) {
+            updateContent("");
+        }
+    }, [content, encodedContent, pasteContent]);
+
+    useEffect(() => {
+        if (window.matchMedia("(prefers-color-scheme:dark)").matches) {
+            setDark(true);
+        }
+        const callback = (e) => {
+            if (e.matches) {
+                setDark(true);
+            } else {
+                setDark(false);
+            }
+        };
+        window.matchMedia("(prefers-color-scheme:dark)").addEventListener("change", callback);
+
+        return () => {
+            window.matchMedia("(prefers-color-scheme:dark)").removeEventListener("change", callback);
+        }
+    }, []);
+
+    const panes = [
+        {
+            menuItem: "Upload",
+            render: () => (
+                !file
+                    ? (
+                        <div
+                            onDrop={ (event: React.DragEvent<HTMLDivElement>) => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                setDragOver(false);
+                                if (event.dataTransfer.files[0]) {
+                                    const file = event.dataTransfer.files[0];
+                                    addFile(file);
+                                }
+                            }
+                            }
+                            onDragOver={ event => {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                setDragOver(true);
+                            } }
+                            onDragLeave={ () => {
+                                setDragOver(false);
+                            } }
+                        >
+                            <Segment placeholder className={ `drop-zone ${ dragOver ? "drag-over" : "" }` }>
+                                <div className="certificate-upload-placeholder">
+                                    <CertificateIllustrations.uploadPlaceholder.ReactComponent/>
+                                    <p className="description">Drag and drop file here</p>
+                                    <p className="description">– or –</p>
+                                </div>
+                                <Button basic primary onClick={ (event) => {
+                                    event.preventDefault();
+                                    fileUpload.current.click();
+                                } }>
+                                    Upload
+                                </Button>
+                            </Segment>
+                        </div>
+                    )
+                    : (
+                        <Segment placeholder>
+                            <Segment textAlign="center" basic>
+                                <Icon name='file code outline' size='huge'/>
+                                <p className="file-name">{ file.name }</p>
+                                <Icon name="trash alternate" link onClick={ () => {
+                                    setFile(null);
+                                    setContent("");
+                                    setEncodedContent("");
+                                    setFileError(false);
+                                } }/>
+                            </Segment>
+                        </Segment>
+                    )
+            )
+        },
+        {
+            menuItem: "Paste",
+            render: () => (
+                <Form>
+                    <TextArea
+                        rows={ 13 }
+                        placeholder="Paste the content File"
+                        value={ pasteContent }
+                        onChange={ (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+                            setPasteContent(event.target.value);
+                            setEncodeError(false);
+                            setFileError(false);
+                        } }
+                        spellCheck={ false }
+                        className={ `certificate-editor ${ dark ? "dark" : "light" }` }
+                    />
+                </Form>
+            )
+        }
+    ];
+
+    /**
+     * Add the file.
+     * @param file File to be added.
+     */
+    const addFile = (file: File): void => {
+        setFile(file);
+        setEncodeError(false);
+        setFileError(false);
+        const fileName = file.name.split(".");
+        // removes the file extension
+        fileName.pop();
+        !name && setName(fileName.join("."));
+        readFile(file);
+    };
+
+    const readFile = ((newFile: File) => {
+
+        const reader = new FileReader();
+        reader.readAsText(newFile);
+        reader.onload = () => {
+            setContent(reader.result as string);
+            setEncodedContent(btoa(reader.result as string));
+        };
+    });
+
+    return (
+        <>
+            <input
+                ref={ fileUpload }
+                type="file"
+                accept={ fileTypeToUpload }
+                hidden
+                onChange={ (event) => {
+                    const file: File = event.target.files[0];
+                    event.target.value = null;
+                    addFile(file);
+                } }
+            />
+            {
+                fileError
+                    ?
+                    <Message negative attached="bottom">
+                        <Message.Header> Either add a file or paste the content of the file</Message.Header>
+                    </Message>
+                    : <Divider hidden/>
+            }
+            <Tab
+                className="tabs resource-tabs"
+                menu={ {
+                    pointing: true,
+                    secondary: true
+                } }
+                panes={ panes }
+                activeIndex={ activeIndex }
+                onTabChange={ (event, { activeIndex }) => {
+                    setActiveIndex(parseInt(activeIndex.toString()));
+                } }
+            />
+
+        </>
+
+    )
+};
+
+UploadFile.defaultProps = {
+    encode: false,
+    fileTypeToUpload: "text/xml"
+};

--- a/apps/admin-portal/src/models/application.ts
+++ b/apps/admin-portal/src/models/application.ts
@@ -268,6 +268,18 @@ export enum SupportedApplicationTemplateCategories {
 }
 
 /**
+ * Enum for application template categories.
+ *
+ * @readonly
+ * @enum {string}
+ */
+export enum ApplicationTemplateCategories {
+    DEFAULT = "DEFAULT",
+    CUSTOM = "CUSTOM",
+    DEFAULT_CUSTOM = "DEFAULT_CUSTOM"
+}
+
+/**
  *  Application template technology interface.
  */
 export interface ApplicationTemplateTechnology {

--- a/apps/admin-portal/src/pages/application-template.tsx
+++ b/apps/admin-portal/src/pages/application-template.tsx
@@ -26,7 +26,7 @@ import { CustomApplicationTemplate } from "../components/applications/meta";
 import { ApplicationTemplateIllustrations, EmptyPlaceholderIllustrations } from "../configs";
 import { history } from "../helpers";
 import { PageLayout } from "../layouts";
-import { ApplicationTemplateListItemInterface } from "../models";
+import { ApplicationTemplateCategories, ApplicationTemplateListItemInterface } from "../models";
 import { AppState } from "../store";
 import { ApplicationManagementUtils } from "../utils";
 
@@ -113,7 +113,8 @@ export const ApplicationTemplateSelectPage: FunctionComponent<{}> = (): ReactEle
                             <TemplateGrid<ApplicationTemplateListItemInterface>
                                 type="application"
                                 templates={
-                                    applicationTemplates.filter((template) => template.id !== "custom-application")
+                                    applicationTemplates.filter((template) =>
+                                        template.category === ApplicationTemplateCategories.DEFAULT)
                                 }
                                 templateIcons={ ApplicationTemplateIllustrations }
                                 heading={ t("devPortal:components.applications.templates.quickSetup.heading") }
@@ -143,7 +144,10 @@ export const ApplicationTemplateSelectPage: FunctionComponent<{}> = (): ReactEle
             <div className="custom-templates">
                 <TemplateGrid<ApplicationTemplateListItemInterface>
                     type="application"
-                    templates={ [CustomApplicationTemplate] }
+                    templates={
+                        applicationTemplates.filter((template) =>
+                            template.category === ApplicationTemplateCategories.DEFAULT_CUSTOM)
+                    }
                     templateIcons={ ApplicationTemplateIllustrations }
                     heading={ t("devPortal:components.applications.templates.manualSetup.heading") }
                     subHeading={ t("devPortal:components.applications.templates.manualSetup.subHeading") }

--- a/modules/theme/src/themes/default/elements/button.overrides
+++ b/modules/theme/src/themes/default/elements/button.overrides
@@ -266,6 +266,10 @@
 
 .ui.button {
     &.oidc-regenerate-button {
-        margin-top: 25px;
+        margin-right: @OIDCButtonMarginRight;
+        width: @OIDCButtonWidth;
+    }
+    &.oidc-revoke-button {
+        width: @OIDCButtonWidth;
     }
 }

--- a/modules/theme/src/themes/default/elements/button.variables
+++ b/modules/theme/src/themes/default/elements/button.variables
@@ -57,3 +57,9 @@
 
 @generatePasswordButtonPadding: 12px 27px;
 @generatePasswordButtonMarginTop: 22px;
+
+/*----------------------------
+   OIDC button
+------------------------------*/
+@OIDCButtonMarginRight: 25px;
+@OIDCButtonWidth: 120px;

--- a/modules/theme/src/themes/default/modules/modal.overrides
+++ b/modules/theme/src/themes/default/modules/modal.overrides
@@ -248,6 +248,10 @@
                         &.url {
                             font-style: italic;
                         }
+
+                        &.constrain {
+                            word-wrap: break-word;
+                        }
                     }
                 }
                 .result-container {


### PR DESCRIPTION
## Purpose

1. Add option to create SAML from the metadata file
![image](https://user-images.githubusercontent.com/17597685/80589481-e3542b80-8a37-11ea-873d-8722685f9eb5.png)

2. Move revoke to OIDC form
![image](https://user-images.githubusercontent.com/17597685/80589558-0aaaf880-8a38-11ea-8ef8-784c7084992b.png)

3. Filer application template using categories
* DEFAULT - server default application templates
* CUSTOM - user-added application templates (future)
* DEFAULT_CUSTOM - templates added from the UI eg custom application