### PR TITLE
Fix domain issue when updating user groups

### DIFF
--- a/apps/developer-portal/src/components/identity-providers/settings/outbound-provisioning-settings.tsx
+++ b/apps/developer-portal/src/components/identity-providers/settings/outbound-provisioning-settings.tsx
@@ -374,6 +374,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                     <Grid>
                         <Grid.Row>
                             <Grid.Column width={ 8 }>
+                                <Divider hidden />
                                 <Segment>
                                     <EmptyPlaceholder
                                         title="No outbound provisioning connectors"
@@ -389,6 +390,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                                         ) }
                                     />
                                 </Segment>
+                                <Divider hidden />
                             </Grid.Column>
                         </Grid.Row>
                     </Grid>

--- a/apps/developer-portal/src/components/users/user-groups-edit.tsx
+++ b/apps/developer-portal/src/components/users/user-groups-edit.tsx
@@ -142,7 +142,13 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     }, [ user ]);
 
     useEffect(() => {
-        getRolesList("Primary")
+        let domain = "Primary";
+        const domainName: string[] = user?.userName?.split("/");
+
+        if (domainName.length > 1) {
+            domain = domainName[0];
+        }
+        getRolesList(domain)
             .then((response) => {
                 setPrimaryGroups(response.data.Resources);
             });
@@ -167,7 +173,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
      * The following function remove already assigned roles from the initial roles.
      */
     const removeExistingRoles = () => {
-        const groupListCopy = [ ...primaryGroups ];
+        const groupListCopy = primaryGroups ? [ ...primaryGroups ] : [];
 
         const addedGroups = [];
         _.forEachRight(groupListCopy, (group) => {


### PR DESCRIPTION
## Purpose
> Fixed fetching primary user store roles when updating a user in a secondary user store.