### PR TITLE
Add product version displaying capability + Side panel feature status display capability.

### DIFF
--- a/apps/developer-portal/src/components/applications/settings/sign-on-methods/script-based-flow/script-templates-side-panel.tsx
+++ b/apps/developer-portal/src/components/applications/settings/sign-on-methods/script-based-flow/script-templates-side-panel.tsx
@@ -34,7 +34,7 @@ import { AdaptiveAuthTemplateInterface } from "../../../../../models";
 /**
  * Component ref type.
  */
-export type ScriptTemplatesSidePanelRefType = HTMLFormElement;
+export type ScriptTemplatesSidePanelRefType = HTMLDivElement;
 
 /**
  * Proptypes for the adaptive scripts component.
@@ -64,7 +64,7 @@ interface ScriptTemplatesSidePanelInterface extends TestableComponentInterface {
     /**
      * Ref for the component.
      */
-    ref?: React.RefObject<ScriptTemplatesSidePanelRefType>;
+    ref?: React.Ref<ScriptTemplatesSidePanelRefType>;
     /**
      * Make the form read only.
      */

--- a/apps/developer-portal/src/configs/app.ts
+++ b/apps/developer-portal/src/configs/app.ts
@@ -39,7 +39,7 @@ export class Config {
     /**
      * Get the deployment config.
      *
-     * @return {DeploymentConfigInterface} Deployment config object.
+     * @return {CommonDeploymentConfigInterface} Deployment config object.
      */
     public static getDeploymentConfig(): CommonDeploymentConfigInterface {
         return {
@@ -52,6 +52,7 @@ export class Config {
             clientID: window["AppUtils"].getConfig().clientID,
             clientOrigin: window["AppUtils"].getConfig().clientOrigin,
             loginCallbackUrl: window["AppUtils"].getConfig().loginCallbackURL,
+            productVersion: window["AppUtils"].getConfig().productVersion,
             serverHost: window["AppUtils"].getConfig().serverOriginWithTenant,
             serverOrigin: window["AppUtils"].getConfig().serverOrigin,
             tenant: window["AppUtils"].getConfig().tenant,

--- a/apps/developer-portal/src/layouts/dashboard.tsx
+++ b/apps/developer-portal/src/layouts/dashboard.tsx
@@ -327,6 +327,11 @@ export const DashboardLayout: FunctionComponent<DashboardLayoutPropsInterface> =
                                 :
                                 config.deployment.applicationName
                             }
+                            version={ {
+                                milestoneNumber: config.deployment.productVersion?.milestoneNumber,
+                                releaseType: config.deployment.productVersion?.releaseType,
+                                versionNumber: config.deployment.productVersion?.versionNumber
+                            } }
                         />
                     ) }
                     brandLink={ config.deployment.appHomePath }

--- a/apps/developer-portal/src/public/app-utils.js
+++ b/apps/developer-portal/src/public/app-utils.js
@@ -98,6 +98,7 @@ var AppUtils = AppUtils || (function() {
                     _config.loginCallbackPath,
                 logoutCallbackURL: _config.clientOrigin + this.getTenantPath() + "/" + _config.appBaseName + 
                     _config.logoutCallbackPath,
+                productVersion: _config.productVersion,
                 routes: _config.routePaths,
                 serverOrigin: _config.serverOrigin,
                 serverOriginWithTenant: _config.serverOrigin + this.getTenantPath(),

--- a/apps/developer-portal/src/public/deployment.config.json
+++ b/apps/developer-portal/src/public/deployment.config.json
@@ -8,6 +8,11 @@
     "i18nResourcePath": "",
     "loginCallbackPath": "/login",
     "logoutCallbackPath": "/login",
+    "productVersion": {
+        "releaseType": "milestone",
+        "versionNumber": "5.11.0",
+        "milestoneNumber": "20"
+    },
     "routePaths": {
         "home": "/overview",
         "login": "/login",

--- a/apps/user-portal/src/components/header/header.tsx
+++ b/apps/user-portal/src/components/header/header.tsx
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
+import { Logo, ProductBrand } from "@wso2is/react-components";
 import _ from "lodash";
 import React, { SyntheticEvent, useEffect } from "react";
 import { useTranslation } from "react-i18next";
@@ -38,7 +40,7 @@ import { resolveUserDisplayName, resolveUsername } from "../../helpers";
 import { AlertLevels, AuthStateInterface, LinkedAccountInterface } from "../../models";
 import { AppState } from "../../store";
 import { addAlert, getProfileInformation, getProfileLinkedAccounts } from "../../store/actions";
-import { Title, UserAvatar } from "../shared";
+import { UserAvatar } from "../shared";
 
 /**
  * Header component prop types.
@@ -151,7 +153,25 @@ export const Header: React.FunctionComponent<HeaderProps> = (props: HeaderProps)
                     : null
                 }
                 <Menu.Item as={ Link } to={ GlobalConfig.appHomePath } header>
-                    <Title style={ { marginTop: 0 } } />
+                    <ProductBrand
+                        style={ { marginTop: 0 } }
+                        logo={ (
+                            <Logo
+                                className="portal-logo"
+                                image={
+                                    resolveAppLogoFilePath(window[ "AppUtils" ].getConfig().ui.appLogoPath,
+                                        `${ window[ "AppUtils" ].getConfig().clientOrigin }/` +
+                                        `${ window[ "AppUtils" ].getConfig().appBase }/libs/themes/default`)
+                                }
+                            />
+                        ) }
+                        name={ GlobalConfig.applicationName }
+                        version={ {
+                            milestoneNumber: window[ "AppUtils" ].getConfig().productVersion?.milestoneNumber,
+                            releaseType: window[ "AppUtils" ].getConfig().productVersion?.releaseType,
+                            versionNumber: window[ "AppUtils" ].getConfig().productVersion?.versionNumber
+                        } }
+                    />
                 </Menu.Item>
                 { (
                     <Menu.Menu position="right">

--- a/apps/user-portal/src/components/shared/ui.tsx
+++ b/apps/user-portal/src/components/shared/ui.tsx
@@ -16,10 +16,12 @@
  * under the License.
  */
 
+import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
+import { Logo } from "@wso2is/react-components";
 import classNames from "classnames";
 import * as React from "react";
 import { Image } from "semantic-ui-react";
-import { HomeTileIconImages, UserImage } from "../../configs";
+import { GlobalConfig, HomeTileIconImages, UserImage } from "../../configs";
 
 interface ImageProps {
     classes?: any;
@@ -33,6 +35,37 @@ type HomeTileIconImagePropInputs = "Profile" | "Security" | "Consent";
 interface HomeTileIconImageProps extends ImageProps {
     icon: HomeTileIconImagePropInputs;
 }
+
+interface TitleProps {
+    classes?: any;
+    style?: any;
+    children?: any;
+}
+
+/**
+ * TODO: Remove once `layouts/login` is removed.
+ * @deprecated Use `ProductBrand` from `@wso2is/react-components`.
+ */
+export const Title = (props: TitleProps) => {
+    const { classes, style, children } = props;
+
+    return (
+        <div className={ classNames(classes, "product-title") } style={ style }>
+            <Logo
+                className="portal-logo"
+                image={
+                    resolveAppLogoFilePath(window["AppUtils"].getConfig().ui.appLogoPath,
+                        `${window["AppUtils"].getConfig().clientOrigin}/` +
+                        `${window["AppUtils"].getConfig().appBase}/libs/themes/default`)
+                }
+            />
+            <h1 className={ classNames(classes, "product-title-text") } style={ style }>
+                { GlobalConfig.applicationName }
+            </h1>
+            { children }
+        </div>
+    );
+};
 
 export const UserImagePlaceHolder = (props: ImageProps) => {
     const { classes, size, floated } = props;

--- a/apps/user-portal/src/components/shared/ui.tsx
+++ b/apps/user-portal/src/components/shared/ui.tsx
@@ -16,12 +16,10 @@
  * under the License.
  */
 
-import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
-import { Logo } from "@wso2is/react-components";
 import classNames from "classnames";
 import * as React from "react";
 import { Image } from "semantic-ui-react";
-import { GlobalConfig, HomeTileIconImages, UserImage } from "../../configs";
+import { HomeTileIconImages, UserImage } from "../../configs";
 
 interface ImageProps {
     classes?: any;
@@ -35,33 +33,6 @@ type HomeTileIconImagePropInputs = "Profile" | "Security" | "Consent";
 interface HomeTileIconImageProps extends ImageProps {
     icon: HomeTileIconImagePropInputs;
 }
-
-interface TitleProps {
-    classes?: any;
-    style?: any;
-    children?: any;
-}
-
-export const Title = (props: TitleProps) => {
-    const { classes, style, children } = props;
-
-    return (
-        <div className={ classNames(classes, "product-title") } style={ style }>
-            <Logo
-                className="portal-logo"
-                image={
-                    resolveAppLogoFilePath(window["AppUtils"].getConfig().ui.appLogoPath,
-                        `${window["AppUtils"].getConfig().clientOrigin}/` +
-                        `${window["AppUtils"].getConfig().appBase}/libs/themes/default`)
-                }
-            />
-            <h1 className={ classNames(classes, "product-title-text") } style={ style }>
-                { GlobalConfig.applicationName }
-            </h1>
-            { children }
-        </div>
-    );
-};
 
 export const UserImagePlaceHolder = (props: ImageProps) => {
     const { classes, size, floated } = props;

--- a/apps/user-portal/src/public/app-utils.js
+++ b/apps/user-portal/src/public/app-utils.js
@@ -92,6 +92,7 @@ var AppUtils = AppUtils || (function() {
                     _config.loginCallbackPath,
                 logoutCallbackURL: _config.clientOrigin + this.getTenantPath() + "/" + _config.appBaseName + 
                     _config.logoutCallbackPath,
+                productVersion: _config.productVersion,
                 routes: _config.routePaths,
                 serverOrigin: _config.serverOrigin,
                 serverOriginWithTenant: _config.serverOrigin + this.getTenantPath(),

--- a/apps/user-portal/src/public/deployment.config.json
+++ b/apps/user-portal/src/public/deployment.config.json
@@ -3,6 +3,11 @@
     "clientID": "USER_PORTAL",
     "loginCallbackPath": "/login",
     "logoutCallbackPath": "/login",
+    "productVersion": {
+        "releaseType": "milestone",
+        "versionNumber": "5.11.0",
+        "milestoneNumber": "20"
+    },
     "routePaths": {
         "home": "/overview",
         "login": "/login",

--- a/apps/user-portal/tsconfig.json
+++ b/apps/user-portal/tsconfig.json
@@ -1,7 +1,18 @@
 {
     "compilerOptions": {
         "baseUrl": ".",
-        "paths": { "*": ["types/*"] }
+        "paths": {
+            "*": ["types/*"],
+            "@wso2is/core/api": ["node_modules/@wso2is/core/dist/src/api"],
+            "@wso2is/core/configs": ["node_modules/@wso2is/core/dist/src/configs"],
+            "@wso2is/core/constants": ["node_modules/@wso2is/core/dist/src/constants"],
+            "@wso2is/core/exceptions": ["node_modules/@wso2is/core/dist/src/exceptions"],
+            "@wso2is/core/helpers": ["node_modules/@wso2is/core/dist/src/helpers"],
+            "@wso2is/core/hooks": ["node_modules/@wso2is/core/dist/src/hooks"],
+            "@wso2is/core/models": ["node_modules/@wso2is/core/dist/src/models"],
+            "@wso2is/core/store": ["node_modules/@wso2is/core/dist/src/store"],
+            "@wso2is/core/utils": ["node_modules/@wso2is/core/dist/src/utils"]
+        }
     },
     "extends": "../../configs/common.tsconfig.json"
 }

--- a/modules/core/src/models/config.ts
+++ b/modules/core/src/models/config.ts
@@ -90,6 +90,10 @@ export interface CommonDeploymentConfigInterface {
      */
     loginCallbackUrl: string;
     /**
+     * Product version.
+     */
+    productVersion: ProductVersionInterface;
+    /**
      * Host of the Identity Sever.
      * ex: https://localhost:9443
      */
@@ -108,6 +112,24 @@ export interface CommonDeploymentConfigInterface {
      * ex: `/t/`
      */
     tenantPath: string;
+}
+
+/**
+ * Product version config interface.
+ */
+export interface ProductVersionInterface {
+    /**
+     * Release type.
+     */
+    releaseType?: "milestone" | "alpha" | "beta" | "rc" | string;
+    /**
+     * Product version number.
+     */
+    versionNumber?: string;
+    /**
+     * Milestone version number.
+     */
+    milestoneNumber?: string;
 }
 
 /**

--- a/modules/core/src/models/core.ts
+++ b/modules/core/src/models/core.ts
@@ -70,7 +70,7 @@ export interface RuntimeConfigInterface {
     /**
      * Name of the application. ex: "User Portal".
      */
-    applicationName: string;
+    applicationName?: string;
     /**
      * Client host. ex: "https://localhost:9000".
      */
@@ -86,7 +86,7 @@ export interface RuntimeConfigInterface {
     /**
      * Login callback URL. ex: "https://localhost:9000/user-portal/login".
      */
-    loginCallbackUrl: string;
+    loginCallbackUrl?: string;
     /**
      * Server host. ex: "https://localhost:9443".
      */

--- a/modules/core/src/models/route.ts
+++ b/modules/core/src/models/route.ts
@@ -69,6 +69,10 @@ export interface StaticRouteInterface {
      * Should the item be displayed on the side panel.
      */
     showOnSidePanel: boolean;
+    /**
+     * Status of the feature.
+     */
+    featureStatus?: "new" | "alpha" | "beta" | string;
 }
 
 /**

--- a/modules/react-components/src/brand/product-brand.tsx
+++ b/modules/react-components/src/brand/product-brand.tsx
@@ -55,7 +55,7 @@ export interface ProductVersionUIInterface extends ProductVersionInterface {
     /**
      * Color for the release label.
      */
-    labelColor?: SemanticCOLORS;
+    labelColor?: SemanticCOLORS | "auto" | "primary" | "secondary";
     /**
      * Text case.
      */
@@ -83,14 +83,30 @@ export const ProductBrand: FunctionComponent<PropsWithChildren<ProductBrandProps
         [ "data-testid" ]: testId
     } = props;
 
+    const versionLabelClasses = classNames(
+        "version-label",
+        {
+            "primary" : !version.labelColor,
+            [ version.labelColor ]: version.labelColor === "primary" || version.labelColor === "secondary"
+        }
+    );
+
     /**
      * Resolves the version label color.
      *
      * @return {SemanticCOLORS} Resolved color.
      */
     const resolveVersionLabelColor = (): SemanticCOLORS => {
-        if (version.labelColor) {
+        if (version.labelColor
+            && !(version.labelColor === "auto"
+                || version.labelColor === "primary"
+                || version.labelColor === "secondary")) {
+
             return version.labelColor;
+        }
+
+        if (version.labelColor === "primary" || version.labelColor === "secondary") {
+            return "orange";
         }
 
         if (version.releaseType === "alpha") {
@@ -100,9 +116,10 @@ export const ProductBrand: FunctionComponent<PropsWithChildren<ProductBrandProps
         } else if (version.releaseType === "rc") {
             return "green";
         } else if (version.releaseType === "milestone") {
-            return "orange";
+            return "violet";
         }
-        return "blue";
+
+        return "orange";
     };
 
     /**
@@ -136,7 +153,7 @@ export const ProductBrand: FunctionComponent<PropsWithChildren<ProductBrandProps
                 <div className="product-title-meta">
                     <Label
                         color={ resolveVersionLabelColor() }
-                        className="version-label"
+                        className={ versionLabelClasses }
                         size="mini"
                         data-testid={ `${ testId }-version` }
                     >

--- a/modules/react-components/src/brand/product-brand.tsx
+++ b/modules/react-components/src/brand/product-brand.tsx
@@ -19,6 +19,8 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
+import { Label, SemanticCOLORS } from "semantic-ui-react";
+import { Heading } from "../typography";
 
 /**
  * Product brand component Prop types.
@@ -40,6 +42,36 @@ export interface ProductBrandPropsInterface extends TestableComponentInterface {
      * Custom styles object.
      */
     style?: object;
+    /**
+     * Product version.
+     */
+    version?: ProductVersionInterface;
+}
+
+/**
+ * Product version interface
+ */
+export interface ProductVersionInterface {
+    /**
+     * Release type.
+     */
+    releaseType?: "milestone" | "alpha" | "beta" | "rc" | string;
+    /**
+     * Product version number.
+     */
+    versionNumber?: string;
+    /**
+     * Milestone version number.
+     */
+    milestoneNumber?: string;
+    /**
+     * Color for the release label.
+     */
+    labelColor?: SemanticCOLORS;
+    /**
+     * Text case.
+     */
+    textCase?: "lowercase" | "uppercase";
 }
 
 /**
@@ -59,20 +91,83 @@ export const ProductBrand: FunctionComponent<PropsWithChildren<ProductBrandProps
         logo,
         name,
         style,
+        version,
         [ "data-testid" ]: testId
     } = props;
 
+    /**
+     * Resolves the version label color.
+     *
+     * @return {SemanticCOLORS} Resolved color.
+     */
+    const resolveVersionLabelColor = (): SemanticCOLORS => {
+        if (version.labelColor) {
+            return version.labelColor;
+        }
+
+        if (version.releaseType === "alpha") {
+            return "red";
+        } else if (version.releaseType === "beta") {
+            return "teal";
+        } else if (version.releaseType === "rc") {
+            return "green";
+        } else if (version.releaseType === "milestone") {
+            return "orange";
+        }
+        return "blue";
+    };
+
+    /**
+     * Resolves the release version.
+     *
+     * @return {string} Resolved release version.
+     */
+    const resolveReleaseVersion = (): string => {
+        if (!version.releaseType && !version.versionNumber) {
+            return null;
+        }
+
+        let releaseVersion = version.versionNumber + " " + version.releaseType;
+
+        if (version.releaseType === "milestone" && version.milestoneNumber) {
+            releaseVersion = version.versionNumber + " " + "M" + version.milestoneNumber;
+        }
+
+        if (version.textCase === "lowercase") {
+            return releaseVersion.toLowerCase();
+        } else if (version.textCase === "uppercase") {
+            return releaseVersion.toUpperCase();
+        }
+
+        return releaseVersion.toUpperCase();
+    };
+
     return (
         <div className={ classNames(className, "product-title") } style={ style } data-testid={ testId }>
-            { logo && logo }
-            <h1
-                className={ classNames(className, "product-title-text") }
-                style={ style }
-                data-testid={ `${ testId }-title` }
-            >
-                { name }
-            </h1>
-            { children }
+            { version && (version.releaseType || version.versionNumber) && (
+                <div className="product-title-meta">
+                    <Label
+                        color={ resolveVersionLabelColor() }
+                        className="version-label"
+                        size="mini"
+                        data-testid={ `${ testId }-version` }
+                    >
+                        { resolveReleaseVersion() }
+                    </Label>
+                </div>
+            ) }
+            <div className="product-title-main">
+                { logo && logo }
+                <Heading
+                    className={ classNames(className, "product-title-text") }
+                    style={ style }
+                    data-testid={ `${ testId }-title` }
+                    compact
+                >
+                    { name }
+                </Heading>
+                { children }
+            </div>
         </div>
     );
 };

--- a/modules/react-components/src/brand/product-brand.tsx
+++ b/modules/react-components/src/brand/product-brand.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { TestableComponentInterface } from "@wso2is/core/models";
+import { ProductVersionInterface, TestableComponentInterface } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
 import { Label, SemanticCOLORS } from "semantic-ui-react";
@@ -45,25 +45,13 @@ export interface ProductBrandPropsInterface extends TestableComponentInterface {
     /**
      * Product version.
      */
-    version?: ProductVersionInterface;
+    version?: ProductVersionUIInterface;
 }
 
 /**
- * Product version interface
+ * Product version interface for UI.
  */
-export interface ProductVersionInterface {
-    /**
-     * Release type.
-     */
-    releaseType?: "milestone" | "alpha" | "beta" | "rc" | string;
-    /**
-     * Product version number.
-     */
-    versionNumber?: string;
-    /**
-     * Milestone version number.
-     */
-    milestoneNumber?: string;
+export interface ProductVersionUIInterface extends ProductVersionInterface {
     /**
      * Color for the release label.
      */
@@ -127,10 +115,10 @@ export const ProductBrand: FunctionComponent<PropsWithChildren<ProductBrandProps
             return null;
         }
 
-        let releaseVersion = version.versionNumber + " " + version.releaseType;
+        let releaseVersion = `${ version.versionNumber ?? "" } ${ version.releaseType ?? "" }`;
 
         if (version.releaseType === "milestone" && version.milestoneNumber) {
-            releaseVersion = version.versionNumber + " " + "M" + version.milestoneNumber;
+            releaseVersion = `${ version.versionNumber ?? "" } M${ version.milestoneNumber }`;
         }
 
         if (version.textCase === "lowercase") {

--- a/modules/react-components/src/side-panel/side-panel-item.tsx
+++ b/modules/react-components/src/side-panel/side-panel-item.tsx
@@ -18,6 +18,7 @@
 
 import { ChildRouteInterface, RouteInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { AuthenticateUtils } from "@wso2is/core/utils";
+import _ from "lodash";
 import React, { ReactElement } from "react";
 import { Menu } from "semantic-ui-react";
 import { CommonSidePanelPropsInterface } from "./side-panel";
@@ -124,7 +125,7 @@ export const SidePanelItem: React.FunctionComponent<SidePanelItemPropsInterface>
                             }` }
                             active={ selected && (selected.path === route.path) }
                             onClick={ (): void => onSidePanelItemClick(route) }
-                            data-testid={ testId }
+                            data-testid={ `${ testId }-${ _.kebabCase(route.id) }` }
                         >
                             <GenericIcon
                                 className="left-icon"

--- a/modules/react-components/src/side-panel/side-panel-item.tsx
+++ b/modules/react-components/src/side-panel/side-panel-item.tsx
@@ -20,7 +20,7 @@ import { ChildRouteInterface, RouteInterface, TestableComponentInterface } from 
 import { AuthenticateUtils } from "@wso2is/core/utils";
 import _ from "lodash";
 import React, { ReactElement } from "react";
-import { Menu } from "semantic-ui-react";
+import { Label, Menu, SemanticCOLORS } from "semantic-ui-react";
 import { CommonSidePanelPropsInterface } from "./side-panel";
 import { SidePanelItemGroup } from "./side-panel-item-group";
 import { GenericIcon, GenericIconSizes } from "../icon";
@@ -113,6 +113,23 @@ export const SidePanelItem: React.FunctionComponent<SidePanelItemPropsInterface>
         return recurse(children);
     };
 
+    /**
+     * Resolves the label color to display the status of the feature .
+     *
+     * @return {SemanticCOLORS} Resolved color.
+     */
+    const resolveFeatureStatusLabelColor = (): SemanticCOLORS => {
+        if (route.featureStatus === "new") {
+            return "red";
+        } else if (route.featureStatus === "beta") {
+            return "teal";
+        } else if (route.featureStatus === "alpha") {
+            return "orange";
+        }
+
+        return "blue";
+    };
+
     return (
         <>
             {
@@ -138,6 +155,16 @@ export const SidePanelItem: React.FunctionComponent<SidePanelItemPropsInterface>
                             />
                             <span className="route-name" data-testid={ `${ testId }-label` }>
                                 { translationHook ? translationHook(route.name) : route.name }
+                                { route.featureStatus && (
+                                    <Label
+                                        color={ resolveFeatureStatusLabelColor() }
+                                        className="feature-status-label"
+                                        size="mini"
+                                        data-testid={ `${ testId }-version` }
+                                    >
+                                        { route.featureStatus.toUpperCase() }
+                                    </Label>
+                                ) }
                             </span>
                             {
                                 // Check if any of the child items are defined to be shown on the side panel.

--- a/modules/react-components/stories/components/brand/brand.stories.tsx
+++ b/modules/react-components/stories/components/brand/brand.stories.tsx
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-import { Logo, ProductBrand } from "../../../src";
-import React, { ReactElement } from "react";
+import { select, text, withKnobs } from "@storybook/addon-knobs";
 import { Logo as LogoImage } from "@wso2is/theme";
+import * as React from "react";
 import { meta } from "./brand.stories.meta";
-import { withKnobs } from "@storybook/addon-knobs";
+import { Logo, ProductBrand } from "../../../src";
 
 export default {
     decorators: [ withKnobs ],
@@ -36,10 +36,53 @@ export default {
  *
  * @return {React.ReactElement}
  */
-export const DefaultProductBrand = (): ReactElement => (
+export const DefaultProductBrand = (): React.ReactElement => (
     <ProductBrand
-        name="Developer Portal"
-        logo={ <Logo image={ LogoImage } /> }
+        name={ text("Product title", "Developer Portal") }
+        logo={
+            <Logo image={ text("Logo URL", null) ? text("Logo URL", null) : LogoImage }/>
+        }
+        version={ {
+            labelColor: select(
+                "Version label color",
+                {
+                    BLACK: "black",
+                    BLUE: "blue",
+                    BROWN: "brown",
+                    GREEN: "green",
+                    GREY: "grey",
+                    OLIVE: "olive",
+                    ORANGE: "orange",
+                    PINK: "pink",
+                    PURPLE: "purple",
+                    RED: "red",
+                    TEAL: "teal",
+                    VIOLET: "violet",
+                    YELLOW: "yellow"
+                },
+                null
+            ),
+            milestoneNumber: text("Milestone number", undefined),
+            releaseType: select(
+                "Release type",
+                {
+                    ALPHA: "alpha",
+                    BETA: "beta",
+                    MILESTONE: "milestone",
+                    RC: "rc"
+                },
+                "alpha"
+            ),
+            textCase: select(
+                "Version Text Case",
+                {
+                    Lowercase: "lowercase",
+                    Uppercase: "uppercase"
+                },
+                null
+            ),
+            versionNumber: text("Version number", "5.11.0")
+        } }
     />
 );
 

--- a/modules/react-components/stories/components/brand/brand.stories.tsx
+++ b/modules/react-components/stories/components/brand/brand.stories.tsx
@@ -54,8 +54,10 @@ export const DefaultProductBrand = (): React.ReactElement => (
                     OLIVE: "olive",
                     ORANGE: "orange",
                     PINK: "pink",
+                    PRIMARY: "primary",
                     PURPLE: "purple",
                     RED: "red",
+                    SECONDARY: "secondary",
                     TEAL: "teal",
                     VIOLET: "violet",
                     YELLOW: "yellow"

--- a/modules/react-components/stories/components/side-panel/side-panel.stories.meta.ts
+++ b/modules/react-components/stories/components/side-panel/side-panel.stories.meta.ts
@@ -49,6 +49,7 @@ export const ROUTES: RouteInterface[] = [
     },
     {
         component: null,
+        featureStatus: "alpha",
         icon: "apps",
         id: "applications",
         name: "Applications",
@@ -67,6 +68,7 @@ export const ROUTES: RouteInterface[] = [
     },
     {
         component: null,
+        featureStatus: "new",
         icon: "security",
         id: "security",
         name: "Security",
@@ -117,6 +119,7 @@ export const ROUTES_WITH_CHILDREN: RouteInterface[] = [
             }
         ],
         component: null,
+        featureStatus: "alpha",
         icon: "apps",
         id: "applications",
         name: "Applications",
@@ -137,6 +140,7 @@ export const ROUTES_WITH_CHILDREN: RouteInterface[] = [
             },
             {
                 component: null,
+                featureStatus: "beta",
                 icon: "childIcon",
                 id: "preferences",
                 name: "Preferences",
@@ -164,6 +168,7 @@ export const ROUTES_WITH_CHILDREN: RouteInterface[] = [
     },
     {
         component: null,
+        featureStatus: "new",
         icon: "security",
         id: "security",
         name: "Security",

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -46,6 +46,13 @@ body {
                 padding: 3px 6px;
                 font-size: 0.6em;
                 font-weight: 600;
+
+                &.primary {
+                    background-color: @primaryColor !important;
+                }
+                &.secondary {
+                    background-color: @secondaryColor !important;
+                }
             }
         }
         .product-logo {

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -39,6 +39,15 @@ body {
     }
 
     .product-title {
+        .product-title-meta {
+            text-align: right;
+
+            .version-label {
+                padding: 3px 6px;
+                font-size: 0.6em;
+                font-weight: 600;
+            }
+        }
         .product-logo {
             width: 60px;
             vertical-align: text-top;

--- a/modules/theme/src/themes/default/collections/menu.overrides
+++ b/modules/theme/src/themes/default/collections/menu.overrides
@@ -175,6 +175,13 @@
                 cursor: pointer;
                 color: @sidePanelDefaultFontColor;
                 padding: 10px 5px;
+
+                .feature-status-label {
+                    padding: 3px 6px;
+                    margin-left: 6px;
+                    font-size: 0.6em;
+                    font-weight: 600;
+                }
             }
 
             svg, .icon {


### PR DESCRIPTION
## Purpose
1. Deployments(specially cloud deployments) often times require to display the product status i.e `alpha`, `beta`, etc.
2. Features in the portals would also benefit if the status of them are displayed to the users.

## Goals
1. Add version label to the `ProductBrand` component which can be configurable through the deployment config.
2. Add a label to the side panel item component to display feature status.

## Approach

1. Product Brand

**Usage**

```tsx
<ProductBrand
    ...
    version={ {
        milestoneNumber: config.deployment.productVersion?.milestoneNumber,
        releaseType: config.deployment.productVersion?.releaseType,
        versionNumber: config.deployment.productVersion?.versionNumber
     } }
    ...
/>
```

Config - `public/deployment.config.json`

```json
{
    ...
    "productVersion": {
        "releaseType": "milestone",
        "versionNumber": "5.11.0",
        "milestoneNumber": "20"
    },
    ...
}
```

<img width="355" alt="Screen Shot 2020-05-22 at 2 54 32 PM" src="https://user-images.githubusercontent.com/25959096/82654593-99c5bd80-9c3e-11ea-899e-2b4abe5307a5.png">

2. Side Panel

**Usage**

Config - `configs/routes.ts`

```ts
{
     ...
    {
        component: null,
        featureStatus: "new",
        icon: "security",
        id: "security",
        name: "Security",
        path: "/security",
        protected: true,
        showOnSidePanel: true
    },
    ...
}
```

<img width="325" alt="Screen Shot 2020-05-22 at 2 53 59 PM" src="https://user-images.githubusercontent.com/25959096/82654546-887cb100-9c3e-11ea-9730-e3b3dc41ec43.png">

