### PR TITLE
Add tenant admin preference for authentication portal & recovery portal 

### DIFF
--- a/apps/authentication-portal/pom.xml
+++ b/apps/authentication-portal/pom.xml
@@ -92,6 +92,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.mgt.endpoint.util</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
             <scope>provided</scope>
             <exclusions>

--- a/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
+++ b/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
@@ -152,6 +152,9 @@
         <listener-class>
             org.wso2.carbon.identity.application.authentication.endpoint.util.listener.AuthenticationEndpointContextListener
         </listener-class>
+        <listener-class>
+            org.wso2.carbon.identity.mgt.endpoint.util.listener.IdentityManagementEndpointContextListener
+        </listener-class>
     </listener>
 
     <servlet>

--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -334,10 +334,10 @@
     %>
 
     <div class="buttons">
-        <% if (isRecoveryEPAvailable && (isUsernameRecoveryEnabledByTenantAdmin || isPasswordRecoveryEnabledByTenantAdmin)) { %>
+        <% if (isRecoveryEPAvailable && (isUsernameRecoveryEnabledInTenant || isPasswordRecoveryEnabledInTenant)) { %>
         <div class="field">
             <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.username.password")%>
-            <% if (!isIdentifierFirstLogin(inputType) && isUsernameRecoveryEnabledByTenantAdmin) { %>
+            <% if (!isIdentifierFirstLogin(inputType) && isUsernameRecoveryEnabledInTenant) { %>
             <a
                 id="usernameRecoverLink"
                 tabindex="5"
@@ -347,10 +347,10 @@
                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.username")%>
             </a>
             <% }
-              if (isUsernameRecoveryEnabledByTenantAdmin && isPasswordRecoveryEnabledByTenantAdmin) { %>
+              if (isUsernameRecoveryEnabledInTenant && isPasswordRecoveryEnabledInTenant) { %>
             <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.username.password.or")%>
             <% }
-              if (isPasswordRecoveryEnabledByTenantAdmin) { %>
+              if (isPasswordRecoveryEnabledInTenant) { %>
             <a
                 id="passwordRecoverLink"
                 tabindex="6"
@@ -408,7 +408,7 @@
 
     <div class="ui two column stackable grid">
         <div class="column mobile center aligned tablet left aligned computer left aligned buttons tablet no-padding-left-first-child computer no-padding-left-first-child">
-            <% if (isSelfSignUpEPAvailable && !isIdentifierFirstLogin(inputType)) { %>
+            <% if (isSelfSignUpEPAvailable && !isIdentifierFirstLogin(inputType) && isSelfSignUpEnabledInTenant) { %>
             <button
                 type="button"
                 onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(getRegistrationUrl(accountRegistrationEndpointURL, urlEncodedURL, urlParameters))%>';"

--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -40,7 +40,7 @@
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.SelfRegistrationMgtClientException" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClientException" %>
 
 <jsp:directive.include file="includes/init-loginform-action-url.jsp"/>
 <script>
@@ -323,7 +323,7 @@
             isSelfSignUpEnabledInTenant = preferenceRetrievalClient.checkSelfRegistration(tenantDomain);
             isUsernameRecoveryEnabledInTenant = preferenceRetrievalClient.checkUsernameRecovery(tenantDomain);
             isPasswordRecoveryEnabledInTenant = preferenceRetrievalClient.checkPasswordRecovery(tenantDomain);
-        } catch (SelfRegistrationMgtClientException e) {
+        } catch (PreferenceRetrievalClientException e) {
             request.setAttribute("error", true);
             request.setAttribute("errorMsg", AuthenticationEndpointUtil
                             .i18n(resourceBundle, "something.went.wrong.contact.admin"));

--- a/apps/authentication-portal/src/main/webapp/includes/init-url.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/init-url.jsp
@@ -40,5 +40,10 @@
         tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
     } else {
         tenantDomain = request.getParameter("tenantDomain");
+        String tenantDomainFromURL = request.getParameter("t");
+
+        if (!StringUtils.isBlank(tenantDomainFromURL)) {
+            tenantDomain = tenantDomainFromURL;
+        }
     }
 %>

--- a/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -122,3 +122,4 @@ name=Name
 error=Error
 Cannot.obtain.username.from.server.response=Cannot obtain username from server response
 Enter.tenant.domain=Please enter your tenant domain.
+something.went.wrong.contact.admin=Something went wrong during the recovery process. Please contact identity admin.

--- a/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
+++ b/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
@@ -118,3 +118,4 @@ Um9sZQ__=Rôle
 business.homepage=http://wso2.com/
 name=Nom
 error=Erreur
+something.went.wrong.contact.admin=Une erreur s'est produite lors du processus de récupération. Veuillez contacter l'administrateur d'identité.

--- a/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -88,7 +88,6 @@
 
     Boolean isQuestionBasedPasswordRecoveryEnabledByTenant = false;
     Boolean isNotificationBasedPasswordRecoveryEnabledByTenant = false;
-    PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
     try {
         PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
         isQuestionBasedPasswordRecoveryEnabledByTenant = preferenceRetrievalClient.checkQuestionBasedPasswordRecovery(tenantDomain);

--- a/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -25,6 +25,8 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.ReCaptchaApi" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.ReCaptchaProperties" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.User" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
 <%@ page import="java.io.File" %>
@@ -82,6 +84,21 @@
     if (request.getAttribute("reCaptcha") != null &&
             "TRUE".equalsIgnoreCase((String) request.getAttribute("reCaptcha"))) {
         reCaptchaEnabled = true;
+    }
+
+    Boolean isQuestionBasedPasswordRecoveryEnabledByTenant = false;
+    Boolean isNotificationBasedPasswordRecoveryEnabledByTenant = false;
+    PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
+    try {
+        PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
+        isQuestionBasedPasswordRecoveryEnabledByTenant = preferenceRetrievalClient.checkQuestionBasedPasswordRecovery(tenantDomain);
+        isNotificationBasedPasswordRecoveryEnabledByTenant = preferenceRetrievalClient.checkNotificationBasedPasswordRecovery(tenantDomain);
+    } catch (PreferenceRetrievalClientException e) {
+        request.setAttribute("error", true);
+        request.setAttribute("errorMsg", IdentityManagementEndpointUtil
+                        .i18n(recoveryResourceBundle, "something.went.wrong.contact.admin"));
+        IdentityManagementEndpointUtil.addErrorInformation(request, e);
+        request.getRequestDispatcher("error.jsp").forward(request, response);
     }
 %>
 
@@ -162,7 +179,10 @@
                             }
                         %>
 
-                        <% if (isEmailNotificationEnabled) { %>
+                        <%
+                            if (isEmailNotificationEnabled && isNotificationBasedPasswordRecoveryEnabledByTenant
+                                                    && isQuestionBasedPasswordRecoveryEnabledByTenant ) {
+                        %>
                         <div class="ui secondary segment" style="text-align: left;">
                             <div class="field">
                                 <div class="ui radio checkbox">
@@ -178,6 +198,10 @@
                                     </label>
                                 </div>
                             </div>
+                        </div>
+                        <% } else if (isNotificationBasedPasswordRecoveryEnabledByTenant){ %>
+                        <div class="field">
+                            <input type="hidden" name="recoveryOption" value="EMAIL"/>
                         </div>
                         <% } else { %>
                         <div class="field">

--- a/apps/recovery-portal/src/main/webapp/tenant-resolve.jsp
+++ b/apps/recovery-portal/src/main/webapp/tenant-resolve.jsp
@@ -26,8 +26,14 @@
         tenantDomain = IdentityTenantUtil.getTenantDomainFromContext();
     } else {
         tenantDomain = request.getParameter("tenantDomain");
+        String tenantDomainInURL = request.getParameter("t");
+
         if (StringUtils.isBlank(tenantDomain)) {
             tenantDomain = request.getParameter(IdentityManagementEndpointConstants.TENANT_DOMAIN);
+        }
+
+        if (!StringUtils.isBlank(tenantDomainInURL)) {
+            tenantDomain = tenantDomainInURL;
         }
     }
 %>

--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.18.222</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.225</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.oauth.version>6.4.98</carbon.identity.oauth.version>
         <carbon.identity.oauth.imp.pkg.version.range>[6.1.0, 7.0.0)</carbon.identity.oauth.imp.pkg.version.range>


### PR DESCRIPTION
## Purpose
> Fix https://github.com/wso2/product-is/issues/10935

## Screenshots

>All options Enabled

![image](https://user-images.githubusercontent.com/17597685/104172855-ec9cf100-542a-11eb-9983-44839d1f2686.png)

#### Self-Registration
>Disabled

![image](https://user-images.githubusercontent.com/17597685/104173031-2e2d9c00-542b-11eb-8045-6096ea184347.png)

#### Username Recovery
>Disabled

![image](https://user-images.githubusercontent.com/17597685/104173293-8cf31580-542b-11eb-99a0-b1c6b93b9dad.png)

#### Password Recovery 
>Disabled (both question & notification recovery should be disabled)

![image](https://user-images.githubusercontent.com/17597685/104173517-e2c7bd80-542b-11eb-80b2-e5f8b28ae650.png)

### Note:

Depends on framework PR: https://github.com/wso2/carbon-identity-framework/pull/3317
