### PR TITLE
Redirect to the homepage if logout fails

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -50,6 +50,7 @@ import _ from "lodash";
 import { UAParser } from "ua-parser-js";
 import { Config } from "../../../core/configs";
 import { CommonConstants } from "../../../core/constants";
+import { history } from "../../../core/helpers";
 import { store } from "../../../core/store";
 import { HttpUtils } from "../../../core/utils";
 
@@ -97,7 +98,7 @@ export const getProfileInformation = (
                                 addAlert<AlertInterface>({
                                     description: error.response.data.description,
                                     level: AlertLevels.ERROR,
-                                    message: I18n.instance.t("console:manage.notifications.getProfileSchema." + 
+                                    message: I18n.instance.t("console:manage.notifications.getProfileSchema." +
                                         "error.message")
                                 })
                             );
@@ -139,7 +140,7 @@ export const getProfileInformation = (
 
             dispatch(
                 addAlert({
-                    description: I18n.instance.t("console:manage.notifications.getProfileInfo.genericError." + 
+                    description: I18n.instance.t("console:manage.notifications.getProfileInfo.genericError." +
                         "description"),
                     level: AlertLevels.ERROR,
                     message: I18n.instance.t("console:manage.notifications.getProfileInfo.genericError.message")
@@ -312,5 +313,7 @@ export const handleSignOut = () => (dispatch) => {
         .then(() => {
             AuthenticateUtils.removeAuthenticationCallbackUrl(AppConstants.CONSOLE_APP);
             dispatch(setSignOut());
+        }).catch(() => {
+            history.push(window[ "AppUtils" ].getConfig().routes.home);
         });
 };

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -21,13 +21,13 @@ import {
     AuthenticatedUserInterface,
     Hooks,
     IdentityClient,
+    LOGOUT_URL,
     OIDC_SESSION_IFRAME_ENDPOINT,
     ResponseMode,
     ServiceResourcesType,
     Storage,
     TOKEN_ENDPOINT,
-    UserInfo,
-    LOGOUT_URL
+    UserInfo
 } from "@asgardio/oidc-js";
 import { getProfileSchemas } from "@wso2is/core/api";
 import { AppConstants, TokenConstants } from "@wso2is/core/constants";
@@ -43,6 +43,7 @@ import { AuthAction, authenticateActionTypes } from "./types";
 import { getProfileInfo, getUserReadOnlyStatus, switchAccount } from "../../api";
 import { Config } from "../../configs";
 import { CommonConstants } from "../../constants";
+import { history } from "../../helpers";
 import {
     AlertLevels,
     BasicProfileInterface,
@@ -412,6 +413,8 @@ export const handleSignOut = () => (dispatch) => {
         .then(() => {
             AuthenticateUtils.removeAuthenticationCallbackUrl(AppConstants.MY_ACCOUNT_APP);
             dispatch(setSignOut());
+        }).catch(() => {
+            history.push(window["AppUtils"].getConfig().routes.home);
         });
 };
 


### PR DESCRIPTION
## Purpose
> Sometimes, logging out returned a session-not-found error. This issue has been addressed by redirecting the user to the homepage.
![image](https://user-images.githubusercontent.com/20745428/105680282-7f528b00-5f15-11eb-83be-14390905ef6e.png)

