### PR TITLE
Change group/role separation property name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
     - .autoconf
     - $HOME/.m2
-script: mvn clean install
+script: mvn clean install -q
 sudo: true
 language: node_js
 node_js:

--- a/apps/console/src/features/users/components/user-roles-edit.tsx
+++ b/apps/console/src/features/users/components/user-roles-edit.tsx
@@ -288,7 +288,7 @@ export const UserRolesList: FunctionComponent<UserRolesPropsInterface> = (
                 ],
                 "Operations": [{
                     "op": "remove",
-                    "path":"users[value eq " + user.id + "]"
+                    "path": "users[value eq " + user.id + "]"
                 }]
             },
             method: "PATCH"

--- a/apps/console/src/features/users/components/user-roles-edit.tsx
+++ b/apps/console/src/features/users/components/user-roles-edit.tsx
@@ -288,11 +288,7 @@ export const UserRolesList: FunctionComponent<UserRolesPropsInterface> = (
                 ],
                 "Operations": [{
                     "op": "remove",
-                    "value": {
-                        "users": [{
-                            "value": user.id
-                        }]
-                    }
+                    "path":"users[value eq " + user.id + "]"
                 }]
             },
             method: "PATCH"

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -384,7 +384,7 @@
            {% endfor %}
            {% endif %}
         },
-        "isGroupAndRoleSeparationEnabled": {{ authorization_manager.properties.GroupAndRoleSeparationEnabled }},
+        "isGroupAndRoleSeparationEnabled": {{ authorization_manager.properties.group_and_role_separation_enabled }},
         "productName": "{{ console.ui.product_name }}",
         "productVersionConfig": {
             {% if console.product_version.configs.items() is defined %}


### PR DESCRIPTION
## Purpose

- Changed the property name which read the roles and group separation configuration to align with the change in [1].
- Fixed role patch request issue.

  [1] - https://github.com/wso2/carbon-kernel/pull/2797