### PR TITLE
Split appName config & Add theme config fallback

### DIFF
--- a/apps/admin-portal/src/components/shared/header.tsx
+++ b/apps/admin-portal/src/components/shared/header.tsx
@@ -119,6 +119,11 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             ) }
             brand={ (
                 <ProductBrand
+                    appName={
+                        (state.appName && state.appName !== "")
+                            ? state.appName
+                            : config.ui.appName
+                    }
                     style={ { marginTop: 0 } }
                     logo={
                         (state.logo && state.logo !== "")
@@ -135,10 +140,10 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                                 />
                             )
                     }
-                    name={ state.productName && state.productName !== "" ?
-                        state.productName
-                        :
-                        config.deployment.applicationName
+                    productName={
+                        (state.productName && state.productName !== "")
+                            ? state.productName
+                            : config.ui.productName
                     }
                     version={ config.deployment.productVersion }
                 />

--- a/apps/admin-portal/src/configs/app.ts
+++ b/apps/admin-portal/src/configs/app.ts
@@ -46,7 +46,7 @@ export class Config {
             appBaseNameWithoutTenant: window["AppUtils"].getConfig().appBase,
             appHomePath: window["AppUtils"].getConfig().routes.home,
             appLoginPath: window["AppUtils"].getConfig().routes.login,
-            applicationName: window["AppUtils"].getConfig().ui.appName,
+            appName: window["AppUtils"].getConfig().ui.appName,
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             clientOrigin: window["AppUtils"].getConfig().clientOrigin,
@@ -140,9 +140,11 @@ export class Config {
         return {
             announcements: window["AppUtils"].getConfig().ui.announcements,
             appCopyright: `${window["AppUtils"].getConfig().ui.appCopyright} \u00A9 ${ new Date().getFullYear() }`,
+            appName: window["AppUtils"].getConfig().ui.appName,
             appTitle: window["AppUtils"].getConfig().ui.appTitle,
             features: window["AppUtils"].getConfig().ui.features,
-            gravatarConfig: window["AppUtils"].getConfig().ui.gravatarConfig
+            gravatarConfig: window["AppUtils"].getConfig().ui.gravatarConfig,
+            productName: window["AppUtils"].getConfig().ui.productName
         };
     }
 }

--- a/apps/admin-portal/src/configs/app.ts
+++ b/apps/admin-portal/src/configs/app.ts
@@ -46,7 +46,6 @@ export class Config {
             appBaseNameWithoutTenant: window["AppUtils"].getConfig().appBase,
             appHomePath: window["AppUtils"].getConfig().routes.home,
             appLoginPath: window["AppUtils"].getConfig().routes.login,
-            appName: window["AppUtils"].getConfig().ui.appName,
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             clientOrigin: window["AppUtils"].getConfig().clientOrigin,

--- a/apps/admin-portal/src/constants/ui-constants.ts
+++ b/apps/admin-portal/src/constants/ui-constants.ts
@@ -76,4 +76,10 @@ export class UIConstants {
      * @type {number}
      */
     public static readonly DEFAULT_STATS_LIST_ITEM_LIMIT: number = 5;
+
+    /**
+     * Default theme of the portal.
+     * @type {string}
+     */
+    public static readonly DEFAULT_THEME: string = "default";
 }

--- a/apps/admin-portal/src/index.tsx
+++ b/apps/admin-portal/src/index.tsx
@@ -33,6 +33,7 @@ import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./app";
 import { Config } from "./configs";
+import { UIConstants } from "./constants";
 import { store } from "./store";
 import { HttpUtils } from "./utils";
 
@@ -88,7 +89,11 @@ I18n.init({
 ReactDOM.render(
     (
         <Provider store={ store }>
-            <ThemeProvider initialState={ { theme: window["AppUtils"].getConfig().ui.theme.name } }>
+            <ThemeProvider
+                initialState={ {
+                    theme: window["AppUtils"].getConfig().ui?.theme?.name ?? UIConstants.DEFAULT_THEME
+                } }
+            >
                 <BrowserRouter>
                     <App/>
                 </BrowserRouter>

--- a/apps/admin-portal/src/public/deployment.config.json
+++ b/apps/admin-portal/src/public/deployment.config.json
@@ -26,8 +26,8 @@
     },
     "ui": {
         "appCopyright": "WSO2 Identity Server",
-        "appTitle": "WSO2 Identity Server Admin Dashboard",
-        "appName": "Identity Server",
+        "appTitle": "Admin | WSO2 Identity Server",
+        "appName": "Admin",
         "appLogoPath": "/assets/images/logo.svg",
         "features": {
             "attributeDialects": {
@@ -178,6 +178,7 @@
         "gravatarConfig": {
             "fallback": "404"
         },
+        "productName": "Identity Server",
         "theme": {
             "name": "default"
         }

--- a/apps/developer-portal/src/components/shared/header.tsx
+++ b/apps/developer-portal/src/components/shared/header.tsx
@@ -119,6 +119,11 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             ) }
             brand={ (
                 <ProductBrand
+                    appName={
+                        (state.appName && state.appName !== "")
+                            ? state.appName
+                            : config.ui.appName
+                    }
                     style={ { marginTop: 0 } }
                     logo={
                         (state.logo && state.logo !== "")
@@ -135,10 +140,10 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                                 />
                             )
                     }
-                    name={ state.productName && state.productName !== "" ?
-                        state.productName
-                        :
-                        config.deployment.applicationName
+                    productName={
+                        (state.productName && state.productName !== "")
+                            ? state.productName
+                            : config.ui.productName
                     }
                     version={ config.deployment.productVersion }
                 />

--- a/apps/developer-portal/src/configs/app.ts
+++ b/apps/developer-portal/src/configs/app.ts
@@ -49,7 +49,6 @@ export class Config {
             appBaseNameWithoutTenant: window["AppUtils"].getConfig().appBase,
             appHomePath: window["AppUtils"].getConfig().routes.home,
             appLoginPath: window["AppUtils"].getConfig().routes.login,
-            applicationName: window["AppUtils"].getConfig().ui.appName,
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             clientOrigin: window["AppUtils"].getConfig().clientOrigin,
@@ -126,11 +125,13 @@ export class Config {
         return {
             announcements: window["AppUtils"].getConfig().ui.announcements,
             appCopyright: `${window["AppUtils"].getConfig().ui.appCopyright} \u00A9 ${ new Date().getFullYear() }`,
+            appName: window["AppUtils"].getConfig().ui.appName,
             appTitle: window["AppUtils"].getConfig().ui.appTitle,
             doNotDeleteApplications: window["doNotDeleteApplications"] || [],
             doNotDeleteIdentityProviders: window["doNotDeleteIdentityProviders"] || [],
             features: window["AppUtils"].getConfig().ui.features,
-            gravatarConfig: window["AppUtils"].getConfig().ui.gravatarConfig
+            gravatarConfig: window["AppUtils"].getConfig().ui.gravatarConfig,
+            productName: window["AppUtils"].getConfig().ui.productName
         };
     }
 }

--- a/apps/developer-portal/src/constants/ui-constants.ts
+++ b/apps/developer-portal/src/constants/ui-constants.ts
@@ -84,4 +84,10 @@ export class UIConstants {
      * @type {number}
      */
     public static readonly DEFAULT_STATS_LIST_ITEM_LIMIT: number = 5;
+
+    /**
+     * Default theme of the portal.
+     * @type {string}
+     */
+    public static readonly DEFAULT_THEME: string = "default";
 }

--- a/apps/developer-portal/src/index.tsx
+++ b/apps/developer-portal/src/index.tsx
@@ -33,6 +33,7 @@ import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./app";
 import { Config } from "./configs";
+import { UIConstants } from "./constants";
 import { store } from "./store";
 import { HttpUtils } from "./utils";
 
@@ -88,7 +89,11 @@ I18n.init({
 ReactDOM.render(
     (
         <Provider store={ store }>
-            <ThemeProvider initialState={ { theme: window["AppUtils"].getConfig().ui.theme.name } }>
+            <ThemeProvider
+                initialState={ {
+                    theme: window["AppUtils"].getConfig().ui?.theme?.name ?? UIConstants.DEFAULT_THEME
+                } }
+            >
                 <BrowserRouter>
                     <App/>
                 </BrowserRouter>

--- a/apps/developer-portal/src/public/deployment.config.json
+++ b/apps/developer-portal/src/public/deployment.config.json
@@ -37,8 +37,8 @@
     },
     "ui": {
         "appCopyright": "WSO2 Identity Server",
-        "appTitle": "WSO2 Identity Server Developer Dashboard",
-        "appName": "Identity Server",
+        "appTitle": "Developer | WSO2 Identity Server",
+        "appName": "Developer",
         "appLogoPath": "/assets/images/logo.svg",
         "features": {
             "applications": {
@@ -81,6 +81,7 @@
         "gravatarConfig": {
             "fallback": "404"
         },
+        "productName": "Identity Server",
         "theme": {
             "name": "default"
         }

--- a/apps/user-portal/src/api/applications.ts
+++ b/apps/user-portal/src/api/applications.ts
@@ -63,7 +63,7 @@ export const fetchApplications = (
                 && response.data.applications.length
                 && response.data.applications.length > 0) {
                 applications = response.data.applications.filter(
-                    (app) => app.name !== store.getState().config.ui.applicationName);
+                    (app) => app.name !== store.getState().config.ui.appName);
             }
 
             return Promise.resolve({

--- a/apps/user-portal/src/components/shared/header.tsx
+++ b/apps/user-portal/src/components/shared/header.tsx
@@ -177,6 +177,11 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             ) }
             brand={ (
                 <ProductBrand
+                    appName={
+                        (state.appName && state.appName !== "")
+                            ? state.appName
+                            : config.ui.appName
+                    }
                     style={ { marginTop: 0 } }
                     logo={
                         (state.logo && state.logo !== "")
@@ -193,10 +198,10 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                                 />
                             )
                     }
-                    name={ state.productName && state.productName !== "" ?
-                        state.productName
-                        :
-                        config.deployment.applicationName
+                    productName={
+                        (state.productName && state.productName !== "")
+                            ? state.productName
+                            : config.ui.productName
                     }
                     version={ config.deployment.productVersion }
                 />

--- a/apps/user-portal/src/components/shared/ui.tsx
+++ b/apps/user-portal/src/components/shared/ui.tsx
@@ -55,7 +55,7 @@ export const Title = (props: TitleProps) => {
                 }
             />
             <h1 className={ classNames(classes, "product-title-text") } style={ style }>
-                { store.getState().config.deployment.applicationName }
+                { store.getState().config.ui.appName }
             </h1>
             { children }
         </div>

--- a/apps/user-portal/src/components/side-panel/side-panel-items.tsx
+++ b/apps/user-portal/src/components/side-panel/side-panel-items.tsx
@@ -117,7 +117,7 @@ export const SidePanelItems: React.FunctionComponent<SidePanelItemsProps> = (
                                     as={ NavLink }
                                     to={ route.path }
                                     name={ route.name }
-                                    className={ `side-panel-item ${ activeRoute(route.path) }` }
+                                    className={ `side-panel-item ${ activeRoute(route.path) } hover-highlighted` }
                                     active={ activeRoute(route.path) === "active" }
                                     onClick={ onSidePanelItemClick }
                                     key={ index }

--- a/apps/user-portal/src/configs/app.ts
+++ b/apps/user-portal/src/configs/app.ts
@@ -46,7 +46,6 @@ export class Config {
             appBaseNameWithoutTenant: window["AppUtils"].getConfig().appBase,
             appHomePath: window["AppUtils"].getConfig().routes.home,
             appLoginPath: window["AppUtils"].getConfig().routes.login,
-            applicationName: window["AppUtils"].getConfig().ui.appName,
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             clientOrigin: window["AppUtils"].getConfig().clientOrigin,
@@ -103,9 +102,11 @@ export class Config {
     public static getUIConfig(): UIConfigInterface {
         return {
             announcements: window["AppUtils"].getConfig().ui.announcements,
+            appName: window["AppUtils"].getConfig().ui.appName,
             authenticatorApp: { apps: [ { link: "", name: "" } ] },
             copyrightText: `${window["AppUtils"].getConfig().ui.appCopyright} \u00A9 ${ new Date().getFullYear() }`,
             features: window["AppUtils"].getConfig().ui.features,
+            productName: window["AppUtils"].getConfig().ui.productName,
             titleText: window["AppUtils"].getConfig().appTitle
         };
     }

--- a/apps/user-portal/src/constants/ui-constants.ts
+++ b/apps/user-portal/src/constants/ui-constants.ts
@@ -87,3 +87,24 @@ export const WARNING_ACCOUNT_STATUS_UPPER_LIMIT = 70;
  * @default
  */
 export const ERROR_ACCOUNT_STATUS_UPPER_LIMIT = 40;
+
+/**
+ * Class containing ui constants.
+ */
+export class UIConstants {
+
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     *
+     * @hideconstructor
+     */
+    /* eslint-disable @typescript-eslint/no-empty-function */
+    private constructor() { }
+
+    /**
+     * Default theme of the portal.
+     * @type {string}
+     */
+    public static readonly DEFAULT_THEME: string = "default";
+}

--- a/apps/user-portal/src/index.tsx
+++ b/apps/user-portal/src/index.tsx
@@ -37,6 +37,7 @@ import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./app";
 import { Config } from "./configs";
+import { UIConstants } from "./constants";
 import { store } from "./store";
 import { setSupportedI18nLanguages } from "./store/actions";
 import { onHttpRequestError, onHttpRequestFinish, onHttpRequestStart, onHttpRequestSuccess } from "./utils";
@@ -94,7 +95,11 @@ I18n.init({
 ReactDOM.render(
     (
         <Provider store={ store }>
-            <ThemeProvider initialState={ { theme: window["AppUtils"].getConfig().ui.theme.name } }>
+            <ThemeProvider
+                initialState={ {
+                    theme: window["AppUtils"].getConfig().ui?.theme?.name ?? UIConstants.DEFAULT_THEME
+                } }
+            >
                 <BrowserRouter>
                     <App />
                 </BrowserRouter>

--- a/apps/user-portal/src/public/deployment.config.json
+++ b/apps/user-portal/src/public/deployment.config.json
@@ -18,8 +18,8 @@
     },
     "ui": {
         "appCopyright": "WSO2 Identity Server",
-        "appTitle": "Manage your WSO2 Identity Server Account",
-        "appName": "Identity Server Account",
+        "appTitle": "Account | WSO2 Identity Server",
+        "appName": "Account",
         "appLogoPath": "/assets/images/logo.svg",
         "authenticatorApp": {
             "enabled": true
@@ -76,6 +76,7 @@
                 }
             }
         },
+        "productName": "Identity Server",
         "theme": {
             "name": "default"
         }

--- a/features/org.wso2.identity.apps.admin.portal.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.admin.portal.server.feature/resources/deployment.config.json.j2
@@ -289,6 +289,7 @@
            {% endfor %}
            {% endif %}
         },
+        "productName": "{{ admin_portal.ui.product_name }}",
         "theme": {
             {% if admin_portal.ui.theme is defined %}
                 {% for key, value in admin_portal.ui.theme.items() %}

--- a/features/org.wso2.identity.apps.developer.portal.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.developer.portal.server.feature/resources/deployment.config.json.j2
@@ -133,6 +133,7 @@
            {% endfor %}
            {% endif %}
         },
+        "productName": "{{ developer_portal.ui.product_name }}",
         "theme": {
             {% if developer_portal.ui.theme is defined %}
                 {% for key, value in developer_portal.ui.theme.items() %}

--- a/features/org.wso2.identity.apps.user.portal.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.user.portal.server.feature/resources/deployment.config.json.j2
@@ -180,6 +180,7 @@
                 }
             }
         },
+        "productName": "{{ user_portal.ui.product_name }}",
         "theme": {
             {% if user_portal.ui.theme is defined %}
                 {% for key, value in user_portal.ui.theme.items() %}

--- a/modules/core/src/models/config.ts
+++ b/modules/core/src/models/config.ts
@@ -70,11 +70,6 @@ export interface CommonDeploymentConfigInterface {
      */
     appLoginPath: string;
     /**
-     * Name of the application.
-     * ex: `DEVELOPER PORTAL`
-     */
-    applicationName: string;
-    /**
      * Host of the client application.
      * ex: `https://localhost:9001`
      */
@@ -180,6 +175,11 @@ export interface CommonUIConfigInterface {
      */
     appCopyright?: string;
     /**
+     * Name of the application.
+     * ex: `Developer`
+     */
+    appName: string;
+    /**
      * Title text for the browser window.
      * ex: `WSO2 Identity Server`
      */
@@ -192,6 +192,11 @@ export interface CommonUIConfigInterface {
      * Application features configurations
      */
     features?: FeatureConfigInterface;
+    /**
+     * Name of the product.
+     * ex: `Identity Server`
+     */
+    productName: string;
 }
 
 /**

--- a/modules/react-components/src/components/brand/product-brand.tsx
+++ b/modules/react-components/src/components/brand/product-brand.tsx
@@ -28,6 +28,10 @@ import { Heading } from "../typography";
  */
 export interface ProductBrandPropsInterface extends TestableComponentInterface {
     /**
+     * App name.
+     */
+    appName?: string;
+    /**
      * Additional CSS classes.
      */
     className?: string;
@@ -38,7 +42,7 @@ export interface ProductBrandPropsInterface extends TestableComponentInterface {
     /**
      * Product name.
      */
-    name: string;
+    productName?: string;
     /**
      * Custom styles object.
      */
@@ -83,15 +87,21 @@ export const ProductBrand: FunctionComponent<PropsWithChildren<ProductBrandProps
 ): ReactElement => {
 
     const {
+        appName,
         children,
         className,
         logo,
-        name,
+        productName,
         style,
         version,
         versionUISettings,
         [ "data-testid" ]: testId
     } = props;
+
+    const mainClasses = classNames(
+        className,
+        "product-title"
+    );
 
     const versionLabelClasses = classNames(
         "version-label",
@@ -171,18 +181,23 @@ export const ProductBrand: FunctionComponent<PropsWithChildren<ProductBrandProps
     };
 
     return (
-        <div className={ classNames(className, "product-title") } style={ style } data-testid={ testId }>
+        <div className={ mainClasses } style={ style } data-testid={ testId }>
             { version && resolveReleaseVersionLabel() }
             <div className="product-title-main">
                 { logo && logo }
-                <Heading
-                    className={ classNames(className, "product-title-text") }
-                    style={ style }
-                    data-testid={ `${ testId }-title` }
-                    compact
-                >
-                    { name }
-                </Heading>
+                {
+                    (appName || productName) && (
+                        <Heading
+                            className={ "product-title-text" }
+                            style={ style }
+                            data-testid={ `${ testId }-title` }
+                            compact
+                        >
+                            { productName }
+                            { appName && <span className="app-name">{ appName }</span> }
+                        </Heading>
+                    )
+                }
                 { children }
             </div>
         </div>

--- a/modules/react-components/stories/components/brand/brand.stories.tsx
+++ b/modules/react-components/stories/components/brand/brand.stories.tsx
@@ -17,7 +17,6 @@
  */
 
 import { text, withKnobs } from "@storybook/addon-knobs";
-import { Logo as LogoImage } from "@wso2is/theme";
 import * as React from "react";
 import { meta } from "./brand.stories.meta";
 import { Logo, ProductBrand } from "../../../src";
@@ -38,10 +37,13 @@ export default {
  */
 export const DefaultProductBrand = (): React.ReactElement => (
     <ProductBrand
-        name={ text("Product title", "Developer Portal") }
+        appName={ text("App Name", "Developer") }
         logo={
-            <Logo image={ text("Logo URL", null) ? text("Logo URL", null) : LogoImage }/>
+            <Logo image={
+                text("Logo URL", "https://wso2.cachefly.net/wso2/sites/all/2020-theme/images/wso2-logo.svg")
+            }/>
         }
+        productName={ text("Product Name", "Identity Server") }
         version={ text("version", "5.11.0-M24-SNAPSHOT") }
     />
 );

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -78,6 +78,12 @@ body {
         display: inline-block;
         vertical-align: sub;
         margin-left: 0.2em;
+        
+        .app-name {
+            margin: @productTitleAppNameMargin;
+            font-size: @productTitleAppNameFontSize;
+            font-weight: @productTitleAppNameFontWeight;
+        }
     }
     .user-image {
         width: 100px !important;

--- a/modules/theme/src/themes/default/globals/product.variables
+++ b/modules/theme/src/themes/default/globals/product.variables
@@ -103,3 +103,6 @@
 @productTitleTextTransform: uppercase;
 @productTitleFontWeight: 400;
 @productTitleFontSize: 1.4rem;
+@productTitleAppNameMargin: 0 0 0 5px;
+@productTitleAppNameFontSize: inherit;
+@productTitleAppNameFontWeight: 300;


### PR DESCRIPTION
## Purpose
Application name can be configured using the `ui.appName` config but inorder to achieve something like bellow, the config should be split into two.

<img width="397" alt="Screen Shot 2020-07-09 at 1 55 35 PM" src="https://user-images.githubusercontent.com/25959096/87016111-e9ab1480-c1eb-11ea-8c4b-36791d93ff5a.png">

## Goals
1. This PR introduces a new `ui.productName` config.
2. Add default fallback for theme.

## Related PRs
This PR should be merged after the following PR is merged.
- wso2/carbon-identity-framework#3010
