### PR TITLE
Add Product version appearance configuring support

### DIFF
--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -152,7 +152,12 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                             ? state.productName
                             : config.ui.productName
                     }
-                    version={ config.deployment.productVersion }
+                    version={ config.ui.productVersionConfig?.override ?? config.deployment.productVersion }
+                    versionUISettings={ {
+                        allowSnapshot: config.ui.productVersionConfig?.allowSnapshot,
+                        labelColor: config.ui.productVersionConfig?.labelColor,
+                        textCase: config.ui.productVersionConfig?.textCase
+                    } }
                 />
             ) }
             brandLink={ config.deployment.appHomePath }

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -152,7 +152,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                             ? state.productName
                             : config.ui.productName
                     }
-                    version={ config.ui.productVersionConfig?.override ?? config.deployment.productVersion }
+                    version={ config.ui.productVersionConfig?.versionOverride ?? config.deployment.productVersion }
                     versionUISettings={ {
                         allowSnapshot: config.ui.productVersionConfig?.allowSnapshot,
                         labelColor: config.ui.productVersionConfig?.labelColor,

--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -145,7 +145,8 @@ export class Config {
             doNotDeleteIdentityProviders: window["doNotDeleteIdentityProviders"] || [],
             features: window["AppUtils"].getConfig().ui.features,
             gravatarConfig: window["AppUtils"].getConfig().ui.gravatarConfig,
-            productName: window["AppUtils"].getConfig().ui.productName
+            productName: window["AppUtils"].getConfig().ui.productName,
+            productVersionConfig: window["AppUtils"].getConfig().ui.productVersionConfig
         };
     }
 }

--- a/apps/console/src/public/app-utils.js
+++ b/apps/console/src/public/app-utils.js
@@ -108,6 +108,7 @@ var AppUtils = AppUtils || (function() {
                 logoutCallbackURL: _config.clientOrigin + this.getTenantPath() + "/" + _config.appBaseName + 
                     _config.logoutCallbackPath,
                 productVersion: _config.productVersion,
+                productVersionConfig: _config.ui.productVersionConfig,
                 routes: _config.routePaths,
                 serverOrigin: _config.serverOrigin,
                 serverOriginWithTenant: _config.serverOrigin + this.getTenantPath(),

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -233,6 +233,11 @@
             "fallback": "404"
         },
         "productName": "Identity Server",
+        "productVersionConfig": {
+            "allowSnapshot": true,
+            "textCase": "uppercase",
+            "labelColor": "primary"
+        },
         "theme": {
             "name": "default"
         }

--- a/apps/user-portal/src/components/shared/header.tsx
+++ b/apps/user-portal/src/components/shared/header.tsx
@@ -204,7 +204,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                             ? state.productName
                             : config.ui.productName
                     }
-                    version={ config.ui.productVersionConfig?.override ?? config.deployment.productVersion }
+                    version={ config.ui.productVersionConfig?.versionOverride ?? config.deployment.productVersion }
                     versionUISettings={ {
                         allowSnapshot: config.ui.productVersionConfig?.allowSnapshot,
                         labelColor: config.ui.productVersionConfig?.labelColor,

--- a/apps/user-portal/src/components/shared/header.tsx
+++ b/apps/user-portal/src/components/shared/header.tsx
@@ -204,7 +204,12 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                             ? state.productName
                             : config.ui.productName
                     }
-                    version={ config.deployment.productVersion }
+                    version={ config.ui.productVersionConfig?.override ?? config.deployment.productVersion }
+                    versionUISettings={ {
+                        allowSnapshot: config.ui.productVersionConfig?.allowSnapshot,
+                        labelColor: config.ui.productVersionConfig?.labelColor,
+                        textCase: config.ui.productVersionConfig?.textCase
+                    } }
                 />
             ) }
             brandLink={ config.deployment.appHomePath }

--- a/apps/user-portal/src/configs/app.ts
+++ b/apps/user-portal/src/configs/app.ts
@@ -107,6 +107,7 @@ export class Config {
             copyrightText: `${window["AppUtils"].getConfig().ui.appCopyright} \u00A9 ${ new Date().getFullYear() }`,
             features: window["AppUtils"].getConfig().ui.features,
             productName: window["AppUtils"].getConfig().ui.productName,
+            productVersionConfig: window["AppUtils"].getConfig().ui.productVersionConfig,
             titleText: window["AppUtils"].getConfig().appTitle
         };
     }

--- a/apps/user-portal/src/public/app-utils.js
+++ b/apps/user-portal/src/public/app-utils.js
@@ -93,6 +93,7 @@ var AppUtils = AppUtils || (function() {
                 logoutCallbackURL: _config.clientOrigin + this.getTenantPath() + "/" + _config.appBaseName + 
                     _config.logoutCallbackPath,
                 productVersion: _config.productVersion,
+                productVersionConfig: _config.ui.productVersionConfig,
                 routes: _config.routePaths,
                 serverOrigin: _config.serverOrigin,
                 serverOriginWithTenant: _config.serverOrigin + this.getTenantPath(),

--- a/apps/user-portal/src/public/deployment.config.json
+++ b/apps/user-portal/src/public/deployment.config.json
@@ -77,6 +77,11 @@
             }
         },
         "productName": "Identity Server",
+        "productVersionConfig": {
+            "allowSnapshot": true,
+            "textCase": "uppercase",
+            "labelColor": "primary"
+        },
         "theme": {
             "name": "default"
         }

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -349,6 +349,17 @@
            {% endif %}
         },
         "productName": "{{ console.ui.product_name }}",
+        "productVersionConfig": {
+            {% if console.product_version.configs.items() is defined %}
+            {% for key, value in console.product_version.configs.items() %}
+            {% if value is string %}
+                "{{ key }}": "{{ value }}"{{ "," if not loop.last }}
+            {% else %}
+                "{{ key }}": {{ value }}{{ "," if not loop.last }}
+            {% endif %}
+            {% endfor %}
+            {% endif %}
+        },
         "theme": {
             "name": "{{ console.theme }}"
         }

--- a/features/org.wso2.identity.apps.user.portal.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.user.portal.server.feature/resources/deployment.config.json.j2
@@ -181,6 +181,17 @@
             }
         },
         "productName": "{{ user_portal.ui.product_name }}",
+        "productVersionConfig": {
+            {% if console.product_version.configs.items() is defined %}
+            {% for key, value in console.product_version.configs.items() %}
+            {% if value is string %}
+                "{{ key }}": "{{ value }}"{{ "," if not loop.last }}
+            {% else %}
+                "{{ key }}": {{ value }}{{ "," if not loop.last }}
+            {% endif %}
+            {% endfor %}
+            {% endif %}
+        },
         "theme": {
             "name": "{{ user_portal.theme }}"
         }

--- a/modules/core/src/models/config.ts
+++ b/modules/core/src/models/config.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { ProductVersionConfigInterface } from "./core";
 import { DocumentationProviders, DocumentationStructureFileTypes } from "./documentation";
 import { GravatarConfig } from "./profile";
 
@@ -197,6 +198,11 @@ export interface CommonUIConfigInterface {
      * ex: `Identity Server`
      */
     productName: string;
+    /**
+     * Product version UI configurations.
+     * ex: allowSnapshot, override etc.
+     */
+    productVersionConfig?: ProductVersionConfigInterface;
 }
 
 /**

--- a/modules/core/src/models/core.ts
+++ b/modules/core/src/models/core.ts
@@ -161,7 +161,7 @@ export interface ProductVersionConfigInterface {
     /**
      * Override the parent POM version.
      */
-    override?: string;
+    versionOverride?: string;
     /**
      * Text case.
      */

--- a/modules/core/src/models/core.ts
+++ b/modules/core/src/models/core.ts
@@ -145,3 +145,25 @@ export enum ProductReleaseTypes {
      */
     RC = "rc"
 }
+
+/**
+ * Product version configurations interface.
+ */
+export interface ProductVersionConfigInterface {
+    /**
+     * Show snapshot label.
+     */
+    allowSnapshot?: boolean;
+    /**
+     * Color for the release label.
+     */
+    labelColor?: "auto" | "primary" | "secondary" | string;
+    /**
+     * Override the parent POM version.
+     */
+    override?: string;
+    /**
+     * Text case.
+     */
+    textCase?: "lowercase" | "uppercase";
+}

--- a/modules/react-components/src/components/brand/product-brand.tsx
+++ b/modules/react-components/src/components/brand/product-brand.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { ProductReleaseTypes, TestableComponentInterface } from "@wso2is/core/models";
+import { ProductReleaseTypes, ProductVersionConfigInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { CommonUtils } from "@wso2is/core/utils";
 import classNames from "classnames";
 import React, { FunctionComponent, PropsWithChildren, ReactElement, ReactNode } from "react";
@@ -52,27 +52,9 @@ export interface ProductBrandPropsInterface extends TestableComponentInterface {
      */
     version?: string;
     /**
-     * Product version UI settings.
+     * Product version config settings.
      */
-    versionUISettings?: ProductVersionUIInterface;
-}
-
-/**
- * Product version interface for UI.
- */
-export interface ProductVersionUIInterface {
-    /**
-     * Show snapshot label.
-     */
-    allowSnapshot?: boolean;
-    /**
-     * Color for the release label.
-     */
-    labelColor?: SemanticCOLORS | "auto" | "primary" | "secondary";
-    /**
-     * Text case.
-     */
-    textCase?: "lowercase" | "uppercase";
+    versionUISettings?: ProductVersionConfigInterface;
 }
 
 /**
@@ -123,7 +105,7 @@ export const ProductBrand: FunctionComponent<PropsWithChildren<ProductBrandProps
                 || versionUISettings.labelColor === "primary"
                 || versionUISettings.labelColor === "secondary")) {
 
-            return versionUISettings.labelColor;
+            return versionUISettings.labelColor as SemanticCOLORS;
         }
 
         if (versionUISettings.labelColor === "primary" || versionUISettings.labelColor === "secondary") {


### PR DESCRIPTION
## Purpose
The product version displayed in the **Header** component is taken from the parent POM file and currently there is no way to override the version.

## Goals
This PR adds a configuration object to override the version and also to configure the look and feel of the version appearance in the UI.

Fixes wso2/product-is#9170

## Approach

**Usage**

By default the version will be taken from the parent product is version. If the config needs to be changed, do the following changes in `deployment.toml`.

```toml
[console]
product_version.configs.allowSnapshot = false #  Shows the snapshot label if present in product version. Defaults to `false`
product_version.configs.versionOverride = "ALPHA" #  Overrides the version number. Use "" if version should be hidden. Drop the attribute if no change to version number is required.
product_version.configs.textCase = "uppercase" #  Text case for the  version.
product_version.configs.labelColor = "primary" # Color of the label. Supports `auto` | `primary` | `secondary` | `SemanticCOLORS`
```
