### PR TITLE
Fix validation of invalid group name

### DIFF
--- a/apps/console/src/features/groups/components/wizard/group-basics.tsx
+++ b/apps/console/src/features/groups/components/wizard/group-basics.tsx
@@ -17,7 +17,7 @@
  */
 
 import { getUserStoreList } from "@wso2is/core/api";
-import { AlertLevels, TestableComponentInterface, UserStoreDetails } from "@wso2is/core/models";
+import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms, Validation } from "@wso2is/forms";
 import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
@@ -127,11 +127,13 @@ export const GroupBasics: FunctionComponent<GroupBasicProps> = (props: GroupBasi
                     userStoreRegEx = response;
                 });
         } else {
-            await SharedUserStoreUtils.getPrimaryUserStore().then((response: UserStoreDetails) => {
+            await SharedUserStoreUtils.getPrimaryUserStore().then((response) => {
                 setRegExLoading(true);
-                userStoreRegEx = response?.properties.filter(property => 
-                    { return property.name === "RolenameJavaScriptRegEx"; 
-                })[0].value;
+                if (response && response.properties) {
+                    userStoreRegEx = response?.properties?.filter(property => 
+                        { return property.name === "RolenameJavaScriptRegEx"; 
+                    })[0].value;
+                }
             });
         }
 

--- a/apps/console/src/features/groups/components/wizard/group-basics.tsx
+++ b/apps/console/src/features/groups/components/wizard/group-basics.tsx
@@ -17,7 +17,7 @@
  */
 
 import { getUserStoreList } from "@wso2is/core/api";
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertLevels, TestableComponentInterface, UserStoreDetails } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms, Validation } from "@wso2is/forms";
 import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
@@ -127,9 +127,9 @@ export const GroupBasics: FunctionComponent<GroupBasicProps> = (props: GroupBasi
                     userStoreRegEx = response;
                 });
         } else {
-            await SharedUserStoreUtils.getPrimaryUserStore().then(response => {
+            await SharedUserStoreUtils.getPrimaryUserStore().then((response: UserStoreDetails) => {
                 setRegExLoading(true);
-                userStoreRegEx = response.properties.filter(property => 
+                userStoreRegEx = response?.properties.filter(property => 
                     { return property.name === "RolenameJavaScriptRegEx"; 
                 })[0].value;
             });


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/10740

This PR will fix the front end validation for group name when entering invalid characters.

## Approach
If the group is created in the `primary` userstore, the `Group Name RegEx (Javascript)` property for primary user store will be retrieved and tested against the user input or else the relevant `Group Name RegEx (Javascript)` property for the selected user store will be retrieved and tested.

