### PR TITLE
Revamp Governance Connector UIs

### DIFF
--- a/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-connector-form.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-connector-form.tsx
@@ -120,7 +120,7 @@ const DynamicConnectorForm = (props) => {
                 }) }
                 <Grid.Row columns={ 1 } className="pl-3">
                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 14 }>
-                        <PrimaryButton type="submit">{ I18n.instance.t("common:update").toString() }</PrimaryButton>
+                        <PrimaryButton type="submit">{ t("common:update") }</PrimaryButton>
                     </Grid.Column>
                 </Grid.Row>
             </Grid>

--- a/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-governance-connector.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-governance-connector.tsx
@@ -18,6 +18,7 @@
 
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
+import kebabCase from "lodash/kebabCase";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -138,7 +139,7 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
         <DynamicConnectorForm
             onSubmit={ handleSubmit }
             props={ { properties: connector.properties } }
-            form={ connector.category + "-form" }
+            form={ kebabCase(connector.friendlyName) + "-form" }
             initialValues={ getConnectorInitialValues(connector) }
             data-testid={ `${ testId }-${ connector.name }-form` }
         />

--- a/apps/console/src/features/server-configurations/pages/governance-connectors.tsx
+++ b/apps/console/src/features/server-configurations/pages/governance-connectors.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertLevels, ReferableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { PageLayout } from "@wso2is/react-components";
+import { EmphasizedSegment, PageLayout } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -50,6 +50,7 @@ export const GovernanceConnectorsPage: FunctionComponent<GovernanceConnectorsPag
     const { t } = useTranslation();
 
     const [ connectorCategory, setConnectorCategory ] = useState<GovernanceConnectorCategoryInterface>({});
+    const [ connectors, setConnectors ] = useState<GovernanceConnectorInterface & ReferableComponentInterface>([]);
     const [ selectedConnector, setSelectorConnector ] = useState<GovernanceConnectorInterface>(null);
 
     useEffect(() => {
@@ -62,10 +63,14 @@ export const GovernanceConnectorsPage: FunctionComponent<GovernanceConnectorsPag
 
         getConnectorCategory(categoryId)
             .then((response: GovernanceConnectorCategoryInterface) => {
-                response.connectors.map((connector) => {
+
+                response.connectors.map((connector: GovernanceConnectorInterface & ReferableComponentInterface) => {
                     connector.categoryId = categoryId;
+                    connector.ref = React.createRef();
                 });
+
                 setConnectorCategory(response);
+                setConnectors(response?.connectors);
                 !selectedConnector && setSelectorConnector(response.connectors[ 0 ]);
             })
             .catch((error) => {
@@ -108,41 +113,63 @@ export const GovernanceConnectorsPage: FunctionComponent<GovernanceConnectorsPag
             title={ connectorCategory?.name }
             description={
                 connectorCategory?.description
-                    ? t("adminPortal:components.governanceConnectors.connectorSubHeading",
+                    ?? t("adminPortal:components.governanceConnectors.connectorSubHeading",
                     { name: connectorCategory?.name })
-                    : null
             }
             data-testid={ `${ testId }-page-layout` }
         >
             <Grid>
                 <Grid.Row columns={ 2 }>
                     <Grid.Column width={ 12 }>
-                        <Segment basic className="emphasized bordered">
-                            { selectedConnector && (
-                                <DynamicGovernanceConnector
-                                    connector={ selectedConnector }
-                                    data-testid={ `${ testId }-` + selectedConnector?.id }
-                                    onUpdate={ loadCategoryConnectors }
-                                />
-                            ) }
-                        </Segment>
+                        {
+                            (connectors && Array.isArray(connectors) && connectors.length > 0)
+                                ? connectors.map((connector: GovernanceConnectorInterface, index: number) => (
+                                    <EmphasizedSegment key={ index }>
+                                        <div ref={ connector.ref }>
+                                            <DynamicGovernanceConnector
+                                                connector={ connector }
+                                                data-testid={ `${ testId }-` + connector?.id }
+                                                onUpdate={ loadCategoryConnectors }
+                                            />
+                                        </div>
+                                    </EmphasizedSegment>
+                                ))
+                                : null
+                        }
                     </Grid.Column>
                     <Grid.Column width={ 4 }>
-                        <h5>{ t("adminPortal:components.governanceConnectors.categories") }</h5>
-                        <Menu secondary vertical className="governance-connector-categories">
-                            { connectorCategory?.connectors?.map(
-                                (connector: GovernanceConnectorInterface, index: number) => (
-                                    <Menu.Item
-                                        as="a"
-                                        key={ index }
-                                        className={ selectedConnector?.id === connector?.id ? "active" : "" }
-                                        onClick={ () => setSelectorConnector(connector) }
-                                    >
-                                        { connector.friendlyName }
-                                    </Menu.Item>
-                                )
-                            ) }
-                        </Menu>
+                        {
+                            (connectors && Array.isArray(connectors) && connectors.length > 0) && (
+                                <>
+                                    <h5>{ t("adminPortal:components.governanceConnectors.categories") }</h5>
+                                    <Menu secondary vertical className="governance-connector-categories">
+                                        {
+                                            connectors.map((connector: GovernanceConnectorInterface, index: number) => (
+                                                <Menu.Item
+                                                    as="a"
+                                                    key={ index }
+                                                    className={
+                                                        selectedConnector?.id === connector?.id
+                                                            ? "active"
+                                                            : ""
+                                                    }
+                                                    onClick={ () => {
+                                                        // Scroll to the selected connector.
+                                                        connector?.ref?.current?.scrollIntoView({
+                                                            behavior: "smooth", block: "center"
+                                                        });
+
+                                                        setSelectorConnector(connector);
+                                                    } }
+                                                >
+                                                    { connector.friendlyName }
+                                                </Menu.Item>
+                                            ))
+                                        }
+                                    </Menu>
+                                </>
+                            )
+                        }
                     </Grid.Column>
                 </Grid.Row>
             </Grid>

--- a/apps/console/src/features/server-configurations/pages/governance-connectors.tsx
+++ b/apps/console/src/features/server-configurations/pages/governance-connectors.tsx
@@ -34,6 +34,11 @@ import { GovernanceConnectorCategoryInterface, GovernanceConnectorInterface } fr
 type GovernanceConnectorsPageInterface = TestableComponentInterface;
 
 /**
+ * `GovernanceConnectorInterface` type with `ref` attr.
+ */
+type GovernanceConnectorWithRef = GovernanceConnectorInterface & ReferableComponentInterface<HTMLDivElement>;
+
+/**
  * Governance connectors page.
  *
  * @param {GovernanceConnectorsPageInterface} props - Props injected to the component.
@@ -50,8 +55,8 @@ export const GovernanceConnectorsPage: FunctionComponent<GovernanceConnectorsPag
     const { t } = useTranslation();
 
     const [ connectorCategory, setConnectorCategory ] = useState<GovernanceConnectorCategoryInterface>({});
-    const [ connectors, setConnectors ] = useState<GovernanceConnectorInterface & ReferableComponentInterface>([]);
-    const [ selectedConnector, setSelectorConnector ] = useState<GovernanceConnectorInterface>(null);
+    const [ connectors, setConnectors ] = useState<GovernanceConnectorWithRef[]>([]);
+    const [ selectedConnector, setSelectorConnector ] = useState<GovernanceConnectorWithRef>(null);
 
     useEffect(() => {
         loadCategoryConnectors();
@@ -64,14 +69,14 @@ export const GovernanceConnectorsPage: FunctionComponent<GovernanceConnectorsPag
         getConnectorCategory(categoryId)
             .then((response: GovernanceConnectorCategoryInterface) => {
 
-                response.connectors.map((connector: GovernanceConnectorInterface & ReferableComponentInterface) => {
+                response.connectors.map((connector: GovernanceConnectorWithRef) => {
                     connector.categoryId = categoryId;
                     connector.ref = React.createRef();
                 });
 
                 setConnectorCategory(response);
-                setConnectors(response?.connectors);
-                !selectedConnector && setSelectorConnector(response.connectors[ 0 ]);
+                setConnectors(response?.connectors as GovernanceConnectorWithRef[]);
+                !selectedConnector && setSelectorConnector(response.connectors[ 0 ] as GovernanceConnectorWithRef);
             })
             .catch((error) => {
                 if (error.response && error.response.data && error.response.data.detail) {
@@ -123,13 +128,13 @@ export const GovernanceConnectorsPage: FunctionComponent<GovernanceConnectorsPag
                     <Grid.Column width={ 12 }>
                         {
                             (connectors && Array.isArray(connectors) && connectors.length > 0)
-                                ? connectors.map((connector: GovernanceConnectorInterface, index: number) => (
+                                ? connectors.map((connector: GovernanceConnectorWithRef, index: number) => (
                                     <EmphasizedSegment key={ index }>
                                         <div ref={ connector.ref }>
                                             <DynamicGovernanceConnector
                                                 connector={ connector }
                                                 data-testid={ `${ testId }-` + connector?.id }
-                                                onUpdate={ loadCategoryConnectors }
+                                                onUpdate={ () => loadCategoryConnectors() }
                                             />
                                         </div>
                                     </EmphasizedSegment>
@@ -144,7 +149,7 @@ export const GovernanceConnectorsPage: FunctionComponent<GovernanceConnectorsPag
                                     <h5>{ t("adminPortal:components.governanceConnectors.categories") }</h5>
                                     <Menu secondary vertical className="governance-connector-categories">
                                         {
-                                            connectors.map((connector: GovernanceConnectorInterface, index: number) => (
+                                            connectors.map((connector: GovernanceConnectorWithRef, index: number) => (
                                                 <Menu.Item
                                                     as="a"
                                                     key={ index }

--- a/apps/console/src/features/server-configurations/pages/governance-connectors.tsx
+++ b/apps/console/src/features/server-configurations/pages/governance-connectors.tsx
@@ -22,7 +22,7 @@ import { PageLayout } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Grid, Menu, Segment } from "semantic-ui-react";
+import { Grid, Menu } from "semantic-ui-react";
 import { history } from "../../core";
 import { getConnectorCategory } from "../api";
 import { DynamicGovernanceConnector } from "../components";
@@ -106,9 +106,12 @@ export const GovernanceConnectorsPage: FunctionComponent<GovernanceConnectorsPag
     return (
         <PageLayout
             title={ connectorCategory?.name }
-            description={ connectorCategory?.description
-                ?? t("adminPortal:components.governanceConnectors.connectorSubHeading",
-                    { name: connectorCategory?.name }) }
+            description={
+                connectorCategory?.description
+                    ? t("adminPortal:components.governanceConnectors.connectorSubHeading",
+                    { name: connectorCategory?.name })
+                    : null
+            }
             data-testid={ `${ testId }-page-layout` }
         >
             <Grid>

--- a/modules/core/src/models/core.ts
+++ b/modules/core/src/models/core.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { RefObject } from "react";
 import { Notification } from "react-notification-system";
 
 /**
@@ -115,6 +116,16 @@ export interface LoadableComponentInterface {
      * Flag for loading state.
      */
     isLoading?: boolean;
+}
+
+/**
+ * Common interface to be extended to have the `ref` attribute.
+ */
+export interface ReferableComponentInterface<T = {}> {
+    /**
+     * 
+     */
+    ref: RefObject<T>;
 }
 
 /**

--- a/modules/theme/src/themes/default/collections/menu.overrides
+++ b/modules/theme/src/themes/default/collections/menu.overrides
@@ -224,6 +224,8 @@
 
 .ui.vertical.menu {
     &.governance-connector-categories {
+        width: @governanceConnectorCategoriesMenuWidth;
+
         .item.active {
             border-left: @activeBorderWidth @primaryColor solid;
         }

--- a/modules/theme/src/themes/default/collections/menu.variables
+++ b/modules/theme/src/themes/default/collections/menu.variables
@@ -136,4 +136,5 @@
       Governance Connectors
 --------------------------------*/
 
+@governanceConnectorCategoriesMenuWidth: 18rem;
 @activeBorderWidth: 5px;


### PR DESCRIPTION
## Purpose
In governance connectors, for internal navigation, we are using the side panel on right. It has the following issues. For new users this might not be intuitive at once.

## Goals
Fixes https://github.com/wso2/product-is/issues/9900

## Approach
Display all the connectors of a category in a single view and use the menu to scroll to the respective connector.

<img width="1915" alt="Screen Shot 2020-10-27 at 5 34 29 PM" src="https://user-images.githubusercontent.com/25959096/97299353-d8f5db80-187a-11eb-82cd-2e57320d4743.png">
