### PR TITLE
Add default shipped route overriding support from extensions config

### DIFF
--- a/apps/console/src/extensions/extension-menu.tsx
+++ b/apps/console/src/extensions/extension-menu.tsx
@@ -50,6 +50,11 @@ const loadRouteComponents = (routes: RouteInterface[]): RouteInterface[] => {
 
     routes.map(route => {
 
+        // If a component is not defined. Don't load. Useful in overriding scenarios.
+        if (!route.component) {
+            return;
+        }
+
         // When lazy loading the component the import will return an object if we directly
         // pass the component path. Therefore we have overcome this issue by assigning it to a
         // const.

--- a/apps/console/src/features/core/configs/routes.ts
+++ b/apps/console/src/features/core/configs/routes.ts
@@ -17,6 +17,9 @@
  */
 
 import { RouteInterface } from "@wso2is/core/models";
+import keyBy from "lodash/keyBy";
+import merge from "lodash/merge";
+import values from "lodash/values";
 import { lazy } from "react";
 import { getSidePanelIcons } from "./ui";
 import { EXTENSION_ROUTES } from "../../../extensions";
@@ -44,99 +47,109 @@ import { AppConstants } from "../constants";
  */
 export const getDeveloperViewRoutes = (): RouteInterface[] => {
 
-    return [
-        ...EXTENSION_ROUTES().develop,
-        {
-            category: "console:develop.features.sidePanel.categories.application",
-            children: [
-                {
-                    component: lazy(() => import("../../applications/pages/application-template")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+    const routes: RouteInterface[] = values(
+        merge(
+            keyBy(EXTENSION_ROUTES().develop, "id"),
+            keyBy(
+                [
+                    {
+                        category: "console:develop.features.sidePanel.categories.application",
+                        children: [
+                            {
+                                component: lazy(() => import("../../applications/pages/application-template")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "applicationTemplate",
+                                name: "Application Templates",
+                                path: AppConstants.getPaths().get("APPLICATION_TEMPLATES"),
+                                protected: true,
+                                showOnSidePanel: false
+                            },
+                            {
+                                component: lazy(() => import("../../applications/pages/application-edit")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "applicationsEdit",
+                                name: "Application Edit",
+                                path: AppConstants.getPaths().get("APPLICATION_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../applications/pages/applications")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().applications
+                        },
+                        id: "applications",
+                        name: "common:applications",
+                        order: 1,
+                        path: AppConstants.getPaths().get("APPLICATIONS"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "applicationTemplate",
-                    name: "Application Templates",
-                    path: AppConstants.getPaths().get("APPLICATION_TEMPLATES"),
-                    protected: true,
-                    showOnSidePanel: false
-                },
-                {
-                    component: lazy(() => import("../../applications/pages/application-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
-                    },
-                    id: "applicationsEdit",
-                    name: "Application Edit",
-                    path: AppConstants.getPaths().get("APPLICATION_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../applications/pages/applications")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().applications
-            },
-            id: "applications",
-            name: "common:applications",
-            order: 1,
-            path: AppConstants.getPaths().get("APPLICATIONS"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:develop.features.sidePanel.categories.identityProviders",
-            children: [
-                {
-                    component: lazy(() => import("../../identity-providers/pages/identity-provider-template")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
-                    },
-                    id: "identityProviderTemplate",
-                    name: "Identity Provider Templates",
-                    path: AppConstants.getPaths().get("IDP_TEMPLATES"),
-                    protected: true,
-                    showOnSidePanel: false
-                },
-                {
-                    component: lazy(() => import("../../identity-providers/pages/identity-provider-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
-                    },
-                    id: "identityProvidersEdit",
-                    name: "Identity Providers Edit",
-                    path: AppConstants.getPaths().get("IDP_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../identity-providers/pages/identity-providers")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().identityProviders
-            },
-            id: "identityProviders",
-            name: "common:identityProviders",
-            order: 2,
-            path: AppConstants.getPaths().get("IDP"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            component: null,
-            icon: null,
-            id: "404",
-            name: "404",
-            path: "*",
-            protected: true,
-            redirectTo: AppConstants.getPaths().get("PAGE_NOT_FOUND"),
-            showOnSidePanel: false
-        }
-    ];
+                    {
+                        category: "console:develop.features.sidePanel.categories.identityProviders",
+                        children: [
+                            {
+                                component: lazy(() =>
+                                    import("../../identity-providers/pages/identity-provider-template")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "identityProviderTemplate",
+                                name: "Identity Provider Templates",
+                                path: AppConstants.getPaths().get("IDP_TEMPLATES"),
+                                protected: true,
+                                showOnSidePanel: false
+                            },
+                            {
+                                component: lazy(() => import("../../identity-providers/pages/identity-provider-edit")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "identityProvidersEdit",
+                                name: "Identity Providers Edit",
+                                path: AppConstants.getPaths().get("IDP_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../identity-providers/pages/identity-providers")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().identityProviders
+                        },
+                        id: "identityProviders",
+                        name: "common:identityProviders",
+                        order: 2,
+                        path: AppConstants.getPaths().get("IDP"),
+                        protected: true,
+                        showOnSidePanel: true
+                    }
+                ], "id"
+            )
+        )
+    );
+
+    routes.push({
+        component: null,
+        icon: null,
+        id: "404",
+        name: "404",
+        path: "*",
+        protected: true,
+        redirectTo: AppConstants.getPaths().get("PAGE_NOT_FOUND"),
+        showOnSidePanel: false
+    });
+
+    return routes;
 };
 
 /**
@@ -146,335 +159,345 @@ export const getDeveloperViewRoutes = (): RouteInterface[] => {
  */
 export const getAdminViewRoutes = (): RouteInterface[] => {
 
-    return [
-        ...EXTENSION_ROUTES().manage,
-        {
-            category: "console:manage.features.sidePanel.categories.users",
-            children: [
-                {
-                    component: lazy(() => import("../../users/pages/user-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+    const routes: RouteInterface[] = values(
+        merge(
+            keyBy(EXTENSION_ROUTES().manage, "id"),
+            keyBy(
+                [
+                    {
+                        category: "console:manage.features.sidePanel.categories.users",
+                        children: [
+                            {
+                                component: lazy(() => import("../../users/pages/user-edit")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "usersEdit",
+                                name: "console:manage.features.sidePanel.editUsers",
+                                path: AppConstants.getPaths().get("USER_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../users/pages/users")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().users
+                        },
+                        id: "users",
+                        name: "console:manage.features.sidePanel.users",
+                        order: 1,
+                        path: AppConstants.getPaths().get("USERS"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "usersEdit",
-                    name: "console:manage.features.sidePanel.editUsers",
-                    path: AppConstants.getPaths().get("USER_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../users/pages/users")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().users
-            },
-            id: "users",
-            name: "console:manage.features.sidePanel.users",
-            order: 1,
-            path: AppConstants.getPaths().get("USERS"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.users",
-            children: [
-                {
-                    component: lazy(() => import("../../groups/pages/group-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.users",
+                        children: [
+                            {
+                                component: lazy(() => import("../../groups/pages/group-edit")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "groupsEdit",
+                                name: "console:manage.features.sidePanel.editGroups",
+                                path: AppConstants.getPaths().get("GROUP_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../groups/pages/groups")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().groups
+                        },
+                        id: "groups",
+                        name: "console:manage.features.sidePanel.groups",
+                        order: 2,
+                        path: AppConstants.getPaths().get("GROUPS"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "groupsEdit",
-                    name: "console:manage.features.sidePanel.editGroups",
-                    path: AppConstants.getPaths().get("GROUP_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../groups/pages/groups")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().groups
-            },
-            id: "groups",
-            name: "console:manage.features.sidePanel.groups",
-            order: 2,
-            path: AppConstants.getPaths().get("GROUPS"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.users",
-            children: [
-                {
-                    component: lazy(() => import("../../roles/pages/role-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.users",
+                        children: [
+                            {
+                                component: lazy(() => import("../../roles/pages/role-edit")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "rolesEdit",
+                                name: "console:manage.features.sidePanel.editRoles",
+                                path: AppConstants.getPaths().get("ROLE_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../roles/pages/role")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().roles
+                        },
+                        id: "roles",
+                        name: "console:manage.features.sidePanel.roles",
+                        order: 3,
+                        path: AppConstants.getPaths().get("ROLES"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "rolesEdit",
-                    name: "console:manage.features.sidePanel.editRoles",
-                    path: AppConstants.getPaths().get("ROLE_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../roles/pages/role")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().roles
-            },
-            id: "roles",
-            name: "console:manage.features.sidePanel.roles",
-            order: 3,
-            path: AppConstants.getPaths().get("ROLES"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.users",
-            component: lazy(() => import("../../workflow-approvals/pages/approvals")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().approvals
-            },
-            id: "approvals",
-            name: "console:manage.features.sidePanel.approvals",
-            order: 4,
-            path: AppConstants.getPaths().get("APPROVALS"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.attributes",
-            children: [
-                {
-                    component: lazy(() => import("../../claims/pages/local-claims-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.users",
+                        component: lazy(() => import("../../workflow-approvals/pages/approvals")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().approvals
+                        },
+                        id: "approvals",
+                        name: "console:manage.features.sidePanel.approvals",
+                        order: 4,
+                        path: AppConstants.getPaths().get("APPROVALS"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "editLocalClaims",
-                    name: "console:manage.features.sidePanel.editLocalClaims",
-                    path: AppConstants.getPaths().get("LOCAL_CLAIMS_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                },
-                {
-                    component: lazy(() => import("../../claims/pages/local-claims")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.attributes",
+                        children: [
+                            {
+                                component: lazy(() => import("../../claims/pages/local-claims-edit")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "editLocalClaims",
+                                name: "console:manage.features.sidePanel.editLocalClaims",
+                                path: AppConstants.getPaths().get("LOCAL_CLAIMS_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            },
+                            {
+                                component: lazy(() => import("../../claims/pages/local-claims")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "localDialect",
+                                name: "console:manage.features.sidePanel.localDialect",
+                                path: AppConstants.getPaths().get("LOCAL_CLAIMS"),
+                                protected: true,
+                                showOnSidePanel: false
+                            },
+                            {
+                                component: lazy(() => import("../../claims/pages/external-dialect-edit")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "editExternalDialect",
+                                name: "console:manage.features.sidePanel.editExternalDialect",
+                                path: AppConstants.getPaths().get("EXTERNAL_DIALECT_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../claims/pages/claim-dialects")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().claims
+                        },
+                        id: "attributeDialects",
+                        name: "console:manage.features.sidePanel.attributeDialects",
+                        order: 6,
+                        path: AppConstants.getPaths().get("CLAIM_DIALECTS"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "localDialect",
-                    name: "console:manage.features.sidePanel.localDialect",
-                    path: AppConstants.getPaths().get("LOCAL_CLAIMS"),
-                    protected: true,
-                    showOnSidePanel: false
-                },
-                {
-                    component: lazy(() => import("../../claims/pages/external-dialect-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.attributes",
+                        children: [
+                            {
+                                component: lazy(() => import("../../oidc-scopes/pages/oidc-scopes-edit")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "oidcScopesEdit",
+                                name: "OIDC Scopes Edit",
+                                path: AppConstants.getPaths().get("OIDC_SCOPES_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../oidc-scopes/pages/oidc-scopes")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().scopes
+                        },
+                        id: "oidcScopes",
+                        name: "OIDC Scopes",
+                        order: 7,
+                        path: AppConstants.getPaths().get("OIDC_SCOPES"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "editExternalDialect",
-                    name: "console:manage.features.sidePanel.editExternalDialect",
-                    path: AppConstants.getPaths().get("EXTERNAL_DIALECT_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../claims/pages/claim-dialects")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().claims
-            },
-            id: "attributeDialects",
-            name: "console:manage.features.sidePanel.attributeDialects",
-            order: 6,
-            path: AppConstants.getPaths().get("CLAIM_DIALECTS"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.attributes",
-            children: [
-                {
-                    component: lazy(() => import("../../oidc-scopes/pages/oidc-scopes-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        component: lazy(() => import("../pages/customize")),
+                        icon: {
+                            icon: getSidePanelIcons().overview
+                        },
+                        id: "customize",
+                        name: "Customize",
+                        path: AppConstants.getPaths().get("CUSTOMIZE"),
+                        protected: true,
+                        showOnSidePanel: false
                     },
-                    id: "oidcScopesEdit",
-                    name: "OIDC Scopes Edit",
-                    path: AppConstants.getPaths().get("OIDC_SCOPES_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../oidc-scopes/pages/oidc-scopes")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().scopes
-            },
-            id: "oidcScopes",
-            name: "OIDC Scopes",
-            order: 7,
-            path: AppConstants.getPaths().get("OIDC_SCOPES"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            component: lazy(() => import("../pages/customize")),
-            icon: {
-                icon: getSidePanelIcons().overview
-            },
-            id: "customize",
-            name: "Customize",
-            path: AppConstants.getPaths().get("CUSTOMIZE"),
-            protected: true,
-            showOnSidePanel: false
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.userstores",
-            children: [
-                {
-                    component: lazy(() => import("../../userstores/pages/user-stores-edit")),
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.userstores",
+                        children: [
+                            {
+                                component: lazy(() => import("../../userstores/pages/user-stores-edit")),
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "edit-user-store",
+                                name: "console:manage.features.sidePanel.editUserstore",
+                                path: AppConstants.getPaths().get("USERSTORES_EDIT"),
+                                protected: true,
+                                showOnSidePanel: false
+                            },
+                            {
+                                component: lazy(() => import("../../userstores/pages/userstores-templates")),
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "userstore-templates",
+                                name: "console:manage.features.sidePanel.userstoreTemplates",
+                                path: AppConstants.getPaths().get("USERSTORE_TEMPLATES"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../userstores/pages/user-stores")),
+                        icon: {
+                            icon: getSidePanelIcons().userStore
+                        },
+                        id: "userStores",
+                        name: "console:manage.features.sidePanel.userstores",
+                        order: 5,
+                        path: AppConstants.getPaths().get("USERSTORES"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "edit-user-store",
-                    name: "console:manage.features.sidePanel.editUserstore",
-                    path: AppConstants.getPaths().get("USERSTORES_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                },
-                {
-                    component: lazy(() => import("../../userstores/pages/userstores-templates")),
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.certificates",
+                        component: lazy(() => import("../../certificates/pages/certificates-keystore")),
+                        icon: {
+                            icon: getSidePanelIcons().certificate
+                        },
+                        id: "certificates",
+                        name: "console:manage.features.sidePanel.certificates",
+                        order: 8,
+                        path: AppConstants.getPaths().get("CERTIFICATES"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "userstore-templates",
-                    name: "console:manage.features.sidePanel.userstoreTemplates",
-                    path: AppConstants.getPaths().get("USERSTORE_TEMPLATES"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../userstores/pages/user-stores")),
-            icon: {
-                icon: getSidePanelIcons().userStore
-            },
-            id: "userStores",
-            name: "console:manage.features.sidePanel.userstores",
-            order: 5,
-            path: AppConstants.getPaths().get("USERSTORES"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.certificates",
-            component: lazy(() => import("../../certificates/pages/certificates-keystore")),
-            icon: {
-                icon: getSidePanelIcons().certificate
-            },
-            id: "certificates",
-            name: "console:manage.features.sidePanel.certificates",
-            order: 8,
-            path: AppConstants.getPaths().get("CERTIFICATES"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.configurations",
-            children: [
-                {
-                    component: lazy(() => import("../../email-templates/pages/email-templates-page")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.configurations",
+                        children: [
+                            {
+                                component: lazy(() => import("../../email-templates/pages/email-templates-page")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "emailTemplates",
+                                name: "console:manage.features.sidePanel.emailTemplates",
+                                path: AppConstants.getPaths().get("EMAIL_TEMPLATES"),
+                                protected: true,
+                                showOnSidePanel: false
+                            },
+                            {
+                                component: lazy(() => import("../../email-templates/pages/email-template-edit-page")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "emailTemplates",
+                                name: "console:manage.features.sidePanel.addEmailTemplate",
+                                path: AppConstants.getPaths().get("EMAIL_TEMPLATE"),
+                                protected: true,
+                                showOnSidePanel: false
+                            },
+                            {
+                                component: lazy(() => import("../../email-templates/pages/email-template-edit-page")),
+                                exact: true,
+                                icon: {
+                                    icon: getSidePanelIcons().childIcon
+                                },
+                                id: "emailTemplates",
+                                name: "console:manage.features.sidePanel.addEmailTemplateLocale",
+                                path: AppConstants.getPaths().get("EMAIL_TEMPLATE_ADD"),
+                                protected: true,
+                                showOnSidePanel: false
+                            }
+                        ],
+                        component: lazy(() => import("../../email-templates/pages/email-template-types-page")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().emailTemplates
+                        },
+                        id: "emailTemplates",
+                        name: "console:manage.features.sidePanel.emailTemplates",
+                        order: 9,
+                        path: AppConstants.getPaths().get("EMAIL_TEMPLATE_TYPES"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "emailTemplates",
-                    name: "console:manage.features.sidePanel.emailTemplates",
-                    path: AppConstants.getPaths().get("EMAIL_TEMPLATES"),
-                    protected: true,
-                    showOnSidePanel: false
-                },
-                {
-                    component: lazy(() => import("../../email-templates/pages/email-template-edit-page")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
+                    {
+                        category: "console:manage.features.sidePanel.categories.configurations",
+                        component: lazy(() =>
+                            import("../../remote-repository-configuration/pages/remote-repository-config")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().remoteFetch
+                        },
+                        id: "remoteFetchConfig",
+                        name: "Remote Configurations",
+                        order: 10,
+                        path: AppConstants.getPaths().get("REMOTE_REPO_CONFIG"),
+                        protected: true,
+                        showOnSidePanel: true
                     },
-                    id: "emailTemplates",
-                    name: "console:manage.features.sidePanel.addEmailTemplate",
-                    path: AppConstants.getPaths().get("EMAIL_TEMPLATE"),
-                    protected: true,
-                    showOnSidePanel: false
-                },
-                {
-                    component: lazy(() => import("../../email-templates/pages/email-template-edit-page")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
-                    },
-                    id: "emailTemplates",
-                    name: "console:manage.features.sidePanel.addEmailTemplateLocale",
-                    path: AppConstants.getPaths().get("EMAIL_TEMPLATE_ADD"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("../../email-templates/pages/email-template-types-page")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().emailTemplates
-            },
-            id: "emailTemplates",
-            name: "console:manage.features.sidePanel.emailTemplates",
-            order: 9,
-            path: AppConstants.getPaths().get("EMAIL_TEMPLATE_TYPES"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            category: "console:manage.features.sidePanel.categories.configurations",
-            component: lazy(() => import("../../remote-repository-configuration/pages/remote-repository-config")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().remoteFetch
-            },
-            id: "remoteFetchConfig",
-            name: "Remote Configurations",
-            order: 10,
-            path: AppConstants.getPaths().get("REMOTE_REPO_CONFIG"),
-            protected: true,
-            showOnSidePanel: true
-        },
-        {
-            component: lazy(() => import("../../server-configurations/pages/governance-connectors")),
-            exact: true,
-            icon: null,
-            id: "governanceConnectors",
-            name: "console:manage.features.sidePanel.governanceConnectors",
-            order: 11,
-            path: AppConstants.getPaths().get("GOVERNANCE_CONNECTORS"),
-            protected: true,
-            showOnSidePanel: false
-        },
-        {
-            component: null,
-            icon: null,
-            id: "404",
-            name: "404",
-            path: "*",
-            protected: true,
-            redirectTo: AppConstants.getPaths().get("PAGE_NOT_FOUND"),
-            showOnSidePanel: false
-        }
-    ];
+                    {
+                        component: lazy(() => import("../../server-configurations/pages/governance-connectors")),
+                        exact: true,
+                        icon: null,
+                        id: "governanceConnectors",
+                        name: "console:manage.features.sidePanel.governanceConnectors",
+                        order: 11,
+                        path: AppConstants.getPaths().get("GOVERNANCE_CONNECTORS"),
+                        protected: true,
+                        showOnSidePanel: false
+                    }
+                ], "id"
+            )
+        )
+    );
+
+    routes.push({
+        component: null,
+        icon: null,
+        id: "404",
+        name: "404",
+        path: "*",
+        protected: true,
+        redirectTo: AppConstants.getPaths().get("PAGE_NOT_FOUND"),
+        showOnSidePanel: false
+    });
+
+    return routes;
 };
 
 /**
@@ -484,19 +507,24 @@ export const getAdminViewRoutes = (): RouteInterface[] => {
  */
 export const getFullScreenViewRoutes = (): RouteInterface[] => {
 
-    return [
-        ...EXTENSION_ROUTES().fullscreen,
-        {
-            component: null,
-            icon: null,
-            id: "404",
-            name: "404",
-            path: "*",
-            protected: true,
-            redirectTo: AppConstants.getPaths().get("PAGE_NOT_FOUND"),
-            showOnSidePanel: false
-        }
-    ];
+    const routes: RouteInterface[] = values(
+        merge(
+            keyBy(EXTENSION_ROUTES().fullscreen, "id")
+        )
+    );
+
+    routes.push({
+        component: null,
+        icon: null,
+        id: "404",
+        name: "404",
+        path: "*",
+        protected: true,
+        redirectTo: AppConstants.getPaths().get("PAGE_NOT_FOUND"),
+        showOnSidePanel: false
+    });
+
+    return routes;
 };
 
 /**

--- a/apps/console/src/features/core/configs/routes.ts
+++ b/apps/console/src/features/core/configs/routes.ts
@@ -49,7 +49,6 @@ export const getDeveloperViewRoutes = (): RouteInterface[] => {
 
     const routes: RouteInterface[] = values(
         merge(
-            keyBy(EXTENSION_ROUTES().develop, "id"),
             keyBy(
                 [
                     {
@@ -134,7 +133,8 @@ export const getDeveloperViewRoutes = (): RouteInterface[] => {
                         showOnSidePanel: true
                     }
                 ], "id"
-            )
+            ),
+            keyBy(EXTENSION_ROUTES().develop, "id")
         )
     );
 
@@ -161,7 +161,6 @@ export const getAdminViewRoutes = (): RouteInterface[] => {
 
     const routes: RouteInterface[] = values(
         merge(
-            keyBy(EXTENSION_ROUTES().manage, "id"),
             keyBy(
                 [
                     {
@@ -482,7 +481,8 @@ export const getAdminViewRoutes = (): RouteInterface[] => {
                         showOnSidePanel: false
                     }
                 ], "id"
-            )
+            ),
+            keyBy(EXTENSION_ROUTES().manage, "id")
         )
     );
 

--- a/apps/console/src/views/admin.tsx
+++ b/apps/console/src/views/admin.tsx
@@ -161,9 +161,10 @@ export const AdminView: FunctionComponent<AdminViewPropsInterface> = (
             return;
         }
 
-        if (!hasRequiredScopes(featureConfig?.generalConfigurations,
-            featureConfig?.generalConfigurations?.scopes?.read,
-            allowedScopes)) {
+        if (!featureConfig?.generalConfigurations?.enabled
+            || !hasRequiredScopes(featureConfig?.generalConfigurations,
+                featureConfig?.generalConfigurations?.scopes?.read,
+                allowedScopes)) {
 
             setGovernanceConnectorsEvaluated(true);
             return;

--- a/modules/core/src/models/route.ts
+++ b/modules/core/src/models/route.ts
@@ -63,7 +63,7 @@ export interface StaticRouteInterface {
     /**
      * Name to be displayed on the side panel.
      */
-    name: string;
+    name?: string;
     /**
      * Side panel order.
      */
@@ -75,7 +75,7 @@ export interface StaticRouteInterface {
     /**
      * If the route is protected or not.
      */
-    protected: boolean;
+    protected?: boolean;
     /**
      * Redirect path.
      */


### PR DESCRIPTION
## Purpose
Currently, the OOTB routes are not overridable using the extensions config.

## Goals
Add support to achieve $subject.

Fix issue in overriding governance feature visibility.

## Approach
To hide `userstores` feature, put the following in extensions config.

```ts
export const ExtensionsConfig = (): ExtensionsConfigInterface => ({
   ...
    routes: {
         manage: [
            {
                id: "userStores",
                showOnSidePanel: false
            }
         ]
    }
```

To override `users` feature, put the following in extensions config.

```ts
export const ExtensionsConfig = (): ExtensionsConfigInterface => ({
   ...
    routes: {
         manage: [
             {
                  id: "users",
                  name: "Consumer Users",
                  component: "./components/manage-getting-started/getting-started",
            }
         ]
    }
```