### PR TITLE
Fix typo in git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,7 @@ apps/myaccount/src/themes/
 apps/console/src/themes/
 
 # Integration test module.
-tests/coutput/
+tests/output/
 tests/dist/
 
 .classpath


### PR DESCRIPTION
## Purpose
This PR will fix the typo in `gitignore` file to ignore integration test outputs.