### PR TITLE
Fix empty authenticator app list in My Account app

### DIFF
--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
@@ -120,14 +120,14 @@ export const TOTPAuthenticator: React.FunctionComponent<any> = (props): JSX.Elem
                     <Divider hidden />
                     <p className="link" onClick={ refreshCode }>{t(translateKey + "modals.scan.generate")}</p>
                 </Segment>
-                {totpConfig?.apps?.length > 0
+                {totpConfig?.length > 0
                     ? (
                         <Message info>
                             <Message.Header>{t(translateKey + "modals.scan.messageHeading")}</Message.Header>
                             <Message.Content>
                                 {t(translateKey + "modals.scan.messageBody") + " "}
                                 <List bulleted>
-                                    {totpConfig?.apps?.map((app, index) => (
+                                    {totpConfig?.map((app, index) => (
                                         <List.Item key={ index } >
                                             <a
                                                 target="_blank"

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -109,8 +109,8 @@ export class Config {
         return {
             announcements: window["AppUtils"].getConfig().ui.announcements,
             appName: window["AppUtils"].getConfig().ui.appName,
-            authenticatorApp: { apps: [ { link: "", name: "" } ] },
-            copyrightText: `${window["AppUtils"].getConfig().ui.appCopyright} \u00A9 ${ new Date().getFullYear() }`,
+            authenticatorApp: window["AppUtils"].getConfig().ui.authenticatorApp,
+            copyrightText: `${window["AppUtils"].getConfig().ui.appCopyright} \u00A9 ${new Date().getFullYear()}`,
             features: window["AppUtils"].getConfig().ui.features,
             productName: window["AppUtils"].getConfig().ui.productName,
             productVersionConfig: window["AppUtils"].getConfig().ui.productVersionConfig,

--- a/apps/myaccount/src/models/app-config.ts
+++ b/apps/myaccount/src/models/app-config.ts
@@ -100,13 +100,6 @@ export interface AuthenticatorAppInterface {
 }
 
 /**
- * Authenticator app list interface.
- */
-export interface AuthenticatorAppListInterface {
-    apps: AuthenticatorAppInterface[];
-}
-
-/**
  * Dev portal UI config interface.
  */
 export interface UIConfigInterface extends CommonUIConfigInterface {
@@ -122,7 +115,7 @@ export interface UIConfigInterface extends CommonUIConfigInterface {
     /**
      * TOTP authenticator apps.
      */
-    authenticatorApp?: AuthenticatorAppListInterface;
+    authenticatorApp?: AuthenticatorAppInterface[];
 }
 
 /**

--- a/apps/myaccount/src/public/deployment.config.json
+++ b/apps/myaccount/src/public/deployment.config.json
@@ -33,9 +33,7 @@
         "appTitle": "My Account | WSO2 Identity Server",
         "appName": "My Account",
         "appLogoPath": "/assets/images/logo.svg",
-        "authenticatorApp": {
-            "enabled": true
-        },
+        "authenticatorApp": [],
         "features": {
             "applications": {
                 "disabledFeatures": [],


### PR DESCRIPTION
## Purpose
Due to incorrect configurations, an empty authenitcator app list is shown in the My Account app.
![image](https://user-images.githubusercontent.com/20745428/99196130-5c3a8b00-27b0-11eb-9fe0-dd183dc46763.png)

This is because the app is not getting the `authenticatorApp` configuration from the `delpoyment.config.json` file. In addition, the configuration in the file is also wrong. The current config is:
```json
"authenticatorApp": {
    "enabled" : true
}
```

However, the correct configuration should be:
```json
"authenticatorApp": [
    {
        "name": "App Name",
        "link": "https://app.com"
    }
]
```

This PR fixes these issues. 