### PR TITLE
Fix template preview not showing in firefox

### DIFF
--- a/apps/console/src/features/email-templates/components/email-template-editor.tsx
+++ b/apps/console/src/features/email-templates/components/email-template-editor.tsx
@@ -86,7 +86,11 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
         if (iframeDoc) {
             /*
              * Trigger a page load in order to update the content
-             * to the iframe document.
+             * to the iframe document. This is a generic issue with firefox
+             * which doesn't update content when the initial content is null in 
+             * an iframe.
+             * 
+             * See also {@link https://stackoverflow.com/questions/7828502/cannot-set-document-body-innerhtml-of-iframe-in-firefox}
              */
             iframeDoc.open();
             iframeDoc.close();

--- a/apps/console/src/features/email-templates/components/email-template-editor.tsx
+++ b/apps/console/src/features/email-templates/components/email-template-editor.tsx
@@ -83,7 +83,6 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
      */
     const writeToIframe = (): void => {
         // This interval will wait till the iframe is initialized to show content.
-        
         const inter = window.setInterval(function() {
             const iframeDoc = iframe?.current?.contentDocument || iframe?.current?.contentWindow?.document;
 

--- a/apps/console/src/features/email-templates/components/email-template-editor.tsx
+++ b/apps/console/src/features/email-templates/components/email-template-editor.tsx
@@ -82,16 +82,16 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
      * Write content to iFrame.
      */
     const writeToIframe = (): void => {
-        // This interval will wait till the iframe is initialized to show content.
-        const inter = window.setInterval(function() {
-            const iframeDoc = iframe?.current?.contentDocument || iframe?.current?.contentWindow?.document;
-
-            if(iframeDoc.readyState == "complete") {
-
-                window.clearInterval(inter);
-                iframeDoc.body.innerHTML = updatedContent.current;
-            }
-        },100);
+        const iframeDoc = iframe?.current?.contentDocument || iframe?.current?.contentWindow?.document;
+        if (iframeDoc) {
+            /*
+             * Trigger a page load in order to update the content
+             * to the iframe document.
+             */
+            iframeDoc.open();
+            iframeDoc.close();
+            iframeDoc.body.innerHTML = updatedContent.current;
+        }
     };
 
     return (

--- a/apps/console/src/features/email-templates/components/email-template-editor.tsx
+++ b/apps/console/src/features/email-templates/components/email-template-editor.tsx
@@ -66,7 +66,7 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
 
     useEffect(() => {
         writeToIframe();
-    }, [ content ]);
+    }, [ updatedContent.current ]);
 
     useEffect(() => {
         if (isAddFlow && isSignature) {
@@ -82,10 +82,17 @@ export const EmailTemplateEditor: FunctionComponent<EmailTemplateEditorPropsInte
      * Write content to iFrame.
      */
     const writeToIframe = (): void => {
-        const iframeDoc = iframe?.current?.contentDocument || iframe?.current?.contentWindow?.document;
-        if (iframeDoc) {
-            iframeDoc.body.innerHTML = content;
-        }
+        // This interval will wait till the iframe is initialized to show content.
+        
+        const inter = window.setInterval(function() {
+            const iframeDoc = iframe?.current?.contentDocument || iframe?.current?.contentWindow?.document;
+
+            if(iframeDoc.readyState == "complete") {
+
+                window.clearInterval(inter);
+                iframeDoc.body.innerHTML = updatedContent.current;
+            }
+        },100);
     };
 
     return (


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/10417

## Goals
To fix the previewing of the user entered email template content

## Approach
Added a timeout to wait till the `iframe` initialise to load the content.
