### PR TITLE
Add global redux state for help panel.

### DIFF
--- a/apps/developer-portal/src/components/applications/edit-application.tsx
+++ b/apps/developer-portal/src/components/applications/edit-application.tsx
@@ -35,6 +35,7 @@ import {
 } from "./settings";
 import { getInboundProtocolConfig } from "../../api";
 import { ApplicationManagementConstants } from "../../constants";
+import { ComponentExtensionPlaceholder } from "../../extensions";
 import {
     ApplicationInterface,
     ApplicationTemplateListItemInterface,
@@ -44,7 +45,6 @@ import {
 } from "../../models";
 import { AppState } from "../../store";
 import { ApplicationManagementUtils } from "../../utils";
-import { ComponentExtensionPlaceholder } from "../../extensions/";
 
 /**
  * Proptypes for the applications edit component.
@@ -54,6 +54,10 @@ interface EditApplicationPropsInterface extends SBACInterface<FeatureConfigInter
      * Editing application.
      */
     application: ApplicationInterface;
+    /**
+     * Default active tab index.
+     */
+    defaultActiveIndex?: number;
     /**
      * Is the data still loading.
      */
@@ -89,6 +93,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
 
     const {
         application,
+        defaultActiveIndex,
         featureConfig,
         isLoading,
         onDelete,
@@ -408,7 +413,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
 
     return (
         application && !isInboundProtocolsRequestLoading
-            ? <ResourceTab panes={ resolveTabPanes() }/>
+            ? <ResourceTab panes={ resolveTabPanes() } defaultActiveIndex={ defaultActiveIndex } />
             : <ContentLoader/>
     );
 };

--- a/apps/developer-portal/src/models/reducer-state.ts
+++ b/apps/developer-portal/src/models/reducer-state.ts
@@ -46,8 +46,10 @@ export type ConfigReducerStateInterface = CommonConfigReducerStateInterface<
  * Help panel reducer state interface.
  */
 export interface HelpPanelReducerStateInterface {
+    activeTabIndex: number;
     docURL: string;
     docStructure: PortalDocumentationStructureInterface;
+    visibility: boolean;
 }
 
 /**

--- a/apps/developer-portal/src/pages/applications/application-edit.tsx
+++ b/apps/developer-portal/src/pages/applications/application-edit.tsx
@@ -769,8 +769,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             sidebarToggleTooltip={ t("devPortal:components.helpPanel.actions.open") }
             pinButtonTooltip={ t("devPortal:components.helpPanel.actions.pin") }
             unPinButtonTooltip={ t("devPortal:components.helpPanel.actions.unPin") }
-            onHelpPanelClose={ () => dispatch(toggleHelpPanelVisibility(false)) }
-            onHelpPanelOpen={ () => dispatch(toggleHelpPanelVisibility(true)) }
+            onHelpPanelVisibilityChange={ (isVisible: boolean) => dispatch(toggleHelpPanelVisibility(isVisible)) }
             visible={ helpPanelVisibilityGlobalState }
         >
             <PageLayout

--- a/apps/developer-portal/src/pages/applications/application-edit.tsx
+++ b/apps/developer-portal/src/pages/applications/application-edit.tsx
@@ -126,6 +126,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
     ] = useState<boolean>(false);
     const [ tabsActiveIndex, setTabsActiveIndex ] = useState<number>(0);
     const [ isExtensionsAvailable, setIsExtensionsAvailable ] = useState<boolean>(false);
+    const [ defaultActiveIndex, setDefaultActiveIndex ] = useState<number>(0);
 
     /**
      * Fetch the application details on initial component load.
@@ -386,14 +387,21 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
 
     /**
      * Triggered when the application state search param in the URL changes.
+     * TODO: IMPORTANT - Refactor this code.
      */
     useEffect(() => {
         if (!urlSearchParams.get(ApplicationManagementConstants.APP_STATE_URL_SEARCH_PARAM_KEY)) {
+            if (isExtensionsAvailable) {
+                setDefaultActiveIndex(1);
+            }
+
             return;
         }
 
         if (urlSearchParams.get(ApplicationManagementConstants.APP_STATE_URL_SEARCH_PARAM_KEY)
             === ApplicationManagementConstants.APP_STATE_URL_SEARCH_PARAM_VALUE && isExtensionsAvailable) {
+
+            setDefaultActiveIndex(0);
 
             if (helpPanelVisibilityGlobalState) {
                 dispatch(toggleHelpPanelVisibility(false));
@@ -803,6 +811,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             >
                 <EditApplication
                     application={ application }
+                    defaultActiveIndex={ defaultActiveIndex }
                     featureConfig={ featureConfig }
                     isLoading={ isApplicationRequestLoading }
                     onDelete={ handleApplicationDelete }

--- a/apps/developer-portal/src/store/actions/help-panel.ts
+++ b/apps/developer-portal/src/store/actions/help-panel.ts
@@ -18,8 +18,10 @@
 
 import {
     HelpPanelActionTypes,
+    SetHelpPanelActiveTabIndexActionInterface,
     SetHelpPanelDocStructureActionInterface,
-    SetHelpPanelDocsContentURLActionInterface
+    SetHelpPanelDocsContentURLActionInterface,
+    ToggleHelpPanelVisibilityActionInterface
 } from "./types";
 import { PortalDocumentationStructureInterface } from "../../models";
 
@@ -45,4 +47,26 @@ export const setHelpPanelDocStructure = (
 ): SetHelpPanelDocStructureActionInterface => ({
     payload: structure,
     type: HelpPanelActionTypes.SET_HELP_PANEL_DOC_STRUCTURE
+});
+
+/**
+ * Redux action to toggle help panel visibility.
+ *
+ * @param {boolean} isVisible - Should side panel be visible.
+ * @return {ToggleHelpPanelVisibilityActionInterface} An action of type `TOGGLE_HELP_PANEL_VISIBILITY`
+ */
+export const toggleHelpPanelVisibility = (isVisible: boolean): ToggleHelpPanelVisibilityActionInterface => ({
+    payload: isVisible,
+    type: HelpPanelActionTypes.TOGGLE_HELP_PANEL_VISIBILITY
+});
+
+/**
+ * Redux action to set the help panel active tab index.
+ *
+ * @param {number} tabIndex - The active tab index.
+ * @return {SetHelpPanelActiveTabIndexActionInterface} An action of type `SET_HELP_PANEL_ACTIVE_TAB_INDEX`
+ */
+export const setHelpPanelActiveTabIndex = (tabIndex: number): SetHelpPanelActiveTabIndexActionInterface => ({
+    payload: tabIndex,
+    type: HelpPanelActionTypes.SET_HELP_PANEL_ACTIVE_TAB_INDEX
 });

--- a/apps/developer-portal/src/store/actions/types/help-panel.ts
+++ b/apps/developer-portal/src/store/actions/types/help-panel.ts
@@ -36,7 +36,19 @@ export enum HelpPanelActionTypes {
      *
      * @type {string}
      */
-    SET_HELP_PANEL_DOC_STRUCTURE = "SET_HELP_PANEL_DOC_STRUCTURE"
+    SET_HELP_PANEL_DOC_STRUCTURE = "SET_HELP_PANEL_DOC_STRUCTURE",
+    /**
+     * Action type to toggle the help panel visibility.
+     *
+     * @type {string}
+     */
+    TOGGLE_HELP_PANEL_VISIBILITY = "TOGGLE_HELP_PANEL_VISIBILITY",
+    /**
+     * Action type to set the help panel active tab index.
+     *
+     * @type {string}
+     */
+    SET_HELP_PANEL_ACTIVE_TAB_INDEX = "SET_HELP_PANEL_ACTIVE_TAB_INDEX"
 }
 
 /**
@@ -63,7 +75,25 @@ export interface SetHelpPanelDocStructureActionInterface extends HelpPanelBaseAc
 }
 
 /**
+ * Action interface for the help panel visibility action.
+ */
+export interface ToggleHelpPanelVisibilityActionInterface extends HelpPanelBaseActionInterface {
+    payload: boolean;
+    type: HelpPanelActionTypes.TOGGLE_HELP_PANEL_VISIBILITY;
+}
+
+/**
+ * Action interface for the help panel active tab index action.
+ */
+export interface SetHelpPanelActiveTabIndexActionInterface extends HelpPanelBaseActionInterface {
+    payload: number;
+    type: HelpPanelActionTypes.SET_HELP_PANEL_ACTIVE_TAB_INDEX;
+}
+
+/**
  * Export action interfaces.
  */
 export type HelpPanelActions = SetHelpPanelDocsContentURLActionInterface
-    | SetHelpPanelDocStructureActionInterface;
+    | SetHelpPanelDocStructureActionInterface
+    | ToggleHelpPanelVisibilityActionInterface
+    | SetHelpPanelActiveTabIndexActionInterface;

--- a/apps/developer-portal/src/store/reducers/help-panel.ts
+++ b/apps/developer-portal/src/store/reducers/help-panel.ts
@@ -23,8 +23,10 @@ import { HelpPanelActionTypes, HelpPanelActions } from "../actions/types";
  * Help panel reducer initial state.
  */
 const initialState: HelpPanelReducerStateInterface = {
+    activeTabIndex: 0,
     docStructure: null,
-    docURL: null
+    docURL: null,
+    visibility: false
 };
 
 /**
@@ -47,6 +49,16 @@ export const helpPanelReducer = (state: HelpPanelReducerStateInterface = initial
             return {
                 ...state,
                 docStructure: action.payload
+            };
+        case HelpPanelActionTypes.TOGGLE_HELP_PANEL_VISIBILITY:
+            return {
+                ...state,
+                visibility: action.payload
+            };
+        case HelpPanelActionTypes.SET_HELP_PANEL_ACTIVE_TAB_INDEX:
+            return {
+                ...state,
+                activeTabIndex: action.payload
             };
         default:
             return state;

--- a/modules/react-components/src/layouts/help-panel.tsx
+++ b/modules/react-components/src/layouts/help-panel.tsx
@@ -46,13 +46,10 @@ export interface HelpPanelLayoutLayoutPropsInterface extends HelpPanelPropsInter
      */
     onHelpPanelPinToggle: () => void;
     /**
-     * Callback for help panel open.
+     * Callback for help panel visibility change.
+     * @param {boolean} isVisible - Is sidebar visible.
      */
-    onHelpPanelOpen?: () => void;
-    /**
-     * Callback for help panel open.
-     */
-    onHelpPanelClose?: () => void;
+    onHelpPanelVisibilityChange?: (isVisible: boolean) => void;
     /**
      * Flag to distinguish if the panel is pinned.
      */
@@ -126,8 +123,7 @@ export const HelpPanelLayout: FunctionComponent<PropsWithChildren<HelpPanelLayou
         enabled,
         icons,
         onHelpPanelPinToggle,
-        onHelpPanelOpen,
-        onHelpPanelClose,
+        onHelpPanelVisibilityChange,
         isPinned,
         pinButtonTooltip,
         sidebarDirection,
@@ -169,19 +165,12 @@ export const HelpPanelLayout: FunctionComponent<PropsWithChildren<HelpPanelLayou
             return;
         }
 
-        if (visible) {
-            onHelpPanelOpen();
-        } else {
-            onHelpPanelClose();
-        }
-
         setHelpSidebarVisibility(visible);
     }, [ visible ]);
 
     useEffect(() => {
         if (isPinned) {
             setHelpSidebarVisibility(true);
-            onHelpPanelOpen();
         }
     }, [ isPinned ]);
 
@@ -198,7 +187,7 @@ export const HelpPanelLayout: FunctionComponent<PropsWithChildren<HelpPanelLayou
         });
 
         setHelpSidebarVisibility(true);
-        onHelpPanelOpen();
+        onHelpPanelVisibilityChange(true);
     };
 
     /**
@@ -214,13 +203,8 @@ export const HelpPanelLayout: FunctionComponent<PropsWithChildren<HelpPanelLayou
      * Handles the help panel toggle action.
      */
     const handleHelpPanelToggle = () => {
-        if (helpSidebarVisibility) {
-            onHelpPanelClose();
-        } else {
-            onHelpPanelOpen();
-        }
-
         setHelpSidebarVisibility(!helpSidebarVisibility);
+        onHelpPanelVisibilityChange(!helpSidebarVisibility);
     };
 
     return (

--- a/modules/react-components/src/layouts/help-panel.tsx
+++ b/modules/react-components/src/layouts/help-panel.tsx
@@ -46,6 +46,14 @@ export interface HelpPanelLayoutLayoutPropsInterface extends HelpPanelPropsInter
      */
     onHelpPanelPinToggle: () => void;
     /**
+     * Callback for help panel open.
+     */
+    onHelpPanelOpen?: () => void;
+    /**
+     * Callback for help panel open.
+     */
+    onHelpPanelClose?: () => void;
+    /**
      * Flag to distinguish if the panel is pinned.
      */
     isPinned?: boolean;
@@ -70,14 +78,6 @@ export interface HelpPanelLayoutLayoutPropsInterface extends HelpPanelPropsInter
      */
     tabs: HelpPanelPropsInterface["tabs"];
     /**
-     * Triggers the side bar to open.
-     */
-    triggerSidebarOpen?: boolean;
-    /**
-     * Triggers the side bar to close.
-     */
-    triggerSidebarClose?: boolean;
-    /**
      * Tooltip for the unpin button.
      */
     unpinButtonTooltip?: string;
@@ -85,6 +85,10 @@ export interface HelpPanelLayoutLayoutPropsInterface extends HelpPanelPropsInter
      * Tabs active index.
      */
     activeIndex?: number;
+    /**
+     * Side panel external visibility state.
+     */
+    visible?: boolean;
 }
 
 /**
@@ -122,14 +126,15 @@ export const HelpPanelLayout: FunctionComponent<PropsWithChildren<HelpPanelLayou
         enabled,
         icons,
         onHelpPanelPinToggle,
+        onHelpPanelOpen,
+        onHelpPanelClose,
         isPinned,
         pinButtonTooltip,
         sidebarDirection,
         tabs,
-        triggerSidebarOpen,
         activeIndex,
         unpinButtonTooltip,
-        triggerSidebarClose,
+        visible,
         ...rest
     } = props;
 
@@ -160,24 +165,23 @@ export const HelpPanelLayout: FunctionComponent<PropsWithChildren<HelpPanelLayou
     }, [ helpSidebarVisibility ]);
     
     useEffect(() => {
-        if (!triggerSidebarOpen) {
+        if (visible === undefined) {
             return;
         }
 
-        setHelpSidebarVisibility(true);
-    }, [ triggerSidebarOpen ]);
-
-    useEffect(() => {
-        if (!triggerSidebarClose) {
-            return;
+        if (visible) {
+            onHelpPanelOpen();
+        } else {
+            onHelpPanelClose();
         }
 
-        setHelpSidebarVisibility(false);
-    }, [ triggerSidebarClose ]);
+        setHelpSidebarVisibility(visible);
+    }, [ visible ]);
 
     useEffect(() => {
         if (isPinned) {
             setHelpSidebarVisibility(true);
+            onHelpPanelOpen();
         }
     }, [ isPinned ]);
 
@@ -194,6 +198,7 @@ export const HelpPanelLayout: FunctionComponent<PropsWithChildren<HelpPanelLayou
         });
 
         setHelpSidebarVisibility(true);
+        onHelpPanelOpen();
     };
 
     /**
@@ -209,6 +214,12 @@ export const HelpPanelLayout: FunctionComponent<PropsWithChildren<HelpPanelLayou
      * Handles the help panel toggle action.
      */
     const handleHelpPanelToggle = () => {
+        if (helpSidebarVisibility) {
+            onHelpPanelClose();
+        } else {
+            onHelpPanelOpen();
+        }
+
         setHelpSidebarVisibility(!helpSidebarVisibility);
     };
 
@@ -259,6 +270,8 @@ HelpPanelLayout.defaultProps = {
     bordered: "left",
     enabled: true,
     icon: "labeled",
+    onHelpPanelClose: () => null,
+    onHelpPanelOpen: () => null,
     pinButtonTooltip: "Pin",
     raised: false,
     showLabelsOnSidebarMini: false,

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -95,6 +95,12 @@ body {
          Global Helper Classes
 *****************************************/
 
+.link {
+    &.pointing {
+        cursor: pointer;
+    }
+}
+
 .display {
     &-flex {
         display: flex !important;


### PR DESCRIPTION
## Goals

1. Add callbacks and global state props to help panel layout
2. Add more redux logic to handle help panel actions
3. Stop auto opening the help panel when extensions are present
4. Send to second tab when extensions are available
5. Refactor help panel layout callbacks
6. Add pointing link helper css class

## TODO
Look in to the code and refactor.