### PR TITLE
Pass tenant name from access url to the authorize request

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -203,6 +203,9 @@ export const initializeAuthentication = () => (dispatch) => {
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             clockTolerance: window["AppUtils"].getConfig().clockTolerance,
+            customParams :  {
+                t : window["AppUtils"].getTenantName(true)
+            },
             enablePKCE: window["AppUtils"].getConfig().idpConfigs?.enablePKCE
                 ?? true,
             endpoints: {

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -303,6 +303,9 @@ export const initializeAuthentication = () =>(dispatch)=> {
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             clockTolerance: window["AppUtils"].getConfig().clockTolerance,
+            customParams :  {
+                t : window["AppUtils"].getTenantName(true)
+            },
             enablePKCE: window["AppUtils"].getConfig().idpConfigs?.enablePKCE
                 ?? true,
             endpoints: {


### PR DESCRIPTION
## Purpose
> Pass tenant name from access URL to the authorize request, so that the backend side can have per tenant logic
