### PR TITLE
Add user store regEx validations in users/roles/groups sections

### DIFF
--- a/apps/developer-portal/src/components/roles/create-role-wizard/role-basics.tsx
+++ b/apps/developer-portal/src/components/roles/create-role-wizard/role-basics.tsx
@@ -133,7 +133,7 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
      *
      * @param roleName - User input role name
      */
-    async function validateRoleNamePattern(roleName: string) {
+    const validateRoleNamePattern = async (roleName: string): Promise<void> => {
         let userStoreRegEx = "";
         if (userStore !== PRIMARY_DOMAIN) {
             await getUserstoreRegEx(userStore, USERSTORE_REGEX_PROPERTIES.RolenameRegEx)
@@ -145,7 +145,7 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
             userStoreRegEx = PRIMARY_USERSTORE_PROPERTY_VALUES.RolenameJavaScriptRegEx;
         }
         setIsRoleNamePatternValid(validateInputAgainstRegEx(roleName, userStoreRegEx));
-    }
+    };
 
     /**
      * The following function fetch the user store list and set it to the state.

--- a/apps/developer-portal/src/components/roles/create-role-wizard/role-sumary.tsx
+++ b/apps/developer-portal/src/components/roles/create-role-wizard/role-sumary.tsx
@@ -132,7 +132,7 @@ export const CreateRoleSummary: FunctionComponent<AddUserWizardSummaryProps> = (
                                             .map((perm, index) => (
                                                 <Label
                                                     data-testid={
-                                                        `${ testId }-permissions-${ perm.label.lowerCase() }-label`
+                                                        `${ testId }-permissions-${ index }-label`
                                                     }
                                                     key={ index }
                                                     basic

--- a/apps/developer-portal/src/components/roles/edit-role/edit-role-basic.tsx
+++ b/apps/developer-portal/src/components/roles/edit-role/edit-role-basic.tsx
@@ -91,7 +91,7 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
             });
     }, [ nameValue ]);
 
-    async function fetchUserstoreRegEx() {
+    const fetchUserstoreRegEx = async (): Promise<string> => {
         // TODO: Enable when the role object includes user store.
         // if (roleObject && roleObject.displayName.indexOf("/") !== -1) {
         //     // Get the role name regEx for the secondary user store
@@ -105,9 +105,8 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
         //     // Get the role name regEx for the primary user store
         //     regEx = PRIMARY_USERSTORE_PROPERTY_VALUES.RolenameJavaScriptRegEx;
         // }
-        const regEx = PRIMARY_USERSTORE_PROPERTY_VALUES.RolenameJavaScriptRegEx;
-        return regEx;
-    }
+        return PRIMARY_USERSTORE_PROPERTY_VALUES.RolenameJavaScriptRegEx;
+    };
 
     /**
      * The following function handles the role name change.
@@ -115,7 +114,7 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
      * @param event
      * @param data
      */
-    const handleRoleNameChange = (event: ChangeEvent, data: InputOnChangeData) => {
+    const handleRoleNameChange = (event: ChangeEvent, data: InputOnChangeData): void => {
         setNameValue(data.value);
         setIsRoleNamePatternValid(validateInputAgainstRegEx(data.value, userStoreRegEx));
     };
@@ -125,7 +124,7 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
      *
      * @param {AlertInterface} alert - Alert object.
      */
-    const handleAlerts = (alert: AlertInterface) => {
+    const handleAlerts = (alert: AlertInterface): void => {
         dispatch(addAlert(alert));
     };
 

--- a/apps/developer-portal/src/components/roles/role-list.tsx
+++ b/apps/developer-portal/src/components/roles/role-list.tsx
@@ -201,11 +201,11 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
                     ) }
                     image={ EmptyPlaceholderIllustrations.newList }
                     imageSize="tiny"
-                    title={ t("devPortal:components.roles.list.emptyPlaceholders.emptyRoleList.action.title",
+                    title={ t("devPortal:components.roles.list.emptyPlaceholders.emptyRoleList.title",
                         { type: isGroup ? "group" : "role" }) }
                     subtitle={ [
                         t("devPortal:components.roles.list.emptyPlaceholders.emptyRoleList.subtitles.0",
-                            { type: isGroup ? "group" : "role" }),
+                            { type: isGroup ? "groups" : "roles" }),
                         t("devPortal:components.roles.list.emptyPlaceholders.emptyRoleList.subtitles.1",
                             { type: isGroup ? "group" : "role" }),
                         t("devPortal:components.roles.list.emptyPlaceholders.emptyRoleList.subtitles.2",

--- a/apps/developer-portal/src/components/users/add-user.tsx
+++ b/apps/developer-portal/src/components/users/add-user.tsx
@@ -155,7 +155,7 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
      *
      * @param userstore
      */
-    async function setUserStoreRegEx(userstore: string) {
+    const setUserStoreRegEx = async (userstore: string): Promise<void> => {
         if (userstore !== "primary") {
             // Set the username regEx of the secondary user store.
             await getUserstoreRegEx(userstore, USERSTORE_REGEX_PROPERTIES.UsernameRegEx)
@@ -167,14 +167,14 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
             // Set the username regEx of the primary user store.
             setUsernameRegEx(PRIMARY_USERSTORE_PROPERTY_VALUES.UsernameJavaScriptRegEx);
         }
-    }
+    };
 
     /**
      * The following function checks if the password pattern is valid against the user store regEx.
      *
      * @param password
      */
-    async function setPasswordRegEx(password: string) {
+    const setPasswordRegEx = async (password: string): Promise<void> => {
         let passwordRegex = "";
         if (userStore !== "primary") {
             // Set the username regEx of the secondary user store.
@@ -188,7 +188,7 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
             passwordRegex = PRIMARY_USERSTORE_PROPERTY_VALUES.PasswordJavaScriptRegEx;
         }
         setIsPasswordPatternValid(validateInputAgainstRegEx(password, passwordRegex));
-    }
+    };
 
     /**
      * The following function handles the change of the password.

--- a/apps/developer-portal/src/components/users/user-groups-edit.tsx
+++ b/apps/developer-portal/src/components/users/user-groups-edit.tsx
@@ -680,7 +680,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
                                 floated="left"
                                 onClick={ handleCloseAddNewGroupModal }
                             >
-                                Cancel
+                                { t("common:cancel") }
                             </LinkButton>
                         </Grid.Column>
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
@@ -689,7 +689,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
                                 floated="right"
                                 onClick={ () => updateUserGroup(user, tempGroupList) }
                             >
-                                Save
+                                { t("common:save") }
                             </PrimaryButton>
                         </Grid.Column>
                     </Grid.Row>

--- a/apps/developer-portal/src/components/users/user-profile.tsx
+++ b/apps/developer-portal/src/components/users/user-profile.tsx
@@ -21,7 +21,7 @@ import { Field, Forms } from "@wso2is/forms";
 import { ConfirmationModal, DangerZone, DangerZoneGroup } from "@wso2is/react-components";
 import _ from "lodash";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import {Trans, useTranslation} from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Button, Divider, Form, Grid, Input } from "semantic-ui-react";
 import { deleteUser, updateUserInfo } from "../../api";
@@ -278,6 +278,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                 type="text"
                                 value={ profileInfo.get(schema.name) }
                                 key={ key }
+                                disabled={ schema.name === "userName" }
                             />
                         )
                     }

--- a/apps/developer-portal/src/constants/user-store-constants.ts
+++ b/apps/developer-portal/src/constants/user-store-constants.ts
@@ -65,3 +65,21 @@ export const USERSTORE_TYPE_IMAGES = {
     UniqueIDReadOnlyLDAPUserStoreManager: "ldap",
     UniqueIDReadWriteLDAPUserStoreManager: "ldap"
 };
+
+/**
+ * Primary user store property values
+ */
+export const PRIMARY_USERSTORE_PROPERTY_VALUES = {
+    PasswordJavaScriptRegEx: "^[\\S]{5,30}$",
+    RolenameJavaScriptRegEx: "^[\\S]{3,30}$",
+    UsernameJavaScriptRegEx: "^[\\S]{3,30}$"
+};
+
+/**
+ * User store regEx properties
+ */
+export const USERSTORE_REGEX_PROPERTIES = {
+    PasswordRegEx: "PasswordJavaScriptRegEx",
+    RolenameRegEx: "RolenameJavaScriptRegEx",
+    UsernameRegEx: "UsernameJavaScriptRegEx"
+};

--- a/apps/developer-portal/src/utils/index.ts
+++ b/apps/developer-portal/src/utils/index.ts
@@ -27,3 +27,4 @@ export * from "./common-utils";
 export * from "./filter-list";
 export * from "./sort-list";
 export * from "./userstores";
+export * from "./role-management-utils";

--- a/apps/developer-portal/src/utils/role-management-utils.ts
+++ b/apps/developer-portal/src/utils/role-management-utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the 'License'); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { searchRoleList } from "../api";
+import { SearchRoleInterface } from "../models";
+
+/**
+ * Utility class for roles operations.
+ */
+export class RoleManagementUtils {
+
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     *
+     * @hideconstructor
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private constructor() {
+    }
+
+    /**
+     * Util method to validate if the provided role name exists in the system.
+     *
+     * @param roleName - new role name user entered.
+     */
+    public static validateRoleName = (roleName: string): Promise<boolean> => {
+        const searchData: SearchRoleInterface = {
+            filter: "displayName eq " + roleName,
+            schemas: [
+                "urn:ietf:params:scim:api:messages:2.0:SearchRequest"
+            ],
+            startIndex: 1
+        };
+
+         return searchRoleList(searchData)
+            .then((response) => {
+                return response?.data?.totalResults === 0;
+            });
+    };
+}

--- a/apps/developer-portal/src/utils/userstores.ts
+++ b/apps/developer-portal/src/utils/userstores.ts
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+import _ from "lodash";
+import { getAUserStore, getUserStoreList } from "../api";
 import {
     CategorizedProperties,
     TypeProperty,
@@ -179,4 +181,36 @@ export const reOrganizeProperties = (
             required: userRequiredProperties
         }
     };
+};
+
+/**
+ * The following method get the username regEx for the selected user store.
+ *
+ * @param userstore
+ * @param regExName
+ */
+export async function getUserstoreRegEx (userstore: string, regExName: string) {
+    let usernameRegEx: UserStoreProperty = null;
+    return getUserStoreList()
+         .then((response) => {
+            const store = response.data.find(item => item.name === userstore);
+            if (!_.isEmpty(store)) {
+                return getAUserStore(store.id)
+                    .then((resp) => {
+                        usernameRegEx = resp.properties.find(property => property.name === regExName);
+                        return usernameRegEx?.value;
+                    })
+            }
+        });
+}
+
+/**
+ * The following method validate user input against the user store regEx.
+ *
+ * @param inputValue
+ * @param regExValue
+ */
+export const validateInputAgainstRegEx = (inputValue: string, regExValue: string): boolean => {
+    const regEx = new RegExp(regExValue);
+    return regEx.test(inputValue);
 };

--- a/apps/developer-portal/src/utils/userstores.ts
+++ b/apps/developer-portal/src/utils/userstores.ts
@@ -189,7 +189,7 @@ export const reOrganizeProperties = (
  * @param userstore
  * @param regExName
  */
-export async function getUserstoreRegEx (userstore: string, regExName: string) {
+export const getUserstoreRegEx = async (userstore: string, regExName: string): Promise<string> => {
     let usernameRegEx: UserStoreProperty = null;
     return getUserStoreList()
          .then((response) => {
@@ -202,7 +202,7 @@ export async function getUserstoreRegEx (userstore: string, regExName: string) {
                     })
             }
         });
-}
+};
 
 /**
  * The following method validate user input against the user store regEx.

--- a/modules/i18n/src/models/namespaces/dev-portal-ns.ts
+++ b/modules/i18n/src/models/namespaces/dev-portal-ns.ts
@@ -1451,6 +1451,7 @@ export interface DevPortalNS {
                             validations: {
                                 empty: string;
                                 invalid: string;
+                                regExViolation: string;
                             };
                         };
                         newPassword: {
@@ -1458,6 +1459,7 @@ export interface DevPortalNS {
                             placeholder: string;
                             validations: {
                                 empty: string;
+                                regExViolation: string;
                             };
                         };
                         domain: {

--- a/modules/i18n/src/translations/en-US/portals/dev-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/dev-portal.ts
@@ -3402,7 +3402,8 @@ export const devPortal: DevPortalNS = {
                             placeholder: "Enter {{type}} Name",
                             validations: {
                                 duplicate: "A {{type}} already exists with the given {{type}} name.",
-                                empty: "{{type}} Name is required to proceed."
+                                empty: "{{type}} Name is required to proceed.",
+                                invalid: "Please enter a valid {{type}} name."
                             }
                         }
                     }
@@ -4308,7 +4309,8 @@ export const devPortal: DevPortalNS = {
                             label: "New Password",
                             placeholder: "Enter the new password",
                             validations: {
-                                empty: "New password is a required field"
+                                empty: "New password is a required field",
+                                regExViolation: "Please enter a valid password"
                             }
                         },
                         username: {
@@ -4316,7 +4318,8 @@ export const devPortal: DevPortalNS = {
                             placeholder: "Enter the username",
                             validations: {
                                 empty: "Username is a required field",
-                                invalid: "A user already exists with this username."
+                                invalid: "A user already exists with this username.",
+                                regExViolation: "Please enter a valid username"
                             }
                         }
                     },


### PR DESCRIPTION
## Purpose
> Currently in the user/group/role creation and edit flow we don't validate the user inputs like username, password and role name in the developer portal. This PR will introduce the ability to validate such inputs against a regular expression.

Resolves #875

## Approach
> We fetch the regular expressions defined in the user store configuration upon the user's user store selections and validate the above-mentioned inputs against the relevant regEx.
