### PR TITLE
Fix config file path resolving issue in PROD enviroment

### DIFF
--- a/apps/developer-portal/src/index.html
+++ b/apps/developer-portal/src/index.html
@@ -30,7 +30,7 @@
         <script src="<%= htmlWebpackPlugin.options.publicPath %>/app-utils.js"></script>
         <script>
             AppUtils.init({
-                deploymentConfigFile: "deployment.config.json",
+                deploymentConfigFile: "<%= htmlWebpackPlugin.options.publicPath %>/deployment.config.json",
                 serverOrigin: "https://localhost:9443",
                 superTenant: "carbon.super",
                 tenantPrefix: "t"

--- a/apps/developer-portal/src/index.jsp
+++ b/apps/developer-portal/src/index.jsp
@@ -35,7 +35,7 @@
         <script src="<%= htmlWebpackPlugin.options.publicPath %>/app-utils.js"></script>
         <script>
             AppUtils.init({
-                deploymentConfigFile: "deployment.config.json",
+                deploymentConfigFile: "<%= htmlWebpackPlugin.options.publicPath %>/deployment.config.json",
                 serverOrigin: "<%= htmlWebpackPlugin.options.serverUrl %>",
                 superTenant: "<%= htmlWebpackPlugin.options.superTenantConstant %>",
                 tenantPrefix: "<%= htmlWebpackPlugin.options.tenantPrefix %>"

--- a/apps/developer-portal/src/public/app-utils.js
+++ b/apps/developer-portal/src/public/app-utils.js
@@ -125,7 +125,7 @@ var AppUtils = AppUtils || (function() {
 
             _config = _default;
 
-            var userConfigFile = (_config.clientOrigin + "/" + _args.deploymentConfigFile);
+            var userConfigFile = (_config.clientOrigin + _args.deploymentConfigFile);
 
             if (!userConfigFile) {
                 throw "AppUtils.init({deploymentConfigFile: value}) missing.";

--- a/apps/user-portal/src/index.html
+++ b/apps/user-portal/src/index.html
@@ -30,7 +30,7 @@
         <script src="<%= htmlWebpackPlugin.options.publicPath %>/app-utils.js"></script>
         <script>
             AppUtils.init({
-                deploymentConfigFile: "deployment.config.json",
+                deploymentConfigFile: "<%= htmlWebpackPlugin.options.publicPath %>/deployment.config.json",
                 serverOrigin: "https://localhost:9443",
                 superTenant: "carbon.super",
                 tenantPrefix: "t"

--- a/apps/user-portal/src/index.jsp
+++ b/apps/user-portal/src/index.jsp
@@ -35,7 +35,7 @@
         <script src="<%= htmlWebpackPlugin.options.publicPath %>/app-utils.js"></script>
         <script>
             AppUtils.init({
-                deploymentConfigFile: "deployment.config.json",
+                deploymentConfigFile: "<%= htmlWebpackPlugin.options.publicPath %>/deployment.config.json",
                 serverOrigin: "<%= htmlWebpackPlugin.options.serverUrl %>",
                 superTenant: "<%= htmlWebpackPlugin.options.superTenantConstant %>",
                 tenantPrefix: "<%= htmlWebpackPlugin.options.tenantPrefix %>"

--- a/apps/user-portal/src/public/app-utils.js
+++ b/apps/user-portal/src/public/app-utils.js
@@ -119,7 +119,7 @@ var AppUtils = AppUtils || (function() {
 
             _config = _default;
 
-            var userConfigFile = (_config.clientOrigin + "/" + _args.deploymentConfigFile);
+            var userConfigFile = (_config.clientOrigin + _args.deploymentConfigFile);
 
             if (!userConfigFile) {
                 throw "AppUtils.init({deploymentConfigFile: value}) missing.";

--- a/apps/user-portal/src/utils/filter-utils.ts
+++ b/apps/user-portal/src/utils/filter-utils.ts
@@ -52,7 +52,7 @@ export const filteredRoutes = (appConfig): Route[] => {
  * This obtains the app.config.json file from the server
  */
 export const getAppConfig = (): Promise<any> => {
-    return Axios.get(`/${window["AppUtils"].getConfig().appBaseWithTenant}/app.config.json`).then((response) => {
+    return Axios.get(`${window["AppUtils"].getConfig().appBaseWithTenant}/app.config.json`).then((response) => {
         return Promise.resolve(response.data);
     });
 };

--- a/apps/user-portal/src/utils/filter-utils.ts
+++ b/apps/user-portal/src/utils/filter-utils.ts
@@ -52,7 +52,7 @@ export const filteredRoutes = (appConfig): Route[] => {
  * This obtains the app.config.json file from the server
  */
 export const getAppConfig = (): Promise<any> => {
-    return Axios.get(`${window["AppUtils"].getConfig().appBaseWithTenant}/app.config.json`).then((response) => {
+    return Axios.get(`/${window["AppUtils"].getConfig().appBase}/app.config.json`).then((response) => {
         return Promise.resolve(response.data);
     });
 };


### PR DESCRIPTION
## Purpose
1. Portal deployment config paths were not properly resolving inside the IS pack.

<img width="669" alt="Screen Shot 2020-05-14 at 12 05 01 PM" src="https://user-images.githubusercontent.com/25959096/81904503-fee73680-95e0-11ea-841f-7220eba21888.png">

2. In tenant mode, `app.config.json` is fetched from a tenant qualified path and it leads to the following error.

Path - `https://localhost:9443/t/wso2.com/user-portal/app.config.json`

<img width="664" alt="Screen Shot 2020-05-14 at 2 12 33 PM" src="https://user-images.githubusercontent.com/25959096/81912999-fdbc0680-95ec-11ea-9ae0-048b3578e987.png">

## Goals
1. Prepends the necessary base URLs for `deployment.config.json` file path.
2. Remove the extra `/` in user portal `app.config.json` fetch path and use base name without tenant.
