### PR TITLE
Bump auth SDK version to 0.1.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@asgardio/oidc-js": {
-            "version": "0.1.23",
-            "resolved": "https://registry.npmjs.org/@asgardio/oidc-js/-/oidc-js-0.1.23.tgz",
-            "integrity": "sha512-2/A/wJfqnlnWGKx1vrMbPdl+tqITIs5I5FM6gpj0U49MEG9hDq+AmveSq7mdvVEzxmB5JKjS9R33imYa1UVRew=="
+            "version": "0.1.24",
+            "resolved": "https://registry.npmjs.org/@asgardio/oidc-js/-/oidc-js-0.1.24.tgz",
+            "integrity": "sha512-bHdkvnio9ddWn5P8IhkZfY3qe9pHUnX7BFWYgr5So5AyoE2oqQJiRyeT+//QAaWwsXOOXurRob8+f7OUSjaFbw=="
         },
         "@babel/cli": {
             "version": "7.12.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardio/oidc-js": "^0.1.23",
+        "@asgardio/oidc-js": "^0.1.24",
         "@storybook/addon-actions": "^5.3.3",
         "@storybook/addon-centered": "^5.3.6",
         "@storybook/addon-docs": "^5.3.3",


### PR DESCRIPTION
## Purpose
> This to fix an issue when using session storage with response mode set to `form_post`.