### PR TITLE
[Console] Disable actions from the default authenticator

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -459,7 +459,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
      * @param {FederatedAuthenticatorWithMetaInterface} auth - Authenticator.
      * @returns true if {@code auth.data.isDefault} is truthy
      */
-    const _isDefaultAuthenticatorPredicate = (
+    const isDefaultAuthenticatorPredicate = (
         auth: FederatedAuthenticatorWithMetaInterface
     ): boolean => {
         return auth.data?.isDefault;
@@ -474,10 +474,10 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
      * @param authenticator
      * @returns SegmentedAccordionTitleActionInterface
      */
-    const _createAccordionActions = (
+    const createAccordionActions = (
         authenticator: FederatedAuthenticatorWithMetaInterface
     ): SegmentedAccordionTitleActionInterface[] => {
-        const isDefaultAuthenticator = _isDefaultAuthenticatorPredicate(authenticator);
+        const isDefaultAuthenticator = isDefaultAuthenticatorPredicate(authenticator);
         return [
             // Checkbox which triggers the default state of authenticator.
             {
@@ -525,7 +525,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                         key={ index }
                                         globalActions={ [
                                             {
-                                                disabled: _isDefaultAuthenticatorPredicate(authenticator),
+                                                disabled: isDefaultAuthenticatorPredicate(authenticator),
                                                 icon: "trash alternate",
                                                 onClick: handleAuthenticatorDeleteOnClick,
                                                 popoverText: "Remove Authenticator",
@@ -535,7 +535,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                         authenticators={
                                             [
                                                 {
-                                                    actions: _createAccordionActions(authenticator),
+                                                    actions: createAccordionActions(authenticator),
                                                     content: authenticator && (
                                                         <AuthenticatorFormFactory
                                                             metadata={ authenticator.meta }

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -455,17 +455,14 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
     /**
      * A predicate that checks whether a give federated authenticator
      * is a default authenticator.
-     * @param auth
+     *
+     * @param {FederatedAuthenticatorWithMetaInterface} auth - Authenticator.
      * @returns true if {@code auth.data.isDefault} is truthy
      */
     const _isDefaultAuthenticatorPredicate = (
         auth: FederatedAuthenticatorWithMetaInterface
     ): boolean => {
-        if (auth.data == void 0) { // Safe unwrap
-            return false;
-        } else {
-            return auth.data.isDefault;
-        }
+        return auth.data?.isDefault;
     }
 
     /**

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -18,7 +18,13 @@
 
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ConfirmationModal, ContentLoader, EmptyPlaceholder, PrimaryButton, SegmentedAccordionTitleActionInterface } from "@wso2is/react-components";
+import {
+    ConfirmationModal,
+    ContentLoader,
+    EmptyPlaceholder,
+    PrimaryButton,
+    SegmentedAccordionTitleActionInterface
+} from "@wso2is/react-components";
 import _ from "lodash";
 import React, { FormEvent, FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -18,7 +18,7 @@
 
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ConfirmationModal, ContentLoader, EmptyPlaceholder, PrimaryButton } from "@wso2is/react-components";
+import { ConfirmationModal, ContentLoader, EmptyPlaceholder, PrimaryButton, SegmentedAccordionTitleActionInterface } from "@wso2is/react-components";
 import _ from "lodash";
 import React, { FormEvent, FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -446,6 +446,61 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         );
     };
 
+    /**
+     * A predicate that checks whether a give federated authenticator
+     * is a default authenticator.
+     * @param auth
+     * @returns true if {@code auth.data.isDefault} is truthy
+     */
+    const _isDefaultAuthenticatorPredicate = (
+        auth: FederatedAuthenticatorWithMetaInterface
+    ): boolean => {
+        if (auth.data == void 0) { // Safe unwrap
+            return false;
+        } else {
+            return auth.data.isDefault;
+        }
+    }
+
+    /**
+     * A helper function that generates {@link SegmentedAccordionTitleActionInterface}
+     * accordion actions foreach {@code availableAuthenticators} when rendering a
+     * {@link AuthenticatorAccordion}
+     *
+     * @see AuthenticatorAccordionItemInterface.actions
+     * @param authenticator
+     * @returns SegmentedAccordionTitleActionInterface
+     */
+    const _createAccordionActions = (
+        authenticator: FederatedAuthenticatorWithMetaInterface
+    ): SegmentedAccordionTitleActionInterface[] => {
+        const isDefaultAuthenticator = _isDefaultAuthenticatorPredicate(authenticator);
+        return [
+            // Checkbox which triggers the default state of authenticator.
+            {
+                defaultChecked: isDefaultAuthenticator,
+                disabled: authenticator.data?.isDefault || !authenticator.data?.isEnabled,
+                label: t(isDefaultAuthenticator ?
+                    "devPortal:components.idp.forms.authenticatorAccordion.default.0" :
+                    "devPortal:components.idp.forms.authenticatorAccordion.default.1"
+                ),
+                onChange: handleDefaultAuthenticatorChange,
+                type: "checkbox"
+            },
+            // Toggle Switch which enables/disables the authenticator state.
+            {
+                defaultChecked: authenticator.data?.isEnabled,
+                label: t(authenticator.data?.isEnabled ?
+                    "devPortal:components.idp.forms.authenticatorAccordion.enable.0" :
+                    "devPortal:components.idp.forms.authenticatorAccordion.enable.1"
+                ),
+                disabled: isDefaultAuthenticator,
+                onChange: handleAuthenticatorEnableToggle,
+                type: "toggle"
+            }
+        ];
+    };
+
     const showAuthenticatorList = (): ReactElement => {
         return (
             <Grid>
@@ -467,38 +522,17 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                         key={ index }
                                         globalActions={ [
                                             {
+                                                disabled: _isDefaultAuthenticatorPredicate(authenticator),
                                                 icon: "trash alternate",
                                                 onClick: handleAuthenticatorDeleteOnClick,
-                                                type: "icon"
+                                                popoverText: "Remove Authenticator",
+                                                type: "icon",
                                             }
                                         ] }
                                         authenticators={
                                             [
                                                 {
-                                                    actions: [
-                                                        {
-                                                            defaultChecked: authenticator.data?.isDefault,
-                                                            disabled: (authenticator.data?.isDefault ||
-                                                                !authenticator.data?.isEnabled),
-                                                            label: (authenticator.data?.isDefault
-                                                                ? t("devPortal:components.idp.forms." +
-                                                                    "authenticatorAccordion.default.0")
-                                                                : t("devPortal:components.idp.forms." +
-                                                                    "authenticatorAccordion.default.1")),
-                                                            onChange: handleDefaultAuthenticatorChange,
-                                                            type: "checkbox"
-                                                        },
-                                                        {
-                                                            defaultChecked: authenticator.data?.isEnabled,
-                                                            label: (authenticator.data?.isEnabled
-                                                                ? t("devPortal:components.idp.forms." +
-                                                                    "authenticatorAccordion.enable.0")
-                                                                : t("devPortal:components.idp.forms." +
-                                                                    "authenticatorAccordion.enable.1")),
-                                                            onChange: handleAuthenticatorEnableToggle,
-                                                            type: "toggle"
-                                                        }
-                                                    ],
+                                                    actions: _createAccordionActions(authenticator),
                                                     content: authenticator && (
                                                         <AuthenticatorFormFactory
                                                             metadata={ authenticator.meta }

--- a/modules/react-components/src/components/accordion/segmented-accordion/segmented-accordion-title.tsx
+++ b/modules/react-components/src/components/accordion/segmented-accordion/segmented-accordion-title.tsx
@@ -100,6 +100,11 @@ export interface StrictSegmentedAccordionTitleActionInterface {
      * Text for the popover.
      */
     popoverText?: string;
+    /**
+     * Inactive status of this action element.
+     * Default value is always false {@link SegmentedAccordionTitle.defaultProps}
+     */
+    disabled?: boolean;
 }
 
 /**
@@ -169,6 +174,7 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
             onClick,
             popoverText,
             type,
+            disabled,
             ...actionsRest
         } = action;
 
@@ -178,9 +184,11 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
                     <Checkbox
                         toggle
                         label={ label }
+                        disabled={ disabled }
                         onChange={
                             (e: FormEvent<HTMLInputElement>, data: CheckboxProps) => handleActionOnClick(
-                                onChange, e, data, id)
+                                onChange, e, data, id
+                            )
                         }
                         data-testid={ `${ testId }-${ action.type }-action-${ index }` }
                         { ...actionsRest }
@@ -191,6 +199,7 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
                 return (
                     <Checkbox
                         label={ label }
+                        disabled={ disabled }
                         onChange={
                             (e: FormEvent<HTMLInputElement>, data: CheckboxProps) => handleActionOnClick(
                                 onChange, e, data, id)
@@ -204,7 +213,7 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
                 if (typeof icon === "string") {
                     return (
                         <Popup
-                            disabled={ !popoverText }
+                            disabled={ disabled || !popoverText }
                             trigger={ (
                                 <div>
                                     <GenericIcon
@@ -212,9 +221,16 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
                                         defaultIcon
                                         link
                                         inline
+                                        disabled={ disabled }
                                         transparent
                                         verticalAlign="middle"
-                                        icon={ <Icon name={ icon as SemanticICONS } color="grey"/> }
+                                        icon={
+                                            <Icon
+                                                name={ icon as SemanticICONS }
+                                                color="grey"
+                                                className={ classNames({"disabled": disabled}, "") }
+                                            />
+                                        }
                                         onClick={
                                             (e: MouseEvent<HTMLDivElement>) => handleActionOnClick(onClick, e, id)
                                         }
@@ -231,7 +247,7 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
 
                 return (
                     <Popup
-                        disabled={ !popoverText }
+                        disabled={ disabled || !popoverText }
                         trigger={ (
                             <div>
                                 <GenericIcon
@@ -239,6 +255,7 @@ export const SegmentedAccordionTitle: FunctionComponent<SegmentedAccordionTitleP
                                     defaultIcon
                                     link
                                     inline
+                                    disabled={ disabled }
                                     transparent
                                     verticalAlign="middle"
                                     onClick={ (e: MouseEvent<HTMLDivElement>) => handleActionOnClick(onClick, e, id) }
@@ -319,6 +336,7 @@ SegmentedAccordionTitle.defaultProps = {
     attached: true,
     clearing: false,
     "data-testid": "segmented-accordion-title",
+    disabled: false,
     hideChevron: false,
     useEmphasizedSegments: true
 };

--- a/modules/react-components/src/components/icon/generic-icon.tsx
+++ b/modules/react-components/src/components/icon/generic-icon.tsx
@@ -19,7 +19,7 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { PropsWithChildren, ReactElement } from "react";
-import { SemanticVERTICALALIGNMENTS } from "semantic-ui-react";
+import { Icon, SemanticICONS, SemanticVERTICALALIGNMENTS } from "semantic-ui-react";
 
 /**
  * Proptypes for the Generic Icon component.
@@ -45,6 +45,11 @@ export interface GenericIconProps extends TestableComponentInterface {
      * Should the icon appear default i.e grey.
      */
     defaultIcon?: boolean;
+    /**
+     * Inactive status of this icon element.
+     * The default value is always false. Refer {@link GenericIcon.defaultProps}
+     */
+    disabled?: boolean;
     /**
      * Icon fill color.
      */
@@ -162,6 +167,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
         className,
         colored,
         defaultIcon,
+        disabled,
         fill,
         floated,
         hoverable,
@@ -191,6 +197,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
         "bordered": bordered,
         "colored": colored,
         "default": defaultIcon,
+        "disabled": disabled,
         [ typeof fill === "boolean" ? "fill-default" : `fill-${ fill }` ]: fill,
         [`floated-${floated}`]: floated,
         hoverable,
@@ -211,54 +218,87 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
     }, className);
 
     /**
-     * Constructs the icon.
-     * TODO: Add a default icon if the an error occurs rather than returning null.
+     * A default icon if the {@code icon:Icon} null
+     * or empty. For usage {@see constructContent}
+     */
+    const _defaultIconPlaceholder = () => {
+        return <Icon
+            name={ "question" as SemanticICONS }
+            className={ classNames({ "disabled": disabled }, "") }
+            color="grey"
+        />;
+    };
+
+    /**
+     * The icon click action handler. It first checks whether the icon
+     * is disabled or not. And if disabled is {@code true} it will never
+     * fire the provided {@code onClick} handler.
+     *
+     * @param event React.MouseEvent<HTMLDivElement>
+     */
+    const _onIconClickHandler = (event: React.MouseEvent<HTMLDivElement>): void => {
+        if (!disabled) {
+            onClick(event);
+        }
+        // No Operations
+    };
+
+    /**
+     * Constructs the icon. This function is a impure function which depends
+     * on {@code Icon} value above. The {@code Icon} can be one of type from below list: -
+     *
+     * 1. {@link SVGElement}
+     * 2. ReactComponent
+     * 3. {@link React.FunctionComponent}
+     * 4. {@link React.Component}
+     * 5. {@link string} URL or BASE-64 encoded.
      *
      * @return {HTMLElement | SVGElement | React.ReactElement}
      */
     const constructContent = (): HTMLElement | SVGElement | ReactElement | JSX.Element => {
-        if (!Icon) {
-            return null;
-        }
+
+        // If there's no icon passed to this via the parent
+        // then it will return a default icon.
+        if (!Icon) return _defaultIconPlaceholder();
 
         try {
             // Check if the icon is an SVG element
             if (Icon instanceof SVGElement) {
                 return Icon;
             }
-
             // Check if the icon is a module and has `ReactComponent` property.
             // Important when used with SVG's imported with `@svgr/webpack`.
             if (Object.prototype.hasOwnProperty.call(Icon,"ReactComponent")
                 && typeof Icon.ReactComponent === "function") {
-
                 return <Icon.ReactComponent/>;
             }
-
             // Check is icon is a component.
             if (typeof Icon === "function") {
                 return <Icon />;
             }
-
             // Check is icon is a component.
             if (typeof Icon === "object") {
                 return Icon;
             }
-
             // Check if icon passed in is a string. Can be a URL or a base64 encoded.
             if (typeof Icon === "string") {
                 return <img src={ Icon } className="icon" alt="icon"/>;
             }
         } catch (e) {
-            return null;
+            return _defaultIconPlaceholder();
         }
+
     };
 
     return (
-        <div className={ `theme-icon ${classes}` } style={ style } onClick={ onClick } data-testid={ testId }>
+        <div className={ `theme-icon ${classes}` }
+             style={ style }
+             onClick={ _onIconClickHandler }
+             data-testid={ testId }>
             { constructContent() }
         </div>
     );
+
 };
 
 /**
@@ -269,6 +309,7 @@ GenericIcon.defaultProps = {
     bordered: false,
     className: "",
     "data-testid": "generic-icon",
+    disabled: false,
     defaultIcon: false,
     floated: null,
     hoverType: "rounded",

--- a/modules/react-components/src/components/icon/generic-icon.tsx
+++ b/modules/react-components/src/components/icon/generic-icon.tsx
@@ -221,7 +221,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
      * A default icon if the {@code icon:Icon} null
      * or empty. For usage {@see constructContent}
      */
-    const _defaultIconPlaceholder = () => {
+    const defaultIconPlaceholder = () => {
         return <Icon
             name={ "question" as SemanticICONS }
             className={ classNames({ "disabled": disabled }, "") }
@@ -236,7 +236,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
      *
      * @param event React.MouseEvent<HTMLDivElement>
      */
-    const _onIconClickHandler = (event: React.MouseEvent<HTMLDivElement>): void => {
+    const onIconClickHandler = (event: React.MouseEvent<HTMLDivElement>): void => {
         if (!disabled) {
             onClick(event);
         }
@@ -259,7 +259,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
 
         // If there's no icon passed to this via the parent
         // then it will return a default icon.
-        if (!Icon) return _defaultIconPlaceholder();
+        if (!Icon) return defaultIconPlaceholder();
 
         try {
             // Check if the icon is an SVG element
@@ -285,7 +285,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
                 return <img src={ Icon } className="icon" alt="icon"/>;
             }
         } catch (e) {
-            return _defaultIconPlaceholder();
+            return defaultIconPlaceholder();
         }
 
     };
@@ -293,7 +293,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
     return (
         <div className={ `theme-icon ${classes}` }
              style={ style }
-             onClick={ _onIconClickHandler }
+             onClick={ onIconClickHandler }
              data-testid={ testId }>
             { constructContent() }
         </div>


### PR DESCRIPTION
## Purpose
Disable the delete button and enable switch from the default authenticator in the `console` application. #10586
Resolves https://github.com/wso2/product-is/issues/10586

## Goals
To disable the actions of `default authentication` in the authenticator list. It should not allow the user to click on `delete` or `enable | disable` switch elements when its the default.

## Approach
Extended the standalone icon component (`modules/react-components/src/components/icon`) in `@wso2is/react-components` to support icon disable functionality.

![#10586](https://user-images.githubusercontent.com/25561152/100274144-f2766a00-2f83-11eb-8db2-7edfc6f392e1.gif)
