### PR TITLE
Fix connector accordion default and switch toggle action button status labels issue

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -329,7 +329,6 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
     const createAccordionActions = (
         connector: OutboundProvisioningConnectorWithMetaInterface
     ): SegmentedAccordionTitleActionInterface[] => {
-        const isDefaultConnector = connector.data?.isDefault;
         return [
             // Toggle Switch which enables/disables the connector state.
             {

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -206,6 +206,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
      */
     const handleDeleteConnector = (deletingConnector: OutboundProvisioningConnectorWithMetaInterface): void => {
 
+        const EMPTY_STRING = "";
         const connectorList = [];
 
         availableConnectors.map((connector) => {
@@ -216,7 +217,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
 
         const data = {
             connectors: connectorList,
-            defaultConnectorId: identityProvider.provisioning.outboundConnectors.defaultConnectorId
+            defaultConnectorId: EMPTY_STRING
         };
 
         updateOutboundProvisioningConnectors(data, identityProvider.id)

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -380,6 +380,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                                                         globalActions = {
                                                             [
                                                                 {
+                                                                    disabled: connector.data?.isDefault,
                                                                     icon: "trash alternate",
                                                                     onClick: handleAuthenticatorDeleteOnClick,
                                                                     type: "icon"

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -338,7 +338,6 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                     "console:develop.features.idp.forms.outboundConnectorAccordion.enable.0" :
                     "console:develop.features.idp.forms.outboundConnectorAccordion.enable.1"
                 ),
-                disabled: isDefaultConnector,
                 onChange: handleConnectorEnableToggle,
                 type: "toggle"
             }

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -325,6 +325,36 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
         }
     };
 
+    const createAccordionActions = (
+        connector: OutboundProvisioningConnectorWithMetaInterface
+    ): SegmentedAccordionTitleActionInterface[] => {
+        const isDefaultConnector = connector.data?.isDefault;
+        return [
+            // Checkbox which triggers the default state of connector.
+            {
+                defaultChecked: isDefaultConnector,
+                disabled: connector.data?.isDefault || !connector.data?.isEnabled,
+                label: t(isDefaultConnector ?
+                    "devPortal:components.idp.forms.outboundConnectorAccordion.default.0" :
+                    "devPortal:components.idp.forms.outboundConnectorAccordion.default.1"
+                ),
+                onChange: handleDefaultConnectorChange,
+                type: "checkbox"
+            },
+            // Toggle Switch which enables/disables the connector state.
+            {
+                defaultChecked: connector.data?.isEnabled,
+                label: t(connector.data?.isEnabled ?
+                    "devPortal:components.idp.forms.outboundConnectorAccordion.enable.0" :
+                    "devPortal:components.idp.forms.outboundConnectorAccordion.enable.1"
+                ),
+                disabled: isDefaultConnector,
+                onChange: handleConnectorEnableToggle,
+                type: "toggle"
+            }
+        ];
+    };
+
     return (
         <EmphasizedSegment>
             <Grid.Row>

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -289,19 +289,6 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
     };
 
     /**
-     * Handles default connector change event.
-     *
-     * @param {React.FormEvent<HTMLInputElement>} e - Event.
-     * @param {CheckboxProps} data - Checkbox data.
-     * @param {string} id - Id of the connector.
-     */
-    const handleDefaultConnectorChange = (e: FormEvent<HTMLInputElement>, data: CheckboxProps, id: string): void => {
-        const connector = availableConnectors.find(connector => (connector.id === id)).data;
-        connector.isDefault = data.checked;
-        handleConnectorConfigFormSubmit(connector);
-    };
-
-    /**
      * Handles connector enable toggle.
      *
      * @param {React.FormEvent<HTMLInputElement>} e - Event.

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -330,23 +330,12 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
     ): SegmentedAccordionTitleActionInterface[] => {
         const isDefaultConnector = connector.data?.isDefault;
         return [
-            // Checkbox which triggers the default state of connector.
-            {
-                defaultChecked: isDefaultConnector,
-                disabled: connector.data?.isDefault || !connector.data?.isEnabled,
-                label: t(isDefaultConnector ?
-                    "devPortal:components.idp.forms.outboundConnectorAccordion.default.0" :
-                    "devPortal:components.idp.forms.outboundConnectorAccordion.default.1"
-                ),
-                onChange: handleDefaultConnectorChange,
-                type: "checkbox"
-            },
             // Toggle Switch which enables/disables the connector state.
             {
                 defaultChecked: connector.data?.isEnabled,
                 label: t(connector.data?.isEnabled ?
-                    "devPortal:components.idp.forms.outboundConnectorAccordion.enable.0" :
-                    "devPortal:components.idp.forms.outboundConnectorAccordion.enable.1"
+                    "console:develop.features.idp.forms.outboundConnectorAccordion.enable.0" :
+                    "console:develop.features.idp.forms.outboundConnectorAccordion.enable.1"
                 ),
                 disabled: isDefaultConnector,
                 onChange: handleConnectorEnableToggle,
@@ -400,24 +389,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                                                         authenticators={
                                                             [
                                                                 {
-                                                                    actions: [
-                                                                        {
-                                                                            defaultChecked: connector.data?.isDefault,
-                                                                            label: t("console:develop.features.idp." +
-                                                                                "forms.outboundConnectorAccordion." +
-                                                                                "default"),
-                                                                            onChange: handleDefaultConnectorChange,
-                                                                            type: "checkbox"
-                                                                        },
-                                                                        {
-                                                                            defaultChecked: connector?.data?.isEnabled,
-                                                                            label: t("console:develop.features.idp." +
-                                                                                "forms.outboundConnectorAccordion." +
-                                                                                "enable"),
-                                                                            onChange: handleConnectorEnableToggle,
-                                                                            type: "toggle"
-                                                                        }
-                                                                    ],
+                                                                    actions: createAccordionActions(connector),
                                                                     content: (
                                                                         <OutboundProvisioningConnectorFormFactory
                                                                             metadata={ connector.meta }

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -24,7 +24,8 @@ import {
     EmphasizedSegment,
     EmptyPlaceholder,
     Heading,
-    PrimaryButton
+    PrimaryButton,
+    SegmentedAccordionTitleActionInterface
 } from "@wso2is/react-components";
 import React, { FormEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -41,8 +42,8 @@ import {
 import {
     IdentityProviderInterface,
     OutboundProvisioningConnectorInterface,
-    OutboundProvisioningConnectorWithMetaInterface,
-    OutboundProvisioningConnectorsInterface
+    OutboundProvisioningConnectorsInterface,
+    OutboundProvisioningConnectorWithMetaInterface
 } from "../../models";
 import { OutboundProvisioningConnectorFormFactory } from "../forms";
 import {

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -381,7 +381,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                                                         globalActions = {
                                                             [
                                                                 {
-                                                                    disabled: connector.data?.isDefault,
+                                                                    disabled: connector.data?.isEnabled,
                                                                     icon: "trash alternate",
                                                                     onClick: handleAuthenticatorDeleteOnClick,
                                                                     type: "icon"

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -941,8 +941,14 @@ export interface ConsoleNS {
                         };
                     };
                     outboundConnectorAccordion: {
-                        default: string;
-                        enable: string;
+                        default: {
+                            0: string;
+                            1: string;
+                        };
+                        enable: {
+                            0: string;
+                            1: string;
+                        };
                     };
                     common: {
                         requiredErrorMessage: string;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -2380,8 +2380,14 @@ export const console: ConsoleNS = {
                         }
                     },
                     outboundConnectorAccordion: {
-                        default: "Make default",
-                        enable: "Enabled"
+                        default: {
+                            0: "Default",
+                            1: "Make default"
+                        },
+                        enable: {
+                            0: "Enabled",
+                            1: "Disabled"
+                        }
                     },
                     outboundProvisioningRoles: {
                         heading: "OutBound Provisioning Roles",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -2369,8 +2369,14 @@ export const console: ConsoleNS = {
                         }
                     },
                     outboundConnectorAccordion: {
-                        default: "Mettre par défaut",
-                        enable: "Activé"
+                        default: {
+                            0: "Défaut",
+                            1: "Mettre par défaut"
+                        },
+                        enable: {
+                            0: "Activé",
+                            1: "Désactivé"
+                        }
                     },
                     outboundProvisioningRoles: {
                         heading: "Approvisionnement externe des rôles",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -2386,8 +2386,14 @@ export const console: ConsoleNS = {
                         }
                     },
                     outboundConnectorAccordion: {
-                        default: "පෙරනිමිය කරන්න",
-                        enable: "සක්‍රීය කර ඇත"
+                        default: {
+                            0: "පෙරනිමිය",
+                            1: "පෙරනිමිය කරන්න"
+                        },
+                        enable: {
+                            0: "සක්‍රීය කර ඇත",
+                            1: "ආබාඅක්‍රීය කර ඇතධිතයි"
+                        }
                     },
                     outboundProvisioningRoles: {
                         heading: "පිටතට යන ප්‍රතිපාදන කාර්යභාරය",


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-is/issues/9415

## Goals
- [x] To dynamically change the label of Default toggle button as `Default` and `Make Default`
- [x] To dynamically change the label of Enable switch button as `Enabled` & `Disabled`.
- [x] To disable the  trash icon / delete action when it's the `default connector`

## Implementation
![fix](https://user-images.githubusercontent.com/25561152/101178588-33027180-366f-11eb-8df9-67c3c13e6244.gif)
