### PR TITLE
Add status label to represent application state to users

### DIFF
--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -62,6 +62,14 @@ interface EditApplicationPropsInterface extends SBACInterface<FeatureConfigInter
      */
     defaultActiveIndex?: number;
     /**
+     * Used to the configured inbound protocols list from the parent component.
+     */
+    getConfiguredInboundProtocolsList?: (list: string[]) => void;
+    /**
+     * Used to the configured inbound protocol configs from the parent component.
+     */
+    getConfiguredInboundProtocolConfigs?: (configs: object) => void;
+    /**
      * Is the data still loading.
      */
     isLoading?: boolean;
@@ -103,6 +111,8 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
         defaultActiveIndex,
         featureConfig,
         isLoading,
+        getConfiguredInboundProtocolsList,
+        getConfiguredInboundProtocolConfigs,
         onDelete,
         onUpdate,
         template,
@@ -297,11 +307,15 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                     setInboundProtocolList(selectedProtocolList);
                     setInboundProtocolConfig(protocolConfigs);
                     setIsInboundProtocolConfigRequestLoading(false);
+                    getConfiguredInboundProtocolsList(selectedProtocolList);
+                    getConfiguredInboundProtocolConfigs(protocolConfigs);
                 });
         } else {
             setInboundProtocolList([]);
             setInboundProtocolConfig({});
             setIsInboundProtocolConfigRequestLoading(false);
+            getConfiguredInboundProtocolsList([]);
+            getConfiguredInboundProtocolConfigs({});
         }
     };
 
@@ -641,5 +655,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
  * Default props for the application edit component.
  */
 EditApplication.defaultProps = {
-    "data-testid": "edit-application"
+    "data-testid": "edit-application",
+    getConfiguredInboundProtocolConfigs: () => null,
+    getConfiguredInboundProtocolsList: () => null
 };

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -792,6 +792,12 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                     data-testid={ testId }
                     isTabExtensionsAvailable={ (isAvailable) => setIsExtensionsAvailable(isAvailable) }
                     urlSearchParams={ urlSearchParams }
+                    getConfiguredInboundProtocolsList={ (list: string[]) => {
+                        setInboundProtocolList(list)
+                    } }
+                    getConfiguredInboundProtocolConfigs={ (configs: object) => {
+                        setInboundProtocolConfigs(configs)
+                    } }
                 />
             </PageLayout>
         </HelpPanelLayout>

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -25,7 +25,8 @@ import {
     AppAvatar,
     HelpPanelLayout,
     HelpPanelTabInterface,
-    PageLayout
+    PageLayout,
+    LabelWithPopup
 } from "@wso2is/react-components";
 import get from "lodash/get";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
@@ -53,6 +54,8 @@ import { ApplicationManagementConstants } from "../constants";
 import {
     ApplicationInterface,
     ApplicationTemplateListItemInterface,
+    State,
+    SupportedAuthProtocolTypes,
     emptyApplication
 } from "../models";
 import { ApplicationManagementUtils } from "../utils";
@@ -124,6 +127,8 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
     const [ tabsActiveIndex, setTabsActiveIndex ] = useState<number>(0);
     const [ isExtensionsAvailable, setIsExtensionsAvailable ] = useState<boolean>(false);
     const [ defaultActiveIndex, setDefaultActiveIndex ] = useState<number>(0);
+    const [ inboundProtocolList, setInboundProtocolList ] = useState<string[]>(undefined);
+    const [ inboundProtocolConfigs, setInboundProtocolConfigs ] = useState<object>(undefined);
 
     /**
      * Fetch the application details on initial component load.
@@ -726,6 +731,53 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
         }*/
     ];
 
+    /**
+     * Resolves the application status label.
+     * @return {ReactElement}
+     */
+    const resolveApplicationStatusLabel = (): ReactElement => {
+
+        if (!inboundProtocolList || !inboundProtocolConfigs) {
+            return null;
+        }
+
+        if (inboundProtocolList.length === 0) {
+            
+            return (
+                <LabelWithPopup
+                    popupHeader={ t("console:develop.features.applications.popups.appStatus.notConfigured.header") }
+                    popupSubHeader={ t("console:develop.features.applications.popups.appStatus.notConfigured.content") }
+                    labelColor="yellow"
+                />
+            );
+        }
+
+        if (inboundProtocolList.length === 1
+            && inboundProtocolList.includes(SupportedAuthProtocolTypes.OIDC)
+            && inboundProtocolConfigs
+            && inboundProtocolConfigs[ SupportedAuthProtocolTypes.OIDC ]) {
+
+            if (inboundProtocolConfigs[ SupportedAuthProtocolTypes.OIDC ].state === State.REVOKED) {
+
+                return (
+                    <LabelWithPopup
+                        popupHeader={ t("console:develop.features.applications.popups.appStatus.revoked.header") }
+                        popupSubHeader={ t("console:develop.features.applications.popups.appStatus.revoked.content") }
+                        labelColor="grey"
+                    />
+                );
+            }
+        }
+
+        return (
+            <LabelWithPopup
+                popupHeader={ t("console:develop.features.applications.popups.appStatus.active.header") }
+                popupSubHeader={ t("console:develop.features.applications.popups.appStatus.active.content") }
+                labelColor="green"
+            />
+        );
+    };
+
     return (
         <HelpPanelLayout
             activeIndex={ tabsActiveIndex }
@@ -746,7 +798,12 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
         >
             <PageLayout
                 isLoading={ isApplicationRequestLoading }
-                title={ application.name }
+                title={ (
+                    <>
+                        <span>{ application.name }</span>
+                        { resolveApplicationStatusLabel() }
+                    </>
+                ) }
                 contentTopMargin={ true }
                 description={ (
                     <div className="with-label ellipsis">

--- a/modules/i18n/src/models/common.ts
+++ b/modules/i18n/src/models/common.ts
@@ -179,3 +179,12 @@ export interface Message {
     heading: string;
     content: string;
 }
+
+/**
+ * Interface for UI Popup.
+ */
+export interface Popup {
+    content: string;
+    header: string;
+    subHeader: string;
+}

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -22,7 +22,7 @@ import {
     Message,
     ModalInterface,
     Notification,
-    Placeholder,
+    Placeholder, Popup,
     ValidationInterface
 } from "../common";
 
@@ -62,6 +62,13 @@ export interface ConsoleNS {
                         messages: {
                             revokeDisclaimer: Message;
                         };
+                    };
+                };
+                popups: {
+                    appStatus: {
+                        active: Popup;
+                        notConfigured: Popup;
+                        revoked: Popup;
                     };
                 };
             };

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -22,7 +22,8 @@ import {
     Message,
     ModalInterface,
     Notification,
-    Placeholder, Popup,
+    Placeholder, 
+    Popup,
     ValidationInterface
 } from "../common";
 

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -145,6 +145,26 @@ export const console: ConsoleNS = {
                             }
                         }
                     }
+                },
+                popups: {
+                    appStatus: {
+                        active: {
+                            content: "The application is active.",
+                            header: "Active",
+                            subHeader: ""
+                        },
+                        notConfigured: {
+                            content: "The application is not configured. Please configure access configurations.",
+                            header: "Not Configured",
+                            subHeader: ""
+                        },
+                        revoked: {
+                            content: "The application is revoked. Please reactivate the application in access " +
+                                "configurations.",
+                            header: "Revoked",
+                            subHeader: ""
+                        }
+                    }
                 }
             }
         }

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -146,6 +146,27 @@ export const console: ConsoleNS = {
                             }
                         }
                     }
+                },
+                popups: {
+                    appStatus: {
+                        active: {
+                            content: "L'application est active.",
+                            header: "Actif",
+                            subHeader: ""
+                        },
+                        notConfigured: {
+                            content: "L'application n'est pas configurée. Veuillez configurer les configurations " +
+                                "d'accès.",
+                            header: "Pas configuré",
+                            subHeader: ""
+                        },
+                        revoked: {
+                            content: "La demande est révoquée. Veuillez réactiver l'application dans les " +
+                                "configurations d'accès.",
+                            header: "Révoqué",
+                            subHeader: ""
+                        }
+                    }
                 }
             }
         }

--- a/modules/react-components/src/components/index.ts
+++ b/modules/react-components/src/components/index.ts
@@ -34,6 +34,7 @@ export * from "./header";
 export * from "./help-panel";
 export * from "./icon";
 export * from "./input";
+export * from "./label";
 export * from "./language-switcher";
 export * from "./list";
 export * from "./loader";

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -322,6 +322,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
         if (allowedOrigins?.includes(origin) || allowOrigin) {
             return (
                 <LabelWithPopup
+                    className="cors-details-popup"
                     popupHeader={ t("devPortal:components.URLInput.withLabel.positive.header") }
                     popupSubHeader={
                         <>
@@ -366,12 +367,17 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                             { origin }
                         </>
                     }
+                    popupOptions={ {
+                        basic: true,
+                        on: "click"
+                    } }
                     labelColor="green"
                 />
             );
         } else {
             return (
                 <LabelWithPopup
+                    className="cors-details-popup"
                     popupHeader={ t("devPortal:components.URLInput.withLabel.negative.header") }
                     popupSubHeader={
                         <>
@@ -428,6 +434,10 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                             { origin }
                         </>
                     }
+                    popupOptions={ {
+                        basic: true,
+                        on: "click"
+                    } }
                     labelColor="red"
                 />
             );

--- a/modules/react-components/src/components/label/label-with-popup.tsx
+++ b/modules/react-components/src/components/label/label-with-popup.tsx
@@ -16,10 +16,11 @@
  * under the License.
  */
 
+import classNames from "classnames";
 import React, { FunctionComponent, ReactElement, ReactNode } from "react";
-import { Divider, Grid, Label, Popup, SemanticCOLORS } from "semantic-ui-react";
+import { Divider, Grid, Label, LabelProps, Popup, PopupProps } from "semantic-ui-react";
 
-export interface LabelWithPopupPropsInterface {
+export interface LabelWithPopupPropsInterface extends LabelProps {
     /**
      * Header of the popup
      */
@@ -45,9 +46,13 @@ export interface LabelWithPopupPropsInterface {
      */
     popupFooterLeftContent?: ReactNode | string;
     /**
+     * Other props for the popup.
+     */
+    popupOptions?: PopupProps;
+    /**
      * Color of the circular label.
      */
-    labelColor: SemanticCOLORS;
+    labelColor: LabelProps["color"];
 }
 
 /**
@@ -62,65 +67,96 @@ export const LabelWithPopup: FunctionComponent<LabelWithPopupPropsInterface> = (
 ): ReactElement => {
 
     const {
+        className,
         popupHeader,
         popupSubHeader,
         popupContent,
         popupFooterRightActions,
-        popupFooterLeftActions,
         popupFooterLeftContent,
-        labelColor
+        popupOptions,
+        labelColor,
+        ...rest
     } = props;
+
+    const classes = classNames("label-with-popup", className);
+
     return (
         <Popup
-            size="small"
             wide
-            className="cors-details-popup"
-            basic
+            size="small"
+            className={ classes }
             position="right center"
-            on="click"
             trigger={
                 <Label
-                    className="micro spaced-right"
                     circular
-                    color={ labelColor }
                     size="mini"
+                    className="micro spaced-right"
+                    color={ labelColor }
+                    { ...rest }
                 />
             }
+            on="hover"
+            { ...popupOptions }
         >
             <Popup.Content>
                 <Grid>
-                    <Grid.Row>
-                        <Grid.Column>
-                            <Popup.Header>
-                                <strong>{ popupHeader }</strong>
-                            </Popup.Header>
-                            { popupSubHeader }
-                        </Grid.Column>
-                    </Grid.Row>
-                    <Grid.Row>
-                        <Grid.Column>
-                            { popupContent }
-                        </Grid.Column>
-                    </Grid.Row>
-                    <Divider/>
-                    <Grid.Row>
-                        {
-                            popupFooterLeftContent && (
-                                <Grid.Column verticalAlign="middle" floated="left" width={ 10 }>
-                                    { popupFooterLeftContent }
+                    {
+                        (popupHeader || popupSubHeader) && (
+                            <Grid.Row>
+                                <Grid.Column>
+                                    {
+                                        popupHeader && (
+                                            <Popup.Header>
+                                                <strong>{ popupHeader }</strong>
+                                            </Popup.Header>
+                                        )
+                                    }
+                                    { popupSubHeader }
                                 </Grid.Column>
-                            )
-                        }
-                        {
-                            popupFooterRightActions && (
-                                <Grid.Column verticalAlign="middle" floated="right" width={ 6 }>
-                                    { popupFooterRightActions }
+                            </Grid.Row>
+                        )
+                    }
+                    {
+                        popupContent && (
+                            <Grid.Row>
+                                <Grid.Column>
+                                    { popupContent }
                                 </Grid.Column>
-                            )
-                        }
-                    </Grid.Row>
+                            </Grid.Row>
+                        )
+                    }
+                    {
+                        (popupFooterLeftContent || popupFooterRightActions) && (
+                           <>
+                               <Divider/>
+                               <Grid.Row>
+                                   {
+                                       popupFooterLeftContent && (
+                                           <Grid.Column verticalAlign="middle" floated="left" width={ 10 }>
+                                               { popupFooterLeftContent }
+                                           </Grid.Column>
+                                       )
+                                   }
+                                   {
+                                       popupFooterRightActions && (
+                                           <Grid.Column verticalAlign="middle" floated="right" width={ 6 }>
+                                               { popupFooterRightActions }
+                                           </Grid.Column>
+                                       )
+                                   }
+                               </Grid.Row>
+                           </>
+                       )
+                    }
                 </Grid>
             </Popup.Content>
         </Popup>
     );
+};
+
+/**
+ * Default proptypes for component.
+ */
+LabelWithPopup.defaultProps = {
+    "data-testid": "label-with-popup"
 };

--- a/modules/react-components/src/components/page-header/page-header.tsx
+++ b/modules/react-components/src/components/page-header/page-header.tsx
@@ -65,7 +65,7 @@ export interface PageHeaderPropsInterface extends LoadableComponentInterface, Te
     /**
      * Header title.
      */
-    title?: string;
+    title?: string | ReactElement;
     /**
      * Title render element.
      */


### PR DESCRIPTION
## Purpose
Currently the user has no idea of the application's state without navigating to the access tab of the application edit page.

## Goals
This PR introduces a label to represent the application status.

Fixes https://github.com/wso2/product-is/issues/10241

## Approach

**Active State**

<img width="1003" alt="Screen Shot 2020-11-05 at 6 02 29 AM" src="https://user-images.githubusercontent.com/25959096/98183279-d60b8280-1f2d-11eb-906c-d74c1e50f5ec.png">

**Not Configured**

<img width="1001" alt="Screen Shot 2020-11-05 at 6 01 49 AM" src="https://user-images.githubusercontent.com/25959096/98183301-e15eae00-1f2d-11eb-96f5-99c6b180fbdb.png">

**Revoked**

<img width="1002" alt="Screen Shot 2020-11-05 at 6 02 11 AM" src="https://user-images.githubusercontent.com/25959096/98183312-e885bc00-1f2d-11eb-8478-9cf723067dc3.png">
