### PR TITLE
Refactor portal switches UI

### DIFF
--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -37,7 +37,7 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Image, Menu } from "semantic-ui-react";
+import { Container, Image, Menu } from "semantic-ui-react";
 import { ComponentPlaceholder } from "../../../extensions";
 import { history } from "../helpers";
 import { ConfigReducerStateInterface } from "../models";
@@ -165,29 +165,6 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             extensions={ [
                 {
                     component: (
-                        <>
-                            <Menu.Item
-                                name={ config.deployment.developerApp.displayName }
-                                active={ activeView === "DEVELOPER" }
-                                className="portal-switch"
-                                onClick={ () => {
-                                    history.push(config.deployment.developerApp.path);
-                                } }
-                            />
-                            <Menu.Item
-                                name={ config.deployment.adminApp.displayName }
-                                active={ activeView === "ADMIN" }
-                                className="portal-switch"
-                                onClick={ () => {
-                                    history.push(config.deployment.adminApp.path);
-                                } }
-                            />
-                        </>
-                    ),
-                    floated: "left"
-                },
-                {
-                    component: (
                         <Menu.Item>
                             <ComponentPlaceholder section="feedback-button" type="component"/>
                         </Menu.Item>
@@ -214,7 +191,30 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             showUserDropdown={ true }
             onSidePanelToggleClick={ onSidePanelToggleClick }
             { ...rest }
-        />
+        >
+            <div className="secondary-panel">
+                <Container fluid={ fluid }>
+                    <Menu className="inner-menu">
+                        <Menu.Item
+                            name={ config.deployment.developerApp.displayName }
+                            active={ activeView === "DEVELOPER" }
+                            className="portal-switch"
+                            onClick={ () => {
+                                history.push(config.deployment.developerApp.path);
+                            } }
+                        />
+                        <Menu.Item
+                            name={ config.deployment.adminApp.displayName }
+                            active={ activeView === "ADMIN" }
+                            className="portal-switch"
+                            onClick={ () => {
+                                history.push(config.deployment.adminApp.path);
+                            } }
+                        />
+                    </Menu>
+                </Container>
+            </div>
+        </ReusableHeader>
     );
 };
 

--- a/modules/react-components/src/components/header/header.tsx
+++ b/modules/react-components/src/components/header/header.tsx
@@ -256,7 +256,6 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                         )
                     )
                 }
-                { children }
                 { (
                     <Menu.Menu
                         position="right"
@@ -426,6 +425,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                     </Menu.Menu>
                 ) }
             </Container>
+            { children }
         </Menu>
     );
 };

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -466,7 +466,7 @@ body {
 
         &.fluid-dashboard-layout {
             .app-header {
-                .app-header-container {
+                .app-header-container, .secondary-panel {
                     padding: @fluidDashboardLayoutHeaderPadding;
                 }
             }

--- a/modules/theme/src/themes/default/collections/menu.overrides
+++ b/modules/theme/src/themes/default/collections/menu.overrides
@@ -30,6 +30,7 @@
         }
     }
     &.app-header {
+        display: @appHeaderDisplay;
         background: @appHeaderBackground;
         height: @appHeaderHeight;
         box-shadow: @appHeaderBoxShadow;
@@ -166,7 +167,46 @@
                 margin: 0.5rem 0rem;
             }
         }
+
+        .secondary-panel {
+            display: @appHeaderSecondaryPanelDisplay;
+            box-shadow: @appHeaderSecondaryPanelBoxShadow;
+            border-left: @appHeaderSecondaryPanelBorderLeft;
+            border-right: @appHeaderSecondaryPanelBorderRight;
+            border-bottom: @appHeaderSecondaryPanelBorderBottom;
+            border-top: @appHeaderSecondaryPanelBorderTop;
+            background: @appHeaderSecondaryPanelBackground;
+            height: @appHeaderSecondaryPanelHeight;
+
+            .ui.container {
+                height: @appHeaderSecondaryPanelContainerHeight;
+            }
+            .inner-menu {
+                box-shadow: @appHeaderSecondaryPanelInnerMenuBoxShadow;
+                border: @appHeaderSecondaryPanelInnerMenuBorder;
+                border-radius: @appHeaderSecondaryPanelInnerMenuBorderRadius;
+                background: @appHeaderSecondaryPanelInnerMenuBackground;
+                height: @appHeaderSecondaryPanelInnerMenuHeight;
+                
+                .item.portal-switch {
+                    background: @appHeaderSecondaryPanelPortalSwitchBackground;
+                    color: @appHeaderSecondaryPanelPortalSwitchColor;
+                    border-bottom: @appHeaderSecondaryPanelPortalSwitchBorderBottom;
+                    
+                    &.active {
+                        background: @appHeaderSecondaryPanelPortalSwitchActiveBackground;
+                        color: @appHeaderSecondaryPanelPortalSwitchActiveColor;
+                        border-bottom: @appHeaderSecondaryPanelPortalSwitchActiveBorderBottom;
+                    }
+                    
+                    &:first-child {
+                        margin-left: @appHeaderSecondaryPanelPortalSwitchesLeftSpacing;
+                    }
+                }
+            }
+        }
     }
+
     &.app-footer {
         background: @appFooterBackground;
         height: @appFooterHeight;

--- a/modules/theme/src/themes/default/collections/menu.variables
+++ b/modules/theme/src/themes/default/collections/menu.variables
@@ -29,9 +29,36 @@
       App Header
 --------------------*/
 
+@appHeaderDisplay: block;
 @appHeaderBackground: @lightPageBackground;
-@appHeaderHeight: 60px;
+@appHeaderHeight: auto;
 @appHeaderBoxShadow: none;
+
+@appHeaderSecondaryPanelDisplay: block;
+@appHeaderSecondaryPanelHeight: 50px;
+@appHeaderSecondaryPanelBackground: @lightPageBackground;
+@appHeaderSecondaryPanelBoxShadow: none;
+@appHeaderSecondaryPanelBorderLeft: 0;
+@appHeaderSecondaryPanelBorderRight: 0;
+@appHeaderSecondaryPanelBorderBottom: 0;
+@appHeaderSecondaryPanelBorderTop: @defaultBorderWidth solid @borderColor;
+@appHeaderSecondaryPanelInnerMenuBorder: 0;
+@appHeaderSecondaryPanelInnerMenuBoxShadow: none;
+@appHeaderSecondaryPanelInnerMenuBorderRadius: 0;
+@appHeaderSecondaryPanelInnerMenuBackground: @appHeaderSecondaryPanelBackground;
+@appHeaderSecondaryPanelInnerMenuHeight: 100%;
+
+@appHeaderSecondaryPanelPortalSwitchesLeftSpacing: 14px;
+
+@appHeaderSecondaryPanelPortalSwitchBackground: inherit;
+@appHeaderSecondaryPanelPortalSwitchColor: @lightTextColor;
+@appHeaderSecondaryPanelPortalSwitchBorderBottom: 3px solid transparent;
+
+@appHeaderSecondaryPanelPortalSwitchActiveBackground: inherit;
+@appHeaderSecondaryPanelPortalSwitchActiveColor: @textColor;
+@appHeaderSecondaryPanelPortalSwitchActiveBorderBottom: 3px solid @primaryColor;
+
+@appHeaderSecondaryPanelContainerHeight: 100%;
 
 @appHeaderPortalSwitchExtensionBackgroundColor: transparent !important;
 @appHeaderPortalSwitchExtensionColor: @lightTextColor !important;


### PR DESCRIPTION
## Purpose
Currently, the portal switches are on the **Header** itself and it can be quite invisible at times.

## Goals
This PR introduces changes that will bring the switches to a separate panel under the header.

## Approach

<img width="1913" alt="Screen Shot 2020-08-17 at 10 18 26 AM" src="https://user-images.githubusercontent.com/25959096/90358215-03edd300-e073-11ea-94c4-b2cff701361f.png">
