### PR TITLE
Gracefully route less privileged users in Console

### DIFF
--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -233,6 +233,23 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
         setTriggerClearQuery(!triggerClearQuery);
     };
 
+    /**
+     * Renders the Remote Fetch status bar.
+     *
+     * @return {React.ReactElement}
+     */
+    const renderRemoteFetchStatus = (): ReactElement => {
+        
+        if (!hasRequiredScopes(featureConfig?.remoteFetchConfig,
+            featureConfig?.remoteFetchConfig?.scopes?.read,
+            allowedScopes)) {
+            
+            return null;
+        }
+        
+        return <RemoteFetchStatus data-testid={ "remote-fetch" } />;
+    };
+
     return (
         <PageLayout
             action={
@@ -255,9 +272,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
             description={ t("devPortal:pages.applications.subTitle") }
             data-testid={ `${ testId }-page-layout` }
         >
-
-            <RemoteFetchStatus data-testid={ "remote-fetch" } />
-            
+            { renderRemoteFetchStatus() }
             <ListLayout
                 advancedSearch={
                     <AdvancedSearchWithBasicFilters

--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -51,6 +51,10 @@ export interface FeatureConfigInterface {
      */
     applications?: FeatureAccessConfigInterface;
     /**
+     * Workflow approvals feature.
+     */
+    approvals?: FeatureAccessConfigInterface;
+    /**
      * Attribute dialects(Claim dialects) feature.
      */
     attributeDialects?: FeatureAccessConfigInterface;
@@ -74,6 +78,14 @@ export interface FeatureConfigInterface {
      * Identity provider management feature.
      */
     identityProviders?: FeatureAccessConfigInterface;
+    /**
+     * OIDC Scope management feature.
+     */
+    oidcScopes?: FeatureAccessConfigInterface;
+    /**
+     * Remote Fetch Config management feature.
+     */
+    remoteFetchConfig?: FeatureAccessConfigInterface;
     /**
      * Role management feature.
      */

--- a/apps/console/src/features/core/utils/index.ts
+++ b/apps/console/src/features/core/utils/index.ts
@@ -21,5 +21,6 @@ export * from "./common-utils";
 export * from "./filter-list";
 export * from "./help-panel-utils";
 export * from "./http-utils";
+export * from "./route-utils";
 export * from "./sort-list";
 export * from "./user-store-utils";

--- a/apps/console/src/features/core/utils/route-utils.ts
+++ b/apps/console/src/features/core/utils/route-utils.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import { RouteInterface } from "@wso2is/core/models";
+import sortBy from "lodash/sortBy";
+import { AppConstants } from "../constants";
+import { history } from "../helpers";
+
+/**
+ * Utility class for application routes related operations.
+ */
+export class RouteUtils {
+
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     *
+     * @hideconstructor
+     */
+    private constructor() { }
+
+    /*
+     * Gracefully handles application routing to avoid less privileged users from
+     * receiving unauthorized pages.
+     *
+     * @param {RouteInterface[]} routes - Set of app routes.
+     * @param {string} view - Current view ex: Admin or Develop. 
+     * @param {string} pathname - Current path from location.
+     */
+    public static gracefullyHandleRouting(routes: RouteInterface[], view: string, pathname: string): void {
+
+        if (routes && Array.isArray(routes) && routes.length === 1) {
+            if (routes[0].redirectTo === AppConstants.getPaths().get("PAGE_NOT_FOUND")) {
+                if (RouteUtils.isHomePath(view)) {
+                    if (view === AppConstants.getDeveloperViewBasePath()) {
+                        history.push(AppConstants.getAdminViewBasePath());
+
+                        return;
+                    }
+
+                    if (view === AppConstants.getAdminViewBasePath()) {
+                        history.push(AppConstants.getDeveloperViewBasePath());
+
+                        return;
+                    }
+                }
+
+                history.push({
+                    pathname: AppConstants.getPaths().get("UNAUTHORIZED"),
+                    search: "?error=" + AppConstants.LOGIN_ERRORS.get("ACCESS_DENIED")
+                });
+            }
+        }
+
+        const isRouteAvailable: RouteInterface = routes.find((route: RouteInterface) => route.path === pathname);
+
+        if (isRouteAvailable) {
+            return;
+        }
+
+        history.push(sortBy(routes, "order")[0].path);
+    }
+
+    /**
+     * Checks if the passed in path is the home path defined in deployment.config.json.
+     *
+     * @param {string} path - Path to check.
+     * @return {boolean} Is home path or not.
+     */
+    public static isHomePath(path: string): boolean {
+
+        if (path === AppConstants.getAppHomePath()) {
+            return true;
+        }
+
+        return path?.split("/")[0] === AppConstants.getAppHomePath()?.split("/")[0];
+    }
+}

--- a/apps/console/src/features/remote-repository-configuration/components/remote-fetch-status.tsx
+++ b/apps/console/src/features/remote-repository-configuration/components/remote-fetch-status.tsx
@@ -79,6 +79,14 @@ export const RemoteFetchStatus: FunctionComponent<RemoteFetchStatusProps> = (
 
         getRemoteRepoConfigList()
             .then((remoteRepoList: AxiosResponse<InterfaceRemoteRepoListResponse>) => {
+                
+                if (!(remoteRepoList?.data?.remotefetchConfigurations
+                    && Array.isArray(remoteRepoList.data.remotefetchConfigurations)
+                    && remoteRepoList.data.remotefetchConfigurations[ 0 ])) {
+
+                    return;
+                }
+
                 const config: InterfaceRemoteRepoConfig = remoteRepoList.data.remotefetchConfigurations[ 0 ];
 
                 if (remoteRepoList.data.count > 0) {

--- a/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-connector-form.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-connector-form.tsx
@@ -27,7 +27,6 @@ import { AppState } from "../../../core";
 import { ServerConfigurationsConstants } from "../../constants";
 import { ConnectorPropertyInterface } from "../../models";
 import { GovernanceConnectorUtils } from "../../utils";
-import { TFunction } from "i18next";
 
 /**
  * Determine the matching Form component based on the property attributes.

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -212,24 +212,6 @@
                     ]
                 }
             },
-            "users": {
-                "enabled": true,
-                "disabledFeatures": [],
-                "scopes": {
-                    "create": [
-                        "internal_user_mgt_create"
-                    ],
-                    "read": [
-                        "internal_user_mgt_list"
-                    ],
-                    "update": [
-                        "internal_user_mgt_update"
-                    ],
-                    "delete": [
-                        "internal_user_mgt_delete"
-                    ]
-                }
-            },
             "roles": {
                 "enabled": true,
                 "disabledFeatures": [],
@@ -263,6 +245,24 @@
                     ],
                     "delete": [
                         "internal_userstore_delete"
+                    ]
+                }
+            },
+            "users": {
+                "enabled": true,
+                "disabledFeatures": [],
+                "scopes": {
+                    "create": [
+                        "internal_user_mgt_create"
+                    ],
+                    "read": [
+                        "internal_user_mgt_list"
+                    ],
+                    "update": [
+                        "internal_user_mgt_update"
+                    ],
+                    "delete": [
+                        "internal_user_mgt_delete"
                     ]
                 }
             }

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -212,6 +212,24 @@
                     ]
                 }
             },
+            "remoteFetchConfig": {
+                "enabled": true,
+                "disabledFeatures": [],
+                "scopes": {
+                    "create": [
+                        "internal_identity_mgt_view internal_identity_mgt_update internal_identity_mgt_create internal_identity_mgt_delete"
+                    ],
+                    "read": [
+                        "internal_identity_mgt_view internal_identity_mgt_update internal_identity_mgt_create internal_identity_mgt_delete"
+                    ],
+                    "update": [
+                        "internal_identity_mgt_view internal_identity_mgt_update internal_identity_mgt_create internal_identity_mgt_delete"
+                    ],
+                    "delete": [
+                        "internal_identity_mgt_view internal_identity_mgt_update internal_identity_mgt_create internal_identity_mgt_delete"
+                    ]
+                }
+            },
             "roles": {
                 "enabled": true,
                 "disabledFeatures": [],

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -194,6 +194,24 @@
                     ]
                 }
             },
+            "oidcScopes": {
+                "enabled": true,
+                "disabledFeatures": [],
+                "scopes": {
+                    "create": [
+                        "internal_application_mgt_create"
+                    ],
+                    "read": [
+                        "internal_application_mgt_view"
+                    ],
+                    "update": [
+                        "internal_application_mgt_update"
+                    ],
+                    "delete": [
+                        "internal_application_mgt_delete"
+                    ]
+                }
+            },
             "users": {
                 "enabled": true,
                 "disabledFeatures": [],

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -144,18 +144,14 @@
                 "enabled": true,
                 "disabledFeatures": [],
                 "scopes": {
-                    "create": [
-                        "internal_identity_mgt_create"
-                    ],
+                    "create": [],
                     "read": [
-                        "internal_identity_mgt_view"
+                        "internal_idp_view"
                     ],
                     "update": [
-                        "internal_identity_mgt_update"
+                        "internal_idp_update"
                     ],
-                    "delete": [
-                        "internal_identity_mgt_delete"
-                    ]
+                    "delete": []
                 }
             },
             "groups": {
@@ -217,16 +213,28 @@
                 "disabledFeatures": [],
                 "scopes": {
                     "create": [
-                        "internal_identity_mgt_view internal_identity_mgt_update internal_identity_mgt_create internal_identity_mgt_delete"
+                        "internal_identity_mgt_view",
+                        "internal_identity_mgt_update",
+                        "internal_identity_mgt_create",
+                        "internal_identity_mgt_delete"
                     ],
                     "read": [
-                        "internal_identity_mgt_view internal_identity_mgt_update internal_identity_mgt_create internal_identity_mgt_delete"
+                        "internal_identity_mgt_view",
+                        "internal_identity_mgt_update",
+                        "internal_identity_mgt_create",
+                        "internal_identity_mgt_delete"
                     ],
                     "update": [
-                        "internal_identity_mgt_view internal_identity_mgt_update internal_identity_mgt_create internal_identity_mgt_delete"
+                        "internal_identity_mgt_view",
+                        "internal_identity_mgt_update",
+                        "internal_identity_mgt_create",
+                        "internal_identity_mgt_delete"
                     ],
                     "delete": [
-                        "internal_identity_mgt_view internal_identity_mgt_update internal_identity_mgt_create internal_identity_mgt_delete"
+                        "internal_identity_mgt_view",
+                        "internal_identity_mgt_update",
+                        "internal_identity_mgt_create",
+                        "internal_identity_mgt_delete"
                     ]
                 }
             },
@@ -274,7 +282,8 @@
                         "internal_user_mgt_create"
                     ],
                     "read": [
-                        "internal_user_mgt_list"
+                        "internal_user_mgt_list",
+                        "internal_userstore_view"
                     ],
                     "update": [
                         "internal_user_mgt_update"

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1,6 +1,6 @@
 {
     "accountApp": {
-        {% if console.account_app.configs is defined %}
+        {% if console.applications.account_app.configs is defined %}
         {% for key, value in console.applications.account_app.configs.items() %}
             "{{ key }}": "{{ value }}"{{ "," if not loop.last }}
         {% endfor %}

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1,6 +1,6 @@
 {
     "accountApp": {
-        {% if console.applications.account_app.configs is defined %}
+        {% if console.c.account_app.configs is defined %}
         {% for key, value in console.applications.account_app.configs.items() %}
             "{{ key }}": "{{ value }}"{{ "," if not loop.last }}
         {% endfor %}
@@ -128,6 +128,32 @@
                 "scopes": {
                     {% if console.applications.scopes is defined %}
                     {% for operation, scopes in console.applications.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "read": [],
+                        "update": [],
+                        "delete": []
+                    {% endif %}
+                }
+            },
+            "approvals": {
+                "disabledFeatures": [
+                    {% if console.approvals.disabled_features is defined %}
+                    {% for feature in console.approvals.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {{ console.approvals.enabled }},
+                "scopes": {
+                    {% if console.approvals.scopes is defined %}
+                    {% for operation, scopes in console.approvals.scopes.items() %}
                     "{{ operation }}": [
                         {% for scope in scopes %}
                             "{{ scope }}"{{ "," if not loop.last }}

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -350,6 +350,32 @@
                     {% endif %}
                 }
             },
+            "remoteFetchConfig": {
+                "disabledFeatures": [
+                    {% if console.remote_fetch.disabled_features is defined %}
+                    {% for feature in console.remote_fetch.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": true,
+                "scopes": {
+                    {% if console.remote_fetch.scopes is defined %}
+                    {% for operation, scopes in console.remote_fetch.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "read": [],
+                        "update": [],
+                        "delete": []
+                    {% endif %}
+                }
+            },
             "roles": {
                 "disabledFeatures": [
                     {% if console.roles.disabled_features is defined %}

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -324,6 +324,32 @@
                     {% endif %}
                 }
             },
+            "oidcScopes": {
+                "disabledFeatures": [
+                    {% if console.oidc_scopes.disabled_features is defined %}
+                    {% for feature in console.oidc_scopes.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {{ console.oidc_scopes.enabled }},
+                "scopes": {
+                    {% if console.oidc_scopes.scopes is defined %}
+                    {% for operation, scopes in console.oidc_scopes.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "read": [],
+                        "update": [],
+                        "delete": []
+                    {% endif %}
+                }
+            },
             "roles": {
                 "disabledFeatures": [
                     {% if console.roles.disabled_features is defined %}

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1,6 +1,6 @@
 {
     "accountApp": {
-        {% if console.c.account_app.configs is defined %}
+        {% if console.account_app.configs is defined %}
         {% for key, value in console.applications.account_app.configs.items() %}
             "{{ key }}": "{{ value }}"{{ "," if not loop.last }}
         {% endfor %}


### PR DESCRIPTION
## Purpose
Uses with less, but required permissions to access some of the features in the Console were not able to login.

## Goals
With this PR, the app will gracefully fallback to alternative routes to see if the logged in user has access to view them. If not, the un-authorized page is shown as expected.

Fixes https://github.com/wso2/product-is/issues/10229
Fixes https://github.com/wso2/product-is/issues/10396

NOTE: Please merge the following framework PR together with this.
https://github.com/wso2/carbon-identity-framework/pull/3248

## Known Issues
Graceful navigation had been implemented for Console features with this PR. But some features rely on each other and the access should be handled properly for those.

Ex: Users features requires proper permissions for Groups, Roles & User Sessions to access the relevant APIs.

The progress of this improvement is tracked [here](https://github.com/wso2/product-is/issues/10473)