### PR TITLE
Implement read-only view in the user-portal

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -122,7 +122,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     /**
      * This deletes a local claim
-     * @param {string} id 
+     * @param {string} id
      */
     const deleteLocalClaim = (id: string) => {
         deleteAClaim(id).then(() => {
@@ -149,7 +149,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     /**
      * This shows a popup with a delay of 500 ms.
-     * 
+     *
      * @param {React.Dispatch<React.SetStateAction<boolean>>} callback The state dispatch method.
      * @param {React.MutableRefObject<any>} ref The ref object carrying the `setTimeout` ID.
      */
@@ -162,7 +162,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     /**
      * This closes the popup.
-     * 
+     *
      * @param {React.Dispatch<React.SetStateAction<boolean>>} callback The state dispatch method.
      * @param {React.MutableRefObject<any>} ref The ref object carrying the `setTimeout` ID.
      */
@@ -206,7 +206,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             regEx: values.get("regularExpression").toString(),
                             required: values.get("required").length > 0,
                             supportedByDefault: values.get("supportedByDefault").length > 0
-    
+
                         };
                         updateAClaim(claim.id, data).then(() => {
                             dispatch(addAlert(
@@ -299,7 +299,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                     data-testid={ `${ testId }-form-regex-input` }
                                 />
                                 <Popup
-                                    content={ t("adminPortal:components.claims.local.forms.description.regExHint") }
+                                    content={ t("adminPortal:components.claims.local.forms.regExHint") }
                                     inverted
                                     open={ isShowRegExHint }
                                     trigger={ <span></span> }

--- a/apps/user-portal/src/api/profile.ts
+++ b/apps/user-portal/src/api/profile.ts
@@ -22,7 +22,7 @@ import axios from "axios";
 import _ from "lodash";
 import { ApplicationConstants } from "../constants";
 import { history } from "../helpers";
-import { BasicProfileInterface, HttpMethods, MultiValue, ProfileSchema } from "../models";
+import { BasicProfileInterface, HttpMethods, MultiValue, ProfileSchema, ReadOnlyUserStatus } from "../models";
 import { store } from "../store";
 import { toggleSCIMEnabled } from "../store/actions";
 
@@ -38,7 +38,6 @@ const httpClient = IdentityClient.getInstance().httpRequest.bind(IdentityClient.
  *
  * @return {Promise<any>} a promise containing the response.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 export const getUserInfo = (): Promise<any> => {
     const requestConfig = {
         headers: {
@@ -59,6 +58,37 @@ export const getUserInfo = (): Promise<any> => {
         })
         .catch((error) => {
             return Promise.reject(error);
+        });
+};
+
+/**
+ * Retrieve the user read only status of the currently authenticated user.
+ *
+ * @return {Promise<any>} a promise containing the response.
+ */
+export const getUserReadOnlyStatus = (): Promise<ReadOnlyUserStatus> => {
+    const requestConfig = {
+        headers: {
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        url: store.getState().config.endpoints.isReadOnlyUser
+    };
+
+    return httpClient(requestConfig)
+        .then((response) => {
+            if (response.status !== 200) {
+                return Promise.reject(
+                    new Error(`Failed get user read only status from:
+                ${store.getState().config.endpoints.user}`)
+                );
+            }
+            return Promise.resolve(response?.data);
+        })
+        .catch((error) => {
+            console.log(error);
+            return Promise.reject(error?.response?.data);
         });
 };
 
@@ -197,7 +227,7 @@ export const updateProfileInfo = (info: object): Promise<any> => {
             return Promise.resolve(response);
         })
         .catch((error) => {
-            return Promise.reject(error);
+            return Promise.reject(error?.response?.data);
         });
 };
 

--- a/apps/user-portal/src/api/profile.ts
+++ b/apps/user-portal/src/api/profile.ts
@@ -87,7 +87,6 @@ export const getUserReadOnlyStatus = (): Promise<ReadOnlyUserStatus> => {
             return Promise.resolve(response?.data);
         })
         .catch((error) => {
-            console.log(error);
             return Promise.reject(error?.response?.data);
         });
 };

--- a/apps/user-portal/src/components/multi-factor-authentication/multi-factor-authentication.tsx
+++ b/apps/user-portal/src/components/multi-factor-authentication/multi-factor-authentication.tsx
@@ -31,7 +31,7 @@ import { SettingsSection } from "../shared";
 /**
  * Prop types for the basic details component.
  */
-interface MfaProps  extends SBACInterface<FeatureConfigInterface> {
+interface MfaProps extends SBACInterface<FeatureConfigInterface> {
     onAlertFired: (alert: AlertInterface) => void;
 }
 
@@ -40,6 +40,7 @@ export const MultiFactorAuthentication: React.FunctionComponent<MfaProps> = (pro
     const { onAlertFired, featureConfig } = props;
 
     const allowedScopes: string = useSelector((state: AppState) => state?.authenticationInformation?.scope);
+    const isReadOnlyUser = useSelector((state: AppState) => state.authenticationInformation.profileInfo.isReadOnly);
 
     return (
         <SettingsSection
@@ -47,54 +48,36 @@ export const MultiFactorAuthentication: React.FunctionComponent<MfaProps> = (pro
             header={ t("userPortal:sections.mfa.heading") }
         >
             <List divided={ true } verticalAlign="middle" className="main-content-inner">
-                <List.Item className="inner-list-item">
-                    {
-                        hasRequiredScopes(
-                            featureConfig?.security, featureConfig?.security?.scopes?.read,
-                            allowedScopes
-                        ) &&
-                        isFeatureEnabled(
-                            featureConfig?.security,
-                            ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_MFA_SMS")
-                        )
-                        ? (
+                { !isReadOnlyUser
+                    && hasRequiredScopes(featureConfig?.security, featureConfig?.security?.scopes?.read, allowedScopes)
+                    && isFeatureEnabled(
+                        featureConfig?.security,
+                        ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_MFA_SMS")
+                    ) ? (
+                        <List.Item className="inner-list-item">
                             <SMSOTPAuthenticator onAlertFired={ onAlertFired } />
-                        )
-                        : null
-                    }
-                </List.Item>
-                <List.Item className="inner-list-item">
-                    {
-                        hasRequiredScopes(
-                            featureConfig?.security, featureConfig?.security?.scopes?.read,
-                            allowedScopes
-                        ) &&
-                        isFeatureEnabled(
-                            featureConfig?.security,
-                            ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_MFA_FIDO")
-                        )
-                        ? (
+                        </List.Item>
+                    ) : null }
+
+                { hasRequiredScopes(featureConfig?.security, featureConfig?.security?.scopes?.read, allowedScopes) &&
+                    isFeatureEnabled(
+                        featureConfig?.security,
+                        ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_MFA_FIDO")
+                    ) ? (
+                        <List.Item className="inner-list-item">
                             <FIDOAuthenticator onAlertFired={ onAlertFired } />
-                        )
-                        : null
-                    }
-                </List.Item>
-                <List.Item className="inner-list-item">
-                    {
-                        hasRequiredScopes(
-                            featureConfig?.security, featureConfig?.security?.scopes?.read,
-                            allowedScopes
-                        ) &&
-                        isFeatureEnabled(
-                            featureConfig?.security,
-                            ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_MFA_TOTP")
-                        )
-                        ? (
+                        </List.Item>
+                    ) : null }
+
+                { hasRequiredScopes(featureConfig?.security, featureConfig?.security?.scopes?.read, allowedScopes) &&
+                    isFeatureEnabled(
+                        featureConfig?.security,
+                        ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_MFA_TOTP")
+                    ) ? (
+                        <List.Item className="inner-list-item">
                             <TOTPAuthenticator onAlertFired={ onAlertFired } />
-                        )
-                        : null
-                    }
-                </List.Item>
+                        </List.Item>
+                    ) : null }
             </List>
         </SettingsSection>
     );

--- a/apps/user-portal/src/components/profile/profile.tsx
+++ b/apps/user-portal/src/components/profile/profile.tsx
@@ -23,7 +23,9 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Form, Grid, Icon, List, Placeholder, Popup, Responsive } from "semantic-ui-react";
-import { updateProfileInfo } from "../../api";
+import {
+    updateProfileInfo
+} from "../../api";
 import * as UIConstants from "../../constants/ui-constants";
 import { AlertInterface, AlertLevels, AuthStateInterface, ProfileSchema } from "../../models";
 import { AppState } from "../../store";
@@ -56,6 +58,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
     const isSCIMEnabled: boolean = useSelector((state: AppState) => state.profile.isSCIMEnabled);
     const profileSchemaLoader: boolean = useSelector((state: AppState) => state.loaders.isProfileSchemaLoading);
     const [ urlSchema, setUrlSchema ] = useState<ProfileSchema>();
+    const isReadOnlyUser = useSelector((state: AppState) => state.authenticationInformation.profileInfo.isReadOnly);
 
     /**
      * dispatch getProfileInformation action if the profileDetails object is empty
@@ -202,6 +205,16 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                 // Re-fetch the profile information
                 dispatch(getProfileInformation(true));
             }
+        }).catch(error => {
+            onAlertFired({
+                description: error?.detail ?? t(
+                    "userPortal:components.profile.notifications.updateProfileInfo.genericError.description"
+                ),
+                level: AlertLevels.ERROR,
+                message: error?.message ?? t(
+                    "userPortal:components.profile.notifications.updateProfileInfo.genericError.message"
+                )
+            });
         });
 
         // Hide corresponding edit view
@@ -369,7 +382,8 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                             }
                         >
                             <List.Content floated="right">
-                                {schema.mutability !== "READ_ONLY"
+                                { !isReadOnlyUser
+                                    && schema.mutability !== "READ_ONLY"
                                     && schema.name !== "userName"
                                     && !isEmpty(profileInfo.get(schema.name))
                                     ? (

--- a/apps/user-portal/src/components/profile/profile.tsx
+++ b/apps/user-portal/src/components/profile/profile.tsx
@@ -23,9 +23,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Form, Grid, Icon, List, Placeholder, Popup, Responsive } from "semantic-ui-react";
-import {
-    updateProfileInfo
-} from "../../api";
+import { updateProfileInfo } from "../../api";
 import * as UIConstants from "../../constants/ui-constants";
 import { AlertInterface, AlertLevels, AuthStateInterface, ProfileSchema } from "../../models";
 import { AppState } from "../../store";

--- a/apps/user-portal/src/configs/app.ts
+++ b/apps/user-portal/src/configs/app.ts
@@ -77,6 +77,9 @@ export class Config {
             fidoStart: `${this.getDeploymentConfig().serverHost}/api/users/v2/me/webauthn/start-registration`,
             fidoStartUsernameless: `${this.getDeploymentConfig().serverHost}/api/users/v2/me/webauthn/
             start-usernameless-registration`,
+            isReadOnlyUser:`${
+                this.getDeploymentConfig().serverHost
+            }/scim2/Me?attributes=urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.isReadOnlyUser`,
             issuer: `${this.getDeploymentConfig().serverHost}/oauth2/token`,
             jwks: `${this.getDeploymentConfig().serverHost}/oauth2/jwks`,
             logout: `${this.getDeploymentConfig().serverHost}/oidc/logout`,

--- a/apps/user-portal/src/models/app-config.ts
+++ b/apps/user-portal/src/models/app-config.ts
@@ -72,6 +72,7 @@ export interface ServiceResourceEndpointsInterface {
     fidoMetaData: string;
     fidoStart: string;
     fidoStartUsernameless: string;
+    isReadOnlyUser: string;
     issuer: string;
     jwks: string;
     logout: string;

--- a/apps/user-portal/src/models/profile.ts
+++ b/apps/user-portal/src/models/profile.ts
@@ -48,7 +48,8 @@ export interface BasicProfileInterface {
     userImage?: string;
     userName?: string;
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    [key: string]: any;
+    [ key: string ]: any;
+    isReadOnly: boolean;
 }
 
 /**
@@ -149,6 +150,17 @@ export interface ProfileReducerStateInterface {
 }
 
 /**
+ * Model of the is read only user status.
+ */
+export interface ReadOnlyUserStatus {
+    id: string;
+    schemas: string[];
+    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
+        isReadOnlyUser: boolean;
+    };
+}
+
+/**
  * Empty profile completion object.
  *
  * @return {ProfileCompletion}
@@ -166,14 +178,18 @@ export const emptyProfileCompletion = (): ProfileCompletion => ({
         completedCount: 0,
         incompleteAttributes: [],
         totalCount: 0
-    },
+    }
 });
 
 export const createEmptyProfile = (): BasicProfileInterface => ({
     email: "",
     emails: [],
+    isReadOnly: true,
     isSecurity: false,
-    name: { givenName: "", familyName: "" },
+    name: {
+        familyName: "",
+        givenName: ""
+    },
     organisation: "",
     phoneNumbers: [],
     profileUrl: "",

--- a/apps/user-portal/src/pages/account-security.tsx
+++ b/apps/user-portal/src/pages/account-security.tsx
@@ -44,6 +44,7 @@ const AccountSecurityPage = (): ReactElement => {
     const dispatch = useDispatch();
     const accessConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
     const allowedScopes: string = useSelector((state: AppState) => state?.authenticationInformation?.scope);
+    const isReadOnlyUser = useSelector((state: AppState) => state.authenticationInformation.profileInfo.isReadOnly);
 
     /**
      * Dispatches the alert object to the redux store.
@@ -59,102 +60,73 @@ const AccountSecurityPage = (): ReactElement => {
             pageDescription={ t("userPortal:pages.security.subTitle") }
         >
             <Grid>
-                <Grid.Row>
-                    <Grid.Column width={ 16 }>
-                        {
-                            hasRequiredScopes(
-                                accessConfig?.security, accessConfig?.security?.scopes?.read,
-                                allowedScopes
-                            ) &&
-                            isFeatureEnabled(
-                                accessConfig?.security,
-                                ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_CHANGE_PASSWORD")
-                            )
-                            ? (
+                { !isReadOnlyUser &&
+                    hasRequiredScopes(accessConfig?.security, accessConfig?.security?.scopes?.read, allowedScopes) &&
+                    isFeatureEnabled(
+                        accessConfig?.security,
+                        ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_CHANGE_PASSWORD")
+                    ) ? (
+                        <Grid.Row>
+                            <Grid.Column width={ 16 }>
                                 <ChangePassword onAlertFired={ handleAlerts } />
-                            )
-                            : null
-                        }
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row>
-                    <Grid.Column width={ 16 }>
-                        {
-                            hasRequiredScopes(
-                                accessConfig?.security, accessConfig?.security?.scopes?.read,
-                                allowedScopes
-                            ) &&
-                            isFeatureEnabled(
-                                accessConfig?.security,
-                                ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_ACCOUNT_RECOVERY")
-                            )
-                            ? (
+                            </Grid.Column>
+                        </Grid.Row>
+                    ) : null }
+
+                { !isReadOnlyUser &&
+                    hasRequiredScopes(accessConfig?.security, accessConfig?.security?.scopes?.read, allowedScopes) &&
+                    isFeatureEnabled(
+                        accessConfig?.security,
+                        ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_ACCOUNT_RECOVERY")
+                    ) ? (
+                        <Grid.Row>
+                            <Grid.Column width={ 16 }>
                                 <AccountRecoveryComponent
                                     featureConfig={ accessConfig }
                                     onAlertFired={ handleAlerts }
                                 />
-                            )
-                            : null
-                        }
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row>
-                    <Grid.Column width={ 16 }>
-                        {
-                            hasRequiredScopes(
-                                accessConfig?.security, accessConfig?.security?.scopes?.read,
-                                allowedScopes
-                            ) &&
-                            isFeatureEnabled(
-                                accessConfig?.security,
-                                ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_MFA")
-                            )
-                            ? (
+                            </Grid.Column>
+                        </Grid.Row>
+                    ) : null }
+
+                { hasRequiredScopes(accessConfig?.security, accessConfig?.security?.scopes?.read, allowedScopes) &&
+                    isFeatureEnabled(
+                        accessConfig?.security,
+                        ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_MFA")
+                    ) ? (
+                        <Grid.Row>
+                            <Grid.Column width={ 16 }>
                                 <MultiFactorAuthentication
                                     featureConfig={ accessConfig }
                                     onAlertFired={ handleAlerts }
                                 />
-                            )
-                            : null
-                        }
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row>
-                    <Grid.Column width={ 16 }>
-                        {
-                            hasRequiredScopes(
-                                accessConfig?.security, accessConfig?.security?.scopes?.read,
-                                allowedScopes
-                            ) &&
-                            isFeatureEnabled(
-                                accessConfig?.security,
-                                ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_ACTIVE_SESSIONS")
-                            )
-                            ? (
+                            </Grid.Column>
+                        </Grid.Row>
+                    ) : null }
+
+                { hasRequiredScopes(accessConfig?.security, accessConfig?.security?.scopes?.read, allowedScopes) &&
+                    isFeatureEnabled(
+                        accessConfig?.security,
+                        ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_ACTIVE_SESSIONS")
+                    ) ? (
+                        <Grid.Row>
+                            <Grid.Column width={ 16 }>
                                 <UserSessionsComponent onAlertFired={ handleAlerts } />
-                            )
-                            : null
-                        }
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row>
-                    <Grid.Column width={ 16 }>
-                        {
-                            hasRequiredScopes(
-                                accessConfig?.security, accessConfig?.security?.scopes?.read,
-                                allowedScopes
-                            ) &&
-                            isFeatureEnabled(
-                                accessConfig?.security,
-                                ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_CONSENTS")
-                            )
-                            ? (
+                            </Grid.Column>
+                        </Grid.Row>
+                    ) : null }
+
+                { hasRequiredScopes(accessConfig?.security, accessConfig?.security?.scopes?.read, allowedScopes) &&
+                    isFeatureEnabled(
+                        accessConfig?.security,
+                        ApplicationConstants.FEATURE_DICTIONARY.get("SECURITY_CONSENTS")
+                    ) ? (
+                        <Grid.Row>
+                            <Grid.Column width={ 16 }>
                                 <Consents onAlertFired={ handleAlerts } />
-                            )
-                            : null
-                        }
-                    </Grid.Column>
-                </Grid.Row>
+                            </Grid.Column>
+                        </Grid.Row>
+                    ) : null }
             </Grid>
         </InnerPageLayout>
     );

--- a/modules/i18n/src/models/namespaces/user-portal-ns.ts
+++ b/modules/i18n/src/models/namespaces/user-portal-ns.ts
@@ -635,6 +635,7 @@ export interface UserPortalNS {
             };
             notifications: {
                 getProfileInfo: Notification;
+                getUserReadOnlyStatus: Notification;
                 updateProfileInfo: Notification;
             };
             placeholders: {

--- a/modules/i18n/src/translations/en-US/portals/user-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/user-portal.ts
@@ -1067,6 +1067,12 @@ export const userPortal: UserPortalNS = {
                         message: "Successfully retrieved user profile"
                     }
                 },
+                getUserReadOnlyStatus: {
+                    genericError: {
+                        description: "Error occurred while retrieving the read-only status of the user",
+                        message: "Something went wrong"
+                    }
+                },
                 updateProfileInfo: {
                     error: {
                         description: "{{description}}",

--- a/modules/i18n/src/translations/pt-BR/portals/user-portal.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/user-portal.ts
@@ -1049,6 +1049,12 @@ export const userPortal: UserPortalNS = {
                         message: "Perfil de usuário recuperado com sucesso"
                     }
                 },
+                getUserReadOnlyStatus: {
+                    genericError: {
+                        description: "Ocorreu um erro ao recuperar o status somente leitura do usuário",
+                        message: "Algo deu errado"
+                    }
+                },
                 updateProfileInfo: {
                     error: {
                         description: "{{description}}",

--- a/modules/i18n/src/translations/si-LK/portals/user-portal.ts
+++ b/modules/i18n/src/translations/si-LK/portals/user-portal.ts
@@ -1060,6 +1060,12 @@ export const userPortal: UserPortalNS = {
                         message: "පරිශීලක පැතිකඩ සාර්ථකව ලබා ගන්නා ලදි"
                     }
                 },
+                getUserReadOnlyStatus: {
+                    genericError: {
+                        description: "පරිශීලකයාගේ කියවීමට පමණක් තත්ත්වය ලබා ගැනීමේදී දෝෂයක් ඇතිවිය",
+                        message: "දෝෂයක් ඇතිවිය!!!"
+                    }
+                },
                 updateProfileInfo: {
                     error: {
                         description: "{{description}}",

--- a/modules/i18n/src/translations/ta-IN/portals/user-portal.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/user-portal.ts
@@ -1096,6 +1096,12 @@ export const userPortal: UserPortalNS = {
                         message: "பயனர் விபரம் பெறப்பட்டுவிட்டது"
                     }
                 },
+                getUserReadOnlyStatus: {
+                    genericError: {
+                        description: "பயனரின் படிக்க-மட்டும் நிலையை மீட்டெடுக்கும்போது தவறேற்பட்டுவிட்டது",
+                        message: "ஏதோ தவறேற்பட்டுவிட்டது !!!"
+                    }
+                },
                 updateProfileInfo: {
                     error: {
                         description: "பயனர் சுயவிபரத்தை புதுப்பிக்கும் பொழுது தவறேற்பட்டுவிட்டது",

--- a/modules/theme/src/themes/default/elements/list.overrides
+++ b/modules/theme/src/themes/default/elements/list.overrides
@@ -78,6 +78,15 @@
                 overflow: hidden;
                 text-overflow: ellipsis;
             }
+
+            .content {
+                overflow: hidden;
+
+                .list-item-name {
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+            }
         }
         
         &.fill {


### PR DESCRIPTION
## Purpose
> Fetch the read-only status of a user using the updated SCIM API endpoint and disable editing the following if the user is read-only.:
> - Profile
> - Security Questions
> - Email recovery
> - Password
> - MFA SMS number

> Minor fixes:
> - Fix localization issue with regex hint on local attribute edit view
> - Added text-overflow ellipsis to the external attribute name column 