### PR TITLE
Add ability to configure base URLs for SDK init object

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -159,10 +159,34 @@ export const initializeAuthentication = () => (dispatch) => {
         ? Storage.SessionStorage
         : Storage.WebWorker;
 
+    /**
+     * By specifying the base URL, we are restricting the endpoints to which the requests could be sent.
+     * So, an attacker can't obtain the token by sending a request to their endpoint. This is mandatory
+     * when the storage is set to Web Worker.
+     *
+     * @return {string[]}
+     */
+    const resolveBaseUrls = (): string[] => {
+        
+        let baseUrls = window["AppUtils"].getConfig().idpConfigs?.baseUrls;
+        const serverOrigin = window["AppUtils"].getConfig().serverOrigin;
+
+        if (baseUrls) {
+            // If the server origin is not specified in the overridden config, append it.
+            if (!baseUrls.includes(serverOrigin)) {
+                baseUrls = [ ...baseUrls, serverOrigin ];
+            }
+
+            return baseUrls;
+        }
+
+        return [ serverOrigin ];
+    };
+
     const initialize = (response?: any): void => {
         auth.initialize({
             authorizationCode: response?.data?.authCode,
-            baseUrls: [window["AppUtils"].getConfig().serverOrigin],
+            baseUrls: resolveBaseUrls(),
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             enablePKCE: window["AppUtils"].getConfig().idpConfigs?.enablePKCE


### PR DESCRIPTION
## Purpose
Base URLs are required for the SDK init object if the storage is set to `web worker`. By default, only `serverOrigin` added but these URLs are not configurable ATM.

## Goals
This PR adds the ability for the base URLs to be configured through `deployment.toml`.
Fixes https://github.com/wso2/product-is/issues/9792

## Approach

**For Console**

```toml
[console.idp_configs]
baseUrls = [ "https://localhost:8444" ]
```

**For My Account**

```toml
[myaccount.idp_configs]
baseUrls = [ "https://localhost:8444" ]
```
