### PR TITLE
Improve application edit page access configurations tab

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1293,6 +1293,12 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 <Grid.Row columns={ 1 }>
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
                                         <Message warning visible>
+                                            <Message.Header>
+                                                {
+                                                    t("console:develop.features.applications.forms.inboundOIDC." +
+                                                        "messages.revokeDisclaimer.heading")
+                                                }
+                                            </Message.Header>
                                             <p>
                                                 {
                                                     t("console:develop.features.applications.forms.inboundOIDC." +

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -415,7 +415,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 scopeValidator.current.scrollIntoView(options);
                 break;
         }
-    }
+    };
 
     /**
      * submitURL function.
@@ -691,7 +691,11 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                     readOnly={ readOnly }
                                     data-testid={ `${ testId }-grant-type-checkbox-group` }
                                 />
-                                <Hint>This will determine how the application communicates with the token service</Hint>
+                                <Hint>
+                                    {
+                                        t("devPortal:components.applications.forms.inboundOIDC.fields.grant.hint")
+                                    }
+                                </Hint>
                             </Grid.Column>
                         </Grid.Row>
                         <div ref={ url }></div>

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1293,12 +1293,6 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 <Grid.Row columns={ 1 }>
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
                                         <Message warning visible>
-                                            <Message.Header>
-                                                {
-                                                    t("console:develop.features.applications.forms.inboundOIDC." +
-                                                        "messages.revokeDisclaimer.heading")
-                                                }
-                                            </Message.Header>
                                             <p>
                                                 {
                                                     t("console:develop.features.applications.forms.inboundOIDC." +

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1289,6 +1289,28 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 >
                     <Grid>
                         {
+                            (initialValues?.state === State.REVOKED) && (
+                                <Grid.Row columns={ 1 }>
+                                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                                        <Message warning visible>
+                                            <Message.Header>
+                                                {
+                                                    t("console:develop.features.applications.forms.inboundOIDC." +
+                                                        "messages.revokeDisclaimer.heading")
+                                                }
+                                            </Message.Header>
+                                            <p>
+                                                {
+                                                    t("console:develop.features.applications.forms.inboundOIDC." +
+                                                        "messages.revokeDisclaimer.content")
+                                                }
+                                            </p>
+                                        </Message>
+                                    </Grid.Column>
+                                </Grid.Row>
+                            )
+                        }
+                        {
                             initialValues.clientId && (
                                 <Grid.Row columns={ 1 }>
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -532,24 +532,34 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             !readOnly && (
                                                 <>
                                                     <Button
-                                                        color="red"
+                                                        color={
+                                                            (initialValues?.state === State.REVOKED)
+                                                                ? "green"
+                                                                : "red"
+                                                        }
                                                         className="oidc-regenerate-button"
                                                         onClick={ handleRegenerateButton }
                                                         data-testid={ `${ testId }-oidc-regenerate-button` }
                                                     >
-                                                        { t("common:regenerate") }
+                                                        {
+                                                            (initialValues?.state === State.REVOKED)
+                                                                ? t("common:activate")
+                                                                : t("common:regenerate")
+                                                        }
                                                     </Button>
-                                                    <Button
-                                                        color="red"
-                                                        className="oidc-revoke-button"
-                                                        onClick={ handleRevokeButton }
-                                                        disabled={ (initialValues?.state === State.REVOKED) }
-                                                        data-testid={ `${ testId }-oidc-revoke-button` }
-                                                    >
-                                                        { t("common:revoke") }
-                                                    </Button>
+                                                    {
+                                                        (initialValues?.state !== State.REVOKED) && (
+                                                            <Button
+                                                                color="red"
+                                                                className="oidc-revoke-button"
+                                                                onClick={ handleRevokeButton }
+                                                                data-testid={ `${ testId }-oidc-revoke-button` }
+                                                            >
+                                                                { t("common:revoke") }
+                                                            </Button>
+                                                        )
+                                                    }
                                                 </>
-
                                             )
                                         }
                                     </Grid.Column>

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -427,6 +427,830 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      */
     let submitOrigin: (callback: (origin?: string) => void) => void;
 
+    /**
+     * Renders the list of main OIDC config fields.
+     * @return {ReactElement}
+     */
+    const renderOIDCConfigFields = (): ReactElement => (
+        <>
+            <Grid.Row columns={ 2 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                    <Divider />
+                    <Divider hidden />
+                </Grid.Column>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Field
+                        ref={ grant }
+                        name="grant"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.fields.grant.label")
+                        }
+                        type="checkbox"
+                        required={ true }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.fields.grant" +
+                                ".validations.empty")
+                        }
+                        children={ getAllowedGranTypeList(metadata.allowedGrantTypes) }
+                        value={ initialValues.grantTypes }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-grant-type-checkbox-group` }
+                    />
+                    <Hint>
+                        {
+                            t("devPortal:components.applications.forms.inboundOIDC.fields.grant.hint")
+                        }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+            <div ref={ url }></div>
+            <URLInput
+                isAllowEnabled={ false }
+                tenantDomain={ tenantDomain }
+                allowedOrigins={ allowedOriginList }
+                labelEnabled={ true }
+                urlState={ callBackUrls }
+                setURLState={ setCallBackUrls }
+                labelName={
+                    t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls.label")
+                }
+                required={ true }
+                value={ buildCallBackURLWithSeparator(initialValues.callbackURLs?.toString()) }
+                placeholder={
+                    t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls" +
+                        ".placeholder")
+                }
+                validationErrorMsg={
+                    t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls" +
+                        ".validations.empty")
+                }
+                validation={ (value: string) => {
+                    let label: ReactElement = null;
+
+                    const isHttpUrl: boolean = URLUtils.isHttpUrl(value);
+
+                    if (isHttpUrl) {
+                        label = (
+                            <Label basic color="orange" className="mt-2">
+                                { t("console:common.validations.inSecureURL.description") }
+                            </Label>
+                        );
+                    }
+
+                    if (!URLUtils.isHttpsOrHttpUrl(value)) {
+                        label = (
+                            <Label basic color="orange" className="mt-2">
+                                { t("console:common.validations.unrecognizedURL.description") }
+                            </Label>
+                        );
+                    }
+
+                    if (!URLUtils.isMobileDeepLink(value)) {
+                        return false;
+                    }
+
+                    setCallbackURLsErrorLabel(label);
+
+                    return true;
+                } }
+                showError={ showURLError }
+                setShowError={ setShowURLError }
+                hint={
+                    t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls.hint")
+                }
+                readOnly={ readOnly }
+                addURLTooltip={ t("common:addURL") }
+                duplicateURLErrorMessage={ t("common:duplicateURLError") }
+                data-testid={ `${ testId }-callback-url-input` }
+                getSubmit={ (submitFunction: (callback: (url?: string) => void) => void) => {
+                    submitUrl = submitFunction;
+                } }
+                showPredictions={ false }
+                customLabel={ callbackURLsErrorLabel }
+            />
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <div ref={ allowedOrigin }></div>
+                    <URLInput
+                        required
+                        handleAddAllowedOrigin={ (url) => handleAllowOrigin(url) }
+                        urlState={ allowedOrigins }
+                        setURLState={ setAllowedOrigins }
+                        labelName={
+                            t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
+                                ".label")
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
+                                ".placeholder")
+                        }
+                        value={ initialValues?.allowedOrigins?.toString() }
+                        validationErrorMsg={
+                            t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
+                                ".validations.empty")
+                        }
+                        validation={ (value: string) => {
+
+                            let label: ReactElement = null;
+
+                            if (URLUtils.isHttpUrl(value)) {
+                                label = (
+                                    <Label basic color="orange" className="mt-2">
+                                        { t("console:common.validations.inSecureURL.description") }
+                                    </Label>
+                                );
+                            }
+
+                            if (!URLUtils.isHttpsOrHttpUrl(value)) {
+                                label = (
+                                    <Label basic color="orange" className="mt-2">
+                                        { t("console:common.validations.unrecognizedURL.description") }
+                                    </Label>
+                                );
+                            }
+
+                            setAllowedOriginsErrorLabel(label);
+
+                            return true;
+                        } }
+                        computerWidth={ 10 }
+                        setShowError={ setShowOriginError }
+                        showError={ showOriginError }
+                        hint={
+                            t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
+                                ".hint")
+                        }
+                        addURLTooltip={ t("common:addURL") }
+                        duplicateURLErrorMessage={ t("common:duplicateURLError") }
+                        data-testid={ `${ testId }-allowed-origin-url-input` }
+                        getSubmit={ (submitOriginFunction: (callback: (origin?: string) => void) => void
+                        ) => {
+                            submitOrigin = submitOriginFunction;
+                        } }
+                        showPredictions={ false }
+                        customLabel={ allowedOriginsErrorLabel }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Field
+                        ref={ supportPublicClients }
+                        name="supportPublicClients"
+                        label=""
+                        required={ false }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.fields.public" +
+                                ".validations.empty")
+                        }
+                        type="checkbox"
+                        value={
+                            initialValues.publicClient
+                                ? [ "supportPublicClients" ]
+                                : []
+                        }
+                        children={ [
+                            {
+                                label: t("devPortal:components.applications.forms.inboundOIDC" +
+                                    ".fields.public.label"),
+                                value: "supportPublicClients"
+                            }
+                        ] }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-public-client-checkbox` }
+                    />
+                    <Hint>
+                        { t("devPortal:components.applications.forms.inboundOIDC.fields.public.hint") }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+
+            { /* PKCE */ }
+            <Grid.Row columns={ 2 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                    <Divider />
+                    <Divider hidden />
+                </Grid.Column>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Heading as="h5">
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections.pkce" +
+                            ".heading") }
+                    </Heading>
+                    <Hint>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections.pkce" +
+                            ".hint") }
+                    </Hint>
+                    <Divider hidden />
+                    <Field
+                        ref={ pkce }
+                        name="PKCE"
+                        label=""
+                        required={ false }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.pkce" +
+                                ".fields.pkce.validations.empty")
+                        }
+                        type="checkbox"
+                        value={ findPKCE(initialValues.pkce) }
+                        children={ [
+                            {
+                                label: t("devPortal:components.applications.forms.inboundOIDC" +
+                                    ".sections.pkce.fields.pkce.children.mandatory.label"),
+                                value: "mandatory"
+                            },
+                            {
+                                label: t("devPortal:components.applications.forms.inboundOIDC" +
+                                    ".sections.pkce.fields.pkce.children.plainAlg.label"),
+                                value: "supportPlainTransformAlgorithm"
+                            }
+                        ] }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-pkce-checkbox-group` }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+
+            { /* Access Token */ }
+            <Grid.Row columns={ 2 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                    <Divider />
+                    <Divider hidden />
+                </Grid.Column>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Heading as="h5">
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                            ".accessToken.heading") }
+                    </Heading>
+                    <Hint>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections.accessToken" +
+                            ".hint") }
+                    </Hint>
+                    <Divider hidden />
+                    <Field
+                        ref={ type }
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".accessToken.fields.type.label")
+                        }
+                        name="type"
+                        default={
+                            initialValues.accessToken
+                                ? initialValues.accessToken.type
+                                : metadata.accessTokenType.defaultValue
+                        }
+                        type="radio"
+                        children={ getAllowedList(metadata.accessTokenType, true) }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-access-token-type-radio-group` }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
+                    <Field
+                        ref={ bindingType }
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".accessToken.fields.bindingType.label")
+                        }
+                        name="bindingType"
+                        default={
+                            initialValues
+                                ? initialValues.accessToken.bindingType
+                                : metadata.accessTokenBindingType.defaultValue
+                        }
+                        type="radio"
+                        children={ getAllowedList(metadata.accessTokenBindingType, true) }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-access-token-type-radio-group` }
+                        listen={ (values) => {
+                            setIsTokenBindingTypeSelected(values.get("bindingType") !== "None")
+                        } }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+            {
+                isTokenBindingTypeSelected && (
+                    <>
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
+                                <Field
+                                    ref={ validateTokenBinding }
+                                    name="ValidateTokenBinding"
+                                    label=""
+                                    required={ false }
+                                    requiredErrorMessage=""
+                                    type="checkbox"
+                                    value={
+                                        initialValues.accessToken?.validateTokenBinding
+                                            ? [ "validateTokenBinding" ]
+                                            : []
+                                    }
+                                    children={ [
+                                        {
+                                            label: t("devPortal:components.applications.forms.inboundOIDC" +
+                                                ".sections.accessToken.fields.validateBinding.label"),
+                                            value: "validateTokenBinding"
+                                        }
+                                    ] }
+                                    readOnly={ readOnly }
+                                    data-testid={ `${ testId }-access-token-validate-binding-checkbox` }
+                                />
+                                <Hint>
+                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                        ".accessToken.fields.validateBinding.hint") }
+                                </Hint>
+                            </Grid.Column>
+                        </Grid.Row>
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
+                                <Field
+                                    ref={ revokeAccessToken }
+                                    name="RevokeAccessToken"
+                                    label=""
+                                    required={ false }
+                                    requiredErrorMessage=""
+                                    type="checkbox"
+                                    value={
+                                        initialValues.accessToken?.revokeTokensWhenIDPSessionTerminated
+                                            ? [ "revokeAccessToken" ]
+                                            : []
+                                    }
+                                    children={ [
+                                        {
+                                            label: t("devPortal:components.applications.forms.inboundOIDC" +
+                                                ".sections.accessToken.fields.revokeToken.label"),
+                                            value: "revokeAccessToken"
+                                        }
+                                    ] }
+                                    readOnly={ readOnly }
+                                    data-testid={ `${ testId }-access-token-revoke-token-checkbox` }
+                                />
+                                <Hint>
+                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                        ".accessToken.fields.revokeToken.hint") }
+                                </Hint>
+                            </Grid.Column>
+                        </Grid.Row>
+                    </>
+                )
+            }
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
+                    <Field
+                        ref={ userAccessTokenExpiryInSeconds }
+                        name="userAccessTokenExpiryInSeconds"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".accessToken.fields.expiry.label")
+                        }
+                        required={ true }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".accessToken.fields.expiry.validations.empty")
+                        }
+                        value={
+                            initialValues.accessToken
+                                ? initialValues.accessToken.userAccessTokenExpiryInSeconds.toString()
+                                : metadata.defaultUserAccessTokenExpiryTime
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".accessToken.fields.expiry.placeholder")
+                        }
+                        type="number"
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-access-token-expiry-time-input` }
+                    />
+                    <Hint>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                            ".accessToken.fields.expiry.hint") }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+            {/* TODO  Enable this option in future*/ }
+            {/*<Grid.Row columns={ 1 }>*/ }
+            {/*    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>*/ }
+            {/*        <Field*/ }
+            {/*            name="applicationAccessTokenExpiryInSeconds"*/ }
+            {/*            label="Application access token expiry time"*/ }
+            {/*            required={ true }*/ }
+            {/*            requiredErrorMessage="Please fill the application access token expiry time"*/ }
+            {/*            value={ initialValues.accessToken ?*/ }
+            {/*                initialValues.accessToken.
+                        applicationAccessTokenExpiryInSeconds.toString() :*/ }
+            {/*                metadata.defaultApplicationAccessTokenExpiryTime }*/ }
+            {/*            placeholder="Enter the application access token expiry time "*/ }
+            {/*            type="number"*/ }
+            {/*        />*/ }
+            {/*        <Hint>Configure the application access token expiry time (in seconds).</Hint>*/ }
+            {/*    </Grid.Column>*/ }
+            {/*</Grid.Row>*/ }
+
+            { /* Refresh Token */ }
+            <Grid.Row columns={ 2 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                    <Divider />
+                    <Divider hidden />
+                </Grid.Column>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Heading as="h5">
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                            ".refreshToken.heading") }
+                    </Heading>
+                    <Divider hidden />
+                    <Field
+                        ref={ refreshToken }
+                        name="RefreshToken"
+                        label=""
+                        required={ false }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".refreshToken.fields.renew.validations.empty")
+                        }
+                        type="checkbox"
+                        value={
+                            initialValues.refreshToken?.renewRefreshToken
+                                ? [ "refreshToken" ]
+                                : []
+                        }
+                        children={ [
+                            {
+                                label: t("devPortal:components.applications.forms.inboundOIDC" +
+                                    ".sections.refreshToken.fields.renew.label"),
+                                value: "refreshToken"
+                            }
+                        ] }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-renew-refresh-token-checkbox` }
+                    />
+                    <Hint>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                            ".refreshToken.fields.renew.hint") }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
+                    <Field
+                        ref={ expiryInSeconds }
+                        name="expiryInSeconds"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".refreshToken.fields.expiry.label")
+                        }
+                        required={ true }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".refreshToken.fields.expiry.validations.empty")
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".refreshToken.fields.expiry.placeholder")
+                        }
+                        value={ initialValues.refreshToken
+                            ? initialValues.refreshToken.expiryInSeconds.toString()
+                            : metadata.defaultRefreshTokenExpiryTime }
+                        type="number"
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-refresh-token-expiry-time-input` }
+                    />
+                    <Hint>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                            ".refreshToken.fields.expiry.hint") }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+
+            { /* ID Token */ }
+            <Grid.Row columns={ 2 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                    <Divider />
+                    <Divider hidden />
+                </Grid.Column>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Heading as="h5">
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                            ".idToken.heading") }
+                    </Heading>
+                    <Divider hidden />
+                    <Field
+                        ref={ audience }
+                        name="audience"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".idToken.fields.audience.label")
+                        }
+                        required={ false }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.audience.validations.empty")
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.audience.placeholder")
+                        }
+                        value={ initialValues.idToken?.audience.toString() }
+                        type="textarea"
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-audience-textarea` }
+                    />
+                    <Hint>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                            ".fields.audience.hint") }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Field
+                        ref={ encryption }
+                        name="encryption"
+                        label=""
+                        required={ false }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.encryption.validations.empty")
+                        }
+                        type="checkbox"
+                        listen={
+                            (values) => {
+                                setEncryptionEnable(
+                                    !!values.get("encryption").includes("enableEncryption")
+                                );
+                            }
+                        }
+                        value={
+                            initialValues.idToken?.encryption.enabled
+                                ? [ "enableEncryption" ]
+                                : []
+                        }
+                        children={ [
+                            {
+                                label: t("devPortal:components.applications.forms.inboundOIDC" +
+                                    ".sections.idToken.fields.encryption.label"),
+                                value: "enableEncryption"
+                            }
+                        ] }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-encryption-checkbox` }
+                    />
+                    <Hint>Enable ID token encryption.</Hint>
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Field
+                        ref={ algorithm }
+                        name="algorithm"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.algorithm.label")
+                        }
+                        required={ isEncryptionEnabled }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.algorithm.validations.empty")
+                        }
+                        type="dropdown"
+                        default={
+                            initialValues.idToken
+                                ? initialValues.idToken.encryption.algorithm
+                                : metadata.idTokenEncryptionAlgorithm.defaultValue
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".idToken.fields.algorithm.placeholder")
+                        }
+                        children={ getAllowedList(metadata.idTokenEncryptionAlgorithm) }
+                        disabled={ !isEncryptionEnabled }
+                        data-testid={ `${ testId }-encryption-algorithm-dropdown` }
+                    />
+                    <Hint disabled={ !isEncryptionEnabled }>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                            ".fields.algorithm.hint") }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Field
+                        ref={ method }
+                        name="method"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".idToken.fields.method.label")
+                        }
+                        required={ isEncryptionEnabled }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.method.validations.empty")
+                        }
+                        type="dropdown"
+                        default={
+                            initialValues.idToken
+                                ? initialValues.idToken.encryption.method
+                                : metadata.idTokenEncryptionMethod.defaultValue
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.method.placeholder")
+                        }
+                        children={ getAllowedList(metadata.idTokenEncryptionMethod) }
+                        disabled={ !isEncryptionEnabled }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-encryption-method-dropdown` }
+                    />
+                    <Hint disabled={ !isEncryptionEnabled }>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                            ".fields.method.hint") }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
+                    <Field
+                        ref={ idExpiryInSeconds }
+                        name="idExpiryInSeconds"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.expiry.label")
+                        }
+                        required={ true }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.expiry.validations.empty")
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                                ".fields.expiry.placeholder")
+                        }
+                        value={
+                            initialValues.idToken
+                                ? initialValues.idToken.expiryInSeconds.toString()
+                                : metadata.defaultIdTokenExpiryTime
+                        }
+                        type="number"
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-id-token-expiry-time-input` }
+                    />
+                    <Hint>
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
+                            ".fields.expiry.hint") }
+                    </Hint>
+                </Grid.Column>
+            </Grid.Row>
+
+            { /* Logout */ }
+            <Grid.Row columns={ 2 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                    <Divider />
+                    <Divider hidden />
+                </Grid.Column>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Heading as="h5">Logout URLs</Heading>
+                    <Divider hidden />
+                    <Field
+                        ref={ backChannelLogoutUrl }
+                        name="backChannelLogoutUrl"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".logoutURLs.fields.back.label")
+                        }
+                        required={ false }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".logoutURLs.fields.back.validations.empty")
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".logoutURLs.fields.back.placeholder")
+                        }
+                        type="text"
+                        validation={ (value: string, validation: Validation) => {
+                            if (!FormValidation.url(value)) {
+                                validation.isValid = false;
+                                validation.errorMessages.push((
+                                    t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                        ".logoutURLs.fields.back.validations.invalid")
+                                ))
+                            }
+                        } }
+                        value={ initialValues.logout?.backChannelLogoutUrl }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-back-channel-logout-url-input` }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Field
+                        ref={ frontChannelLogoutUrl }
+                        name="frontChannelLogoutUrl"
+                        label={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".logoutURLs.fields.front.label")
+                        }
+                        required={ false }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".logoutURLs.fields.front.validations.empty")
+                        }
+                        placeholder={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".logoutURLs.fields.front.placeholder")
+                        }
+                        type="text"
+                        validation={ (value: string, validation: Validation) => {
+                            if (!FormValidation.url(value)) {
+                                validation.isValid = false;
+                                validation.errorMessages.push((
+                                    t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                        ".logoutURLs.fields.front.validations.invalid")
+                                ));
+                            }
+                        } }
+                        value={ initialValues.logout?.frontChannelLogoutUrl }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-front-channel-logout-url-input` }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Field
+                        ref={ enableRequestObjectSignatureValidation }
+                        name="enableRequestObjectSignatureValidation"
+                        label=""
+                        required={ false }
+                        requiredErrorMessage="this is needed"
+                        type="checkbox"
+                        value={
+                            initialValues.validateRequestObjectSignature
+                                ? [ "EnableRequestObjectSignatureValidation" ]
+                                : []
+                        }
+                        children={ [
+                            {
+                                label: t("devPortal:components.applications.forms.inboundOIDC" +
+                                    ".sections.logoutURLs.fields.signatureValidation.label"),
+                                value: "EnableRequestObjectSignatureValidation"
+                            }
+                        ] }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-request-object-signature-validation-checkbox` }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+            { /* Scope Validators */ }
+            <Grid.Row columns={ 2 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                    <Divider />
+                    <Divider hidden />
+                </Grid.Column>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    <Heading as="h5">
+                        { t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                            ".scopeValidators.heading") }
+                    </Heading>
+                    <Divider hidden />
+                    <Field
+                        ref={ scopeValidator }
+                        name="scopeValidator"
+                        label=""
+                        required={ false }
+                        requiredErrorMessage={
+                            t("devPortal:components.applications.forms.inboundOIDC.sections" +
+                                ".scopeValidators.fields.validator.validations.empty")
+                        }
+                        type="checkbox"
+                        value={ initialValues.scopeValidators }
+                        children={ getAllowedList(metadata.scopeValidators, true) }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-scope-validator-checkbox` }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+            {
+                !readOnly && (
+                    <Grid.Row columns={ 1 }>
+                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                            <Button
+                                primary
+                                type="submit"
+                                size="small"
+                                className="form-button"
+                                data-testid={ `${ testId }-submit-button` }
+                            >
+                                { t("common:update") }
+                            </Button>
+                        </Grid.Column>
+                    </Grid.Row>
+                )
+            }
+        </>
+    );
+
     return (
         metadata ?
             (
@@ -668,821 +1492,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 </Grid.Row>
                             )
                         }
-                        <Grid.Row columns={ 2 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                                <Divider />
-                                <Divider hidden />
-                            </Grid.Column>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Field
-                                    ref={ grant }
-                                    name="grant"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.fields.grant.label")
-                                    }
-                                    type="checkbox"
-                                    required={ true }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.fields.grant" +
-                                            ".validations.empty")
-                                    }
-                                    children={ getAllowedGranTypeList(metadata.allowedGrantTypes) }
-                                    value={ initialValues.grantTypes }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-grant-type-checkbox-group` }
-                                />
-                                <Hint>
-                                    {
-                                        t("devPortal:components.applications.forms.inboundOIDC.fields.grant.hint")
-                                    }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-                        <div ref={ url }></div>
-                        <URLInput
-                            isAllowEnabled={ false }
-                            tenantDomain={ tenantDomain }
-                            allowedOrigins={ allowedOriginList }
-                            labelEnabled={ true }
-                            urlState={ callBackUrls }
-                            setURLState={ setCallBackUrls }
-                            labelName={
-                                t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls.label")
-                            }
-                            required={ true }
-                            value={ buildCallBackURLWithSeparator(initialValues.callbackURLs?.toString()) }
-                            placeholder={
-                                t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls" +
-                                    ".placeholder")
-                            }
-                            validationErrorMsg={
-                                t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls" +
-                                    ".validations.empty")
-                            }
-                            validation={ (value: string) => {
-                                let label: ReactElement = null;
-
-                                const isHttpUrl: boolean = URLUtils.isHttpUrl(value);
-
-                                if (isHttpUrl) {
-                                    label = (
-                                        <Label basic color="orange" className="mt-2">
-                                            { t("console:common.validations.inSecureURL.description") }
-                                        </Label>
-                                    );
-                                }
-
-                                if (!URLUtils.isHttpsOrHttpUrl(value)) {
-                                    label = (
-                                        <Label basic color="orange" className="mt-2">
-                                            { t("console:common.validations.unrecognizedURL.description") }
-                                        </Label>
-                                    );
-                                }
-
-                                if (!URLUtils.isMobileDeepLink(value)) {
-                                    return false;
-                                }
-
-                                setCallbackURLsErrorLabel(label);
-
-                                return true;
-                            } }
-                            showError={ showURLError }
-                            setShowError={ setShowURLError }
-                            hint={
-                                t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls.hint")
-                            }
-                            readOnly={ readOnly }
-                            addURLTooltip={ t("common:addURL") }
-                            duplicateURLErrorMessage={ t("common:duplicateURLError") }
-                            data-testid={ `${ testId }-callback-url-input` }
-                            getSubmit={ (submitFunction: (callback: (url?: string) => void) => void) => {
-                                submitUrl = submitFunction;
-                            } }
-                            showPredictions={ false }
-                            customLabel={ callbackURLsErrorLabel }
-                        />
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <div ref={ allowedOrigin }></div>
-                                <URLInput
-                                    required
-                                    handleAddAllowedOrigin={ (url) => handleAllowOrigin(url) }
-                                    urlState={ allowedOrigins }
-                                    setURLState={ setAllowedOrigins }
-                                    labelName={
-                                        t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
-                                            ".label")
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
-                                            ".placeholder")
-                                    }
-                                    value={ initialValues?.allowedOrigins?.toString() }
-                                    validationErrorMsg={
-                                        t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
-                                            ".validations.empty")
-                                    }
-                                    validation={ (value: string) => {
-
-                                        let label: ReactElement = null;
-
-                                        if (URLUtils.isHttpUrl(value)) {
-                                            label = (
-                                                <Label basic color="orange" className="mt-2">
-                                                    { t("console:common.validations.inSecureURL.description") }
-                                                </Label>
-                                            );
-                                        }
-
-                                        if (!URLUtils.isHttpsOrHttpUrl(value)) {
-                                            label = (
-                                                <Label basic color="orange" className="mt-2">
-                                                    { t("console:common.validations.unrecognizedURL.description") }
-                                                </Label>
-                                            );
-                                        }
-
-                                        setAllowedOriginsErrorLabel(label);
-
-                                        return true;
-                                    } }
-                                    computerWidth={ 10 }
-                                    setShowError={ setShowOriginError }
-                                    showError={ showOriginError }
-                                    hint={
-                                        t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
-                                            ".hint")
-                                    }
-                                    addURLTooltip={ t("common:addURL") }
-                                    duplicateURLErrorMessage={ t("common:duplicateURLError") }
-                                    data-testid={ `${ testId }-allowed-origin-url-input` }
-                                    getSubmit={ (submitOriginFunction: (callback: (origin?: string) => void) => void
-                                    ) => {
-                                        submitOrigin = submitOriginFunction;
-                                    } }
-                                    showPredictions={ false }
-                                    customLabel={ allowedOriginsErrorLabel }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Field
-                                    ref={ supportPublicClients }
-                                    name="supportPublicClients"
-                                    label=""
-                                    required={ false }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.fields.public" +
-                                            ".validations.empty")
-                                    }
-                                    type="checkbox"
-                                    value={
-                                        initialValues.publicClient
-                                            ? [ "supportPublicClients" ]
-                                            : []
-                                    }
-                                    children={ [
-                                        {
-                                            label: t("devPortal:components.applications.forms.inboundOIDC" +
-                                                ".fields.public.label"),
-                                            value: "supportPublicClients"
-                                        }
-                                    ] }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-public-client-checkbox` }
-                                />
-                                <Hint>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.fields.public.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-
-                        { /* PKCE */ }
-                        <Grid.Row columns={ 2 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                                <Divider />
-                                <Divider hidden />
-                            </Grid.Column>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Heading as="h5">
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections.pkce" +
-                                        ".heading") }
-                                </Heading>
-                                <Hint>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections.pkce" +
-                                        ".hint") }
-                                </Hint>
-                                <Divider hidden />
-                                <Field
-                                    ref={ pkce }
-                                    name="PKCE"
-                                    label=""
-                                    required={ false }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.pkce" +
-                                            ".fields.pkce.validations.empty")
-                                    }
-                                    type="checkbox"
-                                    value={ findPKCE(initialValues.pkce) }
-                                    children={ [
-                                        {
-                                            label: t("devPortal:components.applications.forms.inboundOIDC" +
-                                                ".sections.pkce.fields.pkce.children.mandatory.label"),
-                                            value: "mandatory"
-                                        },
-                                        {
-                                            label: t("devPortal:components.applications.forms.inboundOIDC" +
-                                                ".sections.pkce.fields.pkce.children.plainAlg.label"),
-                                            value: "supportPlainTransformAlgorithm"
-                                        }
-                                    ] }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-pkce-checkbox-group` }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
-
-                        { /* Access Token */ }
-                        <Grid.Row columns={ 2 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                                <Divider />
-                                <Divider hidden />
-                            </Grid.Column>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Heading as="h5">
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                        ".accessToken.heading") }
-                                </Heading>
-                                <Hint>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections.accessToken" +
-                                        ".hint") }
-                                </Hint>
-                                <Divider hidden />
-                                <Field
-                                    ref={ type }
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".accessToken.fields.type.label")
-                                    }
-                                    name="type"
-                                    default={
-                                        initialValues.accessToken
-                                            ? initialValues.accessToken.type
-                                            : metadata.accessTokenType.defaultValue
-                                    }
-                                    type="radio"
-                                    children={ getAllowedList(metadata.accessTokenType, true) }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-access-token-type-radio-group` }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
-                                <Field
-                                    ref={ bindingType }
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".accessToken.fields.bindingType.label")
-                                    }
-                                    name="bindingType"
-                                    default={
-                                        initialValues
-                                            ? initialValues.accessToken.bindingType
-                                            : metadata.accessTokenBindingType.defaultValue
-                                    }
-                                    type="radio"
-                                    children={ getAllowedList(metadata.accessTokenBindingType, true) }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-access-token-type-radio-group` }
-                                    listen={ (values) => {
-                                        setIsTokenBindingTypeSelected(values.get("bindingType") !== "None")
-                                    } }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
-                        {
-                            isTokenBindingTypeSelected && (
-                                <>
-                                    <Grid.Row columns={ 1 }>
-                                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
-                                            <Field
-                                                ref={ validateTokenBinding }
-                                                name="ValidateTokenBinding"
-                                                label=""
-                                                required={ false }
-                                                requiredErrorMessage=""
-                                                type="checkbox"
-                                                value={
-                                                    initialValues.accessToken?.validateTokenBinding
-                                                        ? [ "validateTokenBinding" ]
-                                                        : []
-                                                }
-                                                children={ [
-                                                    {
-                                                        label: t("devPortal:components.applications.forms.inboundOIDC" +
-                                                            ".sections.accessToken.fields.validateBinding.label"),
-                                                        value: "validateTokenBinding"
-                                                    }
-                                                ] }
-                                                readOnly={ readOnly }
-                                                data-testid={ `${ testId }-access-token-validate-binding-checkbox` }
-                                            />
-                                            <Hint>
-                                                { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                                    ".accessToken.fields.validateBinding.hint") }
-                                            </Hint>
-                                        </Grid.Column>
-                                    </Grid.Row>
-                                    <Grid.Row columns={ 1 }>
-                                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
-                                            <Field
-                                                ref={ revokeAccessToken }
-                                                name="RevokeAccessToken"
-                                                label=""
-                                                required={ false }
-                                                requiredErrorMessage=""
-                                                type="checkbox"
-                                                value={
-                                                    initialValues.accessToken?.revokeTokensWhenIDPSessionTerminated
-                                                        ? [ "revokeAccessToken" ]
-                                                        : []
-                                                }
-                                                children={ [
-                                                    {
-                                                        label: t("devPortal:components.applications.forms.inboundOIDC" +
-                                                            ".sections.accessToken.fields.revokeToken.label"),
-                                                        value: "revokeAccessToken"
-                                                    }
-                                                ] }
-                                                readOnly={ readOnly }
-                                                data-testid={ `${ testId }-access-token-revoke-token-checkbox` }
-                                            />
-                                            <Hint>
-                                                { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                                    ".accessToken.fields.revokeToken.hint") }
-                                            </Hint>
-                                        </Grid.Column>
-                                    </Grid.Row>
-                                </>
-                            )
-                        }
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
-                                <Field
-                                    ref={ userAccessTokenExpiryInSeconds }
-                                    name="userAccessTokenExpiryInSeconds"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".accessToken.fields.expiry.label")
-                                    }
-                                    required={ true }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".accessToken.fields.expiry.validations.empty")
-                                    }
-                                    value={
-                                        initialValues.accessToken
-                                            ? initialValues.accessToken.userAccessTokenExpiryInSeconds.toString()
-                                            : metadata.defaultUserAccessTokenExpiryTime
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".accessToken.fields.expiry.placeholder")
-                                    }
-                                    type="number"
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-access-token-expiry-time-input` }
-                                />
-                                <Hint>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                        ".accessToken.fields.expiry.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-                        {/* TODO  Enable this option in future*/ }
-                        {/*<Grid.Row columns={ 1 }>*/ }
-                        {/*    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>*/ }
-                        {/*        <Field*/ }
-                        {/*            name="applicationAccessTokenExpiryInSeconds"*/ }
-                        {/*            label="Application access token expiry time"*/ }
-                        {/*            required={ true }*/ }
-                        {/*            requiredErrorMessage="Please fill the application access token expiry time"*/ }
-                        {/*            value={ initialValues.accessToken ?*/ }
-                        {/*                initialValues.accessToken.
-                        applicationAccessTokenExpiryInSeconds.toString() :*/ }
-                        {/*                metadata.defaultApplicationAccessTokenExpiryTime }*/ }
-                        {/*            placeholder="Enter the application access token expiry time "*/ }
-                        {/*            type="number"*/ }
-                        {/*        />*/ }
-                        {/*        <Hint>Configure the application access token expiry time (in seconds).</Hint>*/ }
-                        {/*    </Grid.Column>*/ }
-                        {/*</Grid.Row>*/ }
-
-                        { /* Refresh Token */ }
-                        <Grid.Row columns={ 2 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                                <Divider />
-                                <Divider hidden />
-                            </Grid.Column>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Heading as="h5">
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                        ".refreshToken.heading") }
-                                </Heading>
-                                <Divider hidden />
-                                <Field
-                                    ref={ refreshToken }
-                                    name="RefreshToken"
-                                    label=""
-                                    required={ false }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".refreshToken.fields.renew.validations.empty")
-                                    }
-                                    type="checkbox"
-                                    value={
-                                        initialValues.refreshToken?.renewRefreshToken
-                                            ? [ "refreshToken" ]
-                                            : []
-                                    }
-                                    children={ [
-                                        {
-                                            label: t("devPortal:components.applications.forms.inboundOIDC" +
-                                                ".sections.refreshToken.fields.renew.label"),
-                                            value: "refreshToken"
-                                        }
-                                    ] }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-renew-refresh-token-checkbox` }
-                                />
-                                <Hint>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                        ".refreshToken.fields.renew.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
-                                <Field
-                                    ref={ expiryInSeconds }
-                                    name="expiryInSeconds"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".refreshToken.fields.expiry.label")
-                                    }
-                                    required={ true }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".refreshToken.fields.expiry.validations.empty")
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".refreshToken.fields.expiry.placeholder")
-                                    }
-                                    value={ initialValues.refreshToken
-                                        ? initialValues.refreshToken.expiryInSeconds.toString()
-                                        : metadata.defaultRefreshTokenExpiryTime }
-                                    type="number"
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-refresh-token-expiry-time-input` }
-                                />
-                                <Hint>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                        ".refreshToken.fields.expiry.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-
-                        { /* ID Token */ }
-                        <Grid.Row columns={ 2 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                                <Divider />
-                                <Divider hidden />
-                            </Grid.Column>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Heading as="h5">
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                        ".idToken.heading") }
-                                </Heading>
-                                <Divider hidden />
-                                <Field
-                                    ref={ audience }
-                                    name="audience"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".idToken.fields.audience.label")
-                                    }
-                                    required={ false }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.audience.validations.empty")
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.audience.placeholder")
-                                    }
-                                    value={ initialValues.idToken?.audience.toString() }
-                                    type="textarea"
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-audience-textarea` }
-                                />
-                                <Hint>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                        ".fields.audience.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Field
-                                    ref={ encryption }
-                                    name="encryption"
-                                    label=""
-                                    required={ false }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.encryption.validations.empty")
-                                    }
-                                    type="checkbox"
-                                    listen={
-                                        (values) => {
-                                            setEncryptionEnable(
-                                                !!values.get("encryption").includes("enableEncryption")
-                                            );
-                                        }
-                                    }
-                                    value={
-                                        initialValues.idToken?.encryption.enabled
-                                            ? [ "enableEncryption" ]
-                                            : []
-                                    }
-                                    children={ [
-                                        {
-                                            label: t("devPortal:components.applications.forms.inboundOIDC" +
-                                                ".sections.idToken.fields.encryption.label"),
-                                            value: "enableEncryption"
-                                        }
-                                    ] }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-encryption-checkbox` }
-                                />
-                                <Hint>Enable ID token encryption.</Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Field
-                                    ref={ algorithm }
-                                    name="algorithm"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.algorithm.label")
-                                    }
-                                    required={ isEncryptionEnabled }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.algorithm.validations.empty")
-                                    }
-                                    type="dropdown"
-                                    default={
-                                        initialValues.idToken
-                                            ? initialValues.idToken.encryption.algorithm
-                                            : metadata.idTokenEncryptionAlgorithm.defaultValue
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".idToken.fields.algorithm.placeholder")
-                                    }
-                                    children={ getAllowedList(metadata.idTokenEncryptionAlgorithm) }
-                                    disabled={ !isEncryptionEnabled }
-                                    data-testid={ `${ testId }-encryption-algorithm-dropdown` }
-                                />
-                                <Hint disabled={ !isEncryptionEnabled }>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                        ".fields.algorithm.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Field
-                                    ref={ method }
-                                    name="method"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".idToken.fields.method.label")
-                                    }
-                                    required={ isEncryptionEnabled }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.method.validations.empty")
-                                    }
-                                    type="dropdown"
-                                    default={
-                                        initialValues.idToken
-                                            ? initialValues.idToken.encryption.method
-                                            : metadata.idTokenEncryptionMethod.defaultValue
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.method.placeholder")
-                                    }
-                                    children={ getAllowedList(metadata.idTokenEncryptionMethod) }
-                                    disabled={ !isEncryptionEnabled }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-encryption-method-dropdown` }
-                                />
-                                <Hint disabled={ !isEncryptionEnabled }>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                        ".fields.method.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 5 }>
-                                <Field
-                                    ref={ idExpiryInSeconds }
-                                    name="idExpiryInSeconds"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.expiry.label")
-                                    }
-                                    required={ true }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.expiry.validations.empty")
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                            ".fields.expiry.placeholder")
-                                    }
-                                    value={
-                                        initialValues.idToken
-                                            ? initialValues.idToken.expiryInSeconds.toString()
-                                            : metadata.defaultIdTokenExpiryTime
-                                    }
-                                    type="number"
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-id-token-expiry-time-input` }
-                                />
-                                <Hint>
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections.idToken" +
-                                        ".fields.expiry.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-
-                        { /* Logout */ }
-                        <Grid.Row columns={ 2 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                                <Divider />
-                                <Divider hidden />
-                            </Grid.Column>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Heading as="h5">Logout URLs</Heading>
-                                <Divider hidden />
-                                <Field
-                                    ref={ backChannelLogoutUrl }
-                                    name="backChannelLogoutUrl"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".logoutURLs.fields.back.label")
-                                    }
-                                    required={ false }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".logoutURLs.fields.back.validations.empty")
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".logoutURLs.fields.back.placeholder")
-                                    }
-                                    type="text"
-                                    validation={ (value: string, validation: Validation) => {
-                                        if (!FormValidation.url(value)) {
-                                            validation.isValid = false;
-                                            validation.errorMessages.push((
-                                                t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                                    ".logoutURLs.fields.back.validations.invalid")
-                                            ))
-                                        }
-                                    } }
-                                    value={ initialValues.logout?.backChannelLogoutUrl }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-back-channel-logout-url-input` }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Field
-                                    ref={ frontChannelLogoutUrl }
-                                    name="frontChannelLogoutUrl"
-                                    label={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".logoutURLs.fields.front.label")
-                                    }
-                                    required={ false }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".logoutURLs.fields.front.validations.empty")
-                                    }
-                                    placeholder={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".logoutURLs.fields.front.placeholder")
-                                    }
-                                    type="text"
-                                    validation={ (value: string, validation: Validation) => {
-                                        if (!FormValidation.url(value)) {
-                                            validation.isValid = false;
-                                            validation.errorMessages.push((
-                                                t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                                    ".logoutURLs.fields.front.validations.invalid")
-                                            ));
-                                        }
-                                    } }
-                                    value={ initialValues.logout?.frontChannelLogoutUrl }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-front-channel-logout-url-input` }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row columns={ 1 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Field
-                                    ref={ enableRequestObjectSignatureValidation }
-                                    name="enableRequestObjectSignatureValidation"
-                                    label=""
-                                    required={ false }
-                                    requiredErrorMessage="this is needed"
-                                    type="checkbox"
-                                    value={
-                                        initialValues.validateRequestObjectSignature
-                                            ? [ "EnableRequestObjectSignatureValidation" ]
-                                            : []
-                                    }
-                                    children={ [
-                                        {
-                                            label: t("devPortal:components.applications.forms.inboundOIDC" +
-                                                ".sections.logoutURLs.fields.signatureValidation.label"),
-                                            value: "EnableRequestObjectSignatureValidation"
-                                        }
-                                    ] }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-request-object-signature-validation-checkbox` }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
-                        { /* Scope Validators */ }
-                        <Grid.Row columns={ 2 }>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                                <Divider />
-                                <Divider hidden />
-                            </Grid.Column>
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                <Heading as="h5">
-                                    { t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                        ".scopeValidators.heading") }
-                                </Heading>
-                                <Divider hidden />
-                                <Field
-                                    ref={ scopeValidator }
-                                    name="scopeValidator"
-                                    label=""
-                                    required={ false }
-                                    requiredErrorMessage={
-                                        t("devPortal:components.applications.forms.inboundOIDC.sections" +
-                                            ".scopeValidators.fields.validator.validations.empty")
-                                    }
-                                    type="checkbox"
-                                    value={ initialValues.scopeValidators }
-                                    children={ getAllowedList(metadata.scopeValidators, true) }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-scope-validator-checkbox` }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
-                        {
-                            !readOnly && (
-                                <Grid.Row columns={ 1 }>
-                                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                                        <Button
-                                            primary
-                                            type="submit"
-                                            size="small"
-                                            className="form-button"
-                                            data-testid={ `${ testId }-submit-button` }
-                                        >
-                                            { t("common:update") }
-                                        </Button>
-                                    </Grid.Column>
-                                </Grid.Row>
-                            )
-                        }
+                        { (initialValues?.state !== State.REVOKED) && renderOIDCConfigFields() }
                     </Grid>
                 </Forms>
             )

--- a/apps/console/src/features/core/components/authenticator-accordion.tsx
+++ b/apps/console/src/features/core/components/authenticator-accordion.tsx
@@ -30,6 +30,7 @@ import React, {
     FunctionComponent,
     ReactElement,
     SyntheticEvent,
+    useEffect,
     useState
 } from "react";
 
@@ -45,6 +46,10 @@ export interface AuthenticatorAccordionPropsInterface extends TestableComponentI
      * Initial activeIndexes value.
      */
     defaultActiveIndexes?: number[];
+    /**
+     * Expand the accordion if only single item is present.
+     */
+    defaultExpandSingleItemAccordion?: boolean;
     /**
      * Accordion actions.
      */
@@ -103,12 +108,28 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
         globalActions,
         authenticators,
         defaultActiveIndexes,
+        defaultExpandSingleItemAccordion,
         hideChevron,
         orderBy,
         [ "data-testid" ]: testId
     } = props;
 
     const [ accordionActiveIndexes, setAccordionActiveIndexes ] = useState<number[]>(defaultActiveIndexes);
+
+    /**
+     * If the authenticator count is 1, always open the authenticator panel.
+     */
+    useEffect(() => {
+        if (!defaultExpandSingleItemAccordion) {
+            return;
+        }
+
+        if (!(authenticators && Array.isArray(authenticators) && authenticators.length === 1)) {
+            return;
+        }
+
+        setAccordionActiveIndexes([ 0 ]);
+    }, [ authenticators ]);
 
     /**
      * Handles accordion title click.
@@ -188,6 +209,7 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
 AuthenticatorAccordion.defaultProps = {
     "data-testid": "authenticator-accordion",
     defaultActiveIndexes: [ -1 ],
+    defaultExpandSingleItemAccordion: true,
     hideChevron: false,
     orderBy: undefined
 };

--- a/modules/i18n/src/models/common.ts
+++ b/modules/i18n/src/models/common.ts
@@ -171,3 +171,11 @@ export interface ValidationInterface {
     heading: string;
     description: string;
 }
+
+/**
+ * Interface for UI messages.
+ */
+export interface Message {
+    heading: string;
+    content: string;
+}

--- a/modules/i18n/src/models/namespaces/common-ns.ts
+++ b/modules/i18n/src/models/namespaces/common-ns.ts
@@ -22,6 +22,7 @@
 export interface CommonNS {
     access: string;
     actions: string;
+    activate: string;
     active: string;
     add: string;
     addURL: string;

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -19,6 +19,7 @@
 import {
     Confirmation,
     FormAttributes,
+    Message,
     ModalInterface,
     Notification,
     Placeholder,
@@ -53,6 +54,13 @@ export interface ConsoleNS {
                                clientId: FormAttributes;
                                clientSecret: FormAttributes;
                            };
+                        };
+                    };
+                };
+                forms: {
+                    inboundOIDC: {
+                        messages: {
+                            revokeDisclaimer: Message;
                         };
                     };
                 };

--- a/modules/i18n/src/translations/en-US/portals/common.ts
+++ b/modules/i18n/src/translations/en-US/portals/common.ts
@@ -21,6 +21,7 @@ import { CommonNS } from "../../../models";
 export const common: CommonNS = {
     access: "Access",
     actions: "Actions",
+    activate: "Activate",
     active: "Active",
     add: "Add",
     addURL: "Add value",

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -134,6 +134,17 @@ export const console: ConsoleNS = {
                                 "Please make sure to copy and save it somewhere safe."
                         }
                     }
+                },
+                forms: {
+                    inboundOIDC: {
+                        messages: {
+                            revokeDisclaimer: {
+                                content: "The application has been revoked. Please regenrate the secret if you wish " +
+                                    "to reactivate the application.",
+                                heading: "Application is Revoked"
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/modules/i18n/src/translations/en-US/portals/dev-portal.ts
+++ b/modules/i18n/src/translations/en-US/portals/dev-portal.ts
@@ -676,6 +676,7 @@ export const devPortal: DevPortalNS = {
                             }
                         },
                         grant: {
+                            hint: "This will determine how the application communicates with the token service",
                             label: "Allowed grant type",
                             validations: {
                                 empty: "Select at least a  grant type"

--- a/modules/i18n/src/translations/fr-FR/portals/common.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/common.ts
@@ -21,6 +21,7 @@ import { CommonNS } from "../../../models";
 export const common: CommonNS = {
     access: "Accès",
     actions: "Actions",
+    activate: "Activer",
     active: "Actif",
     add: "Ajouter",
     addURL: "Ajouter la valeur",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -135,6 +135,17 @@ export const console: ConsoleNS = {
                                 "endroit sûr."
                         }
                     }
+                },
+                forms: {
+                    inboundOIDC: {
+                        messages: {
+                            revokeDisclaimer: {
+                                content: "விண்ணப்பம் ரத்து செய்யப்பட்டது. நீங்கள் பயன்பாட்டை மீண்டும் இயக்க விரும்பினால் " +
+                                    "ரகசியத்தை மீண்டும் உருவாக்கவும்.",
+                                heading: "La demande est révoquée"
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/modules/i18n/src/translations/pt-BR/portals/common.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/common.ts
@@ -21,6 +21,7 @@ import { CommonNS } from "../../../models";
 export const common: CommonNS = {
     access: "Acesso",
     actions: "ações",
+    activate: "Ativar",
     active: "Activo",
     add: "AAdicionar",
     addURL: "Adicione URL",

--- a/modules/i18n/src/translations/si-LK/portals/common.ts
+++ b/modules/i18n/src/translations/si-LK/portals/common.ts
@@ -21,6 +21,7 @@ import { CommonNS } from "../../../models";
 export const common: CommonNS = {
     access: "ප්\u200Dරවේශය",
     actions: "ක්‍රියා",
+    activate: "සක්‍රිය කරන්න",
     active: "සක්\u200Dරීයයි",
     add: "එකතු කරන්න",
     addURL: "URL එක් කරන්න",

--- a/modules/i18n/src/translations/ta-IN/portals/common.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/common.ts
@@ -21,6 +21,7 @@ import { CommonNS } from "../../../models";
 export const common: CommonNS = {
     access: "அணுகல்",
     actions: "செயல்கள்",
+    activate: "செயல்படுத்த",
     active: "செயல்பாட்டில் உள்ள",
     add: "சேர்",
     addURL: "URL ஐச் சேர்க்கவும்",


### PR DESCRIPTION
## Purpose
1. When an OIDC application is revoked, it is not intuitive to the user that the application is not usable until the secret is regenerated.
2. When there is only one protocol configured, the accordion is closed by default.

## Goals
Fixes https://github.com/wso2/product-is/issues/10304

## Approach
For revoked applications, the following view will be displayed to guide the users to reactivate their apps.
<img width="1577" alt="Screen Shot 2020-11-04 at 2 46 57 PM" src="https://user-images.githubusercontent.com/25959096/98092399-a2d4df00-1eac-11eb-8692-b0f9cd60b739.png">
