### PR TITLE
Send 'verifyMobile', 'verifyEmail' claims in SCIM2 patch requests

### DIFF
--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -194,7 +194,12 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                 }
             } else {
                 value = schemaNames[0] === "emails"
-                    ? { emails: [values.get(formName)] }
+                    ? {
+                    emails: [values.get(formName)],
+                    [ProfileConstants.SCIM2_ENT_USER_SCHEMA]: {
+                        "verifyEmail": true
+                    }
+                }
                     : { [schemaNames[0]]: values.get(formName) };
             }
         } else {
@@ -213,7 +218,6 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                 };
             }
         }
-
         data.Operations[0].value = value;
         updateProfileInfo(data).then((response) => {
             if (response.status === 200) {

--- a/apps/myaccount/src/components/shared/mobile-update-wizard.tsx
+++ b/apps/myaccount/src/components/shared/mobile-update-wizard.tsx
@@ -92,9 +92,9 @@ export const MobileUpdateWizard: React.FunctionComponent<MobileUpdateWizardProps
                     type: "mobile",
                     value: mobileNumber
                 }
-            ]
+            ],
+            [ProfileConstants.SCIM2_ENT_USER_SCHEMA]: {"verifyMobile": true}
         };
-
         updateProfileInfo(data).then((response) => {
             if (response.status === 200) {
                 // Re-fetch the profile information

--- a/apps/myaccount/src/components/shared/mobile-update-wizard.tsx
+++ b/apps/myaccount/src/components/shared/mobile-update-wizard.tsx
@@ -93,7 +93,7 @@ export const MobileUpdateWizard: React.FunctionComponent<MobileUpdateWizardProps
                     value: mobileNumber
                 }
             ],
-            [ProfileConstants.SCIM2_ENT_USER_SCHEMA]: {"verifyMobile": true}
+            [ProfileConstants.SCIM2_ENT_USER_SCHEMA]: { "verifyMobile": true }
         };
         updateProfileInfo(data).then((response) => {
             if (response.status === 200) {


### PR DESCRIPTION
## Purpose
When email verification is enabled, and email is updated for the first time, the temporary claim 'verifyEmail' set to true should also be sent along with the SCIM2 patch request.
Similarly, when mobile verification is enabled, and mobile is updated for the first time, the temporary claim 'verifyMobile' set to true should also be sent along with the SCIM2 patch request.

These modifications are done to resolve issue : https://github.com/wso2/product-is/issues/10358
