### PR TITLE
Fix listing of super admin permissions for non super admin users

### DIFF
--- a/apps/console/src/features/roles/constants/role-constants.ts
+++ b/apps/console/src/features/roles/constants/role-constants.ts
@@ -46,5 +46,7 @@ export class RoleConstants {
         .set("ROLE_CREATE", "roles.create")
         .set("ROLE_UPDATE", "roles.update")
         .set("ROLE_DELETE", "roles.delete")
-        .set("ROLE_READ", "roles.read")
+        .set("ROLE_READ", "roles.read");
+
+    public static readonly SUPER_ADMIN_PERMISSION_KEY = "/permission/protected";
 }


### PR DESCRIPTION
## Purpose
This PR will fix listing of `super admin permissions` in the role permissions tree for non super admin users. If the user is not a super admin, the tree will be rendered but the `super admin permissions` node and its children will be disabled, yet the user will be able to expand and view the permissions.

<img width="728" alt="Screenshot 2020-12-15 at 12 59 01" src="https://user-images.githubusercontent.com/11191791/102184357-55995380-3ed5-11eb-8f82-9561cdcf10bb.png">

fixes https://github.com/wso2/product-is/issues/10138

## Approach
This uses the `serverConfigs` api from [here](https://is.docs.wso2.com/en/latest/develop/configs-rest-api/#/Server%20Configs/getConfigs) to get the super admin and the value will be checked against the current logged in user.
