### PR TITLE
Add JsDom Support for Jest Unit Tests

### DIFF
--- a/apps/console/jest.config.js
+++ b/apps/console/jest.config.js
@@ -17,10 +17,8 @@
  */
 
 module.exports = {
-    globals: {
-        "window": true
-    },
     moduleFileExtensions: ["js", "jsx", "ts", "tsx", "json", "node"],
+    testEnvironment: "jest-environment-jsdom-global",
     roots: [
         "src"
     ],
@@ -44,9 +42,10 @@ module.exports = {
         "<rootDir>/(build|docs|node_modules)/"
     ],
     moduleNameMapper: {
-        "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$"
+        "\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$"
             : "<rootDir>/test-configs/file-mock.js",
-        "\\.(css|less)$": "<rootDir>/test-configs/style-mock.js"
+        "\\.(css|less)$": "<rootDir>/test-configs/style-mock.js",
+        "\\.svg": "<rootDir>/test-configs/svgrMock.js"
     },
     setupFilesAfterEnv: [
         "<rootDir>/test-configs/setup-test.js"

--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -2777,6 +2777,11 @@
 				}
 			}
 		},
+		"jest-environment-jsdom-global": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom-global/-/jest-environment-jsdom-global-2.0.4.tgz",
+			"integrity": "sha512-1vB8q+PrszXW4Pf7Zgp3eQ4oNVbA7GY6+jmrg1qi6RtYRWDJ60/xdkhjqAbQpX8BRyvqQJYQi66LXER5YNeHXg=="
+		},
 		"jest-environment-node": {
 			"version": "26.3.0",
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",

--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -317,6 +317,23 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/runtime": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+			"integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@babel/runtime-corejs3": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+			"integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+			"requires": {
+				"core-js-pure": "^3.0.0",
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"@babel/template": {
 			"version": "7.10.4",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -828,6 +845,75 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
+		"@testing-library/dom": {
+			"version": "7.24.3",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.3.tgz",
+			"integrity": "sha512-6eW9fUhEbR423FZvoHRwbWm9RUUByLWGayYFNVvqTnQLYvsNpBS4uEuKH9aqr3trhxFwGVneJUonehL3B1sHJw==",
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.10.3",
+				"@types/aria-query": "^4.2.0",
+				"aria-query": "^4.2.2",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.1",
+				"pretty-format": "^26.4.2"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "26.3.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+					"integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^15.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+					"integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+					"requires": {
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"pretty-format": {
+					"version": "26.4.2",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+					"integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+					"requires": {
+						"@jest/types": "^26.3.0",
+						"ansi-regex": "^5.0.0",
+						"ansi-styles": "^4.0.0",
+						"react-is": "^16.12.0"
+					}
+				}
+			}
+		},
+		"@testing-library/user-event": {
+			"version": "12.1.6",
+			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.6.tgz",
+			"integrity": "sha512-BdSe6cmzDEapTBH3s1NKbzu+GyX5bJKraKwVpM2vZF1+EEWxZr0EiA0z9bA5Nux8P+6nKMOZKsXQrj5q/kicfQ==",
+			"requires": {
+				"@babel/runtime": "^7.10.2"
+			}
+		},
+		"@types/aria-query": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+			"integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A=="
+		},
 		"@types/babel__core": {
 			"version": "7.1.9",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
@@ -1021,6 +1107,15 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"aria-query": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+			"integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+			"requires": {
+				"@babel/runtime": "^7.10.2",
+				"@babel/runtime-corejs3": "^7.10.2"
 			}
 		},
 		"arr-diff": {
@@ -1435,6 +1530,11 @@
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
+		"core-js-pure": {
+			"version": "3.6.5",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+			"integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1590,6 +1690,11 @@
 			"version": "25.2.6",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
 			"integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg=="
+		},
+		"dom-accessibility-api": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.3.tgz",
+			"integrity": "sha512-yfqzAi1GFxK6EoJIZKgxqJyK6j/OjEFEUi2qkNThD/kUhoCFSG1izq31B5xuxzbJBGw9/67uPtkPMYAzWL7L7Q=="
 		},
 		"domexception": {
 			"version": "2.0.1",
@@ -4284,6 +4389,11 @@
 			"requires": {
 				"lodash.isplainobject": "^4.0.6"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"regex-not": {
 			"version": "1.0.2",

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -27,6 +27,8 @@
         "test": "../../node_modules/.bin/jest --passWithNoTests"
     },
     "dependencies": {
+        "@testing-library/dom": "^7.24.3",
+        "@testing-library/user-event": "^12.1.6",
         "@types/jest": "^26.0.14",
         "@wso2is/authentication": "^1.0.426",
         "@wso2is/core": "^1.0.426",

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -37,6 +37,8 @@
         "@wso2is/validation": "^1.0.426",
         "country-language": "^0.1.7",
         "jest": "^26.4.2",
+        "jest-environment-jsdom": "^26.3.0",
+        "jest-environment-jsdom-global": "^2.0.4",
         "redux-mock-store": "^1.5.4",
         "ts-jest": "^26.4.0"
     },

--- a/apps/console/test-configs/setup-test.js
+++ b/apps/console/test-configs/setup-test.js
@@ -39,7 +39,7 @@ class Worker {
  * Suggested fix for i18next warnings
  * See also {@link https://github.com/i18next/react-i18next/issues/876}
  */
-jest.mock('react-i18next', () => ({
+jest.mock("react-i18next", () => ({
     useTranslation: () => ({
       t: (key) => ({
         message: key

--- a/apps/console/test-configs/setup-test.js
+++ b/apps/console/test-configs/setup-test.js
@@ -36,6 +36,18 @@ class Worker {
 }
 
 /**
+ * Suggested fix for i18next warnings
+ * See also {@link https://github.com/i18next/react-i18next/issues/876}
+ */
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+      t: (key) => ({
+        message: key
+      })
+    })
+}));
+
+/**
  * Suggested fix for jsdom issue
  * See also {@link https://github.com/jsdom/jsdom/issues/3002}
  */

--- a/apps/console/test-configs/svgrMock.js
+++ b/apps/console/test-configs/svgrMock.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from "react"
+export default "SvgrURL"
+export const ReactComponent = "div"


### PR DESCRIPTION
## Purpose
This PR will add JsDom Support for Jest as well as, remove `react18next` warnings from jest unit tests.