### PR TITLE
Add support to extract tenant domain for theming purposes.

### DIFF
--- a/apps/authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/header.jsp
@@ -17,6 +17,7 @@
   --%>
 
 <%@ include file="localize.jsp" %>
+<%@ include file="init-url.jsp" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/authentication-portal/src/main/webapp/includes/init-url.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/init-url.jsp
@@ -18,6 +18,11 @@
 
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="com.google.gson.Gson" %>
 <%
     String identityServerEndpointContextParam = application.getInitParameter("IdentityServerEndpointContextURL");
     String samlssoURL = "../samlsso";
@@ -40,5 +45,22 @@
         tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
     } else {
         tenantDomain = request.getParameter("tenantDomain");
+    }
+    
+    String tenantForTheming = tenantDomain;
+    // Resolve tenant domain for theming purposes.
+    String authenticationAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
+    if (StringUtils.isBlank(authenticationAPIURL)) {
+        authenticationAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
+    }
+    if (!authenticationAPIURL.endsWith("/")) {
+        authenticationAPIURL += "/";
+    }
+    authenticationAPIURL += "context/" + request.getParameter("sessionDataKey");
+    String contextProps = AuthContextAPIClient.getContextProperties(authenticationAPIURL);
+    Gson gson2 = new Gson();
+    Map<String, Object> params = gson2.fromJson(contextProps, Map.class);
+    if (params != null && params.containsKey("t")) {
+        tenantForTheming = (String) params.get("t");
     }
 %>

--- a/apps/email-otp-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/email-otp-authentication-portal/src/main/webapp/includes/header.jsp
@@ -18,6 +18,7 @@
 
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ include file="localize.jsp" %>
+<%@ include file="init-url.jsp" %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">

--- a/apps/email-otp-authentication-portal/src/main/webapp/includes/init-url.jsp
+++ b/apps/email-otp-authentication-portal/src/main/webapp/includes/init-url.jsp
@@ -1,0 +1,52 @@
+<%--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
+
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="com.google.gson.Gson" %>
+<%
+    String tenantDomain;
+    
+    // Try to resolve tenant domain from auth API.
+    String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
+    if (StringUtils.isBlank(authAPIURL)) {
+        authAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
+    }
+    if (!authAPIURL.endsWith("/")) {
+        authAPIURL += "/";
+    }
+    authAPIURL += "context/" + request.getParameter("sessionDataKey");
+    String contextProps = AuthContextAPIClient.getContextProperties(authAPIURL);
+    Gson gson = new Gson();
+    Map<String, Object> params = gson.fromJson(contextProps, Map.class);
+    
+    if (params != null && params.containsKey("t")) {
+        tenantDomain = (String) params.get("t");
+    } else {
+        // If tenant domain is not set in the context, retrieve from other methods.
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+        } else {
+            tenantDomain = request.getParameter("tenantDomain");
+        }
+    }
+%>

--- a/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -17,6 +17,7 @@
 --%>
 
 <jsp:directive.include file="localize.jsp" />
+<jsp:directive.include file="../tenant-resolve.jsp"/>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/recovery-portal/src/main/webapp/tenant-resolve.jsp
+++ b/apps/recovery-portal/src/main/webapp/tenant-resolve.jsp
@@ -19,6 +19,11 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="com.google.gson.Gson" %>
 
 <%
     String tenantDomain;
@@ -29,5 +34,22 @@
         if (StringUtils.isBlank(tenantDomain)) {
             tenantDomain = request.getParameter(IdentityManagementEndpointConstants.TENANT_DOMAIN);
         }
+    }
+    
+    String tenantForTheming = tenantDomain;
+    // Resolve tenant domain for theming purposes.
+    String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
+    if (StringUtils.isBlank(authAPIURL)) {
+        authAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
+    }
+    if (!authAPIURL.endsWith("/")) {
+        authAPIURL += "/";
+    }
+    authAPIURL += "context/" + request.getParameter("sessionDataKey");
+    String contextProps = AuthContextAPIClient.getContextProperties(authAPIURL);
+    Gson gson = new Gson();
+    Map<String, Object> params = gson.fromJson(contextProps, Map.class);
+    if (params != null && params.containsKey("t")) {
+        tenantForTheming = (String) params.get("t");
     }
 %>

--- a/apps/sms-otp-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/includes/header.jsp
@@ -18,6 +18,7 @@
 
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ include file="localize.jsp" %>
+<%@ include file="init-url.jsp" %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">

--- a/apps/sms-otp-authentication-portal/src/main/webapp/includes/init-url.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/includes/init-url.jsp
@@ -1,0 +1,52 @@
+<%--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
+
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="com.google.gson.Gson" %>
+<%
+    String tenantDomain;
+    
+    // Try to resolve tenant domain from auth API.
+    String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
+    if (StringUtils.isBlank(authAPIURL)) {
+        authAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
+    }
+    if (!authAPIURL.endsWith("/")) {
+        authAPIURL += "/";
+    }
+    authAPIURL += "context/" + request.getParameter("sessionDataKey");
+    String contextProps = AuthContextAPIClient.getContextProperties(authAPIURL);
+    Gson gson = new Gson();
+    Map<String, Object> params = gson.fromJson(contextProps, Map.class);
+    
+    if (params != null && params.containsKey("t")) {
+        tenantDomain = (String) params.get("t");
+    } else {
+        // If tenant domain is not set in the context, retrieve from other methods.
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+        } else {
+            tenantDomain = request.getParameter("tenantDomain");
+        }
+    }
+%>

--- a/apps/totp-authentication-portal/pom.xml
+++ b/apps/totp-authentication-portal/pom.xml
@@ -56,6 +56,14 @@
             <artifactId>encoder</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.endpoint.util</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apps/totp-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/totp-authentication-portal/src/main/webapp/includes/header.jsp
@@ -18,6 +18,7 @@
 
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ include file="localize.jsp" %>
+<%@ include file="init-url.jsp" %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">

--- a/apps/totp-authentication-portal/src/main/webapp/includes/init-url.jsp
+++ b/apps/totp-authentication-portal/src/main/webapp/includes/init-url.jsp
@@ -1,0 +1,52 @@
+<%--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
+
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="com.google.gson.Gson" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
+<%
+    String tenantDomain;
+    
+    // Try to resolve tenant domain from auth API.
+    String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
+    if (StringUtils.isBlank(authAPIURL)) {
+        authAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
+    }
+    if (!authAPIURL.endsWith("/")) {
+        authAPIURL += "/";
+    }
+    authAPIURL += "context/" + request.getParameter("sessionDataKey");
+    String contextProps = AuthContextAPIClient.getContextProperties(authAPIURL);
+    Gson gson = new Gson();
+    Map<String, Object> params = gson.fromJson(contextProps, Map.class);
+    
+    if (params != null && params.containsKey("t")) {
+        tenantDomain = (String) params.get("t");
+    } else {
+        // If tenant domain is not set in the context, retrieve from other methods.
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+        } else {
+            tenantDomain = request.getParameter("tenantDomain");
+        }
+    }
+%>

--- a/apps/x509-certificate-authentication-portal/pom.xml
+++ b/apps/x509-certificate-authentication-portal/pom.xml
@@ -56,6 +56,18 @@
             <groupId>org.wso2.orbit.org.owasp.encoder</groupId>
             <artifactId>encoder</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.endpoint.util</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
@@ -18,6 +18,7 @@
 
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ include file="localize.jsp" %>
+<%@ include file="init-url.jsp" %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">

--- a/apps/x509-certificate-authentication-portal/src/main/webapp/includes/init-url.jsp
+++ b/apps/x509-certificate-authentication-portal/src/main/webapp/includes/init-url.jsp
@@ -1,0 +1,52 @@
+<%--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
+
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="com.google.gson.Gson" %>
+<%
+    String tenantDomain;
+    
+    // Try to resolve tenant domain from auth API.
+    String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
+    if (StringUtils.isBlank(authAPIURL)) {
+        authAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
+    }
+    if (!authAPIURL.endsWith("/")) {
+        authAPIURL += "/";
+    }
+    authAPIURL += "context/" + request.getParameter("sessionDataKey");
+    String contextProps = AuthContextAPIClient.getContextProperties(authAPIURL);
+    Gson gson = new Gson();
+    Map<String, Object> params = gson.fromJson(contextProps, Map.class);
+    
+    if (params != null && params.containsKey("t")) {
+        tenantDomain = (String) params.get("t");
+    } else {
+        // If tenant domain is not set in the context, retrieve from other methods.
+        if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
+        } else {
+            tenantDomain = request.getParameter("tenantDomain");
+        }
+    }
+%>


### PR DESCRIPTION
### Purpose
Allow to resolve the tenant domain in all portals including the authentication portal, which can be used to set tenant domain based theming.

Resolves https://github.com/wso2-enterprise/asgardio-product/issues/857

Depends on https://github.com/wso2/identity-apps/pull/1439