### PR TITLE
Handle malformed URLs and prevent invalid form submission issue in url-input component

### DIFF
--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -355,7 +355,17 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
         }
     }, [ hideComponent ]);
 
-    const handleAllowOrigin = (url: string): void => {
+    /**
+     * Once clicked this function will immediately delegates the
+     * action to the parent above this component. Calls -
+     * {@link React.MouseEvent.preventDefault} to avoid accidental
+     * form submission events.
+     *
+     * @param event {React.MouseEvent<HTMLButtonElement>}
+     * @param url {string} user input
+     */
+    const onAllowOriginClick = (event: React.MouseEvent<HTMLButtonElement>, url: string): void => {
+        event.preventDefault();
         handleAddAllowedOrigin(url);
         allowedOrigins.push(url);
     };
@@ -555,7 +565,9 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                         { shouldShowAllowOriginAction(url) && (
                             <LinkButton
                                 className={ "m-1 p-1 with-no-border orange" }
-                                onClick={ () => handleAllowOrigin(onlyOrigin ? origin : href) }>
+                                onClick={ (e) => {
+                                    onAllowOriginClick(e, onlyOrigin ? origin : href)
+                                } }>
                                 <span style={ { fontWeight: "bold" } }>Allow</span>
                             </LinkButton>
                         ) }

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -181,6 +181,12 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                     url = url.replace(/\/+$/, "");
                 }
             }
+        } else {
+            /**
+             * If the entered URL is a silly input, then we won't add
+             * the input to the state.
+             */
+            return;
         }
 
         const urlValid = validation(url);
@@ -636,7 +642,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                 )
             }
             { urlState && urlState.split(",").map((url) => {
-                if (url !== "") {
+                if (url !== "" && URLUtils.isURLValid(url)) {
                     return urlChipItemWidget(url);
                 }
             }) }


### PR DESCRIPTION
## Purpose
Please note $subject

- FIXES - Ignores silly user inputs like: `https://localhost:32qwertY/gg`
- FIXES - Escapes reverse slash URLs  `https:\\muchwow.io\gg`
- FIXES - Form is submitting intermittently when clicked `Allow` 