### PR TITLE
Move Certificate to Protocol Form + Fix wizard help panel UIs

### DIFF
--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -390,7 +390,6 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
             <GeneralApplicationSettings
                 accessUrl={ application.accessUrl }
                 appId={ application.id }
-                certificate={ application.advancedConfigurations?.certificate }
                 description={ application.description }
                 discoverability={ application.advancedConfigurations?.discoverableByEndUsers }
                 imageUrl={ application.imageUrl }
@@ -410,6 +409,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
         <ResourceTab.Pane controlledSegmentation>
             <AccessConfiguration
                 allowedOriginList={ allowedOrigins }
+                certificate={ application.advancedConfigurations?.certificate }
                 onAllowedOriginsUpdate={ () => setIsAllowedOriginsUpdated(!isAllowedOriginsUpdated) }
                 onApplicationSecretRegenerate={ handleApplicationSecretRegenerate }
                 appId={ application.id }

--- a/apps/console/src/features/applications/components/forms/inbound-custom-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-custom-form.tsx
@@ -16,12 +16,19 @@
  * under the License.
  */
 
-import { TestableComponentInterface } from "@wso2is/core/models";
-import { Field, Forms } from "@wso2is/forms";
-import React, { FunctionComponent, ReactElement, useEffect } from "react";
+import { AlertInterface, AlertLevels, DisplayCertificate, TestableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { CertificateManagementUtils } from "@wso2is/core/utils";
+import { Field, Forms, Validation } from "@wso2is/forms";
+import { Heading, Hint, LinkButton } from "@wso2is/react-components";
+import { FormValidation } from "@wso2is/validation";
+import isEmpty from "lodash/isEmpty";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Grid } from "semantic-ui-react";
+import { useDispatch } from "react-redux";
+import { Button, Divider, Grid } from "semantic-ui-react";
 import {
+    CertificateInterface, CertificateTypeInterface,
     CustomInboundProtocolConfigurationInterface,
     CustomInboundProtocolMetaDataInterface,
     CustomInboundProtocolPropertyInterface,
@@ -29,14 +36,23 @@ import {
     PropertyModelInterface,
     SubmitFormCustomPropertiesInterface
 } from "../../models";
+import { CertificateFormFieldModal } from "../modals";
 
 /**
  * Proptypes for the inbound custom protocol form component.
  */
 interface InboundCustomFormPropsInterface extends TestableComponentInterface {
+    /**
+     * Current certificate configurations.
+     */
+    certificate: CertificateInterface;
     metadata?: CustomInboundProtocolMetaDataInterface;
     initialValues?: CustomInboundProtocolConfigurationInterface;
     onSubmit: (values: any) => void;
+    /**
+     * Make the form read only.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -51,13 +67,34 @@ export const InboundCustomProtocolForm: FunctionComponent<InboundCustomFormProps
 ): ReactElement => {
 
     const {
+        certificate,
         metadata,
         initialValues,
         onSubmit,
+        readOnly,
         [ "data-testid" ]: testId
     } = props;
 
     const { t } = useTranslation();
+
+    const dispatch = useDispatch();
+
+    const [ isPEMSelected, setPEMSelected ] = useState<boolean>(false);
+    const [ showCertificateModal, setShowCertificateModal ] = useState<boolean>(false);
+    const [ PEMValue, setPEMValue ] = useState<string>(undefined);
+    const [ certificateDisplay, setCertificateDisplay ] = useState<DisplayCertificate>(null);
+
+    /**
+     * Set initial PEM values.
+     */
+    useEffect(() => {
+        if (CertificateTypeInterface.PEM === certificate?.type) {
+            setPEMSelected(true);
+            if (certificate?.value) {
+                setPEMValue(certificate.value);
+            }
+        }
+    }, [ certificate ]);
 
     const createInputComponent = (
         (config: CustomInboundProtocolPropertyInterface, initialValue?: PropertyModelInterface) => {
@@ -219,11 +256,21 @@ export const InboundCustomProtocolForm: FunctionComponent<InboundCustomFormProps
             valueProperties.push(property);
         }
         return {
-            configName: initialValues?.configName,
-            name: initialValues?.name,
-            properties: [
-                ...valueProperties
-            ]
+            general: {
+                advancedConfigurations: {
+                    certificate: {
+                        type: values.get("type"),
+                        value: isPEMSelected ? values.get("certificateValue") : values.get("jwksValue")
+                    }
+                }
+            },
+            inbound: {
+                configName: initialValues?.configName,
+                name: initialValues?.name,
+                properties: [
+                    ...valueProperties
+                ]
+            }
         };
     };
 
@@ -233,6 +280,27 @@ export const InboundCustomProtocolForm: FunctionComponent<InboundCustomFormProps
         }
     }, [metadata]);
 
+    /**
+     * Construct the details from the pem value.
+     */
+    const viewCertificate = () => {
+        if (isPEMSelected && PEMValue) {
+            const displayCertificate: DisplayCertificate = CertificateManagementUtils.displayCertificate(
+                null, PEMValue);
+
+            if (displayCertificate) {
+                setCertificateDisplay(displayCertificate);
+                setShowCertificateModal(true);
+            } else {
+                dispatch(addAlert<AlertInterface>({
+                    description: t("console:common.notifications.invalidPEMFile.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("console:common.notifications.invalidPEMFile.genericError.message")
+                }));
+            }
+        }
+    };
+
     return (
         <Forms
             onSubmit={ (values) => {
@@ -241,13 +309,168 @@ export const InboundCustomProtocolForm: FunctionComponent<InboundCustomFormProps
         >
             <Grid>
                 { generateFormElements() }
+                { /* Certificates */ }
                 <Grid.Row columns={ 1 }>
-                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                        <Button primary type="submit" size="small" className="form-button">
-                            { t("common:update") }
-                        </Button>
+                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                        <Divider/>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                        <Heading as="h5">
+                            {
+                                t("console:develop.features.applications.forms." +
+                                    "advancedConfig.sections.certificate.heading") }
+                        </Heading>
+                        <Field
+                            label={
+                                t("console:develop.features.applications.forms." +
+                                    "advancedConfig.sections.certificate.fields.type.label")
+                            }
+                            name="type"
+                            default={ CertificateTypeInterface.JWKS }
+                            listen={
+                                (values) => {
+                                    setPEMSelected(values.get("type") === "PEM");
+                                }
+                            }
+                            type="radio"
+                            value={ certificate?.type }
+                            children={ [
+                                {
+                                    label: t("console:develop.features.applications.forms." +
+                                        "advancedConfig.sections.certificate.fields.type.children.jwks.label"),
+                                    value: CertificateTypeInterface.JWKS
+                                },
+                                {
+                                    label: t("console:develop.features.applications.forms." +
+                                        "advancedConfig.sections.certificate.fields.type.children.pem.label"),
+                                    value: CertificateTypeInterface.PEM
+                                }
+                            ] }
+                            readOnly={ readOnly }
+                            data-testid={ `${ testId }-certificate-type-radio-group` }
+                        />
                     </Grid.Column>
                 </Grid.Row>
+                <Grid.Row columns={ 1 }>
+                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                        {
+                            isPEMSelected
+                                ?
+                                (
+                                    <>
+                                        <Field
+                                            name="certificateValue"
+                                            label={
+                                                t("console:develop.features.applications.forms.advancedConfig" +
+                                                    ".sections.certificate.fields.pemValue.label")
+                                            }
+                                            required={ false }
+                                            requiredErrorMessage={
+                                                t("console:develop.features.applications.forms.advancedConfig" +
+                                                    ".sections.certificate.fields.pemValue.validations.empty")
+                                            }
+                                            placeholder={
+                                                t("console:develop.features.applications.forms.advancedConfig" +
+                                                    ".sections.certificate.fields.pemValue.placeholder")
+                                            }
+                                            type="textarea"
+                                            value={
+                                                (CertificateTypeInterface.PEM === certificate?.type)
+                                                && certificate?.value
+                                            }
+                                            listen={
+                                                (values) => {
+                                                    setPEMValue(
+                                                        values.get("certificateValue") as string
+                                                    );
+                                                }
+                                            }
+                                            readOnly={ readOnly }
+                                            data-testid={ `${ testId }-certificate-textarea` }
+                                        />
+                                        < Hint>
+                                            {
+                                                t("console:develop.features.applications.forms." +
+                                                    "advancedConfig.sections.certificate.fields.pemValue.hint")
+                                            }
+                                        </Hint>
+                                        <LinkButton
+                                            className="certificate-info-link-button"
+                                            onClick={ () => viewCertificate() }
+                                            disabled={ isEmpty(PEMValue) }
+                                            data-testid={ `${ testId }-certificate-info-button` }
+                                        >
+                                            {
+                                                t("console:develop.features.applications.forms." +
+                                                    "advancedConfig.sections.certificate.fields.pemValue." +
+                                                    "actions.view")
+                                            }
+                                        </LinkButton>
+                                    </>
+                                )
+                                : (
+                                    <>
+                                        <Field
+                                            name="jwksValue"
+                                            label={
+                                                t("console:develop.features.applications.forms.advancedConfig" +
+                                                    ".sections.certificate.fields.jwksValue.label")
+                                            }
+                                            required={ false }
+                                            requiredErrorMessage={
+                                                t("console:develop.features.applications.forms.advancedConfig" +
+                                                    ".sections.certificate.fields.jwksValue.validations.empty")
+                                            }
+                                            placeholder={
+                                                t("console:develop.features.applications.forms.advancedConfig" +
+                                                    ".sections.certificate.fields.jwksValue.placeholder") }
+                                            type="text"
+                                            validation={ (value: string, validation: Validation) => {
+                                                if (!FormValidation.url(value)) {
+                                                    validation.isValid = false;
+                                                    validation.errorMessages.push(
+                                                        t(
+                                                            "console:develop.features.applications.forms" +
+                                                            ".advancedConfig.sections.certificate.fields." +
+                                                            "jwksValue.validations.invalid"
+                                                        )
+                                                    );
+                                                }
+                                            } }
+                                            value={
+                                                (CertificateTypeInterface.JWKS === certificate?.type)
+                                                && certificate?.value
+                                            }
+                                            readOnly={ readOnly }
+                                            data-testid={ `${ testId }-jwks-input` }
+                                        />
+                                    </>
+                                )
+                        }
+                    </Grid.Column>
+                </Grid.Row>
+                {
+                    showCertificateModal && (
+                        <CertificateFormFieldModal
+                            open={ showCertificateModal }
+                            certificate={ certificateDisplay }
+                            onClose={ () => {
+                                setShowCertificateModal(false);
+                            } }
+                        />
+                    )
+                }
+                {
+                    !readOnly && (
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                                <Button primary type="submit" size="small" className="form-button">
+                                    { t("common:update") }
+                                </Button>
+                            </Grid.Column>
+                        </Grid.Row>
+                    )
+                }
             </Grid>
         </Forms>
     );

--- a/apps/console/src/features/applications/components/forms/inbound-form-factory.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-form-factory.tsx
@@ -23,12 +23,16 @@ import { InboundOIDCForm } from "./inbound-oidc-form";
 import { InboundPassiveStsForm } from "./inbound-passive-sts-form";
 import { InboundSAMLForm } from "./inbound-saml-form";
 import { InboundWSTrustForm } from "./inbound-ws-trust-form";
-import { ApplicationTemplateListItemInterface, SupportedAuthProtocolTypes } from "../../models";
+import { ApplicationTemplateListItemInterface, CertificateInterface, SupportedAuthProtocolTypes } from "../../models";
 
 /**
  * Proptypes for the inbound form factory component.
  */
 interface InboundFormFactoryInterface extends TestableComponentInterface {
+    /**
+     * Current certificate configurations.
+     */
+    certificate: CertificateInterface;
     metadata?: any;
     initialValues: any;
     onSubmit: (values: any) => void;
@@ -65,6 +69,7 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
 ): ReactElement => {
 
     const {
+        certificate,
         metadata,
         initialValues,
         onSubmit,
@@ -82,6 +87,7 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
         case SupportedAuthProtocolTypes.OIDC:
             return (
                 <InboundOIDCForm
+                    certificate={ certificate }
                     tenantDomain={ tenantDomain }
                     allowedOriginList={ allowedOrigins }
                     initialValues={ initialValues }
@@ -97,6 +103,7 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
         case SupportedAuthProtocolTypes.SAML:
             return (
                 <InboundSAMLForm
+                    certificate={ certificate }
                     initialValues={ initialValues }
                     metadata={ metadata }
                     onSubmit={ onSubmit }
@@ -107,6 +114,7 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
         case SupportedAuthProtocolTypes.WS_TRUST:
             return (
                 <InboundWSTrustForm
+                    certificate={ certificate }
                     initialValues={ initialValues }
                     metadata={ metadata }
                     onSubmit={ onSubmit }
@@ -117,6 +125,7 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
         case SupportedAuthProtocolTypes.WS_FEDERATION:
             return (
                 <InboundPassiveStsForm
+                    certificate={ certificate }
                     initialValues={ initialValues }
                     onSubmit={ onSubmit }
                     readOnly={ readOnly }
@@ -126,6 +135,7 @@ export const InboundFormFactory: FunctionComponent<InboundFormFactoryInterface> 
         case SupportedAuthProtocolTypes.CUSTOM:
             return (
                 <InboundCustomProtocolForm
+                    certificate={ certificate }
                     metadata={ metadata }
                     initialValues={ initialValues }
                     onSubmit={ onSubmit }

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -16,21 +16,31 @@
  * under the License.
  */
 
-import { TestableComponentInterface } from "@wso2is/core/models";
-import { URLUtils } from "@wso2is/core/utils";
+import { AlertInterface, AlertLevels, DisplayCertificate, TestableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { CertificateManagementUtils, URLUtils } from "@wso2is/core/utils";
 import { Field, FormValue, Forms, Validation } from "@wso2is/forms";
-import { ConfirmationModal, CopyInputField, Heading, Hint, URLInput } from "@wso2is/react-components";
+import {
+    ConfirmationModal,
+    CopyInputField,
+    Heading,
+    Hint,
+    LinkButton,
+    URLInput
+} from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import get from "lodash/get";
 import isEmpty from "lodash/isEmpty";
 import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Button, Divider, Form, Grid, Label, Message } from "semantic-ui-react";
 import { AppState } from "../../../core/store";
 import { ApplicationManagementConstants } from "../../constants";
 import {
     ApplicationTemplateListItemInterface,
+    CertificateInterface,
+    CertificateTypeInterface,
     GrantTypeInterface,
     GrantTypeMetaDataInterface,
     MetadataPropertyInterface,
@@ -42,11 +52,16 @@ import {
     emptyOIDCConfig
 } from "../../models";
 import { ApplicationManagementUtils } from "../../utils";
+import { CertificateFormFieldModal } from "../modals";
 
 /**
  * Proptypes for the inbound OIDC form component.
  */
 interface InboundOIDCFormPropsInterface extends TestableComponentInterface {
+    /**
+     * Current certificate configurations.
+     */
+    certificate: CertificateInterface;
     metadata: OIDCMetadataInterface;
     initialValues: OIDCDataInterface;
     onSubmit: (values: any) => void;
@@ -82,6 +97,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 ): ReactElement => {
 
     const {
+        certificate,
         metadata,
         initialValues,
         onSubmit,
@@ -95,6 +111,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     } = props;
 
     const { t } = useTranslation();
+
+    const dispatch = useDispatch();
 
     const isClientSecretHashEnabled: boolean = useSelector((state: AppState) =>
         state.config.ui.isClientSecretHashEnabled);
@@ -116,6 +134,10 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     ] = useState<boolean>(false);
     const [ callbackURLsErrorLabel, setCallbackURLsErrorLabel ] = useState<ReactElement>(null);
     const [ allowedOriginsErrorLabel, setAllowedOriginsErrorLabel ] = useState<ReactElement>(null);
+    const [ isPEMSelected, setPEMSelected ] = useState<boolean>(false);
+    const [ showCertificateModal, setShowCertificateModal ] = useState<boolean>(false);
+    const [ PEMValue, setPEMValue ] = useState<string>(undefined);
+    const [ certificateDisplay, setCertificateDisplay ] = useState<DisplayCertificate>(null);
 
     const clientSecret = useRef<HTMLElement>();
     const grant = useRef<HTMLElement>();
@@ -184,6 +206,18 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
             setIsTokenBindingTypeSelected(true);
         }
     }, [ initialValues?.accessToken ]);
+
+    /**
+     * Set initial PEM values.
+     */
+    useEffect(() => {
+        if (CertificateTypeInterface.PEM === certificate?.type) {
+            setPEMSelected(true);
+            if (certificate?.value) {
+                setPEMValue(certificate.value);
+            }
+        }
+    }, [ certificate ]);
 
     /**
      * Handle grant type change.
@@ -303,7 +337,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @return {any} Sanitized form values.
      */
     const updateConfiguration = (values: any, url?: string, origin?: string): any => {
-        let formValues: any = {
+        let inboundConfigFormValues: any = {
             accessToken: {
                 applicationAccessTokenExpiryInSeconds: Number(metadata.defaultApplicationAccessTokenExpiryTime),
                 bindingType: values.get("bindingType"),
@@ -344,14 +378,14 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         // Add the `allowedOrigins` & `callbackURLs` only if the grant types
         // `authorization_code` and `implicit` are selected.
         if (showCallbackURLField) {
-            formValues = {
-                ...formValues,
+            inboundConfigFormValues = {
+                ...inboundConfigFormValues,
                 allowedOrigins: ApplicationManagementUtils.resolveAllowedOrigins(origin ? origin : allowedOrigins),
                 callbackURLs: [ ApplicationManagementUtils.buildCallBackUrlWithRegExp(url ? url : callBackUrls) ]
             };
         } else {
-            formValues = {
-                ...formValues,
+            inboundConfigFormValues = {
+                ...inboundConfigFormValues,
                 allowedOrigins: [],
                 callbackURLs: []
             };
@@ -359,13 +393,23 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
         // If the app is newly created do not add `clientId` & `clientSecret`.
         if (!initialValues?.clientId || !initialValues?.clientSecret) {
-            return formValues;
+            return inboundConfigFormValues;
         }
 
         return {
-            ...formValues,
-            clientId: initialValues?.clientId,
-            clientSecret: initialValues?.clientSecret
+            general: {
+                advancedConfigurations: {
+                    certificate: {
+                        type: values.get("type"),
+                        value: isPEMSelected ? values.get("certificateValue") : values.get("jwksValue")
+                    }
+                }
+            },
+            inbound: {
+                ...inboundConfigFormValues,
+                clientId: initialValues?.clientId,
+                clientSecret: initialValues?.clientSecret
+            }
         };
     };
 
@@ -478,6 +522,27 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * submitOrigin function.
      */
     let submitOrigin: (callback: (origin?: string) => void) => void;
+
+    /**
+     * Construct the details from the pem value.
+     */
+    const viewCertificate = () => {
+        if (isPEMSelected && PEMValue) {
+            const displayCertificate: DisplayCertificate = CertificateManagementUtils.displayCertificate(
+                null, PEMValue);
+
+            if (displayCertificate) {
+                setCertificateDisplay(displayCertificate);
+                setShowCertificateModal(true);
+            } else {
+                dispatch(addAlert<AlertInterface>({
+                    description: t("console:common.notifications.invalidPEMFile.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("console:common.notifications.invalidPEMFile.genericError.message")
+                }));
+            }
+        }
+    };
 
     /**
      * Renders the list of main OIDC config fields.
@@ -1284,6 +1349,156 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                     />
                 </Grid.Column>
             </Grid.Row>
+            { /* Certificates */ }
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                    <Divider/>
+                </Grid.Column>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ isHelpPanelVisible ? 16 : 8 }>
+                    <Heading as="h5">
+                        {
+                            t("console:develop.features.applications.forms." +
+                                "advancedConfig.sections.certificate.heading") }
+                    </Heading>
+                    <Field
+                        label={
+                            t("console:develop.features.applications.forms." +
+                                "advancedConfig.sections.certificate.fields.type.label")
+                        }
+                        name="type"
+                        default={ CertificateTypeInterface.JWKS }
+                        listen={
+                            (values) => {
+                                setPEMSelected(values.get("type") === "PEM");
+                            }
+                        }
+                        type="radio"
+                        value={ certificate?.type }
+                        children={ [
+                            {
+                                label: t("console:develop.features.applications.forms." +
+                                    "advancedConfig.sections.certificate.fields.type.children.jwks.label"),
+                                value: CertificateTypeInterface.JWKS
+                            },
+                            {
+                                label: t("console:develop.features.applications.forms." +
+                                    "advancedConfig.sections.certificate.fields.type.children.pem.label"),
+                                value: CertificateTypeInterface.PEM
+                            }
+                        ] }
+                        readOnly={ readOnly }
+                        data-testid={ `${ testId }-certificate-type-radio-group` }
+                    />
+                </Grid.Column>
+            </Grid.Row>
+            <Grid.Row columns={ 1 }>
+                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                    {
+                        isPEMSelected
+                            ?
+                            (
+                                <>
+                                    <Field
+                                        name="certificateValue"
+                                        label={
+                                            t("console:develop.features.applications.forms.advancedConfig" +
+                                                ".sections.certificate.fields.pemValue.label")
+                                        }
+                                        required={ false }
+                                        requiredErrorMessage={
+                                            t("console:develop.features.applications.forms.advancedConfig" +
+                                                ".sections.certificate.fields.pemValue.validations.empty")
+                                        }
+                                        placeholder={
+                                            t("console:develop.features.applications.forms.advancedConfig" +
+                                                ".sections.certificate.fields.pemValue.placeholder")
+                                        }
+                                        type="textarea"
+                                        value={
+                                            (CertificateTypeInterface.PEM === certificate?.type)
+                                            && certificate?.value
+                                        }
+                                        listen={
+                                            (values) => {
+                                                setPEMValue(
+                                                    values.get("certificateValue") as string
+                                                );
+                                            }
+                                        }
+                                        readOnly={ readOnly }
+                                        data-testid={ `${ testId }-certificate-textarea` }
+                                    />
+                                    < Hint>
+                                        {
+                                            t("console:develop.features.applications.forms." +
+                                                "advancedConfig.sections.certificate.fields.pemValue.hint")
+                                        }
+                                    </Hint>
+                                    <LinkButton
+                                        className="certificate-info-link-button"
+                                        onClick={ () => viewCertificate() }
+                                        disabled={ isEmpty(PEMValue) }
+                                        data-testid={ `${ testId }-certificate-info-button` }
+                                    >
+                                        {
+                                            t("console:develop.features.applications.forms." +
+                                                "advancedConfig.sections.certificate.fields.pemValue.actions.view")
+                                        }
+                                    </LinkButton>
+                                </>
+                            )
+                            : (
+                                <>
+                                    <Field
+                                        name="jwksValue"
+                                        label={
+                                            t("console:develop.features.applications.forms.advancedConfig" +
+                                                ".sections.certificate.fields.jwksValue.label")
+                                        }
+                                        required={ false }
+                                        requiredErrorMessage={
+                                            t("console:develop.features.applications.forms.advancedConfig" +
+                                                ".sections.certificate.fields.jwksValue.validations.empty")
+                                        }
+                                        placeholder={
+                                            t("console:develop.features.applications.forms.advancedConfig" +
+                                                ".sections.certificate.fields.jwksValue.placeholder") }
+                                        type="text"
+                                        validation={ (value: string, validation: Validation) => {
+                                            if (!FormValidation.url(value)) {
+                                                validation.isValid = false;
+                                                validation.errorMessages.push(
+                                                    t(
+                                                        "console:develop.features.applications.forms" +
+                                                        ".advancedConfig.sections.certificate.fields.jwksValue" +
+                                                        ".validations.invalid"
+                                                    )
+                                                );
+                                            }
+                                        } }
+                                        value={
+                                            (CertificateTypeInterface.JWKS === certificate?.type)
+                                            && certificate?.value
+                                        }
+                                        readOnly={ readOnly }
+                                        data-testid={ `${ testId }-jwks-input` }
+                                    />
+                                </>
+                            )
+                    }
+                </Grid.Column>
+            </Grid.Row>
+            {
+                showCertificateModal && (
+                    <CertificateFormFieldModal
+                        open={ showCertificateModal }
+                        certificate={ certificateDisplay }
+                        onClose={ () => {
+                            setShowCertificateModal(false);
+                        } }
+                    />
+                )
+            }
             {
                 !readOnly && (
                     <Grid.Row columns={ 1 }>

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1780,7 +1780,6 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                             (initialValues?.clientId || initialValues?.clientSecret) && (
                                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ isHelpPanelVisible ? 16 : 10 }>
                                     <Divider />
-                                    <Divider hidden />
                                 </Grid.Column>
                             )
                         }

--- a/apps/console/src/features/applications/components/forms/inbound-ws-trust-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-ws-trust-form.tsx
@@ -16,19 +16,35 @@
  * under the License.
  */
 
-import { TestableComponentInterface } from "@wso2is/core/models";
-import { Field, Forms } from "@wso2is/forms";
-import { Hint } from "@wso2is/react-components";
+import { AlertInterface, AlertLevels, DisplayCertificate, TestableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { CertificateManagementUtils } from "@wso2is/core/utils";
+import { Field, Forms, Validation } from "@wso2is/forms";
+import { Heading, Hint, LinkButton } from "@wso2is/react-components";
+import { FormValidation } from "@wso2is/validation";
 import _ from "lodash";
-import React, { FunctionComponent, ReactElement } from "react";
+import isEmpty from "lodash/isEmpty";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Grid } from "semantic-ui-react";
-import { MetadataPropertyInterface, WSTrustConfigurationInterface, WSTrustMetaDataInterface } from "../../models";
+import { useDispatch } from "react-redux";
+import { Button, Divider, Grid } from "semantic-ui-react";
+import {
+    CertificateInterface,
+    CertificateTypeInterface,
+    MetadataPropertyInterface,
+    WSTrustConfigurationInterface,
+    WSTrustMetaDataInterface
+} from "../../models";
+import { CertificateFormFieldModal } from "../modals";
 
 /**
  * Proptypes for the inbound WS Trust form component.
  */
 interface InboundWSTrustFormPropsInterface extends TestableComponentInterface {
+    /**
+     * Current certificate configurations.
+     */
+    certificate: CertificateInterface;
     metadata: WSTrustMetaDataInterface;
     initialValues: WSTrustConfigurationInterface;
     onSubmit: (values: any) => void;
@@ -50,6 +66,7 @@ export const InboundWSTrustForm: FunctionComponent<InboundWSTrustFormPropsInterf
 ): ReactElement => {
 
     const {
+        certificate,
         metadata,
         initialValues,
         onSubmit,
@@ -58,6 +75,25 @@ export const InboundWSTrustForm: FunctionComponent<InboundWSTrustFormPropsInterf
     } = props;
 
     const { t } = useTranslation();
+
+    const dispatch = useDispatch();
+
+    const [ isPEMSelected, setPEMSelected ] = useState<boolean>(false);
+    const [ showCertificateModal, setShowCertificateModal ] = useState<boolean>(false);
+    const [ PEMValue, setPEMValue ] = useState<string>(undefined);
+    const [ certificateDisplay, setCertificateDisplay ] = useState<DisplayCertificate>(null);
+
+    /**
+     * Set initial PEM values.
+     */
+    useEffect(() => {
+        if (CertificateTypeInterface.PEM === certificate?.type) {
+            setPEMSelected(true);
+            if (certificate?.value) {
+                setPEMValue(certificate.value);
+            }
+        }
+    }, [ certificate ]);
 
     /**
      * Create drop down options.
@@ -83,9 +119,40 @@ export const InboundWSTrustForm: FunctionComponent<InboundWSTrustFormPropsInterf
     const updateConfiguration = (values: any): any => {
 
         return {
-            audience: values.get("audience"),
-            certificateAlias: values.get("certificateAlias")
+            general: {
+                advancedConfigurations: {
+                    certificate: {
+                        type: values.get("type"),
+                        value: isPEMSelected ? values.get("certificateValue") : values.get("jwksValue")
+                    }
+                }
+            },
+            inbound: {
+                audience: values.get("audience"),
+                certificateAlias: values.get("certificateAlias")
+            }
         };
+    };
+
+    /**
+     * Construct the details from the pem value.
+     */
+    const viewCertificate = () => {
+        if (isPEMSelected && PEMValue) {
+            const displayCertificate: DisplayCertificate = CertificateManagementUtils.displayCertificate(
+                null, PEMValue);
+
+            if (displayCertificate) {
+                setCertificateDisplay(displayCertificate);
+                setShowCertificateModal(true);
+            } else {
+                dispatch(addAlert<AlertInterface>({
+                    description: t("console:common.notifications.invalidPEMFile.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("console:common.notifications.invalidPEMFile.genericError.message")
+                }));
+            }
+        }
     };
 
     return (
@@ -154,6 +221,158 @@ export const InboundWSTrustForm: FunctionComponent<InboundWSTrustFormPropsInterf
                                 </Hint>
                             </Grid.Column>
                         </Grid.Row>
+
+                        { /* Certificates */ }
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                                <Divider/>
+                            </Grid.Column>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                                <Heading as="h5">
+                                    {
+                                        t("console:develop.features.applications.forms." +
+                                            "advancedConfig.sections.certificate.heading") }
+                                </Heading>
+                                <Field
+                                    label={
+                                        t("console:develop.features.applications.forms." +
+                                            "advancedConfig.sections.certificate.fields.type.label")
+                                    }
+                                    name="type"
+                                    default={ CertificateTypeInterface.JWKS }
+                                    listen={
+                                        (values) => {
+                                            setPEMSelected(values.get("type") === "PEM");
+                                        }
+                                    }
+                                    type="radio"
+                                    value={ certificate?.type }
+                                    children={ [
+                                        {
+                                            label: t("console:develop.features.applications.forms." +
+                                                "advancedConfig.sections.certificate.fields.type.children.jwks.label"),
+                                            value: CertificateTypeInterface.JWKS
+                                        },
+                                        {
+                                            label: t("console:develop.features.applications.forms." +
+                                                "advancedConfig.sections.certificate.fields.type.children.pem.label"),
+                                            value: CertificateTypeInterface.PEM
+                                        }
+                                    ] }
+                                    readOnly={ readOnly }
+                                    data-testid={ `${ testId }-certificate-type-radio-group` }
+                                />
+                            </Grid.Column>
+                        </Grid.Row>
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                                {
+                                    isPEMSelected
+                                        ?
+                                        (
+                                            <>
+                                                <Field
+                                                    name="certificateValue"
+                                                    label={
+                                                        t("console:develop.features.applications.forms.advancedConfig" +
+                                                            ".sections.certificate.fields.pemValue.label")
+                                                    }
+                                                    required={ false }
+                                                    requiredErrorMessage={
+                                                        t("console:develop.features.applications.forms.advancedConfig" +
+                                                            ".sections.certificate.fields.pemValue.validations.empty")
+                                                    }
+                                                    placeholder={
+                                                        t("console:develop.features.applications.forms.advancedConfig" +
+                                                            ".sections.certificate.fields.pemValue.placeholder")
+                                                    }
+                                                    type="textarea"
+                                                    value={
+                                                        (CertificateTypeInterface.PEM === certificate?.type)
+                                                        && certificate?.value
+                                                    }
+                                                    listen={
+                                                        (values) => {
+                                                            setPEMValue(
+                                                                values.get("certificateValue") as string
+                                                            );
+                                                        }
+                                                    }
+                                                    readOnly={ readOnly }
+                                                    data-testid={ `${ testId }-certificate-textarea` }
+                                                />
+                                                < Hint>
+                                                    {
+                                                        t("console:develop.features.applications.forms." +
+                                                            "advancedConfig.sections.certificate.fields.pemValue.hint")
+                                                    }
+                                                </Hint>
+                                                <LinkButton
+                                                    className="certificate-info-link-button"
+                                                    onClick={ () => viewCertificate() }
+                                                    disabled={ isEmpty(PEMValue) }
+                                                    data-testid={ `${ testId }-certificate-info-button` }
+                                                >
+                                                    {
+                                                        t("console:develop.features.applications.forms." +
+                                                            "advancedConfig.sections.certificate.fields.pemValue." +
+                                                            "actions.view")
+                                                    }
+                                                </LinkButton>
+                                            </>
+                                        )
+                                        : (
+                                            <>
+                                                <Field
+                                                    name="jwksValue"
+                                                    label={
+                                                        t("console:develop.features.applications.forms.advancedConfig" +
+                                                            ".sections.certificate.fields.jwksValue.label")
+                                                    }
+                                                    required={ false }
+                                                    requiredErrorMessage={
+                                                        t("console:develop.features.applications.forms.advancedConfig" +
+                                                            ".sections.certificate.fields.jwksValue.validations.empty")
+                                                    }
+                                                    placeholder={
+                                                        t("console:develop.features.applications.forms.advancedConfig" +
+                                                            ".sections.certificate.fields.jwksValue.placeholder") }
+                                                    type="text"
+                                                    validation={ (value: string, validation: Validation) => {
+                                                        if (!FormValidation.url(value)) {
+                                                            validation.isValid = false;
+                                                            validation.errorMessages.push(
+                                                                t(
+                                                                    "console:develop.features.applications.forms" +
+                                                                    ".advancedConfig.sections.certificate.fields." +
+                                                                    "jwksValue.validations.invalid"
+                                                                )
+                                                            );
+                                                        }
+                                                    } }
+                                                    value={
+                                                        (CertificateTypeInterface.JWKS === certificate?.type)
+                                                        && certificate?.value
+                                                    }
+                                                    readOnly={ readOnly }
+                                                    data-testid={ `${ testId }-jwks-input` }
+                                                />
+                                            </>
+                                        )
+                                }
+                            </Grid.Column>
+                        </Grid.Row>
+                        {
+                            showCertificateModal && (
+                                <CertificateFormFieldModal
+                                    open={ showCertificateModal }
+                                    certificate={ certificateDisplay }
+                                    onClose={ () => {
+                                        setShowCertificateModal(false);
+                                    } }
+                                />
+                            )
+                        }
                         {
                             !readOnly && (
                                 <Grid.Row columns={ 1 }>

--- a/apps/console/src/features/applications/components/modals/certificate-form-field-modal.tsx
+++ b/apps/console/src/features/applications/components/modals/certificate-form-field-modal.tsx
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { DisplayCertificate, TestableComponentInterface } from "@wso2is/core/models";
+import { CertificateManagementUtils } from "@wso2is/core/utils";
+import {
+    Certificate as CertificateDisplay,
+    GenericIcon} from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import { Modal, ModalProps } from "semantic-ui-react";
+import { getCertificateIllustrations } from "../../../core/configs";
+
+/**
+ * Proptypes for the certificate form field modal component.
+ */
+interface CertificateFormFieldModalPropsInterface extends ModalProps, TestableComponentInterface {
+    /**
+     * Current certificate configurations.
+     */
+    certificate: DisplayCertificate;
+}
+
+/**
+ * Certificate form field modal component.
+ *
+ * @param {CertificateFormFieldModalPropsInterface} props - Props injected to the component.
+ *
+ * @return {React.ReactElement}
+ */
+export const CertificateFormFieldModal: FunctionComponent<CertificateFormFieldModalPropsInterface> = (
+    props: CertificateFormFieldModalPropsInterface
+): ReactElement => {
+
+    const {
+        certificate,
+        [ "data-testid" ]: testId,
+        ...rest
+    } = props;
+
+    const { t } = useTranslation();
+
+    return (
+        <Modal
+            closeOnDimmerClick
+            className="certificate-display"
+            dimmer="blurring"
+            size="tiny"
+            data-testid={ `${ testId }-view-certificate-modal` }
+            { ...rest }
+        >
+            <Modal.Header>
+                <div className="certificate-ribbon">
+                    <GenericIcon
+                        inline
+                        transparent
+                        size="auto"
+                        icon={ getCertificateIllustrations().ribbon }
+                    />
+                    <div className="certificate-alias">
+                        View Certificate - {
+                        certificate?.alias
+                            ? certificate?.alias
+                            : certificate?.issuerDN && (
+                            CertificateManagementUtils.searchIssuerDNAlias(certificate?.issuerDN)
+                        )
+                    }
+                    </div><br/>
+                    <div className="certificate-serial">Serial Number: { certificate?.serialNumber }</div>
+                </div>
+            </Modal.Header>
+            <Modal.Content className="certificate-content">
+                <CertificateDisplay
+                    certificate={ certificate }
+                    labels={ {
+                        issuerDN: t("console:manage.features.certificates.keystore.summary.issuerDN"),
+                        subjectDN: t("console:manage.features.certificates.keystore.summary.subjectDN"),
+                        validFrom: t("console:manage.features.certificates.keystore.summary.validFrom"),
+                        validTill: t("console:manage.features.certificates.keystore.summary.validTill"),
+                        version: t("console:manage.features.certificates.keystore.summary.version")
+                    } }
+                />
+            </Modal.Content>
+        </Modal>
+    );
+};
+
+/**
+ * Default props for the component.
+ */
+CertificateFormFieldModal.defaultProps = {
+    "data-testid": "certificate-form-field-modal"
+};

--- a/apps/console/src/features/applications/components/modals/index.ts
+++ b/apps/console/src/features/applications/components/modals/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./certificate-form-field-modal";

--- a/apps/console/src/features/applications/components/settings/general-application-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/general-application-settings.tsx
@@ -34,8 +34,7 @@ import { AppState, FeatureConfigInterface, UIConfigInterface } from "../../../co
 import { deleteApplication, updateApplicationDetails } from "../../api";
 import {
     ApplicationInterface,
-    ApplicationTemplateListItemInterface,
-    CertificateInterface
+    ApplicationTemplateListItemInterface
 } from "../../models";
 import { GeneralDetailsForm } from "../forms";
 
@@ -89,10 +88,6 @@ interface GeneralApplicationSettingsInterface extends SBACInterface<FeatureConfi
      * Application template.
      */
     template?: ApplicationTemplateListItemInterface;
-    /**
-     * Current certificate configurations.
-     */
-    certificate: CertificateInterface;
 }
 
 /**
@@ -117,7 +112,6 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
         isLoading,
         onDelete,
         onUpdate,
-        certificate,
         readOnly,
         [ "data-testid" ]: testId
     } = props;
@@ -261,7 +255,6 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                 <>
                     <EmphasizedSegment>
                         <GeneralDetailsForm
-                            certificate={ certificate }
                             name={ name }
                             appId={ appId }
                             description={ description }

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -370,7 +370,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                                 { notification }
                             </Grid.Column>
                         </Grid.Row>
-                    )}
+                    ) }
                     <Grid.Row columns={ 1 }>
                         <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 14 }>
                             <Field

--- a/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -24,7 +24,7 @@ import intersection from "lodash/intersection";
 import isEmpty from "lodash/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Grid, Label, Message } from "semantic-ui-react";
+import { Grid, Icon, Label, Message } from "semantic-ui-react";
 import { getAuthProtocolMetadata } from "../../api";
 import {
     ApplicationTemplateListItemInterface,
@@ -388,7 +388,7 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                         }
                         { ((!fields || fields.includes("callbackURLs")) && showCallbackURLField ) && (
                             <Grid.Row column={ 1 }>
-                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                     <URLInput
                                         labelEnabled={ true }
                                         handleAddAllowedOrigin={ (url) => handleAddAllowOrigin(url) }
@@ -445,11 +445,14 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                                         showPredictions={ false }
                                         customLabel={ callbackURLsErrorLabel }
                                     />
-                                    <Message visible warning>
-                                        {
-                                            t("console:develop.features.applications.forms.inboundOIDC.fields" +
-                                                ".callBackUrls.validations.required")
-                                        }
+                                    <Message className="with-inline-icon" icon visible warning>
+                                        <Icon name="warning sign" size="mini" />
+                                        <Message.Content>
+                                            {
+                                                t("console:develop.features.applications.forms.inboundOIDC.fields" +
+                                                    ".callBackUrls.validations.required")
+                                            }
+                                        </Message.Content>
                                     </Message>
                                 </Grid.Column>
                             </Grid.Row>

--- a/apps/console/src/features/applications/components/wizard/saml-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/saml-protocol-settings-wizard-form.tsx
@@ -157,7 +157,7 @@ export const SAMLProtocolSettingsWizardForm: FunctionComponent<SAMLProtocolSetti
                     <Grid>
                         { (!fields || fields.includes("issuer")) && (
                             <Grid.Row columns={ 1 }>
-                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                     <Field
                                         name="issuer"
                                         label={
@@ -191,22 +191,22 @@ export const SAMLProtocolSettingsWizardForm: FunctionComponent<SAMLProtocolSetti
                         ) }
                         { (!fields || fields.includes("applicationQualifier")) && (
                             <Grid.Row columns={ 1 }>
-                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                     <Field
                                         name="applicationQualifier"
                                         label={
-                                            t("console:develop.features.applications.forms.inboundSAML.fields.qualifier" +
-                                                ".label")
+                                            t("console:develop.features.applications.forms.inboundSAML" +
+                                                ".fields.qualifier.label")
                                         }
                                         required={ false }
                                         requiredErrorMessage={
-                                            t("console:develop.features.applications.forms.inboundSAML.fields.qualifier" +
-                                                ".validations.empty")
+                                            t("console:develop.features.applications.forms.inboundSAML" +
+                                                ".fields.qualifier.validations.empty")
                                         }
                                         type="text"
                                         placeholder={
-                                            t("console:develop.features.applications.forms.inboundSAML.fields.qualifier" +
-                                                ".placeholder")
+                                            t("console:develop.features.applications.forms.inboundSAML" +
+                                                ".fields.qualifier.placeholder")
                                         }
                                         value={
                                             initialValues?.inboundProtocolConfiguration
@@ -224,58 +224,63 @@ export const SAMLProtocolSettingsWizardForm: FunctionComponent<SAMLProtocolSetti
                             </Grid.Row>
                         ) }
                         { (!fields || fields.includes("assertionConsumerURLs")) && (
-                            <URLInput
-                                urlState={ assertionConsumerUrls }
-                                setURLState={ setAssertionConsumerUrls }
-                                labelName={
-                                    t("console:develop.features.applications.forms.inboundSAML.fields.assertionURLs" +
-                                        ".label")
-                                }
-                                placeholder={
-                                    t("console:develop.features.applications.forms.inboundSAML.fields.assertionURLs" +
-                                        ".placeholder")
-                                }
-                                validationErrorMsg={
-                                    t("console:develop.features.applications.forms.inboundSAML.fields.assertionURLs" +
-                                        ".validations.invalid")
-                                }
-                                validation={ (value: string) => {
+                            <Grid.Row columns={ 1 }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                    <URLInput
+                                        urlState={ assertionConsumerUrls }
+                                        setURLState={ setAssertionConsumerUrls }
+                                        labelName={
+                                            t("console:develop.features.applications.forms.inboundSAML" +
+                                                ".fields.assertionURLs.label")
+                                        }
+                                        placeholder={
+                                            t("console:develop.features.applications.forms.inboundSAML" +
+                                                ".fields.assertionURLs.placeholder")
+                                        }
+                                        validationErrorMsg={
 
-                                    let label: ReactElement = null;
+                                            t("console:develop.features.applications.forms.inboundSAML" +
+                                                ".fields.assertionURLs.validations.invalid")
+                                        }
+                                        validation={ (value: string) => {
 
-                                    if (!URLUtils.isHttpsOrHttpUrl(value)) {
-                                        label = (
-                                            <Label basic color="orange" className="mt-2">
-                                                { t("console:common.validations.unrecognizedURL.description") }
-                                            </Label>
-                                        );
-                                    }
+                                            let label: ReactElement = null;
 
-                                    if (!URLUtils.isMobileDeepLink(value)) {
-                                        return false;
-                                    }
+                                            if (!URLUtils.isHttpsOrHttpUrl(value)) {
+                                                label = (
+                                                    <Label basic color="orange" className="mt-2">
+                                                        { t("console:common.validations.unrecognizedURL.description") }
+                                                    </Label>
+                                                );
+                                            }
 
-                                    setAssertionConsumerURLsErrorLabel(label);
+                                            if (!URLUtils.isMobileDeepLink(value)) {
+                                                return false;
+                                            }
 
-                                    return true;
-                                } }
-                                computerWidth={ 10 }
-                                required={ true }
-                                showError={ showAssertionConsumerUrlError }
-                                setShowError={ setAssertionConsumerUrlError }
-                                hint={
-                                    !hideFieldHints && t("console:develop.features.applications.forms.inboundSAML" +
-                                        ".fields.assertionURLs.hint")
-                                }
-                                addURLTooltip={ t("common:addURL") }
-                                duplicateURLErrorMessage={ t("common:duplicateURLError") }
-                                data-testid={ `${ testId }-assertion-consumer-url-input` }
-                                getSubmit={ (submitFunction: (callback: (url?: string) => void) => void) => {
-                                    submitUrl = submitFunction;
-                                } }
-                                showPredictions={ false }
-                                customLabel={ assertionConsumerURLsErrorLabel }
-                            />
+                                            setAssertionConsumerURLsErrorLabel(label);
+
+                                            return true;
+                                        } }
+                                        computerWidth={ 10 }
+                                        required={ true }
+                                        showError={ showAssertionConsumerUrlError }
+                                        setShowError={ setAssertionConsumerUrlError }
+                                        hint={
+                                            !hideFieldHints && t("console:develop.features.applications" +
+                                                ".forms.inboundSAML.fields.assertionURLs.hint")
+                                        }
+                                        addURLTooltip={ t("common:addURL") }
+                                        duplicateURLErrorMessage={ t("common:duplicateURLError") }
+                                        data-testid={ `${ testId }-assertion-consumer-url-input` }
+                                        getSubmit={ (submitFunction: (callback: (url?: string) => void) => void) => {
+                                            submitUrl = submitFunction;
+                                        } }
+                                        showPredictions={ false }
+                                        customLabel={ assertionConsumerURLsErrorLabel }
+                                    />
+                                </Grid.Column>
+                            </Grid.Row>
                         ) }
                     </Grid>
                 </Forms>

--- a/apps/console/src/features/applications/data/application-templates/templates/oidc-web-application/create-wizard-help.tsx
+++ b/apps/console/src/features/applications/data/application-templates/templates/oidc-web-application/create-wizard-help.tsx
@@ -54,12 +54,6 @@ const OIDCWebApplicationCreateWizardHelp: FunctionComponent<OIDCWebApplicationCr
                     the
                     application.
                 </p>
-                <Message info>
-                    <a href="#" target="_blank">
-                        Click here
-                    </a>{ " " }
-                    to learn more about supported protocols for agent-based single sign-on.
-                </Message>
             </>
 
             <Divider />
@@ -71,7 +65,7 @@ const OIDCWebApplicationCreateWizardHelp: FunctionComponent<OIDCWebApplicationCr
                     Add the list of possible redirect URLs here. You can specify multiple valid URLs.
                     Make sure to specify the protocol (https://) otherwise the redirect may fail in some cases.
                 </p>
-                <p>E.g. https://www.conotoso.com/login</p>
+                <p>E.g. https://sample.app/login</p>
 
                 <p>
                     You can also configure this field later under the <strong>Protocol </strong>

--- a/apps/console/src/features/applications/data/application-templates/templates/saml-web-application/create-wizard-help.tsx
+++ b/apps/console/src/features/applications/data/application-templates/templates/saml-web-application/create-wizard-help.tsx
@@ -54,12 +54,6 @@ const SAMLWebApplicationCreateWizardHelp: FunctionComponent<SAMLWebApplicationCr
                     the
                     application.
                 </p>
-                <Message info>
-                    <a href="#" target="_blank">
-                        Click here
-                    </a>{ " " }
-                    to learn more about supported protocols for agent-based single sign-on.
-                </Message>
             </>
 
             <Divider />

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -86,6 +86,9 @@ export interface ConsoleNS {
             editAvatarModal: ModalInterface;
             sessionTimeoutModal: ModalInterface;
         };
+        notifications: {
+            invalidPEMFile: Notification;
+        };
         placeholders: {
             404: Placeholder;
             accessDenied: Placeholder;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1049,7 +1049,7 @@ export const console: ConsoleNS = {
                                 placeholder: "Enter allowed redirect URLs",
                                 validations: {
                                     empty: "Please add a valid URL.",
-                                    required: "Note: This field is required for a functional app. " +
+                                    required: "This field is required for a functional app. " +
                                         "However, if you are planning to integrate a sample, " +
                                         "this field can be skipped."
                                 }

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -120,6 +120,22 @@ export const console: ConsoleNS = {
                 secondaryButton: "Logout"
             }
         },
+        notifications: {
+            invalidPEMFile: {
+                error: {
+                    description: "{{ description }}",
+                    message: "Decoding Error"
+                },
+                genericError: {
+                    description: "An error occurred while decoding the certificate.",
+                    message: "Decoding Error"
+                },
+                success: {
+                    description: "Successfully decoded the certificate file.",
+                    message: "Decoding Successful"
+                }
+            }
+        },
         placeholders: {
             404: {
                 action: "Back to home",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1039,7 +1039,7 @@ export const console: ConsoleNS = {
                                 placeholder: "Saisir les URLs de redirection",
                                 validations: {
                                     empty: "Veuillez ajouter une URL valide.",
-                                    required: "Remarque: ce champ est obligatoire pour une application fonctionnelle."
+                                    required: "ce champ est obligatoire pour une application fonctionnelle."
                                 }
                             },
                             clientID: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -120,6 +120,22 @@ export const console: ConsoleNS = {
                 secondaryButton: "Déconnexion"
             }
         },
+        notifications: {
+            invalidPEMFile: {
+                error: {
+                    description: "{{ description }}",
+                    message: "Erreur de décodage"
+                },
+                genericError: {
+                    description: "Une erreur s'est produite lors du décodage du certificat.",
+                    message: "Erreur de décodage"
+                },
+                success: {
+                    description: "Décodage réussi du fichier de certificat.",
+                    message: "Décodage réussi"
+                }
+            }
+        },
         placeholders: {
             404: {
                 action: "Revenir à la page d'accueil",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1060,7 +1060,7 @@ export const console: ConsoleNS = {
                                 placeholder: "යළි-යොමුවීම් URL ඇතුළත් කරන්න",
                                 validations: {
                                     empty: "කරුණාකර වලංගු URL එකක් එක් කරන්න.",
-                                    required: "සටහන: ක්‍රියාකාරී යෙදුමක් සඳහා මෙම ක්ෂේත්‍රය අවශ්‍ය වේ."
+                                    required: "ක්‍රියාකාරී යෙදුමක් සඳහා මෙම ක්ෂේත්‍රය අවශ්‍ය වේ."
                                 }
                             },
                             clientID: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -120,6 +120,22 @@ export const console: ConsoleNS = {
                 secondaryButton: "ඉවත් වන්න"
             }
         },
+        notifications: {
+            invalidPEMFile: {
+                error: {
+                    description: "{{ description }}",
+                    message: "විකේතනය කිරීමේ දෝෂය"
+                },
+                genericError: {
+                    description: "සහතිකය විකේතනය කිරීමේදී දෝෂයක් ඇතිවිය.",
+                    message: "විකේතනය කිරීමේ දෝෂය"
+                },
+                success: {
+                    description: "සහතික ගොනුව සාර්ථකව විකේතනය කරන ලදි.",
+                    message: "විකේතනය සාර්ථකයි"
+                }
+            }
+        },
         placeholders: {
             404: {
                 action: "ආපසු ප්‍රධාන පිටුවට යන්න",

--- a/modules/theme/src/themes/default/collections/message.overrides
+++ b/modules/theme/src/themes/default/collections/message.overrides
@@ -24,3 +24,15 @@
         }
     }
 }
+
+/*------------------------
+    Message With Icon
+-------------------------*/
+
+.ui.message {
+    &.with-inline-icon {
+        >.icon:not(.close) {
+            font-size: 2em;
+        }
+    }
+}

--- a/modules/theme/src/themes/default/views/card.overrides
+++ b/modules/theme/src/themes/default/views/card.overrides
@@ -357,6 +357,33 @@
             box-shadow: none !important;
             background: transparent;
 
+            .integrate-radio {
+                flex-grow: 0;
+                width: 80px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+
+                .ui.radio.checkbox {
+                    margin-top: -5px !important;
+                }
+
+                .ui.radio.checkbox label::after {
+                    width: 22px !important;
+                    height: 22px !important;
+                    top: 0px !important;
+                    left: -1px !important;
+                    background-color: @primaryColor !important;
+                }
+
+                .ui.radio.checkbox label::before {
+                    width: 20px !important;
+                    height: 20px !important;
+                    border-color: @nobel !important;
+                    border-width: 2px !important;
+                }
+            }
+
              &.card-selected {
                  box-shadow: none !important;
                  background: @galleryGray;
@@ -387,6 +414,10 @@
                          font-size: 0.9em;
                      }
                  }
+             }
+
+             &:hover {
+                background: @galleryGray;
              }
         }
     }


### PR DESCRIPTION
## Purpose
- Move certificate field from `general` to `protocol` form.
- Remove external doc link in wizard help.

## Goals
Fixes https://github.com/wso2/product-is/issues/10942