### PR TITLE
Add size support to Text component

### DIFF
--- a/modules/react-components/src/components/typography/text.tsx
+++ b/modules/react-components/src/components/typography/text.tsx
@@ -45,6 +45,10 @@ export interface TextPropsInterface extends TestableComponentInterface {
      */
     muted?: boolean;
     /**
+     * Font size.
+     */
+    size?: number | string;
+    /**
      * Custom styles object.
      */
     styles?: object;
@@ -96,6 +100,7 @@ export const Text: React.FunctionComponent<TextPropsInterface> = (
         display,
         inline,
         muted,
+        size,
         styles,
         [ "data-testid" ]: testId,
         truncate,
@@ -136,6 +141,13 @@ export const Text: React.FunctionComponent<TextPropsInterface> = (
             modified = {
                 ...modified,
                 width: width.toString()
+            };
+        }
+        
+        if (size) {
+            modified = {
+                ...modified,
+                fontSize: typeof size === "number" ? `${ size }px` : size
             };
         }
 


### PR DESCRIPTION
*Usage*

```jsx
<Text size="1em">
    Lorem Ipsum is simply dummy text of the printing and typesetting industry.
</Text>
```

```jsx
<Text size={ 16 }>
    Lorem Ipsum is simply dummy text of the printing and typesetting industry.
</Text>
```