### PR TITLE
Fix header UI issue when extensions are not present

### DIFF
--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -157,6 +157,39 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             ) }
             brandLink={ config.deployment.appHomePath }
             basicProfileInfo={ profileInfo }
+            extensions={ [
+                {
+                    component: (
+                        <>
+                            <Menu.Item
+                                name={ config.deployment.developerApp.displayName }
+                                active={ activeView === "DEVELOPER" }
+                                className="portal-switch"
+                                onClick={ () => {
+                                    history.push(config.deployment.developerApp.path);
+                                } }
+                            />
+                            <Menu.Item
+                                name={ config.deployment.adminApp.displayName }
+                                active={ activeView === "ADMIN" }
+                                className="portal-switch"
+                                onClick={ () => {
+                                    history.push(config.deployment.adminApp.path);
+                                } }
+                            />
+                        </>
+                    ),
+                    floated: "left"
+                },
+                {
+                    component: (
+                        <Menu.Item>
+                            <ComponentPlaceholder section="feedback-button" type="component"/>
+                        </Menu.Item>
+                    ),
+                    floated: "right"
+                }
+            ] }
             fluid={ fluid }
             isProfileInfoLoading={ isProfileInfoLoading }
             userDropdownLinks={ [
@@ -176,27 +209,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             showUserDropdown={ true }
             onSidePanelToggleClick={ onSidePanelToggleClick }
             { ...rest }
-        >
-            <Menu.Menu position="left" className="portal-switches" secondary>
-                <Menu.Item
-                    name={ config.deployment.developerApp.displayName }
-                    active={ activeView === "DEVELOPER" }
-                    onClick={ () => {
-                        history.push(config.deployment.developerApp.path);
-                    } }
-                />
-                <Menu.Item
-                    name={ config.deployment.adminApp.displayName }
-                    active={ activeView === "ADMIN" }
-                    onClick={ () => {
-                        history.push(config.deployment.adminApp.path);
-                    } }
-                />
-            </Menu.Menu>
-            <div className="header-extensions">
-                <ComponentPlaceholder section="feedback-button" type="component"/>
-            </div>
-        </ReusableHeader>
+        />
     );
 };
 

--- a/apps/console/src/features/core/configs/routes.ts
+++ b/apps/console/src/features/core/configs/routes.ts
@@ -204,7 +204,16 @@ const DEVELOPER_VIEW_ROUTES: RouteInterface[] = [
         protected: true,
         showOnSidePanel: false
     },
-    ...extensions
+    {
+        component: null,
+        icon: null,
+        id: "404",
+        name: "404",
+        path: "*",
+        protected: true,
+        redirectTo: AppConstants.PATHS.get("PAGE_NOT_FOUND"),
+        showOnSidePanel: false
+    }
 ];
 
 /**
@@ -472,6 +481,16 @@ const ADMIN_VIEW_ROUTES: RouteInterface[] = [
         path: AppConstants.PATHS.get("GOVERNANCE_CONNECTORS"),
         protected: true,
         showOnSidePanel: false
+    },
+    {
+        component: null,
+        icon: null,
+        id: "404",
+        name: "404",
+        path: "*",
+        protected: true,
+        redirectTo: AppConstants.PATHS.get("PAGE_NOT_FOUND"),
+        showOnSidePanel: false
     }
 ];
 
@@ -629,5 +648,5 @@ export const baseRoutes = BASE_ROUTES;
 export const authLayoutRoutes = AUTH_LAYOUT_ROUTES;
 export const defaultLayoutRoutes = DEFAULT_LAYOUT_ROUTES;
 export const errorLayoutRoutes = ERROR_LAYOUT_ROUTES;
-export const developerViewRoutes = DEVELOPER_VIEW_ROUTES;
+export const developerViewRoutes = [ ...extensions, ...DEVELOPER_VIEW_ROUTES ];
 export const adminViewRoutes = ADMIN_VIEW_ROUTES;

--- a/modules/react-components/src/components/header/header.tsx
+++ b/modules/react-components/src/components/header/header.tsx
@@ -44,6 +44,10 @@ export interface HeaderPropsInterface extends TestableComponentInterface {
      * Top announcement component.
      */
     announcement?: ReactNode;
+    /**
+     * Set of extensions.
+     */
+    extensions?: HeaderExtension[];
     // TODO: Add proper type interface.
     basicProfileInfo: any;
     brand?: React.ReactNode;
@@ -63,6 +67,20 @@ export interface HeaderPropsInterface extends TestableComponentInterface {
     userDropdownIcon?: any;
     userDropdownInfoAction?: React.ReactNode;
     userDropdownLinks?: HeaderLinkInterface[];
+}
+
+/**
+ * Header extension interface.
+ */
+interface HeaderExtension {
+    /**
+     * Component to render.
+     */
+    component: ReactNode;
+    /**
+     * Float direction.
+     */
+    floated: "left" | "right";
 }
 
 /**
@@ -115,6 +133,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
         basicProfileInfo,
         children,
         className,
+        extensions,
         fixed,
         fluid,
         isProfileInfoLoading,
@@ -218,13 +237,41 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                         </Menu.Item>
                     )
                 }
+                {
+                    extensions && (
+                        extensions instanceof Array
+                        && extensions.length > 0
+                        && extensions.some((extension: HeaderExtension) => extension.floated === "left")
+                        && (
+                            <Menu.Menu
+                                position="left"
+                                className="header-extensions left"
+                                data-testid={ `${ testId }-left-extensions` }
+                            >
+                                {
+                                    extensions.map((extension: HeaderExtension) => 
+                                        extension.floated === "left" && extension.component)
+                                }
+                            </Menu.Menu>
+                        )
+                    )
+                }
                 { children }
                 { (
                     <Menu.Menu
                         position="right"
-                        className="user-dropdown-wrapper"
+                        className="header-extensions right"
                         data-testid={ `${ testId }-user-dropdown-container` }
                     >
+                        {
+                            extensions && (
+                                extensions instanceof Array
+                                && extensions.length > 0
+                                && extensions.some((extension: HeaderExtension) => extension.floated === "right")
+                                && extensions.map((extension: HeaderExtension) => 
+                                    extension.floated === "right" && extension.component)
+                            )
+                        }
                         {
                             showUserDropdown && (
                                 <Dropdown

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -1739,16 +1739,4 @@ svg.illustration {
     }
 }
 
-.portal-switches {
-    .item {
-        background: transparent !important;
-        color: #7a7a7a !important;
-        
-        &.active {
-            color: rgba(0,0,0,.87) !important;
-            border-bottom: 3px solid @primaryColor;
-        }
-    }
-}
-
 .loadUIOverrides();

--- a/modules/theme/src/themes/default/collections/menu.overrides
+++ b/modules/theme/src/themes/default/collections/menu.overrides
@@ -39,12 +39,14 @@
             height: auto;
         }
         .header-extensions {
-            display: @headerExtensionsDisplay;
-            align-items: @headerExtensionsAlignItems;
-        }
-        .right.menu {
-            &.user-dropdown-wrapper {
-                margin-left: @userDropdownWrapperMarginLeft;        
+            .item.portal-switch {
+                background: @appHeaderPortalSwitchExtensionBackgroundColor;
+                color: @appHeaderPortalSwitchExtensionColor;
+                    
+                &.active {
+                    color: @appHeaderPortalSwitchExtensionActiveColor;
+                    border-bottom: @appHeaderPortalSwitchExtensionActiveBorderBottom;
+                }
             }
         }
         .user-dropdown {

--- a/modules/theme/src/themes/default/collections/menu.variables
+++ b/modules/theme/src/themes/default/collections/menu.variables
@@ -33,7 +33,10 @@
 @appHeaderHeight: 60px;
 @appHeaderBoxShadow: none;
 
-@userDropdownWrapperMarginLeft: 0 !important;
+@appHeaderPortalSwitchExtensionBackgroundColor: transparent !important;
+@appHeaderPortalSwitchExtensionColor: @lightTextColor !important;
+@appHeaderPortalSwitchExtensionActiveColor: @textColor !important;
+@appHeaderPortalSwitchExtensionActiveBorderBottom: 3px solid @primaryColor;
 
 /*-------------------
       App Footer
@@ -101,10 +104,3 @@
 @userDropdownPadding: 8px;
 @userDropdownLinkMargin: 8px 0;
 @userDropdownLinkedAccountMargin: 8px 0;
-
-/*-------------------
-      Extensions
---------------------*/
-
-@headerExtensionsDisplay: flex;
-@headerExtensionsAlignItems: center;


### PR DESCRIPTION
## Purpose
1. The Header component has a UI issue when extensions are not present.
2. User Portal has the word `Account` twice in the product title section.

## Goals
This PR fixes the above issues.

## Approach
Added a new prop called `extensions` to the **Header** component which supports defining the placement of the extension.

Usage

```jsx
<Header
    extensions={ [
        {
            component: <Menu.Item active={ activeView === "DEVELOPER" } className="portal-switch" />,
            floated: "left"
        },
        {
            component: (
                <Menu.Item>
                    <ComponentPlaceholder section="feedback-button" type="component"/>
                </Menu.Item>
            ),
            floated: "right"
        }
    ] }
    ...
/>
```

**Before**

<img width="1915" alt="Screen Shot 2020-08-10 at 2 20 34 AM" src="https://user-images.githubusercontent.com/25959096/89741611-3c5c4280-dab0-11ea-83e8-94942781dcb8.png">

**After**

<img width="1910" alt="Screen Shot 2020-08-10 at 2 21 10 AM" src="https://user-images.githubusercontent.com/25959096/89741610-3a927f00-dab0-11ea-9984-0aca6e779df0.png">

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/3047