### PR TITLE
Fix genericForm prompt in adaptive authentication error

### DIFF
--- a/apps/authentication-portal/src/main/webapp/templates/genericForm.jsp
+++ b/apps/authentication-portal/src/main/webapp/templates/genericForm.jsp
@@ -19,7 +19,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="e" uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" %>
-<jsp:directive.include file="../init-url.jsp"/>
+<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <div>
     <h2 class="wr-title uppercase blue-bg padding-double white boarder-bottom-blue margin-none">

--- a/apps/authentication-portal/src/main/webapp/templates/username.jsp
+++ b/apps/authentication-portal/src/main/webapp/templates/username.jsp
@@ -19,7 +19,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="e" uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" %>
-<jsp:directive.include file="../init-url.jsp"/>
+<jsp:directive.include file="../includes/init-url.jsp"/>
 <%@include file="../localize.jsp" %>
 <%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.isSelfSignUpEPAvailable" %>
 <%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.isRecoveryEPAvailable" %>


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/8347

## Goals
> Changing the path to init-url.jsp fixes the exception thrown by the genericForm prompt in adaptive authentication.

## Approach
> Change the path to init-url.jsp to "../includes/init-url.jsp" in genericForm.jsp and username.jsp

## Documentation
> https://is.docs.wso2.com/en/latest/references/adaptive-authentication-js-api-reference/#prompttemplateid-data-eventhandlers