### PR TITLE
Fix meta default value show as placeholder

### DIFF
--- a/apps/console/src/features/identity-providers/components/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/helpers/form-fields-helper.tsx
@@ -137,9 +137,8 @@ export const getTextField = (eachProp: CommonPluggableComponentPropertyInterface
                 required={ propertyMetadata?.isMandatory }
                 requiredErrorMessage={ I18n.instance.t("console:develop.features.idp.forms.common." + 
                     "requiredErrorMessage") }
-                placeholder={ propertyMetadata?.defaultValue }
                 type="text"
-                value={ eachProp?.value }
+                value={ eachProp?.value || propertyMetadata?.defaultValue }
                 key={ eachProp?.key }
                 disabled={ disable }
                 data-testid={ `${ testId }-${ propertyMetadata?.key }` }


### PR DESCRIPTION
## Purpose
fixes https://github.com/wso2/product-is/issues/10716

## Goals
metadata default values should be shown as actual values in the generated UI inputs rather than as a placeholder value.

## Approach
If a metadata contains a value, it will be considered as the value of the generated metadata form field else, if there is a default value, it will be used as the value.
