### PR TITLE
Send application name as the reference for logincontext endpoint

### DIFF
--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -119,9 +119,9 @@
 
     // Login context request url.
     String sessionDataKey = request.getParameter("sessionDataKey");
-    String relyingParty = request.getParameter("relyingParty");
-    String loginContextRequestUrl = logincontextURL + "?sessionDataKey=" + sessionDataKey + "&relyingParty="
-            + relyingParty;
+    String appName = request.getParameter("sp");
+    String loginContextRequestUrl = logincontextURL + "?sessionDataKey=" + sessionDataKey + "&application="
+            + appName;
     if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
         // We need to send the tenant domain as a query param only in non tenant qualified URL mode.
         loginContextRequestUrl += "&tenantDomain=" + tenantDomain;


### PR DESCRIPTION
## Purpose
Send application name as the reference for logincontext endpoint. 
In https://github.com/wso2/carbon-identity-framework/pull/3274, instead of registry config, access URL of the application is used as the redirect URL. 

In this PR, the application name is sent as an input parameter to retrieve the redirect URL.
