### PR TITLE
Fix email validation issue in self user registration form.

### DIFF
--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -311,6 +311,12 @@
                                     </label>
                                     <input type="email" name="http://wso2.org/claims/emailaddress" class="form-control"
                                            data-validate="email"
+                                        <% if (emailNamePII.getValidationRegex() != null) {
+                                            String pattern = Encode.forHtmlContent(emailNamePII.getValidationRegex());
+                                            String[] patterns = pattern.split("\\\\@");
+                                            String regex = StringUtils.join(patterns, "@");
+                                        %>
+                                        pattern="<%= regex %>"
                                         <% if (emailNamePII.getRequired() || !piisConfigured) {%> required <%}%>
                                         <% if
                                             (skipSignUpEnableCheck && StringUtils.isNotEmpty(emailValue)) {%>

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -312,11 +312,12 @@
                                     <input type="email" name="http://wso2.org/claims/emailaddress" class="form-control"
                                            data-validate="email"
                                         <% if (emailNamePII.getValidationRegex() != null) {
-                                            String pattern = Encode.forHtmlContent(emailNamePII.getValidationRegex());
-                                            String[] patterns = pattern.split("\\\\@");
-                                            String regex = StringUtils.join(patterns, "@");
+                                                String pattern = Encode.forHtmlContent(emailNamePII.getValidationRegex());
+                                                String[] patterns = pattern.split("\\\\@");
+                                                String regex = StringUtils.join(patterns, "@");
                                         %>
                                         pattern="<%= regex %>"
+                                        <% } %>
                                         <% if (emailNamePII.getRequired() || !piisConfigured) {%> required <%}%>
                                         <% if
                                             (skipSignUpEnableCheck && StringUtils.isNotEmpty(emailValue)) {%>


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/product-is/issues/10275

This PR validates the email field using the claim regex value. However, the `@` character is escaped in the regex which makes validation not work properly when used with the`pattern` of an `input` element. So, the escape character is removed before assigning it to the `pattern` attribute. 