### PR TITLE
Enable rendering checkboxes for form fields of user profile

### DIFF
--- a/modules/forms/src/forms.tsx
+++ b/modules/forms/src/forms.tsx
@@ -320,7 +320,7 @@ export const Forms: React.FunctionComponent<React.PropsWithChildren<FormPropsInt
                     const value = tempForm.get(inputField.name);
                     (
                         !((value instanceof Array && value.length > 0)
-                            || (!(value instanceof Array) && !!value.trim()))
+                            || (!(value instanceof Array) && value.trim && !!value.trim()))
                         || isReset
                     )
                         && (!isRadioField(inputField) && inputField.required)


### PR DESCRIPTION
Fix: https://github.com/wso2/product-is/issues/10878

Currently, all the fields in the user profile are rendered as text fields. However, in the `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` schema extension, we can define attribute type to be boolean. 
Such fields should be rendered as checkboxes instead of text fields. 