### PR TITLE
Hide help reference if help link is not available

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/template-description.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/template-description.tsx
@@ -131,17 +131,23 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
 
                     <h4>
                         {
-                            t("console:develop.features.applications.edit.sections.signOnMethod.sections." +
-                                "templateDescription.description.helpReference")
+                            template.helpLink 
+                            ? t("console:develop.features.applications.edit.sections.signOnMethod.sections." +
+                                "templateDescription.description.helpReference") 
+                            : null
                         }
                     </h4>
-                    <Message icon info>
-                        <Icon name="help circle" />
-                        <Message.Content>
-                            <a target="_blank" href={ template.helpLink } rel="noreferrer">{ template.helpLink }</a>
-                        </Message.Content>
-                    </Message>
-
+                    {
+                        template.helpLink 
+                        ? (
+                            <Message icon info>
+                            <Icon name="help circle" />
+                            <Message.Content>
+                                <a target="_blank" href={ template.helpLink } rel="noreferrer">{ template.helpLink }</a>
+                            </Message.Content>
+                            </Message> )
+                        : null
+                    }
                     <h4>
                         {
                             t("console:develop.features.applications.edit.sections.signOnMethod.sections." +


### PR DESCRIPTION
## Purpose
UI fix for https://github.com/wso2-enterprise/asgardeo-product/issues/1075

**Template Description when Help-Link is not available or empty**
![no help](https://user-images.githubusercontent.com/25483865/105841333-6ec81080-5ffa-11eb-8a5a-ad35f0fe2590.png)

**Template Description when Help-Link is available**
![have help](https://user-images.githubusercontent.com/25483865/105841351-7687b500-5ffa-11eb-9a8d-80962410a451.png)
