### PR TITLE
Add ability to configure id_token leeway

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -22,7 +22,7 @@ import {
     Hooks,
     IdentityClient,
     OIDC_SESSION_IFRAME_ENDPOINT,
-    ResponseModeTypes,
+    ResponseMode,
     ServiceResourcesType,
     Storage,
     TOKEN_ENDPOINT,
@@ -152,9 +152,9 @@ export const initializeAuthentication = () => (dispatch) => {
 
     const auth = IdentityClient.getInstance();
 
-    const responseModeFallback: ResponseModeTypes = process.env.NODE_ENV === "production"
-        ? "form_post"
-        : "query";
+    const responseModeFallback: ResponseMode = process.env.NODE_ENV === "production"
+        ? ResponseMode.formPost
+        : ResponseMode.query;
 
     const storageFallback: Storage = new UAParser().getBrowser().name === "IE"
         ? Storage.SessionStorage

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -202,6 +202,7 @@ export const initializeAuthentication = () => (dispatch) => {
             baseUrls: resolveBaseUrls(),
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
+            clockTolerance: window["AppUtils"].getConfig().clockTolerance,
             enablePKCE: window["AppUtils"].getConfig().idpConfigs?.enablePKCE
                 ?? true,
             endpoints: {

--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { ResponseModeTypes, Storage } from "@asgardio/oidc-js";
+import { ResponseMode, Storage } from "@asgardio/oidc-js";
 import {
     CommonConfigInterface,
     CommonDeploymentConfigInterface,
@@ -103,7 +103,7 @@ export interface FeatureConfigInterface {
 /**
  * Portal Deployment config interface inheriting the common configs from core module.
  */
-export interface DeploymentConfigInterface extends CommonDeploymentConfigInterface<ResponseModeTypes, Storage> {
+export interface DeploymentConfigInterface extends CommonDeploymentConfigInterface<ResponseMode, Storage> {
 
     /**
      * Configs of the Admin app.

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -29,6 +29,7 @@
     },
     "idpConfigs": {
         "enablePKCE": true,
+        "clockTolerance": 60,
         "responseMode": "query",
         "scope": [ "SYSTEM" ],
         "serverOrigin": "https://localhost:9443",

--- a/apps/console/test-configs/setup-test.js
+++ b/apps/console/test-configs/setup-test.js
@@ -15,6 +15,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+import { TextDecoder, TextEncoder } from "util";
 require("../jest.config");
 require("@testing-library/jest-dom/extend-expect");
 require("babel-polyfill");
@@ -72,3 +74,8 @@ window.AppUtils = {
 };
 
 window.Worker = Worker;
+
+// jsdom Doesn't seem to have TextEncoder defined in global for the DOM.
+// Hence adding the node.js one. See https://github.com/jsdom/jsdom/issues/2524.
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/apps/myaccount/src/models/app-config.ts
+++ b/apps/myaccount/src/models/app-config.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { ResponseModeTypes, Storage } from "@asgardio/oidc-js";
+import { ResponseMode, Storage } from "@asgardio/oidc-js";
 import {
     CommonConfigInterface,
     CommonDeploymentConfigInterface,
@@ -146,4 +146,4 @@ export interface UIConfigInterface extends CommonUIConfigInterface {
 /**
  * Portal Deployment config interface inheriting the common configs from core module.
  */
-export type DeploymentConfigInterface = CommonDeploymentConfigInterface<ResponseModeTypes, Storage>;
+export type DeploymentConfigInterface = CommonDeploymentConfigInterface<ResponseMode, Storage>;

--- a/apps/myaccount/src/public/deployment.config.json
+++ b/apps/myaccount/src/public/deployment.config.json
@@ -5,6 +5,7 @@
     "debug": false,
     "idpConfigs": {
         "enablePKCE": true,
+        "clockTolerance": 60,
         "responseMode": "query",
         "scope": [ "SYSTEM" ],
         "serverOrigin": "https://localhost:9443",

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -22,7 +22,7 @@ import {
     Hooks,
     IdentityClient,
     OIDC_SESSION_IFRAME_ENDPOINT,
-    ResponseModeTypes,
+    ResponseMode,
     ServiceResourcesType,
     Storage,
     TOKEN_ENDPOINT,
@@ -39,11 +39,7 @@ import { getProfileLinkedAccounts } from ".";
 import { addAlert } from "./global";
 import { setProfileInfoLoader, setProfileSchemaLoader } from "./loaders";
 import { AuthAction, authenticateActionTypes } from "./types";
-import {
-    getProfileInfo,
-    getUserReadOnlyStatus,
-    switchAccount
-} from "../../api";
+import { getProfileInfo, getUserReadOnlyStatus, switchAccount } from "../../api";
 import { Config } from "../../configs";
 import { CommonConstants } from "../../constants";
 import {
@@ -253,9 +249,9 @@ export const initializeAuthentication = () =>(dispatch)=> {
 
     const auth = IdentityClient.getInstance();
 
-    const responseModeFallback: ResponseModeTypes = process.env.NODE_ENV === "production"
-        ? "form_post"
-        : "query";
+    const responseModeFallback: ResponseMode = process.env.NODE_ENV === "production"
+        ? ResponseMode.formPost
+        : ResponseMode.query;
 
     const storageFallback: Storage = new UAParser().getBrowser().name === "IE"
         ? Storage.SessionStorage

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -306,6 +306,7 @@ export const initializeAuthentication = () =>(dispatch)=> {
             baseUrls: resolveBaseUrls(),
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
+            clockTolerance: window["AppUtils"].getConfig().clockTolerance,
             enablePKCE: window["AppUtils"].getConfig().idpConfigs?.enablePKCE
                 ?? true,
             endpoints: {

--- a/apps/myaccount/test-configs/setup-test.ts
+++ b/apps/myaccount/test-configs/setup-test.ts
@@ -17,3 +17,9 @@
  */
 
 import "../node_modules/@testing-library/jest-dom/extend-expect";
+import { TextDecoder, TextEncoder } from "util";
+
+// jsdom Doesn't seem to have TextEncoder defined in global for the DOM.
+// Hence adding the node.js one. See https://github.com/jsdom/jsdom/issues/2524.
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -98,6 +98,22 @@ The Proof Key for Code Exchange (PKCE) is a specification supported by WSO2 Iden
 idp_configs.enablePKCE = true
 ```
 
+#### `clockTolerance`
+
+> :bulb: No value defined in Default JSON
+
+> :checkered_flag: Fallback Value - 60 Seconds (Declared in SDK)
+
+Allowed leeway when validating the id_token. Required to address possible time mismatches between the client and the server.
+[Check the Specification](https://tools.ietf.org/html/rfc7519#page-10)
+
+**Supported Values -** Any number (in Seconds)
+
+```toml
+[console]
+idp_configs.clockTolerance = 120
+```
+
 #### `responseMode`
 
 > :bulb: No value defined in Default JSON

--- a/modules/core/src/models/config.ts
+++ b/modules/core/src/models/config.ts
@@ -297,6 +297,10 @@ export interface IdpConfigInterface<T = {}, S = {}> {
      */
     enablePKCE: boolean;
     /**
+     * Allowed leeway for id_tokens.
+     */
+    clockTolerance: number;
+    /**
      * Authorization code response mode.
      */
     responseMode: T;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,30 @@
     "requires": true,
     "dependencies": {
         "@asgardio/oidc-js": {
-            "version": "0.1.24",
-            "resolved": "https://registry.npmjs.org/@asgardio/oidc-js/-/oidc-js-0.1.24.tgz",
-            "integrity": "sha512-bHdkvnio9ddWn5P8IhkZfY3qe9pHUnX7BFWYgr5So5AyoE2oqQJiRyeT+//QAaWwsXOOXurRob8+f7OUSjaFbw=="
+            "version": "0.1.31",
+            "resolved": "https://registry.npmjs.org/@asgardio/oidc-js/-/oidc-js-0.1.31.tgz",
+            "integrity": "sha512-PwFQLmagu5L4JaTVcvHZ/yh6r03xKW+GOWPLz/fO7eWzF+nA4FdIh4CnBZzMI0hPWJ/aPCxt0SM3t4sfm+wdtg==",
+            "requires": {
+                "@babel/runtime-corejs3": "^7.11.2",
+                "await-semaphore": "^0.1.3",
+                "axios": "^0.21.0",
+                "crypto-js": "^3.1.9-1"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "0.21.0",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
+                    "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+                    "requires": {
+                        "follow-redirects": "^1.10.0"
+                    }
+                },
+                "follow-redirects": {
+                    "version": "1.13.0",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+                    "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+                }
+            }
         },
         "@babel/cli": {
             "version": "7.12.1",
@@ -1175,7 +1196,6 @@
             "version": "7.12.5",
             "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
             "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
-            "dev": true,
             "requires": {
                 "core-js-pure": "^3.0.0",
                 "regenerator-runtime": "^0.13.4"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardio/oidc-js": "^0.1.30",
+        "@asgardio/oidc-js": "^0.1.31",
         "@storybook/addon-actions": "^5.3.3",
         "@storybook/addon-centered": "^5.3.6",
         "@storybook/addon-docs": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "author": "WSO2",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asgardio/oidc-js": "^0.1.24",
+        "@asgardio/oidc-js": "^0.1.30",
         "@storybook/addon-actions": "^5.3.3",
         "@storybook/addon-centered": "^5.3.6",
         "@storybook/addon-docs": "^5.3.3",


### PR DESCRIPTION
## Purpose
Add support for configuring leeway when validating the id_token.

## Goals
Adds support to configure the `clockTolerance` attribute in Asgardio OIDC JS SDK using the app configuration file. (via toml)
Fixes https://github.com/wso2-enterprise/asgardio-product/issues/704

## Approach
`60` seconds is the default `clockTolerance` set from the SDK. You can override this by using the following `deployment.toml` config.

```toml
[console]
idp_configs.clockTolerance = 120
```

Changes were released with https://github.com/asgardio/asgardio-js-oidc-sdk/releases/tag/v0.1.31.

## When to Merge
Once https://github.com/asgardio/asgardio-js-oidc-sdk/pull/81 is merged and the relevant version is bumped in both `Console` & `My Account`.

