### PR TITLE
validate mobile number regex

### DIFF
--- a/apps/sms-otp-authentication-portal/src/main/webapp/mobile.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/mobile.jsp
@@ -23,13 +23,24 @@
 <%@ page import="java.util.Map" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ include file="includes/localize.jsp" %>
+<%@ page import="static java.util.Base64.getDecoder" %>
+<%@ page import="org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 
 <%
     request.getSession().invalidate();
     String queryString = request.getQueryString();
     Map<String, String> idpAuthenticatorMapping = null;
+    String mobileRegex = null;
+    String mobileRegexPolicyValidationErrorMessage = null;
     if (request.getAttribute(Constants.IDP_AUTHENTICATOR_MAP) != null) {
         idpAuthenticatorMapping = (Map<String, String>) request.getAttribute(Constants.IDP_AUTHENTICATOR_MAP);
+    }
+    if (StringUtils.isNotBlank(request.getParameter(SMSOTPConstants.MOBILE_NUMBER_REGEX_PATTERN))) {
+        mobileRegex = new String(getDecoder().decode(request.getParameter(SMSOTPConstants.MOBILE_NUMBER_REGEX_PATTERN)));
+    }
+    if (StringUtils.isNotBlank(request.getParameter(SMSOTPConstants.MOBILE_NUMBER_PATTERN_POLICY_FAILURE_ERROR_MESSAGE))) {
+        mobileRegexPolicyValidationErrorMessage = new String(getDecoder().decode(request.getParameter(SMSOTPConstants.MOBILE_NUMBER_PATTERN_POLICY_FAILURE_ERROR_MESSAGE)));
     }
 
     String errorMessage = IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,"error.retry");
@@ -89,6 +100,7 @@
                             <div class="ui divider hidden"></div>
                     <% } %>
                     <div id="error-msg"></div>
+                    <div id="alertDiv"></div>
                     <div class="segment-form">
                         <form class="ui large form" id="pin_form" name="pin_form" action="../../commonauth"  method="POST">
                             <%
@@ -146,6 +158,10 @@
                         document.getElementById('alertDiv').innerHTML
                             = '<div id="error-msg" class="ui negative message">Please enter the mobile number!</div>'
                               +'<div class="ui divider hidden"></div>';
+                    } else if (!(mobileNumber.match("<%=mobileRegex%>"))) {
+                       document.getElementById('alertDiv').innerHTML
+                          = '<div id="error-msg" class="ui negative message"><%=mobileRegexPolicyValidationErrorMessage%></div>'
+                            +'<div class="ui divider hidden"></div>';
                     } else {
                         $('#pin_form').submit();
                     }


### PR DESCRIPTION
Public Issue : https://github.com/wso2/product-is/issues/10532
Support fix : https://github.com/wso2-support/identity-apps/pull/45
Logic :

Added two idp configurations in sms otp connector.
- Error Regex
- Error message for validation

Both strings will come with response encoded, and here in JSP we decode the strings and check for regex pattern and if validates show error message.

Backend fix: wso2-extensions/identity-outbound-auth-sms-otp#103