### PR TITLE
Add a temporary fix for LDAP pagination Issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,7 +65,7 @@ module.exports = {
         "react/jsx-curly-spacing": [
             "warn",
             {
-                when: "never",
+                when: "always",
                 children: { "when": "always" },
                 allowMultiline: true,
                 spacing: { objectLiterals: "always" }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,6 +71,7 @@ module.exports = {
                 spacing: { objectLiterals: "always" }
             }
         ],
+        "no-unused-vars": 1,
         "react-hooks/exhaustive-deps": ["off"],
         "react/no-children-prop": 0,
         "sort-keys": ["warn", "asc", {"caseSensitive": true, "natural": false, "minKeys": 2}],

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -18,7 +18,7 @@
 
 import { getUserStoreList } from "@wso2is/core/api";
 import { CommonHelpers } from "@wso2is/core/helpers";
-import { AlertInterface, AlertLevels } from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { LocalStorageUtils } from "@wso2is/core/utils";
 import {
@@ -58,13 +58,26 @@ import { UserManagementConstants } from "../constants";
 import { UserListInterface } from "../models";
 
 /**
+ * Props for the Users page.
+ */
+type UsersPageInterface = TestableComponentInterface;
+
+/**
  * Users info page.
  *
+ * @param {UsersPageInterface} props - Props injected to the component.
  * @return {React.ReactElement}
  */
-const UsersPage: FunctionComponent<any> = (): ReactElement => {
+const UsersPage: FunctionComponent<UsersPageInterface> = (
+    props: UsersPageInterface
+): ReactElement => {
+
+    const {
+        [ "data-testid" ]: testId
+    } = props;
 
     const { t } = useTranslation();
+
     const dispatch = useDispatch();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
@@ -419,7 +432,7 @@ const UsersPage: FunctionComponent<any> = (): ReactElement => {
                     )
                 });
             });
-    }
+    };
 
     return (
         <PageLayout
@@ -437,6 +450,7 @@ const UsersPage: FunctionComponent<any> = (): ReactElement => {
             }
             title={ t("adminPortal:pages.users.title") }
             description={ t("adminPortal:pages.users.subTitle") }
+            data-testid={ `${ testId }-page-layout` }
         >
             <ListLayout
                 // TODO add sorting functionality.
@@ -601,6 +615,13 @@ const UsersPage: FunctionComponent<any> = (): ReactElement => {
             </ListLayout>
         </PageLayout>
     );
+};
+
+/**
+ * Default props for the component.
+ */
+UsersPage.defaultProps = {
+    "data-testid": "users"
 };
 
 /**

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -64,8 +64,6 @@ type UsersPageInterface = TestableComponentInterface;
 
 /**
  * Temporary value to append to the list limit to figure out if the next button is there.
- * TODO: Remove this once there is a proper way of getting the correct `totalResults` from LDAP.
- * @remarks This is used in the fix to workaround LDAP pagination issues.
  * @type {number}
  */
 const TEMP_RESOURCE_LIST_ITEM_LIMIT_OFFSET: number = 1;
@@ -116,8 +114,6 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
     const getList = (limit: number, offset: number, filter: string, attribute: string, domain: string) => {
         setUserListRequestLoading(true);
 
-        // Adds a fixed count to the list limit to figure out if there is a next page.
-        // TODO: Remove this once there is a proper way of getting the correct `totalResults` from LDAP.
         const modifiedLimit = limit + TEMP_RESOURCE_LIST_ITEM_LIMIT_OFFSET;
 
         getUsersList(modifiedLimit, offset, filter, attribute, domain)
@@ -211,6 +207,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
      * @remarks There is no proper way to count the total entries in the userstore with LDAP. So as a workaround, when
      * fetching users, we request an extra entry to figure out if there is a next page.
      * TODO: Remove this function and other related variables once there is a proper fix for LDAP pagination.
+     * @see {@link https://github.com/wso2/product-is/issues/7320}
      *
      * @param {UserListInterface} list - Users list retrieved from the API.
      * @param {number} requestedLimit - Requested item limit.

--- a/modules/react-components/src/components/pagination/pagination.tsx
+++ b/modules/react-components/src/components/pagination/pagination.tsx
@@ -40,6 +40,14 @@ export interface PaginationPropsInterface extends PaginationProps, TestableCompo
      */
     currentListSize?: number;
     /**
+     * Disables the next button used in minimal pagination.
+     */
+    disableNextButton?: boolean;
+    /**
+     * Disables the previous button used in minimal pagination.
+     */
+    disablePreviousButton?: boolean;
+    /**
      * Float direction.
      */
     float?: "left" | "right";
@@ -123,6 +131,8 @@ export const Pagination: FunctionComponent<PaginationPropsInterface> = (
     
     const {
         className,
+        disableNextButton,
+        disablePreviousButton,
         itemsPerPageDropdownLabel,
         itemsPerPageDropdownLowerLimit,
         itemsPerPageDropdownMultiple,
@@ -220,12 +230,16 @@ export const Pagination: FunctionComponent<PaginationPropsInterface> = (
                         prevItem={ {
                             "aria-label": "Previous Page",
                             content: previousButtonText,
-                            disabled: (activePage === 1)
+                            disabled: disablePreviousButton !== undefined
+                                ? disablePreviousButton
+                                : (activePage === 1)
                         } }
                         nextItem={ {
                             "aria-label": "Next Page",
                             content: nextButtonText,
-                            disabled: (activePage === totalPages)
+                            disabled: disableNextButton !== undefined
+                                ? disableNextButton
+                                : (activePage === totalPages)
                         } }
                     />
                 </>

--- a/modules/react-components/src/components/pagination/pagination.tsx
+++ b/modules/react-components/src/components/pagination/pagination.tsx
@@ -107,7 +107,7 @@ export interface PaginationPropsInterface extends PaginationProps, TestableCompo
      * @param {React.MouseEvent<HTMLAnchorElement, MouseEvent>} event MouseEvent.
      * @param {PaginationProps} data Pagination props data.
      */
-    onPageChange: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>, data: PaginationProps) => void;
+    onPageChange?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>, data: PaginationProps) => void;
     /**
      * Toggles pagination reset.
      */

--- a/modules/react-components/src/components/pagination/pagination.tsx
+++ b/modules/react-components/src/components/pagination/pagination.tsx
@@ -60,11 +60,23 @@ export interface PaginationPropsInterface extends PaginationProps, TestableCompo
      */
     itemsPerPageDropdownUpperLimit?: number;
     /**
+     * Minimal Mode toggle.
+     */
+    minimal?: boolean;
+    /**
+     * Overrides the default Next button text.
+     */
+    nextButtonText?: string;
+    /**
      * Callback for items per page change.
      * @param {React.SyntheticEvent<HTMLElement>} event - Click event.
      * @param {DropdownProps} data - Data.
      */
     onItemsPerPageDropdownChange?: (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => void;
+    /**
+     * Overrides the default Previous button text.
+     */
+    previousButtonText?: string;
     /**
      * Items per page dropdown visibility.
      */
@@ -73,6 +85,10 @@ export interface PaginationPropsInterface extends PaginationProps, TestableCompo
      * Show/ Hide list summary.
      */
     showListSummary?: boolean;
+    /**
+     * Whether to show page numbers on minimal mode.
+     */
+    showPagesOnMinimalMode?: boolean;
     /**
      * Total size of the list.
      */
@@ -107,17 +123,19 @@ export const Pagination: FunctionComponent<PaginationPropsInterface> = (
     
     const {
         className,
-        currentListSize,
         itemsPerPageDropdownLabel,
         itemsPerPageDropdownLowerLimit,
         itemsPerPageDropdownMultiple,
         itemsPerPageDropdownUpperLimit,
+        minimal,
+        nextButtonText,
         onItemsPerPageDropdownChange,
         onPageChange,
+        previousButtonText,
         resetPagination,
         showItemsPerPageDropdown,
-        showListSummary,
-        totalListSize,
+        showPagesOnMinimalMode,
+        totalPages,
         [ "data-testid" ]: testId,
         ...rest
     } = props;
@@ -161,31 +179,77 @@ export const Pagination: FunctionComponent<PaginationPropsInterface> = (
         onPageChange(event, data);
     };
 
+    /**
+     * Renders the content based on the mode.
+     * @return {React.ReactElement}
+     */
+    const renderChildren = (): ReactElement => {
+
+        const ItemsPerPageDropdown: ReactElement = (
+            showItemsPerPageDropdown && (
+                <label className="page-limit-label">
+                    { itemsPerPageDropdownLabel }
+                    <Dropdown
+                        data-testid={ `${ testId }-items-per-page-dropdown` }
+                        className="labeled horizontal right page-limit-dropdown"
+                        compact
+                        defaultValue={ itemsPerPageDropdownLowerLimit }
+                        options={ generatePageCountDropdownOptions() }
+                        onChange={ onItemsPerPageDropdownChange }
+                        selection
+                    />
+                </label>
+            )
+        );
+
+        if (minimal) {
+            return (
+                <>
+                    { ItemsPerPageDropdown }
+                    <SemanticPagination
+                        { ...rest }
+                        totalPages={ totalPages }
+                        className="list-pagination"
+                        data-testid={ `${ testId }-steps` }
+                        activePage={ activePage }
+                        onPageChange={ pageChangeHandler }
+                        ellipsisItem={ null }
+                        firstItem={ null }
+                        lastItem={ null }
+                        pageItem={ showPagesOnMinimalMode ? undefined : null }
+                        prevItem={ {
+                            "aria-label": "Previous Page",
+                            content: previousButtonText,
+                            disabled: (activePage === 1)
+                        } }
+                        nextItem={ {
+                            "aria-label": "Next Page",
+                            content: nextButtonText,
+                            disabled: (activePage === totalPages)
+                        } }
+                    />
+                </>
+            )
+        }
+
+        return (
+            <>
+                { ItemsPerPageDropdown }
+                <SemanticPagination
+                    { ...rest }
+                    totalPages={ totalPages }
+                    className="list-pagination"
+                    data-testid={ `${ testId }-steps` }
+                    activePage={ activePage }
+                    onPageChange={ pageChangeHandler }
+                />
+            </>
+        )
+    };
+
     return (
         <div className={ classes } data-testid={ testId }>
-            {
-                showItemsPerPageDropdown && (
-                    <label className="page-limit-label">
-                        { itemsPerPageDropdownLabel }
-                        <Dropdown
-                            data-testid={ `${ testId }-items-per-page-dropdown` }
-                            className="labeled horizontal right page-limit-dropdown"
-                            compact
-                            defaultValue={ itemsPerPageDropdownLowerLimit }
-                            options={ generatePageCountDropdownOptions() }
-                            onChange={ onItemsPerPageDropdownChange }
-                            selection
-                        />
-                    </label>
-                )
-            }
-            <SemanticPagination
-                { ...rest }
-                className="list-pagination"
-                data-testid={ `${ testId }-steps` }
-                activePage={ activePage }
-                onPageChange={ pageChangeHandler }
-            />
+            { renderChildren() }
         </div>
     );
 };
@@ -200,5 +264,9 @@ Pagination.defaultProps =  {
     itemsPerPageDropdownLowerLimit: 10,
     itemsPerPageDropdownMultiple: 10,
     itemsPerPageDropdownUpperLimit: 50,
-    showItemsPerPageDropdown: true
+    minimal: false,
+    nextButtonText: "Next",
+    previousButtonText: "Previous",
+    showItemsPerPageDropdown: false,
+    showPagesOnMinimalMode: false
 };

--- a/modules/react-components/src/layouts/list.tsx
+++ b/modules/react-components/src/layouts/list.tsx
@@ -79,7 +79,7 @@ export interface ListLayoutPropsInterface extends PaginationProps, TestableCompo
     /**
      * Extra props to override the default pagination props.
      */
-    paginationOptions?: PaginationPropsInterface;
+    paginationOptions?: Omit<PaginationPropsInterface, "totalPages">;
     /**
      * Flag to reset the pagination.
      */

--- a/modules/react-components/src/layouts/list.tsx
+++ b/modules/react-components/src/layouts/list.tsx
@@ -29,7 +29,7 @@ import {
     PaginationProps,
     Popup
 } from "semantic-ui-react";
-import { Pagination } from "../components";
+import { Pagination, PaginationPropsInterface } from "../components";
 
 /**
  * List layout component Prop types.
@@ -76,6 +76,10 @@ export interface ListLayoutPropsInterface extends PaginationProps, TestableCompo
      * @param {boolean} isAscending - Is the order ascending.
      */
     onSortOrderChange?: (isAscending: boolean) => void;
+    /**
+     * Extra props to override the default pagination props.
+     */
+    paginationOptions?: PaginationPropsInterface;
     /**
      * Flag to reset the pagination.
      */
@@ -138,6 +142,7 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
         onPageChange,
         onSortStrategyChange,
         onSortOrderChange,
+        paginationOptions,
         resetPagination,
         rightActionPanel,
         showPagination,
@@ -247,6 +252,7 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
                                 totalPages={ totalPages }
                                 onPageChange={ onPageChange }
                                 onItemsPerPageDropdownChange={ onItemsPerPageDropdownChange }
+                                { ...paginationOptions }
                             />
                         )
                         : null

--- a/modules/react-components/src/layouts/list.tsx
+++ b/modules/react-components/src/layouts/list.tsx
@@ -56,6 +56,10 @@ export interface ListLayoutPropsInterface extends PaginationProps, TestableCompo
      */
     listItemLimit?: number;
     /**
+     * Flag to enable pagination minimal mode. 
+     */
+    minimalPagination?: boolean;
+    /**
      * Callback to be fired on page number change.
      * @param {React.MouseEvent<HTMLAnchorElement, MouseEvent>} event - Event.
      * @param {PaginationProps} data - Pagination data.
@@ -84,6 +88,10 @@ export interface ListLayoutPropsInterface extends PaginationProps, TestableCompo
      * Flag to toggle pagination visibility.
      */
     showPagination?: boolean;
+    /**
+     * Flag to toggle pagination page limit dropdown visibility.
+     */
+    showPaginationPageLimit?: boolean;
     /**
      * Flag to toggle top action panel visibility.
      */
@@ -125,7 +133,7 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
         children,
         className,
         leftActionPanel,
-        listItemLimit,
+        minimalPagination,
         onItemsPerPageDropdownChange,
         onPageChange,
         onSortStrategyChange,
@@ -133,6 +141,7 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
         resetPagination,
         rightActionPanel,
         showPagination,
+        showPaginationPageLimit,
         showTopActionPanel,
         sortOptions,
         sortStrategy,
@@ -230,6 +239,8 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
                     (showPagination && totalListSize)
                         ? (
                             <Pagination
+                                minimal={ minimalPagination }
+                                showItemsPerPageDropdown={ showPaginationPageLimit }
                                 data-testid={ `${ testId }-pagination` }
                                 resetPagination={ resetPagination }
                                 totalListSize={ totalListSize }
@@ -251,6 +262,8 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
 ListLayout.defaultProps = {
     advancedSearchPosition: "left",
     "data-testid": "list-layout",
+    minimalPagination: true,
     showPagination: false,
+    showPaginationPageLimit: true,
     showTopActionPanel: true
 };

--- a/modules/react-components/stories/components/pagination/index.ts
+++ b/modules/react-components/stories/components/pagination/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+export * from "./pagination.stories";

--- a/modules/react-components/stories/components/pagination/pagination.stories.meta.ts
+++ b/modules/react-components/stories/components/pagination/pagination.stories.meta.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import { StoryCategories } from "../../hierarchy";
+import { StoryMetaInterface } from "../../models";
+
+export const meta: StoryMetaInterface = {
+    components: [ "Pagination" ],
+    description: "Component to Pagination.",
+    stories: [
+        {
+            description: "Default Pagination.",
+            title: "Default"
+        },
+        {
+            description: "Pagination with items per page dropdown.",
+            title: "Pagination With Items Per Page"
+        },
+        {
+            description: "Minimal Pagination with only next and previous buttons.",
+            title: "Minimal Pagination"
+        }
+    ],
+    title: `${ StoryCategories.COMPONENTS }/Pagination`
+};

--- a/modules/react-components/stories/components/pagination/pagination.stories.tsx
+++ b/modules/react-components/stories/components/pagination/pagination.stories.tsx
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import { action } from "@storybook/addon-actions";
+import React, { ReactElement } from "react";
+import { meta } from "./pagination.stories.meta";
+import { Pagination } from "../../../src";
+
+export default {
+    parameters: {
+        component: Pagination,
+        componentSubtitle: meta.description
+    },
+    title: "Components API/Components/Pagination"
+};
+
+/**
+ * Story to display default pagination.
+ *
+ * @return {React.ReactElement}
+ */
+export const DefaultPagination = (): ReactElement => (
+    <Pagination
+        onPageChange={ ({ activePage }: { activePage: number }) => action("Active Page - " + activePage) }
+        totalPages={ 5 }
+    />
+);
+
+DefaultPagination.story = {
+    parameters: {
+        docs: {
+            storyDescription: meta.stories[ 0 ].description
+        }
+    }
+};
+
+/**
+ * Story to display pagination with items per page dropdown.
+ *
+ * @return {React.ReactElement}
+ */
+export const PaginationWithItemsPerPage = (): ReactElement => (
+    <Pagination
+        showItemsPerPageDropdown
+        onPageChange={ ({ activePage }: { activePage: number }) => action("Active Page - " + activePage) }
+        totalPages={ 5 }
+    />
+);
+
+PaginationWithItemsPerPage.story = {
+    parameters: {
+        docs: {
+            storyDescription: meta.stories[ 1 ].description
+        }
+    }
+};
+
+/**
+ * Story to display a minimal pagination.
+ *
+ * @return {React.ReactElement}
+ */
+export const Minimal = (): ReactElement => (
+    <Pagination
+        minimal
+        totalPages={ 5 }
+        onPageChange={ ({ activePage }: { activePage: number }) => action("Active Page - " + activePage) }
+    />
+);
+
+Minimal.story = {
+    parameters: {
+        docs: {
+            storyDescription: meta.stories[ 2 ].description
+        }
+    }
+};


### PR DESCRIPTION
## Purpose
There is no proper way to count the total entries in the userstore hence resulting in the inacurate totalResults count [1][2].

[1] https://github.com/wso2/product-is/issues/7320
[2] http://wso2-oxygen-tank.10903.n7.nabble.com/Issue-in-USER-and-ROLES-count-implementation-td160975.html

## Goals
This PR revamps the pagination component and adds a temporary workaround to overcome the LDAP pagination issue.

Fixes https://github.com/wso2/product-is/issues/9806

## Approach
1. When fetching users, an extra entry is requested to figure out if there is a next page.
2. Removed page numbers from pagination and created a minimal version of the pagination component.

<img width="1910" alt="Screen Shot 2020-10-28 at 11 11 08 PM" src="https://user-images.githubusercontent.com/25959096/97475241-00c86a80-1973-11eb-879b-0bf607fd2aa4.png">

3. Integrate the new pagination component to the list views.

<img width="1916" alt="Screen Shot 2020-10-28 at 11 14 18 PM" src="https://user-images.githubusercontent.com/25959096/97475543-661c5b80-1973-11eb-8d29-434a4184e93c.png">

## Known Issues
At the time of implementation, there is a know issue with the `5.11.0-BETA` pack, where the SCIM pagination doesn't function as expected [3]

[3] https://github.com/wso2/product-is/issues/9957

## TODO
Revert the temp fix in the users feature when there is a way to properly resolve the pagination issue from the backend itself.
