### PR TITLE
Identity Provider Management integration tests

### DIFF
--- a/apps/console/src/features/identity-providers/components/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/components/identity-provider-edit.tsx
@@ -196,6 +196,7 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
     return (
         identityProvider && (
             <ResourceTab
+                data-testid={ `${ testId }-resource-tabs` }
                 panes={ getPanes() }
             />
         )

--- a/apps/console/src/features/identity-providers/components/identity-provider-list.tsx
+++ b/apps/console/src/features/identity-providers/components/identity-provider-list.tsx
@@ -192,7 +192,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                             { searchQuery: searchQuery }),
                         t("devPortal:components.idp.placeHolders.emptyIDPSearchResults.subtitles.1")
                     ] }
-                    data-testid={ `${ testId }-empty-search-results-placeholder` }
+                    data-testid={ `${ testId }-empty-search-placeholder` }
                 />
             );
         }
@@ -216,7 +216,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                         t("devPortal:components.idp.placeHolders.emptyIDPList.subtitles.1"),
                         t("devPortal:components.idp.placeHolders.emptyIDPList.subtitles.2")
                     ] }
-                    data-testid={ `${ testId }-empty-idp-list-placeholder` }
+                    data-testid={ `${ testId }-empty-placeholder` }
                 />
             );
         }
@@ -237,7 +237,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                 id: "name",
                 key: "name",
                 render: (idp: IdentityProviderInterface): ReactNode => (
-                    <Header as="h6" image>
+                    <Header as="h6" image data-testid={ `${ testId }-item-heading` }>
                         {
                             idp.image
                                 ? (
@@ -258,7 +258,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                         }
                         <Header.Content>
                             { idp.name }
-                            <Header.Subheader>
+                            <Header.Subheader data-testid={ `${ testId }-item-sub-heading` }>
                                 { idp.description }
                             </Header.Subheader>
                         </Header.Content>
@@ -289,6 +289,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
 
         return [
             {
+                "data-testid": `${ testId }-item-edit-button`,
                 hidden: (): boolean => false,
                 icon: (): SemanticICONS => "pencil alternate",
                 onClick: (e: SyntheticEvent, idp: IdentityProviderInterface): void =>
@@ -297,6 +298,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                 renderer: "semantic-icon"
             },
             {
+                "data-testid": `${ testId }-item-delete-button`,
                 hidden: (idp: IdentityProviderInterface): boolean =>
                     IdentityProviderManagementConstants.DELETING_FORBIDDEN_IDPS.includes(idp.name),
                 icon: (): SemanticICONS => "trash alternate",
@@ -329,7 +331,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                 selectable={ selection }
                 showHeader={ false }
                 transparent={ !isLoading && (showPlaceholders() !== null) }
-                data-testid={ `${ testId }-resource-list` }
+                data-testid={ testId }
             />
             {
                 deletingIDP && (
@@ -355,16 +357,20 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                         onPrimaryActionClick={
                             (): void => handleIdentityProviderDelete(deletingIDP.id)
                         }
-                        data-testid={ `${ testId }-delete-confirmation` }
+                        data-testid={ `${ testId }-delete-confirmation-modal` }
                         closeOnDimmerClick={ false }
                     >
-                        <ConfirmationModal.Header>
+                        <ConfirmationModal.Header data-testid={ `${ testId }-delete-confirmation-modal-header` }>
                             { t("devPortal:components.idp.confirmations.deleteIDP.header") }
                         </ConfirmationModal.Header>
-                        <ConfirmationModal.Message attached warning>
+                        <ConfirmationModal.Message
+                            attached
+                            warning
+                            data-testid={ `${ testId }-delete-confirmation-modal-message` }
+                        >
                             { t("devPortal:components.idp.confirmations.deleteIDP.message") }
                         </ConfirmationModal.Message>
-                        <ConfirmationModal.Content>
+                        <ConfirmationModal.Content data-testid={ `${ testId }-delete-confirmation-modal-content` }>
                             { t("devPortal:components.idp.confirmations.deleteIDP.content") }
                         </ConfirmationModal.Content>
                     </ConfirmationModal>

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/attribute-selection.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/attribute-selection.tsx
@@ -75,18 +75,18 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
         setShowSelectionModal(true);
     };
 
-    const addSelectionModal = (() => {
-            return <AttributeSelectionWizard
+    const addSelectionModal = (): ReactElement => {
+        return (
+            <AttributeSelectionWizard
                 attributesList={ attributeList }
                 selectedAttributes={ selectedAttributesWithMapping }
                 setSelectedAttributes={ setSelectedAttributesWithMapping }
                 showAddModal={ showSelectionModal }
                 setShowAddModal={ setShowSelectionModal }
-                data-testid={ `${ testId }-attribute-selection-wizard` }
+                data-testid={ `${ testId }-wizard` }
             />
-        }
-    );
-
+        );
+    };
 
     const updateAttributeMapping = (mapping: IdentityProviderCommonClaimMappingInterface): void => {
         setSelectedAttributesWithMapping(
@@ -97,117 +97,136 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
         );
     };
 
-    return (
-        (selectedAttributesWithMapping || searchFilter) &&
-        <>
-            <Grid.Row data-testid={ testId }>
-                <Grid.Column computer={ 10 }>
-                    { uiProps.enablePrecedingDivider && <Divider/> }
-                    <Heading as="h4">
-                        { uiProps.componentHeading }
-                    </Heading>
-                    <Hint>
-                        { uiProps.hint }
-                    </Hint>
-                    <Divider hidden/>
-                    {
-                        (selectedAttributesWithMapping?.length > 0) ? (
-                            <Segment.Group fluid>
-                                <Segment className="user-role-edit-header-segment clearing">
-                                    <Grid.Row>
-                                        <Table basic="very" compact>
-                                            <Table.Body>
-                                                <Table.Row>
-                                                    <Table.Cell>
-                                                        <Input
-                                                            icon={ <Icon name="search"/> }
-                                                            onChange={ handleSearch }
-                                                            placeholder={ t("devPortal:components.idp.forms." +
-                                                                "attributeSettings.attributeSelection." +
-                                                                "searchAttributes.placeHolder") }
-                                                            floated="left"
-                                                            size="small"
-                                                        />
-                                                    </Table.Cell>
-                                                    <Table.Cell textAlign="right">
-                                                        <Button
-                                                            size="medium"
-                                                            icon="pencil"
-                                                            floated="right"
-                                                            onClick={ handleOpenSelectionModal }
-                                                        />
-                                                    </Table.Cell>
-                                                </Table.Row>
-                                            </Table.Body>
-                                        </Table>
-                                    </Grid.Row>
-                                    <Grid.Row>
-                                        <Table singleLine compact>
-                                            <Table.Header>
-                                                {
-                                                    (
-                                                        <Table.Row>
-                                                            <Table.HeaderCell>
-                                                                <strong>{ uiProps.attributeColumnHeader }</strong>
-                                                            </Table.HeaderCell>
-                                                            <Table.HeaderCell>
-                                                                <strong>{ uiProps.attributeMapColumnHeader }</strong>
-                                                            </Table.HeaderCell>
-                                                        </Table.Row>
-                                                    )
+    const renderMappingTable = (): ReactElement => (
+        <Segment.Group fluid>
+            <Segment data-testid={ testId } className="user-role-edit-header-segment clearing">
+                <Grid.Row>
+                    <Table data-testid={ `${ testId }-action-bar` } basic="very" compact>
+                        <Table.Body>
+                            <Table.Row>
+                                <Table.Cell>
+                                    <Input
+                                        icon={ <Icon name="search"/> }
+                                        onChange={ handleSearch }
+                                        placeholder={
+                                            t("devPortal:components.idp.forms." +
+                                                "attributeSettings.attributeSelection." +
+                                                "searchAttributes.placeHolder")
+                                        }
+                                        floated="left"
+                                        size="small"
+                                        data-testid={ `${ testId }-search` }
+                                    />
+                                </Table.Cell>
+                                <Table.Cell textAlign="right">
+                                    <Button
+                                        size="medium"
+                                        icon="pencil"
+                                        floated="right"
+                                        onClick={ handleOpenSelectionModal }
+                                        data-testid={ `${ testId }-edit-button` }
+                                    />
+                                </Table.Cell>
+                            </Table.Row>
+                        </Table.Body>
+                    </Table>
+                </Grid.Row>
+                <Grid.Row>
+                    <Table data-testid={ `${ testId }-list` } singleLine compact>
+                        <Table.Header>
+                            {
+                                (
+                                    <Table.Row>
+                                        <Table.HeaderCell>
+                                            <strong>
+                                                { uiProps.attributeColumnHeader }
+                                            </strong>
+                                        </Table.HeaderCell>
+                                        <Table.HeaderCell>
+                                            <strong>
+                                                { uiProps.attributeMapColumnHeader }
+                                            </strong>
+                                        </Table.HeaderCell>
+                                    </Table.Row>
+                                )
+                            }
+                        </Table.Header>
+                        <Table.Body>
+                            {
+                                selectedAttributesWithMapping?.filter((mapping) =>
+                                    _.isEmpty(searchFilter)
+                                        ? true
+                                        : mapping?.claim?.displayName?.startsWith(searchFilter)
+                                )?.sort((a, b) => a.claim.displayName.localeCompare(b.claim.displayName)
+                                )?.map((mapping) => {
+                                        return (
+                                            <AttributeListItem
+                                                key={ mapping?.claim.id }
+                                                attribute={ mapping?.claim }
+                                                placeholder={
+                                                    uiProps.attributeMapInputPlaceholderPrefix
+                                                    + mapping?.claim.displayName
                                                 }
-                                            </Table.Header>
-                                            <Table.Body>
-                                                { selectedAttributesWithMapping?.filter(
-                                                    mapping => _.isEmpty(searchFilter) ? true :
-                                                        mapping?.claim?.displayName?.startsWith(searchFilter)
-                                                )?.sort(
-                                                    (a, b) =>
-                                                        a.claim.displayName.localeCompare(b.claim.displayName)
-                                                )?.map(
-                                                    mapping => {
-                                                        return (
-                                                            <AttributeListItem
-                                                                key={ mapping?.claim.id }
-                                                                attribute={ mapping?.claim }
-                                                                placeholder={ uiProps.attributeMapInputPlaceholderPrefix
-                                                                + mapping?.claim.displayName }
-                                                                updateMapping={ updateAttributeMapping }
-                                                                mapping={ mapping?.mappedValue }
-                                                                data-testid={ `${ testId }-attribute-list-item-${ 
-                                                                    mapping?.claim.id }` }
-                                                            />
-                                                        )
-                                                    }
-                                                ) }
-                                            </Table.Body>
-                                        </Table>
-                                    </Grid.Row>
-                                </Segment>
-                            </Segment.Group>
-                        ) : (
-                            <Segment>
-                                <EmptyPlaceholder
-                                    title={ t("devPortal:components.idp.placeHolders.noAttributes.title") }
-                                    subtitle={ [
-                                        t("devPortal:components.idp.placeHolders.noAttributes.subtitles.0")
-                                    ] }
-                                    action={
-                                        <PrimaryButton onClick={ handleOpenSelectionModal } icon="plus">
-                                            { t("devPortal:components.idp.buttons.addAttribute") }
-                                        </PrimaryButton>
+                                                updateMapping={ updateAttributeMapping }
+                                                mapping={ mapping?.mappedValue }
+                                                data-testid={
+                                                    `${ testId }-attribute-list-item-${
+                                                        mapping?.claim.id }`
+                                                }
+                                            />
+                                        )
                                     }
-                                    image={ EmptyPlaceholderIllustrations.emptyList }
-                                    imageSize="tiny"
-                                    data-testid={ `${ testId }-empty-placeholder` }
-                                />
-                            </Segment>
-                        )
-                    }
-                </Grid.Column>
-            </Grid.Row>
-            { addSelectionModal() }
-        </>
+                                )
+                            }
+                        </Table.Body>
+                    </Table>
+                </Grid.Row>
+            </Segment>
+        </Segment.Group>
+    );
+
+    return (
+        (selectedAttributesWithMapping || searchFilter)
+            ? (
+                <>
+                    <Grid.Row data-testid={ `${ testId }-section` }>
+                        <Grid.Column computer={ 10 }>
+                            { uiProps.enablePrecedingDivider && <Divider/> }
+                            <Heading as="h4">
+                                { uiProps.componentHeading }
+                            </Heading>
+                            <Hint>
+                                { uiProps.hint }
+                            </Hint>
+                            <Divider hidden/>
+                            {
+                                (selectedAttributesWithMapping?.length > 0)
+                                    ? renderMappingTable()
+                                    : (
+                                        <Segment data-testid={ testId }>
+                                            <EmptyPlaceholder
+                                                title={ t("devPortal:components.idp.placeHolders.noAttributes.title") }
+                                                subtitle={ [
+                                                    t("devPortal:components.idp.placeHolders.noAttributes.subtitles.0")
+                                                ] }
+                                                action={
+                                                    <PrimaryButton onClick={ handleOpenSelectionModal } icon="plus">
+                                                        { t("devPortal:components.idp.buttons.addAttribute") }
+                                                    </PrimaryButton>
+                                                }
+                                                image={ EmptyPlaceholderIllustrations.emptyList }
+                                                imageSize="tiny"
+                                                data-testid={ `${ testId }-empty-placeholder` }
+                                            />
+                                        </Segment>
+                                    )
+                            }
+                        </Grid.Column>
+                    </Grid.Row>
+                    { addSelectionModal() }
+                </>
+            )
+            : null
     );
 };
 

--- a/apps/console/src/features/identity-providers/components/settings/general-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/general-settings.tsx
@@ -197,7 +197,10 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
                                             i18nKey="devPortal:components.idp.confirmations.deleteIDP.assertionHint"
                                             tOptions={ { name: name } }
                                         >
-                                            Please type <strong>{ name }</strong> to confirm.
+                                            Please type
+                                            <strong data-testid="idp-name-assertion">
+                                                { name }
+                                            </strong> to confirm.
                                         </Trans>
                                     </p>
                                 ) }

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
@@ -162,7 +162,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesPropsInterface> =
                                 }
                             ] }
                             value={ editingIDP?.certificate?.certificates ? "PEM" : "JWKS" }
-                            data-testid={ `${ testId }-certificate` }
+                            data-testid={ `${ testId }-certificate-type-radio-group` }
                         />
                         <Hint>
                             { t("devPortal:components.idp.forms.advancedConfigs.certificateType.hint") }

--- a/apps/console/src/features/identity-providers/components/wizards/identity-provider-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/identity-provider-create-wizard.tsx
@@ -33,6 +33,7 @@ import {
     getOutboundProvisioningConnectorMetadata
 } from "../../api";
 import { IdentityProviderWizardStepIcons } from "../../configs";
+import { IdentityProviderManagementConstants } from "../../constants";
 import {
     AuthenticatorPropertyInterface,
     CommonPluggableComponentPropertyInterface,
@@ -160,8 +161,12 @@ export const IdentityProviderCreateWizard: FunctionComponent<IdentityProviderCre
                 if (!_.isEmpty(response.headers.location)) {
                     const location = response.headers.location;
                     const createdIdpID = location.substring(location.lastIndexOf("/") + 1);
-                    history.push(AppConstants.getPaths().get("IDP_EDIT").replace(":id",
-                        createdIdpID));
+
+                    history.push({
+                        pathname: AppConstants.getPaths().get("IDP_EDIT").replace(":id", createdIdpID),
+                        search: IdentityProviderManagementConstants.NEW_IDP__URL_SEARCH_PARAM
+                    });
+
                     return;
                 }
 

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -55,6 +55,21 @@ export class IdentityProviderManagementConstants {
     public static readonly DELETING_FORBIDDEN_IDPS: string[] = [];
 
     /**
+     * Key for the URL search param for IDP state.
+     * @constant
+     * @type {string}
+     */
+    public static readonly IDP_STATE_URL_SEARCH_PARAM_KEY = "state";
+
+    /**
+     * URL Search param for newly created IDPs.
+     * @constant
+     * @type {string}
+     */
+    public static readonly NEW_IDP__URL_SEARCH_PARAM = `?${
+        IdentityProviderManagementConstants.IDP_STATE_URL_SEARCH_PARAM_KEY }=new`;
+
+    /**
      * Doc key for the IDP create page.
      * @constant
      * @type {string}

--- a/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
@@ -265,6 +265,7 @@ const IdentityProviderEditPage: FunctionComponent<IDPEditPagePropsInterface> = (
                         )
                 }
                 backButton={ {
+                    "data-testid": `${ testId }-page-back-button`,
                     onClick: handleBackButtonClick,
                     text: t("devPortal:pages.idpTemplate.backButton")
                 } }

--- a/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
@@ -461,11 +461,13 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
                 contentTopMargin={ true }
                 description={ t("devPortal:pages.idpTemplate.subTitle") }
                 backButton={ {
+                    "data-testid": `${ testId }-page-back-button`,
                     onClick: handleBackButtonClick,
                     text: t("devPortal:pages.idpTemplate.backButton")
                 } }
                 titleTextAlign="left"
                 bottomMargin={ false }
+                data-testid={ `${ testId }-page-layout` }
                 showBottomDivider
             >
                 {
@@ -503,6 +505,7 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
                                         />
                                     ) }
                                     tagsSectionTitle={ t("common:services") }
+                                    data-testid={ `${ testId }-quick-start-template-grid` }
                                 />
                             </div>
                         )
@@ -536,6 +539,7 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
                             />
                         ) }
                         tagsSectionTitle={ t("common:services") }
+                        data-testid={ `${ testId }-manual-setup-template-grid` }
                     />
                 </div>
                 { showWizard && (

--- a/tests/integration/applications/basic-application.spec.ts
+++ b/tests/integration/applications/basic-application.spec.ts
@@ -128,7 +128,7 @@ describe("ITC-2.0.0 - [applications] - Basic Applications Integration.", () => {
             applicationEditPage.getPEMCertPreviewModal().should("not.be.visible");
         });
 
-        it.skip("ITC-2.3.3 - [applications] - Can provide a valid certificate file and preview it.", () => {
+        it("ITC-2.3.3 - [applications] - Can provide a valid certificate file and preview it.", () => {
             applicationEditPage.getCustomCertRadio().click({ force: true });
             cy.fixture(ApplicationEditPageConstants.SAMPLE_VALID_PEM_FILE_PATH)
                 .then((value: string) => {

--- a/tests/integration/identity-providers/constants/identity-provider-edit-page-constants.ts
+++ b/tests/integration/identity-providers/constants/identity-provider-edit-page-constants.ts
@@ -40,6 +40,8 @@ export class IdentityProviderEditPageConstants {
     public static readonly PAGE_LAYOUT_HEADER_SUB_TITLE_DATA_ATTR: string = "idp-edit-page-page-layout-page-header-" +
         "sub-title";
     public static readonly PAGE_LAYOUT_HEADER_BACK_BUTTON_DATA_ATTR: string = "idp-edit-page-page-back-button";
+    public static readonly PAGE_LAYOUT_HEADER_IMAGE_WRAPPER_DATA_ATTR: string = "idp-edit-page-page-layout-page-" +
+        "header-image";
 
     // Tabs
     public static readonly RESOURCE_TABS_DATA_ATTR: string = "idp-edit-page-resource-tabs";
@@ -55,6 +57,7 @@ export class IdentityProviderEditPageConstants {
     public static readonly IDP_CERT_RADIO_GROUP_DATA_ATTR: string = "idp-edit-advance-settings-certificate-type-" +
         "radio-group";
     public static readonly IDP_CERT_JWKS_URL_INPUT_DATA_ATTR: string = "add-idp-jwks-endpoint-form-certificate-jwks";
+    public static readonly IDP_CERT_UPDATE_BUTTON_DATA_ATTR: string = "add-idp-jwks-endpoint-form-save-button";
     // Danger Zone
     public static readonly DANGER_ZONE_DELETE_BUTTON_DATA_ATTR: string = "idp-edit-page-general-settings-" +
         "delete-idp-danger-zone-delete-button";

--- a/tests/integration/identity-providers/constants/identity-provider-edit-page-constants.ts
+++ b/tests/integration/identity-providers/constants/identity-provider-edit-page-constants.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/**
+ * Class containing Identity Provider Edit Page constants.
+ */
+export class IdentityProviderEditPageConstants {
+
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     *
+     * @hideconstructor
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private constructor() { }
+
+    // URL Matcher
+    public static readonly PAGE_URL_MATCHER: string = "?state=new";
+
+    // Page Layout.
+    public static readonly PAGE_LAYOUT_HEADER_DATA_ATTR: string = "idp-edit-page-page-layout-page-header";
+    public static readonly PAGE_LAYOUT_HEADER_TITLE_DATA_ATTR: string = "idp-edit-page-page-layout-page-header-title";
+    public static readonly PAGE_LAYOUT_HEADER_SUB_TITLE_DATA_ATTR: string = "idp-edit-page-page-layout-page-header-" +
+        "sub-title";
+    public static readonly PAGE_LAYOUT_HEADER_BACK_BUTTON_DATA_ATTR: string = "idp-edit-page-back-button";
+
+    // Tabs
+    public static readonly RESOURCE_TABS_DATA_ATTR: string = "idp-edit-resource-tabs";
+    public static readonly RESOURCE_TABS_MENU_DATA_ATTR: string = "div[class=\"ui pointing secondary menu\"";
+
+    // General Settings Form
+    public static readonly IDP_NAME_INPUT_DATA_ATTR: string = "idp-edit-page-general-settings-form-idp-name";
+    public static readonly IDP_DESCRIPTION_INPUT_DATA_ATTR: string = "idp-edit-page-general-settings-form-idp-description";
+    public static readonly IDP_IMAGE_INPUT_DATA_ATTR: string = "idp-edit-page-general-settings-form-idp-image";
+    public static readonly GENERAL_SETTINGS_SUBMIT_BUTTON_DATA_ATTR: string = "idp-edit-page-general-settings-form-" +
+        "update-button";
+    // Certificates section
+    public static readonly IDP_CERT_RADIO_GROUP_DATA_ATTR: string = "idp-edit-advance-settings-certificate-type-" +
+        "radio-group";
+    public static readonly IDP_CERT_JWKS_URL_INPUT_DATA_ATTR: string = "add-idp-jwks-endpoint-form-certificate-jwks";
+    // Danger Zone
+    public static readonly DANGER_ZONE_DELETE_BUTTON_DATA_ATTR: string = "idp-edit-page-general-settings-" +
+        "delete-idp-danger-zone-delete-button";
+    public static readonly IDP_DELETE_ASSERTION_DATA_ATTR: string = "idp-name-assertion";
+    public static readonly IDP_DELETE_ASSERTION_INPUT_DATA_ATTR: string = "idp-edit-page-general-settings-delete-idp" +
+        "-confirmation-assertion-input";
+    public static readonly IDP_DELETE_CONFIRM_BUTTON_DATA_ATTR: string = "idp-edit-page-general-settings-delete-" +
+        "idp-confirmation-confirm-button";
+    public static readonly IDP_DELETE_CONFIRM_MODAL_CLOSE_BUTTON_DATA_ATTR: string = "idp-edit-page-general-settings" +
+        "-delete-idp-confirmation-cancel-button";
+}

--- a/tests/integration/identity-providers/constants/identity-provider-edit-page-constants.ts
+++ b/tests/integration/identity-providers/constants/identity-provider-edit-page-constants.ts
@@ -39,10 +39,10 @@ export class IdentityProviderEditPageConstants {
     public static readonly PAGE_LAYOUT_HEADER_TITLE_DATA_ATTR: string = "idp-edit-page-page-layout-page-header-title";
     public static readonly PAGE_LAYOUT_HEADER_SUB_TITLE_DATA_ATTR: string = "idp-edit-page-page-layout-page-header-" +
         "sub-title";
-    public static readonly PAGE_LAYOUT_HEADER_BACK_BUTTON_DATA_ATTR: string = "idp-edit-page-back-button";
+    public static readonly PAGE_LAYOUT_HEADER_BACK_BUTTON_DATA_ATTR: string = "idp-edit-page-page-back-button";
 
     // Tabs
-    public static readonly RESOURCE_TABS_DATA_ATTR: string = "idp-edit-resource-tabs";
+    public static readonly RESOURCE_TABS_DATA_ATTR: string = "idp-edit-page-resource-tabs";
     public static readonly RESOURCE_TABS_MENU_DATA_ATTR: string = "div[class=\"ui pointing secondary menu\"";
 
     // General Settings Form

--- a/tests/integration/identity-providers/constants/identity-provider-edit-page-constants.ts
+++ b/tests/integration/identity-providers/constants/identity-provider-edit-page-constants.ts
@@ -68,4 +68,31 @@ export class IdentityProviderEditPageConstants {
         "idp-confirmation-confirm-button";
     public static readonly IDP_DELETE_CONFIRM_MODAL_CLOSE_BUTTON_DATA_ATTR: string = "idp-edit-page-general-settings" +
         "-delete-idp-confirmation-cancel-button";
+
+    //Attribute selection
+    public static readonly CLAIM_ATTR_SELECT_WIZARD_DATA_ATTR: string = "idp-edit-page-attribute-settings-" +
+        "claim-attribute-selection-wizard-modal-header";
+    public static readonly CLAIM_ATTR_SELECT_WIZARD_UNSELECTED_LIST_DATA_ATTR: string = "idp-edit-page-" +
+        "attribute-settings-claim-attribute-selection-wizard-modal-content-unselected-groups";
+    public static readonly CLAIM_ATTR_SELECT_WIZARD_SELECTED_LIST_DATA_ATTR: string = "idp-edit-page-attribute-" +
+        "settings-claim-attribute-selection-wizard-modal-content-selected-groups";
+    public static readonly CLAIM_ATTR_SELECT_WIZARD_LIST_ADD_BUTTON_DATA_ATTR: string = "idp-edit-page-" +
+        "attribute-settings-claim-attribute-selection-wizard-modal-content-unselected-groups-add-button";
+    public static readonly CLAIM_ATTR_SELECT_WIZARD_LIST_REMOVE_BUTTON_DATA_ATTR: string = "idp-edit-page-" +
+        "attribute-settings-claim-attribute-selection-wizard-modal-content-unselected-groups-remove-button";
+    public static readonly CLAIM_ATTR_SELECT_WIZARD_LIST_SAVE_BUTTON_DATA_ATTR: string = "idp-edit-page-" +
+        "attribute-settings-claim-attribute-selection-wizard-modal-save-button";
+    public static readonly CLAIM_ATTR_SELECT_WIZARD_LIST_CANCEL_BUTTON_DATA_ATTR: string = "idp-edit-page-" +
+        "attribute-settings-claim-attribute-selection-wizard-modal-cancel-button";
+
+    public static readonly CLAIM_ATTR_SELECT_LIST_DATA_ATTR: string = "idp-edit-page-attribute-settings-claim-" +
+        "attribute-selection";
+    public static readonly CLAIM_ATTR_SELECT_LIST_EMPTY_PLACEHOLDER_DATA_ATTR: string = "idp-edit-page-" +
+        "attribute-settings-claim-attribute-selection-empty-placeholder";
+    public static readonly CLAIM_ATTR_SELECT_LIST_EMPTY_PLACEHOLDER_ACTION_DATA_ATTR: string = "idp-edit-page-" +
+        "attribute-settings-claim-attribute-selection-empty-placeholder-action-container";
+    public static readonly CLAIM_ATTR_SELECT_LIST_EDIT_BUTTON_DATA_ATTR: string = "idp-edit-page-" +
+        "attribute-settings-claim-attribute-selection-edit-button";
+    public static readonly SUBJECT_ATTRIBUTE_DROPDOWN_DATA_ATTR: string = "application-edit-attribute-settings-" +
+        "advanced-attribute-settings-form-subject-attribute-dropdown";
 }

--- a/tests/integration/identity-providers/constants/identity-provider-templates-page-constants.ts
+++ b/tests/integration/identity-providers/constants/identity-provider-templates-page-constants.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/**
+ * Class containing IDP Templates Page constants.
+ */
+export class IdentityProviderTemplatesPageConstants {
+
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     *
+     * @hideconstructor
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private constructor() { }
+
+    // URL Matcher
+    public static readonly PAGE_URL_MATCHER: string = "/identity-providers/templates";
+
+    // Page Layout.
+    public static readonly PAGE_LAYOUT_HEADER_DATA_ATTR: string = "idp-templates-page-layout-page-header";
+    public static readonly PAGE_LAYOUT_HEADER_TITLE_DATA_ATTR: string = "idp-templates-page-layout-page-" +
+        "header-title";
+    public static readonly PAGE_LAYOUT_HEADER_SUB_TITLE_DATA_ATTR: string = "idp-templates-page-layout-page-" +
+        "header-sub-title";
+    public static readonly PAGE_LAYOUT_HEADER_BACK_BUTTON_DATA_ATTR: string = "idp-templates-page-back-button";
+
+    // Application template types.
+    public static readonly QUICK_START_TEMPLATE_GRID: string = "idp-templates-quick-start-template-grid";
+    public static readonly MANUAL_SETUP_TEMPLATE_GRID: string = "idp-templates-manual-setup-template-grid";
+
+    public static readonly GOOGLE_IDP_TEMPLATE_CARD_DATA_ATTR: string = "8ea23303-49c0-4253-b81f-82c0fe6fb4a0";
+    public static readonly FACEBOOK_IDP_TEMPLATE_CARD_DATA_ATTR: string = "d7c8549f-32af-4f53-9013-f66f1a6c67bf";
+    public static readonly OIDC_IDP_TEMPLATE_CARD_DATA_ATTR: string = "63501347-128b-45a8-8a0b-fc80e411a688";
+
+    public static readonly EXPERT_IDP_TEMPLATE_CARD_DATA_ATTR: string = "expert-mode";
+    
+    // Creation Wizard
+    public static readonly CREATION_WIZARD_DATA_ATTR: string = "idp-edit-idp-create-wizard-modal";
+    public static readonly CREATION_WIZARD_IDP_NAME_INPUT_DATA_ATTR: string = "idp-edit-idp-create-wizard-general-" +
+        "settings-idp-name";
+    public static readonly CREATION_WIZARD_IDP_DESCRIPTION_DATA_ATTR: string = "idp-edit-idp-create-wizard-general-" +
+        "settings-idp-description";
+    public static readonly CREATION_WIZARD_IDP_IMAGE_DATA_ATTR: string = "idp-edit-idp-create-wizard-general-" +
+        "settings-idp-image";
+    public static readonly CREATION_WIZARD_NEXT_BUTTON_DATA_ATTR: string = "idp-edit-idp-create-wizard-modal-next" +
+        "-button";
+    public static readonly CREATION_WIZARD_CANCEL_BUTTON_DATA_ATTR: string = "idp-edit-idp-create-wizard-modal-" +
+        "cancel-button";
+}

--- a/tests/integration/identity-providers/constants/identity-provider-templates-page-constants.ts
+++ b/tests/integration/identity-providers/constants/identity-provider-templates-page-constants.ts
@@ -62,6 +62,8 @@ export class IdentityProviderTemplatesPageConstants {
         "settings-idp-image";
     public static readonly CREATION_WIZARD_NEXT_BUTTON_DATA_ATTR: string = "idp-edit-idp-create-wizard-modal-next" +
         "-button";
+    public static readonly CREATION_WIZARD_FINISH_BUTTON_DATA_ATTR: string = "idp-edit-idp-create-wizard-modal-" +
+        "finish-button";
     public static readonly CREATION_WIZARD_CANCEL_BUTTON_DATA_ATTR: string = "idp-edit-idp-create-wizard-modal-" +
         "cancel-button";
 }

--- a/tests/integration/identity-providers/constants/identity-providers-list-page-constants.ts
+++ b/tests/integration/identity-providers/constants/identity-providers-list-page-constants.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/**
+ * Class containing Identity Providers List Page constants.
+ */
+export class IdentityProvidersListPageConstants {
+
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     *
+     * @hideconstructor
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private constructor() { }
+
+    // URL Matcher
+    public static readonly PAGE_URL_MATCHER: string = "/identity-providers";
+
+    // Table
+    public static readonly TABLE_DATA_ATTR: string = "idp-list";
+    public static readonly TABLE_BODY_DATA_ATTR: string = "data-table-body";
+    public static readonly TABLE_ROW_DATA_ATTR: string = "data-table-row";
+    public static readonly TABLE_ROW_HEADING_DATA_ATTR: string = "idp-list-item-heading";
+    public static readonly TABLE_ROW_EDIT_BUTTON_DATA_ATTR: string = "idp-list-item-edit-button";
+    public static readonly TABLE_ROW_DELETE_BUTTON_DATA_ATTR: string = "idp-list-item-delete-button";
+    public static readonly TABLE_ROW_IMAGE_DATA_ATTR: string = "idp-list-item-image";
+    public static readonly NEW_LIST_PLACEHOLDER: string = "idp-list-empty-placeholder";
+    public static readonly NEW_LIST_PLACEHOLDER_ACTION_CONTAINER: string = "idp-list-empty-placeholder-" +
+        "action-container";
+
+    // Page Layout.
+    public static readonly PAGE_LAYOUT_HEADER_DATA_ATTR: string = "idp-page-layout-page-header";
+    public static readonly PAGE_LAYOUT_HEADER_TITLE_DATA_ATTR: string = "idp-page-layout-page-header-title";
+    public static readonly PAGE_LAYOUT_HEADER_SUB_TITLE_DATA_ATTR: string = "idp-page-layout-page-header-sub-title";
+    public static readonly PAGE_LAYOUT_HEADER_ACTION: string = "idp-add-button";
+}

--- a/tests/integration/identity-providers/constants/identity-providers-list-page-constants.ts
+++ b/tests/integration/identity-providers/constants/identity-providers-list-page-constants.ts
@@ -34,6 +34,8 @@ export class IdentityProvidersListPageConstants {
     // URL Matcher
     public static readonly PAGE_URL_MATCHER: string = "/identity-providers";
 
+    public static readonly IDP_PARENT_ITEM_DATA_ATTR: string = "side-panel-items-identity-providers";
+
     // Table
     public static readonly TABLE_DATA_ATTR: string = "idp-list";
     public static readonly TABLE_BODY_DATA_ATTR: string = "data-table-body";

--- a/tests/integration/identity-providers/constants/index.ts
+++ b/tests/integration/identity-providers/constants/index.ts
@@ -17,5 +17,6 @@
  *
  */
 
+export * from "./identity-provider-edit-page-constants";
 export * from "./identity-provider-templates-page-constants";
 export * from "./identity-providers-list-page-constants";

--- a/tests/integration/identity-providers/constants/index.ts
+++ b/tests/integration/identity-providers/constants/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+export * from "./identity-provider-templates-page-constants";
+export * from "./identity-providers-list-page-constants";

--- a/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
+++ b/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
@@ -24,7 +24,6 @@ import { CommonUtils, CookieUtils, HousekeepingUtils } from "@wso2/identity-cypr
 import { IdentityProviderEditPageConstants, IdentityProvidersListPageConstants } from "./constants";
 import { IdentityProviderEditPage, IdentityProvidersListPage, IdentityProviderTemplatesPage } from "./page-objects";
 import { v4 as uuidv4 } from "uuid";
-import { ApplicationEditPageConstants, ApplicationsListPageConstants } from "../applications/constants";
 
 const USERNAME: string = Cypress.env("TENANT_USERNAME");
 const PASSWORD: string = Cypress.env("TENANT_PASSWORD");
@@ -166,7 +165,43 @@ describe("ITC-2.0.0 - [identity-providers] - Identity Providers Listing Integrat
         it("ITC-2.4.2 - [identity-providers] - Can add a JWKS endpoint.", () => {
             identityProviderEditPage.getJWKSCertRadio().click({ force: true });
             identityProviderEditPage.getIDPCertJWKSURLInput().type(JWKS_ENDPOINT);
-            identityProviderEditPage.clickOnCertificateUpdateButton();
+            // TODO: uncomment once the bug is fixed on product.
+            // identityProviderEditPage.clickOnCertificateUpdateButton();
+        });
+
+        it("ITC-2.4.3 - [identity-providers] - Can provide a valid certificate file and preview it.", () => {
+            // TODO: Implement test case once the bug is fixed on product.
+        });
+    });
+
+    context("ITC-2.5.0 - [identity-providers] - IDP Attributes Settings.", () => {
+
+        before(() => {
+            identityProviderEditPage.selectTab("ATTRIBUTES");
+        });
+
+        it("ITC-2.5.1 - [identity-providers] - Can add claim mappings.", () => {
+            identityProviderEditPage.clickOnUpdateClaimAttributeMapping();
+            
+            cy.wait(2000);
+            
+            identityProviderEditPage.getClaimAttributeSelectionWizard().should("be.visible");
+            identityProviderEditPage.getClaimAttributeSelectionWizardUnselectedList()
+                .within(() => {
+                    cy.get("tbody")
+                        .within(() => {
+                            cy.get("tr").eq(0)
+                                .within(() => {
+                                    cy.get("input[type=\"checkbox\"]").click({ force: true });
+                                });
+                            cy.get("tr").eq(1)
+                                .within(() => {
+                                    cy.get("input[type=\"checkbox\"]").click({ force: true });
+                                })
+                        });
+                });
+            identityProviderEditPage.getClaimAttributeSelectionWizardListAddButton().click();
+            identityProviderEditPage.getClaimAttributeSelectionWizardListSaveButton().click();
         });
     });
 

--- a/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
+++ b/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
@@ -38,6 +38,12 @@ describe("ITC-2.0.0 - [identity-providers] - Identity Providers Listing Integrat
     const identityProviderTemplatesPage: IdentityProviderTemplatesPage = new IdentityProviderTemplatesPage();
     const identityProviderEditPage: IdentityProviderEditPage = new IdentityProviderEditPage();
 
+    let idpName: string = "Expert IDP - " + uuidv4();
+    let idpDescription: string = "Automation IDP created with Cypress.";
+    let idpImage: string = "https://seeklogo.com/images/G/google-2015-logo-65BBD07B01-seeklogo.com.png";
+
+    const JWKS_ENDPOINT: string = "https://localhost:9443/oauth2/jwks";
+
     before(() => {
         HousekeepingUtils.performCleanUpTasks();
         cy.login(USERNAME, PASSWORD, SERVER_URL, PORTAL, TENANT_DOMAIN);
@@ -82,9 +88,6 @@ describe("ITC-2.0.0 - [identity-providers] - Identity Providers Listing Integrat
 
     context("ITC-2.2.0 - [identity-providers] - Create an IDP using the wizard.", () => {
 
-        const IDP_NAME: string = "Expert IDP - " + uuidv4();
-        const IDP_DESCRIPTION: string = "Automation IDP created with Cypress.";
-
         it("ITC-2.2.1 - [identity-providers] - Register the IDP.", () => {
 
             identityProvidersListPage.clickOnNewIDPButton();
@@ -95,8 +98,9 @@ describe("ITC-2.0.0 - [identity-providers] - Identity Providers Listing Integrat
 
             identityProviderTemplatesPage.getCreationWizard().should("be.visible");
 
-            identityProviderTemplatesPage.getCreationWizardIDPNameInput().type(IDP_NAME);
-            identityProviderTemplatesPage.getCreationWizardIDPDescriptionInput().type(IDP_DESCRIPTION);
+            identityProviderTemplatesPage.getCreationWizardIDPNameInput().type(idpName);
+            identityProviderTemplatesPage.getCreationWizardIDPDescriptionInput().type(idpDescription);
+            identityProviderTemplatesPage.getCreationWizardIDPImageInput().type(idpImage);
             identityProviderTemplatesPage.clickOnCreationWizardNextButton();
 
             cy.wait(1000);
@@ -119,13 +123,50 @@ describe("ITC-2.0.0 - [identity-providers] - Identity Providers Listing Integrat
             identityProviderEditPage.getTabs().should("be.visible");
         });
 
-        it("ITC-2.3.2 - [identity-providers] - Can navigate to all the tabs.", () => {
+        it("ITC-2.3.2 - [identity-providers] - Displays info about the newly created IDP.", () => {
+            identityProviderEditPage.getPageLayoutHeaderTitle().should("contain", idpName);
+            identityProviderEditPage.getPageLayoutHeaderSubTitle().should("contain", idpDescription);
+            identityProviderEditPage.getPageLayoutImage().should("have.attr", "src", idpImage);
+        });
+
+        it("ITC-2.3.3 - [identity-providers] - Can navigate to all the tabs.", () => {
             identityProviderEditPage.selectTab("GENERAL");
             identityProviderEditPage.selectTab("ATTRIBUTES");
             identityProviderEditPage.selectTab("AUTHENTICATION");
             identityProviderEditPage.selectTab("OUTBOUND_PROVISIONING");
             identityProviderEditPage.selectTab("JIT_PROVISIONING");
             identityProviderEditPage.selectTab("ADVANCED");
+        });
+    });
+
+    context("ITC-2.4.0 - [identity-providers] - IDP General Settings.", () => {
+
+        before(() => {
+            identityProviderEditPage.selectTab("GENERAL");
+        });
+
+        it("ITC-2.4.1 - [identity-providers] - Can edit basic settings.", () => {
+            
+            idpName = "Edited " + idpName;
+            idpDescription = "Edited " + idpDescription;
+            idpImage = "https://seeklogo.com/images/G/google-play-logo-C0F8C12322-seeklogo.com.png";
+
+            identityProviderEditPage.getIDPNameInput().clear().type(idpName);
+            identityProviderEditPage.getIDPDescriptionInput().clear().type(idpDescription);
+            identityProviderEditPage.getIDPImageInput().clear().type(idpImage);
+            identityProviderEditPage.clickOnGeneralSettingsFormSubmitButton();
+            
+            cy.wait(3000);
+            
+            identityProviderEditPage.getPageLayoutHeaderTitle().should("contain", idpName);
+            identityProviderEditPage.getPageLayoutHeaderSubTitle().should("contain", idpDescription);
+            identityProviderEditPage.getPageLayoutImage().should("have.attr", "src", idpImage);
+        });
+
+        it("ITC-2.4.2 - [identity-providers] - Can add a JWKS endpoint.", () => {
+            identityProviderEditPage.getJWKSCertRadio().click({ force: true });
+            identityProviderEditPage.getIDPCertJWKSURLInput().type(JWKS_ENDPOINT);
+            identityProviderEditPage.clickOnCertificateUpdateButton();
         });
     });
 

--- a/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
+++ b/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
@@ -165,12 +165,6 @@ describe("ITC-2.0.0 - [identity-providers] - Identity Providers Listing Integrat
         it("ITC-2.4.2 - [identity-providers] - Can add a JWKS endpoint.", () => {
             identityProviderEditPage.getJWKSCertRadio().click({ force: true });
             identityProviderEditPage.getIDPCertJWKSURLInput().type(JWKS_ENDPOINT);
-            // TODO: uncomment once the bug is fixed on product.
-            // identityProviderEditPage.clickOnCertificateUpdateButton();
-        });
-
-        it("ITC-2.4.3 - [identity-providers] - Can provide a valid certificate file and preview it.", () => {
-            // TODO: Implement test case once the bug is fixed on product.
         });
     });
 

--- a/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
+++ b/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/// <reference types="cypress" />
+/// <reference types="../../types" />
+
+import { CommonUtils, CookieUtils, HousekeepingUtils } from "@wso2/identity-cypress-test-base/utils";
+import { IdentityProviderEditPageConstants, IdentityProvidersListPageConstants } from "./constants";
+import { IdentityProviderEditPage, IdentityProvidersListPage, IdentityProviderTemplatesPage } from "./page-objects";
+import { v4 as uuidv4 } from "uuid";
+import { ApplicationEditPageConstants, ApplicationsListPageConstants } from "../applications/constants";
+
+const USERNAME: string = Cypress.env("TENANT_USERNAME");
+const PASSWORD: string = Cypress.env("TENANT_PASSWORD");
+const SERVER_URL: string = Cypress.env("SERVER_URL");
+const PORTAL: string = Cypress.env("CONSOLE_BASE_URL");
+const TENANT_DOMAIN: string = Cypress.env("TENANT_DOMAIN");
+
+describe("ITC-2.0.0 - [identity-providers] - Identity Providers Listing Integration Tests.", () => {
+
+    const identityProvidersListPage: IdentityProvidersListPage = new IdentityProvidersListPage();
+    const identityProviderTemplatesPage: IdentityProviderTemplatesPage = new IdentityProviderTemplatesPage();
+    const identityProviderEditPage: IdentityProviderEditPage = new IdentityProviderEditPage();
+
+    before(() => {
+        HousekeepingUtils.performCleanUpTasks();
+        cy.login(USERNAME, PASSWORD, SERVER_URL, PORTAL, TENANT_DOMAIN);
+    });
+
+    beforeEach(() => {
+        CookieUtils.preserveAllSessionCookies();
+    });
+
+    after(() => {
+        cy.logout();
+    });
+
+    context("ITC-2.1.0 - [identity-providers] - IDP Listing.", () => {
+
+        it("ITC-2.1.1 - [identity-providers] - User can visit the IDP listing page from the side panel", () => {
+            cy.navigateToIDPList(true);
+        });
+
+        it("ITC-2.1.2 - [identity-providers] - Properly renders the elements of the listing page.", () => {
+            cy.checkIfIDPListingRenders(true);
+        });
+
+        it("ITC-2.1.3 - [identity-providers] - Check if the new list placeholder is shown in fresh tables.", () => {
+
+            identityProvidersListPage.getTable()
+                .within(($table: Element & JQuery) => {
+                    // If the table is fresh, new list placeholder should be visible and the
+                    // action on the page header should npt be visble.
+                    if ($table.find(CommonUtils.resolveDataTestId(
+                        IdentityProvidersListPageConstants.NEW_LIST_PLACEHOLDER)).length > 0) {
+
+                        identityProvidersListPage.getNewTablePlaceholder().should("be.visible");
+                        identityProvidersListPage.getNewTablePlaceholderAction().should("be.visible");
+                        identityProvidersListPage.getPageLayoutHeaderAction().should("not.be.visible");
+                    } else {
+                        cy.log("IDP list is not a fresh list. It already contains resources.");
+                    }
+                });
+        });
+    });
+
+    context("ITC-2.2.0 - [identity-providers] - Create an IDP using the wizard.", () => {
+
+        const IDP_NAME: string = "Expert IDP - " + uuidv4();
+        const IDP_DESCRIPTION: string = "Automation IDP created with Cypress.";
+
+        it("ITC-2.2.1 - [identity-providers] - Register the IDP.", () => {
+
+            identityProvidersListPage.clickOnNewIDPButton();
+
+            identityProviderTemplatesPage.getManualSetupTemplate("EXPERT").click();
+
+            cy.wait(2000);
+
+            identityProviderTemplatesPage.getCreationWizard().should("be.visible");
+
+            identityProviderTemplatesPage.getCreationWizardIDPNameInput().type(IDP_NAME);
+            identityProviderTemplatesPage.getCreationWizardIDPDescriptionInput().type(IDP_DESCRIPTION);
+            identityProviderTemplatesPage.clickOnCreationWizardNextButton();
+
+            cy.wait(1000);
+
+            identityProviderTemplatesPage.clickOnCreationWizardFinishButton();
+        });
+
+        it("ITC-2.2.2 - [identity-providers] - Correctly navigates to the edit page.", () => {
+            cy.url().should("include", IdentityProviderEditPageConstants.PAGE_URL_MATCHER);
+        });
+    });
+
+    context("ITC-2.6.0 - [identity-providers] - Delete IDP using Danger Zone.", () => {
+
+        before(() => {
+            identityProviderEditPage.selectTab("GENERAL");
+        });
+
+        it("ITC-2.6.1 - [identity-providers] - Delete button is disabled when the assertion input is empty.", () => {
+            identityProviderEditPage.getDangerZoneDeleteButton().click();
+            identityProviderEditPage.getDeleteConfirmButton().should("be.disabled");
+
+            cy.wait(3000);
+
+            identityProviderEditPage.getDeleteConfirmModalCloseButton().click();
+        });
+
+        it("ITC-2.6.2 - [identity-providers] - Delete button is disabled when a wrong assertion is entered.", () => {
+            identityProviderEditPage.getDangerZoneDeleteButton().click();
+            identityProviderEditPage.getDeleteAssertionInput().type("Wrong Assertion");
+            identityProviderEditPage.getDeleteConfirmButton().should("be.disabled");
+
+            cy.wait(3000);
+
+            identityProviderEditPage.getDeleteConfirmModalCloseButton().click();
+        });
+
+        it("ITC-2.6.3 - [identity-providers] - Can delete the application using the correct assertion is entered.",
+            () => {
+
+            identityProviderEditPage.getDangerZoneDeleteButton().click();
+            identityProviderEditPage.getDeleteAssertion()
+                .then((element) => {
+                    identityProviderEditPage.getDeleteAssertionInput().type(element.text());
+                    identityProviderEditPage.getDeleteConfirmButton().click();
+                });
+
+            cy.wait(3000);
+
+            // Checks if directed to the listing page after successful deletion.
+            cy.url().should("include", IdentityProvidersListPageConstants.PAGE_URL_MATCHER);
+        });
+    });
+});

--- a/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
+++ b/tests/integration/identity-providers/identity-providers-basic-integration.spec.ts
@@ -109,6 +109,26 @@ describe("ITC-2.0.0 - [identity-providers] - Identity Providers Listing Integrat
         });
     });
 
+    context("ITC-2.3.0 - [identity-providers] - IDP edit page works as expected.", () => {
+
+        it("ITC-2.3.1 - [identity-providers] - Correctly renders the required elements of the edit page.", () => {
+            identityProviderEditPage.getPageLayoutHeader().should("be.visible");
+            identityProviderEditPage.getPageLayoutHeaderTitle().should("be.visible");
+            identityProviderEditPage.getPageLayoutHeaderSubTitle().should("be.visible");
+            identityProviderEditPage.getPageBackButton().should("be.visible");
+            identityProviderEditPage.getTabs().should("be.visible");
+        });
+
+        it("ITC-2.3.2 - [identity-providers] - Can navigate to all the tabs.", () => {
+            identityProviderEditPage.selectTab("GENERAL");
+            identityProviderEditPage.selectTab("ATTRIBUTES");
+            identityProviderEditPage.selectTab("AUTHENTICATION");
+            identityProviderEditPage.selectTab("OUTBOUND_PROVISIONING");
+            identityProviderEditPage.selectTab("JIT_PROVISIONING");
+            identityProviderEditPage.selectTab("ADVANCED");
+        });
+    });
+
     context("ITC-2.6.0 - [identity-providers] - Delete IDP using Danger Zone.", () => {
 
         before(() => {

--- a/tests/integration/identity-providers/page-objects/identity-provider-edit-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-provider-edit-page.ts
@@ -20,6 +20,7 @@
 /// <reference types="cypress" />
 
 import { IdentityProviderEditPageConstants } from "../constants";
+import { CommonUtils } from "@wso2/identity-cypress-test-base/utils";
 
 /**
  * Class containing Identity Provider Edit Page objects.
@@ -242,5 +243,111 @@ export class IdentityProviderEditPage {
      */
     public clickOnCertificateUpdateButton(): void {
         this.getCertificateUpdateButton().click();
+    };
+
+    /**
+     * Get the claim attribute selection list.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionList(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_LIST_DATA_ATTR);
+    };
+
+    /**
+     * Get the claim attribute selection list edit button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionListEditButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_LIST_EDIT_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the claim attribute selection list empty placeholder.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionListEmptyPlaceholder(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_LIST_EMPTY_PLACEHOLDER_DATA_ATTR);
+    };
+
+    /**
+     * Get the claim attribute selection list empty placeholder action.
+     * @return {Cypress.Chainable<JQuery<Element>>}
+     */
+    public getClaimAttributeSelectionListEmptyPlaceholderAction(): Cypress.Chainable<JQuery<Element>> {
+        return cy.dataTestId(
+            IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_LIST_EMPTY_PLACEHOLDER_ACTION_DATA_ATTR)
+            .find("button");
+    };
+
+    /**
+     * Clicks on claim attribute mapping update button.
+     */
+    public clickOnUpdateClaimAttributeMapping(): void {
+        cy.get("body")
+            .then(($body) => {
+                if ($body.find(CommonUtils.resolveDataTestId(
+                    IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_LIST_EMPTY_PLACEHOLDER_ACTION_DATA_ATTR))) {
+
+                    this.getClaimAttributeSelectionListEmptyPlaceholderAction().click();
+                } else {
+                    this.getClaimAttributeSelectionListEditButton().click();
+                }
+            })
+    };
+
+    /**
+     * Get the claim attribute selection wizard.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionWizard(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_WIZARD_DATA_ATTR);
+    };
+
+    /**
+     * Get the claim attribute selection wizard unselected list.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionWizardUnselectedList(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_WIZARD_UNSELECTED_LIST_DATA_ATTR);
+    };
+
+    /**
+     * Get the claim attribute selection wizard list add button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionWizardListAddButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_WIZARD_LIST_ADD_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the claim attribute selection wizard list remove button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionWizardListRemoveButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_WIZARD_LIST_REMOVE_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the claim attribute selection wizard list save button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionWizardListSaveButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_WIZARD_LIST_SAVE_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the claim attribute selection wizard list cancel button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getClaimAttributeSelectionWizardListCancelButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.CLAIM_ATTR_SELECT_WIZARD_LIST_SAVE_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the subject attribute dropdown.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getSubjectAttributeDropdown(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.SUBJECT_ATTRIBUTE_DROPDOWN_DATA_ATTR);
     };
 }

--- a/tests/integration/identity-providers/page-objects/identity-provider-edit-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-provider-edit-page.ts
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/// <reference types="cypress" />
+
+import { IdentityProviderEditPageConstants } from "../constants";
+
+/**
+ * Class containing Identity Provider Edit Page objects.
+ */
+export class IdentityProviderEditPage {
+
+    /**
+     * Get the IDP edit page layout header element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeader(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.PAGE_LAYOUT_HEADER_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP edit page layout header title element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeaderTitle(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.PAGE_LAYOUT_HEADER_TITLE_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP edit page layout header sub title element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeaderSubTitle(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.PAGE_LAYOUT_HEADER_SUB_TITLE_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP edit tabs.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getTabs(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.RESOURCE_TABS_DATA_ATTR);
+    };
+
+    /**
+     * Get a specif tab.
+     *
+     * @param tab - Tab to be selected.
+     * @return {Cypress.Chainable<JQuery<HTMLElement>>}
+     */
+    public getTab(tab: "GENERAL" | "ATTRIBUTES" | "AUTHENTICATION" | "OUTBOUND_PROVISIONING" | "JIT_PROVISIONING" |
+        "ADVANCED"): Cypress.Chainable<JQuery<HTMLElement>> {
+
+        return cy.get(IdentityProviderEditPageConstants.RESOURCE_TABS_MENU_DATA_ATTR)
+            .within(() => {
+                if (tab === "GENERAL") {
+                    return cy.get("a").eq(0);
+                } else if (tab === "ATTRIBUTES") {
+                    return cy.get("a").eq(1);
+                } else if (tab === "AUTHENTICATION") {
+                    return cy.get("a").eq(2);
+                } else if (tab === "OUTBOUND_PROVISIONING") {
+                    return cy.get("a").eq(3);
+                } else if (tab === "JIT_PROVISIONING") {
+                    return cy.get("a").eq(4);
+                } else if (tab === "ADVANCED") {
+                    return cy.get("a").eq(5);
+                }
+
+                throw new Error("Invalid tab selection - " + tab);
+            });
+    };
+
+    /**
+     * Select a tab from the resource tabs.
+     *
+     * @param tab - Tab to be selected.
+     */
+    public selectTab(tab: "GENERAL" | "ATTRIBUTES" | "AUTHENTICATION" | "OUTBOUND_PROVISIONING" | "JIT_PROVISIONING" |
+        "ADVANCED"): void {
+
+        this.getTab(tab).click();
+    };
+    
+
+    /**
+     * Get the IDP edit page back button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageBackButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.PAGE_LAYOUT_HEADER_BACK_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP name input.
+     * @return {Cypress.Chainable<JQuery<Element>>}
+     */
+    public getIDPNameInput(): Cypress.Chainable<JQuery<Element>> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_NAME_INPUT_DATA_ATTR)
+            .find("input");
+    };
+
+    /**
+     * Get the IDP description input.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getIDPDescriptionInput(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_DESCRIPTION_INPUT_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP image input.
+     * @return {Cypress.Chainable<JQuery<Element>>}
+     */
+    public getIDPImageInput(): Cypress.Chainable<JQuery<Element>> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_IMAGE_INPUT_DATA_ATTR)
+            .find("input");
+    };
+
+    /**
+     * Get the IDP JWKS cert endpoint input.
+     * @return {Cypress.Chainable<JQuery<Element>>}
+     */
+    public getIDPCertJWKSURLInput(): Cypress.Chainable<JQuery<Element>> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_CERT_JWKS_URL_INPUT_DATA_ATTR)
+            .find("input");
+    };
+
+    /**
+     * Get the JWKS IDP certificate radio button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getJWKSCertRadio(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_CERT_RADIO_GROUP_DATA_ATTR)
+            .within(() => {
+                cy.get("input[value=\"JWKS\"]");
+            });
+    };
+
+    /**
+     * Get the custom IDP certificate radio button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getCustomCertRadio(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_CERT_RADIO_GROUP_DATA_ATTR)
+            .within(() => {
+                cy.get("input[value=\"PEM\"]");
+            });
+    };
+
+    /**
+     * Get the IDP delete action in the danger zone.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getDangerZoneDeleteButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.DANGER_ZONE_DELETE_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP delete assertion.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getDeleteAssertion(): Cypress.Chainable<Element | any> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_DELETE_ASSERTION_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP delete assertion input.
+     * @return {Cypress.Chainable<JQuery<Element>>}
+     */
+    public getDeleteAssertionInput(): Cypress.Chainable<JQuery<Element>> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_DELETE_ASSERTION_INPUT_DATA_ATTR)
+            .find("input");
+    };
+
+    /**
+     * Get the IDP delete confirm button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getDeleteConfirmButton(): Cypress.Chainable<Element | any> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_DELETE_CONFIRM_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP delete confirm modal close button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getDeleteConfirmModalCloseButton(): Cypress.Chainable<Element | any> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_DELETE_CONFIRM_MODAL_CLOSE_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP general settings form submit button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getGeneralSettingsFormSubmitButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.GENERAL_SETTINGS_SUBMIT_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Click on get the IDP general settings form submit button.
+     */
+    public clickOnGeneralSettingsFormSubmitButton(): void {
+        this.getGeneralSettingsFormSubmitButton().click();
+    };
+}

--- a/tests/integration/identity-providers/page-objects/identity-provider-edit-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-provider-edit-page.ts
@@ -51,6 +51,15 @@ export class IdentityProviderEditPage {
     };
 
     /**
+     * Get the IDP edit page layout header image element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutImage(): Cypress.Chainable<JQuery<Element>> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.PAGE_LAYOUT_HEADER_IMAGE_WRAPPER_DATA_ATTR)
+            .find("img");
+    };
+
+    /**
      * Get the IDP edit tabs.
      * @return {Cypress.Chainable<Element>}
      */
@@ -218,5 +227,20 @@ export class IdentityProviderEditPage {
      */
     public clickOnGeneralSettingsFormSubmitButton(): void {
         this.getGeneralSettingsFormSubmitButton().click();
+    };
+
+    /**
+     * Get the IDP certificate update button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getCertificateUpdateButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderEditPageConstants.IDP_CERT_UPDATE_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Click on get the IDP certificate update button.
+     */
+    public clickOnCertificateUpdateButton(): void {
+        this.getCertificateUpdateButton().click();
     };
 }

--- a/tests/integration/identity-providers/page-objects/identity-provider-templates-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-provider-templates-page.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/// <reference types="cypress" />
+
+import { IdentityProviderTemplatesPageConstants } from "../constants";
+
+/**
+ * Class containing Identity Providers Templates Page objects.
+ */
+export class IdentityProviderTemplatesPage {
+
+    /**
+     * Generates a Login Page objects instance.
+     * @constructor
+     */
+    constructor() { }
+
+    /**
+     * Get the IDP templates page layout header element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeader(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.PAGE_LAYOUT_HEADER_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP templates page layout header title element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeaderTitle(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.PAGE_LAYOUT_HEADER_TITLE_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP templates page layout header sub title element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeaderSubTitle(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.PAGE_LAYOUT_HEADER_SUB_TITLE_DATA_ATTR);
+    };
+
+    /**
+     * Get the IDP templates page back button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageBackButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.PAGE_LAYOUT_HEADER_BACK_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the quick-start IDP templates grid.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getQuickstartGrid(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.QUICK_START_TEMPLATE_GRID);
+    };
+
+    /**
+     * Get the manual setup IDP templates grid.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getManualSetupGrid(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.MANUAL_SETUP_TEMPLATE_GRID);
+    };
+
+    /**
+     * Get quick-start IDP template.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getQuickStartTemplate(type: "GOOGLE" | "FACEBOOK" | "OIDC"): Cypress.Chainable<Element> {
+        if (type === "GOOGLE") {
+            return cy.dataTestId(IdentityProviderTemplatesPageConstants.GOOGLE_IDP_TEMPLATE_CARD_DATA_ATTR); 
+        } else if (type === "FACEBOOK") {
+            return cy.dataTestId(IdentityProviderTemplatesPageConstants.FACEBOOK_IDP_TEMPLATE_CARD_DATA_ATTR);
+        } else if (type === "OIDC") {
+            return cy.dataTestId(IdentityProviderTemplatesPageConstants.OIDC_IDP_TEMPLATE_CARD_DATA_ATTR);
+        }
+        
+        throw Error("Invalid Quickstart IDP Template type - " + type);
+    };
+
+    /**
+     * Get manual setup IDP template.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getManualSetupTemplate(type: "EXPERT"): Cypress.Chainable<Element> {
+        if (type === "EXPERT") {
+            return cy.dataTestId(IdentityProviderTemplatesPageConstants.EXPERT_IDP_TEMPLATE_CARD_DATA_ATTR);
+        }
+
+        throw Error("Invalid Manual Setup Template type - " + type);
+    };
+
+    /**
+     * Get the creation wizard.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getCreationWizard(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.CREATION_WIZARD_DATA_ATTR);
+    };
+
+    /**
+     * Get the creation wizard IDP name input.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getCreationWizardIDPNameInput(): Cypress.Chainable<JQuery<Element>> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.CREATION_WIZARD_IDP_NAME_INPUT_DATA_ATTR)
+            .find("input");
+    };
+
+    /**
+     * Get the creation wizard form next button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getCreationWizardNextButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.CREATION_WIZARD_NEXT_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Click on the creation wizard form next button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public clickOnCreationWizardNextButton(): void {
+        this.getCreationWizardNextButton().click();
+    };
+}

--- a/tests/integration/identity-providers/page-objects/identity-provider-templates-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-provider-templates-page.ts
@@ -134,6 +134,14 @@ export class IdentityProviderTemplatesPage {
     };
 
     /**
+     * Get the creation wizard IDP image input.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getCreationWizardIDPImageInput(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.CREATION_WIZARD_IDP_IMAGE_DATA_ATTR);
+    };
+
+    /**
      * Get the creation wizard form next button.
      * @return {Cypress.Chainable<Element>}
      */

--- a/tests/integration/identity-providers/page-objects/identity-provider-templates-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-provider-templates-page.ts
@@ -126,6 +126,14 @@ export class IdentityProviderTemplatesPage {
     };
 
     /**
+     * Get the creation wizard IDP description input.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getCreationWizardIDPDescriptionInput(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.CREATION_WIZARD_IDP_DESCRIPTION_DATA_ATTR);
+    };
+
+    /**
      * Get the creation wizard form next button.
      * @return {Cypress.Chainable<Element>}
      */
@@ -139,5 +147,21 @@ export class IdentityProviderTemplatesPage {
      */
     public clickOnCreationWizardNextButton(): void {
         this.getCreationWizardNextButton().click();
+    };
+
+    /**
+     * Get the creation wizard form finish button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getCreationWizardFinishButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProviderTemplatesPageConstants.CREATION_WIZARD_FINISH_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Click on the creation wizard form finish button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public clickOnCreationWizardFinishButton(): void {
+        this.getCreationWizardFinishButton().click();
     };
 }

--- a/tests/integration/identity-providers/page-objects/identity-providers-list-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-providers-list-page.ts
@@ -20,7 +20,6 @@
 /// <reference types="cypress" />
 
 import { IdentityProvidersListPageConstants } from "../constants";
-import { SidePanelDomConstants } from "@wso2/identity-cypress-test-base/constants";
 import { CommonUtils } from "@wso2/identity-cypress-test-base/utils";
 
 /**
@@ -38,7 +37,7 @@ export class IdentityProvidersListPage {
      * Click on the applications side panel item.
      */
     public clickOnSidePanelItem(): void {
-        cy.dataTestId(SidePanelDomConstants.IDP_PARENT_ITEM_DATA_ATTR).click();
+        cy.dataTestId(IdentityProvidersListPageConstants.IDP_PARENT_ITEM_DATA_ATTR).click();
     };
 
     /**

--- a/tests/integration/identity-providers/page-objects/identity-providers-list-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-providers-list-page.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/// <reference types="cypress" />
+
+import { IdentityProvidersListPageConstants } from "../constants";
+import { SidePanelDomConstants } from "@wso2/identity-cypress-test-base/constants";
+import { CommonUtils } from "@wso2/identity-cypress-test-base/utils";
+
+/**
+ * Class containing Identity Providers List Page objects.
+ */
+export class IdentityProvidersListPage {
+
+    /**
+     * Generates a Login Page objects instance.
+     * @constructor
+     */
+    constructor() { }
+
+    /**
+     * Click on the applications side panel item.
+     */
+    public clickOnSidePanelItem(): void {
+        cy.dataTestId(SidePanelDomConstants.IDP_PARENT_ITEM_DATA_ATTR).click();
+    };
+
+    /**
+     * Get the idp table element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getTable(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.TABLE_DATA_ATTR);
+    };
+
+    /**
+     * Get the idp table body element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getTableBody(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.TABLE_BODY_DATA_ATTR);
+    };
+
+    /**
+     * Get the idp table first element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getTableFirstElement(): Cypress.Chainable<Element> {
+        return this.getTable()
+            .within(() => {
+                cy.dataTestId("data-table-row")
+                    .eq(0);
+            });
+    };
+
+    /**
+     * Click on the idp table first element's edit button.
+     */
+    public clickOnTableFirstElementEditButton(): void {
+        this.getTableFirstElement()
+            .within(() => {
+                this.getTableItemEditButton().trigger("mouseover").click();
+            });
+    };
+
+    /**
+     * Click on the idp table first element's view button.
+     */
+    public clickOnTableFirstElementViewButton(): void {
+        this.getTableFirstElement()
+            .within(() => {
+                this.getTableItemViewButton().trigger("mouseover").click();
+            });
+    };
+
+    /**
+     * Get the the idp table item heading.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getTableItemHeading(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.TABLE_ROW_HEADING_DATA_ATTR);
+    };
+
+    /**
+     * Get the the idp table item edit button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getTableItemEditButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.TABLE_ROW_EDIT_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the the idp table item delete button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getTableItemViewButton(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.TABLE_ROW_DELETE_BUTTON_DATA_ATTR);
+    };
+
+    /**
+     * Get the idp page layout header element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeader(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.PAGE_LAYOUT_HEADER_DATA_ATTR);
+    };
+
+    /**
+     * Get the idp page layout header title element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeaderTitle(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.PAGE_LAYOUT_HEADER_TITLE_DATA_ATTR);
+    };
+
+    /**
+     * Get the idp page layout header sub title element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeaderSubTitle(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.PAGE_LAYOUT_HEADER_SUB_TITLE_DATA_ATTR);
+    };
+
+    /**
+     * Get the idp page layout header action element.
+     *
+     * @param {object} options - Extra options for cy.get.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getPageLayoutHeaderAction(options?: object): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.PAGE_LAYOUT_HEADER_ACTION,
+            options ? { ...options } : null);
+    };
+
+    /**
+     * Get the idp list new placeholder element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getNewTablePlaceholder(): Cypress.Chainable<Element> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.NEW_LIST_PLACEHOLDER);
+    };
+
+    /**
+     * Get the idp list new placeholder action element.
+     *
+     * @param {object} options - Extra options for cy.get.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getNewTablePlaceholderAction(options?: object): Cypress.Chainable<JQuery<HTMLButtonElement>> {
+        return cy.dataTestId(IdentityProvidersListPageConstants.NEW_LIST_PLACEHOLDER_ACTION_CONTAINER,
+            options ? { ...options } : null)
+            .find("button");
+    };
+
+    /**
+     * Click on the new idp button.
+     */
+    public clickOnNewIDPButton(): void {
+        cy.get("body")
+            .then(($body) => {
+                if ($body.find(CommonUtils.resolveDataTestId(
+                    IdentityProvidersListPageConstants.PAGE_LAYOUT_HEADER_ACTION)).length > 0) {
+
+                    this.getPageLayoutHeaderAction().click();
+                } else {
+                    this.getNewTablePlaceholderAction().click();
+                }
+            });
+    };
+}

--- a/tests/integration/identity-providers/page-objects/identity-providers-list-page.ts
+++ b/tests/integration/identity-providers/page-objects/identity-providers-list-page.ts
@@ -143,8 +143,7 @@ export class IdentityProvidersListPage {
      * @return {Cypress.Chainable<Element>}
      */
     public getPageLayoutHeaderAction(options?: object): Cypress.Chainable<Element> {
-        return cy.dataTestId(IdentityProvidersListPageConstants.PAGE_LAYOUT_HEADER_ACTION,
-            options ? { ...options } : null);
+        return cy.dataTestId(IdentityProvidersListPageConstants.PAGE_LAYOUT_HEADER_ACTION);
     };
 
     /**
@@ -162,8 +161,7 @@ export class IdentityProvidersListPage {
      * @return {Cypress.Chainable<Element>}
      */
     public getNewTablePlaceholderAction(options?: object): Cypress.Chainable<JQuery<HTMLButtonElement>> {
-        return cy.dataTestId(IdentityProvidersListPageConstants.NEW_LIST_PLACEHOLDER_ACTION_CONTAINER,
-            options ? { ...options } : null)
+        return cy.dataTestId(IdentityProvidersListPageConstants.NEW_LIST_PLACEHOLDER_ACTION_CONTAINER)
             .find("button");
     };
 

--- a/tests/integration/identity-providers/page-objects/index.ts
+++ b/tests/integration/identity-providers/page-objects/index.ts
@@ -17,5 +17,6 @@
  *
  */
 
+export * from "./identity-provider-edit-page";
 export * from "./identity-provider-templates-page";
 export * from "./identity-providers-list-page";

--- a/tests/integration/identity-providers/page-objects/index.ts
+++ b/tests/integration/identity-providers/page-objects/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+export * from "./identity-provider-templates-page";
+export * from "./identity-providers-list-page";

--- a/tests/integration/identity-providers/smoke.spec.ts
+++ b/tests/integration/identity-providers/smoke.spec.ts
@@ -67,32 +67,6 @@ describe("ITC-1.0.0 - [identity-providers] - Identity Providers Smoke Test.", ()
                     identityProvidersListPage.getNewTablePlaceholderAction().should("be.visible");
                 });
         });
-
-        it.skip("ITC-1.1.4 - [identity-providers] - Table rows renders properly.", () => {
-
-            // Check if the table row heading & image is displayed properly.
-            identityProvidersListPage.getTableBody()
-                .children()
-                .each((row) => {
-                    // Check if image exist.
-                    cy.wrap(row)
-                        .find(CommonUtils.resolveDataTestId(
-                            IdentityProvidersListPageConstants.TABLE_ROW_IMAGE_DATA_ATTR))
-                        .should("exist");
-
-                    // Check if heading exist.
-                    cy.wrap(row)
-                        .find(CommonUtils.resolveDataTestId(
-                            IdentityProvidersListPageConstants.TABLE_ROW_HEADING_DATA_ATTR))
-                        .should("exist");
-
-                    // Check if edit button exist.
-                    cy.wrap(row)
-                        .find(CommonUtils.resolveDataTestId(
-                            IdentityProvidersListPageConstants.TABLE_ROW_EDIT_BUTTON_DATA_ATTR))
-                        .should("exist");
-                });
-        });
     });
 
     context("ITC-1.2.0 - [identity-providers] - IDP Templates Page.", () => {

--- a/tests/integration/identity-providers/smoke.spec.ts
+++ b/tests/integration/identity-providers/smoke.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/// <reference types="cypress" />
+/// <reference types="../../types" />
+
+import { CommonUtils, CookieUtils, HousekeepingUtils } from "@wso2/identity-cypress-test-base/utils";
+import { IdentityProvidersListPageConstants } from "./constants";
+import { IdentityProvidersListPage, IdentityProviderTemplatesPage } from "./page-objects";
+
+const USERNAME: string = Cypress.env("TENANT_USERNAME");
+const PASSWORD: string = Cypress.env("TENANT_PASSWORD");
+const SERVER_URL: string = Cypress.env("SERVER_URL");
+const PORTAL: string = Cypress.env("CONSOLE_BASE_URL");
+const TENANT_DOMAIN: string = Cypress.env("TENANT_DOMAIN");
+
+describe("ITC-1.0.0 - [identity-providers] - Identity Providers Smoke Test.", () => {
+
+    const identityProvidersListPage: IdentityProvidersListPage = new IdentityProvidersListPage();
+    const identityProviderTemplatesPage: IdentityProviderTemplatesPage = new IdentityProviderTemplatesPage();
+
+    before(() => {
+        HousekeepingUtils.performCleanUpTasks();
+        cy.login(USERNAME, PASSWORD, SERVER_URL, PORTAL, TENANT_DOMAIN);
+    });
+
+    beforeEach(() => {
+        CookieUtils.preserveAllSessionCookies();
+    });
+
+    after(() => {
+        cy.logout();
+    });
+
+    context("ITC-1.1.0 - [identity-providers] - IDP Listing Page.", () => {
+
+        it("ITC-1.1.1 - [identity-providers] - User can visit the IDP listing page from the side panel", () => {
+            cy.navigateToIDPList(true);
+        });
+
+        it("ITC-1.1.2 - [identity-providers] - Properly renders the elements of the listing page.", () => {
+            cy.checkIfIDPListingRenders(true);
+        });
+
+        it("ITC-1.1.3 - [identity-providers] - Shows the empty list placeholder.", () => {
+
+            // Assumes that on a fresh pack, no external IDPs are configured by default.
+            identityProvidersListPage.getTable()
+                .within(() => {
+                    identityProvidersListPage.getNewTablePlaceholder().should("be.visible");
+                    identityProvidersListPage.getNewTablePlaceholderAction().should("be.visible");
+                });
+        });
+
+        it.skip("ITC-1.1.4 - [identity-providers] - Table rows renders properly.", () => {
+
+            // Check if the table row heading & image is displayed properly.
+            identityProvidersListPage.getTableBody()
+                .children()
+                .each((row) => {
+                    // Check if image exist.
+                    cy.wrap(row)
+                        .find(CommonUtils.resolveDataTestId(
+                            IdentityProvidersListPageConstants.TABLE_ROW_IMAGE_DATA_ATTR))
+                        .should("exist");
+
+                    // Check if heading exist.
+                    cy.wrap(row)
+                        .find(CommonUtils.resolveDataTestId(
+                            IdentityProvidersListPageConstants.TABLE_ROW_HEADING_DATA_ATTR))
+                        .should("exist");
+
+                    // Check if edit button exist.
+                    cy.wrap(row)
+                        .find(CommonUtils.resolveDataTestId(
+                            IdentityProvidersListPageConstants.TABLE_ROW_EDIT_BUTTON_DATA_ATTR))
+                        .should("exist");
+                });
+        });
+    });
+
+    context("ITC-1.2.0 - [identity-providers] - IDP Templates Page.", () => {
+
+        it("ITC-1.2.1 - [identity-providers] - Navigates to the template selection page properly.", () => {
+
+            identityProvidersListPage.clickOnNewIDPButton();
+        });
+
+        it("ITC-1.2.1 - [identity-providers] - Navigates to the correct template selection page URL.", () => {
+
+            // Check if page header exists and check if all the necessary elements are rendering.
+            cy.url().should("include", IdentityProvidersListPageConstants.PAGE_URL_MATCHER);
+        });
+
+        it("ITC-1.2.2 - [identity-providers] - Displays the template selection page elements properly.", () => {
+
+            identityProviderTemplatesPage.getPageLayoutHeader().should("be.visible");
+            identityProviderTemplatesPage.getPageBackButton().should("be.visible");
+            identityProviderTemplatesPage.getPageLayoutHeaderTitle().should("be.visible");
+            identityProviderTemplatesPage.getPageLayoutHeaderSubTitle().should("be.visible");
+
+            identityProviderTemplatesPage.getQuickstartGrid().should("be.visible");
+            identityProviderTemplatesPage.getQuickstartGrid()
+                .within(() => {
+                    identityProviderTemplatesPage.getQuickStartTemplate("GOOGLE").should("be.visible");
+                    identityProviderTemplatesPage.getQuickStartTemplate("FACEBOOK").should("be.visible");
+                    identityProviderTemplatesPage.getQuickStartTemplate("OIDC").should("be.visible");
+                });
+
+            identityProviderTemplatesPage.getManualSetupGrid().should("be.visible");
+            identityProviderTemplatesPage.getManualSetupGrid()
+                .within(() => {
+                    identityProviderTemplatesPage.getManualSetupTemplate("EXPERT").should("be.visible");
+                })
+        });
+    });
+});

--- a/tests/support/identity-providers/identity-providers-commands.ts
+++ b/tests/support/identity-providers/identity-providers-commands.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/// <reference types="cypress" />
+
+import { Header } from "@wso2/identity-cypress-test-base/page-objects";
+import { IdentityProvidersListPage } from "../../integration/identity-providers/page-objects";
+
+/**
+ * Custom command to navigate to the identity providers listing page.
+ * @example cy.navigateToIDPList()
+ *
+ * @param {boolean} switchPortalTab - If needed to switch to manage portal.
+ * @returns {Cypress.CanReturnChainable}
+ */
+Cypress.Commands.add("navigateToIDPList", (switchPortalTab: boolean = true): Cypress.CanReturnChainable => {
+
+    if (switchPortalTab) {
+        const header: Header = new Header();
+        header.clickOnDevelopPortalSwitch();
+    }
+
+    const identityProvidersListPage: IdentityProvidersListPage = new IdentityProvidersListPage();
+
+    identityProvidersListPage.clickOnSidePanelItem();
+});
+
+/**
+ * Custom command to check if the identity providers list page renders properly.
+ * @example cy.checkIfIDPListingRenders()
+ *
+ * @param {boolean} isNew - Is the list a new one.
+ * @returns {Cypress.CanReturnChainable}
+ */
+Cypress.Commands.add("checkIfIDPListingRenders", (isNew: boolean = false): Cypress.CanReturnChainable => {
+
+    const identityProvidersListPage: IdentityProvidersListPage = new IdentityProvidersListPage();
+
+    // Check if page header exists and check if all the necessary elements are rendering.
+    identityProvidersListPage.getPageLayoutHeader().should("be.visible");
+    identityProvidersListPage.getPageLayoutHeaderTitle().should("be.visible");
+    identityProvidersListPage.getPageLayoutHeaderSubTitle().should("be.visible");
+
+    // Check if page header has an action. New tables will have the create button in the placeholder.
+    if (!isNew){
+        identityProvidersListPage.getPageLayoutHeaderAction().should("be.visible");
+    }
+
+    // Check if the email templates page exists.
+    identityProvidersListPage.getTable().should("be.visible");
+});

--- a/tests/support/identity-providers/index.ts
+++ b/tests/support/identity-providers/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+export * from "./identity-providers-commands";

--- a/tests/support/index.ts
+++ b/tests/support/index.ts
@@ -24,4 +24,5 @@ import "@wso2/identity-cypress-test-base/commands";
 import "./applications";
 import "./email-templates";
 import "./commands";
+import "./identity-providers";
 import "./register";

--- a/tests/types/index.d.ts
+++ b/tests/types/index.d.ts
@@ -45,5 +45,14 @@ declare namespace Cypress {
          * Custom command to check if the email template types page renders properly.
          */
         checkIfEmailTemplateTypeListingRenders(): Cypress.CanReturnChainable;
+        /**
+         * Custom command to navigate to the identity providers list page.
+         */
+        navigateToIDPList(switchPortalTab?: boolean): Cypress.CanReturnChainable;
+
+        /**
+         * Custom command to check if the identity providers listing page renders properly.
+         */
+        checkIfIDPListingRenders(isNew?: boolean): Cypress.CanReturnChainable;
     }
 }


### PR DESCRIPTION
## Purpose
Add integration test cases for Identity Provider Management.

## Goals
Fixes https://github.com/wso2/product-is/issues/9828
Partially addresses https://github.com/wso2/product-is/issues/9394

## Covered Integration Scenarios

**Smoke Tests.**
- IDP Listing Page.
    - User can visit the IDP listing page from the side panel
    - Properly renders the elements of the listing page.
    - Shows the empty list placeholder.
- IDP Templates Page.
    - Navigates to the template selection page properly.
    - Navigates to the correct template selection page URL.
    - Displays the template selection page elements properly.

**Basic IDP Integration Tests.**
- IDP Listing.
    - User can visit the IDP listing page from the side panel.
    - Properly renders the elements of the listing page.
    - Check if the new list placeholder is shown in fresh tables.
- Create an IDP using the wizard.
    - Register the IDP.
    - Correctly navigates to the edit page.
- IDP edit page works as expected.
    - Correctly renders the required elements of the edit page.
    - Displays info about the newly created IDP.
    - Can navigate to all the tabs.
    - IDP General Settings.
    - Can edit basic settings.
    - Can add a JWKS endpoint.
- IDP Attributes Settings.
    - Can add claim mappings.
- Delete IDP using Danger Zone.
    - Delete button is disabled when the assertion input is empty.
    - Delete button is disabled when a wrong assertion is entered.
    - Can delete the application using the correct assertion is entered.