### PR TITLE
Rename Portal Apps to new naming

### DIFF
--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -6,14 +6,14 @@
     "clientID": "CONSOLE",
     "debug": false,
     "adminApp": {
-        "basePath": "/admin",
-        "displayName": "Admin",
-        "path": "/admin/overview"
+        "basePath": "/manage",
+        "displayName": "Manage",
+        "path": "/manage/overview"
     },
     "developerApp": {
-        "basePath": "/developer",
-        "displayName": "Developer",
-        "path": "/developer/overview"
+        "basePath": "/develop",
+        "displayName": "Develop",
+        "path": "/develop/overview"
     },
     "documentation": {
         "baseURL": "https://api.github.com",
@@ -32,7 +32,7 @@
     "productVersion": "",
     "serverOrigin": "https://localhost:9443",
     "routePaths": {
-        "home": "/developer/overview",
+        "home": "/develop/overview",
         "login": "/login",
         "logout": "/logout"
     },


### PR DESCRIPTION
## Purpose
This PR will rename the portal apps from `Developer` to `Develop` and `Admin` to `Manage`.

## Related PRs
[PR - 1](https://github.com/wso2/carbon-identity-framework/pull/3060)

