### PR TITLE
Fix back button issue in invalid self signup code error page

### DIFF
--- a/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/error.jsp
@@ -89,7 +89,7 @@
 
     <script>
         $(document).ready(function () {
-            // Checks if the `callback` URL param is preset, and if not, hides the `Go Back` button.
+            // Checks if the `callback` URL param is present, and if not, hides the `Go Back` button.
             if ("<%=StringUtils.isEmpty(callback)%>" === "true") {
                 $("#action-buttons").hide();
             }

--- a/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/error.jsp
@@ -89,8 +89,13 @@
 
     <script>
         function goBack() {
-            // If the self sign up code is invalid, navigate the users to the server home.
-            if ("<%=errorCode%>" === "<%=IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode()%>") {
+    
+            var errorCodeFromParams = "<%=errorCode%>";
+            var invalidConfirmationErrorCode = "<%=IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode()%>";
+
+            // Check if the error is related to the confirmation code being invalid.
+            // If so, navigate the users to the server home.
+            if (errorCodeFromParams === invalidConfirmationErrorCode) {
                 var redirect = "<%=IdentityUtil.getServerURL("", true, true)%>";
                 window.location.href = redirect;
     

--- a/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/error.jsp
@@ -21,7 +21,6 @@
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.recovery.IdentityRecoveryConstants" %>
-<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
 <jsp:directive.include file="includes/localize.jsp"/>
@@ -29,6 +28,7 @@
 <%
     String errorMsg = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorMsg"));
     String errorCode = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorCode"));
+    String callback = request.getParameter("callback");
     if (StringUtils.isBlank(errorMsg)) {
         errorMsg = IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Server.failed.to.respond");
     }
@@ -66,7 +66,7 @@
                         <p><%=IdentityManagementEndpointUtil.i18nBase64(recoveryResourceBundle, errorMsg)%></p>
                     </div>
 
-                    <div class="buttons">
+                    <div id="action-buttons" class="buttons">
                         <a href="javascript:goBack()" class="ui button primary button">
                             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Go back")%>
                         </a>
@@ -88,17 +88,23 @@
     <% } %>
 
     <script>
+        $(document).ready(function () {
+            // Checks if the `callback` URL param is preset, and if not, hides the `Go Back` button.
+            if ("<%=StringUtils.isEmpty(callback)%>" === "true") {
+                $("#action-buttons").hide();
+            }
+        });
+
         function goBack() {
-    
+
             var errorCodeFromParams = "<%=errorCode%>";
             var invalidConfirmationErrorCode = "<%=IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode()%>";
 
             // Check if the error is related to the confirmation code being invalid.
-            // If so, navigate the users to the server home.
+            // If so, navigate the users to the URL defined in `callback` URL param.
             if (errorCodeFromParams === invalidConfirmationErrorCode) {
-                var redirect = "<%=IdentityUtil.getServerURL("", true, true)%>";
-                window.location.href = redirect;
-    
+                window.location.href = "<%=callback%>";
+
                 return;
             }
     

--- a/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/error.jsp
@@ -90,12 +90,12 @@
     <script>
         function goBack() {
             // If the self sign up code is invalid, navigate the users to the server home.
-            <% if (errorCode.equalsIgnoreCase(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode())) {%>
+            if ("<%=errorCode%>" === "<%=IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode()%>") {
                 var redirect = "<%=IdentityUtil.getServerURL("", true, true)%>";
                 window.location.href = redirect;
     
                 return;
-            <%}%>
+            }
     
             window.history.back();
         }

--- a/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/error.jsp
@@ -20,6 +20,8 @@
 <%@ page isErrorPage="true" %>
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.recovery.IdentityRecoveryConstants" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
 <jsp:directive.include file="includes/localize.jsp"/>
@@ -87,6 +89,14 @@
 
     <script>
         function goBack() {
+            // If the self sign up code is invalid, navigate the users to the server home.
+            <% if (errorCode.equalsIgnoreCase(IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode())) {%>
+                var redirect = "<%=IdentityUtil.getServerURL("", true, true)%>";
+                window.location.href = redirect;
+    
+                return;
+            <%}%>
+    
             window.history.back();
         }
     </script>


### PR DESCRIPTION
## Purpose
Go Back button does not work when the self registration code is invalid.

## Goals
Fixes https://github.com/wso2/product-is/issues/9473

## Approach
Changed the back button callback function to redirect the users to the URL specified in the `callback` URL param.

Ex: In the following scenario, the user will be directed to https://localhost:9443/registration.jsp when the `Go Back` button is clicked.

https://localhost:9443/accountrecoveryendpoint/confirmliteuserregistration.do?confirmation=2c4ea233-250c-4c33-8210-96a0f0725d02&tenantdomain=carbon.super&callback=https://localhost:9443/registration.jsp

As a precaution, i added a check to hide the `Go Back` button incase if the `callback` URL param is not available for some reason.