### PR TITLE
Remove duplicated description in TOTP page

### DIFF
--- a/apps/totp-authentication-portal/src/main/webapp/enableTOTP.jsp
+++ b/apps/totp-authentication-portal/src/main/webapp/enableTOTP.jsp
@@ -106,7 +106,6 @@
                                             <div class="ui negative message"><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "error.retry")%></div>
                                             <div class="ui divider hidden"></div>
                                 <% } }  %>
-                                <p>You have not enabled TOTP authentication. Please enable it.</p>
 
                                 <p><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "error.totp.not.enabled.please.enable")%></p>
                                 


### PR DESCRIPTION
Fixing duplicated description in the TOTP enable page

![image](https://user-images.githubusercontent.com/5237653/104907226-c0451f80-59aa-11eb-86fa-bbc07c409296.png)
