### PR TITLE
[Forms] Add form state checking capability to `@wso2is/forms` module

### DIFF
--- a/apps/developer-portal/src/components/shared/editing-resource-navigation-confirmation-modal.tsx
+++ b/apps/developer-portal/src/components/shared/editing-resource-navigation-confirmation-modal.tsx
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ConfirmationModal, ConfirmationModalPropsInterface } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Resource tab navigation confirmation modal.
+ */
+export type EditingResourceNavigationConfirmationModalInterface = ConfirmationModalPropsInterface;
+
+/**
+ * Confirmation modal to show a disclaimer message to users notifying
+ * when trying to navigate away from partially filled formed.
+ *
+ * @param {EditingResourceNavigationConfirmationModalInterface} props - Props injected to the component.
+ * @return {React.ReactElement}
+ */
+export const EditingResourceNavigationConfirmationModal: FunctionComponent<
+    EditingResourceNavigationConfirmationModalInterface
+    > = (
+        props: EditingResourceNavigationConfirmationModalInterface
+): ReactElement => {
+
+    const {
+        [ "data-testid" ]: testId,
+        ...rest
+    } = props;
+
+    const { t } = useTranslation();
+
+    return (
+        <ConfirmationModal
+            primaryAction={ t("devPortal:confirmations.resourceEditTabNav.primaryAction") }
+            secondaryAction={ t("devPortal:confirmations.resourceEditTabNav.secondaryAction") }
+            data-testid={ testId  }
+            { ...rest }
+        >
+            <ConfirmationModal.Header
+                data-testid={ `${ testId }-header` }
+            >
+                { t("devPortal:confirmations.resourceEditTabNav.header") }
+            </ConfirmationModal.Header>
+            <ConfirmationModal.Message
+                attached
+                warning
+                data-testid={ `${ testId }-message` }
+            >
+                { t("devPortal:confirmations.resourceEditTabNav.message") }
+            </ConfirmationModal.Message>
+            <ConfirmationModal.Content
+                data-testid={ `${ testId }-content` }
+            >
+                { t("devPortal:confirmations.resourceEditTabNav.content") }
+            </ConfirmationModal.Content>
+        </ConfirmationModal>
+    );
+};
+
+/**
+ * Default props for the component.
+ */
+EditingResourceNavigationConfirmationModal.defaultProps = {
+    "data-testid": "tan-nav-confirmation-modal",
+    type: "warning"
+};

--- a/apps/developer-portal/src/components/shared/index.ts
+++ b/apps/developer-portal/src/components/shared/index.ts
@@ -18,4 +18,5 @@
 
 export * from "./advanced-search-with-basic-filters";
 export * from "./authenticator-accordion";
+export * from "./editing-resource-navigation-confirmation-modal";
 export * from "./upload-certificate";

--- a/modules/forms/package.json
+++ b/modules/forms/package.json
@@ -26,7 +26,9 @@
         "run-script-os": "^1.0.7"
     },
     "peerDependencies": {
-        "classnames": "*"
+        "@types/lodash": "*",
+        "classnames": "*",
+        "lodash": "*"
     },
     "author": "WSO2",
     "license": "Apache-2.0"

--- a/modules/forms/src/forms.tsx
+++ b/modules/forms/src/forms.tsx
@@ -45,6 +45,9 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
         // This holds the values of the form fields
         const [ form, setForm ] = useState(new Map<string, FormValue>());
 
+        // This holds the set of initial values of the form fields
+        const [ initialValues, setInitialValues ] = useState<Map<string, FormValue>>(undefined);
+
         // This specifies if any of the fields in the form has been touched or not
         const [ isPure, setIsPure ] = useState(true);
 
@@ -325,7 +328,7 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
                 });
 
                 return tempIterable;
-            }
+            };
 
             /**
              * In case an existing form field is dynamically removed, remove all its data.
@@ -344,6 +347,7 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
             setForm(leanForm);
             setValidFields(leanValidFields);
             setRequiredFields(leanRequiredFields);
+            setInitialFormValues(tempForm);
         };
 
         /**
@@ -529,6 +533,19 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
                     }
                 }
             });
+        };
+
+        /**
+         * Sets the initial form values.
+         *
+         * @param {Map<string, FormValue>} values - Form values.
+         */
+        const setInitialFormValues = (values: Map<string, FormValue>): void => {
+            if (initialValues !== undefined) {
+                return;
+            }
+
+            setInitialValues(values);
         };
 
         const mutatedChildren: React.ReactElement[] = children ? [ ...parseChildren(children, formFields) ] : null;

--- a/modules/forms/src/forms.tsx
+++ b/modules/forms/src/forms.tsx
@@ -592,7 +592,8 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
                 return;
             }
 
-            setInitialValues(values);
+            // Clone values to avoid any mutations.
+            setInitialValues(_.cloneDeep(values));
         };
 
         const mutatedChildren: React.ReactElement[] = children ? [ ...parseChildren(children, formFields) ] : null;

--- a/modules/forms/src/forms.tsx
+++ b/modules/forms/src/forms.tsx
@@ -35,6 +35,10 @@ interface FormPropsInterface {
      * @param {FormState} state - From state.
      */
     onFormStateChange?: (state: FormState) => void;
+    /**
+     * Trigger re-initialization of initial values.
+     */
+    reinitialize?: boolean;
     resetState?: boolean;
     submitState?: boolean;
     ref?: React.Ref<any>;
@@ -46,7 +50,7 @@ interface FormPropsInterface {
 export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInterface>> =
     React.forwardRef((props: React.PropsWithChildren<FormPropsInterface>, ref): JSX.Element => {
 
-        const { onSubmit, resetState, submitState, onChange, children, onFormStateChange } = props;
+        const { onSubmit, resetState, submitState, onChange, children, onFormStateChange, reinitialize } = props;
 
         // This holds the values of the form fields
         const [ form, setForm ] = useState(new Map<string, FormValue>());
@@ -531,6 +535,13 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
         }, [ resetState ]);
 
         /**
+         * Calls initialize function when an re-initialization is triggered externally
+         */
+        useNonInitialEffect(() => {
+            setInitialFormValues(form, true);
+        }, [ reinitialize ]);
+
+        /**
          * Initializes the state of the from every time the passed formFields prop changes
          */
         useEffect(() => {
@@ -586,9 +597,10 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
          * Sets the initial form values.
          *
          * @param {Map<string, FormValue>} values - Form values.
+         * @param {boolean} forceInit - Forcefully re-initialize the form.
          */
-        const setInitialFormValues = (values: Map<string, FormValue>): void => {
-            if (initialValues !== undefined) {
+        const setInitialFormValues = (values: Map<string, FormValue>, forceInit: boolean = false): void => {
+            if (!forceInit && initialValues !== undefined) {
                 return;
             }
 

--- a/modules/forms/src/models/forms.ts
+++ b/modules/forms/src/models/forms.ts
@@ -269,3 +269,11 @@ export type FormField =
  * FormField value types
  */
 export type FormValue = string | string[];
+
+/**
+ * Interface for form state.
+ */
+export interface FormState {
+    dirty: boolean;
+    pristine: boolean;
+}

--- a/modules/forms/src/selectors/index.ts
+++ b/modules/forms/src/selectors/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,8 +16,5 @@
  * under the License.
  */
 
-export * from "./forms";
-export * from "./models";
-export * from "./selectors";
-export { Field, GroupFields } from "./components";
-export * from "./utils";
+export * from "./is-dirty";
+export * from "./is-pristine";

--- a/modules/forms/src/selectors/is-dirty.ts
+++ b/modules/forms/src/selectors/is-dirty.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,8 +16,19 @@
  * under the License.
  */
 
-export * from "./forms";
-export * from "./models";
-export * from "./selectors";
-export { Field, GroupFields } from "./components";
-export * from "./utils";
+import { RefObject } from "react";
+import { isPristine } from "./is-pristine";
+
+/**
+ * This selector checks if the initial values provided to the form
+ * have been altered.
+ * @example
+ * const formRef = useRef(null);
+ * isDirty(formRef);
+ *
+ * @param {React.RefObject<HTMLFormElement>} ref - Form ref.
+ * @return {boolean} If dirty or not.
+ */
+export const isDirty = (ref: RefObject<HTMLFormElement>): boolean => {
+    return !isPristine(ref);
+};

--- a/modules/forms/src/selectors/is-pristine.ts
+++ b/modules/forms/src/selectors/is-pristine.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import _ from "lodash";
+import { RefObject } from "react";
+
+/**
+ * This selector checks if the initial values provided to the form
+ * have not been altered.
+ * @example
+ * const formRef = useRef(null);
+ * isPristine(formRef);
+ *
+ * @param {React.RefObject<HTMLFormElement>} ref - Form ref.
+ * @return {boolean} If pristine or not.
+ */
+export const isPristine = (ref: RefObject<HTMLFormElement>): boolean => {
+    if (!ref?.current?.props?.initialValues || !ref?.current?.props?.values) {
+        return true;
+    }
+
+    return _.isEqual(ref.current.props.initialValues, ref.current.props.values);
+};

--- a/modules/i18n/src/models/common.ts
+++ b/modules/i18n/src/models/common.ts
@@ -64,7 +64,9 @@ export interface Confirmation {
     header: string;
     message: string;
     content: string;
-    assertionHint: string;
+    assertionHint?: string;
+    primaryAction?: string;
+    secondaryAction?: string;
 }
 
 /**

--- a/modules/i18n/src/models/namespaces/dev-portal-ns.ts
+++ b/modules/i18n/src/models/namespaces/dev-portal-ns.ts
@@ -1120,6 +1120,9 @@ export interface DevPortalNS {
             };
         };
     };
+    confirmations: {
+        resourceEditTabNav: Confirmation;
+    };
     notifications: {
         endSession: Notification;
         getProfileInfo: Notification;

--- a/modules/i18n/src/translations/en-US/portals/dev-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/dev-portal.ts
@@ -2681,6 +2681,16 @@ export const devPortal: DevPortalNS = {
             searchPlaceholder: "Search {{type}}"
         }
     },
+    confirmations: {
+        resourceEditTabNav: {
+            content: "You have unsaved changes. If you move to a different section, you will loose all the changes " +
+                "and will not be able to recover again. Are you sure you want proceed?",
+            header: "Confirm Navigation",
+            message: "If you leave this section , any changes you have made will be lost.",
+            primaryAction: "Leave",
+            secondaryAction: "Stay"
+        }
+    },
     notifications: {
         endSession: {
             error: {


### PR DESCRIPTION
## Purpose
Currently the forms module doesn't have any inbuilt capabilities which can be used to peek the form state i.e if the form is `pristine` or not.

## Goals
This PR adds the following functionalities.

1. `onFormStateChange()` - Callback function to get the state of the form.

**Usage**

```tsx
import { Forms, FormState } from "@wso2is/forms";

const [ isFormPristine, setIsFormPristine ] = useState<boolean>(true);
const [ isFormDirty, setIsFormDirty ] = useState<boolean>(false);

<Forms
    onFormStateChange={ (state: FormState) => {
        setIsFormPristine(state.pristine);
        setIsFormDirty(state.dirty);
    } }
    ...
/>
```
2. Two new selectors have been added which can be used for the same purpose.

```tsx
import { Forms, isDirty, isPristine } from "@wso2is/forms";

const formRef = useRef<HTMLFormElement>(null);

const [ isFormPristine, setIsFormPristine ] = useState<boolean>(true);
const [ isFormDirty, setIsFormDirty ] = useState<boolean>(false);

useEffect(() => {
    setIsFormPristine(isPristine(formRef));
    setIsFormDirty(isDirty(formRef));
}, [ ]);

<Forms
    ref={ formRef }
    ...
/>    
```

3.  Trigger re-initialization of the form from outside.

```tsx
const [ reinitializeTrigger, setReinitializeTrigger ] = useTrigger();

useEffect(() => {
    setReinitializeTrigger();
}, [ initialValues ]);

<Forms
    reinitialize={ reinitializeTrigger }
    ...
/>    
```