### PR TITLE
Fix 404 issues when extensions are present in tenant SaaS mode

### DIFF
--- a/apps/console/src/features/core/configs/routes.ts
+++ b/apps/console/src/features/core/configs/routes.ts
@@ -25,11 +25,6 @@ import { AdminView, DeveloperView } from "../../../views";
 import { AppConstants } from "../constants";
 
 /**
- * Load extension routes if available.
- */
-const extensions = EXTENSION_ROUTES();
-
-/**
  * Get Developer View Routes.
  *
  * @remarks
@@ -50,7 +45,7 @@ const extensions = EXTENSION_ROUTES();
 export const getDeveloperViewRoutes = (): RouteInterface[] => {
 
     return [
-        ...extensions,
+        ...EXTENSION_ROUTES(),
         {
             category: "devPortal:components.sidePanel.categories.application",
             children: [


### PR DESCRIPTION
## Purpose
When feature extensions are added, the defined routes direct to 404 page.

## Goals
Fixes https://github.com/wso2/product-is/issues/9597

## Approach
Since the extension routes are declared as a module level variable, the change to the base name is not captured. Removing the module variable and using the routes getter function inside the `getDeveloperViewRoutes()` function fixed the issue.