### PR TITLE
Tenant qualify getClaimsForUsernameRecovery calls in multi-claim password recovery flows

### DIFF
--- a/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
@@ -59,7 +59,7 @@
     List<Claim> claims;
     UsernameRecoveryApi usernameRecoveryApi = new UsernameRecoveryApi();
     try {
-        claims = usernameRecoveryApi.getClaimsForUsernameRecovery(null, true);
+        claims = usernameRecoveryApi.getClaimsForUsernameRecovery(tenantDomain, true);
     } catch (ApiException e) {
         IdentityManagementEndpointUtil.addErrorInformation(request, e);
         request.getRequestDispatcher("error.jsp").forward(request, response);

--- a/apps/recovery-portal/src/main/webapp/password-recovery-with-claims.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-with-claims.jsp
@@ -78,7 +78,7 @@
     List<Claim> claims;
     UsernameRecoveryApi usernameRecoveryApi = new UsernameRecoveryApi();
     try {
-        claims = usernameRecoveryApi.getClaimsForUsernameRecovery(null, true);
+        claims = usernameRecoveryApi.getClaimsForUsernameRecovery(tenantDomain, true);
     } catch (ApiException e) {
         request.setAttribute("error", true);
         request.setAttribute("errorMsg", e.getMessage());


### PR DESCRIPTION
## Purpose

This PR applies the tenant qualified API calls introduces in https://github.com/wso2/identity-apps/pull/1313 to the multi-claim password recovery flow.
