### PR TITLE
Add ability to manage user sessions in Console

### DIFF
--- a/apps/console/src/features/core/configs/ui.ts
+++ b/apps/console/src/features/core/configs/ui.ts
@@ -172,3 +172,7 @@ export const CertificateIllustrations = {
     ribbon: CertificateRibbon,
     uploadPlaceholder: FileUploadIllustration
 };
+
+export const UserSessionAccordionIcons = {
+    terminate: ForbiddenIcon
+};

--- a/apps/console/src/features/users/api/users.ts
+++ b/apps/console/src/features/users/api/users.ts
@@ -19,9 +19,10 @@
 import { IdentityClient } from "@asgardio/oidc-js";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { HttpMethods, ProfileInfoInterface } from "@wso2is/core/models";
+import { AxiosError, AxiosResponse } from "axios";
 import { store } from "../../core";
 import { UserManagementConstants } from "../constants";
-import { UserListInterface } from "../models";
+import { UserListInterface, UserSessionsInterface } from "../models";
 
 /**
  * Initialize an axios Http client.
@@ -195,6 +196,136 @@ export const updateUserInfo = (userId: string, data: object): Promise<ProfileInf
         .catch((error) => {
             throw new IdentityAppsApiException(
                 UserManagementConstants.USER_INFO_UPDATE_ERROR,
+                error.stack,
+                error.code,
+                error.request,
+                error.response,
+                error.config);
+        });
+};
+
+/**
+ * Retrieves information related to the active sessions of a user identified by the user-id.
+ *
+ * @param {string} userId - User ID.
+ * @return {Promise<AxiosResponse<UserSessionsInterface>>} a promise containing the response.
+ * @throws {IdentityAppsApiException}
+ */
+export const getUserSessions = (userId: string): Promise<AxiosResponse<UserSessionsInterface>> => {
+
+    const requestConfig = {
+        headers: {
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        url: store.getState().config.endpoints.userSessions.replace("{0}", userId)
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse<UserSessionsInterface>) => {
+            if (response.status !== 200) {
+                throw new IdentityAppsApiException(
+                    UserManagementConstants.GET_USER_SESSIONS_REQUEST_INVALID_STATUS_CODE_ERROR,
+                    null,
+                    response.status,
+                    response.request,
+                    response,
+                    response.config);
+            }
+
+            return Promise.resolve(response);
+        })
+        .catch((error: AxiosError) => {
+            throw new IdentityAppsApiException(
+                UserManagementConstants.GET_USER_SESSIONS_REQUEST_ERROR,
+                error.stack,
+                error.code,
+                error.request,
+                error.response,
+                error.config);
+        });
+};
+
+/**
+ * Terminates a specific user session of a user.
+ *
+ * @param {string} userId - User ID.
+ * @param {string} sessionId - ID of the session.
+ * @return {Promise<AxiosResponse>} a promise containing the response.
+ * @throws {IdentityAppsApiException}
+ */
+export const terminateUserSession = (userId: string, sessionId: string): Promise<AxiosResponse> => {
+
+    const requestConfig = {
+        headers: {
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.DELETE,
+        url: store.getState().config.endpoints.userSessions.replace("{0}", userId) + `/${ sessionId }`
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse<UserSessionsInterface>) => {
+            if (response.status !== 204) {
+                throw new IdentityAppsApiException(
+                    UserManagementConstants.TERMINATE_USER_SESSION_REQUEST_INVALID_STATUS_CODE_ERROR,
+                    null,
+                    response.status,
+                    response.request,
+                    response,
+                    response.config);
+            }
+
+            return Promise.resolve(response);
+        })
+        .catch((error: AxiosError) => {
+            throw new IdentityAppsApiException(
+                UserManagementConstants.TERMINATE_USER_SESSION_REQUEST_ERROR,
+                error.stack,
+                error.code,
+                error.request,
+                error.response,
+                error.config);
+        });
+};
+
+/**
+ * Terminates all the user session of a user.
+ *
+ * @param {string} userId - User ID.
+ * @return {Promise<AxiosResponse>} a promise containing the response.
+ * @throws {IdentityAppsApiException}
+ */
+export const terminateAllUserSessions = (userId: string): Promise<AxiosResponse> => {
+
+    const requestConfig = {
+        headers: {
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.DELETE,
+        url: store.getState().config.endpoints.userSessions.replace("{0}", userId)
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse<UserSessionsInterface>) => {
+            if (response.status !== 204) {
+                throw new IdentityAppsApiException(
+                    UserManagementConstants.TERMINATE_ALL_USER_SESSIONS_REQUEST_INVALID_STATUS_CODE_ERROR,
+                    null,
+                    response.status,
+                    response.request,
+                    response,
+                    response.config);
+            }
+
+            return Promise.resolve(response);
+        })
+        .catch((error: AxiosError) => {
+            throw new IdentityAppsApiException(
+                UserManagementConstants.TERMINATE_ALL_USER_SESSIONS_ERROR,
                 error.stack,
                 error.code,
                 error.request,

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -26,6 +26,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { UserGroupsList } from "./user-groups-edit";
 import { UserProfile } from "./user-profile";
 import { UserRolesList } from "./user-roles-edit";
+import { UserSessions } from "./user-sessions";
 import { FeatureConfigInterface } from "../../core/models";
 import { AppState } from "../../core/store";
 import { UserManagementConstants } from "../constants";
@@ -91,7 +92,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
 
     const panes = () => ([
         {
-            menuItem: t("adminPortal:components.user.editUser.menu.menuItems.0"),
+            menuItem: t("console:manage.features.users.editUser.tab.menuItems.0"),
             render: () => (
                 <ResourceTab.Pane controlledSegmentation attached={ false }>
                     <UserProfile
@@ -104,7 +105,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
             )
         },
         {
-            menuItem: t("adminPortal:components.user.editUser.menu.menuItems.1"),
+            menuItem: t("console:manage.features.users.editUser.tab.menuItems.1"),
             render: () => (
                 <ResourceTab.Pane controlledSegmentation attached={ false }>
                     <UserGroupsList
@@ -117,7 +118,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
             )
         },
         {
-            menuItem: t("adminPortal:components.user.editUser.menu.menuItems.2"),
+            menuItem: t("console:manage.features.users.editUser.tab.menuItems.2"),
             render: () => (
                 <ResourceTab.Pane controlledSegmentation attached={ false }>
                     <UserRolesList
@@ -127,6 +128,14 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                         handleUserUpdate={ handleUserUpdate }
                         isReadOnly={ isReadOnly }
                     />
+                </ResourceTab.Pane>
+            )
+        },
+        {
+            menuItem: t("console:manage.features.users.editUser.tab.menuItems.3"),
+            render: () => (
+                <ResourceTab.Pane controlledSegmentation attached={ false }>
+                    <UserSessions user={ user } />
                 </ResourceTab.Pane>
             )
         }

--- a/apps/console/src/features/users/components/index.ts
+++ b/apps/console/src/features/users/components/index.ts
@@ -25,4 +25,5 @@ export * from "./edit-user";
 export * from "./user-groups-edit";
 export * from "./user-roles-edit";
 export * from "./users-list-options";
+export * from "./user-sessions";
 export * from "./wizard";

--- a/apps/console/src/features/users/components/user-sessions.tsx
+++ b/apps/console/src/features/users/components/user-sessions.tsx
@@ -45,7 +45,7 @@ import React, {
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Grid, Icon, Label, List, SemanticICONS } from "semantic-ui-react";
-import { EmptyPlaceholderIllustrations, FeatureConfigInterface } from "../../core";
+import { EmptyPlaceholderIllustrations, FeatureConfigInterface, UserSessionAccordionIcons } from "../../core";
 import { getUserSessions, terminateAllUserSessions, terminateUserSession } from "../api";
 import { ApplicationSessionInterface, UserSessionInterface, UserSessionsInterface } from "../models";
 
@@ -71,7 +71,6 @@ interface UserSessionsPropsInterface extends SBACInterface<FeatureConfigInterfac
  * Component to manage user sessions.
  *
  * @param {UserSessionsPropsInterface} props - Props injected to the component.
- *
  * @return {React.ReactElement}
  */
 export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
@@ -103,7 +102,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
         showAllSessionsTerminateConfirmationModal,
         setShowAllSessionsTerminateConfirmationModal
     ] = useState<boolean>(false);
-    
+
+    /**
+     * Fetches the active sessions once the user prop is avaiable.
+     */
     useEffect(() => {
 
         if (!user || !user.id) {
@@ -143,7 +145,7 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                 }
 
                 dispatch(addAlert<AlertInterface>({
-                    description:  t("console:manage.features.users.userSessions.notifications.getUserSessions." +
+                    description: t("console:manage.features.users.userSessions.notifications.getUserSessions." +
                         "genericError.description"),
                     level: AlertLevels.ERROR,
                     message: t(
@@ -179,8 +181,7 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
             }
         };
 
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const [ key, value ] of Object.entries(deviceType)) {
+        for (const value of Object.values(deviceType)) {
             if (value.values.includes(type)) {
                 return value.icon as SemanticICONS;
             }
@@ -286,6 +287,12 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
         setAccordionActiveIndexes(newIndexes);
     };
 
+    /**
+     * Renders user session details.
+     *
+     * @param {UserSessionInterface} session - User session object.
+     * @return {React.ReactElement}
+     */
     const renderSessionDetails = (session: UserSessionInterface): ReactElement => {
 
         userAgentParser.uaString = session.userAgent;
@@ -297,7 +304,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                         <Grid padded>
                             <Grid.Row columns={ 2 }>
                                 <Grid.Column width={ 5 }>
-                                    { t("common:operatingSystem") }
+                                    {
+                                        t("console:manage.features.users.userSessions.components.sessionDetails" +
+                                            ".labels.os")
+                                    }
                                 </Grid.Column>
                                 <Grid.Column width={ 11 }>
                                     <List.Description>
@@ -311,7 +321,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                             </Grid.Row>
                             <Grid.Row columns={ 2 }>
                                 <Grid.Column width={ 5 }>
-                                    { t("common:browser") }
+                                    {
+                                        t("console:manage.features.users.userSessions.components.sessionDetails" +
+                                            ".labels.browser")
+                                    }
                                 </Grid.Column>
                                 <Grid.Column width={ 11 }>
                                     <List.Description>
@@ -325,7 +338,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                             </Grid.Row>
                             <Grid.Row columns={ 2 }>
                                 <Grid.Column width={ 5 }>
-                                    { t("common:ipAddress") }
+                                    {
+                                        t("console:manage.features.users.userSessions.components.sessionDetails" +
+                                            ".labels.ip")
+                                    }
                                 </Grid.Column>
                                 <Grid.Column width={ 11 }>
                                     <List.Description>{ session.ip }</List.Description>
@@ -336,7 +352,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                     ? (
                                         <Grid.Row columns={ 2 }>
                                             <Grid.Column width={ 5 }>
-                                                { t("common:deviceModel") }
+                                                {
+                                                    t("console:manage.features.users.userSessions.components" +
+                                                        ".sessionDetails.labels.deviceModel")
+                                                }
                                             </Grid.Column>
                                             <Grid.Column width={ 11 }>
                                                 <List.Description>
@@ -351,7 +370,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                             }
                             <Grid.Row columns={ 2 }>
                                 <Grid.Column width={ 5 }>
-                                    { t("common:loginTime") }
+                                    {
+                                        t("console:manage.features.users.userSessions.components" +
+                                            ".sessionDetails.labels.loginTime")
+                                    }
                                 </Grid.Column>
                                 <Grid.Column width={ 11 }>
                                     <List.Description>
@@ -361,7 +383,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                             </Grid.Row>
                             <Grid.Row columns={ 2 }>
                                 <Grid.Column width={ 5 }>
-                                    { t("common:lastAccessed") }
+                                    {
+                                        t("console:manage.features.users.userSessions.components" +
+                                            ".sessionDetails.labels.lastAccessed")
+                                    }
                                 </Grid.Column>
                                 <Grid.Column width={ 11 }>
                                     <List.Description>
@@ -374,7 +399,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                     ? (
                                         <Grid.Row columns={ 2 }>
                                             <Grid.Column width={ 5 }>
-                                                Recent Activity
+                                                {
+                                                    t("console:manage.features.users.userSessions.components" +
+                                                        ".sessionDetails.labels.recentActivity")
+                                                }
                                             </Grid.Column>
                                             <Grid.Column mobile={ 16 } computer={ 11 }>
                                                 {
@@ -388,11 +416,25 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                                                 color="green"
                                                                 size="mini"
                                                             />
-                                                            Logged in on <strong>
-                                                            { application.appName }
-                                                        </strong> as <strong>
-                                                            { application.subject.split("@")[ 0 ] }
-                                                        </strong>
+                                                            <Trans
+                                                                i18nKey={
+                                                                    "console:manage.features.users.userSessions" +
+                                                                    ".components.sessionDetails.labels.loggedInAs"
+                                                                }
+                                                                tOptions={ {
+                                                                    app: application.appName,
+                                                                    user: application.subject.split("@")[ 0 ]
+                                                                } }
+                                                            >
+                                                                { "Logged in on " }
+                                                                <strong>
+                                                                    { application.appName }
+                                                                </strong>
+                                                                { " as " }
+                                                                <strong>
+                                                                    { application.subject.split("@")[ 0 ] }
+                                                                </strong>
+                                                            </Trans>
                                                         </List.Description>
                                                     ))
                                                 }
@@ -410,7 +452,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                             setShowSessionTerminateConfirmationModal(true);
                                         } }
                                     >
-                                        Terminate Session
+                                        {
+                                            t("console:manage.features.users.userSessions.components.sessionDetails" +
+                                                ".actions.terminateSession")
+                                        }
                                     </DangerButton>
                                 </Grid.Column>
                             </Grid.Row>
@@ -421,7 +466,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
         );
     };
 
-    const handleAllSessionsTerminate = () => {
+    /**
+     * Terminates all active user sessions.
+     */
+    const handleAllSessionsTerminate = (): void => {
 
         terminateAllUserSessions(user.id)
             .then(() => {
@@ -465,12 +513,17 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
             });
     };
 
-    const handleSessionTerminate = (sessionId: string) => {
+    /**
+     * Terminate the selected user session.
+     *
+     * @param {string} sessionId - ID of the session to be terminated.
+     */
+    const handleSessionTerminate = (sessionId: string): void => {
 
         terminateUserSession(user.id, sessionId)
             .then(() => {
                 dispatch(addAlert<AlertInterface>({
-                    description:  t("console:manage.features.users.userSessions.notifications.terminateUserSession." +
+                    description: t("console:manage.features.users.userSessions.notifications.terminateUserSession." +
                         "success.description"),
                     level: AlertLevels.SUCCESS,
                     message: t(
@@ -495,7 +548,7 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                 }
 
                 dispatch(addAlert<AlertInterface>({
-                    description:  t("console:manage.features.users.userSessions.notifications.terminateUserSession." +
+                    description: t("console:manage.features.users.userSessions.notifications.terminateUserSession." +
                         "genericError.description"),
                     level: AlertLevels.ERROR,
                     message: t(
@@ -505,8 +558,80 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                 }));
             })
             .finally(() => {
-               fetchUserSessions(user.id); 
+                fetchUserSessions(user.id);
             });
+    };
+
+    /**
+     * Renders the session listing accordion.
+     * @return {React.ReactElement}
+     */
+    const renderAccordion = (): ReactElement => {
+
+        return (
+            <SegmentedAccordion fluid data-testid={ `${ testId }-accordion` }>
+                {
+                    userSessions.sessions.map((session: UserSessionInterface, index: number) => {
+
+                        userAgentParser.uaString = session.userAgent;
+
+                        return (
+                            <Fragment key={ session.id }>
+                                <SegmentedAccordion.Title
+                                    id={ session.id }
+                                    data-testid={ `${ testId }-${ session.id }-title` }
+                                    active={ accordionActiveIndexes.includes(index) }
+                                    index={ index }
+                                    onClick={ handleAccordionOnClick }
+                                    content={ (
+                                        <>
+                                            <GenericIcon
+                                                transparent
+                                                icon={ (
+                                                    <Icon
+                                                        name={ resolveDeviceType(userAgentParser.device.type) }
+                                                        color="grey"
+                                                    />
+                                                ) }
+                                                spaced="right"
+                                                floated="left"
+                                                size="micro"
+                                                data-testid={
+                                                    `${ testId }-${ session.id }-title-icon`
+                                                }
+                                            />
+                                            { userAgentParser.browser.name }
+                                            { " on " }
+                                            { userAgentParser.os.name }
+                                        </>
+                                    ) }
+                                    actions={ [
+                                        {
+                                            icon: {
+                                                icon: UserSessionAccordionIcons.terminate
+                                            },
+                                            onClick: () => {
+                                                setTerminatingSession(session);
+                                                setShowSessionTerminateConfirmationModal(true);
+                                            },
+                                            popoverText: t("common:terminate"),
+                                            type: "icon"
+                                        }
+                                    ] }
+                                    hideChevron={ false }
+                                />
+                                <SegmentedAccordion.Content
+                                    active={ accordionActiveIndexes.includes(index) }
+                                    data-testid={ `${ testId }-${ session.id }-content` }
+                                >
+                                    { renderSessionDetails(session) }
+                                </SegmentedAccordion.Content>
+                            </Fragment>
+                        )
+                    })
+                }
+            </SegmentedAccordion>
+        );
     };
 
     return (
@@ -524,82 +649,16 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                     data-testid={ `${ testId }-terminate-all-button` }
                                     onClick={ () => setShowAllSessionsTerminateConfirmationModal(true) }
                                 >
-                                    <Icon name="stop circle outline"/>
-                                    Terminate All
+                                    {
+                                        t("console:manage.features.users.userSessions.components.sessionDetails" +
+                                            ".actions.terminateAllSessions")
+                                    }
                                 </DangerButton>
                             </Grid.Column>
                         </Grid.Row>
                         <Grid.Row>
                             <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
-                                <SegmentedAccordion fluid data-testid={ `${ testId }-accordion` }>
-                                    {
-                                        (userSessions
-                                            && userSessions.sessions
-                                            && Array.isArray(userSessions.sessions)
-                                            && userSessions.sessions.length > 0)
-                                            ? userSessions.sessions
-                                                .map((session: UserSessionInterface, index: number) => {
-
-                                                    userAgentParser.uaString = session.userAgent;
-
-                                                    return (
-                                                        <Fragment key={ session.id }>
-                                                            <SegmentedAccordion.Title
-                                                                id={ session.id }
-                                                                data-testid={ `${ testId }-${ session.id }-title` }
-                                                                active={ accordionActiveIndexes.includes(index) }
-                                                                index={ index }
-                                                                onClick={ handleAccordionOnClick }
-                                                                content={ (
-                                                                    <>
-                                                                        <GenericIcon
-                                                                            transparent
-                                                                            icon={ (
-                                                                                <Icon
-                                                                                    name={
-                                                                                        resolveDeviceType(
-                                                                                            userAgentParser.device.type
-                                                                                        )
-                                                                                    }
-                                                                                    color="grey"
-                                                                                />
-                                                                            ) }
-                                                                            spaced="right"
-                                                                            floated="left"
-                                                                            size="micro"
-                                                                            data-testid={
-                                                                                `${ testId }-${ session.id }-title-icon`
-                                                                            }
-                                                                        />
-                                                                        { userAgentParser.browser.name }
-                                                                        { " on " }
-                                                                        { userAgentParser.os.name }
-                                                                    </>
-                                                                ) }
-                                                                actions={ [
-                                                                    {
-                                                                        icon: "stop circle",
-                                                                        onClick: () => {
-                                                                            setTerminatingSession(session);
-                                                                            setShowSessionTerminateConfirmationModal(true);
-                                                                        },
-                                                                        type: "icon"
-                                                                    }
-                                                                ] }
-                                                                hideChevron={ false }
-                                                            />
-                                                            <SegmentedAccordion.Content
-                                                                active={ accordionActiveIndexes.includes(index) }
-                                                                data-testid={ `${ testId }-${ session.id }-content` }
-                                                            >
-                                                                { renderSessionDetails(session) }
-                                                            </SegmentedAccordion.Content>
-                                                        </Fragment>
-                                                    )
-                                                })
-                                            : null
-                                    }
-                                </SegmentedAccordion>
+                                { renderAccordion() }
                             </Grid.Column>
                         </Grid.Row>
                         {
@@ -608,10 +667,10 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                     onClose={ (): void => {
                                         if (showSessionTerminateConfirmationModal) {
                                             setShowSessionTerminateConfirmationModal(false);
-                                            
+    
                                             return;
                                         }
-
+    
                                         setShowAllSessionsTerminateConfirmationModal(false);
                                     } }
                                     type="warning"
@@ -642,20 +701,20 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                     onSecondaryActionClick={ (): void => {
                                         if (showSessionTerminateConfirmationModal) {
                                             setShowSessionTerminateConfirmationModal(false);
-
+    
                                             return;
                                         }
-
+    
                                         setShowAllSessionsTerminateConfirmationModal(false);
                                     } }
                                     onPrimaryActionClick={ (): void => {
                                         if (showSessionTerminateConfirmationModal) {
                                             handleSessionTerminate(terminatingSession.id);
                                             setShowSessionTerminateConfirmationModal(false);
-
+    
                                             return;
                                         }
-
+    
                                         handleAllSessionsTerminate();
                                         setShowAllSessionsTerminateConfirmationModal(false);
                                     } }
@@ -721,7 +780,7 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                 :
                 (
                     <EmptyPlaceholder
-                        image={ EmptyPlaceholderIllustrations.emptySearch }
+                        image={ EmptyPlaceholderIllustrations.emptyList }
                         imageSize="tiny"
                         title={
                             t("console:manage.features.users.userSessions.placeholders.emptyListPlaceholder.title")

--- a/apps/console/src/features/users/components/user-sessions.tsx
+++ b/apps/console/src/features/users/components/user-sessions.tsx
@@ -28,7 +28,9 @@ import { addAlert } from "@wso2is/core/store";
 import {
     ConfirmationModal,
     ContentLoader,
-    DangerButton, GenericIcon,
+    DangerButton,
+    EmptyPlaceholder,
+    GenericIcon,
     SegmentedAccordion
 } from "@wso2is/react-components";
 import { AxiosError, AxiosResponse } from "axios";
@@ -43,7 +45,7 @@ import React, {
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Grid, Icon, Label, List, SemanticICONS } from "semantic-ui-react";
-import { FeatureConfigInterface } from "../../core";
+import { EmptyPlaceholderIllustrations, FeatureConfigInterface } from "../../core";
 import { getUserSessions, terminateAllUserSessions, terminateUserSession } from "../api";
 import { ApplicationSessionInterface, UserSessionInterface, UserSessionsInterface } from "../models";
 
@@ -522,7 +524,7 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                     data-testid={ `${ testId }-terminate-all-button` }
                                     onClick={ () => setShowAllSessionsTerminateConfirmationModal(true) }
                                 >
-                                    <Icon name="add"/>
+                                    <Icon name="stop circle outline"/>
                                     Terminate All
                                 </DangerButton>
                             </Grid.Column>
@@ -576,8 +578,11 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                                                 ) }
                                                                 actions={ [
                                                                     {
-                                                                        icon: "trash alternate",
-                                                                        onClick: () => null,
+                                                                        icon: "stop circle",
+                                                                        onClick: () => {
+                                                                            setTerminatingSession(session);
+                                                                            setShowSessionTerminateConfirmationModal(true);
+                                                                        },
                                                                         type: "icon"
                                                                     }
                                                                 ] }
@@ -713,7 +718,19 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                         }
                     </Grid>
                 )
-                : null
+                :
+                (
+                    <EmptyPlaceholder
+                        image={ EmptyPlaceholderIllustrations.emptySearch }
+                        imageSize="tiny"
+                        title={
+                            t("console:manage.features.users.userSessions.placeholders.emptyListPlaceholder.title")
+                        }
+                        subtitle={ [
+                            t("console:manage.features.users.userSessions.placeholders.emptyListPlaceholder.subtitles")
+                        ] }
+                    />
+                )
             : <ContentLoader/>
     );
 };

--- a/apps/console/src/features/users/components/user-sessions.tsx
+++ b/apps/console/src/features/users/components/user-sessions.tsx
@@ -1,0 +1,541 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { UserAgentParser } from "@wso2is/core/helpers";
+import {
+    AlertInterface,
+    AlertLevels,
+    ProfileInfoInterface,
+    SBACInterface,
+    TestableComponentInterface
+} from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import {
+    ContentLoader,
+    DangerButton,
+    SegmentedAccordion
+} from "@wso2is/react-components";
+import { AxiosError, AxiosResponse } from "axios";
+import moment from "moment";
+import React, {
+    Fragment,
+    FunctionComponent,
+    ReactElement,
+    SyntheticEvent, useEffect,
+    useState
+} from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Grid, Icon, Label, List, SemanticICONS } from "semantic-ui-react";
+import { FeatureConfigInterface } from "../../core";
+import { getUserSessions, terminateAllUserSessions, terminateUserSession } from "../api";
+import { ApplicationSessionInterface, UserSessionInterface, UserSessionsInterface } from "../models";
+
+/**
+ * Proptypes for the user sessions component.
+ */
+interface UserSessionsPropsInterface extends SBACInterface<FeatureConfigInterface>, TestableComponentInterface {
+    /**
+     * Initial activeIndexes value.
+     */
+    defaultActiveIndexes?: number[];
+    /**
+     * Is the application info request loading.
+     */
+    isLoading?: boolean;
+    /**
+     * User profile
+     */
+    user: ProfileInfoInterface;
+}
+
+/**
+ * Component to manage user sessions.
+ *
+ * @param {UserSessionsPropsInterface} props - Props injected to the component.
+ *
+ * @return {React.ReactElement}
+ */
+export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
+    props: UserSessionsPropsInterface
+): ReactElement => {
+
+    const {
+        defaultActiveIndexes,
+        isLoading,
+        user,
+        [ "data-testid" ]: testId
+    } = props;
+
+    const userAgentParser = new UserAgentParser();
+
+    const { t } = useTranslation();
+
+    const dispatch = useDispatch();
+
+    const [ userSessions, setUserSessions ] = useState<UserSessionsInterface>(undefined);
+    const [ isUserSessionsFetchRequestLoading, setIsUserSessionsFetchRequestLoading ] = useState<boolean>(false);
+    const [ accordionActiveIndexes, setAccordionActiveIndexes ] = useState<number[]>(defaultActiveIndexes);
+    
+    useEffect(() => {
+
+        if (!user || !user.id) {
+            return;
+        }
+
+        fetchUserSessions(user.id);
+    }, [ user ]);
+
+    /**
+     * Fetches the active user sessions belonging to a specific user.
+     *
+     * @param {string} id - User ID
+     */
+    const fetchUserSessions = (id: string): void => {
+
+        setIsUserSessionsFetchRequestLoading(true);
+
+        getUserSessions(id)
+            .then((response: AxiosResponse<UserSessionsInterface>) => {
+                setUserSessions(response.data);
+            })
+            .catch((error: AxiosError) => {
+                if (error.response
+                    && error.response.data
+                    && (error.response.data.description || error.response.data.detail)) {
+
+                    dispatch(addAlert<AlertInterface>({
+                        description: error.response.data.description || error.response.data.detail,
+                        level: AlertLevels.ERROR,
+                        message: t(
+                            "console:manage.features.users.userSessions.notifications.getUserSessions.error.message"
+                        )
+                    }));
+
+                    return;
+                }
+
+                dispatch(addAlert<AlertInterface>({
+                    description: "console:manage.features.users.userSessions.notifications.getUserSessions." +
+                        "genericError.description",
+                    level: AlertLevels.ERROR,
+                    message: t(
+                        "console:manage.features.users.userSessions.notifications.getUserSessions." +
+                        "genericError.message"
+                    )
+                }));
+            })
+            .finally(() => {
+                setIsUserSessionsFetchRequestLoading(false);
+            });
+    };
+
+    /**
+     * Resolves an icon for the operating system type extracted from the user agent string.
+     *
+     * @param {string} type - Operating system type.
+     * @return {SemanticICONS}
+     */
+    const resolveOSIcon = (type: string): SemanticICONS => {
+
+        const osType = {
+            android: {
+                icon: "android",
+                values: [ "Android" ]
+            },
+            ios: {
+                icon: "apple",
+                values: [ "iOS" ]
+            },
+            linux: {
+                icon: "linux",
+                values: [ "Linux" ]
+            },
+            mac: {
+                icon: "apple",
+                values: [ "Mac OS" ]
+            },
+            windows: {
+                icon: "windows",
+                values: [ "Windows [Phone/Mobile]" ]
+            }
+        };
+
+        for (const value of Object.values(osType)) {
+            if (value.values.includes(type)) {
+                return value.icon as SemanticICONS;
+            }
+        }
+    };
+
+    /**
+     * Resolves an icon for the browser type extracted from the user agent string.
+     *
+     * @param {string} type - Browser type.
+     * @return {SemanticICONS}
+     */
+    const resolveBrowserIcon = (type: string): SemanticICONS => {
+
+        const browserType = {
+            chrome: {
+                icon: "chrome",
+                values: [ "Chrome", "Chrome Headless", "Chrome WebView", "Chromium" ]
+            },
+            edge: {
+                icon: "edge",
+                values: [ "Edge" ]
+            },
+            firefox: {
+                icon: "firefox",
+                values: [ "Firefox" ]
+            },
+            opera: {
+                icon: "opera",
+                values: [ "Opera Coast", "Opera Mini", "Opera Mobi", "Opera Tablet", "Opera" ]
+            },
+            safari: {
+                icon: "safari",
+                values: [ "Mobile Safari", "Safari" ]
+            }
+        };
+
+        for (const value of Object.values(browserType)) {
+            if (value.values.includes(type)) {
+                return value.icon as SemanticICONS;
+            }
+        }
+    };
+
+    /**
+     * Handles accordion title click.
+     *
+     * @param {React.SyntheticEvent} e - Click event.
+     * @param {number} index - Clicked on index.
+     */
+    const handleAccordionOnClick = (e: SyntheticEvent, { index }: { index: number }): void => {
+
+        const newIndexes = [ ...accordionActiveIndexes ];
+
+        if (newIndexes.includes(index)) {
+            const removingIndex = newIndexes.indexOf(index);
+            newIndexes.splice(removingIndex, 1);
+        } else {
+            newIndexes.push(index);
+        }
+
+        setAccordionActiveIndexes(newIndexes);
+    };
+
+    const renderSessionDetails = (session: UserSessionInterface): ReactElement => {
+
+        userAgentParser.uaString = session.userAgent;
+
+        return (
+            <Grid.Row>
+                <Grid.Column>
+                    <List.Content>
+                        <Grid padded>
+                            <Grid.Row columns={ 2 }>
+                                <Grid.Column width={ 5 }>
+                                    { t("common:operatingSystem") }
+                                </Grid.Column>
+                                <Grid.Column width={ 11 }>
+                                    <List.Description>
+                                        <Icon
+                                            name={ resolveOSIcon(userAgentParser.os.name) }
+                                            color="grey"
+                                        />
+                                        { userAgentParser.os.name }{ " " }{ userAgentParser.os.version }
+                                    </List.Description>
+                                </Grid.Column>
+                            </Grid.Row>
+                            <Grid.Row columns={ 2 }>
+                                <Grid.Column width={ 5 }>
+                                    { t("common:browser") }
+                                </Grid.Column>
+                                <Grid.Column width={ 11 }>
+                                    <List.Description>
+                                        <Icon
+                                            name={ resolveBrowserIcon(userAgentParser.browser.name) }
+                                            color="grey"
+                                        />
+                                        { userAgentParser.browser.name }{ " " }{ userAgentParser.browser.version }
+                                    </List.Description>
+                                </Grid.Column>
+                            </Grid.Row>
+                            <Grid.Row columns={ 2 }>
+                                <Grid.Column width={ 5 }>
+                                    { t("common:ipAddress") }
+                                </Grid.Column>
+                                <Grid.Column width={ 11 }>
+                                    <List.Description>{ session.ip }</List.Description>
+                                </Grid.Column>
+                            </Grid.Row>
+                            {
+                                userAgentParser.device.vendor
+                                    ? (
+                                        <Grid.Row columns={ 2 }>
+                                            <Grid.Column width={ 5 }>
+                                                { t("common:deviceModel") }
+                                            </Grid.Column>
+                                            <Grid.Column width={ 11 }>
+                                                <List.Description>
+                                                    { userAgentParser.device.vendor }
+                                                    { " " }
+                                                    { userAgentParser.device.model }
+                                                </List.Description>
+                                            </Grid.Column>
+                                        </Grid.Row>
+                                    )
+                                    : null
+                            }
+                            <Grid.Row columns={ 2 }>
+                                <Grid.Column width={ 5 }>
+                                    { t("common:loginTime") }
+                                </Grid.Column>
+                                <Grid.Column width={ 11 }>
+                                    <List.Description>
+                                        { moment(parseInt(session.loginTime, 10)).format("lll") }
+                                    </List.Description>
+                                </Grid.Column>
+                            </Grid.Row>
+                            <Grid.Row columns={ 2 }>
+                                <Grid.Column width={ 5 }>
+                                    { t("common:lastAccessed") }
+                                </Grid.Column>
+                                <Grid.Column width={ 11 }>
+                                    <List.Description>
+                                        { moment(parseInt(session.lastAccessTime, 10)).fromNow() }
+                                    </List.Description>
+                                </Grid.Column>
+                            </Grid.Row>
+                            {
+                                (session.applications && session.applications.length > 0)
+                                    ? (
+                                        <Grid.Row columns={ 2 }>
+                                            <Grid.Column width={ 5 }>
+                                                Recent Activity
+                                            </Grid.Column>
+                                            <Grid.Column mobile={ 16 } computer={ 11 }>
+                                                {
+                                                    session.applications.map((application: ApplicationSessionInterface,
+                                                                              index: number) => (
+
+                                                        <List.Description className="pb-2" key={ index }>
+                                                            <Label
+                                                                className="micro spaced-right"
+                                                                circular
+                                                                color="green"
+                                                                size="mini"
+                                                            />
+                                                            Logged in on <strong>
+                                                            { application.appName }
+                                                        </strong> as <strong>
+                                                            { application.subject.split("@")[ 0 ] }
+                                                        </strong>
+                                                        </List.Description>
+                                                    ))
+                                                }
+                                            </Grid.Column>
+                                        </Grid.Row>
+                                    )
+                                    : null
+                            }
+                            <Grid.Row columns={ 1 }>
+                                <Grid.Column width={ 16 }>
+                                    <DangerButton
+                                        data-testid={ `${ testId }-terminate-button` }
+                                        onClick={ () => handleSessionTerminate(session.id) }
+                                    >
+                                        Terminate Session
+                                    </DangerButton>
+                                </Grid.Column>
+                            </Grid.Row>
+                        </Grid>
+                    </List.Content>
+                </Grid.Column>
+            </Grid.Row>
+        );
+    };
+
+    const handleAllSessionsTerminate = () => {
+
+        terminateAllUserSessions(user.id)
+            .then(() => {
+                dispatch(addAlert<AlertInterface>({
+                    description: "console:manage.features.users.userSessions.notifications.terminateAllUserSessions." +
+                        "success.description",
+                    level: AlertLevels.SUCCESS,
+                    message: t(
+                        "console:manage.features.users.userSessions.notifications.terminateAllUserSessions." +
+                        "success.message"
+                    )
+                }));
+            })
+            .catch((error: AxiosError) => {
+                if (error.response
+                    && error.response.data
+                    && (error.response.data.description || error.response.data.detail)) {
+
+                    dispatch(addAlert<AlertInterface>({
+                        description: error.response.data.description || error.response.data.detail,
+                        level: AlertLevels.ERROR,
+                        message: t("console:manage.features.users.userSessions.notifications" +
+                            ".terminateAllUserSessions.error.message")
+                    }));
+
+                    return;
+                }
+
+                dispatch(addAlert<AlertInterface>({
+                    description: "console:manage.features.users.userSessions.notifications.terminateAllUserSessions." +
+                        "genericError.description",
+                    level: AlertLevels.ERROR,
+                    message: t(
+                        "console:manage.features.users.userSessions.notifications.terminateAllUserSessions." +
+                        "genericError.message"
+                    )
+                }));
+            })
+            .finally(() => {
+                fetchUserSessions(user.id);
+            });
+    };
+
+    const handleSessionTerminate = (sessionId: string) => {
+
+        terminateUserSession(user.id, sessionId)
+            .then(() => {
+                dispatch(addAlert<AlertInterface>({
+                    description: "console:manage.features.users.userSessions.notifications.terminateUserSession." +
+                        "success.description",
+                    level: AlertLevels.SUCCESS,
+                    message: t(
+                        "console:manage.features.users.userSessions.notifications.terminateUserSession." +
+                        "success.message"
+                    )
+                }));
+            })
+            .catch((error: AxiosError) => {
+                if (error.response
+                    && error.response.data
+                    && (error.response.data.description || error.response.data.detail)) {
+
+                    dispatch(addAlert<AlertInterface>({
+                        description: error.response.data.description || error.response.data.detail,
+                        level: AlertLevels.ERROR,
+                        message: t("console:manage.features.users.userSessions.notifications" +
+                            ".terminateUserSession.error.message")
+                    }));
+
+                    return;
+                }
+
+                dispatch(addAlert<AlertInterface>({
+                    description: "console:manage.features.users.userSessions.notifications.terminateUserSession." +
+                        "genericError.description",
+                    level: AlertLevels.ERROR,
+                    message: t(
+                        "console:manage.features.users.userSessions.notifications.terminateUserSession." +
+                        "genericError.message"
+                    )
+                }));
+            })
+            .finally(() => {
+               fetchUserSessions(user.id); 
+            });
+    };
+
+    return (
+        (!isLoading && !isUserSessionsFetchRequestLoading)
+            ? (userSessions
+                && userSessions.sessions
+                && Array.isArray(userSessions.sessions)
+                && userSessions.sessions.length > 0)
+                ? (
+                    <Grid data-testid={ testId }>
+                        <Grid.Row>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                <DangerButton
+                                    floated="right"
+                                    data-testid={ `${ testId }-terminate-all-button` }
+                                    onClick={ handleAllSessionsTerminate }
+                                >
+                                    <Icon name="add"/>
+                                    Terminate All
+                                </DangerButton>
+                            </Grid.Column>
+                        </Grid.Row>
+                        <Grid.Row>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                <SegmentedAccordion fluid data-testid={ `${ testId }-accordion` }>
+                                    {
+                                        (userSessions
+                                            && userSessions.sessions
+                                            && Array.isArray(userSessions.sessions)
+                                            && userSessions.sessions.length > 0)
+                                            ? userSessions.sessions
+                                                .map((session: UserSessionInterface, index: number) => (
+                                                    <Fragment key={ session.id }>
+                                                        <SegmentedAccordion.Title
+                                                            id={ session.id }
+                                                            data-testid={ `${ testId }-${ session.id }-title` }
+                                                            active={ accordionActiveIndexes.includes(index) }
+                                                            index={ index }
+                                                            onClick={ handleAccordionOnClick }
+                                                            content={ (
+                                                                <>
+                                                                    { session.lastAccessTime }
+                                                                </>
+                                                            ) }
+                                                            actions={ [
+                                                                {
+                                                                    icon: "trash alternate",
+                                                                    onClick: () => null,
+                                                                    type: "icon"
+                                                                }
+                                                            ] }
+                                                            hideChevron={ false }
+                                                        />
+                                                        <SegmentedAccordion.Content
+                                                            active={ accordionActiveIndexes.includes(index) }
+                                                            data-testid={ `${ testId }-${ session.id }-content` }
+                                                        >
+                                                            { renderSessionDetails(session) }
+                                                        </SegmentedAccordion.Content>
+                                                    </Fragment>
+                                            ))
+                                            : null
+                                    }
+                                </SegmentedAccordion>
+                            </Grid.Column>
+                        </Grid.Row>
+                    </Grid>
+                )
+                : null
+            : <ContentLoader/>
+    );
+};
+
+/**
+ * Default props for the user sessions component.
+ */
+UserSessions.defaultProps = {
+    "data-testid": "user-sessions",
+    defaultActiveIndexes: [ -1 ]
+};

--- a/apps/console/src/features/users/components/users-list.tsx
+++ b/apps/console/src/features/users/components/users-list.tsx
@@ -379,7 +379,7 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
                 onColumnSelectionChange={ onColumnSelectionChange }
                 onRowClick={ (e: SyntheticEvent, user: UserBasicInterface): void => {
                     handleUserEdit(user?.id);
-                    onListItemClick(e, user);
+                    onListItemClick && onListItemClick(e, user);
                 } }
                 placeholders={ showPlaceholders() }
                 selectable={ selection }

--- a/apps/console/src/features/users/configs/endpoints.ts
+++ b/apps/console/src/features/users/configs/endpoints.ts
@@ -28,6 +28,7 @@ export const getUsersResourceEndpoints = (serverHost: string): UsersResourceEndp
     return {
         bulk: `${ serverHost }/scim2/Bulk`,
         groups: `${ serverHost }/scim2/Groups`,
+        userSessions: `${ serverHost }/api/users/v1/{0}/sessions`,
         userStores: `${ serverHost }/api/server/v1/userstores`,
         users: `${ serverHost }/scim2/Users`
     }

--- a/apps/console/src/features/users/constants/user-management-constants.ts
+++ b/apps/console/src/features/users/constants/user-management-constants.ts
@@ -69,6 +69,18 @@ export class UserManagementConstants {
 
     // API errors
     public static readonly USER_INFO_UPDATE_ERROR: string = "Could not update the user information.";
+    public static readonly GET_USER_SESSIONS_REQUEST_INVALID_STATUS_CODE_ERROR: string = "Received an invalid " +
+        "status code while retrieving the user sessions.";
+    public static readonly GET_USER_SESSIONS_REQUEST_ERROR: string = "Could not retrieve the user sessions " +
+        "due to some error.";
+    public static readonly TERMINATE_USER_SESSION_REQUEST_INVALID_STATUS_CODE_ERROR: string = "Received an invalid " +
+        "status code while terminating the user sessions.";
+    public static readonly TERMINATE_USER_SESSION_REQUEST_ERROR: string = "Could not terminate the user session " +
+        "due to some error.";
+    public static readonly TERMINATE_ALL_USER_SESSIONS_REQUEST_INVALID_STATUS_CODE_ERROR: string = "Received an " +
+        "invalid status code while terminating all the user sessions.";
+    public static readonly TERMINATE_ALL_USER_SESSIONS_ERROR: string = "Could not terminate all the user sessions " +
+        "due to some error.";
 
     /**
      * Set of SCIM2 schema names.

--- a/apps/console/src/features/users/models/endpoints.ts
+++ b/apps/console/src/features/users/models/endpoints.ts
@@ -22,6 +22,7 @@
 export interface UsersResourceEndpointsInterface {
     bulk: string;
     groups: string;
+    userSessions: string;
     userStores: string;
     users: string;
 }

--- a/apps/console/src/features/users/models/user.ts
+++ b/apps/console/src/features/users/models/user.ts
@@ -155,3 +155,74 @@ export const createEmptyUserBasicWizard = (): AddUserWizardStateInterface => ({
     roles: [],
     userName: ""
 });
+
+/**
+ * Interface for User Sessions response.
+ */
+export interface UserSessionsInterface {
+    /**
+     * Id of the user.
+     * @example 00000001
+     */
+    userId: string;
+    /**
+     * List of active sessions.
+     */
+    sessions: UserSessionInterface[];
+}
+
+/**
+ * Interface for a User Session.
+ */
+export interface UserSessionInterface {
+    /**
+     * List of applications in the session.
+     */
+    applications: ApplicationSessionInterface[];
+    /**
+     * User agent of the session.
+     * @example Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1
+     */
+    userAgent: string;
+    /**
+     * IP address of the session.
+     * @example: 172.95.192.63
+     */
+    ip: string;
+    /**
+     * Login time of the session.
+     * @example: 1560412617
+     */
+    loginTime: string;
+    /**
+     * Last access time of the session.
+     * @example: 1560416196
+     */
+    lastAccessTime: string;
+    /**
+     * ID of the session.
+     * @example: 8d9806d1-4efc-483e-a96a-a0fa77d4328b
+     */
+    id: string;
+}
+
+/**
+ * Interface for the Application Session.
+ */
+export interface ApplicationSessionInterface {
+    /**
+     *  Username of the logged in user for the application.
+     *  @example: apiuser01
+     */
+    subject: string;
+    /**
+     * Name of the application.
+     * @example: sampleApp
+     */
+    appName: string;
+    /**
+     * ID of the application.
+     * @example: 012
+     */
+    appId: string;
+}

--- a/modules/i18n/src/models/namespaces/admin-portal-ns.ts
+++ b/modules/i18n/src/models/namespaces/admin-portal-ns.ts
@@ -1076,13 +1076,6 @@ export interface AdminPortalNS {
                     header: string;
                     dangerZone: DangerZone;
                 };
-                menu: {
-                    menuItems: {
-                        0: string;
-                        1: string;
-                        2: string;
-                    };
-                };
             };
             forms: {
                 addUserForm: {

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { ModalInterface, ValidationInterface } from "../common";
+import { ModalInterface, Notification, ValidationInterface } from "../common";
 
 /**
  * Model for the Console namespace
@@ -30,6 +30,29 @@ export interface ConsoleNS {
         validations: {
             inSecureURL: ValidationInterface;
             unrecognizedURL: ValidationInterface;
+        };
+    };
+    manage: {
+        features: {
+            users: {
+                editUser: {
+                    tab: {
+                        menuItems: {
+                            0: string;
+                            1: string;
+                            2: string;
+                            3: string;
+                        };
+                    };
+                };
+                userSessions: {
+                    notifications: {
+                        getUserSessions: Notification;
+                        terminateAllUserSessions: Notification;
+                        terminateUserSession: Notification;
+                    };
+                };
+            };
         };
     };
 }

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Confirmation, ModalInterface, Notification, ValidationInterface } from "../common";
+import { Confirmation, ModalInterface, Notification, Placeholder, ValidationInterface } from "../common";
 
 /**
  * Model for the Console namespace
@@ -54,6 +54,9 @@ export interface ConsoleNS {
                         getUserSessions: Notification;
                         terminateAllUserSessions: Notification;
                         terminateUserSession: Notification;
+                    };
+                    placeholders: {
+                        emptyListPlaceholder: Placeholder;
                     };
                 };
             };

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -50,6 +50,24 @@ export interface ConsoleNS {
                     };
                 };
                 userSessions: {
+                    components: {
+                        sessionDetails: {
+                            actions: {
+                                terminateAllSessions: string;
+                                terminateSession: string;
+                            };
+                            labels: {
+                                browser: string;
+                                deviceModel: string;
+                                ip: string;
+                                lastAccessed: string;
+                                loggedInAs: string;
+                                loginTime: string;
+                                os: string;
+                                recentActivity: string;
+                            };
+                        };
+                    };
                     notifications: {
                         getUserSessions: Notification;
                         terminateAllUserSessions: Notification;

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { ModalInterface, Notification, ValidationInterface } from "../common";
+import { Confirmation, ModalInterface, Notification, ValidationInterface } from "../common";
 
 /**
  * Model for the Console namespace
@@ -35,6 +35,10 @@ export interface ConsoleNS {
     manage: {
         features: {
             users: {
+                confirmations: {
+                    terminateAllSessions: Confirmation;
+                    terminateSession: Confirmation;
+                };
                 editUser: {
                     tab: {
                         menuItems: {

--- a/modules/i18n/src/translations/en-US/portals/admin-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/admin-portal.ts
@@ -1843,13 +1843,6 @@ export const adminPortal: AdminPortalNS = {
                         subheader: "Once you delete a user, there is no going back. Please be certain."
                     },
                     header: "Danger Zone"
-                },
-                menu: {
-                    menuItems: {
-                        0: "Profile",
-                        1: "Groups",
-                        2: "Roles"
-                    }
                 }
             },
             forms: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -162,6 +162,12 @@ export const console: ConsoleNS = {
                                 message: "Termination Successful"
                             }
                         }
+                    },
+                    placeholders: {
+                        emptyListPlaceholder: {
+                            subtitles: "There are no active sessions for this users.",
+                            title: "No active sessions"
+                        }
                     }
                 }
             }

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -92,6 +92,22 @@ export const console: ConsoleNS = {
     manage: {
         features: {
             users: {
+                confirmations: {
+                    terminateAllSessions: {
+                        assertionHint: "Please type <1>{{ name }}</1> to confirm.",
+                        content: "If you proceed with this action, the user will be logged out of all active " +
+                            "sessions. They will loose the progress of any ongoing tasks. Please proceed with caution.",
+                        header: "Are you sure?",
+                        message: "This action is irreversible and will permanently terminate all the active sessions."
+                    },
+                    terminateSession: {
+                        assertionHint: "Please type <1>{{ name }}</1> to confirm.",
+                        content: "If you proceed with this action, the user will be logged out of the selected " +
+                            "session. They will loose the progress of any ongoing tasks. Please proceed with caution.",
+                        header: "Are you sure?",
+                        message: "This action is irreversible and will permanently terminate the session."
+                    }
+                },
                 editUser: {
                     tab: {
                         menuItems: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -88,5 +88,67 @@ export const console: ConsoleNS = {
                 heading: "Unrecognized URL"
             }
         }
+    },
+    manage: {
+        features: {
+            users: {
+                editUser: {
+                    tab: {
+                        menuItems: {
+                            0: "Profile",
+                            1: "Groups",
+                            2: "Roles",
+                            3: "Sessions"
+                        }
+                    }
+                },
+                userSessions: {
+                    notifications: {
+                        getUserSessions: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "Retrieval Error"
+                            },
+                            genericError: {
+                                description: "An error occurred while retrieving user sessions.",
+                                message: "Retrieval Error"
+                            },
+                            success: {
+                                description: "Successfully retrieved user sessions.",
+                                message: "Retrieval Successful"
+                            }
+                        },
+                        terminateAllUserSessions: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "Termination Error"
+                            },
+                            genericError: {
+                                description: "An error occurred while terminating the user sessions.",
+                                message: "Termination Error"
+                            },
+                            success: {
+                                description: "Successfully terminated all the user sessions.",
+                                message: "Termination Successful"
+                            }
+                        },
+                        terminateUserSession: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "Termination Error"
+                            },
+                            genericError: {
+                                description: "An error occurred while terminating the user session.",
+                                message: "Termination Error"
+                            },
+                            success: {
+                                description: "Successfully terminated the user session.",
+                                message: "Termination Successful"
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 };

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -114,11 +114,29 @@ export const console: ConsoleNS = {
                             0: "Profile",
                             1: "Groups",
                             2: "Roles",
-                            3: "Sessions"
+                            3: "Active Sessions"
                         }
                     }
                 },
                 userSessions: {
+                    components: {
+                        sessionDetails: {
+                            actions: {
+                                terminateAllSessions: "Terminate All",
+                                terminateSession: "TerminateSession"
+                            },
+                            labels: {
+                                browser: "Browser",
+                                deviceModel: "Device Model",
+                                ip: "IP Address",
+                                lastAccessed: "Last Accessed",
+                                loggedInAs: "Logged in on <1>{{ app }}</1> as <3>{{ user }}</3>",
+                                loginTime: "Login Time",
+                                os: "Operating System",
+                                recentActivity: "Recent Activity"
+                            }
+                        }
+                    },
                     notifications: {
                         getUserSessions: {
                             error: {

--- a/modules/i18n/src/translations/fr-FR/portals/admin-portal.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/admin-portal.ts
@@ -1840,16 +1840,10 @@ export const adminPortal: AdminPortalNS = {
                     dangerZone: {
                         actionTitle: "Supprimer l'utilisateur",
                         header: "Supprimer l'utilisateur",
-                        subheader: "Cette action est irréversible et supprimera définitivement l'utilisateur. Êtes-vous ABSOLUMENT certain de vouloir supprimer cet utilisateur ?"
+                        subheader: "Cette action est irréversible et supprimera définitivement l'utilisateur. " +
+                            "Êtes-vous ABSOLUMENT certain de vouloir supprimer cet utilisateur ?"
                     },
                     header: "Zone sensible"
-                },
-                menu: {
-                    menuItems: {
-                        0: "Profil",
-                        1: "Groupes",
-                        2: "Rôles"
-                    }
                 }
             },
             forms: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -27,8 +27,8 @@ export const console: ConsoleNS = {
                         errors: {
                             noAssociation: {
                                 content: "Il semble que l'e-mail sélectionné ne soit pas enregistré sur Gravatar. " +
-                                    "Ouvrez un compte Gravatar en vous rendant sur le site officiel de Gravatar ou utilisez " +
-                                    "l'un des choix suivants.",
+                                    "Ouvrez un compte Gravatar en vous rendant sur le site officiel de Gravatar ou " +
+                                    "utilisez l'un des choix suivants.",
                                 header: "Aucune image Gravatar correspondante trouvée !"
                             }
                         },
@@ -39,8 +39,8 @@ export const console: ConsoleNS = {
                         input: {
                             errors: {
                                 http: {
-                                    content: "L'URL sélectionnée pointe vers une image non sécurisée servie par HTTP. " +
-                                        "Veuillez procéder avec prudence.",
+                                    content: "L'URL sélectionnée pointe vers une image non sécurisée servie par " +
+                                        "HTTP. Veuillez procéder avec prudence.",
                                     header: "Contenu non sécurisé !"
                                 },
                                 invalid: {
@@ -51,8 +51,8 @@ export const console: ConsoleNS = {
                             placeholder: "Entrez l'URL de l'image.",
                             warnings: {
                                 dataURL: {
-                                    content: "L'utilisation d'URL avec un grand nombre de caractères peut entraîner des problèmes " +
-                                        "de taille en base de données. Procédez avec prudence.",
+                                    content: "L'utilisation d'URL avec un grand nombre de caractères peut entraîner " +
+                                        "des problèmes de taille en base de données. Procédez avec prudence.",
                                     header: "Vérifiez l'URL des données saisies !"
                                 }
                             }
@@ -86,6 +86,69 @@ export const console: ConsoleNS = {
             unrecognizedURL: {
                 description: "L'URL saisie n'est ni HTTP ni HTTPS. Veuillez procéder avec prudence.",
                 heading: "URL non reconnue"
+            }
+        }
+    },
+    manage: {
+        features: {
+            users: {
+                editUser: {
+                    tab: {
+                        menuItems: {
+                            0: "Profil",
+                            1: "Groupes",
+                            2: "Rôles",
+                            3: "Séances"
+                        }
+                    }
+                },
+                userSessions: {
+                    notifications: {
+                        getUserSessions: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "Erreur de récupération"
+                            },
+                            genericError: {
+                                description: "Une erreur s'est produite lors de la récupération des sessions " +
+                                    "utilisateur.",
+                                message: "Erreur de récupération"
+                            },
+                            success: {
+                                description: "Sessions utilisateur récupérées avec succès.",
+                                message: "Récupération réussie"
+                            }
+                        },
+                        terminateAllUserSessions: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "Erreur de terminaison"
+                            },
+                            genericError: {
+                                description: "Une erreur s'est produite lors de la fin des sessions utilisateur.",
+                                message: "Erreur de terminaison"
+                            },
+                            success: {
+                                description: "Terminé avec succès toutes les sessions utilisateur.",
+                                message: "Résiliation réussie"
+                            }
+                        },
+                        terminateUserSession: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "Erreur de terminaison"
+                            },
+                            genericError: {
+                                description: "Une erreur s'est produite lors de la fin de la session utilisateur.",
+                                message: "Erreur de terminaison"
+                            },
+                            success: {
+                                description: "Terminé avec succès la session utilisateur.",
+                                message: "Résiliation réussie"
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -166,6 +166,12 @@ export const console: ConsoleNS = {
                                 message: "Résiliation réussie"
                             }
                         }
+                    },
+                    placeholders: {
+                        emptyListPlaceholder: {
+                            subtitles: "Il n'y a aucune session active pour cet utilisateur.",
+                            title: "Aucune session active"
+                        }
                     }
                 }
             }

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -92,6 +92,25 @@ export const console: ConsoleNS = {
     manage: {
         features: {
             users: {
+                confirmations: {
+                    terminateAllSessions: {
+                        assertionHint: "Veuillez taper <1>{{ name }}</1> pour confirmer.",
+                        content: "Si vous procédez à cette action, l'utilisateur sera déconnecté de toutes les " +
+                            "sessions actives. Ils perdront la progression de toutes les tâches en cours. " +
+                            "Veuillez procéder avec prudence.",
+                        header: "Êtes-vous sûr?",
+                        message: "Cette action est irréversible et mettra fin définitivement à toutes les sessions " +
+                            "actives."
+                    },
+                    terminateSession: {
+                        assertionHint: "Veuillez taper <1>{{ name }}</1> pour confirmer.",
+                        content: "Si vous procédez à cette action, l'utilisateur sera déconnecté de la session " +
+                            "sélectionnée. Ils perdront la progression de toutes les tâches en cours. Veuillez " +
+                            "procéder avec prudence.",
+                        header: "Êtes-vous sûr?",
+                        message: "Cette action est irréversible et mettra fin définitivement à la session."
+                    }
+                },
                 editUser: {
                     tab: {
                         menuItems: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -117,11 +117,29 @@ export const console: ConsoleNS = {
                             0: "Profil",
                             1: "Groupes",
                             2: "Rôles",
-                            3: "Séances"
+                            3: "Sessions Actives"
                         }
                     }
                 },
                 userSessions: {
+                    components: {
+                        sessionDetails: {
+                            actions: {
+                                terminateAllSessions: "Terminer tout",
+                                terminateSession: "Terminer la session"
+                            },
+                            labels: {
+                                browser: "Navigateur",
+                                deviceModel: "Modèle d'appareil",
+                                ip: "Adresse IP",
+                                lastAccessed: "Dernier accès",
+                                loggedInAs: "Connecté sous <1>{{ app }}</1> en tant que <3>{{ user }}</3>",
+                                loginTime: "Heure de connexion",
+                                os: "Système opérateur",
+                                recentActivity: "Activité récente"
+                            }
+                        }
+                    },
                     notifications: {
                         getUserSessions: {
                             error: {

--- a/modules/i18n/src/translations/fr-FR/portals/dev-portal.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/dev-portal.ts
@@ -396,7 +396,7 @@ export const devPortal: DevPortalNS = {
                                     getRequestPathAuthenticators: {
                                         error: {
                                             description: "{{ description }}",
-                                            message: "Retrieval Error"
+                                            message: "Erreur de récupération"
                                         },
                                         genericError: {
                                             description: "An error occurred while retrieving request path " +


### PR DESCRIPTION
## Purpose
Privileged admin users need the capability to view and terminate sessions of other users.

## Goals
Fixes https://github.com/wso2/product-is/issues/9813

## Approach
Used the [Session Management REST API](https://is.docs.wso2.com/en/latest/develop/session-mgt-rest-api/) to populate an active session listing view per user.

<img width="1911" alt="Screen Shot 2020-10-20 at 4 44 17 PM" src="https://user-images.githubusercontent.com/25959096/96580523-08926a00-12f6-11eb-8f87-999172ed56c3.png">


