### PR TITLE
Fix wso2/product-is#9476: On-board portals as SaaS apps

### DIFF
--- a/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
+++ b/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
@@ -29,14 +29,13 @@ import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.registry.core.service.RegistryService;
-import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.ui.CarbonSSOSessionManager;
-import org.wso2.identity.apps.common.listner.AppPortalTenantMgtListener;
 import org.wso2.identity.apps.common.util.AppPortalConstants;
 import org.wso2.identity.apps.common.util.AppPortalUtils;
 
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_ID;
+import static org.wso2.identity.apps.common.util.AppPortalConstants.SYSTEM_PROP_SKIP_SERVER_INITIALIZATION;
 
 /***
  * OSGi service component which configure the service providers for portals.
@@ -55,8 +54,12 @@ public class AppsCommonServiceComponent {
 
         try {
             // Initialize portal applications.
-            AppPortalUtils.initiatePortals(SUPER_TENANT_DOMAIN_NAME, SUPER_TENANT_ID);
-            bundleContext.registerService(TenantMgtListener.class.getName(), new AppPortalTenantMgtListener(), null);
+            if (skipPortalInitialization()) {
+                log.debug("Portal application initialization is skipped.");
+            } else {
+                // Initialize portal applications.
+                AppPortalUtils.initiatePortals(SUPER_TENANT_DOMAIN_NAME, SUPER_TENANT_ID);
+            }
 
             for (AppPortalConstants.AppPortal appPortal : AppPortalConstants.AppPortal.values()) {
                 log.info(appPortal.getName() + " URL : " + IdentityUtil
@@ -160,5 +163,10 @@ public class AppsCommonServiceComponent {
 
     protected void unsetCarbonSSOSessionManager(CarbonSSOSessionManager carbonSSOSessionManager) {
 
+    }
+
+    private static boolean skipPortalInitialization() {
+
+        return System.getProperty(SYSTEM_PROP_SKIP_SERVER_INITIALIZATION) != null;
     }
 }

--- a/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalConstants.java
+++ b/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalConstants.java
@@ -33,6 +33,8 @@ public class AppPortalConstants {
 
     public static final String GRANT_TYPE_ACCOUNT_SWITCH = "account_switch";
 
+    public static final String SYSTEM_PROP_SKIP_SERVER_INITIALIZATION = "skipServerInitialization";
+
     private AppPortalConstants() {
 
     }

--- a/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -109,7 +109,7 @@ public class AppPortalUtils {
     }
 
     /**
-     * Create portal application.
+     * Create portal SaaS application.
      *
      * @param appName        Application name.
      * @param appOwner       Application owner.
@@ -124,6 +124,7 @@ public class AppPortalUtils {
         ServiceProvider serviceProvider = new ServiceProvider();
         serviceProvider.setApplicationName(appName);
         serviceProvider.setDescription(appDescription);
+        serviceProvider.setSaasApp(true);
 
         InboundAuthenticationRequestConfig inboundAuthenticationRequestConfig
                 = new InboundAuthenticationRequestConfig();


### PR DESCRIPTION
## Purpose
Fixes wso2/product-is#9476

This PR will do the following

1. On-board portals as SaaS SPs to super tenant during 1st startup
2. Removes engaging `TenantMgtListener` which on-boarded portals on tenant creation
3. Provide the capability to prevent on-boarding portal SPs through `-DskipServerInitialization` startup parameter