### PR TITLE
Show userstore property update delay notification

### DIFF
--- a/apps/console/src/features/userstores/api/user-stores.ts
+++ b/apps/console/src/features/userstores/api/user-stores.ts
@@ -186,10 +186,8 @@ export const deleteUserStore = (id: string): Promise<any> => {
 /**
  * Patches a userstore.
  *
- * @param {string} id Userstore ID.
- * @param {string} path The path to patch.
- * @param {string} value The data to be patched with.
- *
+ * @param {string} id - Userstore ID.
+ * @param {PatchData[]} data - Payload.
  * @return {Promise<any>} Response
  */
 export const patchUserStore = (id: string, data: PatchData[]): Promise<any> => {

--- a/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
@@ -65,7 +65,6 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
 
     const {
         userStore,
-        //update,
         id,
         properties,
         [ "data-testid" ]: testId
@@ -260,36 +259,47 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
             ]
             : requiredData;
 
-        updateUserStore(id, data).then(() => {
-            patchUserStore(id, patchData).then(() => {
+        updateUserStore(id, data)
+            .then(() => {
+                patchUserStore(id, patchData)
+                    .then(() => {
+                        dispatch(addAlert({
+                            description: t("adminPortal:components.userstores.notifications." +
+                                "updateUserstore.success.description"),
+                            level: AlertLevels.SUCCESS,
+                            message: t("adminPortal:components.userstores.notifications." +
+                                "updateUserstore.success.message")
+                        }));
+
+                        // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
+                        // applied at once. As a temp solution, a notification informing the delay is shown here.
+                        // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                        dispatch(addAlert({
+                            description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
+                            level: AlertLevels.WARNING,
+                            message: t("adminPortal:components.userstores.notifications.updateDelay.message")
+                        }));
+                    })
+                    .catch((error) => {
+                        dispatch(addAlert({
+                            description: error?.description
+                                || t("adminPortal:components.userstores.notifications." +
+                                    "updateUserstore.genericError.description"),
+                            level: AlertLevels.ERROR,
+                            message: error?.message || t("adminPortal:components.userstores.notifications." +
+                                "updateUserstore.genericError.message")
+                        }));
+                    });
+            })
+            .catch((error) => {
                 dispatch(addAlert({
-                    description: t("adminPortal:components.userstores.notifications." +
-                        "updateUserstore.success.description"),
-                    level: AlertLevels.SUCCESS,
-                    message: t("adminPortal:components.userstores.notifications." +
-                        "updateUserstore.success.message")
-                }));
-                // Prevent update until the userstore update delay is fixed.
-                //update();
-            }).catch(error => {
-                dispatch(addAlert({
-                    description: error?.description
-                        || t("adminPortal:components.userstores.notifications." +
-                            "updateUserstore.genericError.description"),
+                    description: error?.description ?? t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.genericError.description"),
                     level: AlertLevels.ERROR,
-                    message: error?.message || t("adminPortal:components.userstores.notifications." +
+                    message: error?.message ?? t("adminPortal:components.userstores.notifications." +
                         "updateUserstore.genericError.message")
                 }));
             });
-        }).catch((error) => {
-            dispatch(addAlert({
-                description: error?.description ?? t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.genericError.description"),
-                level: AlertLevels.ERROR,
-                message: error?.message ?? t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.genericError.message")
-            }));
-        });
     };
 
     /**
@@ -307,31 +317,40 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
             operation: "REPLACE",
             path: `/properties/${ name }`,
             value: data.checked ? "false" : "true"
-        }
+        };
 
-        patchUserStore(id, [ patchData ]).then(() => {
-            setEnabled(data.checked);
+        patchUserStore(id, [ patchData ])
+            .then(() => {
+                setEnabled(data.checked);
 
-            dispatch(addAlert({
-                description: t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.success.description"),
-                level: AlertLevels.SUCCESS,
-                message: t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.success.message")
-            }));
-            // Prevent update until the userstore update delay is fixed.
-            //update();
-        }).catch(error => {
-            dispatch(addAlert({
-                description: error?.description
-                    || t("adminPortal:components.userstores.notifications." +
-                        "updateUserstore.genericError.description"),
-                level: AlertLevels.ERROR,
-                message: error?.message || t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.genericError.message")
-            }));
-        });
-    }
+                dispatch(addAlert({
+                    description: t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.success.message")
+                }));
+
+                // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
+                // applied at once. As a temp solution, a notification informing the delay is shown here.
+                // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                dispatch(addAlert({
+                    description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
+                    level: AlertLevels.WARNING,
+                    message: t("adminPortal:components.userstores.notifications.updateDelay.message")
+                }));
+            })
+            .catch(error => {
+                dispatch(addAlert({
+                    description: error?.description
+                        || t("adminPortal:components.userstores.notifications." +
+                            "updateUserstore.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: error?.message || t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.genericError.message")
+                }));
+            });
+    };
 
     return (
         <>
@@ -357,7 +376,7 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
                                     data-testid={ `${ testId }-form-name-input` }
                                 />
                                 <Field
-                                    label={ t("adminPortal:components.userstores.forms.general.description.label") }
+                                    label={ t("adminPortal:components.userstores.forms.general.type.label") }
                                     name="type"
                                     type="text"
                                     disabled

--- a/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
@@ -67,6 +67,7 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
         userStore,
         id,
         properties,
+        update,
         [ "data-testid" ]: testId
     } = props;
 
@@ -273,12 +274,15 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
 
                         // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                         // applied at once. As a temp solution, a notification informing the delay is shown here.
-                        // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                        // TODO: Remove delay notification once backend is fixed.
                         dispatch(addAlert<AlertInterface>({
                             description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                             level: AlertLevels.WARNING,
                             message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                         }));
+
+                        // Re-fetch the userstore details
+                        update();
                     })
                     .catch((error) => {
                         dispatch(addAlert<AlertInterface>({
@@ -333,12 +337,15 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
 
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
-                // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                // TODO: Remove delay notification once backend is fixed.
                 dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                     level: AlertLevels.WARNING,
                     message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                 }));
+
+                // Re-fetch the userstore details
+                update();
             })
             .catch(error => {
                 dispatch(addAlert<AlertInterface>({

--- a/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
@@ -274,6 +274,7 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
 
                         // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                         // applied at once. As a temp solution, a notification informing the delay is shown here.
+                        // See https://github.com/wso2/product-is/issues/9767 for updates on the backend improvement.
                         // TODO: Remove delay notification once backend is fixed.
                         dispatch(addAlert<AlertInterface>({
                             description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
@@ -337,6 +338,7 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
 
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
+                // See https://github.com/wso2/product-is/issues/9767 for updates on the backend improvement.
                 // TODO: Remove delay notification once backend is fixed.
                 dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),

--- a/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
@@ -16,7 +16,7 @@
 * under the License.
 */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms } from "@wso2is/forms";
 import { ConfirmationModal, DangerZone, EmphasizedSegment, LinkButton, PrimaryButton } from "@wso2is/react-components";
@@ -263,7 +263,7 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
             .then(() => {
                 patchUserStore(id, patchData)
                     .then(() => {
-                        dispatch(addAlert({
+                        dispatch(addAlert<AlertInterface>({
                             description: t("adminPortal:components.userstores.notifications." +
                                 "updateUserstore.success.description"),
                             level: AlertLevels.SUCCESS,
@@ -274,14 +274,14 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
                         // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                         // applied at once. As a temp solution, a notification informing the delay is shown here.
                         // TODO: Remove delay notification and fetch the new updates once backend is fixed.
-                        dispatch(addAlert({
+                        dispatch(addAlert<AlertInterface>({
                             description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                             level: AlertLevels.WARNING,
                             message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                         }));
                     })
                     .catch((error) => {
-                        dispatch(addAlert({
+                        dispatch(addAlert<AlertInterface>({
                             description: error?.description
                                 || t("adminPortal:components.userstores.notifications." +
                                     "updateUserstore.genericError.description"),
@@ -292,7 +292,7 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
                     });
             })
             .catch((error) => {
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: error?.description ?? t("adminPortal:components.userstores.notifications." +
                         "updateUserstore.genericError.description"),
                     level: AlertLevels.ERROR,
@@ -323,7 +323,7 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
             .then(() => {
                 setEnabled(data.checked);
 
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications." +
                         "updateUserstore.success.description"),
                     level: AlertLevels.SUCCESS,
@@ -334,14 +334,14 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
                 // TODO: Remove delay notification and fetch the new updates once backend is fixed.
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                     level: AlertLevels.WARNING,
                     message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                 }));
             })
             .catch(error => {
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: error?.description
                         || t("adminPortal:components.userstores.notifications." +
                             "updateUserstore.genericError.description"),

--- a/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
@@ -16,7 +16,7 @@
 * under the License.
 */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms } from "@wso2is/forms";
 import { EmphasizedSegment, LinkButton, PrimaryButton } from "@wso2is/react-components";
@@ -230,7 +230,7 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
 
         patchUserStore(id, data)
             .then(() => {
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications." +
                         "updateUserstore.success.description"),
                     level: AlertLevels.SUCCESS,
@@ -241,14 +241,14 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
                 // TODO: Remove delay notification and fetch the new updates once backend is fixed.
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                     level: AlertLevels.WARNING,
                     message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                 }));
             })
             .catch(error => {
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: error?.description
                         || t("adminPortal:components.userstores.notifications." +
                             "updateUserstore.genericError.description"),

--- a/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
@@ -66,6 +66,7 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
         id,
         properties,
         type,
+        update,
         [ "data-testid" ]: testId
     } = props;
 
@@ -240,12 +241,15 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
 
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
-                // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                // TODO: Remove delay notification once backend is fixed.
                 dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                     level: AlertLevels.WARNING,
                     message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                 }));
+
+                // Re-fetch the userstore details
+                update();
             })
             .catch(error => {
                 dispatch(addAlert<AlertInterface>({

--- a/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
@@ -63,7 +63,6 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
 ): ReactElement => {
 
     const {
-        update,
         id,
         properties,
         type,
@@ -229,25 +228,35 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
             ]
             : requiredData;
 
-        patchUserStore(id, data).then(() => {
-            dispatch(addAlert({
-                description: t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.success.description"),
-                level: AlertLevels.SUCCESS,
-                message: t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.success.message")
-            }));
-            update();
-        }).catch(error => {
-            dispatch(addAlert({
-                description: error?.description
-                    || t("adminPortal:components.userstores.notifications." +
-                        "updateUserstore.genericError.description"),
-                level: AlertLevels.ERROR,
-                message: error?.message || t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.genericError.message")
-            }));
-        });
+        patchUserStore(id, data)
+            .then(() => {
+                dispatch(addAlert({
+                    description: t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.success.message")
+                }));
+
+                // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
+                // applied at once. As a temp solution, a notification informing the delay is shown here.
+                // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                dispatch(addAlert({
+                    description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
+                    level: AlertLevels.WARNING,
+                    message: t("adminPortal:components.userstores.notifications.updateDelay.message")
+                }));
+            })
+            .catch(error => {
+                dispatch(addAlert({
+                    description: error?.description
+                        || t("adminPortal:components.userstores.notifications." +
+                            "updateUserstore.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: error?.message || t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.genericError.message")
+                }));
+            });
     };
 
     return (

--- a/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
@@ -241,6 +241,7 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
 
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
+                // See https://github.com/wso2/product-is/issues/9767 for updates on the backend improvement.
                 // TODO: Remove delay notification once backend is fixed.
                 dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),

--- a/apps/console/src/features/userstores/components/edit/edit-group-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-group-details-userstore.tsx
@@ -62,7 +62,6 @@ export const EditGroupDetails: FunctionComponent<EditGroupDetailsPropsInterface>
 ): ReactElement => {
 
     const {
-        update,
         id,
         properties,
         [ "data-testid" ]: testId
@@ -177,25 +176,35 @@ export const EditGroupDetails: FunctionComponent<EditGroupDetailsPropsInterface>
             ]
             : requiredData;
 
-        patchUserStore(id, data).then(() => {
-            dispatch(addAlert({
-                description: t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.success.description"),
-                level: AlertLevels.SUCCESS,
-                message: t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.success.message")
-            }));
-            update();
-        }).catch(error => {
-            dispatch(addAlert({
-                description: error?.description
-                    || t("adminPortal:components.userstores.notifications." +
-                        "updateUserstore.genericError.description"),
-                level: AlertLevels.ERROR,
-                message: error?.message || t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.genericError.message")
-            }));
-        });
+        patchUserStore(id, data)
+            .then(() => {
+                dispatch(addAlert({
+                    description: t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.success.message")
+                }));
+
+                // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
+                // applied at once. As a temp solution, a notification informing the delay is shown here.
+                // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                dispatch(addAlert({
+                    description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
+                    level: AlertLevels.WARNING,
+                    message: t("adminPortal:components.userstores.notifications.updateDelay.message")
+                }));
+            })
+            .catch(error => {
+                dispatch(addAlert({
+                    description: error?.description
+                        || t("adminPortal:components.userstores.notifications." +
+                            "updateUserstore.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: error?.message || t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.genericError.message")
+                }));
+            });
     };
 
     return (

--- a/apps/console/src/features/userstores/components/edit/edit-group-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-group-details-userstore.tsx
@@ -64,6 +64,7 @@ export const EditGroupDetails: FunctionComponent<EditGroupDetailsPropsInterface>
     const {
         id,
         properties,
+        update,
         [ "data-testid" ]: testId
     } = props;
 
@@ -194,6 +195,9 @@ export const EditGroupDetails: FunctionComponent<EditGroupDetailsPropsInterface>
                     level: AlertLevels.WARNING,
                     message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                 }));
+
+                // Re-fetch the userstore details
+                update();
             })
             .catch(error => {
                 dispatch(addAlert<AlertInterface>({

--- a/apps/console/src/features/userstores/components/edit/edit-group-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-group-details-userstore.tsx
@@ -16,7 +16,7 @@
 * under the License.
 */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms } from "@wso2is/forms";
 import { EmphasizedSegment, LinkButton, PrimaryButton } from "@wso2is/react-components";
@@ -178,7 +178,7 @@ export const EditGroupDetails: FunctionComponent<EditGroupDetailsPropsInterface>
 
         patchUserStore(id, data)
             .then(() => {
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications." +
                         "updateUserstore.success.description"),
                     level: AlertLevels.SUCCESS,
@@ -189,14 +189,14 @@ export const EditGroupDetails: FunctionComponent<EditGroupDetailsPropsInterface>
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
                 // TODO: Remove delay notification and fetch the new updates once backend is fixed.
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                     level: AlertLevels.WARNING,
                     message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                 }));
             })
             .catch(error => {
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: error?.description
                         || t("adminPortal:components.userstores.notifications." +
                             "updateUserstore.genericError.description"),

--- a/apps/console/src/features/userstores/components/edit/edit-group-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-group-details-userstore.tsx
@@ -189,6 +189,7 @@ export const EditGroupDetails: FunctionComponent<EditGroupDetailsPropsInterface>
 
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
+                // See https://github.com/wso2/product-is/issues/9767 for updates on the backend improvement.
                 // TODO: Remove delay notification and fetch the new updates once backend is fixed.
                 dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),

--- a/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
@@ -181,6 +181,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
 
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
+                // See https://github.com/wso2/product-is/issues/9767 for updates on the backend improvement.
                 // TODO: Remove delay notification once the backend is fixed.
                 dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),

--- a/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
@@ -64,6 +64,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
     const {
         id,
         properties,
+        update,
         [ "data-testid" ]: testId
     } = props;
 
@@ -180,12 +181,15 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
 
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
-                // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                // TODO: Remove delay notification once the backend is fixed.
                 dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                     level: AlertLevels.WARNING,
                     message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                 }));
+
+                // Re-fetch the userstore details
+                update();
             })
             .catch(error => {
                 dispatch(addAlert<AlertInterface>({

--- a/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
@@ -62,7 +62,6 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
 ): ReactElement => {
 
     const {
-        update,
         id,
         properties,
         [ "data-testid" ]: testId
@@ -169,25 +168,35 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
             ]
             : requiredData;
 
-        patchUserStore(id, data).then(() => {
-            dispatch(addAlert({
-                description: t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.success.description"),
-                level: AlertLevels.SUCCESS,
-                message: t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.success.message")
-            }));
-            update();
-        }).catch(error => {
-            dispatch(addAlert({
-                description: error?.description
-                    || t("adminPortal:components.userstores.notifications." +
-                        "updateUserstore.genericError.description"),
-                level: AlertLevels.ERROR,
-                message: error?.message || t("adminPortal:components.userstores.notifications." +
-                    "updateUserstore.genericError.message")
-            }));
-        });
+        patchUserStore(id, data)
+            .then(() => {
+                dispatch(addAlert({
+                    description: t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.success.message")
+                }));
+
+                // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
+                // applied at once. As a temp solution, a notification informing the delay is shown here.
+                // TODO: Remove delay notification and fetch the new updates once backend is fixed.
+                dispatch(addAlert({
+                    description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
+                    level: AlertLevels.WARNING,
+                    message: t("adminPortal:components.userstores.notifications.updateDelay.message")
+                }));
+            })
+            .catch(error => {
+                dispatch(addAlert({
+                    description: error?.description
+                        || t("adminPortal:components.userstores.notifications." +
+                            "updateUserstore.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: error?.message || t("adminPortal:components.userstores.notifications." +
+                        "updateUserstore.genericError.message")
+                }));
+            });
     };
 
     return (

--- a/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
@@ -16,7 +16,7 @@
 * under the License.
 */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms } from "@wso2is/forms";
 import { EmphasizedSegment, LinkButton, PrimaryButton } from "@wso2is/react-components";
@@ -170,7 +170,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
 
         patchUserStore(id, data)
             .then(() => {
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications." +
                         "updateUserstore.success.description"),
                     level: AlertLevels.SUCCESS,
@@ -181,14 +181,14 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
                 // ATM, userstore operations run as an async task in the backend. Hence, The changes aren't 
                 // applied at once. As a temp solution, a notification informing the delay is shown here.
                 // TODO: Remove delay notification and fetch the new updates once backend is fixed.
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: t("adminPortal:components.userstores.notifications.updateDelay.description"),
                     level: AlertLevels.WARNING,
                     message: t("adminPortal:components.userstores.notifications.updateDelay.message")
                 }));
             })
             .catch(error => {
-                dispatch(addAlert({
+                dispatch(addAlert<AlertInterface>({
                     description: error?.description
                         || t("adminPortal:components.userstores.notifications." +
                             "updateUserstore.genericError.description"),

--- a/apps/console/src/features/userstores/pages/user-stores-edit.tsx
+++ b/apps/console/src/features/userstores/pages/user-stores-edit.tsx
@@ -209,7 +209,16 @@ const UserStoresEditPage: FunctionComponent<UserStoresEditPageInterface> = (
             bottomMargin={ false }
             data-testid={ `${ testId }-page-layout` }
         >
-            <ResourceTab panes={ panes } data-testid={ `${ testId }-tabs` }/>
+            <ResourceTab
+                panes={ panes }
+                onTabChange={ () => {
+                    // Re-fetch userstore details on every tab change to try to get the latest available updated
+                    // userstore properties due to the asynchronous nature of userstore operations.
+                    // TODO: Remove once the userstore operations are made synchronous.
+                    getUserStore()
+                } }
+                data-testid={ `${ testId }-tabs` }
+            />
         </PageLayout>
     )
 };

--- a/modules/i18n/src/models/namespaces/admin-portal-ns.ts
+++ b/modules/i18n/src/models/namespaces/admin-portal-ns.ts
@@ -1552,6 +1552,7 @@ export interface AdminPortalNS {
                 updateUserstore: Notification;
                 testConnection: Notification;
                 addUserstore: Notification;
+                updateDelay: NotificationItem;
             };
             confirmation: {
                 hint: string;

--- a/modules/i18n/src/translations/en-US/portals/admin-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/admin-portal.ts
@@ -2758,6 +2758,10 @@ export const adminPortal: AdminPortalNS = {
                         message: "Connection successful!"
                     }
                 },
+                updateDelay: {
+                    description: "It might take some time for the updated properties to appear.",
+                    message: "Updating properties takes time"
+                },
                 updateUserstore: {
                     genericError: {
                         description: "An error occurred while updating the userstore.",

--- a/modules/i18n/src/translations/fr-FR/portals/admin-portal.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/admin-portal.ts
@@ -2778,6 +2778,10 @@ export const adminPortal: AdminPortalNS = {
                         message: "Connexion réussie !"
                     }
                 },
+                updateDelay: {
+                    description: "L'apparition des propriétés mises à jour peut prendre un certain temps.",
+                    message: "La mise à jour des propriétés prend du temps"
+                },
                 updateUserstore: {
                     genericError: {
                         description: "Une erreur s'est produite lors de la mise à jour de l'annuaire.",


### PR DESCRIPTION
## Purpose
Userstore operations run as an async task, hence the updates that the user does are not updated at once.

## Goals
Fixes https://github.com/wso2/product-is/issues/10181

## Approach
Show a warning message notifying the user of possible delays in property updates.
