### PR TITLE
Fix issues in application management component

### DIFF
--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -168,7 +168,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
     }, [ isAllowedOriginsUpdated ]);
 
     useEffect(() => {
-        if (tabPaneExtensions) {
+        if (tabPaneExtensions && Array.isArray(tabPaneExtensions) && tabPaneExtensions.length > 0) {
             isTabExtensionsAvailable(true);
             return;
         }

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -168,16 +168,21 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
     }, [ isAllowedOriginsUpdated ]);
 
     useEffect(() => {
-        if (tabPaneExtensions && Array.isArray(tabPaneExtensions) && tabPaneExtensions.length > 0) {
-            isTabExtensionsAvailable(true);
+        if (tabPaneExtensions) {
             return;
         }
 
-        setTabPaneExtensions(ComponentExtensionPlaceholder({
+        const extensions: any[] = ComponentExtensionPlaceholder({
             component: "application",
             subComponent: "edit",
             type: "tab"
-        }));
+        });
+
+        if (Array.isArray(extensions) && extensions.length > 0) {
+            isTabExtensionsAvailable(true);
+        }
+
+        setTabPaneExtensions(extensions);
     }, [ tabPaneExtensions ]);
 
     /**

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1329,7 +1329,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                             )
                         }
                         {
-                            initialValues.clientSecret && (
+                            (initialValues.clientSecret && (initialValues?.state !== State.REVOKED)) && (
                                 <Grid.Row columns={ 2 }>
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
                                         <Form.Field>

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -158,9 +158,14 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
 
             return url;
         } else {
-            const availableURls = urlState.split(",");
-            const duplicate = availableURls.includes(url);
+            const availableURls: string[] = !urlState
+                ? []
+                : urlState.split(",");
+
+            const duplicate: boolean = availableURls.includes(url);
+
             urlValid && setDuplicateURL(duplicate);
+
             if (urlValid && !duplicate) {
                 setURLState((url + "," + urlState));
                 setChangeUrl("");

--- a/modules/theme/src/themes/default/views/card.overrides
+++ b/modules/theme/src/themes/default/views/card.overrides
@@ -347,79 +347,81 @@
              Template Card Variation
 *********************************************/
 
-.ui.card {
-    &.template-card {
-        width: @templateCardDefaultWidth;
-        transition: @templateCardTransition;
-        border: @templateCardBorder;
-        box-shadow: none;
-
-        &:hover {
-            transform: none;
-            text-decoration: none;
-            cursor: pointer;
-            box-shadow: @templateCardHoverBoxShadow;
-        }
-        &.inline {
-            display: inline-block;
-            margin-right: @templateCardRightSpacing;
-        }
-        &.selected {
-            border-bottom-width: @templateCardBorderBottomWidth;
-            border-bottom-color: @templateCardSelectedStateBorderBottomColor;
-        }
-        &.disabled {
-            cursor: not-allowed;
-            filter: grayscale(100%);
-        }
-        .card-image-container {
-        }
-        .card-text-container {
-            padding: @templateCardTextContainerPadding;
-            border-top: none;
-
-            .header {
-                font-size: @templateCardHeaderFontSize;
-                font-weight: @templateCardHeaderFontWeight;
-                line-height: @templateCardHeaderLineHeight;
-                max-width: @templateCardHeaderMaxWidth;
-                white-space: nowrap;
-                text-overflow: ellipsis;
-                overflow: hidden;
+.ui.cards {
+    .ui.card {
+        &.template-card {
+            width: @templateCardDefaultWidth;
+            transition: @templateCardTransition;
+            border: @templateCardBorder;
+            box-shadow: none;
+    
+            &:hover {
+                transform: none;
+                text-decoration: none;
+                cursor: pointer;
+                box-shadow: @templateCardHoverBoxShadow;
             }
-            .description {
-                font-size: @templateCardDescriptionFontSize;
-                max-width: @templateCardDescriptionMaxWidth;
-                min-height: @templateCardDescriptionMinHeight;
-                display: -webkit-box;
-                -webkit-line-clamp: 2;
-                -webkit-box-orient: vertical;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                height: @templateCardDescriptionHeight;
+            &.inline {
+                display: inline-block;
+                margin-right: @templateCardRightSpacing;
             }
-            .tags-container {
-                margin: 8px 0;
-
-                .title {
-                    font-size: @templateCardTagTitleFontSize;
-                    color: @lightFontColor;
-                    margin-bottom: 5px;
+            &.selected {
+                border-bottom-width: @templateCardBorderBottomWidth;
+                border-bottom-color: @templateCardSelectedStateBorderBottomColor;
+            }
+            &.disabled {
+                cursor: not-allowed;
+                filter: grayscale(100%);
+            }
+            .card-image-container {
+            }
+            .card-text-container {
+                padding: @templateCardTextContainerPadding;
+                border-top: none;
+    
+                .header {
+                    font-size: @templateCardHeaderFontSize;
+                    font-weight: @templateCardHeaderFontWeight;
+                    line-height: @templateCardHeaderLineHeight;
+                    max-width: @templateCardHeaderMaxWidth;
+                    white-space: nowrap;
+                    text-overflow: ellipsis;
+                    overflow: hidden;
                 }
-                
-                .tags {
-                    .tag-icon {
-                        color: @templateCardTagIconColor;
+                .description {
+                    font-size: @templateCardDescriptionFontSize;
+                    max-width: @templateCardDescriptionMaxWidth;
+                    min-height: @templateCardDescriptionMinHeight;
+                    display: -webkit-box;
+                    -webkit-line-clamp: 2;
+                    -webkit-box-orient: vertical;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    height: @templateCardDescriptionHeight;
+                }
+                .tags-container {
+                    margin: 8px 0;
+    
+                    .title {
+                        font-size: @templateCardTagTitleFontSize;
+                        color: @lightFontColor;
+                        margin-bottom: 5px;
                     }
                     
-                    .tag {
-                        &.default {
-                            font-size: @templateCardTextTagFontSize;
-                            color: @templateCardTextTagColor;
+                    .tags {
+                        .tag-icon {
+                            color: @templateCardTagIconColor;
                         }
                         
-                        &:not(:first-child) {
-                            margin: @templateCardTextTagMargin;
+                        .tag {
+                            &.default {
+                                font-size: @templateCardTextTagFontSize;
+                                color: @templateCardTextTagColor;
+                            }
+                            
+                            &:not(:first-child) {
+                                margin: @templateCardTextTagMargin;
+                            }
                         }
                     }
                 }

--- a/modules/theme/src/themes/default/views/card.variables
+++ b/modules/theme/src/themes/default/views/card.variables
@@ -89,9 +89,9 @@ Recent Application Card
 @templateCardTransition: @defaultCardTransition;
 @templateCardBorder: @defaultCardBorder;
 @templateCardTextContainerPadding: 0.8em 1em;
-@templateCardHeaderFontSize: 1em !important;
-@templateCardHeaderFontWeight: 500 !important;
-@templateCardHeaderLineHeight: 1.3em !important;
+@templateCardHeaderFontSize: 1em;
+@templateCardHeaderFontWeight: 500;
+@templateCardHeaderLineHeight: 1.3em;
 @templateCardDescriptionFontSize: 0.8em;
 @templateCardDescriptionHeight: 3.5em;
 @templateCardHeaderMaxWidth: 100%;

--- a/modules/theme/src/themes/default/views/card.variables
+++ b/modules/theme/src/themes/default/views/card.variables
@@ -89,9 +89,9 @@ Recent Application Card
 @templateCardTransition: @defaultCardTransition;
 @templateCardBorder: @defaultCardBorder;
 @templateCardTextContainerPadding: 0.8em 1em;
-@templateCardHeaderFontSize: 1em;
-@templateCardHeaderFontWeight: 500;
-@templateCardHeaderLineHeight: 1.3em;
+@templateCardHeaderFontSize: 1em !important;
+@templateCardHeaderFontWeight: 500 !important;
+@templateCardHeaderLineHeight: 1.3em !important;
 @templateCardDescriptionFontSize: 0.8em;
 @templateCardDescriptionHeight: 3.5em;
 @templateCardHeaderMaxWidth: 100%;


### PR DESCRIPTION
## Purpose
1. Application/IDP template card styles have been overridden by a recent change and they should be reset back to previous look and feel.
2. Client secret input is shown when the application is revoked which is redundant.
3. UI breaks when non http URLs are entered to the URLInput component in wizards.
4. In Applications edit mode, users are always directed to the second tab after the initial creation.

## Goals
Fixes https://github.com/wso2/product-is/issues/10332
Fixes https://github.com/wso2/product-is/issues/10333
Fixes https://github.com/wso2/product-is/issues/10334

## Approach

### Fix for 1

**Before**

<img width="1639" alt="Screen Shot 2020-11-04 at 3 43 57 PM" src="https://user-images.githubusercontent.com/25959096/98143286-e81a0080-1eee-11eb-870e-14e511bfabb8.png">

**After**

<img width="1296" alt="Screen Shot 2020-11-04 at 3 44 22 PM" src="https://user-images.githubusercontent.com/25959096/98143376-05e76580-1eef-11eb-9391-6303c6a7b2d3.png">

### Fix for 2

<img width="1605" alt="Screen Shot 2020-11-04 at 9 52 34 PM" src="https://user-images.githubusercontent.com/25959096/98143424-126bbe00-1eef-11eb-9337-7d7970c1b16c.png">

### Fix for 3

<img width="1918" alt="Screen Shot 2020-11-04 at 8 15 14 PM" src="https://user-images.githubusercontent.com/25959096/98143479-28797e80-1eef-11eb-8473-95af2bdfc2fd.png">
