### PR TITLE
Fix issues with IdPs, users list, apps list and groups list

### DIFF
--- a/apps/console/src/features/groups/pages/groups.tsx
+++ b/apps/console/src/features/groups/pages/groups.tsx
@@ -19,7 +19,7 @@
 import { getUserStoreList } from "@wso2is/core/api";
 import { AlertInterface, AlertLevels, RolesInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ListLayout, PageLayout, PrimaryButton } from "@wso2is/react-components";
+import { ListLayout, PageLayout, PrimaryButton, EmptyPlaceholder } from "@wso2is/react-components";
 import _ from "lodash";
 import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -30,8 +30,12 @@ import {
     AppState,
     FeatureConfigInterface,
     SharedUserStoreUtils,
-    UIConstants
+    UIConstants,
+    UserStoreProperty,
+    getAUserStore,
+    EmptyPlaceholderIllustrations
 } from "../../core";
+import { UserStorePostData } from "../../userstores";
 import { deleteGroupById, getGroupList, searchGroupList } from "../api";
 import { GroupList } from "../components";
 import { CreateGroupWizard } from "../components/wizard";
@@ -78,6 +82,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     const [ isGroupsListRequestLoading, setGroupsListRequestLoading ] = useState<boolean>(false);
     const [ triggerClearQuery, setTriggerClearQuery ] = useState<boolean>(false);
     const [ readOnlyUserStoresList, setReadOnlyUserStoresList ] = useState<string[]>(undefined);
+    const [ groupsError, setGroupsError ] = useState<boolean>(false);
 
     const [ groupList, setGroupsList ] = useState<GroupsInterface[]>([]);
     const [ paginatedGroups, setPaginatedGroups ] = useState<GroupsInterface[]>([]);
@@ -128,7 +133,29 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                         setPaginatedGroups([]);
                         setIsEmptyResults(true);
                     }
+                    setGroupsError(false);
+                } else {
+                    dispatch(addAlert({
+                        description: t("adminPortal:components.groups.notifications." +
+                            "fetchGroups.genericError.description"),
+                        level: AlertLevels.ERROR,
+                        message: t("adminPortal:components.groups.notifications.fetchGroups.genericError.message")
+                    }));
+                    setGroupsError(true);
+                    setGroupsList([]);
+                    setPaginatedGroups([]);
                 }
+            }).catch((error) => {
+                dispatch(addAlert({
+                    description: error?.response?.data?.description ?? error?.response?.data?.detail
+                        ?? t("adminPortal:components.groups.notifications.fetchGroups.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: error?.response?.data?.message
+                        ?? t("adminPortal:components.groups.notifications.fetchGroups.genericError.message")
+                }));
+                setGroupsError(true);
+                setGroupsList([]);
+                setPaginatedGroups([]);
             })
             .finally(() => {
                 setGroupsListRequestLoading(false);
@@ -163,14 +190,22 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                 if (storeOptions === []) {
                     storeOptions.push(storeOption);
                 }
+
                 response.data.map((store, index) => {
-                        storeOption = {
-                            key: index,
-                            text: store.name,
-                            value: store.name
-                        };
-                        storeOptions.push(storeOption);
-                    }
+                    getAUserStore(store.id).then((response: UserStorePostData) => {
+                        const isDisabled = response.properties.find(
+                            (property: UserStoreProperty) => property.name === "Disabled").value === "true";
+
+                        if (!isDisabled) {
+                            storeOption = {
+                                key: index,
+                                text: store.name,
+                                value: store.name
+                            };
+                            storeOptions.push(storeOption);
+                        }
+                    });
+                }
                 );
 
                 setUserStoresList(storeOptions);
@@ -371,51 +406,61 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                 showPagination={ paginatedGroups.length > 0  }
                 showTopActionPanel={ isGroupsListRequestLoading
                     || !(!searchQuery
+                        && !groupsError
                         && userStoreOptions.length < 3
                         && paginatedGroups?.length <= 0) }
                 totalPages={ Math.ceil(groupList?.length / listItemLimit) }
                 totalListSize={ groupList?.length }
             >
-                <GroupList
-                    advancedSearch={ (
-                        <AdvancedSearchWithBasicFilters
-                            data-testid="group-mgt-groups-list-advanced-search"
-                            onFilter={ handleUserFilter  }
-                            filterAttributeOptions={ [
-                                {
-                                    key: 0,
-                                    text: "Name",
-                                    value: "displayName"
+                { groupsError
+                    ? <EmptyPlaceholder
+                        subtitle={ [ t("adminPortal:components.groups.placeholders.groupsError.subtitles.0"),
+                            t("adminPortal:components.groups.placeholders.groupsError.subtitles.1") ] }
+                        title={ t("adminPortal:components.groups.placeholders.groupsError.title") }
+                        image={ EmptyPlaceholderIllustrations.genericError }
+                        imageSize="tiny"
+                    /> :
+                    <GroupList
+                        advancedSearch={ (
+                            <AdvancedSearchWithBasicFilters
+                                data-testid="group-mgt-groups-list-advanced-search"
+                                onFilter={ handleUserFilter }
+                                filterAttributeOptions={ [
+                                    {
+                                        key: 0,
+                                        text: "Name",
+                                        value: "displayName"
+                                    }
+                                ] }
+                                filterAttributePlaceholder={
+                                    t("adminPortal:components.groups.advancedSearch.form.inputs.filterAttribute" +
+                                        ".placeholder")
                                 }
-                            ] }
-                            filterAttributePlaceholder={
-                                t("adminPortal:components.groups.advancedSearch.form.inputs.filterAttribute" +
-                                    ".placeholder")
-                            }
-                            filterConditionsPlaceholder={
-                                t("adminPortal:components.groups.advancedSearch.form.inputs.filterCondition" +
-                                    ".placeholder")
-                            }
-                            filterValuePlaceholder={
-                                t("adminPortal:components.groups.advancedSearch.form.inputs.filterValue" +
-                                    ".placeholder")
-                            }
-                            placeholder={ t("adminPortal:components.groups.advancedSearch.placeholder") }
-                            defaultSearchAttribute="displayName"
-                            defaultSearchOperator="sw"
-                            triggerClearQuery={ triggerClearQuery }
-                        />
-                    ) }
-                    data-testid="group-mgt-groups-list"
-                    handleGroupDelete={ handleOnDelete }
-                    isLoading={ isGroupsListRequestLoading }
-                    onEmptyListPlaceholderActionClick={ () => setShowWizard(true) }
-                    onSearchQueryClear={ handleSearchQueryClear }
-                    groupList={ paginatedGroups }
-                    searchQuery={ searchQuery }
-                    readOnlyUserStores={ readOnlyUserStoresList }
-                    featureConfig={ featureConfig }
-                />
+                                filterConditionsPlaceholder={
+                                    t("adminPortal:components.groups.advancedSearch.form.inputs.filterCondition" +
+                                        ".placeholder")
+                                }
+                                filterValuePlaceholder={
+                                    t("adminPortal:components.groups.advancedSearch.form.inputs.filterValue" +
+                                        ".placeholder")
+                                }
+                                placeholder={ t("adminPortal:components.groups.advancedSearch.placeholder") }
+                                defaultSearchAttribute="displayName"
+                                defaultSearchOperator="sw"
+                                triggerClearQuery={ triggerClearQuery }
+                            />
+                        ) }
+                        data-testid="group-mgt-groups-list"
+                        handleGroupDelete={ handleOnDelete }
+                        isLoading={ isGroupsListRequestLoading }
+                        onEmptyListPlaceholderActionClick={ () => setShowWizard(true) }
+                        onSearchQueryClear={ handleSearchQueryClear }
+                        groupList={ paginatedGroups }
+                        searchQuery={ searchQuery }
+                        readOnlyUserStores={ readOnlyUserStoresList }
+                        featureConfig={ featureConfig }
+                    />
+                }
             </ListLayout>
             {
                 showWizard && (

--- a/apps/console/src/features/groups/pages/groups.tsx
+++ b/apps/console/src/features/groups/pages/groups.tsx
@@ -19,7 +19,12 @@
 import { getUserStoreList } from "@wso2is/core/api";
 import { AlertInterface, AlertLevels, RolesInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ListLayout, PageLayout, PrimaryButton, EmptyPlaceholder } from "@wso2is/react-components";
+import {
+    EmptyPlaceholder,
+    ListLayout,
+    PageLayout,
+    PrimaryButton
+} from "@wso2is/react-components";
 import _ from "lodash";
 import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -28,12 +33,12 @@ import { Dropdown, DropdownItemProps, DropdownProps, Icon, PaginationProps } fro
 import {
     AdvancedSearchWithBasicFilters,
     AppState,
+    EmptyPlaceholderIllustrations,
     FeatureConfigInterface,
     SharedUserStoreUtils,
     UIConstants,
     UserStoreProperty,
-    getAUserStore,
-    EmptyPlaceholderIllustrations
+    getAUserStore
 } from "../../core";
 import { UserStorePostData } from "../../userstores";
 import { deleteGroupById, getGroupList, searchGroupList } from "../api";

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -512,12 +512,12 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                                     icon: {
                                                         icon: authenticator.id && (getFederatedAuthenticators().find(
                                                             (fedAuth) =>
-                                                            (fedAuth.authenticatorId === authenticator.id))).icon
+                                                            (fedAuth.authenticatorId === authenticator.id)))?.icon
                                                     },
                                                     id: authenticator?.id,
                                                     title: authenticator.id && (getFederatedAuthenticators().find(
                                                         (fedAuth) =>
-                                                        (fedAuth.authenticatorId === authenticator.id))).displayName
+                                                        (fedAuth.authenticatorId === authenticator.id)))?.displayName
                                                 }
                                             ]
                                         }

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -39,6 +39,7 @@ import {
     FeatureConfigInterface,
     SharedUserStoreUtils,
     UIConstants,
+    getAUserStore,
     store
 } from "../../core";
 import {
@@ -46,6 +47,11 @@ import {
     ServerConfigurationsConstants,
     getConnectorCategory
 } from "../../server-configurations";
+import {
+    UserStoreListItem,
+    UserStorePostData,
+    UserStoreProperty
+} from "../../userstores";
 import { deleteUser, getUsersList } from "../api";
 import { AddUserWizard, UsersList, UsersListOptionsComponent } from "../components";
 import { UserManagementConstants } from "../constants";
@@ -158,17 +164,17 @@ const UsersPage: FunctionComponent<any> = (): ReactElement => {
      */
     const getUserStores = () => {
         const storeOptions = [
-                {
-                    key: -2,
-                    text: t("adminPortal:components.users.userstores.userstoreOptions.all"),
-                    value: "all"
-                },
-                {
-                    key: -1,
-                    text: t("adminPortal:components.users.userstores.userstoreOptions.primary"),
-                    value: "primary"
-                }
-            ];
+            {
+                key: -2,
+                text: t("adminPortal:components.users.userstores.userstoreOptions.all"),
+                value: "all"
+            },
+            {
+                key: -1,
+                text: t("adminPortal:components.users.userstores.userstoreOptions.primary"),
+                value: "primary"
+            }
+        ];
 
         let storeOption = {
             key: null,
@@ -181,14 +187,22 @@ const UsersPage: FunctionComponent<any> = (): ReactElement => {
                 if (storeOptions === []) {
                     storeOptions.push(storeOption);
                 }
-                response.data.map((store, index) => {
-                        storeOption = {
-                            key: index,
-                            text: store.name,
-                            value: store.name
-                        };
-                        storeOptions.push(storeOption);
-                    }
+                response.data.map((store: UserStoreListItem, index) => {
+                    getAUserStore(store.id).then((response: UserStorePostData) => {
+                        const isDisabled = response.properties.find(
+                            (property: UserStoreProperty) => property.name === "Disabled").value === "true";
+
+                        if (!isDisabled) {
+                            storeOption = {
+                                key: index,
+                                text: store.name,
+                                value: store.name
+                            };
+                            storeOptions.push(storeOption);
+                        }
+                    });
+
+                }
                 );
                 setUserStoresList(storeOptions);
             });

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -96,7 +96,25 @@ const UsersPage: FunctionComponent<any> = (): ReactElement => {
 
         getUsersList(limit, offset, filter, attribute, domain)
             .then((response) => {
-                setUsersList(response);
+                const data = { ...response };
+
+                data.Resources = data.Resources.map((resource) => {
+                    let email: string = null;
+                    if (resource.emails instanceof Array) {
+                        const emailElement = resource.emails[ 0 ];
+                        if (typeof emailElement === "string") {
+                            email = emailElement;
+                        } else {
+                            email = emailElement.value;
+                        }
+                    }
+
+                    resource.emails = [email];
+
+                    return resource;
+                });
+
+                setUsersList(data);
                 setUserStoreError(false);
             }).catch((error) => {
                 dispatch(addAlert({

--- a/modules/i18n/src/models/namespaces/admin-portal-ns.ts
+++ b/modules/i18n/src/models/namespaces/admin-portal-ns.ts
@@ -589,6 +589,10 @@ export interface AdminPortalNS {
                 updateGroup: Notification;
                 createGroup: Notification;
                 createPermission: Notification;
+                fetchGroups: Notification;
+            };
+            placeholders: {
+                groupsError: Placeholder;
             };
         };
         header: {

--- a/modules/i18n/src/models/namespaces/dev-portal-ns.ts
+++ b/modules/i18n/src/models/namespaces/dev-portal-ns.ts
@@ -805,6 +805,7 @@ export interface DevPortalNS {
                     requiredErrorMessage: string;
                     invalidURLErrorMessage: string;
                     invalidQueryParamErrorMessage: string;
+                    customProperties: string;
                 };
                 generalDetails: {
                     name: FormAttributes;

--- a/modules/i18n/src/translations/en-US/portals/admin-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/admin-portal.ts
@@ -1115,6 +1115,12 @@ export const adminPortal: AdminPortalNS = {
                         message: "Group deleted successfully"
                     }
                 },
+                fetchGroups: {
+                    genericError: {
+                        description: "An error occurred while fetching groups.",
+                        message: "Something went wrong"
+                    }
+                },
                 updateGroup: {
                     error: {
                         description: "{{description}}",
@@ -1128,6 +1134,15 @@ export const adminPortal: AdminPortalNS = {
                         description: "The selected group was updated successfully.",
                         message: "Group updated successfully"
                     }
+                }
+            },
+            placeholders: {
+                groupsError: {
+                    subtitles: [
+                        "An error occurred while trying to fetch groups from the userstore.",
+                        "Please make sure that teh connection details of the userstore are accurate."
+                    ],
+                    title:"Couldn't fetch groups from the userstore"
                 }
             }
         },

--- a/modules/i18n/src/translations/en-US/portals/dev-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/dev-portal.ts
@@ -1896,6 +1896,7 @@ export const devPortal: DevPortalNS = {
                     }
                 },
                 common: {
+                    customProperties: "Custom Properties",
                     invalidQueryParamErrorMessage: "These are not valid query parameters",
                     invalidURLErrorMessage: "This is not a valid URL",
                     requiredErrorMessage: "This is required"


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/9647
> Resolves https://github.com/wso2/product-is/issues/9632
> Resolves https://github.com/wso2/product-is/issues/9496
> Partially resolves https://github.com/wso2/product-is/issues/9588

## Solution for https://github.com/wso2/product-is/issues/9496

Since we can't know for sure on which page `wso2carbon-local-sp` will appear, once the response to fetch applications is received, the response is searched for this application. If this application is found, then another request is sent with the limit incremented by one so that the list can display 10 applications after removing `wso2carbon-local-sp`. The offset is also then incremented by one to make sure that the last application is not repeated in the pages to follow. 