### PR TITLE
Temporarily hide overview pages in console application

### DIFF
--- a/apps/console/src/features/core/configs/routes.ts
+++ b/apps/console/src/features/core/configs/routes.ts
@@ -82,7 +82,7 @@ const DEVELOPER_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "applications",
         name: "common:applications",
-        order: 2,
+        order: 1,
         path: AppConstants.PATHS.get("APPLICATIONS"),
         protected: true,
         showOnSidePanel: true
@@ -121,7 +121,7 @@ const DEVELOPER_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "identityProviders",
         name: "common:identityProviders",
-        order: 3,
+        order: 2,
         path: AppConstants.PATHS.get("IDP"),
         protected: true,
         showOnSidePanel: true
@@ -149,7 +149,7 @@ const DEVELOPER_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "remote-repo",
         name: "Remote Repo Config",
-        order: 4,
+        order: 3,
         path: AppConstants.PATHS.get("REMOTE_REPO_CONFIG"),
         protected: true,
         showOnSidePanel: true
@@ -176,7 +176,7 @@ const DEVELOPER_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "oidcScopes",
         name: "OIDC Scopes",
-        order: 5,
+        order: 4,
         path: AppConstants.PATHS.get("OIDC_SCOPES"),
         protected: true,
         showOnSidePanel: true
@@ -231,7 +231,7 @@ const ADMIN_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "users",
         name: "adminPortal:components.sidePanel.users",
-        order: 2,
+        order: 1,
         path: AppConstants.PATHS.get("USERS"),
         protected: true,
         showOnSidePanel: true
@@ -287,7 +287,7 @@ const ADMIN_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "roles",
         name: "adminPortal:components.sidePanel.roles",
-        order: 2,
+        order: 3,
         path: AppConstants.PATHS.get("ROLES"),
         protected: true,
         showOnSidePanel: true
@@ -339,7 +339,7 @@ const ADMIN_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "attributeDialects",
         name: "adminPortal:components.sidePanel.attributeDialects",
-        order: 5,
+        order: 6,
         path: AppConstants.PATHS.get("CLAIM_DIALECTS"),
         protected: true,
         showOnSidePanel: true
@@ -376,7 +376,7 @@ const ADMIN_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "userStores",
         name: "adminPortal:components.sidePanel.userstores",
-        order: 3,
+        order: 4,
         path: AppConstants.PATHS.get("USERSTORES"),
         protected: true,
         showOnSidePanel: true
@@ -389,7 +389,7 @@ const ADMIN_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "certificates",
         name: "adminPortal:components.sidePanel.certificates",
-        order: 4,
+        order: 5,
         path: AppConstants.PATHS.get("CERTIFICATES"),
         protected: true,
         showOnSidePanel: true
@@ -441,7 +441,7 @@ const ADMIN_VIEW_ROUTES: RouteInterface[] = [
         },
         id: "emailTemplates",
         name: "adminPortal:components.sidePanel.emailTemplates",
-        order: 6,
+        order: 7,
         path: AppConstants.PATHS.get("EMAIL_TEMPLATES"),
         protected: true,
         showOnSidePanel: true
@@ -452,7 +452,7 @@ const ADMIN_VIEW_ROUTES: RouteInterface[] = [
         icon: null,
         id: "governanceConnectors",
         name: "adminPortal:components.sidePanel.governanceConnectors",
-        order: 6,
+        order: 8,
         path: AppConstants.PATHS.get("GOVERNANCE_CONNECTORS"),
         protected: true,
         showOnSidePanel: false

--- a/apps/console/src/features/core/configs/routes.ts
+++ b/apps/console/src/features/core/configs/routes.ts
@@ -49,18 +49,6 @@ const extensions = EXTENSION_ROUTES();
  */
 const DEVELOPER_VIEW_ROUTES: RouteInterface[] = [
     {
-        component: lazy(() => import("../../developer-overview/pages/overview")),
-        icon: {
-            icon: SidePanelIcons.overview
-        },
-        id: "overview",
-        name: "devPortal:components.sidePanel.overview",
-        order: 1,
-        path: AppConstants.PATHS.get("DEVELOPER_OVERVIEW"),
-        protected: true,
-        showOnSidePanel: true
-    },
-    {
         children: [
             {
                 component: lazy(() => import("../../applications/pages/application-template")),
@@ -220,19 +208,6 @@ const DEVELOPER_VIEW_ROUTES: RouteInterface[] = [
  * Admin View Layout Routes array.
  */
 const ADMIN_VIEW_ROUTES: RouteInterface[] = [
-    {
-        category: "adminPortal:components.sidePanel.categories.general",
-        component: lazy(() => import("../../admin-overview/pages/overview")),
-        icon: {
-            icon: SidePanelIcons.overview
-        },
-        id: "overview",
-        name: "adminPortal:components.sidePanel.overview",
-        order: 1,
-        path: AppConstants.PATHS.get("ADMIN_OVERVIEW"),
-        protected: true,
-        showOnSidePanel: true
-    },
     {
         category: "adminPortal:components.sidePanel.categories.users",
         children: [

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -8,12 +8,12 @@
     "adminApp": {
         "basePath": "/manage",
         "displayName": "Manage",
-        "path": "/manage/overview"
+        "path": "/manage/users"
     },
     "developerApp": {
         "basePath": "/develop",
         "displayName": "Develop",
-        "path": "/develop/overview"
+        "path": "/develop/applications"
     },
     "documentation": {
         "baseURL": "https://api.github.com",
@@ -32,7 +32,7 @@
     "productVersion": "",
     "serverOrigin": "https://localhost:9443",
     "routePaths": {
-        "home": "/develop/overview",
+        "home": "/develop/applications",
         "login": "/login",
         "logout": "/logout"
     },

--- a/apps/console/src/views/admin.tsx
+++ b/apps/console/src/views/admin.tsx
@@ -144,7 +144,7 @@ export const AdminView: FunctionComponent<AdminViewPropsInterface> = (
 
                 const filteredRoutesClone = [ ...filteredRoutes ];
 
-                governanceConnectorCategories.map(category => {
+                governanceConnectorCategories.map((category: GovernanceConnectorCategoryInterface) => {
                     let subCategoryExists = false;
                     category.connectors?.map(connector => {
                         if (connector.subCategory !== "DEFAULT") {
@@ -165,7 +165,6 @@ export const AdminView: FunctionComponent<AdminViewPropsInterface> = (
                         },
                         id: category.id,
                         name: category.name,
-                        order: 6,
                         path: AppConstants.PATHS.get("GOVERNANCE_CONNECTORS").replace(":id", category.id),
                         protected: true,
                         showOnSidePanel: true


### PR DESCRIPTION
## Purpose
Currently, the overview pages in console application just contain quick-jumps and counts. These pages do not serve a grater purpose hence it would be better to temporally remove them until there are proper analytics APIs available for better use of overview pages. 

## Goals
This PR will introduce changes that will prevent overview pages from registering in routes.

## Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/3071
