### PR TITLE
Fix pagination visible issue when only wso2carbon-local-sp is available in applications list response.

### DIFF
--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -120,7 +120,6 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
         getAppLists(listItemLimit, listOffset, null);
     }, [ listOffset, listItemLimit ]);
 
-
     /**
      * Retrieves the list of applications.
      *
@@ -149,7 +148,6 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                 } else {
                     setAppList(response);
                 }
-
             })
             .catch((error) => {
                 if (error.response && error.response.data && error.response.data.description) {
@@ -295,7 +293,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                 onItemsPerPageDropdownChange={ handleItemsPerPageDropdownChange }
                 onPageChange={ handlePaginationChange }
                 onSortStrategyChange={ handleListSortingStrategyOnChange }
-                showPagination={ true }
+                showPagination={ (appList?.totalResults - listOffsetAddition) !== 0 }
                 showTopActionPanel={ isApplicationListRequestLoading || !(!searchQuery && appList?.totalResults <= 0) }
                 sortOptions={ APPLICATIONS_LIST_SORTING_OPTIONS }
                 sortStrategy={ listSortingStrategy }


### PR DESCRIPTION
## Purpose
Displays Pagination UI features when there are no visible applications in the Console due to the availability of the `wso2carbon-local-sp`.

## Goals
Fixes https://github.com/wso2/product-is/issues/10284

## Approach

`wso2carbon-local-sp` should not be returned from the API. There's an issue[1] already tracked to monitor the progress of the imptrovement. Until then, as a workaround if only the local sp is available in the response, the pagination has been hidden.

[1] https://github.com/wso2/product-is/issues/9682

<img width="1379" alt="Screen Shot 2020-11-04 at 3 39 28 AM" src="https://user-images.githubusercontent.com/25959096/98046135-a2f2c180-1e4f-11eb-9fd6-14cbc56624ed.png">

