### PR TITLE
 Connectors and Authenticators collapsible when more then One available

### DIFF
--- a/apps/console/src/features/applications/components/settings/provisioning/inbound-provisioning-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/provisioning/inbound-provisioning-configuration.tsx
@@ -21,10 +21,10 @@ import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Heading } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Divider, Grid } from "semantic-ui-react";
+import { AccordionTitleProps, Divider, Grid } from "semantic-ui-react";
 import { AppState, AuthenticatorAccordion, FeatureConfigInterface } from "../../../../core";
 import { updateApplicationConfigurations } from "../../../api";
 import { ProvisioningConfigurationInterface, SimpleUserStoreListItemInterface } from "../../../models";
@@ -52,6 +52,10 @@ interface InboundProvisioningConfigurationsPropsInterface extends SBACInterface<
      * Make the form read only.
      */
     readOnly?: boolean;
+    /**
+     * Initial activeIndexes value.
+     */
+    defaultActiveIndexes?: number[];
 }
 
 /**
@@ -69,6 +73,7 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
         provisioningConfigurations,
         onUpdate,
         featureConfig,
+        defaultActiveIndexes,
         readOnly,
         [ "data-testid" ]: testId
     } = props;
@@ -80,6 +85,8 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
     const [ userStore, setUserStore ] = useState<SimpleUserStoreListItemInterface[]>([]);
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
+
+    const [ accordionActiveIndexes, setAccordionActiveIndexes ] = useState<number[]>(defaultActiveIndexes);
 
     /**
      * Handles the provisioning config form submit action.
@@ -110,6 +117,28 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
             });
     };
 
+    /**
+     * Handles accordion title click.
+     *
+     * @param {React.SyntheticEvent} e - Click event.
+     * @param {AccordionTitleProps} SegmentedAuthenticatedAccordion - Clicked title.
+     */
+    const handleAccordionOnClick = (e: MouseEvent<HTMLDivElement>,
+                                    SegmentedAuthenticatedAccordion: AccordionTitleProps): void => {
+        if (!SegmentedAuthenticatedAccordion) {
+            return;
+        }
+        const newIndexes = [ ...accordionActiveIndexes ];
+
+        if (newIndexes.includes(SegmentedAuthenticatedAccordion.accordionIndex)) {
+            const removingIndex = newIndexes.indexOf(SegmentedAuthenticatedAccordion.accordionIndex);
+            newIndexes.splice(removingIndex, 1);
+        } else {
+            newIndexes.push(SegmentedAuthenticatedAccordion.accordionIndex);
+        }
+
+        setAccordionActiveIndexes(newIndexes);
+    };
 
     useEffect(() => {
         const userstore: SimpleUserStoreListItemInterface[] = [];
@@ -161,6 +190,9 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
                                     }
                                 ]
                             }
+                            accordionActiveIndexes = { accordionActiveIndexes }
+                            accordionIndex = { 0 }
+                            handleAccordionOnClick = { handleAccordionOnClick }
                             data-testid={ `${ testId }-inbound-connector-accordion` }
                         />
                     </Grid.Column>
@@ -175,5 +207,6 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
  * Default props for the application inbound provisioning configurations component.
  */
 InboundProvisioningConfigurations.defaultProps = {
-    "data-testid": "application-inbound-provisioning-configurations"
+    "data-testid": "application-inbound-provisioning-configurations",
+    defaultActiveIndexes: [ -1 ]
 };

--- a/apps/console/src/features/applications/components/settings/provisioning/outbound-provisioning-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/provisioning/outbound-provisioning-configuration.tsx
@@ -19,10 +19,10 @@
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ConfirmationModal, EmptyPlaceholder, Heading, PrimaryButton } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Divider, Grid, Icon, Segment } from "semantic-ui-react";
+import { AccordionTitleProps, Divider, Grid, Icon, Segment} from "semantic-ui-react";
 import { AuthenticatorAccordion, getEmptyPlaceholderIllustrations } from "../../../../core";
 import { IdentityProviderInterface, getIdentityProviderList } from "../../../../identity-providers";
 import { updateApplicationConfigurations } from "../../../api";
@@ -53,6 +53,10 @@ interface OutboundProvisioningConfigurationPropsInterface extends TestableCompon
      * Make the form read only.
      */
     readOnly?: boolean;
+    /**
+     * Initial activeIndexes value.
+     */
+    defaultActiveIndexes?: number[];
 }
 
 /**
@@ -70,6 +74,7 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
         application,
         onUpdate,
         readOnly,
+        defaultActiveIndexes,
         [ "data-testid" ]: testId
     } = props;
 
@@ -80,6 +85,7 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
     const [ showWizard, setShowWizard ] = useState<boolean>(false);
     const [ showDeleteConfirmationModal, setShowDeleteConfirmationModal ] = useState<boolean>(false);
     const [ idpList, setIdpList ] = useState<IdentityProviderInterface[]>(undefined);
+    const [ accordionActiveIndexes, setAccordionActiveIndexes ] = useState<number[]>(defaultActiveIndexes);
 
     const [
         deletingIdp,
@@ -131,6 +137,29 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
                         ".message")
                 }));
             });
+    };
+
+    /**
+     * Handles accordion title click.
+     *
+     * @param {React.SyntheticEvent} e - Click event.
+     * @param {AccordionTitleProps} SegmentedAuthenticatedAccordion - Clicked title.
+     */
+    const handleAccordionOnClick = (e: MouseEvent<HTMLDivElement>,
+                                    SegmentedAuthenticatedAccordion: AccordionTitleProps): void => {
+        if (!SegmentedAuthenticatedAccordion) {
+            return;
+        }
+        const newIndexes = [ ...accordionActiveIndexes ];
+
+        if (newIndexes.includes(SegmentedAuthenticatedAccordion.accordionIndex)) {
+            const removingIndex = newIndexes.indexOf(SegmentedAuthenticatedAccordion.accordionIndex);
+            newIndexes.splice(removingIndex, 1);
+        } else {
+            newIndexes.push(SegmentedAuthenticatedAccordion.accordionIndex);
+        }
+
+        setAccordionActiveIndexes(newIndexes);
     };
 
     const updateConfiguration = (values: any) => {
@@ -204,7 +233,7 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
                             <Grid.Column>
                                 {
                                     application?.provisioningConfigurations?.outboundProvisioningIdps?.map(
-                                        (provisioningIdp) => {
+                                        (provisioningIdp, index) => {
                                         return (
                                             <AuthenticatorAccordion
                                                 key={ provisioningIdp.idp }
@@ -240,6 +269,9 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
                                                         }
                                                     ]
                                                 }
+                                                accordionActiveIndexes = { accordionActiveIndexes }
+                                                accordionIndex = { index }
+                                                handleAccordionOnClick = { handleAccordionOnClick }
                                                 data-testid={ `${ testId }-outbound-connector-accordion` }
                                             />
                                         );
@@ -351,5 +383,6 @@ export const OutboundProvisioningConfiguration: FunctionComponent<OutboundProvis
  * Default props for the application outbound provisioning configurations component.
  */
 OutboundProvisioningConfiguration.defaultProps = {
-    "data-testid": "application-outbound-provisioning-configurations"
+    "data-testid": "application-outbound-provisioning-configurations",
+    defaultActiveIndexes: [ -1 ]
 };

--- a/apps/console/src/features/core/components/authenticator-accordion.tsx
+++ b/apps/console/src/features/core/components/authenticator-accordion.tsx
@@ -29,9 +29,6 @@ import React, {
     Fragment,
     FunctionComponent,
     ReactElement,
-    SyntheticEvent,
-    useEffect,
-    useState
 } from "react";
 
 /**
@@ -42,14 +39,6 @@ export interface AuthenticatorAccordionPropsInterface extends TestableComponentI
      * Set of authenticators.
      */
     authenticators: AuthenticatorAccordionItemInterface[];
-    /**
-     * Initial activeIndexes value.
-     */
-    defaultActiveIndexes?: number[];
-    /**
-     * Expand the accordion if only single item is present.
-     */
-    defaultExpandSingleItemAccordion?: boolean;
     /**
      * Accordion actions.
      */
@@ -62,6 +51,18 @@ export interface AuthenticatorAccordionPropsInterface extends TestableComponentI
      * Attribute to sort the array.
      */
     orderBy?: string;
+    /**
+     * List of active accordion indexes.
+     */
+    accordionActiveIndexes?: number[];
+    /**
+     * Accordion index.
+     */
+    accordionIndex?: number;
+    /**
+     * Handle accordion on click method.
+     */
+    handleAccordionOnClick?: SegmentedAccordionTitlePropsInterface["handleAccordionOnClick"];
 }
 
 /**
@@ -105,50 +106,15 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
 ): ReactElement => {
 
     const {
+        accordionIndex,
+        handleAccordionOnClick,
         globalActions,
         authenticators,
-        defaultActiveIndexes,
-        defaultExpandSingleItemAccordion,
+        accordionActiveIndexes,
         hideChevron,
         orderBy,
         [ "data-testid" ]: testId
     } = props;
-
-    const [ accordionActiveIndexes, setAccordionActiveIndexes ] = useState<number[]>(defaultActiveIndexes);
-
-    /**
-     * If the authenticator count is 1, always open the authenticator panel.
-     */
-    useEffect(() => {
-        if (!defaultExpandSingleItemAccordion) {
-            return;
-        }
-
-        if (!(authenticators && Array.isArray(authenticators) && authenticators.length === 1)) {
-            return;
-        }
-
-        setAccordionActiveIndexes([ 0 ]);
-    }, [ authenticators ]);
-
-    /**
-     * Handles accordion title click.
-     *
-     * @param {React.SyntheticEvent} e - Click event.
-     * @param {number} index - Clicked on index.
-     */
-    const handleAccordionOnClick = (e: SyntheticEvent, { index }: { index: number }): void => {
-        const newIndexes = [ ...accordionActiveIndexes ];
-
-        if (newIndexes.includes(index)) {
-            const removingIndex = newIndexes.indexOf(index);
-            newIndexes.splice(removingIndex, 1);
-        } else {
-            newIndexes.push(index);
-        }
-
-        setAccordionActiveIndexes(newIndexes);
-    };
 
     return (authenticators
             ?
@@ -160,12 +126,12 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
                     _.sortBy(authenticators, orderBy).map((authenticator, index) => (
                         !authenticator.hidden
                             ? (
-                                <Fragment key={ index }>
+                                <Fragment key={ accordionIndex }>
                                     <SegmentedAccordion.Title
                                         id={ authenticator.id }
                                         data-testid={ `${ testId }-${ authenticator.id }-title` }
-                                        active={ accordionActiveIndexes.includes(index) }
-                                        index={ index }
+                                        active={ accordionActiveIndexes.includes(accordionIndex) }
+                                        accordionIndex={ accordionIndex }
                                         onClick={ handleAccordionOnClick }
                                         content={ (
                                             <>
@@ -188,7 +154,7 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
                                         hideChevron={ hideChevron }
                                     />
                                     <SegmentedAccordion.Content
-                                        active={ accordionActiveIndexes.includes(index) }
+                                        active={ accordionActiveIndexes.includes(accordionIndex) }
                                         data-testid={ `${ testId }-${ authenticator.id }-content` }
                                     >
                                         { authenticator.content }
@@ -208,8 +174,6 @@ export const AuthenticatorAccordion: FunctionComponent<AuthenticatorAccordionPro
  */
 AuthenticatorAccordion.defaultProps = {
     "data-testid": "authenticator-accordion",
-    defaultActiveIndexes: [ -1 ],
-    defaultExpandSingleItemAccordion: true,
     hideChevron: false,
     orderBy: undefined
 };

--- a/apps/console/src/features/groups/components/group-list.tsx
+++ b/apps/console/src/features/groups/components/group-list.tsx
@@ -373,7 +373,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
                 onRowClick={
                     (e: SyntheticEvent, group: GroupsInterface): void => {
                         handleGroupEdit(group?.id);
-                        onListItemClick(e, group);
+                        onListItemClick && onListItemClick(e, group);
                     }
                 }
                 placeholders={ showPlaceholders() }

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -27,10 +27,10 @@ import {
     PrimaryButton,
     SegmentedAccordionTitleActionInterface
 } from "@wso2is/react-components";
-import React, { FormEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FormEvent, FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { CheckboxProps, Divider, Grid, Icon, Segment } from "semantic-ui-react";
+import { AccordionTitleProps, CheckboxProps, Divider, Grid, Icon, Segment } from "semantic-ui-react";
 import { OutboundProvisioningRoles } from "./outbound-provisioning";
 import { AuthenticatorAccordion, getEmptyPlaceholderIllustrations } from "../../../core";
 import {
@@ -73,6 +73,10 @@ interface ProvisioningSettingsPropsInterface extends TestableComponentInterface 
      * Callback to update the idp details.
      */
     onUpdate: (id: string) => void;
+    /**
+     * Initial activeIndexes value.
+     */
+    defaultActiveIndexes?: number[];
 }
 
 /**
@@ -90,6 +94,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
         outboundConnectors,
         isLoading,
         onUpdate,
+        defaultActiveIndexes,
         [ "data-testid" ]: testId
     } = props;
 
@@ -106,6 +111,8 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
         deletingConnector,
         setDeletingConnector
     ] = useState<OutboundProvisioningConnectorWithMetaInterface>(undefined);
+    const [ accordionActiveIndexes, setAccordionActiveIndexes ] = useState<number[]>(defaultActiveIndexes);
+
 
     /**
      * Fetch available connectors for the identity provider.
@@ -258,6 +265,30 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
     };
 
     /**
+     * Handles accordion title click.
+     *
+     * @param {React.SyntheticEvent} e - Click event.
+     * @param {AccordionTitleProps} SegmentedAuthenticatedAccordion - Clicked title.
+     */
+    const handleAccordionOnClick = (e: MouseEvent<HTMLDivElement>,
+                                    SegmentedAuthenticatedAccordion: AccordionTitleProps): void => {
+        if (!SegmentedAuthenticatedAccordion) {
+            return;
+        }
+        const newIndexes = [ ...accordionActiveIndexes ];
+
+        if (newIndexes.includes(SegmentedAuthenticatedAccordion.accordionIndex)) {
+            const removingIndex = newIndexes.indexOf(SegmentedAuthenticatedAccordion.accordionIndex);
+            newIndexes.splice(removingIndex, 1);
+        } else {
+            newIndexes.push(SegmentedAuthenticatedAccordion.accordionIndex);
+        }
+
+        setAccordionActiveIndexes(newIndexes);
+    };
+
+
+    /**
      * Handles connector delete button on click action.
      *
      * @param {React.MouseEvent<HTMLDivElement>} e - Click event.
@@ -370,6 +401,9 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                                                                 }
                                                             ]
                                                         }
+                                                        accordionActiveIndexes = { accordionActiveIndexes }
+                                                        accordionIndex = { index }
+                                                        handleAccordionOnClick = { handleAccordionOnClick }
                                                         data-testid={ `${testId}-accordion` }
                                                     />
                                                 );
@@ -485,5 +519,6 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
  * Default proptypes for the IDP outbound provisioning settings component.
  */
 OutboundProvisioningSettings.defaultProps = {
-    "data-testid": "idp-edit-outbound-provisioning-settings"
+    "data-testid": "idp-edit-outbound-provisioning-settings",
+    defaultActiveIndexes: [ -1 ]
 };

--- a/modules/react-components/src/components/accordion/segmented-accordion/segmented-accordion-title.tsx
+++ b/modules/react-components/src/components/accordion/segmented-accordion/segmented-accordion-title.tsx
@@ -57,6 +57,11 @@ export interface SegmentedAccordionTitlePropsInterface extends AccordionTitlePro
      * Flag to determine if emphasized segments should be used.
      */
     useEmphasizedSegments?: boolean;
+    /**
+     * Handle accordion on click method.
+     */
+    handleAccordionOnClick?:
+        (e: MouseEvent<HTMLDivElement>, SegmentedAuthenticatedAccordion: AccordionTitleProps) => void;
 }
 
 /**


### PR DESCRIPTION

## Purpose
Fixes https://github.com/wso2/product-is/issues/10946
Fixes https://github.com/wso2/product-is/issues/10719

## Goals
> Shrunk the authentication accordion according to its parent component.

## Approach
> We moved configs for the shrunk accordion to its parent component.

## User stories
Before
![BeforeIDPAuthentication](https://user-images.githubusercontent.com/25488962/105000759-c0015e80-5a54-11eb-8ddb-3c6761f6b1ec.png)

After
![afterIDPauthentication2items](https://user-images.githubusercontent.com/25488962/105000782-c98ac680-5a54-11eb-8c41-fe214d156afa.png)
Note that if you have more than one connector, all of them will in a shucked state.

Application->Provisioning-> Inbound Provisioning . SCIM Inbound provision will be shucked by default.
Before
![beforeIDPOPScimOnly](https://user-images.githubusercontent.com/25488962/105000858-e8895880-5a54-11eb-85e7-ea24a1f11897.png)

After
![afterSPIPSCIMonly](https://user-images.githubusercontent.com/25488962/105000876-efb06680-5a54-11eb-97bf-2527c2fe8b99.png)

