### PR TITLE
Add expert mode SP template

### DIFF
--- a/apps/console/src/features/applications/components/meta/custom-application-template.meta.ts
+++ b/apps/console/src/features/applications/components/meta/custom-application-template.meta.ts
@@ -16,16 +16,22 @@
  * under the License.
  */
 
-import { ApplicationTemplateCategories, ApplicationTemplateListItemInterface } from "../../models";
+import { ApplicationTemplateCategories, ApplicationTemplateInterface } from "../../models";
 
-export const CustomApplicationTemplate: ApplicationTemplateListItemInterface = {
+export const CUSTOM_APPLICATION_TEMPLATE_ID: string = "custom-application";
+
+export const CustomApplicationTemplate: ApplicationTemplateInterface = {
+    application: undefined,
     authenticationProtocol: "",
-    category: ApplicationTemplateCategories.DEFAULT_CUSTOM,
+    category: ApplicationTemplateCategories.MANUAL,
     description: "Manually configure the inbound authentication protocol, authentication flow, etc.",
     displayOrder: 0,
     id: "custom-application",
     image: "customApp",
     name: "Custom Application",
     self: "",
+    subTemplates: [],
+    subTemplatesSectionTitle: "",
+    templateGroup: "",
     types: []
 };

--- a/apps/console/src/features/applications/components/wizard/application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/application-create-wizard.tsx
@@ -60,6 +60,7 @@ import {
 } from "../../models";
 import { setAuthProtocolMeta } from "../../store";
 import {
+    CUSTOM_APPLICATION_TEMPLATE_ID,
     OAuthProtocolTemplate,
     OAuthProtocolTemplateItem,
     PassiveStsProtocolTemplate,
@@ -466,7 +467,7 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
                     />
                 );
             case WizardStepsFormTypes.GENERAL_SETTINGS:
-                if (selectedTemplate.id === "custom-application") {
+                if (selectedTemplate.id === CUSTOM_APPLICATION_TEMPLATE_ID) {
                     return (
                         <GeneralSettingsWizardForm
                             triggerSubmit={ submitGeneralSettings }
@@ -609,7 +610,7 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
      */
     useEffect(() => {
         if (selectedTemplate) {
-            if (selectedTemplate.id === "custom-application") {
+            if (selectedTemplate.id === CUSTOM_APPLICATION_TEMPLATE_ID) {
                 const NEW_STEPS: WizardStepInterface[] = [ ...STEPS ];
                 setWizardSteps(NEW_STEPS.splice(1, 1));
             } else {

--- a/apps/console/src/features/applications/models/application.ts
+++ b/apps/console/src/features/applications/models/application.ts
@@ -292,7 +292,7 @@ export enum ApplicationTemplateCategories {
      */
     DEFAULT = "DEFAULT",
     /**
-     * FOr default templates groups.
+     * For default templates groups.
      * ex: web-application, mobile, desktop etc.
      * @type {string}
      */
@@ -307,7 +307,7 @@ export enum ApplicationTemplateCategories {
      * Templates added manually which are not available in the API.
      * @type {string}
      */
-    DEFAULT_CUSTOM = "DEFAULT_CUSTOM"
+    MANUAL = "MANUAL"
 }
 
 /**

--- a/apps/console/src/features/applications/pages/application-template.tsx
+++ b/apps/console/src/features/applications/pages/application-template.tsx
@@ -24,7 +24,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider, Dropdown, DropdownItemProps, DropdownProps, Grid, Icon, Input } from "semantic-ui-react";
 import { AppConstants, AppState, EmptyPlaceholderIllustrations, history } from "../../core";
-import { CustomApplicationTemplate, MinimalAppCreateWizard } from "../components";
+import { CUSTOM_APPLICATION_TEMPLATE_ID, CustomApplicationTemplate, MinimalAppCreateWizard } from "../components";
 import { ApplicationTemplateIllustrations } from "../configs";
 import { ApplicationManagementConstants } from "../constants";
 import { ApplicationTemplateCategories, ApplicationTemplateListItemInterface } from "../models";
@@ -156,16 +156,20 @@ const ApplicationTemplateSelectPage: FunctionComponent<ApplicationTemplateSelect
      */
     const handleTemplateSelection = (e: SyntheticEvent, { id }: { id: string }): void => {
 
+        if (id === CUSTOM_APPLICATION_TEMPLATE_ID) {
+            setSelectedTemplate(CustomApplicationTemplate);
+            setShowWizard(true);
+
+            return;
+        }
+
         const selected = applicationTemplates?.find((template) => template.id === id);
 
-        if (id === "custom-application") {
-            setSelectedTemplate(CustomApplicationTemplate);
-        } else {
-            if (!selected) {
-                return;
-            }
-            setSelectedTemplate(selected);
+        if (!selected) {
+            return;
         }
+
+        setSelectedTemplate(selected);
         setShowWizard(true);
     };
 
@@ -259,7 +263,11 @@ const ApplicationTemplateSelectPage: FunctionComponent<ApplicationTemplateSelect
                     <div className="templates quick-start-templates">
                         {
                             renderTemplateGrid(
-                                [ ApplicationTemplateCategories.DEFAULT, ApplicationTemplateCategories.DEFAULT_GROUP ],
+                                [
+                                    ApplicationTemplateCategories.DEFAULT,
+                                    ApplicationTemplateCategories.DEFAULT_GROUP,
+                                    ApplicationTemplateCategories.MANUAL
+                                ],
                                 {
                                     "data-testid": `${ testId }-quick-start-template-grid`,
                                     heading: "General Applications",
@@ -427,6 +435,7 @@ const ApplicationTemplateSelectPage: FunctionComponent<ApplicationTemplateSelect
                     subTitle={ selectedTemplate?.description }
                     closeWizard={ (): void => setShowWizard(false) }
                     template={ selectedTemplate }
+                    showHelpPanel={ selectedTemplate.id !== CUSTOM_APPLICATION_TEMPLATE_ID }
                     subTemplates={ selectedTemplate?.subTemplates }
                     subTemplatesSectionTitle={ selectedTemplate?.subTemplatesSectionTitle }
                     addProtocol={ false }


### PR DESCRIPTION
## Purpose
If a user needs to add a protocol like Passive STS & WS-Trust, they have to create an Application with an unrelated protocol and then add the desired protocol at the edit page

## Goals
Fixes https://github.com/wso2/product-is/issues/9715

## Approach
Add an `Custom Application` template which only takes the application name as an input.