### PR TITLE
Use form_post response mode in authorize requests.

### DIFF
--- a/apps/developer-portal/src/index.jsp
+++ b/apps/developer-portal/src/index.jsp
@@ -34,6 +34,14 @@
 
         <script src="<%= htmlWebpackPlugin.options.publicPath %>/app-utils.js"></script>
         <script>
+            // When OAuth2 response mode is set to "form_post", Authorization code sent in a POST.
+            // In such cases, the code is added to the sessionStorage under the key "code".
+            const authorizationCode = "<%= htmlWebpackPlugin.options.authorizationCode %>";
+
+            if (authorizationCode) {
+                window.sessionStorage.setItem("code", authorizationCode);
+            }
+
             AppUtils.init({
                 serverOrigin: "<%= htmlWebpackPlugin.options.serverUrl %>",
                 superTenant: "<%= htmlWebpackPlugin.options.superTenantConstant %>",

--- a/apps/developer-portal/src/index.jsp
+++ b/apps/developer-portal/src/index.jsp
@@ -38,7 +38,7 @@
             // In such cases, the code is added to the sessionStorage under the key "code".
             const authorizationCode = "<%= htmlWebpackPlugin.options.authorizationCode %>";
 
-            if (authorizationCode) {
+            if (authorizationCode !== "null") {
                 window.sessionStorage.setItem("code", authorizationCode);
             }
 

--- a/apps/developer-portal/src/store/actions/authenticate.ts
+++ b/apps/developer-portal/src/store/actions/authenticate.ts
@@ -158,12 +158,13 @@ export const getProfileInformation = () => (dispatch): void => {
  */
 const identityManager = (() => {
     let instance: ConfigInterface;
- 
+
     const createInstance = () => {
         return new IdentityClient({
             callbackURL: store.getState().config.deployment.loginCallbackUrl,
             clientHost: store.getState().config.deployment.clientHost,
             clientID: store.getState().config.deployment.clientID,
+            responseMode: process.env.NODE_ENV === "production" ? "form_post" : null,
             scope: [ SYSTEM_SCOPE ],
             serverOrigin: store.getState().config.deployment.serverOrigin,
             tenant: store.getState().config.deployment.tenant,

--- a/apps/developer-portal/webpack.config.js
+++ b/apps/developer-portal/webpack.config.js
@@ -60,7 +60,8 @@ module.exports = (env) => {
                 serverUrl: "<%=getServerURL(\"\", true, true)%>",
                 superTenantConstant: "<%=SUPER_TENANT_DOMAIN_NAME%>",
                 tenantDelimiter: "\"/\"+'<%=TENANT_AWARE_URL_PREFIX%>'+\"/\"",
-                tenantPrefix: '<%=TENANT_AWARE_URL_PREFIX%>'
+                tenantPrefix: '<%=TENANT_AWARE_URL_PREFIX%>',
+                authorizationCode: "<%=request.getParameter(\"code\")%>"
             });
         }
         else {
@@ -207,7 +208,7 @@ module.exports = (env) => {
             compileAppIndex(),
             new webpack.DefinePlugin({
                 "process.env": {
-                    NODE_ENV: JSON.stringify(process.env.NODE_ENV)
+                    NODE_ENV: JSON.stringify(env.NODE_ENV)
                 },
                 "typeof window": JSON.stringify("object")
             })

--- a/apps/developer-portal/webpack.config.js
+++ b/apps/developer-portal/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = (env) => {
                 serverUrl: "<%=getServerURL(\"\", true, true)%>",
                 superTenantConstant: "<%=SUPER_TENANT_DOMAIN_NAME%>",
                 tenantDelimiter: "\"/\"+'<%=TENANT_AWARE_URL_PREFIX%>'+\"/\"",
-                tenantPrefix: '<%=TENANT_AWARE_URL_PREFIX%>',
+                tenantPrefix: "<%=TENANT_AWARE_URL_PREFIX%>",
                 authorizationCode: "<%=request.getParameter(\"code\")%>"
             });
         }

--- a/apps/user-portal/src/index.jsp
+++ b/apps/user-portal/src/index.jsp
@@ -34,6 +34,14 @@
 
         <script src="<%= htmlWebpackPlugin.options.publicPath %>/app-utils.js"></script>
         <script>
+            // When OAuth2 response mode is set to "form_post", Authorization code sent in a POST.
+            // In such cases, the code is added to the sessionStorage under the key "code".
+            const authorizationCode = "<%= htmlWebpackPlugin.options.authorizationCode %>";
+
+            if (authorizationCode) {
+                window.sessionStorage.setItem("code", authorizationCode);
+            }
+
             AppUtils.init({
                 serverOrigin: "<%= htmlWebpackPlugin.options.serverUrl %>",
                 superTenant: "<%= htmlWebpackPlugin.options.superTenantConstant %>",

--- a/apps/user-portal/src/index.jsp
+++ b/apps/user-portal/src/index.jsp
@@ -38,7 +38,7 @@
             // In such cases, the code is added to the sessionStorage under the key "code".
             const authorizationCode = "<%= htmlWebpackPlugin.options.authorizationCode %>";
 
-            if (authorizationCode) {
+            if (authorizationCode !== "null") {
                 window.sessionStorage.setItem("code", authorizationCode);
             }
 

--- a/apps/user-portal/src/store/actions/authenticate.ts
+++ b/apps/user-portal/src/store/actions/authenticate.ts
@@ -172,12 +172,13 @@ export const getProfileInformation = (updateProfileCompletion = false) => (dispa
  */
 const identityManager = (() => {
     let instance: ClientInteface;
- 
+
     const createInstance = () => {
         return new IdentityClient({
             callbackURL: window["AppUtils"].getConfig().loginCallbackURL,
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
+            responseMode: process.env.NODE_ENV === "production" ? "form_post" : null,
             serverOrigin: window["AppUtils"].getConfig().serverOrigin,
             tenant: window["AppUtils"].getConfig().tenant,
             tenantPath: window["AppUtils"].getConfig().tenantPath

--- a/apps/user-portal/webpack.config.js
+++ b/apps/user-portal/webpack.config.js
@@ -60,7 +60,8 @@ module.exports = (env) => {
                 serverUrl: "<%=getServerURL(\"\", true, true)%>",
                 superTenantConstant: "<%=SUPER_TENANT_DOMAIN_NAME%>",
                 tenantDelimiter: "\"/\"+'<%=TENANT_AWARE_URL_PREFIX%>'+\"/\"",
-                tenantPrefix: '<%=TENANT_AWARE_URL_PREFIX%>'
+                tenantPrefix: '<%=TENANT_AWARE_URL_PREFIX%>',
+                authorizationCode: "<%=request.getParameter(\"code\")%>"
             });
         }
         else {
@@ -201,7 +202,7 @@ module.exports = (env) => {
             compileAppIndex(),
             new webpack.DefinePlugin({
                 "process.env": {
-                    NODE_ENV: JSON.stringify(process.env.NODE_ENV)
+                    NODE_ENV: JSON.stringify(env.NODE_ENV)
                 },
                 "typeof window": JSON.stringify("object")
             })

--- a/apps/user-portal/webpack.config.js
+++ b/apps/user-portal/webpack.config.js
@@ -60,7 +60,7 @@ module.exports = (env) => {
                 serverUrl: "<%=getServerURL(\"\", true, true)%>",
                 superTenantConstant: "<%=SUPER_TENANT_DOMAIN_NAME%>",
                 tenantDelimiter: "\"/\"+'<%=TENANT_AWARE_URL_PREFIX%>'+\"/\"",
-                tenantPrefix: '<%=TENANT_AWARE_URL_PREFIX%>',
+                tenantPrefix: "<%=TENANT_AWARE_URL_PREFIX%>",
                 authorizationCode: "<%=request.getParameter(\"code\")%>"
             });
         }

--- a/modules/authentication/src/client.ts
+++ b/modules/authentication/src/client.ts
@@ -20,6 +20,7 @@ import { handleSignIn } from "./actions/sign-in";
 import { handleSignOut } from "./actions/sign-out";
 import * as AUTHENTICATION_TYPES from "./constants";
 import { ConfigInterface } from "./models/client";
+import { ResponseModeTypes } from "./models/oidc-request-params";
 
 /**
  * The login scope.
@@ -53,6 +54,7 @@ const DefaultConfig = {
     clientSecret: null,
     consentDenied: false,
     enablePKCE: true,
+    responseMode: null,
     scope: [LOGIN_SCOPE, HUMAN_TASK_SCOPE],
     tenant: DEFAULT_SUPER_TENANT
 };
@@ -72,6 +74,7 @@ export class IdentityClient implements ConfigInterface {
     public clientSecret!: string;
     public consentDenied!: boolean;
     public enablePKCE!: boolean;
+    public responseMode!: ResponseModeTypes;
     public scope!: string[];
     public serverOrigin: string;
     public tenant!: string;
@@ -98,6 +101,7 @@ export class IdentityClient implements ConfigInterface {
         this.clientSecret = resolve("clientSecret");
         this.consentDenied = resolve("consentDenied");
         this.enablePKCE = resolve("enablePKCE");
+        this.responseMode = resolve("responseMode");
         this.scope = resolve("scope");
         this.serverOrigin = resolve("serverOrigin");
         this.tenant = resolve("tenant");

--- a/modules/authentication/src/models/client.ts
+++ b/modules/authentication/src/models/client.ts
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+import { ResponseModeTypes } from "./oidc-request-params";
+
 /**
  * SDK Client config parameters.
  */
@@ -28,6 +30,7 @@ export interface ConfigInterface {
     consentDenied?: boolean;
     enablePKCE?: boolean;
     prompt?: string;
+    responseMode?: ResponseModeTypes;
     scope?: string[];
     serverOrigin: string;
     tenant?: string;

--- a/modules/authentication/src/models/oidc-request-params.ts
+++ b/modules/authentication/src/models/oidc-request-params.ts
@@ -27,6 +27,7 @@ export interface OIDCRequestParamsInterface {
     enablePKCE: boolean;
     prompt?: string;
     redirectUri: string;
+    responseMode?: ResponseModeTypes;
     scope?: string[];
     serverOrigin: string;
 }
@@ -46,3 +47,8 @@ export interface AccountSwitchRequestParams {
     clientHost: string;
     serverOrigin: string;
 }
+
+/**
+ * Supported OAuth2 response types.
+ */
+export type ResponseModeTypes = "query" | "form_post";

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "repository": "https://github.com/wso2/identity-apps.git",
     "scripts": {
         "prebuild": "lerna bootstrap",
+        "build:dev": "npm install && npm run build",
         "build": "lerna run build --stream",
         "clean": "lerna run clean --stream",
         "clean-all": "npm run remove-package-lock && npm run remove-maven-folders && npm run remove-node-modules",


### PR DESCRIPTION
## Purpose
Currently, for authorize requests the portals use default response mode i.e `query` which triggers a redirect to the `redirect_uri`. But as per spec[1], there are security implications to encoding response values in the query string .

## Goals
This PR will implement changes to enable the Javascript SDK (`@wso2is/authentication`) to support multiple response modes (`query` & `form_post`).

## Approach
1. Add logic to read the authorization code from the POST params in index.jsp. And then save the code in the session storage.
2. Extend authorization code extraction logic in SDK to support reading from URL params as well as session storage.

NOTE: In dev mode, sending POST requests to routes is not possible. Therefore, a check was added at SDK initialization to only use `form_post` in production environment.

```ts
new IdentityClient({
    ...
    responseMode: process.env.NODE_ENV === "production" ? "form_post" : null,
    ...
});
```

## TODO
1. Add support to extract the `code` when the response mode is `fragment`(Needed when the SDK supports implicit grant type).
2. Add support for `web_message` response mode.

[1] https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html