### PR TITLE
Temporarily hide `account-switch` grant from UI

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -27,7 +27,9 @@ import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Button, Divider, Form, Grid, Label, Message } from "semantic-ui-react";
 import { AppState } from "../../../core/store";
+import { ApplicationManagementConstants } from "../../constants";
 import {
+    GrantTypeInterface,
     GrantTypeMetaDataInterface,
     MetadataPropertyInterface,
     OAuth2PKCEConfigurationInterface,
@@ -207,12 +209,20 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @return {any[]}
      */
     const getAllowedGranTypeList = (metadataProp: GrantTypeMetaDataInterface): any[] => {
+
         const allowedList = [];
+
         if (metadataProp) {
-            metadataProp.options.map((grant) => {
+            metadataProp.options.map((grant: GrantTypeInterface) => {
+                // Hides the grant types specified in the array.
+                // TODO: Remove this once the specified grant types such as `account-switch` are handled properly.
+                // See https://github.com/wso2/product-is/issues/8806.
+                if (ApplicationManagementConstants.HIDDEN_GRANT_TYPES.includes(grant.name)) {
+                    return;
+                }
+
                 allowedList.push({ label: grant.displayName, value: grant.name });
             });
-
         }
 
         return allowedList;

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -306,14 +306,14 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         };
 
         // If the app is newly created do not add `clientId` & `clientSecret`.
-        if (!initialValues?.clientId || !values.get("clientSecret")) {
+        if (!initialValues?.clientId || !initialValues?.clientSecret) {
             return formValues;
         }
 
         return {
             ...formValues,
             clientId: initialValues?.clientId,
-            clientSecret: values.get("clientSecret")
+            clientSecret: initialValues?.clientSecret
         };
     };
 

--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -151,6 +151,13 @@ export class ApplicationManagementConstants {
     ];
 
     /**
+     * Set of grant types to hide from the UI.
+     * @constant
+     * @type {string[]}
+     */
+    public static readonly HIDDEN_GRANT_TYPES: string[] = [ "account_switch" ];
+
+    /**
      * Key for the SPA template.
      * @constant
      * @type {string}

--- a/apps/console/src/features/applications/models/application-inbound.ts
+++ b/apps/console/src/features/applications/models/application-inbound.ts
@@ -35,7 +35,7 @@ export interface MetadataPropertyInterface {
     defaultValue?: string;
 }
 
-interface GrantTypeInterface {
+export interface GrantTypeInterface {
     name?: string;
     displayName?: string;
 }


### PR DESCRIPTION
## Purpose
`account-switch` grant type is use only for a specific case that user portal functionality and eventually we need to switch it to a response_type. Hence it no point of showing that in among OIDC grant for normal apps.

## Goals
Fixes https://github.com/wso2/product-is/issues/8806

## Approach
Hide `account-switch` from UI.
