### PR TITLE
Add support to change product logo in runtime

### DIFF
--- a/apps/developer-portal/src/layouts/dashboard.tsx
+++ b/apps/developer-portal/src/layouts/dashboard.tsx
@@ -17,11 +17,11 @@
  */
 
 import { getProfileInfo } from "@wso2is/core/api";
+import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
 import { ChildRouteInterface, RouteInterface } from "@wso2is/core/models";
 import { RouteUtils } from "@wso2is/core/utils";
 import { I18n, LanguageChangeException, SupportedLanguagesMeta } from "@wso2is/i18n";
-import { Footer, Header, Logo, ProductBrand, SidePanel } from "@wso2is/react-components";
-import { ThemeContext } from "@wso2is/react-components";
+import { Footer, Header, Logo, ProductBrand, SidePanel, ThemeContext } from "@wso2is/react-components";
 import classNames from "classnames";
 import _ from "lodash";
 import React, {
@@ -39,7 +39,7 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import { Button, Image, Responsive } from "semantic-ui-react";
 import { BaseLayout } from "./base";
 import { ProtectedRoute } from "../components";
-import { LogoImage, SidePanelIcons, SidePanelMiscIcons, routes } from "../configs";
+import { SidePanelIcons, SidePanelMiscIcons, routes } from "../configs";
 import { UIConstants } from "../constants";
 import { history } from "../helpers";
 import { AuthStateInterface, ConfigReducerStateInterface, FeatureConfigInterface } from "../models";
@@ -306,10 +306,20 @@ export const DashboardLayout: FunctionComponent<DashboardLayoutPropsInterface> =
                     brand={ (
                         <ProductBrand
                             style={ { marginTop: 0 } }
-                            logo={  state.logo && state.logo !== "" ?
-                                <Image src={ state.logo } style={ { maxHeight: 25 } } />
-                                :
-                                <Logo image={ LogoImage } />
+                            logo={
+                                (state.logo && state.logo !== "")
+                                    ? <Image src={ state.logo } style={ { maxHeight: 25 } } />
+                                    : (
+                                        <Logo
+                                            className="portal-logo"
+                                            image={
+                                                resolveAppLogoFilePath(window["AppUtils"].getConfig().ui.appLogoPath,
+                                                    `${window["AppUtils"].getConfig().clientOrigin}/` +
+                                                    `${window["AppUtils"].getConfig().appBase}/libs/themes/` +
+                                                    state.theme)
+                                            }
+                                        />
+                                    )
                             }
                             name={ state.productName && state.productName !== "" ?
                                 state.productName

--- a/apps/developer-portal/src/public/deployment.config.json
+++ b/apps/developer-portal/src/public/deployment.config.json
@@ -16,6 +16,7 @@
     "ui": {
         "appCopyright": "WSO2 Identity Server",
         "appTitle": "WSO2 Identity Server Developer Dashboard",
-        "appName": "Identity Server"
+        "appName": "Identity Server",
+        "appLogoPath": "/assets/images/logo.svg"
     }
 }

--- a/apps/user-portal/package.json
+++ b/apps/user-portal/package.json
@@ -25,6 +25,7 @@
         "@wso2is/core": "^1.0.257",
         "@wso2is/forms": "^1.0.257",
         "@wso2is/http": "^1.0.257",
+        "@wso2is/react-components": "^1.0.257",
         "@wso2is/theme": "^1.0.257",
         "@wso2is/validation": "^1.0.257",
         "qrcode.react": "^1.0.0"

--- a/apps/user-portal/src/components/shared/ui.tsx
+++ b/apps/user-portal/src/components/shared/ui.tsx
@@ -16,11 +16,12 @@
  * under the License.
  */
 
+import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
+import { Logo } from "@wso2is/react-components";
 import classNames from "classnames";
 import * as React from "react";
 import { Image } from "semantic-ui-react";
-import { ThemeIcon } from "./icon";
-import { GlobalConfig, HomeTileIconImages, LogoImage, UserImage } from "../../configs";
+import { GlobalConfig, HomeTileIconImages, UserImage } from "../../configs";
 
 interface ImageProps {
     classes?: any;
@@ -41,27 +42,19 @@ interface TitleProps {
     children?: any;
 }
 
-export const Logo = (props: ImageProps) => {
-    const { classes, size, style } = props;
-
-    return (
-        <ThemeIcon
-            icon={ LogoImage }
-            className={ classNames(classes, "product-logo") }
-            size={ size }
-            style={ style }
-            transparent
-            inline
-        />
-    );
-};
-
 export const Title = (props: TitleProps) => {
     const { classes, style, children } = props;
 
     return (
         <div className={ classNames(classes, "product-title") } style={ style }>
-            <Logo />
+            <Logo
+                className="portal-logo"
+                image={
+                    resolveAppLogoFilePath(window["AppUtils"].getConfig().ui.appLogoPath,
+                        `${window["AppUtils"].getConfig().clientOrigin}/` +
+                        `${window["AppUtils"].getConfig().appBase}/libs/themes/default`)
+                }
+            />
             <h1 className={ classNames(classes, "product-title-text") } style={ style }>
                 { GlobalConfig.applicationName }
             </h1>

--- a/apps/user-portal/src/public/deployment.config.json
+++ b/apps/user-portal/src/public/deployment.config.json
@@ -11,6 +11,7 @@
     "ui": {
         "appCopyright": "WSO2 Identity Server",
         "appTitle": "Manage you WSO2 Identity Server Account",
-        "appName": "Identity Server Account"
+        "appName": "Identity Server Account",
+        "appLogoPath": "/assets/images/logo.svg"
     }
 }

--- a/modules/core/src/__tests__/__mocks__/mock-deployment-config.ts
+++ b/modules/core/src/__tests__/__mocks__/mock-deployment-config.ts
@@ -16,5 +16,27 @@
  * under the License.
  */
 
-export * from "./mock-config";
-export * from "./mock-deployment-config";
+/* eslint-disable sort-keys */
+export const deploymentConfigMock = {
+    accountAppURL: {
+        path: "/user-portal/overview"
+    },
+    appBaseName: "developer-portal",
+    clientID: "DEVELOPER_PORTAL",
+    debug: false,
+    i18nResourcePath: "",
+    loginCallbackPath: "/login",
+    logoutCallbackPath: "/login",
+    routePaths: {
+        home: "/applications",
+        login: "/login",
+        logout: "/logout"
+    },
+    ui: {
+        appCopyright: "WSO2 Identity Server",
+        appTitle: "WSO2 Identity Server Developer Dashboard",
+        appName: "Identity Server",
+        appLogoPath: "/assets/images/logo.svg"
+    }
+};
+/* eslint-enable sort-keys */

--- a/modules/core/src/__tests__/helpers/portal-branding.test.ts
+++ b/modules/core/src/__tests__/helpers/portal-branding.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import { resolveAppLogoFilePath, shouldResolveAppLogoFilePath } from "../../helpers";
+import { deploymentConfigMock } from "../__mocks__";
+
+describe("App logo path resolving necessity checker helper function", () => {
+
+    test("Should return true for relative paths", () => {
+        expect(shouldResolveAppLogoFilePath(deploymentConfigMock.ui.appLogoPath)).toBe(true);
+    });
+
+    test("Should return false for HTTP urls", () => {
+        const path = "http://builtwithreact.io/img/logo.svg";
+
+        expect(shouldResolveAppLogoFilePath(path)).toBe(false);
+    });
+
+    test("Should return false for HTTPS urls", () => {
+        const path = "https://cdn4.iconfinder.com/data/icons/logos-3/600/React.js_logo-512.png";
+
+        expect(shouldResolveAppLogoFilePath(path)).toBe(false);
+    });
+
+    test("Should return false for data urls", () => {
+        const path = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+
+        expect(shouldResolveAppLogoFilePath(path)).toBe(false);
+    });
+});
+
+describe("App logo path resolver helper function", () => {
+
+    test("Should properly resolve relative paths", () => {
+        const path = deploymentConfigMock.ui.appLogoPath;
+        const prefix = "https://localhost:9443/developer-portal/";
+
+        expect(resolveAppLogoFilePath(path, prefix))
+            .toEqual("https://localhost:9443/developer-portal/assets/images/logo.svg");
+    });
+
+    test("Should return the same path for hosted URLs", () => {
+        const path = "http://builtwithreact.io/img/logo.svg";
+        const prefix = "https://localhost:9443/developer-portal/";
+
+        expect(resolveAppLogoFilePath(path, prefix)).toEqual(path);
+    });
+
+    test("Should return the same url for data URLs", () => {
+        const path = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+        const prefix = "https://localhost:9443/developer-portal/";
+
+        expect(resolveAppLogoFilePath(path, prefix)).toEqual(path);
+    });
+});

--- a/modules/core/src/helpers/index.ts
+++ b/modules/core/src/helpers/index.ts
@@ -17,6 +17,7 @@
  */
 
 export * from "./access-control";
+export * from "./portal-branding";
 export * from "./history";
 export * from "./http-headers";
 export * from "./profile";

--- a/modules/core/src/helpers/portal-branding.ts
+++ b/modules/core/src/helpers/portal-branding.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { StringUtils, URLUtils } from "../utils";
+
+/**
+ * Checks if the Logo file path provided in the config file should be resolved or not.
+ * If the provided path is a hosted resource or a data URL, It is not required
+ * to resolve the path relative to the bundle.
+ *
+ * @param {string} path - Given app logo path in config.
+ *
+ * @return Should the path be resolved or not.
+ */
+export const shouldResolveAppLogoFilePath = (path: string): boolean => {
+    return !(URLUtils.isHttpsUrl(path) || URLUtils.isHttpUrl(path) || URLUtils.isDataUrl(path));
+};
+
+/**
+ * Resolves the app logo file path.
+ *
+ * @example
+ * // returns "https://localhost:9443/developer-portal/assets/images/logo.jpg"
+ * resolveAppLogoFilePath("/assets/images/logo.jpg", "https://localhost:9443/developer-portal/");
+ * // returns "http://builtwithreact.io/img/logo.svg"
+ * resolveAppLogoFilePath("http://builtwithreact.io/img/logo.svg", "https://localhost:9443/developer-portal/");
+ *
+ * @param {string} path - Given app logo path in config.
+ *
+ * @return Should the path be resolved or not.
+ */
+export const resolveAppLogoFilePath = (path: string, prefix: string) => {
+    // If resolving path is not necessary, return the original.
+    if (!shouldResolveAppLogoFilePath(path)) {
+        return path;
+    }
+
+    return StringUtils.removeSlashesFromPath(prefix, false, true)
+        + "/" + StringUtils.removeSlashesFromPath(path, true, false);
+};

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -24,8 +24,8 @@
 .loadVariables();
 
 @spacer: 1rem;
-
 @pageHeaderMaxWidth: 600px;
+@productLogoHeight: 22px;
 
 each(range(5), {
     .ui.divider.hidden.x@{value} {
@@ -43,6 +43,13 @@ body {
             width: 60px;
             vertical-align: text-top;
             margin-right: 5px;
+
+            .icon {
+                height: @productLogoHeight;
+            }
+            &.portal-logo {
+                width: auto !important;
+            }
         }
         .product-title-text {
             text-transform: uppercase;


### PR DESCRIPTION
## Purpose
In the current implementation, the product logo is resolved through `@svgr/webpack` loader and it injects the SVG code into the HTML directly. This is great for dynamically styling the svgs' but this makes it hard to change the logo through the final distribution bundle.

## Goals
Make changes to enable easy logo changes through the final distribution bundle.

## Approach

Added an entry(`appLogoPath`) under the `ui` section of the `deployment.config.json`.

```json
{
    ...
    "ui": {
        ...
        "appLogoPath": "/assets/images/logo.svg"
    }
}
```

This PR introduces changes to support the following path types.

1. **Relative** paths will be resolved from the resource bundle.

Ex. `/assets/images/logo.svg` will be resolved as `https://localhost:9443/t/wso2.com/developer-portal/libs/themes/default/assets/images/logo.svg`

<img width="262" alt="Screen Shot 2020-05-14 at 5 47 01 PM" src="https://user-images.githubusercontent.com/25959096/81935316-17217a80-960e-11ea-88d6-78df7b9bf47f.png">

2. **Hosted** Images.

URLs like [this](https://cdn4.iconfinder.com/data/icons/logos-and-brands/512/97_Docker_logo_logos-512.png) will be displayed as follows.

<img width="234" alt="Screen Shot 2020-05-14 at 5 46 10 PM" src="https://user-images.githubusercontent.com/25959096/81935454-4b953680-960e-11ea-9ee0-ab472de37a3a.png">

3. **Data URLs**

Base64 encoded data URLs(`data:image/svg+xml;base64,.....`) will be displayed as follows.

<img width="232" alt="Screen Shot 2020-05-14 at 5 45 17 PM" src="https://user-images.githubusercontent.com/25959096/81935517-610a6080-960e-11ea-9b94-1866f849636b.png">
