### PR TITLE
Fix ID token validation issue when multiple audiences are present.

### DIFF
--- a/modules/oauth-web-worker/src/utils/crypto.ts
+++ b/modules/oauth-web-worker/src/utils/crypto.ts
@@ -118,7 +118,9 @@ export const isValidIdToken = (
 ): boolean => {
     return KJUR.jws.JWS.verifyJWT(idToken, jwk, {
         alg: getSupportedSignatureAlgorithms(),
-        aud: [clientID],
+        // `jsrsasign` typings only allow string[] as aud but string should also be possible.
+        // TODO: Remove any casting once the @types/jsrsasign contains a fix.
+        aud: clientID as any,
         iss: [issuer],
         sub: [username]
     });


### PR DESCRIPTION
## Purpose
If the audience in the ID token has elements other than the `clientID`, the validation fails. This was fixed in the `@wso2/authentication` module but when migrating to the web worker, the fix had been missed.

## Goals
With this PR, validation will pass if the `aud` array has elements other than the `clientID`.

## Approach
`aud: [clientID],` was changed to `aud: clientID as any,`.

NOTE: `any`casting was necessary since the `@types/jsrsasign` has incorrect typings for the `aud` array.

## Related PRs
https://github.com/wso2/identity-apps/pull/138
