### PR TITLE
Show password options only in the add user wizard  if the email verification option is enabled

### DIFF
--- a/apps/console/src/features/server-configurations/constants/server-configurations-constants.ts
+++ b/apps/console/src/features/server-configurations/constants/server-configurations-constants.ts
@@ -109,6 +109,16 @@ export class ServerConfigurationsConstants {
 	 */
 	public static readonly PASSWORD_POLICY_CONNECTOR_ID: string = "cGFzc3dvcmRQb2xpY3k";
 
+    /**
+     * UUID of the user on boarding connector.
+     */
+    public static readonly USER_ONBOARDING_CONNECTOR_ID: string = "dXNlci1lbWFpbC12ZXJpZmljYXRpb24";
+
+    /**
+     * User onboarding API Keyword constants.
+     */
+    public static readonly EMAIL_VERIFICATION_ENABLED: string = "EmailVerification.Enable";
+
 	/**
 	 * Self registration API Keyword constants.
 	 */

--- a/apps/console/src/features/users/components/add-user.tsx
+++ b/apps/console/src/features/users/components/add-user.tsx
@@ -41,6 +41,7 @@ import { BasicUserDetailsInterface } from "../models";
 interface AddUserProps {
     initialValues: any;
     triggerSubmit: boolean;
+    emailVerificationEnabled: boolean;
     onSubmit: (values: any) => void;
 }
 
@@ -54,6 +55,7 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
     const {
         initialValues,
         triggerSubmit,
+        emailVerificationEnabled,
         onSubmit
     } = props;
 
@@ -515,20 +517,22 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
                         />
                     </Grid.Column>
                 </Grid.Row>
-                <Grid.Row columns={ 1 }>
-                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                        <Field
-                            data-testid="user-mgt-add-user-form-passwordOption-radio-button"
-                            type="radio"
-                            label={ t("adminPortal:components.user.forms.addUserForm.buttons.radioButton.label") }
-                            name="passwordOption"
-                            default="createPw"
-                            listen={ (values) => { setPasswordOption(values.get("passwordOption").toString()); } }
-                            children={ passwordOptions }
-                            value={ initialValues && initialValues.passwordOption }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
+                { emailVerificationEnabled &&
+                    <Grid.Row columns={ 1 }>
+                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                            <Field
+                                data-testid="user-mgt-add-user-form-passwordOption-radio-button"
+                                type="radio"
+                                label={ t("adminPortal:components.user.forms.addUserForm.buttons.radioButton.label") }
+                                name="passwordOption"
+                                default="createPw"
+                                listen={ (values) => { setPasswordOption(values.get("passwordOption").toString()); } }
+                                children={ passwordOptions }
+                                value={ initialValues && initialValues.passwordOption }
+                            />
+                        </Grid.Column>
+                    </Grid.Row>
+                }
                 { handlePasswordOptions() }
             </Grid>
         </Forms>

--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -46,6 +46,7 @@ interface AddUserWizardPropsInterface extends TestableComponentInterface {
     listItemLimit: number;
     updateList: () => void;
     rolesList: any;
+    emailVerificationEnabled: boolean;
 }
 
 /**
@@ -79,6 +80,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
     const {
         closeWizard,
         currentStep,
+        emailVerificationEnabled,
         [ "data-testid" ]: testId
     } = props;
 
@@ -381,7 +383,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                         givenName: userInfo.firstName
                     },
                     password,
-                    profileUrl: userInfo.profileUrl, 
+                    profileUrl: userInfo.profileUrl,
                     userName
                 }
             )
@@ -528,6 +530,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                 <AddUser
                     triggerSubmit={ submitGeneralSettings }
                     initialValues={ wizardState && wizardState[ WizardStepsFormTypes.BASIC_DETAILS ] }
+                    emailVerificationEnabled={ emailVerificationEnabled }
                     onSubmit={ (values) => handleWizardFormSubmit(values, WizardStepsFormTypes.BASIC_DETAILS) }
                 />
             ),
@@ -684,5 +687,6 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
  * Default props for the add user wizard.
  */
 AddUserWizard.defaultProps = {
-    currentStep: 0
+    currentStep: 0,
+    emailVerificationEnabled: false
 };

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -34,38 +34,15 @@ import {
     UIConstants,
     store
 } from "../../core";
-import { GovernanceConnectorInterface, getConnectorCategory } from "../../server-configurations";
+import {
+    GovernanceConnectorInterface,
+    ServerConfigurationsConstants,
+    getConnectorCategory
+} from "../../server-configurations";
 import { deleteUser, getUsersList } from "../api";
 import { AddUserWizard, UsersList, UsersListOptionsComponent } from "../components";
 import { UserManagementConstants } from "../constants";
 import { UserListInterface } from "../models";
-
-/**
- * Th id of the account manage,ent policy connector category.
- *
- * @constant
- * @type {string}
- * @default
- */
-const ACCOUNT_MANAGEMENT_POLICY_CONNECTOR_ID = "QWNjb3VudCBNYW5hZ2VtZW50IFBvbGljaWVz";
-
-/**
- * The id of the user on boarding connector.
- *
- * @constant
- * @type {string}
- * @default
- */
-const USER_ONBOARDING_CONNECTOR_ID = "dXNlci1lbWFpbC12ZXJpZmljYXRpb24";
-
-/**
- * The name of the email verification enabled key.
- *
- * @constant
- * @type {string}
- * @default
- */
-const EMAIL_VERIFICATION_ENABLED = "EmailVerification.Enable";
 
 /**
  * Users info page.
@@ -358,15 +335,16 @@ const UsersPage: FunctionComponent<any> = (): ReactElement => {
      * Handles the click event of the create new user button.
      */
     const handleAddNewUserWizardClick = (): void => {
-        getConnectorCategory(ACCOUNT_MANAGEMENT_POLICY_CONNECTOR_ID)
+        getConnectorCategory(ServerConfigurationsConstants.IDENTITY_GOVERNANCE_ACCOUNT_MANAGEMENT_POLICIES_ID)
             .then((response) => {
                 const connectors: GovernanceConnectorInterface[]  = response?.connectors;
                 const userOnboardingConnector = connectors.find(
-                    (connector: GovernanceConnectorInterface) => connector.id === USER_ONBOARDING_CONNECTOR_ID
+                    (connector: GovernanceConnectorInterface) => connector.id
+                        === ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID
                 );
 
                 const emailVerification = userOnboardingConnector.properties.find(
-                    property => property.name === EMAIL_VERIFICATION_ENABLED);
+                    property => property.name === ServerConfigurationsConstants.EMAIL_VERIFICATION_ENABLED);
 
                 setEmailVerificationEnabled(emailVerification.value === "true");
             }).catch((error) => {


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/9512
When the email verification option is enabled in the user onboarding settings:
![image](https://user-images.githubusercontent.com/20745428/93875967-a264f800-fcf3-11ea-9632-8b9d3c3a9027.png)

When the email verification is disabled:
![image](https://user-images.githubusercontent.com/20745428/93876001-b3ae0480-fcf3-11ea-9513-b517ce7f5ac3.png)
