### PR TITLE
Add tenant admin preference for account recovery section in My account

### DIFF
--- a/apps/myaccount/src/api/preference.ts
+++ b/apps/myaccount/src/api/preference.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentityClient } from "@asgardio/oidc-js";
+import { HttpMethods } from "../models";
+import { store } from "../store";
+
+/**
+ * Get an axios instance.
+ *
+ * @type {AxiosHttpClientInstance}
+ */
+const httpClient = IdentityClient.getInstance().httpRequest.bind(IdentityClient.getInstance());
+
+/**
+ * Get account recovery preferences.
+ *
+ * @param data connector & property details
+ */
+export const getPreference = (data: object): Promise<any> => {
+    const requestConfig = {
+        data,
+        headers: {
+            "Accept": "application/json",
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost
+        },
+        method: HttpMethods.POST,
+        url: store.getState().config.endpoints.preference
+    };
+
+    return httpClient(requestConfig)
+        .then((response) => {
+            if (response.status !== 200) {
+                return Promise.reject(new Error("Failed to load account recovery preferences"));
+            }
+
+            return Promise.resolve(response?.data);
+        })
+        .catch((error) => {
+            return Promise.reject(error);
+        });
+};

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -85,6 +85,7 @@ export class Config {
             jwks: `${this.getDeploymentConfig().serverHost}/oauth2/jwks`,
             logout: `${this.getDeploymentConfig().serverHost}/oidc/logout`,
             me: `${this.getDeploymentConfig().serverHost}/scim2/Me`,
+            preference: `${this.getDeploymentConfig().serverHost}/api/server/v1/identity-governance/preferences`,
             profileSchemas: `${this.getDeploymentConfig().serverHost}/scim2/Schemas`,
             revoke: `${this.getDeploymentConfig().serverHost}/oauth2/revoke`,
             sessions: `${this.getDeploymentConfig().serverHost}/api/users/v1/me/sessions`,

--- a/apps/myaccount/src/models/app-config.ts
+++ b/apps/myaccount/src/models/app-config.ts
@@ -77,6 +77,7 @@ export interface ServiceResourceEndpointsInterface {
     jwks: string;
     logout: string;
     me: string;
+    preference: string;
     profileSchemas: string;
     sessions: string;
     smsOtpResend: string;

--- a/apps/myaccount/src/models/index.ts
+++ b/apps/myaccount/src/models/index.ts
@@ -35,3 +35,4 @@ export * from "./app-config";
 export * from "./reducer-state";
 export * from "./ua-parser";
 export * from "./configs";
+export * from "./preference";

--- a/apps/myaccount/src/models/preference.ts
+++ b/apps/myaccount/src/models/preference.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,14 +16,26 @@
  * under the License.
  */
 
-export * from "./applications";
-export * from "./change-password";
-export * from "./linked-accounts";
-export * from "./profile";
-export * from "./security-questions";
-export * from "./multi-factor-fido";
-export * from "./user-sessions";
-export * from "./multi-factor-totp";
-export * from "./verify-mobile-smsotp";
-export * from "./configs";
-export * from "./preference";
+/**
+ * Preference Request model
+ */
+export interface PreferenceRequest {
+    "connector-name": string;
+    properties: string[];
+}
+
+/**
+ * Preference Property model
+ */
+export interface PreferenceProperty {
+    name: string;
+    value: string;
+}
+
+/**
+ * PreferenceConnector Response model
+ */
+export interface PreferenceConnectorResponse {
+    "connector-name": string;
+    properties: PreferenceProperty[];
+}

--- a/modules/i18n/src/models/namespaces/myaccount-ns.ts
+++ b/modules/i18n/src/models/namespaces/myaccount-ns.ts
@@ -72,6 +72,9 @@ export interface MyAccountNS {
                 };
                 heading: string;
             };
+            preference?: {
+                notifications?: Notification;
+            };
             emailRecovery: {
                 descriptions: {
                     add: string;

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -38,8 +38,8 @@ export const myAccount: MyAccountNS = {
                         message: "Something went wrong"
                     },
                     success: {
-                        description: "The email address in the user profile has been updated successfully",
-                        message: "Email Address Updated Successfully"
+                        description: "Successfully retrieved the recovery preference",
+                        message: "Recovery preference retrieval successful"
                     }
                 }
             },

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -27,6 +27,22 @@ export const myAccount: MyAccountNS = {
                 },
                 heading: "Code Recovery"
             },
+            preference: {
+                notifications: {
+                    error: {
+                        description: "{{description}}",
+                        message: "Error getting the recovery preference"
+                    },
+                    genericError: {
+                        description: "Error occurred while getting the recovery preference",
+                        message: "Something went wrong"
+                    },
+                    success: {
+                        description: "The email address in the user profile has been updated successfully",
+                        message: "Email Address Updated Successfully"
+                    }
+                }
+            },
             emailRecovery: {
                 descriptions: {
                     add: "Add or update recovery email address",

--- a/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
@@ -27,6 +27,22 @@ export const myAccount: MyAccountNS = {
                 },
                 heading: "Codes de récupération"
             },
+            preference: {
+                notifications: {
+                    error: {
+                        description: "{{description}}",
+                        message: "Erreur lors de l'obtention de la préférence de récupération"
+                    },
+                    genericError: {
+                        description: "Une erreur s'est produite lors de l'obtention de la préférence de récupération",
+                        message: "Un problème est survenu"
+                    },
+                    success: {
+                        description: "Récupération réussie de la préférence de récupération",
+                        message: "Récupération des préférences de récupération réussie"
+                    }
+                }
+            },
             emailRecovery: {
                 descriptions: {
                     add: "Ajouter ou mettre à jour l'e-mail de récupération",

--- a/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
@@ -27,6 +27,22 @@ export const myAccount: MyAccountNS = {
                 },
                 heading: "Recuperação de código"
             },
+            preference: {
+                notifications: {
+                    error: {
+                        description: "{{description}}",
+                        message: "Erro ao obter a preferência de recuperação"
+                    },
+                    genericError: {
+                        description: "Ocorreu um erro ao obter a preferência de recuperação",
+                        message: "Algo deu errado"
+                    },
+                    success: {
+                        description: "A preferência de recuperação foi recuperada com sucesso",
+                        message: "Recuperação de preferência de recuperação bem-sucedida"
+                    }
+                }
+            },
             emailRecovery: {
                 descriptions: {
                     add: "Adicionar um endereço de email de recuperação",

--- a/modules/i18n/src/translations/si-LK/portals/myaccount.ts
+++ b/modules/i18n/src/translations/si-LK/portals/myaccount.ts
@@ -27,6 +27,22 @@ export const myAccount: MyAccountNS = {
                 },
                 heading: "කේත ප්\u200Dරතිසාධනය"
             },
+            preference: {
+                notifications: {
+                    error: {
+                        description: "{{description}}",
+                        message: "ප්‍රතිසාධන මනාපය ලබා ගැනීමේ දෝෂයකි"
+                    },
+                    genericError: {
+                        description: "ප්‍රතිසාධන මනාපය ලබා ගැනීමේදී දෝෂයක් ඇතිවිය",
+                        message: "මොකක්හරි වැරැද්දක් වෙලා"
+                    },
+                    success: {
+                        description: "ප්‍රතිසාධන මනාපය සාර්ථකව ලබා ගන්නා ලදි",
+                        message: "ප්‍රතිසාධන මනාප ලබා ගැනීම සාර්ථකයි"
+                    }
+                }
+            },
             emailRecovery: {
                 descriptions: {
                     add: "ප්\u200Dරතිසාධන ඊමේල් තැපැල් ලිපිනයක් එක් කරන්න",

--- a/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
@@ -27,6 +27,22 @@ export const myAccount: MyAccountNS = {
                 },
                 heading: "குறியீட்டு மீட்பு"
             },
+            preference: {
+                notifications: {
+                    error: {
+                        description: "{{description}}",
+                        message: "மீட்டெடுப்பு விருப்பத்தைப் பெறுவதில் பிழை"
+                    },
+                    genericError: {
+                        description: "மீட்பு விருப்பத்தைப் பெறும்போது பிழை ஏற்பட்டது",
+                        message: "ஏதோ தவறு நடந்துவிட்டது"
+                    },
+                    success: {
+                        description: "மீட்பு விருப்பத்தை வெற்றிகரமாக மீட்டெடுத்தது",
+                        message: "மீட்பு விருப்பம் மீட்டெடுப்பு வெற்றிகரமாக"
+                    }
+                }
+            },
             emailRecovery: {
                 descriptions: {
                     add: "மீட்பு மின்னஞ்சல் முகவரிய சேர்க்க",


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-is/issues/10915.

## Screenshots

#### if  both recoveries are enabled
![image](https://user-images.githubusercontent.com/17597685/104014033-67220280-51d8-11eb-9040-9a932a766c01.png)

#### if  both recoveries are disabled
![image](https://user-images.githubusercontent.com/17597685/104014205-ab150780-51d8-11eb-9872-2f730a4de9c7.png)

#### if only notification password recovery or username recovery enabled 
![image](https://user-images.githubusercontent.com/17597685/104013897-2629ee00-51d8-11eb-887b-0eb1c2db6ec4.png)

#### if only question based password recovery enabled
![image](https://user-images.githubusercontent.com/17597685/104013711-d64b2700-51d7-11eb-9fe2-e2da7a2faf4b.png)

