### PR TITLE
[Dev Portal] Add localization placeholders for Email Templates + Fix UI Issue

### DIFF
--- a/apps/developer-portal/src/components/applications/application-list.tsx
+++ b/apps/developer-portal/src/components/applications/application-list.tsx
@@ -17,7 +17,12 @@
  */
 
 import { hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
-import { AlertLevels, LoadableComponentInterface, SBACInterface } from "@wso2is/core/models";
+import {
+    AlertLevels,
+    LoadableComponentInterface,
+    SBACInterface,
+    TestableComponentInterface
+} from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import {
     AppAvatar,
@@ -50,7 +55,9 @@ import { ApplicationManagementUtils } from "../../utils";
  *
  * Proptypes for the applications list component.
  */
-interface ApplicationListPropsInterface extends SBACInterface<FeatureConfigInterface>, LoadableComponentInterface {
+interface ApplicationListPropsInterface extends SBACInterface<FeatureConfigInterface>, LoadableComponentInterface,
+    TestableComponentInterface {
+
     /**
      * Application list.
      */
@@ -77,6 +84,7 @@ interface ApplicationListPropsInterface extends SBACInterface<FeatureConfigInter
  * Application list component.
  *
  * @param {ApplicationListPropsInterface} props - Props injected to the component.
+ *
  * @return {React.ReactElement}
  */
 export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> = (
@@ -90,7 +98,8 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
         onApplicationDelete,
         onEmptyListPlaceholderActionClick,
         onSearchQueryClear,
-        searchQuery
+        searchQuery,
+        [ "data-testid" ]: testId
     } = props;
 
     const { t } = useTranslation();
@@ -232,6 +241,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                         t("devPortal:placeholders.emptySearchResult.subtitles.0", { query: searchQuery }),
                         t("devPortal:placeholders.emptySearchResult.subtitles.1")
                     ] }
+                    data-testid={ `${ testId }-empty-search-placeholder` }
                 />
             );
         }
@@ -253,6 +263,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                         t("devPortal:components.applications.placeholders.emptyList.subtitles.1"),
                         t("devPortal:components.applications.placeholders.emptyList.subtitles.2")
                     ] }
+                    data-testid={ `${ testId }-empty-placeholder` }
                 />
             );
         }
@@ -269,6 +280,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                     count: UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT,
                     imageType: "square"
                 } }
+                data-testid={ testId }
             >
                 {
                     list?.applications && list.applications instanceof Array && list.applications.length > 0
@@ -293,6 +305,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                                                 image={ app.image }
                                                 size="mini"
                                                 floated="left"
+                                                data-testid={ `${ testId }-item-image` }
                                             />
                                         ) }
                                         itemHeader={ app.name }
@@ -305,7 +318,11 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                                                     && applicationTemplates
                                                         .find((template) => template.name === templateName)
                                                     && (
-                                                        <Label size="mini" className="compact spaced-right">
+                                                        <Label
+                                                            size="mini"
+                                                            className="compact spaced-right"
+                                                            data-testid={ `${ testId }-template-type` }
+                                                        >
                                                             { templateName }
                                                         </Label>
                                                     )
@@ -313,6 +330,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                                                 { description }
                                             </>
                                         ) }
+                                        data-testid={ `${ testId }-item` }
                                     />
                                 );
                             }
@@ -345,14 +363,23 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                         secondaryAction={ t("common:cancel") }
                         onSecondaryActionClick={ (): void => setShowDeleteConfirmationModal(false) }
                         onPrimaryActionClick={ (): void => handleApplicationDelete(deletingApplication.id) }
+                        data-testid={ `${ testId }-delete-confirmation-modal` }
                     >
-                        <ConfirmationModal.Header>
+                        <ConfirmationModal.Header
+                            data-testid={ `${ testId }-delete-confirmation-modal-header` }
+                        >
                             { t("devPortal:components.applications.confirmations.deleteApplication.header") }
                         </ConfirmationModal.Header>
-                        <ConfirmationModal.Message attached warning>
+                        <ConfirmationModal.Message
+                            attached
+                            warning
+                            data-testid={ `${ testId }-delete-confirmation-modal-message` }
+                        >
                             { t("devPortal:components.applications.confirmations.deleteApplication.message") }
                         </ConfirmationModal.Message>
-                        <ConfirmationModal.Content>
+                        <ConfirmationModal.Content
+                            data-testid={ `${ testId }-delete-confirmation-modal-content` }
+                        >
                             { t("devPortal:components.applications.confirmations.deleteApplication.content") }
                         </ConfirmationModal.Content>
                     </ConfirmationModal>
@@ -360,4 +387,11 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
             }
         </>
     );
+};
+
+/**
+ * Default props for the component.
+ */
+ApplicationList.defaultProps = {
+    "data-testid": "application-list"
 };

--- a/apps/developer-portal/src/components/email-templates/create-template/add-template-type-wizard.tsx
+++ b/apps/developer-portal/src/components/email-templates/create-template/add-template-type-wizard.tsx
@@ -81,7 +81,7 @@ export const EmailTemplateTypeWizard: FunctionComponent<EmailTemplateTypeWizardP
             />
         ),
         icon: ApplicationWizardStepIcons.general,
-        title: "Template Type"
+        title: t("devPortal:components.emailTemplateTypes.wizards.addTemplateType.steps.templateType.heading")
     }];
 
     const createTemplateType = (templateTypeName: string): void => {
@@ -122,8 +122,10 @@ export const EmailTemplateTypeWizard: FunctionComponent<EmailTemplateTypeWizardP
             data-testid={ testId }
         >
             <Modal.Header className="wizard-header template-type-wizard">
-                Create Email Template Type
-                <Heading as="h6">Create a new template type to associate with email requirements.</Heading>
+                { t("devPortal:components.emailTemplateTypes.wizards.addTemplateType.heading") }
+                <Heading as="h6">
+                    { t("devPortal:components.emailTemplateTypes.wizards.addTemplateType.subHeading") }
+                </Heading>
             </Modal.Header>
             <Modal.Content className="content-container" scrolling>
                 {WIZARD_STEPS[currentStep].content}
@@ -137,7 +139,7 @@ export const EmailTemplateTypeWizard: FunctionComponent<EmailTemplateTypeWizardP
                                 onClick={ () => { onCloseHandler() } }
                                 data-testid={ `${ testId }-cancel-button` }
                             >
-                                Cancel
+                                { t("cancel") }
                             </LinkButton>
                         </Grid.Column>
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
@@ -146,7 +148,7 @@ export const EmailTemplateTypeWizard: FunctionComponent<EmailTemplateTypeWizardP
                                 onClick={ setFinishSubmit }
                                 data-testid={ `${ testId }-create-button` }
                             >
-                                Create Template Type
+                                { t("devPortal:components.emailTemplateTypes.buttons.createTemplateType") }
                             </PrimaryButton>
                         </Grid.Column>
                     </Grid.Row>

--- a/apps/developer-portal/src/components/email-templates/create-template/add-template-type.tsx
+++ b/apps/developer-portal/src/components/email-templates/create-template/add-template-type.tsx
@@ -19,6 +19,7 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Forms } from "@wso2is/forms";
 import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
 import { Grid, GridColumn, GridRow } from "semantic-ui-react";
 
 /**
@@ -46,6 +47,8 @@ export const AddEmailTemplateType: FunctionComponent<AddEmailTemplateTypePropsIn
         [ "data-testid" ]: testId
     } = props;
 
+    const { t } = useTranslation();
+
     /**
      * Util method to collect form data for processing.
      * 
@@ -70,10 +73,18 @@ export const AddEmailTemplateType: FunctionComponent<AddEmailTemplateTypePropsIn
                         <Field
                             type="text"
                             name="templatetype"
-                            label="Template Type Name"
-                            placeholder="Enter a template type name"
+                            label={
+                                t("devPortal:components.emailTemplateTypes.forms.addTemplateType.fields.type.label")
+                            }
+                            placeholder={
+                                t("devPortal:components.emailTemplateTypes.forms.addTemplateType.fields.type" +
+                                    ".placeholder")
+                            }
                             required={ true }
-                            requiredErrorMessage="Template type name is required to proceed."
+                            requiredErrorMessage={
+                                t("devPortal:components.emailTemplateTypes.forms.addTemplateType.fields.type" +
+                                    ".validations.empty")
+                            }
                             data-testid={ `${ testId }-type-input` }
                         />
                     </GridColumn>

--- a/apps/developer-portal/src/components/email-templates/create-template/add-template.tsx
+++ b/apps/developer-portal/src/components/email-templates/create-template/add-template.tsx
@@ -208,10 +208,17 @@ export const AddLocaleTemplate: FunctionComponent<AddLocaleTemplatePropsInterfac
                             <Form.Field>
                                 <label>Locale</label>
                                 <Dropdown
-                                    placeholder="Select Locale"
-                                    label="Locale "
+                                    placeholder={
+                                        t("devPortal:components.emailLocale.forms.addLocale.fields.locale.placeholder")
+                                    }
+                                    label={
+                                        t("devPortal:components.emailLocale.forms.addLocale.fields.locale.label")
+                                    }
                                     name="locale"
-                                    requiredErrorMessage="Select locale"
+                                    requiredErrorMessage={
+                                        t("devPortal:components.emailLocale.forms.addLocale.fields.locale" +
+                                            ".validations.empty")
+                                    }
                                     required={ true }
                                     options={ localeList ? localeList : [] }
                                     onChange={ (event: SyntheticEvent, data: DropdownProps) => {
@@ -232,11 +239,17 @@ export const AddLocaleTemplate: FunctionComponent<AddLocaleTemplatePropsInterfac
                 <Grid.Row columns={ 1 }>
                     <Grid.Column mobile={ 12 } tablet={ 12 } computer={ 4 }>
                         <Field
-                            name={ "emailSubject" }
-                            label={ "Subject" }
+                            name="emailSubject"
+                            label={
+                                t("devPortal:components.emailLocale.forms.addLocale.fields.subject.label")
+                            }
                             required={ true }
-                            requiredErrorMessage={ "Email Subject is required" }
-                            placeholder={ "Enter your email subject" }
+                            requiredErrorMessage={
+                                t("devPortal:components.emailLocale.forms.addLocale.fields.subject.validations.empty")
+                            }
+                            placeholder={
+                                t("devPortal:components.emailLocale.forms.addLocale.fields.subject.placeholder")
+                            }
                             type="text"
                             value={ subject }
                             data-testid={ `${ testId }-subject-input` }
@@ -246,7 +259,9 @@ export const AddLocaleTemplate: FunctionComponent<AddLocaleTemplatePropsInterfac
                 <Grid.Row columns={ 1 }>
                     <Grid.Column mobile={ 12 } tablet={ 12 } computer={ 12 }>
                         <Form.Field>
-                            <label>Body</label>
+                            <label>
+                                { t("devPortal:components.emailLocale.forms.addLocale.fields.bodyEditor.label") }
+                            </label>
                             <EmailTemplateEditor 
                                 htmlContent={ htmlBodyContent } 
                                 isReadOnly={ false }
@@ -261,7 +276,10 @@ export const AddLocaleTemplate: FunctionComponent<AddLocaleTemplatePropsInterfac
                 <Grid.Row columns={ 1 }>
                     <Grid.Column mobile={ 12 } tablet={ 12 } computer={ 12 }>
                         <Form.Field>
-                            <label>Mail signature</label>
+                            <label>
+                                { t("devPortal:components.emailLocale.forms.addLocale.fields.signatureEditor" +
+                                    ".label") }
+                            </label>
                             <EmailTemplateEditor 
                                 htmlContent={ htmlFooterContent } 
                                 isReadOnly={ false }
@@ -283,7 +301,11 @@ export const AddLocaleTemplate: FunctionComponent<AddLocaleTemplatePropsInterfac
                             className="form-button"
                             data-testid={ `${ testId }-submit-button` }
                         >
-                            {templateId === "" ? "Add Locale Template" : "Save Changes" }
+                            {
+                                (templateId === "")
+                                    ? t("devPortal:components.emailLocale.buttons.addLocaleTemplate")
+                                    : t("devPortal:components.emailLocale.buttons.saveChanges")
+                            }
                         </Button>
                     </Grid.Column>
                 </Grid.Row>

--- a/apps/developer-portal/src/components/email-templates/email-code-editor/email-editor.tsx
+++ b/apps/developer-portal/src/components/email-templates/email-code-editor/email-editor.tsx
@@ -19,6 +19,7 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { CodeEditor, ResourceTab } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { EMAIL_STARTER_TEMPLATE } from "../../../constants";
 
 interface EmailTemplateEditorPropsInterface extends TestableComponentInterface {
@@ -54,6 +55,8 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
         [ "data-testid" ]: testId
     } = props;
 
+    const { t } = useTranslation();
+
     const [ content, setContent ] = useState<string>("");
 
     useEffect(() => {
@@ -71,7 +74,8 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
                     <div className="render-view" data-testid={ `${ testId }-preview-only-render-view` }>
                         <iframe id="iframe" srcDoc={ content }>
                             <p data-testid={ `${ testId }-iframe-unsupported-error` }>
-                                Your browser does not support iframes.
+                                { t("devPortal:components.emailTemplates.notifications.iframeUnsupported" +
+                                    ".genericError.description") }
                             </p>
                         </iframe>
                     </div>
@@ -80,7 +84,7 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
                         defaultActiveTab={ isAddFlow ? 1 : 0  }
                         panes={ [
                             {
-                                menuItem: "Preview",
+                                menuItem: t("devPortal:components.emailTemplates.editor.tabs.preview.tabName"),
                                 render: () => (
                                     <ResourceTab.Pane
                                         className="render-view"
@@ -89,14 +93,15 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
                                     >
                                         <iframe id="iframe" srcDoc={ content }>
                                             <p data-testid={ `${ testId }-iframe-unsupported-error` }>
-                                                Your browser does not support iframes.
+                                                { t("devPortal:components.emailTemplates.notifications" +
+                                                    ".iframeUnsupported.genericError.description") }
                                             </p>
                                         </iframe>
                                     </ResourceTab.Pane>
                                 )
                             },
                             {
-                                menuItem: "HTML Code",
+                                menuItem: t("devPortal:components.emailTemplates.editor.tabs.code.tabName"),
                                 render: () => (
                                     <ResourceTab.Pane attached={ false }>
                                         <CodeEditor

--- a/apps/developer-portal/src/components/email-templates/template-list.tsx
+++ b/apps/developer-portal/src/components/email-templates/template-list.tsx
@@ -26,6 +26,7 @@ import {
 } from "@wso2is/react-components";
 import * as CountryLanguage from "country-language";
 import React, { FunctionComponent, ReactElement, useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
 import { Flag, FlagNameValues, Icon } from "semantic-ui-react";
 import { ViewLocaleTemplate } from "./view-template";
 import { EmailTemplateIllustrations } from "../../configs";
@@ -63,6 +64,8 @@ export const EmailTemplateList: FunctionComponent<EmailTemplateListPropsInterfac
         [ "data-testid" ]: testId
     } = props;
 
+    const { t } = useTranslation();
+
     const [ showViewLocaleWizArd, setShowViewLocaleWizard ] = useState<boolean>(false);
     const [ currentViewTemplate, setCurrentViewTemplate ] = useState<string>("");
 
@@ -85,14 +88,14 @@ export const EmailTemplateList: FunctionComponent<EmailTemplateListPropsInterfac
                     action={
                         <PrimaryButton onClick={ onEmptyListPlaceholderActionClick }>
                             <Icon name="add"/>
-                            New Template
+                            { t("devPortal:components.emailTemplates.placeholders.emptyList.action") }
                         </PrimaryButton>
                     }
-                    title="Add Template"
+                    title={ t("devPortal:components.emailTemplates.placeholders.emptyList.title") }
                     subtitle={ [
-                        "Currently there are no templates available for the selected",
-                        "email template type. You can add a new template clicking on the",
-                        "button below."
+                        t("devPortal:components.emailTemplates.placeholders.emptyList.subtitles.0"),
+                        t("devPortal:components.emailTemplates.placeholders.emptyList.subtitles.1"),
+                        t("devPortal:components.emailTemplates.placeholders.emptyList.subtitles.2")
                     ] }
                     image={ EmailTemplateIllustrations.emptyEmailListing }
                     imageSize="tiny"
@@ -142,12 +145,12 @@ export const EmailTemplateList: FunctionComponent<EmailTemplateListPropsInterfac
                                             setCurrentViewTemplate(template.id);
                                             setShowViewLocaleWizard(true);
                                         },
-                                        popupText: "View Template",
+                                        popupText: t("devPortal:components.emailTemplates.buttons.viewTemplate"),
                                         type: "button"
                                     }, {
                                         icon: "pencil alternate",
                                         onClick: () => handleEditTemplate(templateTypeId, template.id),
-                                        popupText: "Edit Template",
+                                        popupText: t("devPortal:components.emailTemplates.buttons.editTemplate"),
                                         type: "button"
                                     }, {
                                         icon: "trash alternate",
@@ -155,7 +158,7 @@ export const EmailTemplateList: FunctionComponent<EmailTemplateListPropsInterfac
                                             setCurrentDeletingTemplate(template);
                                             setShowTemplateDeleteConfirmation(true);
                                         },
-                                        popupText: "Delete Template",
+                                        popupText: t("devPortal:components.emailTemplates.buttons.deleteTemplate"),
                                         type: "button"
                                     } ] }
                                     itemHeader={
@@ -194,11 +197,19 @@ export const EmailTemplateList: FunctionComponent<EmailTemplateListPropsInterfac
                         open={ showTemplateDeleteConfirmation }
                         assertion={ currentDeletingTemplate.id }
                         assertionHint={
-                            <p>Please type <strong>{ currentDeletingTemplate.id }</strong> to confirm. </p>
+                            <p>
+                                <Trans
+                                    i18nKey={ "devPortal:components.emailTemplates.confirmations.deleteTemplate" +
+                                    ".assertionHint" }
+                                    tOptions={ { id: currentDeletingTemplate.id } }
+                                >
+                                    Please type <strong>{ currentDeletingTemplate.id }</strong> to confirm.
+                                </Trans>
+                            </p>
                         }
                         assertionType="input"
-                        primaryAction="Confirm"
-                        secondaryAction="Cancel"
+                        primaryAction={ t("common:confirm") }
+                        secondaryAction={ t("common:cancel") }
                         onSecondaryActionClick={ (): void => setShowTemplateDeleteConfirmation(false) }
                         onPrimaryActionClick={ (): void => {
                             onDelete(templateTypeId, currentDeletingTemplate.id);
@@ -209,20 +220,19 @@ export const EmailTemplateList: FunctionComponent<EmailTemplateListPropsInterfac
                         <ConfirmationModal.Header
                             data-testid={ `${ testId }-delete-confirmation-modal-header` }
                         >
-                            Are you sure?
+                            { t("devPortal:components.emailTemplates.confirmations.deleteTemplate.header") }
                         </ConfirmationModal.Header>
                         <ConfirmationModal.Message
                             attached
                             warning
                             data-testid={ `${ testId }-delete-confirmation-modal-message` }
                         >
-                            This action is irreversible and will permanently delete the selected email template.
+                            { t("devPortal:components.emailTemplates.confirmations.deleteTemplate.message") }
                         </ConfirmationModal.Message>
                         <ConfirmationModal.Content
                             data-testid={ `${ testId }-delete-confirmation-modal-content` }
                         >
-                            If you delete this email template, all associated work flows will no longer
-                            have a valid email template to work with. Please proceed cautiously.
+                            { t("devPortal:components.emailTemplates.confirmations.deleteTemplate.content") }
                         </ConfirmationModal.Content>
                     </ConfirmationModal>
                 )

--- a/apps/developer-portal/src/components/email-templates/template-type-list.tsx
+++ b/apps/developer-portal/src/components/email-templates/template-type-list.tsx
@@ -25,6 +25,7 @@ import {
     ResourceListItem
 } from "@wso2is/react-components";
 import React, { FunctionComponent , ReactElement, useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
 import { Icon, Image } from "semantic-ui-react";
 import { EmailTemplateIllustrations } from "../../configs";
 import { EMAIL_TEMPLATE_VIEW_PATH, UIConstants } from "../../constants";
@@ -60,6 +61,8 @@ export const EmailTemplateTypeList: FunctionComponent<EmailTemplateListPropsInte
         [ "data-testid" ]: testId
     } = props;
 
+    const { t } = useTranslation();
+
     const [ showTemplateTypeDeleteConfirmation, setShowTemplateTypeDeleteConfirmation ] = useState<boolean>(false);
     const [ currentDeletingTemplate, setCurrentDeletingTemplate ] = useState<EmailTemplateType>(undefined);
 
@@ -79,14 +82,14 @@ export const EmailTemplateTypeList: FunctionComponent<EmailTemplateListPropsInte
                     action={
                         <PrimaryButton onClick={ onEmptyListPlaceholderActionClick }>
                             <Icon name="add"/>
-                            New Template Type
+                            { t("devPortal:components.emailTemplateTypes.placeholders.emptyList.action") }
                         </PrimaryButton>
                     }
-                    title="Add new Template Type"
+                    title={ t("devPortal:components.emailTemplateTypes.placeholders.emptyList.title") }
                     subtitle={ [
-                        "Currently there are no templates types available.",
-                        "You can add a new template type by clicking on the",
-                        "button below."
+                        t("devPortal:components.emailTemplateTypes.placeholders.emptyList.subtitles.0"),
+                        t("devPortal:components.emailTemplateTypes.placeholders.emptyList.subtitles.1"),
+                        t("devPortal:components.emailTemplateTypes.placeholders.emptyList.subtitles.2")
                     ] }
                     image={ EmailTemplateIllustrations.emptyEmailListing }
                     imageSize="tiny"
@@ -118,7 +121,7 @@ export const EmailTemplateTypeList: FunctionComponent<EmailTemplateListPropsInte
                                 actions={ [{
                                     icon: "pencil alternate",
                                     onClick: () => handleEditTemplate(template.id),
-                                    popupText: "Edit Template",
+                                    popupText: t("devPortal:components.emailTemplateTypes.buttons.editTemplate"),
                                     type: "button"
                                 },{
                                     icon: "trash alternate",
@@ -127,7 +130,7 @@ export const EmailTemplateTypeList: FunctionComponent<EmailTemplateListPropsInte
                                         setShowTemplateTypeDeleteConfirmation(true)
 
                                     },
-                                    popupText: "Delete Template",
+                                    popupText: t("devPortal:components.emailTemplateTypes.buttons.deleteTemplate"),
                                     type: "button"
                                 }] }
                                 avatar={ (
@@ -159,12 +162,20 @@ export const EmailTemplateTypeList: FunctionComponent<EmailTemplateListPropsInte
                         type="warning"
                         open={ showTemplateTypeDeleteConfirmation }
                         assertion={ currentDeletingTemplate.displayName }
-                        assertionHint={ 
-                            <p>Please type <strong>{ currentDeletingTemplate.displayName }</strong> to confirm. </p> 
+                        assertionHint={
+                            <p>
+                                <Trans
+                                    i18nKey={ "devPortal:components.emailTemplateTypes.confirmations" +
+                                    ".deleteTemplateType.assertionHint" }
+                                    tOptions={ { id: currentDeletingTemplate.displayName } }
+                                >
+                                    Please type <strong>{ currentDeletingTemplate.displayName }</strong> to confirm.
+                                </Trans>
+                            </p>
                         }
                         assertionType="input"
-                        primaryAction="Confirm"
-                        secondaryAction="Cancel"
+                        primaryAction={ t("common:confirm") }
+                        secondaryAction={ t("common:cancel") }
                         onSecondaryActionClick={ (): void => setShowTemplateTypeDeleteConfirmation(false) }
                         onPrimaryActionClick={ (): void => {
                             onDelete(currentDeletingTemplate.id);
@@ -175,21 +186,22 @@ export const EmailTemplateTypeList: FunctionComponent<EmailTemplateListPropsInte
                         <ConfirmationModal.Header
                             data-testid={ `${ testId }-delete-confirmation-modal-header` }
                         >
-                            Are you sure?
+                            { t("devPortal:components.emailTemplateTypes.confirmations.deleteTemplateType" +
+                                ".header") }
                         </ConfirmationModal.Header>
                         <ConfirmationModal.Message
                             attached
                             warning
                             data-testid={ `${ testId }-delete-confirmation-modal-message` }
                         >
-                            This action is irreversible and will permanently delete the selected email template type.
+                            { t("devPortal:components.emailTemplateTypes.confirmations.deleteTemplateType" +
+                                ".message") }
                         </ConfirmationModal.Message>
                         <ConfirmationModal.Content
                             data-testid={ `${ testId }-delete-confirmation-modal-content` }
                         >
-                            If you delete this email template type, all associated work flows will no longer
-                            have a valid email template to work with and this will delete all the locale templates 
-                            associated with this template type. Please proceed cautiously.
+                            { t("devPortal:components.emailTemplateTypes.confirmations.deleteTemplateType" +
+                                ".content") }
                         </ConfirmationModal.Content>
                     </ConfirmationModal>
                 )

--- a/apps/developer-portal/src/components/email-templates/view-template.tsx
+++ b/apps/developer-portal/src/components/email-templates/view-template.tsx
@@ -20,6 +20,7 @@ import { TestableComponentInterface } from "@wso2is/core/models";
 import { Heading, LinkButton, PrimaryButton } from "@wso2is/react-components";
 import { AxiosResponse } from "axios";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Grid, Modal } from "semantic-ui-react";
 import { EmailTemplateEditor } from "./email-code-editor";
 import { getTemplateDetails } from "../../api";
@@ -44,8 +45,6 @@ export const ViewLocaleTemplate: FunctionComponent<ViewLocaleTemplatePropsInterf
     props: ViewLocaleTemplatePropsInterface
 ): ReactElement => {
 
-    const [ templateData, setTemplateData ] = useState<EmailTemplate>(undefined);
-
     const {
         onCloseHandler,
         onEditHandler,
@@ -53,6 +52,10 @@ export const ViewLocaleTemplate: FunctionComponent<ViewLocaleTemplatePropsInterf
         templateId,
         [ "data-testid" ]: testId
     } = props;
+
+    const { t } = useTranslation();
+
+    const [ templateData, setTemplateData ] = useState<EmailTemplate>(undefined);
 
     useEffect(() => {
         getTemplateDetails(templateTypeId, templateId)
@@ -90,7 +93,9 @@ export const ViewLocaleTemplate: FunctionComponent<ViewLocaleTemplatePropsInterf
         >
             <Modal.Header className="wizard-header template-type-wizard">
                 { templateData?.subject }
-                <Heading as="h6">Email Template Preview</Heading>
+                <Heading as="h6">
+                    { t("devPortal:components.emailTemplates.viewTemplate.heading") }
+                </Heading>
             </Modal.Header>
             <Modal.Content className="content-container template-view-content" scrolling>
                 {WIZARD_STEPS[0].content}
@@ -104,7 +109,7 @@ export const ViewLocaleTemplate: FunctionComponent<ViewLocaleTemplatePropsInterf
                                 onClick={ () => { onCloseHandler() } }
                                 data-testid={ `${ testId }-modal-cancel-button` }
                             >
-                                Cancel
+                                { t("common:cancel") }
                             </LinkButton>
                         </Grid.Column>
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
@@ -113,7 +118,7 @@ export const ViewLocaleTemplate: FunctionComponent<ViewLocaleTemplatePropsInterf
                                 onClick={ () => { onEditHandler() } }
                                 data-testid={ `${ testId }-modal-edit-button` }
                             >
-                                Edit Template
+                                { t("devPortal:components.emailTemplates.buttons.editTemplate") }
                             </PrimaryButton>
                         </Grid.Column>
                     </Grid.Row>

--- a/apps/developer-portal/src/pages/applications/application-template.tsx
+++ b/apps/developer-portal/src/pages/applications/application-template.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { TestableComponentInterface } from "@wso2is/core/models";
 import { ContentLoader, EmptyPlaceholder, TemplateGrid } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -32,11 +33,24 @@ import { AppState } from "../../store";
 import { ApplicationManagementUtils } from "../../utils";
 
 /**
+ * Props for the Applications templates page.
+ */
+type ApplicationTemplateSelectPageInterface = TestableComponentInterface;
+
+/**
  * Choose the application template from this page.
+ *
+ * @param {ApplicationTemplateSelectPageInterface} props - Props injected to the component.
  *
  * @return {React.ReactElement}
  */
-export const ApplicationTemplateSelectPage: FunctionComponent<{}> = (): ReactElement => {
+export const ApplicationTemplateSelectPage: FunctionComponent<ApplicationTemplateSelectPageInterface> = (
+    props: ApplicationTemplateSelectPageInterface
+): ReactElement => {
+
+    const {
+        [ "data-testid" ]: testId
+    } = props;
 
     const { t } = useTranslation();
 
@@ -106,6 +120,7 @@ export const ApplicationTemplateSelectPage: FunctionComponent<{}> = (): ReactEle
             titleTextAlign="left"
             bottomMargin={ false }
             showBottomDivider
+            data-testid={ `${ testId }-page-layout` }
         >
             {
                 (applicationTemplates && !isApplicationTemplateRequestLoading)
@@ -133,9 +148,11 @@ export const ApplicationTemplateSelectPage: FunctionComponent<{}> = (): ReactEle
                                         imageSize="tiny"
                                         title={ t("devPortal:components.templates.emptyPlaceholder.title") }
                                         subtitle={ [t("devPortal:components.templates.emptyPlaceholder.subtitles")] }
+                                        data-testid={ `${ testId }-quick-start-template-grid-empty-placeholder` }
                                     />
                                 ) }
                                 tagsSectionTitle={ t("common:technologies") }
+                                data-testid={ `${ testId }-quick-start-template-grid` }
                             />
                         </div>
                     )
@@ -165,9 +182,11 @@ export const ApplicationTemplateSelectPage: FunctionComponent<{}> = (): ReactEle
                             imageSize="tiny"
                             title={ t("devPortal:components.templates.emptyPlaceholder.title") }
                             subtitle={ [t("devPortal:components.templates.emptyPlaceholder.subtitles")] }
+                            data-testid={ `${ testId }-custom-template-grid-empty-placeholder` }
                         />
                     ) }
                     tagsSectionTitle={ t("common:technologies") }
+                    data-testid={ `${ testId }-custom-template-grid` }
                 />
             </div>
             {
@@ -183,4 +202,11 @@ export const ApplicationTemplateSelectPage: FunctionComponent<{}> = (): ReactEle
             }
         </PageLayout>
     );
+};
+
+/**
+ * Default props for the component.
+ */
+ApplicationTemplateSelectPage.defaultProps = {
+    "data-testid": "application-templates"
 };

--- a/apps/developer-portal/src/pages/applications/applications.tsx
+++ b/apps/developer-portal/src/pages/applications/applications.tsx
@@ -17,7 +17,7 @@
  */
 
 import { hasRequiredScopes } from "@wso2is/core/helpers";
-import { AlertLevels } from "@wso2is/core/models";
+import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { I18n } from "@wso2is/i18n";
 import { PrimaryButton } from "@wso2is/react-components";
@@ -65,11 +65,24 @@ const APPLICATIONS_LIST_SORTING_OPTIONS: DropdownItemProps[] = [
 ];
 
 /**
- * Overview page.
+ * Props for the Applications page.
+ */
+type ApplicationsPageInterface = TestableComponentInterface;
+
+/**
+ * Applications page.
+ *
+ * @param {ApplicationsPageInterface} props - Props injected to the component.
  *
  * @return {React.ReactElement}
  */
-export const ApplicationsPage: FunctionComponent<{}> = (): ReactElement => {
+export const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
+    props: ApplicationsPageInterface
+): ReactElement => {
+
+    const {
+        [ "data-testid" ]: testId
+    } = props;
 
     const { t } = useTranslation();
 
@@ -197,6 +210,7 @@ export const ApplicationsPage: FunctionComponent<{}> = (): ReactElement => {
             title={ t("devPortal:pages.applications.title") }
             description={ t("devPortal:pages.applications.subTitle") }
             showBottomDivider={ true }
+            data-testid={ `${ testId }-page-layout` }
         >
             <ListLayout
                 advancedSearch={
@@ -225,6 +239,7 @@ export const ApplicationsPage: FunctionComponent<{}> = (): ReactElement => {
                         defaultSearchAttribute="name"
                         defaultSearchOperator="co"
                         triggerClearQuery={ triggerClearQuery }
+                        data-testid={ `${ testId }-list-advanced-search` }
                     />
                 }
                 currentListSize={ appList.count }
@@ -239,6 +254,7 @@ export const ApplicationsPage: FunctionComponent<{}> = (): ReactElement => {
                                 onClick={ (): void => {
                                     history.push(ApplicationConstants.PATHS.get("APPLICATION_TEMPLATES"));
                                 } }
+                                data-testid={ `${ testId }-list-layout-add-button` }
                             >
                                 <Icon name="add"/>
                                 { t("devPortal:components.applications.list.actions.add") }
@@ -252,6 +268,7 @@ export const ApplicationsPage: FunctionComponent<{}> = (): ReactElement => {
                 sortStrategy={ listSortingStrategy }
                 totalPages={ Math.ceil(appList.totalResults / listItemLimit) }
                 totalListSize={ appList.totalResults }
+                data-testid={ `${ testId }-list-layout` }
             >
                 <ApplicationList
                     featureConfig={ featureConfig }
@@ -263,8 +280,16 @@ export const ApplicationsPage: FunctionComponent<{}> = (): ReactElement => {
                     }
                     onSearchQueryClear={ handleSearchQueryClear }
                     searchQuery={ searchQuery }
+                    data-testid={ `${ testId }-list` }
                 />
             </ListLayout>
         </PageLayout>
     );
+};
+
+/**
+ * Default props for the component.
+ */
+ApplicationsPage.defaultProps = {
+    "data-testid": "applications"
 };

--- a/apps/developer-portal/src/pages/email-templates/email-locale-add.tsx
+++ b/apps/developer-portal/src/pages/email-templates/email-locale-add.tsx
@@ -20,6 +20,7 @@ import { TestableComponentInterface } from "@wso2is/core/models";
 import { AxiosResponse } from "axios";
 import * as CountryLanguage from "country-language";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { getEmailTemplate } from "../../api";
 import { AddLocaleTemplate } from "../../components";
 import { EMAIL_TEMPLATE_VIEW_PATH } from "../../constants";
@@ -47,6 +48,8 @@ export const AddTemplateLocale: FunctionComponent<AddTemplateLocalePageInterface
     const {
         [ "data-testid" ]: testId
     } = props;
+
+    const { t } = useTranslation();
 
     const [ templateTypeId, setTemplateTypeId ] = useState<string>("");
     const [ templateId, setTemplateId ] = useState<string>("");
@@ -102,12 +105,14 @@ export const AddTemplateLocale: FunctionComponent<AddTemplateLocalePageInterface
 
     return (
         <PageLayout
-            title={ templateId === "" ? 
-                "Add new template for " + emailTemplateTypeDetails?.displayName : 
-                "Edit template - " + localeName }
+            title={ templateId === ""
+                ? t("devPortal:pages.emailLocaleAddWithDisplayName.title",
+                    { displayName: emailTemplateTypeDetails?.displayName })
+                : t("devPortal:pages.emailLocaleAdd.title", { name: localeName })
+            }
             backButton={ {
                 onClick: handleBackButtonClick,
-                text: "Go back to " + emailTemplateName + " template"
+                text: t("devPortal:pages.emailLocaleAdd.backButton", { name: emailTemplateName })
             } }
             titleTextAlign="left"
             showBottomDivider={ true }

--- a/apps/developer-portal/src/pages/email-templates/email-template-types.tsx
+++ b/apps/developer-portal/src/pages/email-templates/email-template-types.tsx
@@ -33,7 +33,7 @@ import { AlertInterface, EmailTemplateType } from "../../models";
 /**
  * Props for the Email Templates Types page.
  */
-type EmailTemplateTypesPageInterface = TestableComponentInterface
+type EmailTemplateTypesPageInterface = TestableComponentInterface;
 
 /**
  * Component to list available email template types.
@@ -151,8 +151,8 @@ export const EmailTemplateTypes: FunctionComponent<EmailTemplateTypesPageInterfa
     return (
         <PageLayout
             isLoading={ isTemplateTypesFetchRequestLoading }
-            title="Email Templates Types"
-            description="Create and manage templates types."
+            title={ t("devPortal:pages.emailTemplateTypes.title") }
+            description={ t("devPortal:pages.emailTemplateTypes.subTitle") }
             showBottomDivider={ true }
             data-testid={ `${ testId }-page-layout` }
         >
@@ -171,7 +171,7 @@ export const EmailTemplateTypes: FunctionComponent<EmailTemplateTypesPageInterfa
                             data-testid={ `${ testId }-list-layout-add-button` }
                         >
                             <Icon name="add"/>
-                            New Template Type
+                            { t("devPortal:components.emailTemplateTypes.buttons.newType") }
                         </PrimaryButton>
                     )
                 }

--- a/apps/developer-portal/src/pages/email-templates/email-templates.tsx
+++ b/apps/developer-portal/src/pages/email-templates/email-templates.tsx
@@ -34,7 +34,7 @@ import { AlertInterface, AlertLevels, EmailTemplate, EmailTemplateDetails } from
 /**
  * Props for the Email Templates page.
  */
-type EmailTemplatesPageInterface = TestableComponentInterface
+type EmailTemplatesPageInterface = TestableComponentInterface;
 
 /**
  * Component will list all available locale based email templates for
@@ -187,12 +187,15 @@ export const EmailTemplates: FunctionComponent<EmailTemplatesPageInterface> = (
     return (
         <PageLayout
             isLoading={ isEmailTemplatesFetchRequestLoading }
-            title={ emailTemplateTypeDetails && 
-                    emailTemplateTypeDetails.displayName ? "Templates - " + emailTemplateTypeDetails.displayName 
-                    : "Email Templates" }
+            title={
+                (emailTemplateTypeDetails && emailTemplateTypeDetails.displayName)
+                    ? t("devPortal:pages.emailTemplatesWithDisplayName.title",
+                    { displayName: emailTemplateTypeDetails.displayName })
+                    : t("devPortal:pages.emailTemplates.title")
+            }
             backButton={ {
                 onClick: handleBackButtonClick,
-                text: "Go back to email templates types"
+                text: t("devPortal:pages.emailTemplates.backButton")
             } }
             titleTextAlign="left"
             bottomMargin={ false }
@@ -213,7 +216,7 @@ export const EmailTemplates: FunctionComponent<EmailTemplatesPageInterface> = (
                             data-testid={ `${ testId }-list-layout-add-button` }
                         >
                             <Icon name="add"/>
-                            New Template
+                            { t("devPortal:components.emailTemplates.buttons.newTemplate") }
                         </PrimaryButton>
                     )
                 }

--- a/apps/developer-portal/src/pages/email-templates/email-templates.tsx
+++ b/apps/developer-portal/src/pages/email-templates/email-templates.tsx
@@ -221,6 +221,7 @@ export const EmailTemplates: FunctionComponent<EmailTemplatesPageInterface> = (
                     )
                 }
                 data-testid={ `${ testId }-list-layout` }
+                showTopActionPanel={ isEmailTemplatesFetchRequestLoading || emailTemplates?.length  > 0 }
             >
                 <EmailTemplateList
                     isLoading={ isEmailTemplatesFetchRequestLoading }

--- a/modules/i18n/src/models/namespaces/dev-portal-ns.ts
+++ b/modules/i18n/src/models/namespaces/dev-portal-ns.ts
@@ -944,18 +944,86 @@ export interface DevPortalNS {
                 warning: string;
             };
         };
+        emailLocale: {
+            buttons: {
+                addLocaleTemplate: string;
+                saveChanges: string;
+            };
+            forms: {
+                addLocale: {
+                    fields: {
+                        bodyEditor: FormAttributes;
+                        locale: FormAttributes;
+                        signatureEditor: FormAttributes;
+                        subject: FormAttributes;
+                    };
+                };
+            };
+        };
         emailTemplateTypes: {
+            buttons: {
+                createTemplateType: string;
+                deleteTemplate: string;
+                editTemplate: string;
+                newType: string;
+            };
+            confirmations: {
+                deleteTemplateType: Confirmation;
+            };
+            forms: {
+                addTemplateType: {
+                    fields: {
+                        type: FormAttributes;
+                    };
+                };
+            };
             notifications: {
                 deleteTemplateType: Notification;
                 updateTemplateType: Notification;
                 createTemplateType: Notification;
             };
+            placeholders: {
+                emptyList: Placeholder;
+            };
+            wizards: {
+                addTemplateType: {
+                    heading: string;
+                    subHeading: string;
+                    steps: {};
+                };
+            };
         };
         emailTemplates: {
+            buttons: {
+                editTemplate: string;
+                deleteTemplate: string;
+                newTemplate: string;
+                viewTemplate: string;
+            };
+            confirmations: {
+                deleteTemplate: Confirmation;
+            };
+            editor: {
+                tabs: {
+                    code: {
+                        tabName: string;
+                    };
+                    preview: {
+                        tabName: string;
+                    };
+                };
+            };
             notifications: {
                 deleteTemplate: Notification;
-                updateTemplate: Notification;
                 createTemplate: Notification;
+                iframeUnsupported: Notification;
+                updateTemplate: Notification;
+            };
+            placeholders: {
+                emptyList: Placeholder;
+            };
+            viewTemplate: {
+                heading: string;
             };
         };
         helpPanel: {
@@ -2236,6 +2304,11 @@ export interface DevPortalNS {
         applicationTemplate: EditPage;
         applications: Page;
         applicationsEdit: EditPage;
+        emailLocaleAdd: EditPage;
+        emailLocaleAddWithDisplayName: EditPage;
+        emailTemplateTypes: Page;
+        emailTemplates: EditPage;
+        emailTemplatesWithDisplayName: EditPage;
         groups: Page;
         idp: Page;
         idpTemplate: {

--- a/modules/i18n/src/translations/en-US/portals/dev-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/dev-portal.ts
@@ -2149,7 +2149,69 @@ export const devPortal: DevPortalNS = {
                 }
             }
         },
+        emailLocale: {
+            buttons: {
+                addLocaleTemplate: "Add Locale Template",
+                saveChanges: "Save Changes"
+            },
+            forms: {
+                addLocale: {
+                    fields: {
+                        bodyEditor: {
+                            label: "Body"
+                        },
+                        locale: {
+                            label: "Locale",
+                            placeholder: "Select Locale",
+                            validations: {
+                                empty: "Select locale"
+                            }
+                        },
+                        signatureEditor: {
+                            label: "Mail signature"
+                        },
+                        subject: {
+                            label: "Subject",
+                            placeholder: "Enter your email subject",
+                            validations: {
+                                empty: "Email Subject is required"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         emailTemplateTypes: {
+            buttons: {
+                createTemplateType: "Create Template Type",
+                deleteTemplate: "Delete Template",
+                editTemplate: "Edit Template",
+                newType: "New Template Type"
+            },
+            confirmations: {
+                deleteTemplateType: {
+                    assertionHint: "Please type <1>{{ id }}</1> to confirm.",
+                    content: "If you delete this email template type, all associated work flows will no longer " +
+                        "have a valid email template to work with and this will delete all the locale templates " +
+                        "associated with this template type. Please proceed cautiously.",
+                    header: "Are you sure?",
+                    message: "This action is irreversible and will permanently delete the selected email template " +
+                        "type."
+                }
+            },
+            forms: {
+                addTemplateType: {
+                    fields: {
+                        type: {
+                            label: "Template Type Name",
+                            placeholder: "Enter a template type name",
+                            validations: {
+                                empty: "Template type name is required to proceed."
+                            }
+                        }
+                    }
+                }
+            },
             notifications: {
                 createTemplateType: {
                     error: {
@@ -2193,9 +2255,56 @@ export const devPortal: DevPortalNS = {
                         message: "Email template type update successful"
                     }
                 }
+            },
+            placeholders: {
+                emptyList: {
+                    action: "New Template Type",
+                    subtitles: {
+                        0: "Currently there are no templates types available.",
+                        2: "You can add a new template type by ",
+                        3: "clicking on the button below."
+                    },
+                    title: "Add new Template Type",
+                }
+            },
+            wizards: {
+                addTemplateType: {
+                    heading: "Create Email Template Type",
+                    steps: {
+                        templateType: {
+                            heading: "Template Type"
+                        }
+                    },
+                    subHeading: "Create a new template type to associate with email requirements."
+                }
             }
         },
         emailTemplates: {
+            buttons: {
+                deleteTemplate: "Delete Template",
+                editTemplate: "Edit Template",
+                newTemplate: "New Template",
+                viewTemplate: "View Template"
+            },
+            confirmations: {
+                deleteTemplate: {
+                    assertionHint: "Please type <1>{{ id }}</1> to confirm.",
+                    content: "If you delete this email template, all associated work flows will no longer " +
+                        "have a valid email template to work with. Please proceed cautiously.",
+                    header: "Are you sure?",
+                    message: "This action is irreversible and will permanently delete the selected email template."
+                }
+            },
+            editor: {
+                tabs: {
+                    code: {
+                        tabName: "HTML Code"
+                    },
+                    preview: {
+                        tabName: "Preview"
+                    }
+                }
+            },
             notifications: {
                 createTemplate: {
                     error: {
@@ -2225,6 +2334,12 @@ export const devPortal: DevPortalNS = {
                         message: "Email template delete successful"
                     }
                 },
+                iframeUnsupported: {
+                    genericError: {
+                        description: "Your browser does not support iframes.",
+                        message: "Unsupported"
+                    }
+                },
                 updateTemplate: {
                     error: {
                         description: "{{description}}",
@@ -2239,6 +2354,20 @@ export const devPortal: DevPortalNS = {
                         message: "Email template update successful"
                     }
                 }
+            },
+            placeholders: {
+                emptyList: {
+                    action: "New Template",
+                    subtitles: {
+                        0: "Currently there are no templates available for the selected",
+                        1: "email template type. You can add a new template by ",
+                        2: "clicking on the button below."
+                    },
+                    title: "Add Template"
+                }
+            },
+            viewTemplate: {
+                heading: "Email Template Preview"
             }
         },
         footer: {
@@ -4857,6 +4986,30 @@ export const devPortal: DevPortalNS = {
             backButton: "Go back to applications",
             subTitle: null,
             title: null
+        },
+        emailLocaleAdd: {
+            backButton: "Go back to {{name}} template",
+            subTitle: null,
+            title: "Edit template - {{name}}"
+        },
+        emailLocaleAddWithDisplayName: {
+            backButton: "Go back to {{name}} template",
+            subTitle: null,
+            title: "Add new template for {{displayName}}"
+        },
+        emailTemplateTypes: {
+            subTitle: "Create and manage templates types.",
+            title: "Email Templates Types"
+        },
+        emailTemplates: {
+            backButton: "Go back to email templates types",
+            subTitle: null,
+            title: "Email Templates"
+        },
+        emailTemplatesWithDisplayName: {
+            backButton: "Go back to applications",
+            subTitle: null,
+            title: "Templates - {{displayName}}"
         },
         groups: {
             subTitle: "Create and manage user groups, assign permissions for groups.",


### PR DESCRIPTION
## Purpose
Email template components should support localization.

## Goals
1. This PR adds localization placeholders to the email template component.
2. And also fixes an UI issue in email template listing page.

<img width="1918" alt="Screen Shot 2020-05-14 at 2 21 06 AM" src="https://user-images.githubusercontent.com/25959096/81868244-ab003180-958f-11ea-87a8-0ce1f8f7ff9c.png">
