### PR TITLE
Add support to create an OIDC app without the callback URLs in the manual setup

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1337,6 +1337,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 } else {
                                     submitOrigin((origin) => {
                                         // TODO: Remove the empty check when the backend is fixed.
+                                        // Issue reported: https://github.com/wso2/product-is/issues/9933
                                         if (isEmpty(allowedOrigins) && isEmpty(origin)) {
                                             setShowOriginError(true);
                                             scrollToInValidField("allowedOrigin");

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -18,7 +18,7 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
-import { Field, Forms, Validation } from "@wso2is/forms";
+import { Field, Forms, FormValue, Validation } from "@wso2is/forms";
 import { ConfirmationModal, CopyInputField, Heading, Hint, URLInput } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import { isEmpty } from "lodash";
@@ -95,6 +95,9 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const [ callBackUrls, setCallBackUrls ] = useState("");
     const [ showURLError, setShowURLError ] = useState(false);
     const [ showOriginError, setShowOriginError ] = useState(false);
+    const [ showCallbackURLField, setShowCallbackURLField ] = useState<boolean>(undefined);
+    const [ selectedGrantTypes, setSelectedGrantTypes ] = useState<string[]>(undefined);
+    const [ isGrantChanged, setGrantChanged ] = useState<boolean>(false);
     const [ showRegenerateConfirmationModal, setShowRegenerateConfirmationModal ] = useState<boolean>(false);
     const [ showRevokeConfirmationModal, setShowRevokeConfirmationModal ] = useState<boolean>(false);
     const [ allowedOrigins, setAllowedOrigins ] = useState("");
@@ -129,6 +132,29 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const scopeValidator = useRef<HTMLElement>();
 
     /**
+     * Check whether to show the callback url or not
+     */
+    useEffect(() => {
+        if (selectedGrantTypes?.includes("authorization_code") || selectedGrantTypes?.includes("implicit")) {
+            setShowCallbackURLField(true);
+        } else {
+            setShowCallbackURLField(false);
+        }
+
+    }, [ selectedGrantTypes, isGrantChanged ]);
+
+    useEffect(() => {
+        if (selectedGrantTypes !== undefined) {
+            return;
+        }
+
+        if (initialValues?.grantTypes) {
+            setSelectedGrantTypes(initialValues?.grantTypes);
+        }
+
+    }, [ initialValues ]);
+
+    /**
      * Sets if a valid token binding type is selected.
      */
     useEffect(() => {
@@ -136,6 +162,17 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
             setIsTokenBindingTypeSelected(true);
         }
     }, [ initialValues?.accessToken?.bindingType ]);
+
+    /**
+     * Handle grant type change.
+     *
+     * @param {Map<string, FormValue>} values - Form values
+     */
+    const handleGrantTypeChange = (values: Map<string, FormValue>) => {
+        const grants: string[] = values.get("grant") as string[];
+        setSelectedGrantTypes(grants);
+        setGrantChanged(!isGrantChanged);
+    };
 
     /**
      * Add regexp to multiple callbackUrls and update configs.
@@ -161,7 +198,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         if (origins.split(",").length > 1) {
             return origins.split(",");
         }
-        return [ origins ];
+        return origins && (origins !== "") ? [ origins ] : [];
     };
 
     /**
@@ -276,7 +313,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @return {any} Sanitized form values.
      */
     const updateConfiguration = (values: any, url?: string, origin?: string): any => {
-        const formValues = {
+        let formValues: any = {
             accessToken: {
                 applicationAccessTokenExpiryInSeconds: Number(metadata.defaultApplicationAccessTokenExpiryTime),
                 bindingType: values.get("bindingType"),
@@ -285,8 +322,6 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 userAccessTokenExpiryInSeconds: Number(values.get("userAccessTokenExpiryInSeconds")),
                 validateTokenBinding: values.get("ValidateTokenBinding")?.length > 0
             },
-            allowedOrigins: resolveAllowedOrigins(origin ? origin : allowedOrigins),
-            callbackURLs: [ buildCallBackUrlWithRegExp(url ? url : callBackUrls) ],
             grantTypes: values.get("grant"),
             idToken: {
                 audience: [ values.get("audience") ],
@@ -315,6 +350,22 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
             scopeValidators: values.get("scopeValidator"),
             validateRequestObjectSignature: values.get("enableRequestObjectSignatureValidation").length > 0
         };
+
+        // Add the `allowedOrigins` & `callbackURLs` only if the grant types
+        // `authorization_code` and `implicit` are selected.
+        if (showCallbackURLField) {
+            formValues = {
+                ...formValues,
+                allowedOrigins: resolveAllowedOrigins(origin ? origin : allowedOrigins),
+                callbackURLs: [ buildCallBackUrlWithRegExp(url ? url : callBackUrls) ],
+            }
+        } else {
+            formValues = {
+                ...formValues,
+                allowedOrigins: [],
+                callbackURLs: [],
+            }
+        }
 
         // If the app is newly created do not add `clientId` & `clientSecret`.
         if (!initialValues?.clientId || !initialValues?.clientSecret) {
@@ -465,6 +516,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                         children={ getAllowedGranTypeList(metadata.allowedGrantTypes) }
                         value={ initialValues.grantTypes }
                         readOnly={ readOnly }
+                        listen={ (values) => handleGrantTypeChange(values) }
                         data-testid={ `${ testId }-grant-type-checkbox-group` }
                     />
                     <Hint>
@@ -474,53 +526,56 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                     </Hint>
                 </Grid.Column>
             </Grid.Row>
-            <div ref={ url }></div>
-            <URLInput
-                isAllowEnabled={ false }
-                tenantDomain={ tenantDomain }
-                allowedOrigins={ allowedOriginList }
-                labelEnabled={ true }
-                urlState={ callBackUrls }
-                setURLState={ setCallBackUrls }
-                labelName={
-                    t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls.label")
-                }
-                required={ true }
-                value={ buildCallBackURLWithSeparator(initialValues.callbackURLs?.toString()) }
-                placeholder={
-                    t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls" +
-                        ".placeholder")
-                }
-                validationErrorMsg={
-                    t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls" +
-                        ".validations.empty")
-                }
-                validation={ (value: string) => {
-                    let label: ReactElement = null;
+            {
+                showCallbackURLField && (
+                    <>
+                        <div ref={ url }></div>
+                        <URLInput
+                            isAllowEnabled={ false }
+                            tenantDomain={ tenantDomain }
+                            allowedOrigins={ allowedOriginList }
+                            labelEnabled={ true }
+                            urlState={ callBackUrls }
+                            setURLState={ setCallBackUrls }
+                            labelName={
+                                t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls.label")
+                            }
+                            required={ true }
+                            value={ buildCallBackURLWithSeparator(initialValues.callbackURLs?.toString()) }
+                            placeholder={
+                                t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls" +
+                                    ".placeholder")
+                            }
+                            validationErrorMsg={
+                                t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls" +
+                                    ".validations.empty")
+                            }
+                            validation={ (value: string) => {
+                                let label: ReactElement = null;
 
-                    const isHttpUrl: boolean = URLUtils.isHttpUrl(value);
+                                const isHttpUrl: boolean = URLUtils.isHttpUrl(value);
 
-                    if (isHttpUrl) {
-                        label = (
-                            <Label basic color="orange" className="mt-2">
-                                { t("console:common.validations.inSecureURL.description") }
-                            </Label>
-                        );
-                    }
+                                if (isHttpUrl) {
+                                    label = (
+                                        <Label basic color="orange" className="mt-2">
+                                            { t("console:common.validations.inSecureURL.description") }
+                                        </Label>
+                                    );
+                                }
 
-                    if (!URLUtils.isHttpsOrHttpUrl(value)) {
-                        label = (
-                            <Label basic color="orange" className="mt-2">
-                                { t("console:common.validations.unrecognizedURL.description") }
-                            </Label>
-                        );
-                    }
+                                if (!URLUtils.isHttpsOrHttpUrl(value)) {
+                                    label = (
+                                        <Label basic color="orange" className="mt-2">
+                                            { t("console:common.validations.unrecognizedURL.description") }
+                                        </Label>
+                                    );
+                                }
 
-                    if (!URLUtils.isMobileDeepLink(value)) {
-                        return false;
-                    }
+                                if (!URLUtils.isMobileDeepLink(value)) {
+                                    return false;
+                                }
 
-                    setCallbackURLsErrorLabel(label);
+                                setCallbackURLsErrorLabel(label);
 
                     return true;
                 } }
@@ -562,23 +617,23 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                         }
                         validation={ (value: string) => {
 
-                            let label: ReactElement = null;
+                                        let label: ReactElement = null;
 
-                            if (URLUtils.isHttpUrl(value)) {
-                                label = (
-                                    <Label basic color="orange" className="mt-2">
-                                        { t("console:common.validations.inSecureURL.description") }
-                                    </Label>
-                                );
-                            }
+                                        if (URLUtils.isHttpUrl(value)) {
+                                            label = (
+                                                <Label basic color="orange" className="mt-2">
+                                                    { t("console:common.validations.inSecureURL.description") }
+                                                </Label>
+                                            );
+                                        }
 
-                            if (!URLUtils.isHttpsOrHttpUrl(value)) {
-                                label = (
-                                    <Label basic color="orange" className="mt-2">
-                                        { t("console:common.validations.unrecognizedURL.description") }
-                                    </Label>
-                                );
-                            }
+                                        if (!URLUtils.isHttpsOrHttpUrl(value)) {
+                                            label = (
+                                                <Label basic color="orange" className="mt-2">
+                                                    { t("console:common.validations.unrecognizedURL.description") }
+                                                </Label>
+                                            );
+                                        }
 
                             if (!URLUtils.isMobileDeepLink(value)) {
                                 return false;
@@ -586,27 +641,30 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
                             setAllowedOriginsErrorLabel(label);
 
-                            return true;
-                        } }
-                        computerWidth={ 10 }
-                        setShowError={ setShowOriginError }
-                        showError={ showOriginError }
-                        hint={
-                            t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
-                                ".hint")
-                        }
-                        addURLTooltip={ t("common:addURL") }
-                        duplicateURLErrorMessage={ t("common:duplicateURLError") }
-                        data-testid={ `${ testId }-allowed-origin-url-input` }
-                        getSubmit={ (submitOriginFunction: (callback: (origin?: string) => void) => void
-                        ) => {
-                            submitOrigin = submitOriginFunction;
-                        } }
-                        showPredictions={ false }
-                        customLabel={ allowedOriginsErrorLabel }
-                    />
-                </Grid.Column>
-            </Grid.Row>
+                                        return true;
+                                    } }
+                                    computerWidth={ 10 }
+                                    setShowError={ setShowOriginError }
+                                    showError={ showOriginError }
+                                    hint={
+                                        t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
+                                            ".hint")
+                                    }
+                                    addURLTooltip={ t("common:addURL") }
+                                    duplicateURLErrorMessage={ t("common:duplicateURLError") }
+                                    data-testid={ `${ testId }-allowed-origin-url-input` }
+                                    getSubmit={ (submitOriginFunction: (callback: (origin?: string) => void) => void
+                                    ) => {
+                                        submitOrigin = submitOriginFunction;
+                                    } }
+                                    showPredictions={ false }
+                                    customLabel={ allowedOriginsErrorLabel }
+                                />
+                            </Grid.Column>
+                        </Grid.Row>
+                    </>
+                )
+            }
             <Grid.Row columns={ 1 }>
                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ isHelpPanelVisible ? 16 : 8 }>
                     <Field
@@ -1271,22 +1329,26 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
             (
                 <Forms
                     onSubmit={ (values) => {
-                        submitUrl((url: string) => {
-                            if (isEmpty(callBackUrls) && isEmpty(url)) {
-                                setShowURLError(true);
-                                scrollToInValidField("url");
-                            } else {
-                                submitOrigin((origin) => {
-                                    // TODO: Remove the empty check when the backend is fixed.
-                                    if (isEmpty(allowedOrigins) && isEmpty(origin)) {
-                                        setShowOriginError(true);
-                                        scrollToInValidField("allowedOrigin");
-                                    } else {
-                                        onSubmit(updateConfiguration(values, url, origin));
-                                    }
-                                });
-                            }
-                        });
+                        if (showCallbackURLField) {
+                            submitUrl((url: string) => {
+                                if (isEmpty(callBackUrls) && isEmpty(url)) {
+                                    setShowURLError(true);
+                                    scrollToInValidField("url");
+                                } else {
+                                    submitOrigin((origin) => {
+                                        // TODO: Remove the empty check when the backend is fixed.
+                                        if (isEmpty(allowedOrigins) && isEmpty(origin)) {
+                                            setShowOriginError(true);
+                                            scrollToInValidField("allowedOrigin");
+                                        } else {
+                                            onSubmit(updateConfiguration(values, url, origin));
+                                        }
+                                    });
+                                }
+                            });
+                        } else {
+                            onSubmit(updateConfiguration(values, undefined, undefined));
+                        }
                     } }
                     onSubmitError={ (requiredFields: Map<string, boolean>, validFields: Map<string, Validation>) => {
                         const iterator = requiredFields.entries();

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -577,45 +577,45 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
                                 setCallbackURLsErrorLabel(label);
 
-                    return true;
-                } }
-                showError={ showURLError }
-                setShowError={ setShowURLError }
-                hint={
-                    t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls.hint")
-                }
-                readOnly={ readOnly }
-                addURLTooltip={ t("common:addURL") }
-                duplicateURLErrorMessage={ t("common:duplicateURLError") }
-                data-testid={ `${ testId }-callback-url-input` }
-                getSubmit={ (submitFunction: (callback: (url?: string) => void) => void) => {
-                    submitUrl = submitFunction;
-                } }
-                showPredictions={ false }
-                customLabel={ callbackURLsErrorLabel }
-            />
-            <Grid.Row columns={ 1 }>
-                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ isHelpPanelVisible ? 16 : 8 }>
-                    <div ref={ allowedOrigin }></div>
-                    <URLInput
-                        required
-                        handleAddAllowedOrigin={ (url) => handleAllowOrigin(url) }
-                        urlState={ allowedOrigins }
-                        setURLState={ setAllowedOrigins }
-                        labelName={
-                            t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
-                                ".label")
-                        }
-                        placeholder={
-                            t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
-                                ".placeholder")
-                        }
-                        value={ initialValues?.allowedOrigins?.toString() }
-                        validationErrorMsg={
-                            t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
-                                ".validations.empty")
-                        }
-                        validation={ (value: string) => {
+                                return true;
+                            } }
+                            showError={ showURLError }
+                            setShowError={ setShowURLError }
+                            hint={
+                                t("devPortal:components.applications.forms.inboundOIDC.fields.callBackUrls.hint")
+                            }
+                            readOnly={ readOnly }
+                            addURLTooltip={ t("common:addURL") }
+                            duplicateURLErrorMessage={ t("common:duplicateURLError") }
+                            data-testid={ `${ testId }-callback-url-input` }
+                            getSubmit={ (submitFunction: (callback: (url?: string) => void) => void) => {
+                                submitUrl = submitFunction;
+                            } }
+                            showPredictions={ false }
+                            customLabel={ callbackURLsErrorLabel }
+                        />
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ isHelpPanelVisible ? 16 : 8 }>
+                                <div ref={ allowedOrigin }></div>
+                                <URLInput
+                                    required
+                                    handleAddAllowedOrigin={ (url) => handleAllowOrigin(url) }
+                                    urlState={ allowedOrigins }
+                                    setURLState={ setAllowedOrigins }
+                                    labelName={
+                                        t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
+                                            ".label")
+                                    }
+                                    placeholder={
+                                        t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
+                                            ".placeholder")
+                                    }
+                                    value={ initialValues?.allowedOrigins?.toString() }
+                                    validationErrorMsg={
+                                        t("devPortal:components.applications.forms.inboundOIDC.fields.allowedOrigins" +
+                                            ".validations.empty")
+                                    }
+                                    validation={ (value: string) => {
 
                                         let label: ReactElement = null;
 
@@ -635,11 +635,11 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             );
                                         }
 
-                            if (!URLUtils.isMobileDeepLink(value)) {
-                                return false;
-                            }
+                                        if (!URLUtils.isMobileDeepLink(value)) {
+                                            return false;
+                                        }
 
-                            setAllowedOriginsErrorLabel(label);
+                                        setAllowedOriginsErrorLabel(label);
 
                                         return true;
                                     } }

--- a/apps/console/src/features/applications/components/wizard/application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/application-create-wizard.tsx
@@ -270,7 +270,8 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
      *
      * @param values - Form values.
      */
-    const HandleApplicationProtocolsUpdate = (values: any): void => {
+    const handleApplicationProtocolsUpdate = (values: any): void => {
+        console.log("Values", values);
         updateAuthProtocolConfig(appId, values, selectedTemplate.authenticationProtocol)
             .then(() => {
                 dispatch(addAlert({
@@ -512,6 +513,8 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
 
                         return (
                             <OauthProtocolSettingsWizardForm
+                                isProtocolConfig={ true }
+                                selectedTemplate={ selectedTemplate }
                                 triggerSubmit={ submitOAuth }
                                 fields={ [ "callbackURLs" ] }
                                 initialValues={ wizardState && wizardState[WizardStepsFormTypes.PROTOCOL_SETTINGS] }
@@ -587,7 +590,7 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
                         <ProtocolWizardSummary
                             triggerSubmit={ finishSubmit }
                             summary={ generateWizardSummary() }
-                            onSubmit={ HandleApplicationProtocolsUpdate }
+                            onSubmit={ handleApplicationProtocolsUpdate }
                             image={ selectedTemplate.authenticationProtocol }
                             customProtocol={ selectedCustomInboundProtocol }
                             samlMetaFileSelected={ selectedSAMLMetaFile }

--- a/apps/console/src/features/applications/components/wizard/application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/application-create-wizard.tsx
@@ -271,7 +271,6 @@ export const ApplicationCreateWizard: FunctionComponent<ApplicationCreateWizardP
      * @param values - Form values.
      */
     const handleApplicationProtocolsUpdate = (values: any): void => {
-        console.log("Values", values);
         updateAuthProtocolConfig(appId, values, selectedTemplate.authenticationProtocol)
             .then(() => {
                 dispatch(addAlert({

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -303,6 +303,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         if (selectedTemplate.authenticationProtocol === SupportedAuthProtocolTypes.OIDC) {
             return (
                 <OauthProtocolSettingsWizardForm
+                    isProtocolConfig={ false }
                     tenantDomain={ tenantName }
                     allowedOrigins={ allowedOrigins }
                     fields={ [ "callbackURLs" ] }

--- a/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from "react-i18next";
 import { Grid, Label } from "semantic-ui-react";
 import {
     ApplicationTemplateListItemInterface,
+    DefaultProtocolTemplate,
     GrantTypeMetaDataInterface,
     MainApplicationInterface,
     OIDCMetadataInterface
@@ -119,7 +120,7 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
     const [ showRefreshToken, setShowRefreshToken ] = useState(false);
     const [ showURLError, setShowURLError ] = useState(false);
     const [ callbackURLsErrorLabel, setCallbackURLsErrorLabel ] = useState<ReactElement>(null);
-    const [ showCallbackURLField, setShowCallbackURLField ] = useState(true);
+    const [ showCallbackURLField, setShowCallbackURLField ] = useState<boolean>(true);
     const [ OIDCMeta, setOIDCMeta ] = useState<OIDCMetadataInterface>(undefined);
     const [ selectedGrantTypes, setSelectedGrantTypes ] = useState<string[]>(undefined);
     const [ isGrantChanged, setGrantChanged ] = useState<boolean>(false);
@@ -133,7 +134,7 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
      * Show the grant types only for the custom protocol template.
      */
     useEffect(() => {
-        if (selectedTemplate?.id === "default-oidc") {
+        if (selectedTemplate?.id === DefaultProtocolTemplate.OIDC) {
             setShowGrantTypes(true)
         }
     }, [ selectedTemplate ]);

--- a/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -18,14 +18,20 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
-import { Field, Forms } from "@wso2is/forms";
+import { Field, Forms, FormValue } from "@wso2is/forms";
 import { ContentLoader, Hint, URLInput } from "@wso2is/react-components";
 import intersection from "lodash/intersection";
 import isEmpty from "lodash/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Grid, Label } from "semantic-ui-react";
-import { MainApplicationInterface } from "../../models";
+import {
+    ApplicationTemplateListItemInterface,
+    GrantTypeMetaDataInterface,
+    MainApplicationInterface,
+    OIDCMetadataInterface
+} from "../../models";
+import { getAuthProtocolMetadata } from "../../api";
 
 /**
  * Proptypes for the oauth protocol settings wizard form component.
@@ -68,6 +74,15 @@ interface OAuthProtocolSettingsWizardFormPropsInterface extends TestableComponen
      * Tenant domain
      */
     tenantDomain?: string;
+    /**
+     * Template meta data.
+     */
+    selectedTemplate?: ApplicationTemplateListItemInterface;
+    /**
+     * Flag to identify whether the form is used in protocol
+     * creation modal.
+     */
+    isProtocolConfig?: boolean;
 }
 
 /**
@@ -82,6 +97,8 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
 ): ReactElement => {
 
     const {
+        selectedTemplate,
+        isProtocolConfig,
         allowedOrigins,
         fields,
         hideFieldHints,
@@ -102,12 +119,65 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
     const [ showRefreshToken, setShowRefreshToken ] = useState(false);
     const [ showURLError, setShowURLError ] = useState(false);
     const [ callbackURLsErrorLabel, setCallbackURLsErrorLabel ] = useState<ReactElement>(null);
-    // TODO enable after fixing callbackURL.
-    // const [showCallbackUrl, setShowCallbackUrl] = useState(false);
+    const [ showCallbackURLField, setShowCallbackURLField ] = useState(true);
+    const [ OIDCMeta, setOIDCMeta ] = useState<OIDCMetadataInterface>(undefined);
+    const [ selectedGrantTypes, setSelectedGrantTypes ] = useState<string[]>(undefined);
+    const [ isGrantChanged, setGrantChanged ] = useState<boolean>(false);
+    const [ showGrantTypes, setShowGrantTypes ] = useState<boolean>(false);
 
     // Maintain the state if the user allowed the CORS for the
     // origin of the configured callback URL(s).
     const [ allowCORSUrls, setAllowCORSUrls ] = useState<string[]>([]);
+
+    /**
+     * Show the grant types only for the custom protocol template.
+     */
+    useEffect(() => {
+        if (selectedTemplate?.id === "default-oidc") {
+            setShowGrantTypes(true)
+        }
+    }, [ selectedTemplate ]);
+
+    /**
+     * Check whether to show the callback url or not
+     */
+    useEffect(() => {
+        if (selectedGrantTypes?.includes("authorization_code") || selectedGrantTypes?.includes("implicit")) {
+            setShowCallbackURLField(true);
+        } else {
+            setShowCallbackURLField(false);
+        }
+
+    }, [ selectedGrantTypes, isGrantChanged ]);
+
+    useEffect(() => {
+        if (selectedGrantTypes !== undefined) {
+            return;
+        }
+
+        if (templateValues?.inboundProtocolConfiguration?.oidc?.grantTypes) {
+            setSelectedGrantTypes([ ...templateValues?.inboundProtocolConfiguration?.oidc?.grantTypes ]);
+        }
+
+    }, [ templateValues ]);
+
+    useEffect(() => {
+        if (OIDCMeta !== undefined) {
+            return;
+        }
+
+        getAuthProtocolMetadata(selectedTemplate?.authenticationProtocol)
+            .then((response) => {
+                setOIDCMeta(response)
+            });
+    }, [ OIDCMeta ]);
+
+    useEffect(() => {
+        const allowedGrantTypes = templateValues?.inboundProtocolConfiguration?.oidc?.grantTypes;
+        if (intersection(allowedGrantTypes, [ "refresh_token" ]).length > 0) {
+            setShowRefreshToken(true);
+        }
+    }, [ templateValues ]);
 
     /**
      * Add regexp to multiple callbackUrls and update configs.
@@ -116,9 +186,9 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
      * @return {string} Prepared callback URL.
      */
     const buildCallBackUrlWithRegExp = (urls: string): string => {
-        let callbackURL = urls.replace(/['"]+/g, "");
-        if (callbackURL.split(",").length > 1) {
-            callbackURL = "regexp=(" + callbackURL.split(",").join("|") + ")";
+        let callbackURL = urls?.replace(/['"]+/g, "");
+        if (callbackURL?.split(",").length > 1) {
+            callbackURL = "regexp=(" + callbackURL?.split(",").join("|") + ")";
         }
         return callbackURL;
     };
@@ -170,27 +240,6 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
         }
     }, [ initialValues ]);
 
-
-    // /**
-    //  *  check whether to show the callback url or not
-    //  *  TODO  Enable this after fixing callbackURL component.
-    //  */
-    // useEffect(() => {
-    //     const allowedGrantTypes = templateValues.inboundProtocolConfiguration.oidc.grantTypes;
-    //     if (_.intersection(allowedGrantTypes, ["authorization_code", "implicit"]).length > 0) {
-    //        setShowCallbackUrl(true);
-    //        // setCallBackUrls("");
-    //     }
-    // }, [initialValues]);
-
-    useEffect(() => {
-        const allowedGrantTypes = templateValues?.inboundProtocolConfiguration?.oidc?.grantTypes;
-        if (intersection(allowedGrantTypes, [ "refresh_token" ]).length > 0) {
-            setShowRefreshToken(true);
-        }
-    }, [ templateValues ]);
-
-
     /**
      * Sanitizes and prepares the form values for submission.
      *
@@ -205,7 +254,7 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
             }
         };
 
-        if (showCallbackURL || (!fields || fields.includes("callbackURLs"))) {
+        if (showCallbackURLField && (showCallbackURL || !fields || fields.includes("callbackURLs"))) {
             config.inboundProtocolConfiguration.oidc[ "callbackURLs" ]
                 = [ buildCallBackUrlWithRegExp(urls ? urls : callBackUrls) ];
         }
@@ -221,7 +270,12 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
             };
         }
 
-        if (showCallbackURL || (!fields || fields.includes("callbackURLs"))) {
+        if (showCallbackURLField && (showCallbackURL || !fields || fields.includes("callbackURLs"))) {
+            config.inboundProtocolConfiguration.oidc[ "allowedOrigins" ] = allowCORSUrls;
+        }
+
+        if (!showCallbackURLField && selectedGrantTypes) {
+            config.inboundProtocolConfiguration.oidc[ "grantTypes" ] = selectedGrantTypes;
             config.inboundProtocolConfiguration.oidc[ "allowedOrigins" ] = allowCORSUrls;
         }
 
@@ -240,6 +294,36 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
     };
 
     /**
+     * Creates options for Radio GrantTypeMetaDataInterface options.
+     *
+     * @param {GrantTypeMetaDataInterface} metadataProp - Metadata.
+     *
+     * @return {any[]}
+     */
+    const getAllowedGranTypeList = (metadataProp: GrantTypeMetaDataInterface): any[] => {
+        const allowedList = [];
+        if (metadataProp) {
+            metadataProp.options.map((grant) => {
+                allowedList.push({ label: grant.displayName, value: grant.name });
+            });
+
+        }
+
+        return allowedList;
+    };
+
+    /**
+     * Handle grant type change.
+     *
+     * @param {Map<string, FormValue>} values - Form values
+     */
+    const handleGrantTypeChange = (values: Map<string, FormValue>) => {
+        const grants: string[] = values.get("grant") as string[];
+        setSelectedGrantTypes(grants);
+        setGrantChanged(!isGrantChanged);
+    };
+
+    /**
      * submitURL function.
      */
     let submitUrl: (callback: (url?: string) => void) => void;
@@ -249,18 +333,53 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
             ? (
                 <Forms
                     onSubmit={ (values) => {
-                        submitUrl((url: string) => {
-                            if (isEmpty(callBackUrls) && isEmpty(url)) {
-                                setShowURLError(true);
-                            } else {
-                                onSubmit(getFormValues(values, url));
-                            }
-                        });
+                        if (showCallbackURLField || !isProtocolConfig) {
+                            submitUrl((url: string) => {
+                                if ((callBackUrls) && isEmpty(url)) {
+                                    setShowURLError(true);
+                                } else {
+                                    onSubmit(getFormValues(values, url));
+                                }
+                            });
+                        } else {
+                            onSubmit(getFormValues(values));
+                        }
                     } }
                     submitState={ triggerSubmit }
                 >
                     <Grid>
-                        { !fields || fields.includes("callbackURLs") && (
+                        {
+                            (isProtocolConfig && showGrantTypes) && (
+                                <Grid.Row columns={ 1 }>
+                                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                                        <Field
+                                            name="grant"
+                                            label={
+                                                t("devPortal:components.applications.forms.inboundOIDC.fields." +
+                                                    "grant.label")
+                                            }
+                                            type="checkbox"
+                                            required={ true }
+                                            requiredErrorMessage={
+                                                t("devPortal:components.applications.forms.inboundOIDC.fields." +
+                                                    "grant.validations.empty")
+                                            }
+                                            children={ getAllowedGranTypeList(OIDCMeta?.allowedGrantTypes) }
+                                            value={ templateValues?.inboundProtocolConfiguration?.oidc?.grantTypes }
+                                            data-testid={ `${ testId }-grant-type-checkbox-group` }
+                                            listen={ (values) => handleGrantTypeChange(values) }
+                                        />
+                                        <Hint>
+                                            {
+                                                t("devPortal:components.applications.forms.inboundOIDC.fields." +
+                                                    "grant.hint")
+                                            }
+                                        </Hint>
+                                    </Grid.Column>
+                                </Grid.Row>
+                            )
+                        }
+                        { ((!fields || fields.includes("callbackURLs")) && showCallbackURLField ) && (
                             <Grid.Row column={ 1 }>
                                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
                                     <URLInput

--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -584,54 +584,54 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
 
         return (
             <>
-                <DangerZoneGroup
-                    sectionHeader={ t("adminPortal:components.user.editUser.dangerZoneGroup.header") }
-                >
-                    {
-                        configSettings?.accountDisable === "true" && (
-                            <DangerZone
-                                data-testid={ `${ testId }-danger-zone` }
-                                actionTitle={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
-                                    "disableUserZone.actionTitle") }
-                                header={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
-                                    "disableUserZone.header") }
-                                subheader={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
-                                    "disableUserZone.subheader") }
-                                onActionClick={ undefined }
-                                toggle={ {
-                                    checked: accountDisable
-                                        ? accountDisable
-                                        : user[ProfileConstants.SCIM2_ENT_USER_SCHEMA]?.accountDisabled,
-                                    id: "accountDisabled",
-                                    onChange: handleDangerZoneToggles
-                                } }
-                            />
-                        )
-                    }
-                    {
-                        configSettings?.accountLock === "true" && (
-                            <DangerZone
-                                data-testid={ `${ testId }-danger-zone` }
-                                actionTitle={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
-                                    "lockUserZone.actionTitle") }
-                                header={ t("adminPortal:components.user.editUser.dangerZoneGroup.lockUserZone." +
-                                    "header") }
-                                subheader={ t("adminPortal:components.user.editUser.dangerZoneGroup.lockUserZone." +
-                                    "subheader") }
-                                onActionClick={ undefined }
-                                toggle={ {
-                                    checked: accountLock
-                                        ? accountLock
-                                        : user[ProfileConstants.SCIM2_ENT_USER_SCHEMA]?.accountLocked,
-                                    id: "accountLocked",
-                                    onChange: handleDangerZoneToggles
-                                } }
-                            />
-                        )
-                    }
-                    {
-                        (hasRequiredScopes(featureConfig?.users, featureConfig?.applications?.scopes?.delete,
-                            allowedScopes) && !isReadOnly && user.userName !== "admin") && (
+                {
+                    (hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.delete,
+                        allowedScopes) && !isReadOnly && user.userName !== "admin") && (
+                        <DangerZoneGroup
+                            sectionHeader={ t("adminPortal:components.user.editUser.dangerZoneGroup.header") }
+                        >
+                            {
+                                configSettings?.accountDisable === "true" && (
+                                    <DangerZone
+                                        data-testid={ `${ testId }-danger-zone` }
+                                        actionTitle={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
+                                            "disableUserZone.actionTitle") }
+                                        header={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
+                                            "disableUserZone.header") }
+                                        subheader={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
+                                            "disableUserZone.subheader") }
+                                        onActionClick={ undefined }
+                                        toggle={ {
+                                            checked: accountDisable
+                                                ? accountDisable
+                                                : user[ProfileConstants.SCIM2_ENT_USER_SCHEMA]?.accountDisabled,
+                                            id: "accountDisabled",
+                                            onChange: handleDangerZoneToggles
+                                        } }
+                                    />
+                                )
+                            }
+                            {
+                                configSettings?.accountLock === "true" && (
+                                    <DangerZone
+                                        data-testid={ `${ testId }-danger-zone` }
+                                        actionTitle={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
+                                            "lockUserZone.actionTitle") }
+                                        header={ t("adminPortal:components.user.editUser.dangerZoneGroup.lockUserZone." +
+                                            "header") }
+                                        subheader={ t("adminPortal:components.user.editUser.dangerZoneGroup.lockUserZone." +
+                                            "subheader") }
+                                        onActionClick={ undefined }
+                                        toggle={ {
+                                            checked: accountLock
+                                                ? accountLock
+                                                : user[ProfileConstants.SCIM2_ENT_USER_SCHEMA]?.accountLocked,
+                                            id: "accountLocked",
+                                            onChange: handleDangerZoneToggles
+                                        } }
+                                    />
+                                )
+                            }
                             <DangerZone
                                 data-testid={ `${ testId }-danger-zone` }
                                 actionTitle={ t("adminPortal:components.user.editUser.dangerZoneGroup." +
@@ -645,9 +645,10 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                     setDeletingUser(user);
                                 } }
                             />
-                        )
-                    }
-                </DangerZoneGroup>
+                            )
+                        </DangerZoneGroup>
+                    )
+                }
             </>
         )
     };
@@ -748,50 +749,58 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                     <Grid.Row>
                         <Grid.Column>
                             {
-                                connectorProperties && (
-                                    <Popup
-                                        trigger={
-                                            <Button
-                                                onClick={ handleForcePasswordReset }
-                                                basic
-                                                color="grey"
-                                                floated="right"
-                                            >
-                                                <Icon name="redo"/>
-                                                Reset Password
-                                            </Button>
-                                        }
-                                        position="bottom center"
-                                        hoverable
-                                        inverted
-                                        size="huge"
-                                        className="list-options-popup"
-                                    >
-                                       <Popup.Header>
-                                           Password Reset Options
-                                        </Popup.Header>
-                                        <Divider/>
-                                        <Popup.Content>
+                                (hasRequiredScopes(featureConfig?.users,
+                                    featureConfig?.users?.scopes?.update, allowedScopes) &&
+                                    !isReadOnly && user.userName !== "admin") && (
+                                        <>
                                             {
-                                                connectorProperties?.length > 1 && (
-                                                    <List>
-                                                        { resolveConfigurationList(connectorProperties) }
-                                                    </List>
+                                                connectorProperties && (
+                                                    <Popup
+                                                        trigger={
+                                                            <Button
+                                                                onClick={ handleForcePasswordReset }
+                                                                basic
+                                                                color="grey"
+                                                                floated="right"
+                                                            >
+                                                                <Icon name="redo"/>
+                                                                Reset Password
+                                                            </Button>
+                                                        }
+                                                        position="bottom center"
+                                                        hoverable
+                                                        inverted
+                                                        size="huge"
+                                                        className="list-options-popup"
+                                                    >
+                                                        <Popup.Header>
+                                                            Password Reset Options
+                                                        </Popup.Header>
+                                                        <Divider/>
+                                                        <Popup.Content>
+                                                            {
+                                                                connectorProperties?.length > 1 && (
+                                                                    <List>
+                                                                        { resolveConfigurationList(connectorProperties) }
+                                                                    </List>
+                                                                )
+                                                            }
+                                                        </Popup.Content>
+                                                    </Popup>
                                                 )
                                             }
-                                        </Popup.Content>
-                                    </Popup>
+                                            <Button
+                                                basic
+                                                color="orange"
+                                                onClick={ () => setOpenChangePasswordModal(true) }
+                                                floated="right"
+                                            >
+                                                <Icon name="edit outline" />
+                                                Change Password
+                                            </Button>
+                                        </>
                                 )
                             }
-                            <Button
-                                basic
-                                color="orange"
-                                onClick={ () => setOpenChangePasswordModal(true) }
-                                floated="right"
-                            >
-                                <Icon name="edit outline" />
-                                Change Password
-                            </Button>
                         </Grid.Column>
                     </Grid.Row>
                 </Grid>

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -160,9 +160,9 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
         } else {
             const availableURls: string[] = !urlState
                 ? []
-                : urlState.split(",");
+                : urlState?.split(",");
 
-            const duplicate: boolean = availableURls.includes(url);
+            const duplicate: boolean = availableURls?.includes(url);
 
             urlValid && setDuplicateURL(duplicate);
 


### PR DESCRIPTION
### Purpose

- This PR introduces the capability to add OIDC protocol to an application without specifying the callback URL if a grant type that doesn't require a callback URL is configured.
- This also improves the application edit section to update the application protocol without specifying the callback URL if the configured grant type doesn't use a callback URL.
- Resolves https://github.com/wso2/product-is/issues/10221