### PR TITLE
[Dev Portal] Integrate Userstore template images + Userstore listing UI fixes

### DIFF
--- a/apps/developer-portal/src/configs/ui.ts
+++ b/apps/developer-portal/src/configs/ui.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+    ActiveDirectoryUserstoreIllustration,
     AlertIcon,
     AndroidLogo,
     AngularLogo,
@@ -50,8 +51,8 @@ import {
     DragIcon,
     DragSquaresIcon,
     DummyUser,
-    EmailOTPIcon,
     EmailIcon,
+    EmailOTPIcon,
     EmptySearchResultsIllustration,
     ErrorIcon,
     ExpertModeIdPIcon,
@@ -67,9 +68,11 @@ import {
     HTMLLogo,
     HomeTileIcons,
     InfoIcon,
+    JDBCUserstoreIllustration,
     JWTLogo,
     JavaLogo,
     JavaScriptLogo,
+    LDAPUserstoreIllustration,
     LaunchIcon,
     LockShieldIcon,
     Logo,
@@ -91,14 +94,14 @@ import {
     ReactLogo,
     ReportIcon,
     SAMLWebAppTemplateIllustration,
+    SCIMLogo,
     SMSOTPIcon,
     SPATemplateIllustration,
+    SPMLLogo,
     SalesforceLogo,
     SamlLogo,
-    SCIMLogo,
     SettigsSectionIconSet,
     SpinWheelIcon,
-    SPMLLogo,
     SuccessIcon,
     TOTPIcon,
     TwitterIdPIcon,
@@ -142,7 +145,7 @@ export const SidePanelIcons = {
     serverConfigurations: GearsIcon,
     userStore: DatabaseIcon,
     usersAndRoles: UserIcon
-}
+};
 
 export const SidePanelMiscIcons = {
     caretRight: CaretRightIcon
@@ -371,4 +374,11 @@ export const OutboundProvisioningConnectorWizard = {
     connectorDetails: DocumentIcon,
     connectorSelection: GearsIcon,
     summary: ReportIcon
+};
+
+export const UserstoreTemplateIllustrations = {
+    ad: ActiveDirectoryUserstoreIllustration,
+    default: CustomApplicationTemplateIllustration,
+    jdbc: JDBCUserstoreIllustration,
+    ldap: LDAPUserstoreIllustration
 };

--- a/apps/developer-portal/src/constants/user-store-constants.ts
+++ b/apps/developer-portal/src/constants/user-store-constants.ts
@@ -50,3 +50,18 @@ export const USERSTORE_TYPE_DISPLAY_NAMES = {
     UniqueIDReadOnlyLDAPUserStoreManager: "Read Only LDAP",
     UniqueIDReadWriteLDAPUserStoreManager: "Read Write LDAP"
 };
+
+/**
+ * User store type to image mapping.
+ */
+export const USERSTORE_TYPE_IMAGES = {
+    ActiveDirectoryUserStoreManager: "ad",
+    CarbonRemoteUserStoreManger: "default",
+    JDBCUserStoreManager: "jdbc",
+    ReadOnlyLDAPUserStoreManager: "ldap",
+    ReadWriteLDAPUserStoreManager: "ldap",
+    UniqueIDActiveDirectoryUserStoreManager: "ad",
+    UniqueIDJDBCUserStoreManager: "jdbc",
+    UniqueIDReadOnlyLDAPUserStoreManager: "ldap",
+    UniqueIDReadWriteLDAPUserStoreManager: "ldap"
+};

--- a/apps/developer-portal/src/pages/user-stores.tsx
+++ b/apps/developer-portal/src/pages/user-stores.tsx
@@ -249,6 +249,7 @@ export const UserStores = (): ReactElement => {
                     showPagination={ true }
                     sortOptions={ SORT_BY }
                     sortStrategy={ sortBy }
+                    showTopActionPanel={ isLoading || !(!searchQuery && filteredUserStores?.length <= 0) }
                     totalPages={ Math.ceil(filteredUserStores?.length / listItemLimit) }
                     totalListSize={ filteredUserStores?.length }
                 >

--- a/apps/developer-portal/src/pages/userstores-templates.tsx
+++ b/apps/developer-portal/src/pages/userstores-templates.tsx
@@ -23,8 +23,13 @@ import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { getAType, getUserstoreTypes } from "../api";
 import { AddUserStore } from "../components";
-import { ApplicationTemplateIllustrations, EmptyPlaceholderIllustrations } from "../configs";
-import { USERSTORE_TYPE_DISPLAY_NAMES, USER_STORES_PATH, USER_STORE_TYPE_DESCRIPTIONS } from "../constants";
+import { EmptyPlaceholderIllustrations, UserstoreTemplateIllustrations } from "../configs";
+import {
+    USERSTORE_TYPE_DISPLAY_NAMES,
+    USERSTORE_TYPE_IMAGES,
+    USER_STORES_PATH,
+    USER_STORE_TYPE_DESCRIPTIONS
+} from "../constants";
 import { history } from "../helpers";
 import { PageLayout } from "../layouts";
 import { AlertLevels, TypeResponse, UserstoreType } from "../models";
@@ -97,7 +102,7 @@ export const UserstoresTemplates: FunctionComponent<{}> = (): ReactElement => {
                                 description: type.description
                                     ?? USER_STORE_TYPE_DESCRIPTIONS[ type.typeName ],
                                 id: type.typeId,
-                                image: "customApp",
+                                image: USERSTORE_TYPE_IMAGES[ type.typeName ],
                                 name: USERSTORE_TYPE_DISPLAY_NAMES[ type.typeName ]
                             }
                         )
@@ -107,7 +112,7 @@ export const UserstoresTemplates: FunctionComponent<{}> = (): ReactElement => {
                                 description: type.description
                                     ?? USER_STORE_TYPE_DESCRIPTIONS[ type.typeName ],
                                 id: type.typeId,
-                                image: "customApp",
+                                image: USERSTORE_TYPE_IMAGES[ type.typeName ],
                                 name: USERSTORE_TYPE_DISPLAY_NAMES[ type.typeName ]
                             }
                         )
@@ -166,7 +171,7 @@ export const UserstoresTemplates: FunctionComponent<{}> = (): ReactElement => {
                                 onTemplateSelect={ (e: SyntheticEvent, { id }: { id: string }) => {
                                     setSelectedType(rawUserstoreTypes.find((type) => type.typeId === id));
                                 } }
-                                templateIcons={ ApplicationTemplateIllustrations }
+                                templateIcons={ UserstoreTemplateIllustrations }
                                 paginate={ true }
                                 paginationLimit={ 4 }
                                 paginationOptions={ {

--- a/modules/theme/src/index.js
+++ b/modules/theme/src/index.js
@@ -175,6 +175,14 @@ export const GoogleIdPIcon =
 export const TwitterIdPIcon =
     require("../dist/lib/themes/default/assets/images/identity-providers/twitter-idp-illustration.svg");
 
+// Userstore template illustrations
+export const ActiveDirectoryUserstoreIllustration =
+    require("../dist/lib/themes/default/assets/images/illustrations/ad-illustration.svg");
+export const JDBCUserstoreIllustration =
+    require("../dist/lib/themes/default/assets/images/illustrations/jdbc-illustration.svg");
+export const LDAPUserstoreIllustration =
+    require("../dist/lib/themes/default/assets/images/illustrations/ldap-illustration.svg");
+
 // Logos
 export const GravatarLogo = require("../dist/lib/themes/default/assets/images/gravatar-logo.png");
 export const Logo = require("../dist/lib/themes/default/assets/images/logo.svg");


### PR DESCRIPTION
$subject

#### Integrate template images.

<img width="1507" alt="Screen Shot 2020-05-03 at 12 57 49 AM" src="https://user-images.githubusercontent.com/25959096/80878419-3dbfe700-8cd9-11ea-8cb7-79fa518cdaa0.png">

#### Fix top panel visibility issue in fresh userstore list

Before

<img width="1249" alt="Screen Shot 2020-05-03 at 1 04 58 AM" src="https://user-images.githubusercontent.com/25959096/80884450-e884d500-8cda-11ea-8f68-0acdf0075159.png">

After

<img width="1248" alt="Screen Shot 2020-05-03 at 1 04 30 AM" src="https://user-images.githubusercontent.com/25959096/80883225-9348c380-8cda-11ea-81ba-f9db55737ee2.png">