### PR TITLE
Add environment specific ESLint Configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,24 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+// Base ESLint Config which can be extended to be used in the development environment.
+
 module.exports = {
     extends: [
         "eslint:recommended",
@@ -108,7 +129,10 @@ module.exports = {
                         variables: false,
                         typedefs: false
                     }
-                ]
+                ],
+                // In development, error level is set to `warn`. This will be overridden
+                // by the production env linting config.
+                "no-debugger": 1
             }
         }
     ]

--- a/.prod.eslintrc.js
+++ b/.prod.eslintrc.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+// Base ESLint Config which can be extended to be used in the production environment.
+
+module.exports = {
+    extends: [
+        "./.eslintrc.js"
+    ],
+    rules: {
+        // In production, build should fail if debug points are used.
+        "no-debugger": 2,
+    }
+};

--- a/apps/console/.eslintrc.js
+++ b/apps/console/.eslintrc.js
@@ -1,3 +1,24 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+// ESLint Config which will be used by the IDE/Editors & webpack in development environments.
+
 module.exports = {
     extends: [
         "../../.eslintrc.js"

--- a/apps/console/.prod.eslintrc.js
+++ b/apps/console/.prod.eslintrc.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+// ESLint Config which will be used by webpack in production environments.
+// Override any of the rules that has to specifically apply to the app's production build
+// which are not there in the base prod config.
+
+module.exports = {
+    extends: [
+        "../../.prod.eslintrc.js"
+    ]
+};

--- a/apps/console/src/features/applications/components/forms/inbound-saml-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-saml-form.tsx
@@ -321,8 +321,6 @@ export const InboundSAMLForm: FunctionComponent<InboundSAMLFormPropsInterface> =
             (
                 <Forms
                     onSubmit={ (values) => {
-                        // eslint-disable-next-line no-debugger
-                        debugger;
                         if (isEmpty(assertionConsumerUrls)) {
                             setAssertionConsumerUrlError(true);
                             scrollToInValidField("consumerURL");
@@ -331,8 +329,6 @@ export const InboundSAMLForm: FunctionComponent<InboundSAMLFormPropsInterface> =
                         }
                     } }
                     onSubmitError={ (requiredFields: Map<string, boolean>, validFields: Map<string, Validation>) => {
-                        // eslint-disable-next-line no-debugger
-                        debugger;
                         const iterator = requiredFields.entries();
                         let result = iterator.next();
 

--- a/apps/console/webpack.config.js
+++ b/apps/console/webpack.config.js
@@ -34,6 +34,10 @@ const isSourceMapsEnabledInProduction = false;
 // Enable/Disable profiling in Production.
 const isProfilingEnabledInProduction = false;
 
+// ESLint Config File Names
+const DEVELOPMENT_ESLINT_CONFIG = ".eslintrc.js";
+const PRODUCTION_ESLINT_CONFIG = ".prod.eslintrc.js";
+
 module.exports = (env) => {
 
     // Build Environments.
@@ -56,6 +60,13 @@ module.exports = (env) => {
     // Build configurations.
     const distFolder = path.resolve(__dirname, "build", basename);
     const titleText = deploymentConfig.ui.appTitle;
+
+    // Paths to configs & other required files.
+    const PATHS = {
+        eslintrc: isProduction
+            ? path.resolve(__dirname, PRODUCTION_ESLINT_CONFIG)
+            : path.resolve(__dirname, DEVELOPMENT_ESLINT_CONFIG)
+    };
 
     return {
         devServer: {
@@ -166,6 +177,7 @@ module.exports = (env) => {
                         {
                             loader: "eslint-loader",
                             options: {
+                                configFile: PATHS.eslintrc,
                                 happyPackMode: true,
                                 transpileOnly: true
                             }

--- a/apps/myaccount/.eslintrc.js
+++ b/apps/myaccount/.eslintrc.js
@@ -1,3 +1,24 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+// ESLint Config which will be used by the IDE/Editors & webpack in development environments.
+
 module.exports = {
     extends: [
         "../../.eslintrc.js"

--- a/apps/myaccount/.prod.eslintrc.js
+++ b/apps/myaccount/.prod.eslintrc.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+// ESLint Config which will be used by webpack in production environments.
+// Override any of the rules that has to specifically apply to the app's production build
+// which are not there in the base prod config.
+
+module.exports = {
+    extends: [
+        "../../.prod.eslintrc.js"
+    ]
+};

--- a/apps/myaccount/webpack.config.js
+++ b/apps/myaccount/webpack.config.js
@@ -34,6 +34,10 @@ const isSourceMapsEnabledInProduction = false;
 // Enable/Disable profiling in Production.
 const isProfilingEnabledInProduction = false;
 
+// ESLint Config File Names
+const DEVELOPMENT_ESLINT_CONFIG = ".eslintrc.js";
+const PRODUCTION_ESLINT_CONFIG = ".prod.eslintrc.js";
+
 module.exports = (env) => {
 
     // Build Environments.
@@ -56,6 +60,13 @@ module.exports = (env) => {
     // Build configurations.
     const distFolder = path.resolve(__dirname, "build", basename);
     const titleText = deploymentConfig.ui.appTitle;
+
+    // Paths to configs & other required files.
+    const PATHS = {
+        eslintrc: isProduction
+            ? path.resolve(__dirname, PRODUCTION_ESLINT_CONFIG)
+            : path.resolve(__dirname, DEVELOPMENT_ESLINT_CONFIG)
+    };
 
     return {
         devServer: {
@@ -160,6 +171,7 @@ module.exports = (env) => {
                         {
                             loader: "eslint-loader",
                             options: {
+                                configFile: PATHS.eslintrc,
                                 happyPackMode: true,
                                 transpileOnly: true
                             }


### PR DESCRIPTION
## Purpose
Some lint rules like `no-debugger` are set to error by the extended plugins and this causes the usage debugger points to fail the development build. And during development we can supress the errors but it'll lead to these debug points to be pushed to vcs by mistake since the build will not catch them due to the supression.

## Goals
This PR introduces the ability to have environment specific lint rules.

## Approach
Added a new ESLint config for production that is extended from the base config and can be used to override any rule that should be applied only in production.

## TODO
`eslint-loader` was deprecated in favor of `eslint-webpack-plugin`. Tried to migrate but faced some issues due to the plugin being unstable. Migration has to be only done when the issues are solved by the developers of the plugin.
Tracker - https://github.com/wso2/product-is/issues/10009