### PR TITLE
Fix issues caused when creating a UniqueReadWriteLDAP Userstore through the console

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 End-user apps in WSO2 Identity Server
 
 |  Branch | Build Status |
-| :------------ |:------------- 
+| :------------ |:-------------
 | master      | [![Build Status](https://wso2.org/jenkins/view/Dashboard/job/platform-builds/job/identity-apps/badge/icon)](https://wso2.org/jenkins/view/Dashboard/job/platform-builds/job/identity-apps/) |
 
 ## Setup build environment
@@ -16,11 +16,11 @@ End-user apps in WSO2 Identity Server
 #### Build
 
 1. Download or clone the project source code from [https://github.com/wso2/identity-apps](https://github.com/wso2/identity-apps)
-2. Run `mvn clean install` from the command line in the project root directory (where the root `pom.xml` is located). 
+2. Run `mvn clean install` from the command line in the project root directory (where the root `pom.xml` is located).
 
 If you are building [product-is](https://github.com/wso2/product-is), the built identity apps dependencies will install to your local `.m2` repository during the build above.
 
-3. Then you just need to build [WSO2 Identiy Server](https://github.com/wso2/product-is) after. _(Follow the guide there)_
+3. Then you just need to build [WSO2 Identity Server](https://github.com/wso2/product-is) after. _(Follow the guide there)_
 
 #### Run
 
@@ -35,7 +35,7 @@ If you are building [product-is](https://github.com/wso2/product-is), the built 
 ```
     [cors]
     allowed_origins = [
-       "https://localhost:9000", 
+       "https://localhost:9000",
        "https://localhost:9001"
     ]
     supported_methods = [

--- a/apps/console/src/features/groups/pages/groups.tsx
+++ b/apps/console/src/features/groups/pages/groups.tsx
@@ -369,7 +369,10 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                     />
                 }
                 showPagination={ paginatedGroups.length > 0  }
-                showTopActionPanel={ isGroupsListRequestLoading || !(!searchQuery && paginatedGroups?.length <= 0) }
+                showTopActionPanel={ isGroupsListRequestLoading
+                    || !(!searchQuery
+                        && userStoreOptions.length < 3
+                        && paginatedGroups?.length <= 0) }
                 totalPages={ Math.ceil(groupList?.length / listItemLimit) }
                 totalListSize={ groupList?.length }
             >

--- a/apps/console/src/features/users/components/add-user.tsx
+++ b/apps/console/src/features/users/components/add-user.tsx
@@ -285,7 +285,7 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
             lastName: values.get("lastName").toString(),
             newPassword: values.get("newPassword") && values.get("newPassword") !== undefined  ?
                 values.get("newPassword").toString() : "",
-            passwordOption: values.get("passwordOption").toString(),
+            passwordOption: values.get("passwordOption")?.toString(),
             userName: values.get("userName").toString()
         };
     };

--- a/apps/console/src/features/userstores/components/add-user-store.tsx
+++ b/apps/console/src/features/userstores/components/add-user-store.tsx
@@ -31,6 +31,7 @@ import { AddUserstoreWizardStepIcons } from "../configs";
 import { USERSTORE_TYPE_DISPLAY_NAMES } from "../constants";
 import {
     CategorizedProperties,
+    TypeProperty,
     UserStorePostData,
     UserStoreProperty,
     UserstoreType
@@ -186,7 +187,29 @@ export const AddUserStore: FunctionComponent<AddUserStoreProps> = (props: AddUse
             };
         });
 
-        return [ ...connectionProperties, ...userProperties, ...groupProperties, ...basicProperties ];
+        const allProperties: UserStoreProperty[] = type.properties.Advanced.map((property: TypeProperty) => {
+            return {
+                name: property.name,
+                value: property.defaultValue
+            }
+        });
+
+        allProperties.push(
+            ...type.properties.Mandatory.map((property: TypeProperty) => {
+                return {
+                    name: property.name,
+                    value: property.defaultValue
+                };
+            }),
+            ...type.properties.Optional.map((property: TypeProperty) => {
+                return {
+                    name: property.name,
+                    value: property.defaultValue
+                };
+            })
+        );
+
+        return [ ...allProperties, ...connectionProperties, ...userProperties, ...groupProperties, ...basicProperties ];
     };
 
     /**


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/9627
> Resolves https://github.com/wso2/product-is/issues/9624

The issue with the userstore was caused by the `Membership Attribute` being empty when creating the userstore. Since that key is not required by default, the UI allowed the user to create the userstore without filling this attribute. To resolve this issue, now the default values are being sent with the API calls. 

The issue in the groups page is resolved by making the top action panel visible when there are multiple userstores. 
![image](https://user-images.githubusercontent.com/20745428/94943050-c515be80-04f4-11eb-9cfe-c2464c0d43e5.png)
