### PR TITLE
Prepare for Read Only applications in Console

### DIFF
--- a/apps/console/src/features/applications/components/application-list.tsx
+++ b/apps/console/src/features/applications/components/application-list.tsx
@@ -50,6 +50,7 @@ import {
 import { deleteApplication } from "../api";
 import { ApplicationManagementConstants } from "../constants";
 import {
+    ApplicationAccessTypes,
     ApplicationListInterface,
     ApplicationListItemInterface,
     ApplicationTemplateListItemInterface
@@ -168,9 +169,15 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
      * Redirects to the applications edit page when the edit button is clicked.
      *
      * @param {string} appId - Application id.
+     * @param {ApplicationAccessTypes} access - Access level of the application.
      */
-    const handleApplicationEdit = (appId: string): void => {
-        history.push(AppConstants.getPaths().get("APPLICATION_EDIT").replace(":id", appId));
+    const handleApplicationEdit = (appId: string, access: ApplicationAccessTypes): void => {
+        history.push({
+            pathname: AppConstants.getPaths().get("APPLICATION_EDIT").replace(":id", appId),
+            search: access === ApplicationAccessTypes.READ
+                ? `?${ ApplicationManagementConstants.APP_READ_ONLY_STATE_URL_SEARCH_PARAM_KEY }=true`
+                : ""
+        });
     };
 
     /**
@@ -314,7 +321,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                     ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT")),
                 icon: (): SemanticICONS => "pencil alternate",
                 onClick: (e: SyntheticEvent, app: ApplicationListItemInterface): void =>
-                    handleApplicationEdit(app?.id),
+                    handleApplicationEdit(app.id, app.access),
                 popupText: (): string => t("common:edit"),
                 renderer: "semantic-icon"
             },
@@ -409,7 +416,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                         app.name !== ApplicationManagementConstants.WSO2_CARBON_LOCAL_SP)
                 }
                 onRowClick={ (e: SyntheticEvent, app: ApplicationListItemInterface): void => {
-                    handleApplicationEdit(app?.id);
+                    handleApplicationEdit(app.id, app.access);
                     onListItemClick && onListItemClick(e, app);
                 } }
                 placeholders={ showPlaceholders() }

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -90,6 +90,10 @@ interface EditApplicationPropsInterface extends SBACInterface<FeatureConfigInter
      */
     isTabExtensionsAvailable: (isAvailable: boolean) => void;
     /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
+    /**
      * URL Search params received to the parent edit page component.
      */
     urlSearchParams?: URLSearchParams;
@@ -117,6 +121,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
         onUpdate,
         template,
         isTabExtensionsAvailable,
+        readOnly,
         urlSearchParams,
         [ "data-testid" ]: testId
     } = props;
@@ -356,6 +361,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 onUpdate={ onUpdate }
                 featureConfig={ featureConfig }
                 template={ template }
+                readOnly={ readOnly }
                 data-testid={ `${ testId }-general-settings` }
             />
         </ResourceTab.Pane>
@@ -376,6 +382,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 inboundProtocolConfig={ inboundProtocolConfig }
                 inboundProtocols={ inboundProtocolList }
                 featureConfig={ featureConfig }
+                readOnly={ readOnly }
                 data-testid={ `${ testId }-access-settings` }
             />
         </ResourceTab.Pane>
@@ -391,6 +398,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                     inboundProtocolList.length === 1 && (inboundProtocolList[ 0 ] === SupportedAuthProtocolTypes.OIDC)
                 }
                 onUpdate={ onUpdate }
+                readOnly={ readOnly }
                 data-testid={ `${ testId }-attribute-settings` }
             />
         </ResourceTab.Pane>
@@ -405,6 +413,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 isLoading={ isLoading }
                 onUpdate={ onUpdate }
                 featureConfig={ featureConfig }
+                readOnly={ readOnly }
                 data-testid={ `${ testId }-sign-on-methods` }
             />
         </ResourceTab.Pane>
@@ -417,6 +426,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 advancedConfigurations={ application.advancedConfigurations }
                 onUpdate={ onUpdate }
                 featureConfig={ featureConfig }
+                readOnly={ readOnly }
                 data-testid={ `${ testId }-advanced-settings` }
             />
         </ResourceTab.Pane>
@@ -429,6 +439,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 provisioningConfigurations={ application.provisioningConfigurations }
                 onUpdate={ onUpdate }
                 featureConfig={ featureConfig }
+                readOnly={ readOnly }
                 data-testid={ `${ testId }-provisioning-settings` }
             />
         </ResourceTab.Pane>

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -36,6 +36,7 @@ import {
     OIDCDataInterface,
     OIDCMetadataInterface,
     State,
+    SupportedAccessTokenBindingTypes,
     emptyOIDCConfig
 } from "../../models";
 
@@ -158,10 +159,23 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * Sets if a valid token binding type is selected.
      */
     useEffect(() => {
-        if (initialValues.accessToken.bindingType !== "None") {
+        // If access token object is empty, return.
+        if (!initialValues?.accessToken || isEmpty(initialValues.accessToken)) {
+            return;
+        }
+
+        // When bindingType is set to none, back-end doesn't send the `bindingType` attr. So default to `None`.
+        if (!initialValues.accessToken.bindingType) {
+            setIsTokenBindingTypeSelected(false);
+            
+            return;
+        }
+
+        // Show the validate options when the bindingType is set to a value other than `None`.
+        if (initialValues.accessToken.bindingType !== SupportedAccessTokenBindingTypes.NONE) {
             setIsTokenBindingTypeSelected(true);
         }
-    }, [ initialValues?.accessToken?.bindingType ]);
+    }, [ initialValues?.accessToken ]);
 
     /**
      * Handle grant type change.
@@ -787,16 +801,19 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                         }
                         name="bindingType"
                         default={
-                            initialValues
+                            initialValues?.accessToken?.bindingType
                                 ? initialValues.accessToken.bindingType
-                                : metadata.accessTokenBindingType.defaultValue
+                                : metadata?.accessTokenBindingType?.defaultValue
+                                    ?? SupportedAccessTokenBindingTypes.NONE
                         }
                         type="radio"
                         children={ getAllowedList(metadata.accessTokenBindingType, true) }
                         readOnly={ readOnly }
                         data-testid={ `${ testId }-access-token-type-radio-group` }
                         listen={ (values) => {
-                            setIsTokenBindingTypeSelected(values.get("bindingType") !== "None");
+                            setIsTokenBindingTypeSelected(
+                                values.get("bindingType") !== SupportedAccessTokenBindingTypes.NONE
+                            );
                         } }
                     />
                 </Grid.Column>

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -101,6 +101,10 @@ interface AccessConfigurationPropsInterface extends SBACInterface<FeatureConfigI
      * Specifies if the inbound protocol list is loading.
      */
     inboundProtocolsLoading?: boolean;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -126,6 +130,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         onAllowedOriginsUpdate,
         onApplicationSecretRegenerate,
         inboundProtocolsLoading,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -325,13 +330,15 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         return (inboundProtocolConfig
                 ?
                 <AuthenticatorAccordion
-                    globalActions={ [
-                        {
-                            icon: "trash alternate",
-                            onClick: handleProtocolDeleteOnClick,
-                            type: "icon"
-                        }
-                    ] }
+                    globalActions={
+                        !readOnly && [
+                            {
+                                icon: "trash alternate",
+                                onClick: handleProtocolDeleteOnClick,
+                                type: "icon"
+                            }
+                        ]
+                    }
                     authenticators={
                         Object.keys(inboundProtocolConfig).map((protocol) => {
                             if (Object.values(SupportedAuthProtocolTypes)
@@ -355,7 +362,8 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                                             onApplicationRegenerate={ handleApplicationRegenerate }
                                             onApplicationRevoke={ handleApplicationRevoke }
                                             readOnly={
-                                                !hasRequiredScopes(
+                                                readOnly
+                                                || !hasRequiredScopes(
                                                     featureConfig?.applications,
                                                     featureConfig?.applications?.scopes?.update,
                                                     allowedScopes
@@ -468,20 +476,21 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                     <Grid.Row>
                         <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                             {
-                                inboundProtocols.length > 0
-                                    ? hasRequiredScopes(
-                                        featureConfig?.applications,
+                                (inboundProtocols.length > 0)
+                                    ? !readOnly
+                                    && hasRequiredScopes(featureConfig?.applications,
                                         featureConfig?.applications?.scopes?.update,
-                                        allowedScopes) && (
-                                    <Button
-                                        floated="right"
-                                        primary
-                                        onClick={ () => setShowWizard(true) }
-                                        data-testid={ `${ testId }-new-protocol-button` }
-                                    >
-                                        <Icon name="add"/>New Protocol
-                                    </Button>
-                                )
+                                        allowedScopes)
+                                    && (
+                                        <Button
+                                            floated="right"
+                                            primary
+                                            onClick={ () => setShowWizard(true) }
+                                            data-testid={ `${ testId }-new-protocol-button` }
+                                        >
+                                            <Icon name="add"/>New Protocol
+                                        </Button>
+                                    )
                                     : (
                                         !inboundProtocolsLoading
                                         && <EmptyPlaceholder
@@ -491,7 +500,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                                                     featureConfig?.applications?.scopes?.update,
                                                     allowedScopes) && (
                                                     <PrimaryButton onClick={ () => setShowWizard(true) }>
-                                                        <Icon name="add" />
+                                                        <Icon name="add"/>
                                                         { t("devPortal:components.applications.placeholders" +
                                                             ".emptyProtocolList.action") }
                                                     </PrimaryButton>

--- a/apps/console/src/features/applications/components/settings/advanced-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/advanced-settings.tsx
@@ -44,6 +44,10 @@ interface AdvancedSettingsPropsInterface extends SBACInterface<FeatureConfigInte
      * Callback to update the application details.
      */
     onUpdate: (id: string) => void;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -62,6 +66,7 @@ export const AdvancedSettings: FunctionComponent<AdvancedSettingsPropsInterface>
         advancedConfigurations,
         featureConfig,
         onUpdate,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -116,8 +121,10 @@ export const AdvancedSettings: FunctionComponent<AdvancedSettingsPropsInterface>
                 config={ advancedConfigurations }
                 onSubmit={ handleAdvancedConfigFormSubmit }
                 readOnly={
-                    !hasRequiredScopes(
-                        featureConfig?.applications, featureConfig?.applications?.scopes?.update, allowedScopes)
+                    readOnly
+                    || !hasRequiredScopes(featureConfig?.applications,
+                        featureConfig?.applications?.scopes?.update,
+                        allowedScopes)
                 }
                 data-testid={ `${ testId }-form` }
             />

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
@@ -37,6 +37,10 @@ interface AttributeListItemPropInterface extends TestableComponentInterface {
     initialRequested?: boolean;
     claimMappingOn?: boolean;
     claimMappingError?: boolean;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -63,6 +67,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
         initialRequested,
         claimMappingOn,
         claimMappingError,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -141,6 +146,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                                     value={ mapping?.applicationClaim }
                                     onChange={ handleClaimMapping }
                                     disabled={ !mappingOn }
+                                    readOnly={ readOnly }
                                     required
                                 />
                                 { errorInClaimMapping && (
@@ -161,6 +167,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                                                 defaultChecked={ initialRequested }
                                                 onClick={ handleRequestCheckChange }
                                                 disabled={ !mappingOn }
+                                                readOnly={ readOnly }
                                             />
                                         )
                                     }
@@ -173,7 +180,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                                             ".selection.mappingTable.listItem.actions.makeRequested")
                                     }
                                     inverted
-                                    disabled={ !mappingOn }
+                                    disabled={ readOnly || !mappingOn }
                                 />
                             </Table.Cell>
                         </>
@@ -186,6 +193,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                                         defaultChecked={ initialMandatory }
                                         onClick={ handleMandatoryCheckChange }
                                         disabled={ mappingOn ? !requested : false }
+                                        readOnly={ readOnly }
                                     />
                                 )
                             }
@@ -198,7 +206,13 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                                     ".mappingTable.listItem.actions.makeMandatory")
                             }
                             inverted
-                            disabled={ mappingOn ? !requested : false }
+                            disabled={
+                                readOnly
+                                    ? false
+                                    : mappingOn
+                                        ? !requested
+                                        : false
+                            }
                         />
                     </Table.Cell>
                 </Table.Row>
@@ -215,6 +229,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                                     <Checkbox
                                         defaultChecked={ initialMandatory }
                                         onClick={ handleMandatoryCheckChange }
+                                        readOnly={ readOnly }
                                     />
                                 )
                             }
@@ -226,6 +241,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                                     : t("devPortal:components.applications.edit.sections.attributes.selection" +
                                     ".mappingTable.listItem.actions.makeMandatory")
                             }
+                            disabled={ readOnly }
                             inverted
                         />
                     </Table.Cell>

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
@@ -442,20 +442,25 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                                                                             ".edit.sections.attributes.selection" +
                                                                             ".mappingTable.actions.enable")
                                                                     }
+                                                                    readOnly={ readOnly }
                                                                     data-testid={ `${ testId }-cliam-mapping-toggle` }
                                                                 />
                                                             </Table.Cell>
                                                         )
                                                         }
-                                                        <Table.Cell textAlign="right">
-                                                            <Button
-                                                                size="medium"
-                                                                icon="pencil"
-                                                                floated="right"
-                                                                onClick={ handleOpenSelectionModal }
-                                                                data-testid={ `${ testId }-update-button` }
-                                                            />
-                                                        </Table.Cell>
+                                                        {
+                                                            !readOnly && (
+                                                                <Table.Cell textAlign="right">
+                                                                    <Button
+                                                                        size="medium"
+                                                                        icon="pencil"
+                                                                        floated="right"
+                                                                        onClick={ handleOpenSelectionModal }
+                                                                        data-testid={ `${ testId }-update-button` }
+                                                                    />
+                                                                </Table.Cell>
+                                                            )
+                                                        }
                                                     </Table.Row>
                                                 </Table.Body>
                                             </Table>
@@ -590,6 +595,7 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                                                                             selectRequested={ updateRequested }
                                                                             claimMappingOn={ claimMappingOn }
                                                                             claimMappingError={ claimMappingError }
+                                                                            readOnly={ readOnly }
                                                                             data-testid={ claim.claimURI }
                                                                         />
                                                                     )
@@ -641,6 +647,7 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                                                                             initialMandatory={ claim.mandatory }
                                                                             selectMandatory={ updateMandatory }
                                                                             data-testid={ claim.claimURI }
+                                                                            readOnly={ readOnly }
                                                                         />
                                                                     )
                                                                 })

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -95,6 +95,10 @@ interface AttributeSelectionPropsInterface extends SBACInterface<FeatureConfigIn
      * Callback to update the application details.
      */
     onUpdate: (id: string) => void;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 export const getLocalDialectURI = (): string => {
@@ -130,6 +134,7 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
         claimConfigurations,
         onlyOIDCConfigured,
         onUpdate,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -580,8 +585,10 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                         setClaimMappingOn={ setClaimMappingOn }
                         claimMappingError={ claimMappingError }
                         readOnly={
-                            !hasRequiredScopes(
-                                featureConfig?.applications, featureConfig?.applications?.scopes?.update, allowedScopes)
+                            readOnly
+                            || !hasRequiredScopes(featureConfig?.applications,
+                                featureConfig?.applications?.scopes?.update,
+                                allowedScopes)
                         }
                         data-testid={ `${ testId }-attribute-selection` }
                     />
@@ -594,8 +601,10 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                         initialSubject={ claimConfigurations.subject }
                         claimMappingOn={ claimMappingOn }
                         readOnly={
-                            !hasRequiredScopes(
-                                featureConfig?.applications, featureConfig?.applications?.scopes?.update, allowedScopes)
+                            readOnly
+                            || !hasRequiredScopes(featureConfig?.applications,
+                                featureConfig?.applications?.scopes?.update,
+                                allowedScopes)
                         }
                         data-testid={ `${ testId }-advanced-attribute-settings-form` }
                     />
@@ -604,14 +613,19 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                         onSubmit={ setRoleMapping }
                         initialMappings={ claimConfigurations.role?.mappings }
                         readOnly={
-                            !hasRequiredScopes(
-                                featureConfig?.applications, featureConfig?.applications?.scopes?.update, allowedScopes)
+                            readOnly
+                            || !hasRequiredScopes(featureConfig?.applications,
+                                featureConfig?.applications?.scopes?.update,
+                                allowedScopes)
                         }
                         data-testid={ `${ testId }-role-mapping` }
                     />
                     {
-                        hasRequiredScopes(featureConfig?.applications, featureConfig?.applications?.scopes?.update,
-                            allowedScopes) && (
+                        !readOnly
+                        && hasRequiredScopes(featureConfig?.applications,
+                            featureConfig?.applications?.scopes?.update,
+                            allowedScopes)
+                        && (
                             <Grid.Row>
                                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 3 }>
                                     <Button

--- a/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
@@ -98,9 +98,9 @@ export const RoleMapping: FunctionComponent<RoleMappingPropsInterface> = (
             })
             .catch(() => {
                 dispatch(addAlert({
-                    description: t("devPortal:components.roles.notifications.fetchRoles.genericError.description"),
+                    description: t("adminPortal:components.roles.notifications.fetchRoles.genericError.description"),
                     level: AlertLevels.ERROR,
-                    message: t("devPortal:components.roles.notifications.fetchRoles.genericError.message")
+                    message: t("adminPortal:components.roles.notifications.fetchRoles.genericError.message")
                 }));
             });
     }, [initialMappings]);

--- a/apps/console/src/features/applications/components/settings/general-application-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/general-application-settings.tsx
@@ -83,6 +83,10 @@ interface GeneralApplicationSettingsInterface extends SBACInterface<FeatureConfi
      */
     onUpdate: (id: string) => void;
     /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
+    /**
      * Application template.
      */
     template?: ApplicationTemplateListItemInterface;
@@ -115,6 +119,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
         onDelete,
         onUpdate,
         certificate,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -265,7 +270,8 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                             imageUrl={ imageUrl }
                             accessUrl={ accessUrl }
                             readOnly={
-                                !hasRequiredScopes(
+                                readOnly
+                                || !hasRequiredScopes(
                                     featureConfig?.applications, featureConfig?.applications?.scopes?.update,
                                     allowedScopes
                                 )

--- a/apps/console/src/features/applications/components/settings/provisioning/inbound-provisioning-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/provisioning/inbound-provisioning-configuration.tsx
@@ -69,6 +69,7 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
         provisioningConfigurations,
         onUpdate,
         featureConfig,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -147,7 +148,8 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
                                                 onSubmit={ handleProvisioningConfigFormSubmit }
                                                 useStoreList={ userStore }
                                                 readOnly={
-                                                    !hasRequiredScopes(featureConfig?.applications,
+                                                    readOnly
+                                                    || !hasRequiredScopes(featureConfig?.applications,
                                                         featureConfig?.applications?.scopes?.update,
                                                         allowedScopes)
                                                 }

--- a/apps/console/src/features/applications/components/settings/provisioning/outbound-provisioning-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/provisioning/outbound-provisioning-configuration.tsx
@@ -49,6 +49,10 @@ interface OutboundProvisioningConfigurationPropsInterface extends TestableCompon
      * Callback to update the application details.
      */
     onUpdate: (id: string) => void;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -65,6 +69,7 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
     const {
         application,
         onUpdate,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -176,19 +181,25 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
             {
                 application?.provisioningConfigurations?.outboundProvisioningIdps?.length > 0 ? (
                     <Grid>
-                        <Grid.Row>
-                            <Grid.Column>
-                                <PrimaryButton
-                                    floated="right"
-                                    onClick={ () => setShowWizard(true) }
-                                    data-testid={ `${ testId }-new-idp-button` }
-                                >
-                                    <Icon name="add"/>
-                                    { t("devPortal:components.applications.edit.sections.provisioning.outbound" +
-                                        ".actions.addIdp") }
-                                </PrimaryButton>
-                            </Grid.Column>
-                        </Grid.Row>
+                        {
+                            !readOnly && (
+                                <Grid.Row>
+                                    <Grid.Column>
+                                        <PrimaryButton
+                                            floated="right"
+                                            onClick={ () => setShowWizard(true) }
+                                            data-testid={ `${ testId }-new-idp-button` }
+                                        >
+                                            <Icon name="add"/>
+                                            {
+                                                t("devPortal:components.applications.edit.sections." +
+                                                    "provisioning.outbound.actions.addIdp")
+                                            }
+                                        </PrimaryButton>
+                                    </Grid.Column>
+                                </Grid.Row>
+                            )
+                        }
                         <Grid.Row>
                             <Grid.Column>
                                 {
@@ -197,16 +208,18 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
                                         return (
                                             <AuthenticatorAccordion
                                                 key={ provisioningIdp.idp }
-                                                globalActions={ [
-                                                    {
-                                                        icon: "trash alternate",
-                                                        onClick: (): void => {
-                                                            setShowDeleteConfirmationModal(true);
-                                                            setDeletingIdp(provisioningIdp);
-                                                        },
-                                                        type: "icon"
-                                                    }
-                                                ] }
+                                                globalActions={
+                                                    !readOnly && [
+                                                        {
+                                                            icon: "trash alternate",
+                                                            onClick: (): void => {
+                                                                setShowDeleteConfirmationModal(true);
+                                                                setDeletingIdp(provisioningIdp);
+                                                            },
+                                                            type: "icon"
+                                                        }
+                                                    ]
+                                                }
                                                 authenticators={
                                                     [
                                                         {
@@ -251,13 +264,15 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
                                                 ".emptyOutboundProvisioningIDPs.subtitles")
                                         ] }
                                         imageSize="tiny"
-                                        action={ (
-                                            <PrimaryButton onClick={ () => setShowWizard(true) }>
-                                                <Icon name="add"/>
-                                                { t("devPortal:components.applications.placeholders" +
-                                                    ".emptyOutboundProvisioningIDPs.action") }
-                                            </PrimaryButton>
-                                        ) }
+                                        action={
+                                            !readOnly && (
+                                                <PrimaryButton onClick={ () => setShowWizard(true) }>
+                                                    <Icon name="add"/>
+                                                    { t("devPortal:components.applications.placeholders" +
+                                                        ".emptyOutboundProvisioningIDPs.action") }
+                                                </PrimaryButton>
+                                            )
+                                        }
                                     />
                                 </Segment>
                             </Grid.Column>

--- a/apps/console/src/features/applications/components/settings/provisioning/provisioning-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/provisioning/provisioning-settings.tsx
@@ -43,6 +43,10 @@ interface ProvisioningSettingsPropsInterface extends SBACInterface<FeatureConfig
      * Callback to update the application details.
      */
     onUpdate: (id: string) => void;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -61,6 +65,7 @@ export const ProvisioningSettings: FunctionComponent<ProvisioningSettingsPropsIn
         featureConfig,
         provisioningConfigurations,
         onUpdate,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -73,11 +78,10 @@ export const ProvisioningSettings: FunctionComponent<ProvisioningSettingsPropsIn
                 provisioningConfigurations={ provisioningConfigurations }
                 onUpdate={ onUpdate }
                 readOnly={
-                    !hasRequiredScopes(
-                        featureConfig?.applications,
+                    readOnly
+                    || !hasRequiredScopes(featureConfig?.applications,
                         featureConfig?.applications?.scopes?.update,
-                        allowedScopes
-                    )
+                        allowedScopes)
                 }
                 data-testid={ `${ testId }-inbound-configuration` }
             />
@@ -85,6 +89,12 @@ export const ProvisioningSettings: FunctionComponent<ProvisioningSettingsPropsIn
                 application={ application }
                 provisioningConfigurations={ provisioningConfigurations }
                 onUpdate={ onUpdate }
+                readOnly={
+                    readOnly
+                    || !hasRequiredScopes(featureConfig?.applications,
+                        featureConfig?.applications?.scopes?.update,
+                        allowedScopes)
+                }
                 data-testid={ `${ testId }-outbound-configuration` }
             />
         </>

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
@@ -55,6 +55,10 @@ interface SignOnMethodsPropsInterface extends SBACInterface<FeatureConfigInterfa
      * Callback to update the application details.
      */
     onUpdate: (id: string) => void;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -74,6 +78,7 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
         featureConfig,
         isLoading,
         onUpdate,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -287,6 +292,7 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
                                         setSelectedRequestPathAuthenticators(values.get("requestPathAuthenticators"));
                                     }
                                 }
+                                readOnly={ readOnly }
                                 data-testid={ `${ testId }-request-path-authenticators` }
                             />
                         </Grid.Column>
@@ -304,9 +310,10 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
                 onUpdate={ handleSequenceUpdate }
                 triggerUpdate={ updateTrigger }
                 readOnly={
-                    !hasRequiredScopes(
-                        featureConfig?.applications, featureConfig?.applications?.scopes?.update, allowedScopes
-                    )
+                    readOnly
+                    || !hasRequiredScopes(featureConfig?.applications,
+                        featureConfig?.applications?.scopes?.update,
+                        allowedScopes)
                 }
                 data-testid={ `${ testId }-step-based-flow` }
                 updateSteps={ updateSteps }
@@ -317,9 +324,10 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
                 onTemplateSelect={ handleLoadingDataFromTemplate }
                 onScriptChange={ handleAdaptiveScriptChange }
                 readOnly={
-                    !hasRequiredScopes(
-                        featureConfig?.applications, featureConfig?.applications?.scopes?.update, allowedScopes
-                    )
+                    readOnly
+                    || !hasRequiredScopes(featureConfig?.applications,
+                        featureConfig?.applications?.scopes?.update,
+                        allowedScopes)
                 }
                 data-testid={ `${ testId }-script-based-flow` }
                 authenticationSteps={ steps }
@@ -327,11 +335,12 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
             />
             { requestPathAuthenticators && showRequestPathAuthenticators }
             {
-                hasRequiredScopes(
+                !readOnly
+                && hasRequiredScopes(
                     featureConfig?.applications,
                     featureConfig?.applications?.scopes?.update,
-                    allowedScopes
-                ) && (
+                    allowedScopes)
+                && (
                     <>
                         <Divider hidden />
                         <PrimaryButton

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
@@ -210,12 +210,16 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
                     data-testid={ testId }
                 >
                     <Heading className="step-header" as="h6">{ t("common:step") } { step.id }</Heading>
-                    <Icon
-                        className="delete-button"
-                        name="cancel"
-                        onClick={ (): void => onStepDelete(stepIndex) }
-                        data-testid={ `${ testId }-delete-button` }
-                    />
+                    {
+                        !readOnly && (
+                            <Icon
+                                className="delete-button"
+                                name="cancel"
+                                onClick={ (): void => onStepDelete(stepIndex) }
+                                data-testid={ `${ testId }-delete-button` }
+                            />
+                        )
+                    }
                     <div className="authentication-step">
                         {
                             (step.options && step.options instanceof Array && step.options.length > 0)

--- a/apps/console/src/features/applications/components/wizard/outbound-provisioining-idp-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/outbound-provisioining-idp-wizard-form.tsx
@@ -33,6 +33,10 @@ interface OutboundProvisioningIdpWizardFormPropsInterface extends TestableCompon
     idpList: any;
     onSubmit: (values: any) => void;
     isEdit?: boolean;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 interface DropdownOptionsInterface {
@@ -58,6 +62,7 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
         triggerSubmit,
         onSubmit,
         isEdit,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
@@ -191,6 +196,7 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
                                         t("devPortal:components.applications.forms.outboundProvisioning.fields" +
                                             ".idp.validations.empty")
                                     }
+                                    readOnly={ readOnly }
                                     required={ false }
                                     value={ initialValues?.idp }
                                     listen={ handleIdpChange }
@@ -218,6 +224,7 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
                                 t("devPortal:components.applications.forms.outboundProvisioning.fields" +
                                     ".connector.validations.empty")
                             }
+                            readOnly={ readOnly }
                             required={ true }
                             value={ initialValues?.connector }
                             listen={
@@ -255,6 +262,7 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
                                     setIsRulesChecked(values.get("rules").includes("rules"))
                                 }
                             }
+                            readOnly={ readOnly }
                             data-testid={ `${ testId }-rules-checkbox` }
                         />
                         <Hint>
@@ -276,6 +284,7 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
                                     value: "blocking"
                                 }
                             ] }
+                            readOnly={ readOnly }
                             value={ initialValues?.blocking ? [ "blocking" ] : [] }
                             listen={
                                 (values) => {
@@ -310,6 +319,7 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
                                     setIsJITChecked(values.get("jit").includes("jit"))
                                 }
                             }
+                            readOnly={ readOnly }
                             data-testid={ `${ testId }-jit-checkbox` }
                         />
                         <Hint>
@@ -318,7 +328,7 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
                     </Grid.Column>
                 </Grid.Row>
                 {
-                    isEdit && (
+                    isEdit && !readOnly && (
                         <Grid.Row columns={ 1 }>
                             <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
                                 <PrimaryButton

--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -92,6 +92,13 @@ export class ApplicationManagementConstants {
     public static readonly APP_STATE_URL_SEARCH_PARAM_KEY = "state";
 
     /**
+     * Key for the URL search param for application readonly state.
+     * @constant
+     * @type {string}
+     */
+    public static readonly APP_READ_ONLY_STATE_URL_SEARCH_PARAM_KEY = "readOnly";
+
+    /**
      * Key for the URL search param for client secret hashing enabled flag.
      * @constant
      * @type {string}

--- a/apps/console/src/features/applications/models/application-inbound.ts
+++ b/apps/console/src/features/applications/models/application-inbound.ts
@@ -76,7 +76,7 @@ interface AccessTokenConfigurationInterface {
     type?: string;
     userAccessTokenExpiryInSeconds?: number;
     applicationAccessTokenExpiryInSeconds?: number;
-    bindingType?: string;
+    bindingType?: SupportedAccessTokenBindingTypes | string;
     revokeTokensWhenIDPSessionTerminated?: boolean;
     validateTokenBinding?: boolean;
 }
@@ -425,4 +425,14 @@ export interface OIDCEndpointsInterface {
      * WellKnown endpoint.
      */
     wellKnown?: string;
+}
+
+/**
+ * Enum for the access token binding types.
+ *
+ * @readonly
+ * @enum {string}
+ */
+export enum SupportedAccessTokenBindingTypes {
+    NONE = "None"
 }

--- a/apps/console/src/features/applications/models/application.ts
+++ b/apps/console/src/features/applications/models/application.ts
@@ -28,11 +28,17 @@ import {
  *  Captures the basic details in the applications.
  */
 export interface ApplicationBasicInterface {
+    access?: ApplicationAccessTypes;
     id?: string;
     name: string;
     description?: string;
     accessUrl?: string;
     templateId?: string;
+}
+
+export enum ApplicationAccessTypes {
+    READ = "READ",
+    WRITE = "WRITE"
 }
 
 /**

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -855,6 +855,11 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                     getConfiguredInboundProtocolConfigs={ (configs: object) => {
                         setInboundProtocolConfigs(configs)
                     } }
+                    readOnly={
+                        urlSearchParams.get(
+                            ApplicationManagementConstants.APP_READ_ONLY_STATE_URL_SEARCH_PARAM_KEY
+                        ) === "true"
+                    }
                 />
             </PageLayout>
         </HelpPanelLayout>


### PR DESCRIPTION
## Purpose
New `access` attribute has been introduced to applications listing API and the UI should behave accordingly.

## Goals
Fixes https://github.com/wso2/product-is/issues/8716

## Approach
Read the `access` status from the API response and add `readOnly=true` to the URL as a search param if the application's access is set to `READ`

<img width="1321" alt="Screen Shot 2020-11-12 at 6 32 00 AM" src="https://user-images.githubusercontent.com/25959096/98881823-e7660900-24b0-11eb-80e4-19862f683624.png">

## Known Issues
Since the applications details endpoint(<HOST>/api/server/v1/applications/:id) doesn't return the `access` attribute, if a user refreshes the browser while inside the edit view of a readonly application, the redirect will not have the `readOnly` URL param hence the view will be treated as a normal application.

Possible workaround would be to skip saving paths matching `/console/develop/applications/:id` for redirections.
