### PR TITLE
Fix portals loading issue with no/limited internet connection

### DIFF
--- a/modules/theme/src/themes/default/globals/site.variables
+++ b/modules/theme/src/themes/default/globals/site.variables
@@ -21,6 +21,10 @@
        Fonts
 --------------------*/
 
+// Needed to enable portals to be run offline.
+// Ref - https://github.com/Semantic-Org/Semantic-UI/issues/1521
+@importGoogleFonts : false;
+
 @iconFont          : "font-awesome";
 @fontName          : -apple-system, BlinkMacSystemFont, Segoe WPC, Segoe UI, HelveticaNeue-Light, Ubuntu, Droid Sans, sans-serif, @iconFont;
 @googleFontName    : 'Lato';


### PR DESCRIPTION
## Purpose
Semantic UI dispatches a XHR request to google fonts to obtain `Lato` font. This will be problematic in environments with no internet connections or with limited access to the internet.

## Goals
This PR introduces changes which will disable the google font importing in semantic UI framework.

Fixes wso2/product-is#8820

## Approach
As per[1], doing the following changes in `themes/default/globals/site.variables ` disabled the request.

```css
@importGoogleFonts: false
```

NOTE: `Lato` font can also be maintained locally[2], but currently we are not using it in any of our default shipped themes.

[1] https://github.com/Semantic-Org/Semantic-UI/issues/1521
[2] https://github.com/mterzo/puppetboard/commit/3ed029d44b74e265b421efb822b36428acd4ff6d
