### PR TITLE
Resolve errors caused when moving files from the includes directory to the extensions directory in authentication portals

### DIFF
--- a/apps/authentication-portal/src/main/webapp/add-security-questions.jsp
+++ b/apps/authentication-portal/src/main/webapp/add-security-questions.jsp
@@ -81,7 +81,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -95,7 +95,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -147,7 +147,7 @@
                         <div class="align-right buttons">
                             <input type="submit" class="ui primary large button"
                                 value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "continue")%>">
-        
+
                             <input type="hidden" name="<%="sessionDataKey"%>"
                                 value="<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>"/>
                         </div>
@@ -164,7 +164,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -174,12 +174,12 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script>
         $('select.dropdown').dropdown();
     </script>
-    
+
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/authenticate.jsp
+++ b/apps/authentication-portal/src/main/webapp/authenticate.jsp
@@ -36,7 +36,7 @@
 <%@ page import="java.io.File" %>
 
 <%@include file="includes/localize.jsp" %>
-<jsp:include page="includes/init-url.jsp"/>
+<jsp:directive.include file="includes/init-url.jsp"/>
 
 <%
     String sessionDataKey = request.getParameter(SESSION_DATA_KEY);

--- a/apps/authentication-portal/src/main/webapp/authenticate.jsp
+++ b/apps/authentication-portal/src/main/webapp/authenticate.jsp
@@ -36,7 +36,7 @@
 <%@ page import="java.io.File" %>
 
 <%@include file="includes/localize.jsp" %>
-<jsp:directive.include file="includes/init-url.jsp"/>
+<jsp:include page="includes/init-url.jsp"/>
 
 <%
     String sessionDataKey = request.getParameter(SESSION_DATA_KEY);
@@ -112,7 +112,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -126,7 +126,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -149,7 +149,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -159,7 +159,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type='text/javascript'>

--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -38,8 +38,7 @@
 <%@ page import="org.wso2.carbon.identity.core.URLBuilderException" %>
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
 
-<jsp:include page="includes/init-loginform-action-url.jsp"/>
-
+<jsp:directive.include file="includes/init-loginform-action-url.jsp"/>
 <script>
     function goBack() {
         window.history.back();

--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -38,13 +38,13 @@
 <%@ page import="org.wso2.carbon.identity.core.URLBuilderException" %>
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
 
-<jsp:directive.include file="includes/init-loginform-action-url.jsp"/>
+<jsp:include page="includes/init-loginform-action-url.jsp"/>
 
 <script>
     function goBack() {
         window.history.back();
     }
-    
+
     // Handle form submission preventing double submission.
     $(document).ready(function(){
         $.fn.preventDoubleSubmission = function() {
@@ -56,7 +56,7 @@
                     console.warn("Prevented a possible double submit event");
                 } else {
                     e.preventDefault();
-                    
+
                     var userName = document.getElementById("username");
                     var usernameUserInput = document.getElementById("usernameUserInput");
 
@@ -269,9 +269,9 @@
                     return;
                 }
             }
-        } 
+        }
     %>
-    
+
     <div class="buttons">
         <% if (isRecoveryEPAvailable) { %>
         <div class="field">
@@ -358,7 +358,7 @@
         </div>
         <div class="column mobile center aligned tablet right aligned computer right aligned buttons tablet no-margin-right-last-child computer no-margin-right-last-child">
             <button
-                type="submit"   
+                type="submit"
                 class="ui primary large button"
                 tabindex="4"
                 role="button"
@@ -368,7 +368,7 @@
             </button>
         </div>
     </div>
-    
+
     <% if (Boolean.parseBoolean(loginFailed) && errorCode.equals(IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE) && request.getParameter("resend_username") == null) { %>
     <div class="ui divider hidden"></div>
     <div class="field">

--- a/apps/authentication-portal/src/main/webapp/consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/consent.jsp
@@ -47,7 +47,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -61,7 +61,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
 
@@ -73,7 +73,7 @@
                     </h4>
 
                     <div class="ui divider hidden"></div>
-                    
+
                     <div class="segment-form">
                         <div class="ui secondary segment">
                             <h5><%=AuthenticationEndpointUtil.i18n(resourceBundle, "requested.attributes")%> :</h5>
@@ -178,7 +178,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -188,7 +188,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <div class="ui modal mini" id="modal_claim_validation" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel">
@@ -211,7 +211,7 @@
         function approved() {
             var mandatoryClaimCBs = $(".mandatory-claim");
             var checkedMandatoryClaimCBs = $(".mandatory-claim:checked");
-    
+
             if (checkedMandatoryClaimCBs.length == mandatoryClaimCBs.length) {
                 document.getElementById('consent').value = "approve";
                 document.getElementById("profile").submit();

--- a/apps/authentication-portal/src/main/webapp/cookie_policy.jsp
+++ b/apps/authentication-portal/src/main/webapp/cookie_policy.jsp
@@ -18,7 +18,7 @@
 
 <%@ page import="java.io.File" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-    
+
 <%@ include file="includes/localize.jsp" %>
 
 <!doctype html>
@@ -31,7 +31,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -46,7 +46,7 @@
                     %>
                         <jsp:include page="extensions/product-title.jsp"/>
                     <% } else { %>
-                        <jsp:directive.include file="includes/product-title.jsp"/>
+                        <jsp:include page="includes/product-title.jsp"/>
                     <% } %>
                 </div>
             </div>
@@ -61,7 +61,7 @@
                 %>
                     <jsp:include page="extensions/cookie-policy-content.jsp"/>
                 <% } else { %>
-                    <jsp:directive.include file="includes/cookie-policy-content.jsp"/>
+                    <jsp:include page="includes/cookie-policy-content.jsp"/>
                 <% } %>
             </div>
         </div>
@@ -74,7 +74,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -84,7 +84,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript" src="js/u2f-api.js"></script>

--- a/apps/authentication-portal/src/main/webapp/device-success.jsp
+++ b/apps/authentication-portal/src/main/webapp/device-success.jsp
@@ -31,13 +31,13 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout" onload="loadFunc()">
     <main class="center-segment">
         <div class="ui container medium center aligned middle">
-            
+
             <!-- product-title -->
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
@@ -45,7 +45,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment left aligned">
@@ -84,9 +84,9 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
-    
+
     <!-- footer -->
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
@@ -94,15 +94,15 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">
-    
+
         var userCode;
-    
+
         function loadFunc() {
-    
+
             const urlParams = new URLSearchParams(window.location.search);
             userCode = urlParams.get('user_code');
             document.getElementById("user_code").value = userCode;

--- a/apps/authentication-portal/src/main/webapp/domain.jsp
+++ b/apps/authentication-portal/src/main/webapp/domain.jsp
@@ -49,7 +49,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -63,7 +63,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -100,7 +100,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -110,7 +110,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">

--- a/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
+++ b/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
@@ -28,7 +28,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@include file="includes/localize.jsp" %>
-<jsp:include page="includes/init-url.jsp"/>
+<jsp:directive.include file="includes/init-url.jsp"/>
 <jsp:include page="includes/template-mapper.jsp"/>
 
 <%@ taglib prefix="e" uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" %>

--- a/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
+++ b/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
@@ -28,8 +28,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@include file="includes/localize.jsp" %>
-<jsp:directive.include file="includes/init-url.jsp"/>
-<jsp:directive.include file="includes/template-mapper.jsp"/>
+<jsp:include page="includes/init-url.jsp"/>
+<jsp:include page="includes/template-mapper.jsp"/>
 
 <%@ taglib prefix="e" uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -37,7 +37,7 @@
 <%
     String templateId = request.getParameter("templateId");
     String promptId = request.getParameter("promptId");
-    
+
     String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
     if (StringUtils.isBlank(authAPIURL)) {
         authAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
@@ -64,7 +64,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <script type="text/javascript">
@@ -83,7 +83,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -117,7 +117,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -127,7 +127,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">

--- a/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
+++ b/apps/authentication-portal/src/main/webapp/dynamic_prompt.jsp
@@ -29,7 +29,7 @@
 
 <%@include file="includes/localize.jsp" %>
 <jsp:directive.include file="includes/init-url.jsp"/>
-<jsp:include page="includes/template-mapper.jsp"/>
+<jsp:directive file="includes/template-mapper.jsp"/>
 
 <%@ taglib prefix="e" uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>

--- a/apps/authentication-portal/src/main/webapp/enter-user-code.jsp
+++ b/apps/authentication-portal/src/main/webapp/enter-user-code.jsp
@@ -31,13 +31,13 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout" onload="loadFunc()">
     <main class="center-segment">
         <div class="ui container medium center aligned middle">
-    
+
             <!-- product-title -->
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
@@ -45,14 +45,14 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
-        
+
             <div class="ui segment">
                 <h3 class="ui header">
                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "device.flow.sign.in")%>
                 </h3>
-                
+
                 <div class="segment-form">
                     <form class="ui large form" action="../oauth2/device" method="post" id="loginForm">
                         <div class="field">
@@ -82,7 +82,7 @@
             </div>
         </div>
     </main>
-    
+
     <!-- product-footer -->
     <%
         File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
@@ -90,9 +90,9 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
-    
+
     <!-- footer -->
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
@@ -100,15 +100,15 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
-    
+
     <script type="text/javascript">
         var userCode;
-    
+
         function loadFunc() {
             const urlParams = new URLSearchParams(window.location.search);
-            
+
             userCode = urlParams.get('user_code');
             document.getElementById("user_code").value = userCode;
         }

--- a/apps/authentication-portal/src/main/webapp/fido-auth.jsp
+++ b/apps/authentication-portal/src/main/webapp/fido-auth.jsp
@@ -37,13 +37,13 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout" onload="talkToDevice();">
     <main class="center-segment">
         <div class="ui container medium center aligned middle">
-            
+
             <!-- product-title -->
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
@@ -51,7 +51,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment left aligned">
@@ -60,9 +60,9 @@
                 </h3>
 
                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "touch.your.u2f.device")%>
-                
+
                 <div class="ui divider hidden"></div>
-                
+
                 <div> <img class="img-responsive" src="images/U2F.png"> </div>
 
                 <form method="POST" action="<%=commonauthURL%>" id="form" onsubmit="return false;">
@@ -80,9 +80,9 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
-    
+
     <!-- footer -->
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
@@ -90,9 +90,9 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
-    
+
     <script type="text/javascript" src="js/u2f-api.js"></script>
     <script type="text/javascript">
 

--- a/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
+++ b/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
@@ -37,13 +37,13 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout" onload="talkToDevice();">
     <main class="center-segment">
         <div class="ui container medium center aligned middle">
-            
+
             <!-- product-title -->
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
@@ -51,7 +51,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment center aligned">
@@ -60,9 +60,9 @@
                 </h3>
 
                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "touch.your.u2f.device")%>
-                
+
                 <div class="ui divider hidden"></div>
-                
+
                 <div> <img class="img-responsive" src="images/U2F.png"> </div>
 
                 <form method="POST" action="<%=commonauthURL%>" id="form" onsubmit="return false;">
@@ -80,9 +80,9 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
-    
+
     <!-- footer -->
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
@@ -90,9 +90,9 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
-    
+
     <script type="text/javascript" src="js/u2f-api.js"></script>
     <script type="text/javascript" src="libs/base64js/base64js-1.3.0.min.js"></script>
     <script type="text/javascript" src="libs/base64url.js"></script>

--- a/apps/authentication-portal/src/main/webapp/fido2-uaf.jsp
+++ b/apps/authentication-portal/src/main/webapp/fido2-uaf.jsp
@@ -33,13 +33,13 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <main class="center-segment">
         <div class="ui container medium center aligned middle">
-            
+
             <!-- product-title -->
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
@@ -47,7 +47,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment left aligned">
@@ -92,9 +92,9 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
-    
+
     <!-- footer -->
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
@@ -102,9 +102,9 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
-    
+
     <script type="text/javascript" src="js/u2f-api.js"></script>
     <script type="text/javascript" src="libs/base64js/base64js-1.3.0.min.js"></script>
     <script type="text/javascript" src="libs/base64url.js"></script>
@@ -130,7 +130,7 @@
                 $.ajax({
                     type: "GET",
                     url: "/api/users/v1/me/webauthn/start-authentication?username=admin&" +
-                        "tenantDomain=carbon.super&storeDomain=PRIMARY&appId=https://localhost:9443&" + 
+                        "tenantDomain=carbon.super&storeDomain=PRIMARY&appId=https://localhost:9443&" +
                         "sessionDataKey="+getParameterByName("sessionDataKey"),
                     success: function (data) {
                         if (data) {
@@ -171,7 +171,7 @@
                             authenticatorData: base64url.fromByteArray(response.response.authenticatorData),
                             clientDataJSON: base64url.fromByteArray(response.response.clientDataJSON),
                             signature: base64url.fromByteArray(response.response.signature),
-                            userHandle: response.response.userHandle && 
+                            userHandle: response.response.userHandle &&
                                 base64url.fromByteArray(response.response.userHandle)
                         },
                         clientExtensionResults,

--- a/apps/authentication-portal/src/main/webapp/generic-exception-response.jsp
+++ b/apps/authentication-portal/src/main/webapp/generic-exception-response.jsp
@@ -49,7 +49,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -63,7 +63,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -84,7 +84,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -94,7 +94,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/handle-multiple-sessions.jsp
+++ b/apps/authentication-portal/src/main/webapp/handle-multiple-sessions.jsp
@@ -25,7 +25,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@include file="includes/localize.jsp" %>
-<jsp:include page="includes/init-url.jsp"/>
+<jsp:directive.include file="includes/init-url.jsp"/>
 <jsp:include page="includes/template-mapper.jsp"/>
 
 <%@ taglib prefix="e" uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" %>

--- a/apps/authentication-portal/src/main/webapp/handle-multiple-sessions.jsp
+++ b/apps/authentication-portal/src/main/webapp/handle-multiple-sessions.jsp
@@ -26,7 +26,7 @@
 
 <%@include file="includes/localize.jsp" %>
 <jsp:directive.include file="includes/init-url.jsp"/>
-<jsp:include page="includes/template-mapper.jsp"/>
+<jsp:directive.include file="includes/template-mapper.jsp"/>
 
 <%@ taglib prefix="e" uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>

--- a/apps/authentication-portal/src/main/webapp/handle-multiple-sessions.jsp
+++ b/apps/authentication-portal/src/main/webapp/handle-multiple-sessions.jsp
@@ -25,8 +25,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@include file="includes/localize.jsp" %>
-<jsp:directive.include file="includes/init-url.jsp"/>
-<jsp:directive.include file="includes/template-mapper.jsp"/>
+<jsp:include page="includes/init-url.jsp"/>
+<jsp:include page="includes/template-mapper.jsp"/>
 
 <%@ taglib prefix="e" uri="https://www.owasp.org/index.php/OWASP_Java_Encoder_Project" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
@@ -36,7 +36,7 @@
 <%
     String promptId = request.getParameter("promptId");
     String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
-    
+
     if (StringUtils.isBlank(authAPIURL)) {
         authAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
     }
@@ -45,7 +45,7 @@
     }
     authAPIURL += "context/" + request.getParameter("promptId");
     String contextProperties = AuthContextAPIClient.getContextProperties(authAPIURL);
-    
+
     Gson gson = new Gson();
     Map data = gson.fromJson(contextProperties, Map.class);
 %>
@@ -60,7 +60,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -74,7 +74,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -82,11 +82,11 @@
                     <c:set var="data" value="<%=data%>" scope="request"/>
                     <c:set var="promptId" value="<%=URLEncoder.encode(promptId, StandardCharsets.UTF_8.name())%>"
                             scope="request"/>
-              
+
                     <h3 class="ui header">
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "multiple.active.sessions.found")%>
                     </h3>
-                
+
                     <form class="segment-form" name="sessionsForm" action="<%=commonauthURL%>" method="POST"
                             onsubmit="return validateForm(this.submitted)">
 
@@ -128,21 +128,21 @@
                             <br>
                             <%=AuthenticationEndpointUtil.i18n(resourceBundle, "terminate.unwanted.sessions.message.2")%>.
                         </h4>
-                        
+
                         <input type="hidden" name="promptResp" value="true">
                         <input type="hidden" name="promptId" value="<e:forHtmlAttribute value="${requestScope.promptId}"/>">
-                        
+
                         <div class="align-right buttons">
                             <input name="terminateActiveSessionsAction" type="submit"
                                     onclick="this.form.submitted='terminateActiveSessionsAction';"
                                     class="ui large button"
                                     value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "terminate.selected.active.sessions.and.proceed")%>">
-                    
+
                             <input name="denyLimitActiveSessionsAction" type="submit"
                                     onclick="this.form.submitted='denyLimitActiveSessionsAction';"
                                     class="ui large button"
                                     value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "deny.login")%>">
-                    
+
                             <input name="refreshActiveSessionsAction" type="submit"
                                     onclick="this.form.submitted='refreshActiveSessionsAction';"
                                     class="ui large primary button"
@@ -150,7 +150,7 @@
 
                             <input id="ActiveSessionsLimitAction" type="hidden" name="ActiveSessionsLimitAction"/>
                         </div>
-                    </form>             
+                    </form>
                 </div>
             </div>
         </div>
@@ -179,7 +179,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -189,7 +189,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script>

--- a/apps/authentication-portal/src/main/webapp/identifier-logout-confirm.jsp
+++ b/apps/authentication-portal/src/main/webapp/identifier-logout-confirm.jsp
@@ -32,7 +32,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -46,7 +46,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -86,7 +86,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -96,7 +96,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">
@@ -105,12 +105,12 @@
             document.getElementById('identifier_consent').value = "continue";
             document.getElementById("identifier_logout_confirm_form").submit();
         }
-    
+
         function resetFlow() {
             document.getElementById('identifier_consent').value = "reset";
             document.getElementById("identifier_logout_confirm_form").submit();
         }
-    
+
     </script>
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/identifierauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/identifierauth.jsp
@@ -32,8 +32,7 @@
 <%@ page import="org.wso2.carbon.identity.core.URLBuilderException" %>
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
 
-<jsp:include page="includes/init-loginform-action-url.jsp"/>
-
+<jsp:directive.include file="includes/init-loginform-action-url.jsp"/>
 <script>
     function submitIdentifier () {
         var userName = document.getElementById("username");

--- a/apps/authentication-portal/src/main/webapp/identifierauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/identifierauth.jsp
@@ -32,7 +32,7 @@
 <%@ page import="org.wso2.carbon.identity.core.URLBuilderException" %>
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
 
-<jsp:directive.include file="includes/init-loginform-action-url.jsp"/>
+<jsp:include page="includes/init-loginform-action-url.jsp"/>
 
 <script>
     function submitIdentifier () {
@@ -68,7 +68,7 @@
     <% } else { %>
         <div class="ui visible negative message" style="display: none;" id="error-msg"></div>
     <% } %>
-    
+
     <div class="field">
         <div class="ui fluid left icon input">
             <input
@@ -107,19 +107,19 @@
         String identityMgtEndpointContext = "";
         String urlEncodedURL = "";
         String urlParameters = "";
-        
+
         if (StringUtils.isNotBlank(recoveryEPAvailable)) {
             isRecoveryEPAvailable = Boolean.valueOf(recoveryEPAvailable);
         } else {
             isRecoveryEPAvailable = isRecoveryEPAvailable();
         }
-        
+
         if (StringUtils.isNotBlank(enableSelfSignUpEndpoint)) {
             isSelfSignUpEPAvailable = Boolean.valueOf(enableSelfSignUpEndpoint);
         } else {
             isSelfSignUpEPAvailable = isSelfSignUpEPAvailable();
         }
-  
+
         if (isRecoveryEPAvailable || isSelfSignUpEPAvailable) {
             String scheme = request.getScheme();
             String serverName = request.getServerName();

--- a/apps/authentication-portal/src/main/webapp/includes/cookie-policy-content.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/cookie-policy-content.jsp
@@ -16,6 +16,7 @@
   ~ under the License.
 --%>
 
+<%@ include file="localize.jsp" %>
 <!-- page content -->
 <div class="ui grid">
     <div class="two column row"></div>
@@ -62,16 +63,16 @@
                         <h3 id="security">Security</h3>
                         <ul>
                             <li>WSO2 IS uses selected cookies to identify and prevent security risks.
-                                For example, WSO2 IS may use these cookies to store your session information in order 
+                                For example, WSO2 IS may use these cookies to store your session information in order
                                 to prevent others from changing your password without your username and password.<br><br>
                             </li>
                             <li>WSO2 IS uses session cookies to maintain your active session.<br><br></li>
-                            <li>WSO2 IS may use temporary cookies when performing multi-factor authentication and 
+                            <li>WSO2 IS may use temporary cookies when performing multi-factor authentication and
                                 federated authentication.<br><br>
                             </li>
-                            <li>WSO2 IS may use permanent cookies to detect that you have previously used the same 
-                                device to log in. This is to to calculate the &ldquo;risk level&rdquo; associated 
-                                with your current login attempt. This is primarily to protect you and your account 
+                            <li>WSO2 IS may use permanent cookies to detect that you have previously used the same
+                                device to log in. This is to to calculate the &ldquo;risk level&rdquo; associated
+                                with your current login attempt. This is primarily to protect you and your account
                                 from possible attack.
                             </li>
                         </ul>

--- a/apps/authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/header.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
   --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<%@ include file="localize.jsp" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/authentication-portal/src/main/webapp/includes/privacy-policy-content.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/privacy-policy-content.jsp
@@ -16,6 +16,7 @@
   ~ under the License.
 --%>
 
+<%@ include file="localize.jsp" %>
 <!-- page content -->
 <div class="ui grid">
     <div class="two column row"></div>

--- a/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<%@ include file="localize.jsp" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 
 <!-- footer -->

--- a/apps/authentication-portal/src/main/webapp/includes/product-title.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/product-title.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<%@ include file="localize.jsp" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 
 <div class="product-title">

--- a/apps/authentication-portal/src/main/webapp/includes/title.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/title.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<%@ include file="localize.jsp" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 
 <!-- title -->

--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -34,7 +34,7 @@
 <%@ page import="java.util.Map" %>
 
 <%@ include file="includes/localize.jsp" %>
-<jsp:include page="includes/init-url.jsp"/>
+<jsp:directive.include file="includes/init-url.jsp"/>
 
 <%!
     private static final String FIDO_AUTHENTICATOR = "FIDOAuthenticator";

--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -34,7 +34,7 @@
 <%@ page import="java.util.Map" %>
 
 <%@ include file="includes/localize.jsp" %>
-<jsp:directive.include file="includes/init-url.jsp"/>
+<jsp:include page="includes/init-url.jsp"/>
 
 <%!
     private static final String FIDO_AUTHENTICATOR = "FIDOAuthenticator";
@@ -111,7 +111,7 @@
             response.sendRedirect(redirectURL);
         }
     }
-    
+
     // Login context request url.
     String sessionDataKey = request.getParameter("sessionDataKey");
     String relyingParty = request.getParameter("relyingParty");
@@ -134,7 +134,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <%
@@ -156,7 +156,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -167,7 +167,7 @@
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "login")%>
                     <% } %>
                 </h3>
-                
+
                 <div class="segment-form">
                     <%
                         if (localAuthenticatorNames.size() > 0) {
@@ -202,7 +202,7 @@
                     <%
                             }
                         }
-                
+
                                 if (includeBasicAuth) {
                                     %>
                                         <%@ include file="basicauth.jsp" %>
@@ -213,13 +213,13 @@
                     %>
                     <%if (idpAuthenticatorMapping != null &&
                             idpAuthenticatorMapping.get(Constants.RESIDENT_IDP_RESERVED_NAME) != null) { %>
-                
+
                     <%} %>
                     <%
                         if ((hasLocalLoginOptions && localAuthenticatorNames.size() > 1) || (!hasLocalLoginOptions)
                                 || (hasLocalLoginOptions && idpAuthenticatorMapping != null && idpAuthenticatorMapping.size() > 1)) {
                     %>
-                    <% if (localAuthenticatorNames.contains(BASIC_AUTHENTICATOR) || 
+                    <% if (localAuthenticatorNames.contains(BASIC_AUTHENTICATOR) ||
                             localAuthenticatorNames.contains(IDENTIFIER_EXECUTOR)) { %>
                     <div class="ui divider hidden"></div>
                     <div class="ui horizontal divider">
@@ -264,7 +264,7 @@
                                     </div>
                                 <% } else { %>
                                     <div class="field">
-                                        <button class="ui icon button fluid" 
+                                        <button class="ui icon button fluid"
                                             onclick="handleNoDomain(this,
                                                 '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpName))%>',
                                                 '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getValue()))%>')"
@@ -278,7 +278,7 @@
                                 if (localAuthenticatorNames.contains(IWA_AUTHENTICATOR)) {
                             %>
                             <div class="field">
-                                <button class="ui blue labeled icon button fluid" 
+                                <button class="ui blue labeled icon button fluid"
                                     onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
                                         'IWAAuthenticator')"
@@ -292,7 +292,7 @@
                                 if (localAuthenticatorNames.contains(X509_CERTIFICATE_AUTHENTICATOR)) {
                             %>
                             <div class="field">
-                                <button class="ui grey labeled icon button fluid" 
+                                <button class="ui grey labeled icon button fluid"
                                     onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
                                         'x509CertificateAuthenticator')"
@@ -307,7 +307,7 @@
                                 if (localAuthenticatorNames.contains(FIDO_AUTHENTICATOR)) {
                             %>
                             <div class="field">
-                                <button class="ui grey basic labeled icon button fluid" 
+                                <button class="ui grey basic labeled icon button fluid"
                                     onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
                                         'FIDOAuthenticator')"
@@ -322,7 +322,7 @@
                                 if (localAuthenticatorNames.contains("totp")) {
                             %>
                             <div class="field">
-                                <button class="ui brown labeled icon button fluid" 
+                                <button class="ui brown labeled icon button fluid"
                                     onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
                                         'totp')"
@@ -334,7 +334,7 @@
                             <%
                                         }
                                     }
-                    
+
                                 }
                             } %>
                             </div>
@@ -352,7 +352,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -362,7 +362,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script>
@@ -399,7 +399,7 @@
                 var h = $(document).height();
                 $('.overlay').css("width", w + "px").css("height", h + "px").show();
             });
-            
+
             $('.overlay').click(function () {
                 $(this).hide();
                 $('.main-link').next().hide();
@@ -424,7 +424,7 @@
                 }
             %>
         });
-    
+
         function myFunction(key, value, name) {
             var object = document.getElementById(name);
             var domain = object.value;
@@ -458,7 +458,7 @@
                     "<%=multiOptionURIParam%>";
             }
         }
-    
+
         window.onunload = function(){};
 
         function changeUsername (e) {

--- a/apps/authentication-portal/src/main/webapp/logout.jsp
+++ b/apps/authentication-portal/src/main/webapp/logout.jsp
@@ -31,7 +31,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -45,7 +45,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -61,7 +61,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -71,8 +71,8 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
-    
+
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/long-wait.jsp
+++ b/apps/authentication-portal/src/main/webapp/long-wait.jsp
@@ -22,7 +22,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 
 <%@include file="includes/localize.jsp" %>
-<jsp:include page="includes/init-url.jsp"/>
+<jsp:directive.include file="includes/init-url.jsp"/>
 
 <%
     String sessionDataKey = request.getParameter("sessionDataKey");

--- a/apps/authentication-portal/src/main/webapp/long-wait.jsp
+++ b/apps/authentication-portal/src/main/webapp/long-wait.jsp
@@ -22,7 +22,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 
 <%@include file="includes/localize.jsp" %>
-<jsp:directive.include file="includes/init-url.jsp"/>
+<jsp:include page="includes/init-url.jsp"/>
 
 <%
     String sessionDataKey = request.getParameter("sessionDataKey");
@@ -38,7 +38,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <link href="css/longwait-loader.css" rel="stylesheet">
@@ -54,7 +54,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div id="loader-wrapper">
@@ -73,7 +73,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -83,7 +83,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">
@@ -91,17 +91,17 @@
         var sessionDataKey = '<%=Encode.forJavaScriptBlock(sessionDataKey)%>';
         var refreshInterval = '<%=AdaptiveAuthUtil.getRefreshInterval()%>';
         var timeout = '<%=AdaptiveAuthUtil.getRequestTimeout()%>';
-    
+
         $(document).ready(function () {
             var intervalListener = window.setInterval(function () {
                 checkLongWaitStatus();
             }, refreshInterval);
-    
+
             var timeoutListenerListener = window.setTimeout(function () {
                 window.clearInterval(intervalListener);
                 window.location.replace("retry.do");
             }, timeout);
-    
+
             function checkLongWaitStatus() {
                 $.ajax("/longwaitstatus", {
                     async: false,
@@ -119,21 +119,21 @@
                     }
                 });
             }
-    
+
             function handleStatusResponse(res) {
                 if (res.status === 'COMPLETED') {
                     continueAuthentication();
                 }
             }
-    
+
             function continueAuthentication() {
                 //Redirect to common auth
                 window.clearInterval(intervalListener);
                 document.getElementById("toCommonAuth").submit();
             }
         });
-    
+
     </script>
-    
+
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/oauth2_authz.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_authz.jsp
@@ -51,7 +51,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -65,7 +65,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -73,15 +73,15 @@
                       name="oauth2_authz">
                     <h4><%=Encode.forHtml(request.getParameter("application"))%>
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "request.access.profile")%>:</h4>
-        
-                    <div class="field"> 
+
+                    <div class="field">
                         <%
                             if (displayScopes && StringUtils.isNotBlank(scopeString)) {
                                 // Remove "openid" from the scope list to display.
                                 List<String> openIdScopes = Stream.of(scopeString.split(" "))
                                         .filter(x -> !StringUtils.equalsIgnoreCase(x, "openid"))
                                         .collect(Collectors.toList());
-    
+
                                 if (CollectionUtils.isNotEmpty(openIdScopes)) {
                         %>
                         <div class="ui segment" style="text-align: left;">
@@ -92,12 +92,12 @@
                                         String scopesAsString = String.join(" ", openIdScopes);
                                         Set<Scope> scopes = new OAuth2ScopeService().getScopes(null, null,
                                                 true, scopesAsString);
-        
+
                                         for (Scope scope : scopes) {
                                             String displayName = scope.getDisplayName();
                                             String description = scope.getDescription();
                                             openIdScopes.remove(scope.getName());
-            
+
                                             if (displayName != null) {
                                 %>
                                 <div class="item">
@@ -119,7 +119,7 @@
                                     } catch (IdentityOAuth2ScopeException e) {
                                         // Ignore the error
                                     }
-        
+
                                     // Unregistered scopes if exist, get the consent with provided scope name.
                                     if (CollectionUtils.isNotEmpty(openIdScopes)) {
                                         for (String scope : openIdScopes) {
@@ -143,9 +143,9 @@
                                 }
                             }
                         %>
-            
+
                         <div class="ui divider hidden"></div>
-            
+
                         <div style="text-align: left;">
                             <div class="ui form">
                                 <div class="grouped fields">
@@ -165,13 +165,13 @@
                                 </div>
                             </div>
                         </div>
-                        
+
                     </div>
                     <div class="align-right buttons">
                         <input type="hidden" name="<%=Constants.SESSION_DATA_KEY_CONSENT%>"
                             value="<%=Encode.forHtmlAttribute(request.getParameter(Constants.SESSION_DATA_KEY_CONSENT))%>"/>
                         <input type="hidden" name="consent" id="consent" value="deny"/>
-            
+
                         <input class="ui large button link-button" type="reset"
                                onclick="deny(); return false;"
                                value="<%=AuthenticationEndpointUtil.i18n(resourceBundle,"cancel")%>"/>
@@ -205,7 +205,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -215,14 +215,14 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">
 
         function approved() {
             var scopeApproval = $("input[name='scope-approval']");
-    
+
             // If scope approval radio button is rendered then we need to validate that it's checked
             if (scopeApproval.length > 0) {
                 if (scopeApproval.is(":checked")) {
@@ -233,19 +233,19 @@
                     return;
                 }
             }
-    
+
             document.getElementById("profile").submit();
         }
 
         function hideModal(elem) {
             $(elem).closest('.modal').modal('hide');
         }
-        
+
         function deny() {
             document.getElementById('consent').value = "deny";
             document.getElementById("profile").submit();
         }
-    
+
     </script>
 
 </body>

--- a/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
@@ -35,7 +35,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="includes/localize.jsp" %>
-<jsp:include page="includes/init-url.jsp"/>
+<jsp:directive.include file="includes/init-url.jsp"/>
 
 <%
     String app = request.getParameter("application");

--- a/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
@@ -33,25 +33,25 @@
 <%@ page import="java.util.stream.Stream" %>
 <%@ page import="java.util.Set" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-    
+
 <%@ include file="includes/localize.jsp" %>
-<jsp:directive.include file="includes/init-url.jsp"/>
+<jsp:include page="includes/init-url.jsp"/>
 
 <%
     String app = request.getParameter("application");
     String scopeString = request.getParameter("scope");
     boolean displayScopes = Boolean.parseBoolean(getServletContext().getInitParameter("displayScopes"));
-    
+
     String[] requestedClaimList = new String[0];
     String[] mandatoryClaimList = new String[0];
     if (request.getParameter(Constants.REQUESTED_CLAIMS) != null) {
         requestedClaimList = request.getParameter(Constants.REQUESTED_CLAIMS).split(Constants.CLAIM_SEPARATOR);
     }
-    
+
     if (request.getParameter(Constants.MANDATORY_CLAIMS) != null) {
         mandatoryClaimList = request.getParameter(Constants.MANDATORY_CLAIMS).split(Constants.CLAIM_SEPARATOR);
     }
-    
+
     /*
         This parameter decides whether the consent page will only be used to get consent for sharing claims with the
         Service Provider. If this param is 'true' and user has already given consents for the OIDC scopes, we will be
@@ -70,7 +70,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -84,16 +84,16 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
                 <form class="ui large form" action="<%=oauth2AuthorizeURL%>" method="post" id="profile" name="oauth2_authz">
-                    <h4><%=Encode.forHtml(request.getParameter("application"))%> 
+                    <h4><%=Encode.forHtml(request.getParameter("application"))%>
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "request.access.profile")%>:</h4>
 
                     <div class="ui divider hidden"></div>
-                    
+
                     <div class="segment-form">
 
                         <!-- Prompting for consent is only needed if we have mandatory or requested claims without any consent -->
@@ -174,7 +174,7 @@
                                         List<String> openIdScopes = Stream.of(scopeString.split(" "))
                                                 .filter(x -> !StringUtils.equalsIgnoreCase(x, "openid"))
                                                 .collect(Collectors.toList());
-                        
+
                                         if (CollectionUtils.isNotEmpty(openIdScopes)) {
                                 %>
 
@@ -186,12 +186,12 @@
                                                 String scopesAsString = String.join(" ", openIdScopes);
                                                 Set<Scope> scopes = new OAuth2ScopeService().getScopes(null, null,
                                                         true, scopesAsString);
-        
+
                                                 for (Scope scope : scopes) {
                                                     String displayName = scope.getDisplayName();
                                                     String description = scope.getDescription();
                                                     openIdScopes.remove(scope.getName());
-            
+
                                                     if (displayName != null) {
                                         %>
                                         <div class="item">
@@ -213,7 +213,7 @@
                                             } catch (IdentityOAuth2ScopeException e) {
                                                 // Ignore the error
                                             }
-    
+
                                             // Unregistered scopes if exist, get the consent with provided scope name.
                                             if (CollectionUtils.isNotEmpty(openIdScopes)) {
                                                 for (String scope : openIdScopes) {
@@ -282,7 +282,7 @@
                             <input type="hidden" name="<%=Constants.SESSION_DATA_KEY_CONSENT%>"
                                     value="<%=Encode.forHtmlAttribute(request.getParameter(Constants.SESSION_DATA_KEY_CONSENT))%>"/>
                             <input type="hidden" name="consent" id="consent" value="deny"/>
-               
+
                             <input class="ui large button link-button" type="reset"
                                 onclick="deny(); return false;"
                                 value="<%=AuthenticationEndpointUtil.i18n(resourceBundle,"cancel")%>" />
@@ -303,7 +303,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -313,7 +313,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <div class="ui modal mini" id="modal_claim_validation">
@@ -389,7 +389,7 @@
             document.getElementById('consent').value = "deny";
             document.getElementById("profile").submit();
         }
-        
+
         function hideModal(elem) {
             $(elem).closest('.modal').modal('hide');
         }
@@ -397,7 +397,7 @@
         $('.checkbox.read-only').checkbox({
             uncheckable: false
         });
-        
+
         $(document).ready(function () {
             $("#consent_select_all").click(function () {
                 if (this.checked) {

--- a/apps/authentication-portal/src/main/webapp/oauth2_error.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_error.jsp
@@ -21,7 +21,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="includes/localize.jsp" %>
-<jsp:include page="includes/init-url.jsp"/>
+<jsp:directive.include file="includes/init-url.jsp"/>
 
 <%
     String errorCode = request.getParameter("oauthErrorCode");

--- a/apps/authentication-portal/src/main/webapp/oauth2_error.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_error.jsp
@@ -21,7 +21,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="includes/localize.jsp" %>
-<jsp:directive.include file="includes/init-url.jsp"/>
+<jsp:include page="includes/init-url.jsp"/>
 
 <%
     String errorCode = request.getParameter("oauthErrorCode");
@@ -34,7 +34,7 @@
         errorMsgContext = errorMsg.split(regex)[0] + regex;
         errorMsgApp = errorMsg.split(regex)[1];
     }
-%>  
+%>
 
 <!doctype html>
 <html>
@@ -46,7 +46,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -60,7 +60,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -84,7 +84,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -94,9 +94,9 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
-    
+
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/oauth2_logout_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_logout_consent.jsp
@@ -20,7 +20,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="includes/localize.jsp" %>
-<jsp:directive.include file="includes/init-url.jsp"/>
+<jsp:include page="includes/init-url.jsp"/>
 
 <!doctype html>
 <html>
@@ -32,7 +32,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -46,7 +46,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -60,12 +60,12 @@
                     <div class="field">
                         <button
                             type="submit"
-                            onclick="javascript: approved(); return false;"   
+                            onclick="javascript: approved(); return false;"
                             class="ui primary large button"
                             role="button"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "yes")%></button>
                         <button
                             type="submit"
-                            onclick="javascript: deny(); return false;"   
+                            onclick="javascript: deny(); return false;"
                             class="ui large button link-button"
                             role="button"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "no")%></button>
                     </div>
@@ -82,7 +82,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -92,7 +92,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">

--- a/apps/authentication-portal/src/main/webapp/oauth2_logout_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_logout_consent.jsp
@@ -20,7 +20,7 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="includes/localize.jsp" %>
-<jsp:include page="includes/init-url.jsp"/>
+<jsp:directive.include file="includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/authentication-portal/src/main/webapp/openid_profile.jsp
+++ b/apps/authentication-portal/src/main/webapp/openid_profile.jsp
@@ -43,7 +43,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -57,7 +57,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -116,7 +116,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -126,7 +126,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">

--- a/apps/authentication-portal/src/main/webapp/privacy_policy.jsp
+++ b/apps/authentication-portal/src/main/webapp/privacy_policy.jsp
@@ -18,7 +18,7 @@
 
 <%@ page import="java.io.File" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-    
+
 <%@ include file="includes/localize.jsp" %>
 
 <!doctype html>
@@ -31,7 +31,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -46,7 +46,7 @@
                     %>
                         <jsp:include page="extensions/product-title.jsp"/>
                     <% } else { %>
-                        <jsp:directive.include file="includes/product-title.jsp"/>
+                        <jsp:include page="includes/product-title.jsp"/>
                     <% } %>
                 </div>
             </div>
@@ -61,7 +61,7 @@
                 %>
                         <jsp:include page="extensions/privacy-policy-content.jsp"/>
                 <% } else { %>
-                        <jsp:directive.include file="includes/privacy-policy-content.jsp"/>
+                        <jsp:include page="includes/privacy-policy-content.jsp"/>
                 <% } %>
             </div>
         </div>
@@ -74,7 +74,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -84,7 +84,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript" src="js/u2f-api.js"></script>

--- a/apps/authentication-portal/src/main/webapp/requested-claims.jsp
+++ b/apps/authentication-portal/src/main/webapp/requested-claims.jsp
@@ -47,7 +47,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -61,7 +61,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -75,7 +75,7 @@
                         <strong><%=Encode.forHtmlContent(appName)%></strong>
                          <%=AuthenticationEndpointUtil.i18n(resourceBundle, "requested.claims.recommendation")%>
                     </p>
-                    
+
                     <div class="segment-form">
                         <div>
                             <h3><%=AuthenticationEndpointUtil.i18n(resourceBundle, "requested.attributes")%> :</h3>
@@ -110,7 +110,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -120,7 +120,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
 </body>

--- a/apps/authentication-portal/src/main/webapp/retry.jsp
+++ b/apps/authentication-portal/src/main/webapp/retry.jsp
@@ -46,7 +46,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -60,7 +60,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -81,7 +81,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -91,7 +91,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/samlsso_notification.jsp
+++ b/apps/authentication-portal/src/main/webapp/samlsso_notification.jsp
@@ -32,22 +32,22 @@
 <%
     String stat = request.getParameter(Constants.STATUS);
     String statusMessage = request.getParameter(Constants.STATUS_MSG);
-    
+
     String errorStat = stat;
     String errorMsg = statusMessage;
-    
+
     boolean unrecognizedStatus = true;
     if (EXCEPTION_STATUS.equals(stat) || INVALID_MESSAGE_STATUS.equals(stat)) {
         errorStat = "error.when.processing.authentication.request";
         unrecognizedStatus = false;
     }
-    
+
     boolean unrecognizedStatusMsg = true;
     if (EXCEPTION_MESSAGE.equals(statusMessage) || INVALID_MESSAGE_MESSAGE.equals(statusMessage)) {
         errorMsg = "please.try.login.again";
         unrecognizedStatusMsg = false;
     }
-    
+
     if (stat == null || statusMessage == null || unrecognizedStatus || unrecognizedStatusMsg) {
         errorStat = "authentication.error";
         errorMsg = "something.went.wrong.during.authentication";
@@ -65,7 +65,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -79,7 +79,7 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -97,7 +97,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -107,7 +107,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/samlsso_redirect.jsp
+++ b/apps/authentication-portal/src/main/webapp/samlsso_redirect.jsp
@@ -47,7 +47,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
@@ -61,14 +61,14 @@
             %>
                 <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
                 <p><%=AuthenticationEndpointUtil.i18n(resourceBundle, "you.are.redirected.back.to")%>
                     <%=Encode.forHtmlContent(assertionConsumerURL)%>.
                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "if.the.redirection.fails.please.click")%>.</p>
-                
+
                 <form method="post" action="<%=assertionConsumerURL%>">
                     <div class="align-right buttons">
                         <input type="hidden" name="SAMLResponse" value="<%=Encode.forHtmlAttribute(samlResp)%>"/>
@@ -87,7 +87,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -97,7 +97,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">

--- a/apps/email-otp-authentication-portal/src/main/webapp/emailAddress.jsp
+++ b/apps/email-otp-authentication-portal/src/main/webapp/emailAddress.jsp
@@ -61,7 +61,7 @@
 		<%
 			} else {
 		%>
-		<jsp:directive.include file="includes/header.jsp" />
+		<jsp:include page="includes/header.jsp" />
 		<%
 			}
 		%>
@@ -84,7 +84,7 @@
 					<%
 						} else {
 					%>
-					<jsp:directive.include file="includes/product-title.jsp" />
+					<jsp:include page="includes/product-title.jsp" />
 					<%
 						}
 					%>
@@ -156,7 +156,7 @@
 			<%
 				} else {
 			%>
-			<jsp:directive.include file="includes/product-footer.jsp" />
+			<jsp:include page="includes/product-footer.jsp" />
 			<%
 				}
 			%>
@@ -170,7 +170,7 @@
 			<%
 				} else {
 			%>
-			<jsp:directive.include file="includes/footer.jsp" />
+			<jsp:include page="includes/footer.jsp" />
 			<%
 				}
 			%>
@@ -181,7 +181,7 @@
 						var emailAddress = document
 								.getElementById("EMAIL_ADDRESS").value;
 						if (emailAddress == "") {
-							document.getElementById('alertDiv').innerHTML 
+							document.getElementById('alertDiv').innerHTML
 								= '<div id="error-msg" class="ui negative message">Please enter the emailAddress!</div>'
 								  +'<div class="ui divider hidden"></div>';
 						} else {

--- a/apps/email-otp-authentication-portal/src/main/webapp/emailotp.jsp
+++ b/apps/email-otp-authentication-portal/src/main/webapp/emailotp.jsp
@@ -55,7 +55,7 @@
         %>
         <jsp:include page="extensions/header.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
         <% } %>
 
         <!--[if lt IE 9]>
@@ -75,7 +75,7 @@
                 %>
                 <jsp:include page="extensions/product-title.jsp"/>
                 <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
                 <% } %>
 
                 <div class="ui segment">
@@ -117,7 +117,7 @@
                             <input type="hidden" name="sessionDataKey"
                                 value='<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>'/>
                             <input type='hidden' name='resendCode' id='resendCode' value='false'/>
-                            
+
                             <div class="ui divider hidden"></div>
                             <div class="align-right buttons">
                                 <%
@@ -141,7 +141,7 @@
         %>
         <jsp:include page="extensions/product-footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
         <% } %>
 
         <!-- footer -->
@@ -151,7 +151,7 @@
         %>
         <jsp:include page="extensions/footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
         <% } %>
 
         <script type="text/javascript">
@@ -159,7 +159,7 @@
                 $('#authenticate').click(function () {
                     var code = document.getElementById("OTPCode").value;
                     if (code == "") {
-                        document.getElementById('alertDiv').innerHTML 
+                        document.getElementById('alertDiv').innerHTML
                             = '<div id="error-msg" class="ui negative message">Please enter the code!</div>'
                               +'<div class="ui divider hidden"></div>';
                     } else {

--- a/apps/email-otp-authentication-portal/src/main/webapp/emailotpError.jsp
+++ b/apps/email-otp-authentication-portal/src/main/webapp/emailotpError.jsp
@@ -70,7 +70,7 @@
       %>
       <jsp:include page="extensions/header.jsp" />
       <% } else { %>
-      <jsp:directive.include file="includes/header.jsp" />
+      <jsp:include page="includes/header.jsp" />
       <% } %>
 
       <!--[if lt IE 9]>
@@ -89,7 +89,7 @@
           %>
           <jsp:include page="extensions/product-title.jsp" />
           <% } else { %>
-          <jsp:directive.include file="includes/product-title.jsp" />
+          <jsp:include page="includes/product-title.jsp" />
           <% } %>
 
           <div class="ui segment">
@@ -112,7 +112,7 @@
       %>
       <jsp:include page="extensions/product-footer.jsp" />
       <% } else { %>
-      <jsp:directive.include file="includes/product-footer.jsp" />
+      <jsp:include page="includes/product-footer.jsp" />
       <% } %>
 
       <!-- footer -->
@@ -122,7 +122,7 @@
       %>
       <jsp:include page="extensions/footer.jsp" />
       <% } else { %>
-      <jsp:directive.include file="includes/footer.jsp" />
+      <jsp:include page="includes/footer.jsp" />
       <% } %>
     </body>
 </html>

--- a/apps/email-otp-authentication-portal/src/main/webapp/includes/localize.jsp
+++ b/apps/email-otp-authentication-portal/src/main/webapp/includes/localize.jsp
@@ -16,6 +16,7 @@
   ~ under the License.
 --%>
 
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.EncodedControl" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ page import="java.util.ResourceBundle" %>

--- a/apps/email-otp-authentication-portal/src/main/webapp/includes/title.jsp
+++ b/apps/email-otp-authentication-portal/src/main/webapp/includes/title.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <!-- title -->

--- a/apps/recovery-portal/src/main/webapp/challenge-question-add.jsp
+++ b/apps/recovery-portal/src/main/webapp/challenge-question-add.jsp
@@ -70,7 +70,7 @@
         %>
                 <jsp:include page="extensions/title.jsp"/>
         <% } else { %>
-                <jsp:directive.include file="includes/title.jsp"/>
+                <jsp:include page="includes/title.jsp"/>
         <% } %>
 
         <link rel="icon" href="images/favicon.png" type="image/x-icon"/>
@@ -93,7 +93,7 @@
     %>
             <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/header.jsp"/>
+            <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <!-- page content -->
@@ -185,7 +185,7 @@
     %>
             <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/footer.jsp"/>
+            <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script src="libs/jquery_3.4.1/jquery-3.4.1.js"></script>

--- a/apps/recovery-portal/src/main/webapp/challenge-question-view.jsp
+++ b/apps/recovery-portal/src/main/webapp/challenge-question-view.jsp
@@ -43,7 +43,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <%
@@ -64,7 +64,7 @@
             %>
             <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-title.jsp"/>
+            <jsp:include page="includes/product-title.jsp"/>
             <% } %>
 
             <div class="ui segment">
@@ -128,7 +128,7 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
     <!-- footer -->
     <%
@@ -137,7 +137,7 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 </body>
 </html>

--- a/apps/recovery-portal/src/main/webapp/challenge-questions-view-all.jsp
+++ b/apps/recovery-portal/src/main/webapp/challenge-questions-view-all.jsp
@@ -24,13 +24,13 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.RetryError" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.List" %>
-<jsp:directive.include file="includes/localize.jsp"/>
+<jsp:include page="includes/localize.jsp"/>
 
 <%
     InitiateAllQuestionResponse initiateAllQuestionResponse = (InitiateAllQuestionResponse)
             session.getAttribute("initiateAllQuestionResponse");
     List<Question> challengeQuestions = initiateAllQuestionResponse.getQuestions();
-    
+
     RetryError errorResponse = (RetryError) request.getAttribute("errorResponse");
     boolean reCaptchaEnabled = false;
     if (request.getAttribute("reCaptcha") != null && "TRUE".equalsIgnoreCase((String) request.getAttribute("reCaptcha"))) {
@@ -50,14 +50,14 @@
     %>
             <jsp:include page="extensions/title.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/title.jsp"/>
+            <jsp:include page="includes/title.jsp"/>
     <% } %>
-    
+
     <link rel="icon" href="images/favicon.png" type="image/x-icon"/>
     <link href="libs/bootstrap_3.4.1/css/bootstrap.min.css" rel="stylesheet">
     <link href="css/Roboto.css" rel="stylesheet">
     <link href="css/custom-common.css" rel="stylesheet">
-    
+
     <!--[if lt IE 9]>
     <script src="js/html5shiv.min.js"></script>
     <script src="js/respond.min.js"></script>
@@ -78,12 +78,12 @@
 %>
         <jsp:include page="extensions/header.jsp"/>
 <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
 <% } %>
 
 <!-- page content -->
 <div class="container-fluid body-wrapper">
-    
+
     <div class="row">
         <!-- content -->
         <div class="col-xs-12 col-sm-10 col-md-8 col-lg-5 col-centered wr-login">
@@ -98,7 +98,7 @@
             %>
             <div class="clearfix"></div>
             <div class="boarder-all ">
-                
+
                 <div class="padding-double">
                     <form method="post" action="processsecurityquestions.do" id="securityQuestionForm">
                         <%
@@ -143,7 +143,7 @@
             </div>
         </div>
         <!-- /content/body -->
-    
+
     </div>
 </div>
 <!-- /content/body -->
@@ -158,7 +158,7 @@
 %>
         <jsp:include page="extensions/footer.jsp"/>
 <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
 <% } %>
 
 </body>

--- a/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/error.jsp
@@ -42,7 +42,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout recovery-layout">
@@ -55,7 +55,7 @@
             %>
             <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-title.jsp"/>
+            <jsp:include page="includes/product-title.jsp"/>
             <% } %>
             <div class="ui segment">
                 <div class="segment-form">
@@ -82,7 +82,7 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script>

--- a/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/recovery-portal/src/main/webapp/includes/localize.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/localize.jsp
@@ -16,6 +16,7 @@
   ~ under the License.
 --%>
 
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.EncodedControl" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ page import="java.util.ResourceBundle" %>

--- a/apps/recovery-portal/src/main/webapp/includes/localize.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/localize.jsp
@@ -16,7 +16,6 @@
   ~ under the License.
 --%>
 
-<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.EncodedControl" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ page import="java.util.ResourceBundle" %>

--- a/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <!-- footer -->

--- a/apps/recovery-portal/src/main/webapp/includes/product-title.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/product-title.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <div class="product-title">

--- a/apps/recovery-portal/src/main/webapp/includes/title.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/title.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <!-- title -->

--- a/apps/recovery-portal/src/main/webapp/lite-user-confirm.jsp
+++ b/apps/recovery-portal/src/main/webapp/lite-user-confirm.jsp
@@ -101,7 +101,7 @@
         %>
                 <jsp:include page="extensions/title.jsp"/>
         <% } else { %>
-                <jsp:directive.include file="includes/title.jsp"/>
+                <jsp:include page="includes/title.jsp"/>
         <% } %>
 
         <link rel="icon" href="images/favicon.png" type="image/x-icon"/>
@@ -124,7 +124,7 @@
     %>
             <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/header.jsp"/>
+            <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <!-- page content -->
@@ -160,7 +160,7 @@
     %>
             <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/footer.jsp"/>
+            <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script src="libs/jquery_3.4.1/jquery-3.4.1.js"></script>

--- a/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
@@ -87,7 +87,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body>
@@ -118,7 +118,7 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="application/javascript">

--- a/apps/recovery-portal/src/main/webapp/password-recovery-username-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-username-request.jsp
@@ -45,7 +45,7 @@
         %>
         <jsp:include page="extensions/header.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
         <% } %>
         <!--[if lt IE 9]>
         <script src="js/html5shiv.min.js"></script>
@@ -63,7 +63,7 @@
                 %>
                 <jsp:include page="extensions/product-title.jsp"/>
                 <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
                 <% } %>
 
                 <div class="ui segment">
@@ -98,7 +98,7 @@
                                     }
                                 %>
                                 <input id="isSaaSApp" name="isSaaSApp" value="<%= isSaaSApp %>" type="hidden">
-                            </div> 
+                            </div>
                             <div class="ui message info">
                                 <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                                     "If.you.do.not.specify.tenant.domain.consider.as.super.tenant")%>
@@ -128,7 +128,7 @@
                     </div>
                 </div>
             </div>
-        </main> 
+        </main>
 
         <!-- product-footer -->
         <%
@@ -137,7 +137,7 @@
         %>
         <jsp:include page="extensions/product-footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
         <% } %>
 
         <!-- footer -->
@@ -147,14 +147,14 @@
         %>
         <jsp:include page="extensions/footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
         <% } %>
 
         <script>
             function goBack() {
                 window.history.back();
             }
-            
+
             // Handle form submission preventing double submission.
             $(document).ready(function(){
                 $.fn.preventDoubleSubmission = function() {

--- a/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -83,7 +83,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <%
@@ -104,7 +104,7 @@
             %>
             <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-title.jsp"/>
+            <jsp:include page="includes/product-title.jsp"/>
             <% } %>
             <div class="ui segment">
                 <!-- page content -->
@@ -184,7 +184,7 @@
                         <%
                             }
                         %>
-    
+
                         <%
                             String sessionDataKey = request.getParameter("sessionDataKey");
                             if (sessionDataKey != null) {
@@ -233,7 +233,7 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
     <!-- footer -->
     <%
@@ -242,7 +242,7 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">

--- a/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -83,7 +83,7 @@
 
         try {
             notificationApi.setPasswordPost(resetPasswordRequest);
-    
+
             if (isAutoLoginEnable) {
                 String signature = Base64.getEncoder().encodeToString(SignatureUtil.doSignature(username));
                 JSONObject cookieValueInJson = new JSONObject();
@@ -140,7 +140,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body>
@@ -192,7 +192,7 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="application/javascript">

--- a/apps/recovery-portal/src/main/webapp/password-reset.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-reset.jsp
@@ -53,7 +53,7 @@
         %>
         <jsp:include page="extensions/header.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
         <% } %>
     </head>
     <body class="login-portal layout recovery-layout">
@@ -66,7 +66,7 @@
                 %>
                 <jsp:include page="extensions/product-title.jsp"/>
                 <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
                 <% } %>
                 <div class="ui segment">
                     <!-- content -->
@@ -91,7 +91,7 @@
                                 <input id="reset-password" name="reset-password" type="password"
                                     required="">
                             </div>
-    
+
                             <%
                                 if (username != null) {
                             %>
@@ -111,7 +111,7 @@
                             <%
                                 }
                             %>
-    
+
                             <%
                                 if (sessionDataKey != null) {
                             %>
@@ -122,7 +122,7 @@
                             <%
                                 }
                             %>
-                            
+
                             <%
                                 if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled() && tenantDomain != null) {
                             %>
@@ -161,7 +161,7 @@
         %>
         <jsp:include page="extensions/product-footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
         <% } %>
 
         <!-- footer -->
@@ -171,7 +171,7 @@
         %>
         <jsp:include page="extensions/footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
         <% } %>
 
         <script type="text/javascript">
@@ -191,7 +191,7 @@
                         $("html, body").animate({scrollTop: error_msg.offset().top}, 'slow');
                         return false;
                     }
-                    
+
                     if (password !== password2) {
                         error_msg.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                         "Passwords.did.not.match.please.try.again")%>");

--- a/apps/recovery-portal/src/main/webapp/self-registration-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-complete.jsp
@@ -48,7 +48,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body>
@@ -95,7 +95,7 @@
 %>
 <jsp:include page="extensions/footer.jsp"/>
 <% } else { %>
-<jsp:directive.include file="includes/footer.jsp"/>
+<jsp:include page="includes/footer.jsp"/>
 <% } %>
 
 <script type="application/javascript">

--- a/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -47,7 +47,7 @@
     %>
     <jsp:include page="extensions/title.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/title.jsp"/>
+    <jsp:include page="includes/title.jsp"/>
     <% } %>
 
     <link rel="icon" href="images/favicon.png" type="image/x-icon"/>
@@ -68,7 +68,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <!-- page content -->
@@ -232,7 +232,7 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
 </body>

--- a/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -20,6 +20,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.mgt.constants.SelfRegistrationStatusCodes" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementServiceUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.User" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>

--- a/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -70,7 +70,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout recovery-layout">
@@ -83,7 +83,7 @@
             %>
             <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-title.jsp"/>
+            <jsp:include page="includes/product-title.jsp"/>
             <% } %>
             <div class="ui segment">
                 <h3 class="ui header">
@@ -111,7 +111,7 @@
                             <input id="username" name="username" type="hidden"
                                 <% if(skipSignUpEnableCheck) {%> value="<%=Encode.forHtmlAttribute(username)%>" <%}%>>
                         </div>
-                        
+
                         <% if (isSaaSApp) { %>
                         <p class="ui tiny compact info message">
                             <i class="icon info circle"></i>
@@ -156,7 +156,7 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -166,7 +166,7 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script>

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
@@ -87,7 +87,7 @@
         %>
                 <jsp:include page="extensions/title.jsp"/>
         <% } else { %>
-                <jsp:directive.include file="includes/title.jsp"/>
+                <jsp:include page="includes/title.jsp"/>
         <% } %>
 
         <link rel="icon" href="images/favicon.png" type="image/x-icon"/>
@@ -110,7 +110,7 @@
     %>
             <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/header.jsp"/>
+            <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <!-- page content -->
@@ -146,7 +146,7 @@
     %>
             <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/footer.jsp"/>
+            <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script src="libs/jquery_3.4.1/jquery-3.4.1.js"></script>

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification-notify.jsp
@@ -31,7 +31,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body>
@@ -60,7 +60,7 @@
 %>
 <jsp:include page="extensions/footer.jsp"/>
 <% } else { %>
-<jsp:directive.include file="includes/footer.jsp"/>
+<jsp:include page="includes/footer.jsp"/>
 <% } %>
 
 <script type="application/javascript">

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -178,7 +178,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <%
@@ -199,7 +199,7 @@
             %>
             <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-title.jsp"/>
+            <jsp:include page="includes/product-title.jsp"/>
             <% } %>
             <div class="ui segment">
 
@@ -538,7 +538,7 @@
     %>
     <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/product-footer.jsp"/>
+    <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
 
@@ -549,7 +549,7 @@
     %>
     <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/footer.jsp"/>
+    <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
 
@@ -610,7 +610,7 @@
                     registrationBtn.prop("disabled", true).addClass("disabled");
                 }
             });
-            
+
             $(".form-info").popup();
 
             $("#register").submit(function (e) {
@@ -637,7 +637,7 @@
 
                 var password = $("#password").val();
                 var password2 = $("#password2").val();
-                
+
                 if (password !== password2) {
                     error_msg.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                         "Passwords.did.not.match.please.try.again")%>");
@@ -645,7 +645,7 @@
                     $("html, body").animate({scrollTop: error_msg.offset().top}, 'slow');
                     return false;
                 }
-                
+
                 if(!$("#termsCheckbox")[0].checked){
                         error_msg.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                             "Confirm.Privacy.Policy")%>");

--- a/apps/recovery-portal/src/main/webapp/self-registration-without-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-without-verification.jsp
@@ -75,7 +75,7 @@
         %>
                 <jsp:include page="extensions/title.jsp"/>
         <% } else { %>
-                <jsp:directive.include file="includes/title.jsp"/>
+                <jsp:include page="includes/title.jsp"/>
         <% } %>
 
         <link rel="icon" href="images/favicon.png" type="image/x-icon"/>
@@ -107,7 +107,7 @@
     %>
             <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/header.jsp"/>
+            <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <!-- page content -->
@@ -270,7 +270,7 @@
     %>
             <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-            <jsp:directive.include file="includes/footer.jsp"/>
+            <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script src="libs/jquery_3.4.1/jquery-3.4.1.js"></script>

--- a/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
@@ -54,7 +54,7 @@
     %>
     <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:directive.include file="includes/header.jsp"/>
+    <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body>
@@ -83,11 +83,11 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="application/javascript">
-        
+
         $(document).ready(function () {
             $(".notify").modal({
                 blurring: true,

--- a/apps/recovery-portal/src/main/webapp/username-recovery-tenant-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery-tenant-request.jsp
@@ -38,12 +38,12 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout recovery-layout">
 <!-- page content -->
-<main class="center-segment">  
+<main class="center-segment">
     <div class="ui container large center aligned middle aligned">
         <!-- product-title -->
         <%
@@ -52,7 +52,7 @@
         %>
         <jsp:include page="extensions/product-title.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/product-title.jsp"/>
+        <jsp:include page="includes/product-title.jsp"/>
         <% } %>
         <!-- content -->
         <div class="ui segment">
@@ -105,7 +105,7 @@
                             </button>
                         </div>
                 </form>
-            </div>    
+            </div>
         </div>
     </div>
 </main>
@@ -118,7 +118,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -128,7 +128,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">

--- a/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -44,7 +44,7 @@
         response.sendError(HttpServletResponse.SC_FOUND);
         return;
     }
-    
+
     ReCaptchaApi reCaptchaApi = new ReCaptchaApi();
 
     if (StringUtils.isNotEmpty(tenantDomain)) {
@@ -57,11 +57,11 @@
             return;
         }
     }
-    
+
     try {
         ReCaptchaProperties reCaptchaProperties = reCaptchaApi.getReCaptcha(tenantDomain, true, "ReCaptcha",
                 "username-recovery");
-        
+
         if (reCaptchaProperties != null && reCaptchaProperties.getReCaptchaEnabled()) {
             Map<String, List<String>> headers = new HashMap<>();
             headers.put("reCaptcha", Arrays.asList(String.valueOf(true)));
@@ -75,7 +75,7 @@
         request.getRequestDispatcher("error.jsp").forward(request, response);
         return;
     }
-    
+
     boolean error = IdentityManagementEndpointUtil.getBooleanValue(request.getAttribute("error"));
     String errorMsg = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorMsg"));
 
@@ -134,7 +134,7 @@
     %>
         <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
     <% } %>
 
     <%
@@ -155,7 +155,7 @@
             %>
             <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-title.jsp"/>
+            <jsp:include page="includes/product-title.jsp"/>
             <% } %>
             <div class="ui segment">
                 <h2><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Recover.username")%></h2>
@@ -220,7 +220,7 @@
                         </div>
                         <% } %>
 
-                        <% if (!isSaaSApp && (StringUtils.isNotEmpty(tenantDomain) && !error)) { %> 
+                        <% if (!isSaaSApp && (StringUtils.isNotEmpty(tenantDomain) && !error)) { %>
                         <div>
                             <input id="tenant-domain" type="hidden" name="tenantDomain" value="<%=Encode.forHtmlAttribute(tenantDomain)%>"/>
                         </div>
@@ -232,7 +232,7 @@
                             <input id="tenant-domain" type="text" name="tenantDomain" class="form-control">
                         </div>
                         <% } %>
-                        
+
                         <input type="hidden" id="isUsernameRecovery" name="isUsernameRecovery" value="true">
 
                         <% for (Claim claim : claims) {
@@ -295,7 +295,7 @@
     %>
         <jsp:include page="extensions/product-footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
     <% } %>
 
     <!-- footer -->
@@ -305,7 +305,7 @@
     %>
         <jsp:include page="extensions/footer.jsp"/>
     <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
     <script type="text/javascript">

--- a/apps/sms-otp-authentication-portal/src/main/webapp/includes/title.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/includes/title.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <!-- title -->

--- a/apps/sms-otp-authentication-portal/src/main/webapp/mobile.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/mobile.jsp
@@ -55,7 +55,7 @@
         %>
         <jsp:include page="extensions/header.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
         <% } %>
         <!--[if lt IE 9]>
         <script src="js/html5shiv.min.js"></script>
@@ -73,7 +73,7 @@
                 %>
                 <jsp:include page="extensions/product-title.jsp"/>
                 <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
                 <% } %>
 
                 <div class="ui segment">
@@ -103,7 +103,7 @@
                                 <input type="text" id='MOBILE_NUMBER' name="MOBILE_NUMBER"
                                         class="input-xlarge" size='30'/>
                             </div>
-                            <input type="hidden" name="sessionDataKey" 
+                            <input type="hidden" name="sessionDataKey"
                                     value='<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>'/>
 
                             <div class="align-right buttons">
@@ -114,7 +114,7 @@
                     </div>
                 </div>
             </div>
-        </main> 
+        </main>
 
         <!-- product-footer -->
         <%
@@ -123,7 +123,7 @@
         %>
         <jsp:include page="extensions/product-footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
         <% } %>
 
         <!-- footer -->
@@ -133,7 +133,7 @@
         %>
         <jsp:include page="extensions/footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
         <% } %>
 
         <script type="text/javascript">

--- a/apps/sms-otp-authentication-portal/src/main/webapp/smsotp.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/smsotp.jsp
@@ -59,7 +59,7 @@
         %>
         <jsp:include page="extensions/header.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
         <% } %>
         <!--[if lt IE 9]>
         <script src="js/html5shiv.min.js"></script>
@@ -77,7 +77,7 @@
                 %>
                 <jsp:include page="extensions/product-title.jsp"/>
                 <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
                 <% } %>
 
                 <div class="ui segment">
@@ -133,7 +133,7 @@
                                         <a id="resend">Resend Code</a>
                                     </div>
                                 <% } } %>
-                                <input 
+                                <input
                                     type="button" name="authenticate" id="authenticate"
                                     value="Authenticate" class="ui primary button"/>
                             </div>
@@ -142,8 +142,8 @@
                     </div>
                 </div>
             </div>
-        </main> 
-        
+        </main>
+
         <!-- product-footer -->
         <%
             File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
@@ -151,7 +151,7 @@
         %>
         <jsp:include page="extensions/product-footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
         <% } %>
 
         <!-- footer -->
@@ -161,7 +161,7 @@
         %>
         <jsp:include page="extensions/footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
         <% } %>
 
         <script type="text/javascript">

--- a/apps/sms-otp-authentication-portal/src/main/webapp/smsotpError.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/smsotpError.jsp
@@ -84,7 +84,7 @@
         %>
         <jsp:include page="extensions/header.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
         <% } %>
         <!--[if lt IE 9]>
         <script src="js/html5shiv.min.js"></script>
@@ -102,7 +102,7 @@
                 %>
                 <jsp:include page="extensions/product-title.jsp"/>
                 <% } else { %>
-                <jsp:directive.include file="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
                 <% } %>
 
                 <div class="ui segment">
@@ -121,7 +121,7 @@
                     %>
                 </div>
             </div>
-        </main> 
+        </main>
 
         <!-- product-footer -->
         <%
@@ -130,7 +130,7 @@
         %>
         <jsp:include page="extensions/product-footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/product-footer.jsp"/>
+        <jsp:include page="includes/product-footer.jsp"/>
         <% } %>
 
         <!-- footer -->
@@ -140,7 +140,7 @@
         %>
         <jsp:include page="extensions/footer.jsp"/>
         <% } else { %>
-        <jsp:directive.include file="includes/footer.jsp"/>
+        <jsp:include page="includes/footer.jsp"/>
         <% } %>
     </body>
 </html>

--- a/apps/totp-authentication-portal/src/main/webapp/enableTOTP.jsp
+++ b/apps/totp-authentication-portal/src/main/webapp/enableTOTP.jsp
@@ -61,7 +61,7 @@
             %>
             <jsp:include page="extensions/header.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/header.jsp"/>
+            <jsp:include page="includes/header.jsp"/>
             <% } %>
             <script src="js/gadget.js"></script>
             <script src="js/qrCodeGenerator.js"></script>
@@ -81,7 +81,7 @@
                     %>
                     <jsp:include page="extensions/product-title.jsp"/>
                     <% } else { %>
-                    <jsp:directive.include file="includes/product-title.jsp"/>
+                    <jsp:include page="includes/product-title.jsp"/>
                     <% } %>
 
                     <div class="ui segment">
@@ -106,12 +106,12 @@
                                             <div class="ui divider hidden"></div>
                                 <% } }  %>
                                 <p>You have not enabled TOTP authentication. Please enable it.</p>
-                                
+
                                 <input type="hidden" id="ENABLE_TOTP" name="ENABLE_TOTP" value="false"/>
                                 <input type="hidden" name='ske' id='ske' value='<%=Encode.forHtmlAttribute(request.getParameter("ske"))%>'/>
                                 <input type="hidden" name="sessionDataKey" id="sessionDataKey"
                                     value='<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>'/>
-                                    
+
                                 <div class="ui styled fluid accordion">
                                     <div class="title">
                                         <i class="dropdown icon"></i>
@@ -137,7 +137,7 @@
                         </div>
                     </div>
                 </div>
-            </main> 
+            </main>
 
             <!-- product-footer -->
             <%
@@ -146,7 +146,7 @@
             %>
             <jsp:include page="extensions/product-footer.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-footer.jsp"/>
+            <jsp:include page="includes/product-footer.jsp"/>
             <% } %>
 
             <!-- footer -->
@@ -156,7 +156,7 @@
             %>
             <jsp:include page="extensions/footer.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/footer.jsp"/>
+            <jsp:include page="includes/footer.jsp"/>
             <% } %>
 
             <script type="text/javascript">

--- a/apps/totp-authentication-portal/src/main/webapp/includes/title.jsp
+++ b/apps/totp-authentication-portal/src/main/webapp/includes/title.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <!-- title -->

--- a/apps/totp-authentication-portal/src/main/webapp/totp.jsp
+++ b/apps/totp-authentication-portal/src/main/webapp/totp.jsp
@@ -61,7 +61,7 @@
             %>
             <jsp:include page="extensions/header.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/header.jsp"/>
+            <jsp:include page="includes/header.jsp"/>
             <% } %>
 
             <script src="js/scripts.js"></script>
@@ -105,7 +105,7 @@
                     %>
                     <jsp:include page="extensions/product-title.jsp"/>
                     <% } else { %>
-                    <jsp:directive.include file="includes/product-title.jsp"/>
+                    <jsp:include page="includes/product-title.jsp"/>
                     <% } %>
 
                     <div class="ui segment">
@@ -119,7 +119,7 @@
                                 <div class="ui divider hidden"></div>
                         <% } %>
 
-                        <input id="username" type="hidden" 
+                        <input id="username" type="hidden"
                                value='<%=Encode.forHtmlAttribute(request.getParameter("username"))%>'>
 
                         <div class="segment-form">
@@ -128,11 +128,11 @@
                                 <div class="field">
                                     <input type="text" name="token" class="form-control" placeholder="Verification Code">
                                 </div>
-                                <input id="sessionDataKey" type="hidden" name="sessionDataKey" 
+                                <input id="sessionDataKey" type="hidden" name="sessionDataKey"
                                        value='<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>' />
                                 <div class="ui divider hidden"></div>
                                 <div class="align-right buttons">
-                                    <a class="ui button link-button" id="genToken" href="#" 
+                                    <a class="ui button link-button" id="genToken" href="#"
                                        onclick="return requestTOTPToken();">
                                        Get a Verification Code
                                     </a>
@@ -145,7 +145,7 @@
                                 String multiOptionURI = request.getParameter("multiOptionURI");
                                 if (multiOptionURI != null) {
                             %>
-                                <a class="ui button link-button" id="goBackLink" 
+                                <a class="ui button link-button" id="goBackLink"
                                 href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
                                     Choose a different authentication option
                                 </a>
@@ -154,7 +154,7 @@
                             %>
                     </div>
                 </div>
-            </main> 
+            </main>
 
             <!-- product-footer -->
             <%
@@ -163,7 +163,7 @@
             %>
             <jsp:include page="extensions/product-footer.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-footer.jsp"/>
+            <jsp:include page="includes/product-footer.jsp"/>
             <% } %>
 
             <!-- footer -->
@@ -173,7 +173,7 @@
             %>
             <jsp:include page="extensions/footer.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/footer.jsp"/>
+            <jsp:include page="includes/footer.jsp"/>
             <% } %>
         </body>
     </html>

--- a/apps/totp-authentication-portal/src/main/webapp/totpError.jsp
+++ b/apps/totp-authentication-portal/src/main/webapp/totpError.jsp
@@ -60,7 +60,7 @@
             %>
             <jsp:include page="extensions/header.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/header.jsp"/>
+            <jsp:include page="includes/header.jsp"/>
             <% } %>
 
             <script src="js/scripts.js"></script>
@@ -82,7 +82,7 @@
                     %>
                     <jsp:include page="extensions/product-title.jsp"/>
                     <% } else { %>
-                    <jsp:directive.include file="includes/product-title.jsp"/>
+                    <jsp:include page="includes/product-title.jsp"/>
                     <% } %>
 
                     <div class="ui segment">
@@ -94,12 +94,12 @@
                                 </div>
                                 <div class="ui negative message" id="failed-msg">
                                         Enable the TOTP in your Profile. Cannot proceed further without TOTP authentication.
-                                </div>                        
+                                </div>
                             </form>
                         </div>
                     </div>
                 </div>
-            </main> 
+            </main>
 
             <!-- product-footer -->
             <%
@@ -108,7 +108,7 @@
             %>
             <jsp:include page="extensions/product-footer.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-footer.jsp"/>
+            <jsp:include page="includes/product-footer.jsp"/>
             <% } %>
 
             <!-- footer -->
@@ -118,7 +118,7 @@
             %>
             <jsp:include page="extensions/footer.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/footer.jsp"/>
+            <jsp:include page="includes/footer.jsp"/>
             <% } %>
         </body>
     </html>

--- a/apps/x509-certificate-authentication-portal/src/main/webapp/includes/title.jsp
+++ b/apps/x509-certificate-authentication-portal/src/main/webapp/includes/title.jsp
@@ -16,7 +16,7 @@
   ~ under the License.
 --%>
 
-<!-- localize.jsp MUST already be included in the calling script -->
+<jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <!-- title -->

--- a/apps/x509-certificate-authentication-portal/src/main/webapp/x509CertificateError.jsp
+++ b/apps/x509-certificate-authentication-portal/src/main/webapp/x509CertificateError.jsp
@@ -88,7 +88,7 @@
             %>
             <jsp:include page="extensions/header.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/header.jsp"/>
+            <jsp:include page="includes/header.jsp"/>
             <% } %>
             <script src="js/scripts.js"></script>
             <!--[if lt IE 9]>
@@ -107,7 +107,7 @@
                     %>
                     <jsp:include page="extensions/product-title.jsp"/>
                     <% } else { %>
-                    <jsp:directive.include file="includes/product-title.jsp"/>
+                    <jsp:include page="includes/product-title.jsp"/>
                     <% } %>
 
                     <div class="ui segment">
@@ -121,7 +121,7 @@
                         <div id="alertDiv"></div>
                     </div>
                 </div>
-            </main> 
+            </main>
 
             <!-- product-footer -->
             <%
@@ -130,7 +130,7 @@
             %>
             <jsp:include page="extensions/product-footer.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/product-footer.jsp"/>
+            <jsp:include page="includes/product-footer.jsp"/>
             <% } %>
 
             <!-- footer -->
@@ -140,7 +140,7 @@
             %>
             <jsp:include page="extensions/footer.jsp"/>
             <% } else { %>
-            <jsp:directive.include file="includes/footer.jsp"/>
+            <jsp:include page="includes/footer.jsp"/>
             <% } %>
         </body>
     </html>


### PR DESCRIPTION
## Purpose
>  Resolves https://github.com/wso2/product-is/issues/9299

## Fix
The `localize.jsp`'s variables weren't being loaded because JSP include was an action and not a directive. This caused errors when trying extend the `header.jsp` by copying that file from the includes directory to the extensions directory. 

Since using directives for extensions, like shown below, caused compile time errors, the`localize.jsp` is now imported into the files in the includes directory. 
```jsp
    <%
        File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
        if (headerFile.exists()) {
    %>
        <jsp:directive.include file="extensions/header.jsp"/>
    <% } else { %>
        <jsp:directive.include file="includes/header.jsp"/>
    <% } %>
```

Solution
```jsp
    <%
        File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
        if (headerFile.exists()) {
    %>
        <jsp:include page="extensions/header.jsp"/>
    <% } else { %>
        <jsp:include page="includes/header.jsp"/>
    <% } %>
```

**NOTE: The `localize.jsp` file also has to be moved to the extensions directory along with whatever files you copy from the includes directory to the extensions directory.**