### PR TITLE
Prevent empty password value being sent.

### DIFF
--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -401,7 +401,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                         familyName: userInfo.lastName,
                         givenName: userInfo.firstName
                     },
-                    password: userInfo.newPassword,
+                    password: "ask_password",
                     profileUrl: userInfo.profileUrl,
                     "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
                         askPassword: "true"


### PR DESCRIPTION
## Purpose
>  Prevent empty passwords being sent when the ask-password option is selected.