### PR TITLE
Improve Sign-on methods tab UX 

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
@@ -162,12 +162,12 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
                     ) }
                     content={
                         (
-                            <>
+                            <div>
                                 <Label attached="top">
                                     { t("console:develop.features.applications.edit.sections.signOnMethod.sections" +
                                         ".authenticationFlow.sections.stepBased.actions.selectAuthenticator") }
                                 </Label>
-                                <Form className="mt-3 mb-3" data-testid={ `${ testId }-authenticator-selection` }>
+                                <Form data-testid={ `${ testId }-authenticator-selection` }>
                                     {
                                         authenticator?.authenticators?.map((item) => {
                                             return (
@@ -188,7 +188,7 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
                                         })
                                     }
                                 </Form>
-                            </>
+                            </div>
                         )
                     }
                 >

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -18,13 +18,13 @@
 
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { GenericIcon, Heading, Hint, PrimaryButton } from "@wso2is/react-components";
+import { GenericIcon, Heading, Hint } from "@wso2is/react-components";
 import _ from "lodash";
 import React, { Fragment, FunctionComponent, ReactElement, SyntheticEvent, useEffect, useRef, useState } from "react";
 import { DragDropContext, DropResult } from "react-beautiful-dnd";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Card, Divider, DropdownProps, Form, Grid, Icon, Popup } from "semantic-ui-react";
+import { Button, Card, DropdownProps, Form, Grid, Label, Popup } from "semantic-ui-react";
 import { AuthenticationStep } from "./authentication-step";
 import { AuthenticatorSidePanel } from "./authenticator-side-panel";
 import { getOperationIcons } from "../../../../../core";
@@ -33,6 +33,7 @@ import {
     GenericAuthenticatorInterface,
     IdentityProviderManagementUtils
 } from "../../../../../identity-providers";
+import { getGeneralIcons } from "../../../../configs";
 import { ApplicationManagementConstants } from "../../../../constants";
 import {
     AuthenticationSequenceInterface,
@@ -636,49 +637,65 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
                                         </Form.Field>
                                     </Form>
                                 </Grid.Column>
-                                <Grid.Column computer={ 6 } mobile={ 16 } textAlign="right">
-                                    <PrimaryButton
-                                        onClick={ handleAuthenticationStepAdd }
-                                        data-testid={ `${ testId }-new-authentication-step-button` }
-                                    >
-                                        <Icon name="add" />
-                                        { t(
-                                            "console:develop.features.applications.edit.sections.signOnMethod" +
-                                            ".sections.authenticationFlow.sections.stepBased.actions.addStep"
-                                        ) }
-                                    </PrimaryButton>
-                                </Grid.Column>
                             </Grid.Row>
                         ) }
                         <Grid.Row>
                             <Grid.Column computer={ 16 }>
                                 <div className="authentication-steps-section">
-                                    { authenticationSteps &&
+                                    <div className="flow-button-container with-trail with-margin start">
+                                        <Label basic circular color="blue">Start</Label>
+                                    </div>
+                                    {
+                                        authenticationSteps &&
                                         authenticationSteps instanceof Array &&
                                         authenticationSteps.length > 0
-                                        ? authenticationSteps.map((step, stepIndex) => (
-                                            <Fragment key={ stepIndex }>
-                                                <AuthenticationStep
-                                                    authenticators={ [
-                                                        ...localAuthenticators,
-                                                        ...federatedAuthenticators,
-                                                        ...secondFactorAuthenticators
-                                                    ] }
-                                                    droppableId={ AUTHENTICATION_STEP_DROPPABLE_ID + stepIndex }
-                                                    onStepDelete={ handleStepDelete }
-                                                    onStepOptionAuthenticatorChange={
-                                                        handleStepOptionAuthenticatorChange
-                                                    }
-                                                    onStepOptionDelete={ handleStepOptionDelete }
-                                                    step={ step }
-                                                    stepIndex={ stepIndex }
-                                                    readOnly={ readOnly }
-                                                    data-testid={ `${ testId }-authentication-step-${ stepIndex }` }
-                                                />
-                                                <Divider hidden />
-                                            </Fragment>
-                                        ))
-                                        : null }
+                                            ? authenticationSteps.map((step, stepIndex) => (
+                                                <Fragment key={ stepIndex }>
+                                                    <AuthenticationStep
+                                                        authenticators={ [
+                                                            ...localAuthenticators,
+                                                            ...federatedAuthenticators,
+                                                            ...secondFactorAuthenticators
+                                                        ] }
+                                                        droppableId={ AUTHENTICATION_STEP_DROPPABLE_ID + stepIndex }
+                                                        onStepDelete={ handleStepDelete }
+                                                        onStepOptionAuthenticatorChange={
+                                                            handleStepOptionAuthenticatorChange
+                                                        }
+                                                        onStepOptionDelete={ handleStepOptionDelete }
+                                                        step={ step }
+                                                        stepIndex={ stepIndex }
+                                                        readOnly={ readOnly }
+                                                        data-testid={ `${ testId }-authentication-step-${ stepIndex }` }
+                                                    />
+                                                    <div
+                                                        className="flow-button-container with-trail with-margin start"
+                                                    ></div>
+                                                </Fragment>
+                                            ))
+                                            : null
+                                    }
+                                    <div className="flow-button-container with-trail with-margin">
+                                        <Button
+                                            icon
+                                            basic
+                                            circular
+                                            className="mr-0"
+                                            data-testid={ `${ testId }-new-authentication-step-button` }
+                                            onClick={ handleAuthenticationStepAdd }
+                                        >
+                                            <GenericIcon
+                                                link
+                                                transparent
+                                                as="data-url"
+                                                size="x22"
+                                                icon={ getGeneralIcons().plusIcon }
+                                            />
+                                        </Button>
+                                    </div>
+                                    <div className="flow-button-container pr-3">
+                                        <Label basic circular color="green">Done</Label>
+                                    </div>
                                 </div>
                             </Grid.Column>
                         </Grid.Row>

--- a/apps/console/src/features/applications/configs/ui.ts
+++ b/apps/console/src/features/applications/configs/ui.ts
@@ -134,6 +134,7 @@ export const getGeneralIcons = () => {
     const theme: string = AppConstants && AppConstants.getAppTheme() && AppConstants.getAppTheme().name;
 
     return {
-        addCircleOutline: import(`../../../themes/${ theme }/assets/images/icons/outline-icons/add-circle-outline.svg`)
+        addCircleOutline: import(`../../../themes/${ theme }/assets/images/icons/outline-icons/add-circle-outline.svg`),
+        plusIcon: import(`../../../themes/${ theme }/assets/images/icons/plus-icon.svg`)
     };
 };

--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -157,6 +157,7 @@ export class Config {
             appTitle: window["AppUtils"].getConfig().ui.appTitle,
             features: window["AppUtils"].getConfig().ui.features,
             gravatarConfig: window["AppUtils"].getConfig().ui.gravatarConfig,
+            hiddenAuthenticators: window["AppUtils"].getConfig().ui.hiddenAuthenticators,
             i18nConfigs: window["AppUtils"].getConfig().ui.i18nConfigs,
             isClientSecretHashEnabled: window["AppUtils"].getConfig().ui.isClientSecretHashEnabled,
             isDefaultDialectEditingEnabled: window["AppUtils"].getConfig().ui.isDefaultDialectEditingEnabled,

--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -148,6 +148,10 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      */
     applicationTemplateLoadingStrategy?: ApplicationTemplateLoadingStrategies;
     /**
+     * Set of authenticators to be hidden in application sign on methods.
+     */
+    hiddenAuthenticators?: string[];
+    /**
      * How should the IDP templates be loaded.
      * If `LOCAL` is selected, app will resort to in-app templates.
      * `REMOTE` will fetch templates from the template management REST API.

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -308,6 +308,7 @@
         "gravatarConfig": {
             "fallback": "404"
         },
+        "hiddenAuthenticators": [],
         "i18nConfigs": {
             "showLanguageSwitcher": false
         },

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -478,6 +478,13 @@
            {% endfor %}
            {% endif %}
         },
+        "hiddenAuthenticators": [
+            {% if console.ui.hiddenAuthenticators is defined %}
+                {% for value in console.ui.hiddenAuthenticators %}
+                "{{ value }}"{{ "," if not loop.last }}
+                {% endfor %}
+            {% endif %}
+        ],
         "i18nConfigs": {
             {% if console.i18n_configs.items() is defined %}
             {% for key, value in console.i18n_configs.items() %}

--- a/modules/theme/src/theme-core/definitions/apps/developer-portal.less
+++ b/modules/theme/src/theme-core/definitions/apps/developer-portal.less
@@ -154,6 +154,13 @@
          }
  
          .authentication-steps-section {
+             display: @signOnMethodsAuthStepSectionDisplay;
+             overflow: @signOnMethodsAuthStepSectionOverflow;
+             max-height: @signOnMethodsAuthStepSectionMaxHeight;
+             border: @signOnMethodsAuthStepSectionBorder;
+             padding: @signOnMethodsAuthStepSectionPadding;
+             max-width: @signOnMethodsAuthStepSectionMaxWidth;
+
              .authentication-step-container {
                  .step-header {
                      display: inline-block;
@@ -169,10 +176,15 @@
                      }
                  }
                  .authentication-step {
-                     min-height: 120px;
                      background-color: @whiteSmoke;
                      padding: 15px;
                      border-radius: @defaultBorderRadius;
+                     display: @signOnMethodsAuthStepDisplay;
+                     width: @signOnMethodsAuthStepWidth;
+                     overflow: @signOnMethodsAuthStepOverflow;
+                     flex-direction: @signOnMethodsAuthStepFlexDirection;
+                     min-height: @signOnMethodsAuthStepMinHeight;
+                     flex-wrap: wrap;
                  }
  
                  .checkboxes {
@@ -185,9 +197,44 @@
                      }
                  }
              }
+
+             .trail {
+                 &:after {
+                     content: '';
+                     margin-top: 0;
+                     margin-left: 10px;
+                     width: 50px;
+                     z-index: 9;
+                     height: 0;
+                     border: @signOnMethodsAuthStepBorder;
+                 }
+             }
  
              .add-step-button {
                  padding-left: 0;
+             }
+
+             .flow-button-container {
+                 text-align: center;
+                 align-items: center;
+                 justify-content: center;
+                 display: flex;
+
+                 &.with-trail {
+                     &:after {
+                         content: '';
+                         margin-top: 0;
+                         margin-left: 10px;
+                         width: 47px;
+                         z-index: 9999;
+                         height: 0;
+                         border: @signOnMethodsAuthStepBorder;
+                     }
+                 }
+
+                 &.with-margin {
+                     margin-right: @signOnMethodsAuthStepButtonMarginRight;
+                 }
              }
          }
          &.flex {

--- a/modules/theme/src/themes/default/apps/developer-portal.variables
+++ b/modules/theme/src/themes/default/apps/developer-portal.variables
@@ -41,3 +41,24 @@
 --------------------------------*/
 
 @treeArrowBackgroundColor: #bfbfbf;
+
+/*-------------------------------
+    Sign On Authenticator Panel
+--------------------------------*/
+
+@signOnMethodsAuthStepSectionDisplay: flex;
+@signOnMethodsAuthStepSectionOverflow: auto;
+@signOnMethodsAuthStepSectionMaxHeight: 375px;
+@signOnMethodsAuthStepSectionBorder: @defaultBorderWidth solid @defaultBorderColor;
+@signOnMethodsAuthStepSectionPadding: 3em;
+@signOnMethodsAuthStepSectionMaxWidth: 1150px;
+@signOnMethodsAuthStepBorder: 1px dashed rgba(34,36,38,.15);
+@signOnMethodsAuthStepButtonMarginRight: 10px;
+
+@signOnMethodsAuthStepContainerMarginRight: 68px;
+
+@signOnMethodsAuthStepDisplay: flex;
+@signOnMethodsAuthStepWidth: 210px;
+@signOnMethodsAuthStepOverflow: auto;
+@signOnMethodsAuthStepFlexDirection: row;
+@signOnMethodsAuthStepMinHeight: 220px;


### PR DESCRIPTION
## Purpose
1. Improve the UX of authentication step builder.
2. Show authentication script editor only on demand. 
3. Add ability to hide authenticators by defining in deployment config

## Goals
Addresses $purpose.

## Approach
<img width="1915" alt="Screen Shot 2021-01-27 at 12 11 51 AM" src="https://user-images.githubusercontent.com/25959096/105889760-8ae8a380-6034-11eb-958f-c3e9bd1b19a7.png">
