### PR TITLE
Rename unable to delete message of local attribute

### DIFF
--- a/apps/console/src/features/claims/api/claims.ts
+++ b/apps/console/src/features/claims/api/claims.ts
@@ -156,6 +156,24 @@ export const deleteAClaim = (id: string): Promise<any> => {
             return Promise.resolve(response.data);
         })
         .catch((error) => {
+            /*
+            Todo:
+            Due to : https://github.com/wso2/product-is/issues/8729. We are hard coding following error response for
+            this particular error code. Once the issue resolved at API level, we can remove this hardcoded response.
+            { Issue Description : When deleting a local attribute which is also having associations, error message
+            contains the word "claim" instead of "attribute" }
+            { Hardcoded solution : Refactor error response by replacing "claim" with "attribute" }
+             */
+            if (error?.response?.data?.code === "CMT-50031") {
+                const hardCodedResponse =
+                    {
+                        code: error?.response?.data?.code,
+                        description: "Unable to remove local attribute while having associations with external claims.",
+                        message: "Unable to remove local attribute.",
+                        traceId: error?.response?.data?.traceId
+                    };
+                return Promise.reject(hardCodedResponse);
+            }
             return Promise.reject(error?.response?.data);
         });
 };

--- a/apps/console/src/features/claims/api/claims.ts
+++ b/apps/console/src/features/claims/api/claims.ts
@@ -157,7 +157,7 @@ export const deleteAClaim = (id: string): Promise<any> => {
         })
         .catch((error) => {
             /*
-            Todo:
+            TODO:
             Due to : https://github.com/wso2/product-is/issues/8729. We are hard coding following error response for
             this particular error code. Once the issue resolved at API level, we can remove this hardcoded response.
             { Issue Description : When deleting a local attribute which is also having associations, error message


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/8729



## Approach
We are hard coding following error response for  this particular error code. Once the issue resolved at API level, we can remove this hard coded response. **Cause**, When deleting a local attribute which is also having associations, error message  contains the word "claim" instead of "attribute" . **Solution** : Refactor error response by replacing "claim" with "attribute" 

## User stories
Before
<img width="205" alt="old" src="https://user-images.githubusercontent.com/25488962/105126555-08785500-5b05-11eb-92bc-840b05b7828d.png">
After
![new](https://user-images.githubusercontent.com/25488962/105126670-45444c00-5b05-11eb-98e5-8733641ec2d1.png)
