### PR TITLE
Fix i18n resources GET responding with 404

### DIFF
--- a/apps/console/src/features/core/constants/i18n-constants.ts
+++ b/apps/console/src/features/core/constants/i18n-constants.ts
@@ -91,6 +91,7 @@ export class I18nConstants {
                 store.getState().config.i18n
             )
         },
+        load: "currentOnly", // lookup only current lang key(en-US). Prevents 404 from `en`.
         ns: [ I18nConstants.COMMON_NAMESPACE, I18nConstants.ADMIN_PORTAL_NAMESPACE, I18nConstants.DEV_PORTAL_NAMESPACE ]
     };
 

--- a/apps/console/src/index.tsx
+++ b/apps/console/src/index.tsx
@@ -52,8 +52,10 @@ I18n.init({
         // `https://localhost:9443/<PORTAL>/resources/i18n/meta.json` rather than looking for the file in
         // `https://localhost:9443/t/wso2.com/<PORTAL>/resources/i18n/meta.json`.
         const metaPath = `/${
-            StringUtils.removeSlashesFromPath(Config.getDeploymentConfig().appBaseNameWithoutTenant)
-        }/${ StringUtils.removeSlashesFromPath(Config.getI18nConfig().resourcePath) }/meta.json`;
+            StringUtils.removeSlashesFromPath(Config.getDeploymentConfig().appBaseNameWithoutTenant) }/${
+            StringUtils.removeSlashesFromPath(Config.getI18nConfig().resourcePath) }/${
+            I18nModuleConstants.META_FILENAME
+            }`;
 
         // Fetch the meta file to get the supported languages.
         axios.get(metaPath)

--- a/apps/user-portal/src/constants/i18n-constants.ts
+++ b/apps/user-portal/src/constants/i18n-constants.ts
@@ -73,6 +73,7 @@ export class I18nConstants {
                 store.getState().config.i18n
             )
         },
+        load: "currentOnly", // lookup only current lang key(en-US). Prevents 404 from `en`.
         ns: [ I18nConstants.COMMON_NAMESPACE, I18nConstants.PORTAL_NAMESPACE ]
     };
 

--- a/apps/user-portal/src/index.tsx
+++ b/apps/user-portal/src/index.tsx
@@ -59,8 +59,10 @@ I18n.init({
         // `https://localhost:9443/user-portal/resources/i18n/meta.json` rather than looking for the file in
         // `https://localhost:9443/t/wso2.com/user-portal/resources/i18n/meta.json`.
         const metaPath = `/${
-            StringUtils.removeSlashesFromPath(Config.getDeploymentConfig().appBaseNameWithoutTenant)
-        }/${ StringUtils.removeSlashesFromPath(Config.getI18nConfig().resourcePath) }/meta.json`;
+            StringUtils.removeSlashesFromPath(Config.getDeploymentConfig().appBaseNameWithoutTenant) }/${
+            StringUtils.removeSlashesFromPath(Config.getI18nConfig().resourcePath) }/${
+            I18nModuleConstants.META_FILENAME
+            }`;
 
         // Fetch the meta file to get the supported languages.
         axios.get(metaPath)

--- a/modules/i18n/src/constants.ts
+++ b/modules/i18n/src/constants.ts
@@ -77,4 +77,12 @@ export class I18nModuleConstants {
      * @default
      */
     public static readonly DEFAULT_FALLBACK_LANGUAGE: string = "en-US";
+
+    /**
+     * Metadata file name.
+     * @constant
+     * @type {string}
+     * @default
+     */
+    public static readonly META_FILENAME: string = "meta.json";
 }


### PR DESCRIPTION
## Purpose
When requests for fetching i18n resources are sent in portals, 404 errors can be observed in the browser console and network tab.

## Goals
Fixes wso2/product-is#9244

## Approach
By default, React i18next tries to loads all the possible language codes which might result in 404 responses. To overcome this the following init param can be used.

```ts
/**
     * Language codes to lookup, given set language is
     * 'en-US': 'all' --> ['en-US', 'en', 'dev'],
     * 'currentOnly' --> 'en-US',
     * 'languageOnly' --> 'en'
     * @default 'all'
     */
    load?: 'all' | 'currentOnly' | 'languageOnly';
```
