### PR TITLE
AddResourceFile to support i18n for Email OTP and Sms OTP

### DIFF
--- a/apps/email-otp-authentication-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/apps/email-otp-authentication-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -1,0 +1,115 @@
+#
+# Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#If making new key entries, replace '=' with '_' for base64 encoded key values.
+
+Wso2.identity.server=WSO2 Identity Server
+All.rights.reserved=All Rights Reserved.
+Inc=Inc
+Wso2=wso2
+Identity.server=Identity Server
+Recover.password=Recover Password
+Enter.detail.to.recover.pwd=Enter below details to recover your password
+Username=Username
+Recover.with.mail=Recover with Mail
+Recover.with.question=Recover with Security Questions
+Submit=Submit
+Cancel=Cancel
+Recover.username=Recover Username
+Enter.detail.to.recover.uname=Enter below details to recover your username
+First.name=First Name
+Last.name=Last Name
+Email=Email
+Tenant.domain=Tenant Domain
+Create.account=Create New Account
+Enter.fields.to.cmplete.reg=Fill in the form below to complete registration
+Password=Password
+Confirm.password=Confirm password
+Register=Register
+Already.have.account=Already have an account?
+Sign.in=Sign in
+Information=Information
+Successfully.confirmed=Successfully confirmed
+Confirmation.sent.to.mail=Confirmation link has been sent to your email
+User.registration.completed.successfully=User registration completed successfully
+Close=Close
+Reset.Password=Reset Password
+Enter.new.password=Enter New Password
+Update.security.question=Update Security Questions
+Your.answer=Your Answer
+Update=Update
+Skip=Skip
+Password.recovery.information.sent.to.the.email.registered.with.account=Password recovery information has been sent to the email registered with the account
+Password.cannot.be.empty=Password cannot be empty.
+Updated.the.password.successfully=Updated the password successfully
+Server.failed.to.respond=Server failed to respond.
+No.valid.user.found=No valid user found
+No.recovery.supported.claims.found=No recovery supported claims found
+Unknown.password.recovery.option=Unknown Password Recovery Option
+Username.cannot.be.empty=Username cannot be empty.
+Account.confirmation.sent.to.your.email=Account confirmation has been sent to your email.
+Create.an.account=Create An Account
+Enter.required.fields.to.complete.registration=Enter required fields to complete registration of-
+Next=Next
+Already.have.an.account=Already have an account?
+Username.recovery.information.sent.to.your.email=Username recovery information has been sent to your email. Try again with different attributes if the email is not received.
+Registered.user.not.found.in.session=Registered user not found in session.
+No.security.questions.found.to.recover.password.contact.system.administrator=No Security Questions Found to recover password. Please contact your system Administrator
+Username.is.missing=Username is missing.
+Cannot.process.email.confirmation.code.is.missing=Cannot process the email notification confirmation. confirmation code is missing.
+Passwords.did.not.match.please.try.again=Passwords did not match. Please try again.
+Please.select.reCaptcha=Please select reCaptcha.
+Code=Code
+Message=Message
+Username.missing=Username is missing.
+Pick.username=Pick a username
+Something.went.wrong.while.registering.user=Something went wrong while registering user :
+Please.contact.administrator=. Please contact administrator
+Need.consent.for.following.purposes=We request the following information for the listed purposes.
+I.consent.to.use.them=By selecting preferred attributes, you allow us to use your information for the given purposes.
+Please.note.all.consents.are.mandatory=Please note that all consents are mandatory
+All.asterisked.consents.are.mandatory=All asterisked (*) consents are mandatory
+After.signin.we.use.a.cookie.in.browser=When you sign in, we use a cookie in your browser to track your session. You can read our
+Cookie.policy=Cookie Policy
+For.more.details=for more information.
+I.confirm.that.read.and.understood=I hereby confirm that I have read and understood the
+Privacy.policy=Privacy Policy
+Consent.selection=Consent Selection
+You.need.consent.all.claims=You need to provide consent for all the claims in order to proceed..!
+Need.to.select.all.mandatory.attributes=You need to select all mandatory attributes in order to proceed..!
+Ok=Ok
+Start.signing.up=Start Signing Up
+Enter.your.username.here=Enter your username here
+If.you.specify.tenant.domain.you.registered.under.super.tenant=If you do not specify a tenant domain, you will be registered under super tenant
+Proceed.to.self.register=Proceed to Self Register
+For.security.following.characters.restricted=For security measures following characters are restricted < > ` "
+Start.username.recovery=Start Username Recovery
+Start.password.recovery=Start Password Recovery
+Enter.tenant.here=Enter Your Tenant Domain
+Proceed.username.recovery=Proceed to Username Recovery
+Proceed.password.recovery=Proceed to Password Recovery
+If.you.do.not.specify.tenant.domain.consider.as.super.tenant=If you do not specify a tenant domain, you will be considered under super tenant.
+SW52YWxpZCBhbnN3ZXI_=Invalid answer
+Q291bnRyeQ__=Country
+TW9iaWxl=Mobile
+SU0_=IM
+T3JnYW5pemF0aW9u=Organization
+VVJM=URL
+VGVsZXBob25l=Telephone
+Um9sZQ__=Role
+business.homepage=http://wso2.com/
+name=Name

--- a/apps/sms-otp-authentication-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/apps/sms-otp-authentication-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -1,0 +1,115 @@
+#
+# Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#If making new key entries, replace '=' with '_' for base64 encoded key values.
+
+Wso2.identity.server=WSO2 Identity Server
+All.rights.reserved=All Rights Reserved.
+Inc=Inc
+Wso2=wso2
+Identity.server=Identity Server
+Recover.password=Recover Password
+Enter.detail.to.recover.pwd=Enter below details to recover your password
+Username=Username
+Recover.with.mail=Recover with Mail
+Recover.with.question=Recover with Security Questions
+Submit=Submit
+Cancel=Cancel
+Recover.username=Recover Username
+Enter.detail.to.recover.uname=Enter below details to recover your username
+First.name=First Name
+Last.name=Last Name
+Email=Email
+Tenant.domain=Tenant Domain
+Create.account=Create New Account
+Enter.fields.to.cmplete.reg=Fill in the form below to complete registration
+Password=Password
+Confirm.password=Confirm password
+Register=Register
+Already.have.account=Already have an account?
+Sign.in=Sign in
+Information=Information
+Successfully.confirmed=Successfully confirmed
+Confirmation.sent.to.mail=Confirmation link has been sent to your email
+User.registration.completed.successfully=User registration completed successfully
+Close=Close
+Reset.Password=Reset Password
+Enter.new.password=Enter New Password
+Update.security.question=Update Security Questions
+Your.answer=Your Answer
+Update=Update
+Skip=Skip
+Password.recovery.information.sent.to.the.email.registered.with.account=Password recovery information has been sent to the email registered with the account
+Password.cannot.be.empty=Password cannot be empty.
+Updated.the.password.successfully=Updated the password successfully
+Server.failed.to.respond=Server failed to respond.
+No.valid.user.found=No valid user found
+No.recovery.supported.claims.found=No recovery supported claims found
+Unknown.password.recovery.option=Unknown Password Recovery Option
+Username.cannot.be.empty=Username cannot be empty.
+Account.confirmation.sent.to.your.email=Account confirmation has been sent to your email.
+Create.an.account=Create An Account
+Enter.required.fields.to.complete.registration=Enter required fields to complete registration of-
+Next=Next
+Already.have.an.account=Already have an account?
+Username.recovery.information.sent.to.your.email=Username recovery information has been sent to your email. Try again with different attributes if the email is not received.
+Registered.user.not.found.in.session=Registered user not found in session.
+No.security.questions.found.to.recover.password.contact.system.administrator=No Security Questions Found to recover password. Please contact your system Administrator
+Username.is.missing=Username is missing.
+Cannot.process.email.confirmation.code.is.missing=Cannot process the email notification confirmation. confirmation code is missing.
+Passwords.did.not.match.please.try.again=Passwords did not match. Please try again.
+Please.select.reCaptcha=Please select reCaptcha.
+Code=Code
+Message=Message
+Username.missing=Username is missing.
+Pick.username=Pick a username
+Something.went.wrong.while.registering.user=Something went wrong while registering user :
+Please.contact.administrator=. Please contact administrator
+Need.consent.for.following.purposes=We request the following information for the listed purposes.
+I.consent.to.use.them=By selecting preferred attributes, you allow us to use your information for the given purposes.
+Please.note.all.consents.are.mandatory=Please note that all consents are mandatory
+All.asterisked.consents.are.mandatory=All asterisked (*) consents are mandatory
+After.signin.we.use.a.cookie.in.browser=When you sign in, we use a cookie in your browser to track your session. You can read our
+Cookie.policy=Cookie Policy
+For.more.details=for more information.
+I.confirm.that.read.and.understood=I hereby confirm that I have read and understood the
+Privacy.policy=Privacy Policy
+Consent.selection=Consent Selection
+You.need.consent.all.claims=You need to provide consent for all the claims in order to proceed..!
+Need.to.select.all.mandatory.attributes=You need to select all mandatory attributes in order to proceed..!
+Ok=Ok
+Start.signing.up=Start Signing Up
+Enter.your.username.here=Enter your username here
+If.you.specify.tenant.domain.you.registered.under.super.tenant=If you do not specify a tenant domain, you will be registered under super tenant
+Proceed.to.self.register=Proceed to Self Register
+For.security.following.characters.restricted=For security measures following characters are restricted < > ` "
+Start.username.recovery=Start Username Recovery
+Start.password.recovery=Start Password Recovery
+Enter.tenant.here=Enter Your Tenant Domain
+Proceed.username.recovery=Proceed to Username Recovery
+Proceed.password.recovery=Proceed to Password Recovery
+If.you.do.not.specify.tenant.domain.consider.as.super.tenant=If you do not specify a tenant domain, you will be considered under super tenant.
+SW52YWxpZCBhbnN3ZXI_=Invalid answer
+Q291bnRyeQ__=Country
+TW9iaWxl=Mobile
+SU0_=IM
+T3JnYW5pemF0aW9u=Organization
+VVJM=URL
+VGVsZXBob25l=Telephone
+Um9sZQ__=Role
+business.homepage=http://wso2.com/
+name=Name


### PR DESCRIPTION
## Purpose
Add resource Files to Email OTP and SMS OTP web application. Fix https://github.com/wso2/product-is/issues/9353

## Goals
> Described in the issue.

## Approach
> Described in the issue.

## User stories
> User want to add internationalization strings into email otp and sms otp.

## Release note
> Expected to be in 5.11

## Documentation
> https://is.docs.wso2.com/en/latest/develop/customizing-identity-server-uis/
- Doc PR need to be Done


## Automation tests

- Build the component without errors

- Test the functionality with 5.11.0-m32-SNAPSHOT

- **Test Integration test with 5.11.0-m32-SNAPSHOT**

```
	
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Identity Server Integration Tests 5.11.0-m32-SNAPSHOT:
[INFO] 
[INFO] Identity Server Integration Tests .................. SUCCESS [  5.266 s]
[INFO] WSO2 IS - Integration Test Admin Clients Module .... SUCCESS [  6.905 s]
[INFO] WSO2 IS - Integration UI Pages Module .............. SUCCESS [  1.494 s]
[INFO] WSO2 IS - Integration Test Utils Module ............ SUCCESS [  2.568 s]
[INFO] Custom Attribute Finder ............................ SUCCESS [  1.387 s]
[INFO] WSO2 Identity Integration Test Common .............. SUCCESS [  0.535 s]
[INFO] Identity Test Back-end Module ...................... SUCCESS [  01:55 h]
[INFO] org.wso2.identity.integration.test ................. SUCCESS [  2.240 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:55 h
[INFO] Finished at: 2020-09-03T21:17:49+05:30
[INFO] ------------------------------------------------------------------------

```


## Related PRs (Need to merge before this)
https://github.com/wso2/carbon-identity-framework/pull/3090