### PR TITLE
Implement getting theme from the environment feature in code editor.

### DIFF
--- a/apps/developer-portal/src/components/applications/settings/sign-on-methods/script-based-flow/template-description.tsx
+++ b/apps/developer-portal/src/components/applications/settings/sign-on-methods/script-based-flow/template-description.tsx
@@ -19,9 +19,7 @@
 import { CodeEditor, LinkButton } from "@wso2is/react-components";
 import React, {
     FunctionComponent,
-    ReactElement,
-    useEffect,
-    useState
+    ReactElement
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Icon, List, Message, Modal, Table } from "semantic-ui-react";
@@ -57,30 +55,7 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
 
         const { template, open, onClose } = props;
 
-        const [ dark, setDark ] = useState(false);
-
         const { t } = useTranslation();
-
-        /**
-         * Gets the browser color scheme so that the color scheme of the textarea can be decided.
-         */
-        useEffect(() => {
-            if (window.matchMedia("(prefers-color-scheme:dark)").matches) {
-                setDark(true);
-            }
-            const callback = (e) => {
-                if (e.matches) {
-                    setDark(true);
-                } else {
-                    setDark(false);
-                }
-            };
-            window.matchMedia("(prefers-color-scheme:dark)").addEventListener("change", callback);
-
-            return () => {
-                window.matchMedia("(prefers-color-scheme:dark)").removeEventListener("change", callback);
-            }
-        }, []);
 
         return (
             <Modal open={ open } onClose={ onClose } dimmer="blurring" size="small">
@@ -180,9 +155,9 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
                         options={ {
                             lineWrapping: true
                         } }
-                        theme={ dark ? "dark" : "light" }
                         readOnly={ true }
                         data-testid={ `${template.title}-code-editor` }
+                        getThemeFromEnvironment={ true }
                     />
                 </Modal.Content>
                 <Modal.Actions>

--- a/modules/react-components/src/components/code-editor/code-editor.tsx
+++ b/modules/react-components/src/components/code-editor/code-editor.tsx
@@ -19,7 +19,7 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import JSBeautify from "js-beautify";
 import { JSHINT } from "jshint/dist/jshint";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { UnControlled as CodeMirror, IUnControlledCodeMirror } from "react-codemirror2";
 import "codemirror/addon/lint/lint";
 import "codemirror/addon/lint/javascript-lint";
@@ -86,6 +86,10 @@ export interface CodeEditorProps extends IUnControlledCodeMirror, TestableCompon
      * Editor theme.
      */
     theme?: "dark" | "light";
+    /**
+     * Get theme from the environment.
+     */
+    getThemeFromEnvironment?: boolean;
 }
 
 /**
@@ -101,6 +105,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (
 
     const {
         beautify,
+        getThemeFromEnvironment,
         language,
         lint,
         options,
@@ -110,10 +115,37 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (
         sourceCode,
         tabSize,
         theme,
-        [ "data-testid" ]: testId,
+        ["data-testid"]: testId,
         ...rest
     } = props;
 
+    const [ dark, setDark ] = useState(false);
+    
+    /**
+     * Gets the browser color scheme so that the color scheme of the textarea can be decided.
+     */
+    useEffect(() => {
+        if (getThemeFromEnvironment && window.matchMedia && window.matchMedia("(prefers-color-scheme:dark)").matches) {
+            setDark(true);
+        }
+        const callback = (e) => {
+            if (e.matches) {
+                setDark(true);
+            } else {
+                setDark(false);
+            }
+        };
+        getThemeFromEnvironment &&
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme:dark)").addEventListener("change", callback);
+
+        return () => {
+            getThemeFromEnvironment &&
+                window.matchMedia &&
+                window.matchMedia("(prefers-color-scheme:dark)").removeEventListener("change", callback);
+        }
+    }, [getThemeFromEnvironment]);
+    
     /**
      * Resolves the language mode.
      *
@@ -139,6 +171,10 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (
      * @return {object} Resolved mode.
      */
     const resolveTheme = (): string => {
+        if (getThemeFromEnvironment) {
+            return (dark ? "material" : "default");
+        }
+        
         if (!(theme === "dark" || theme === "light")) {
             throw new Error("Please select a supported theme. Only `dark` and `light` are supported at the moment.");
         }

--- a/modules/react-components/src/components/code-editor/code-editor.tsx
+++ b/modules/react-components/src/components/code-editor/code-editor.tsx
@@ -115,7 +115,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (
         sourceCode,
         tabSize,
         theme,
-        ["data-testid"]: testId,
+        [ "data-testid" ]: testId,
         ...rest
     } = props;
 
@@ -174,7 +174,7 @@ export const CodeEditor: FunctionComponent<CodeEditorProps> = (
         if (getThemeFromEnvironment) {
             return (dark ? "material" : "default");
         }
-        
+
         if (!(theme === "dark" || theme === "light")) {
             throw new Error("Please select a supported theme. Only `dark` and `light` are supported at the moment.");
         }


### PR DESCRIPTION
## Purpose
> The code editor will be set to dark/light mode based on the browser/OS setting. This can be enabled by setting the prop `getThemeFromEnvironment` to `true`.