### PR TITLE
Add ES-Lint running support to PR builder

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -46,6 +46,9 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+    - name: Run Lint
+      id: run-lint
+      run: npm run lint
     - name: Build
       id: build-with-maven
       run: mvn clean install -U

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -46,9 +46,9 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-
-    - name: Run Lint
-      id: run-lint
-      run: npm run lint
     - name: Build
       id: build-with-maven
       run: mvn clean install -U
+    - name: Run Lint
+      id: run-lint
+      run: npm run lint

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -48,7 +48,4 @@ jobs:
           ${{ runner.os }}-maven-
     - name: Build
       id: build-with-maven
-      run: mvn clean install -U
-    - name: Run Lint
-      id: run-lint
-      run: npm run lint
+      run: mvn clean install -U -Dlint.exec.skip=false

--- a/README.md
+++ b/README.md
@@ -84,12 +84,14 @@ If you are building [product-is](https://github.com/wso2/product-is), the built 
 8. Open cloned or downloaded Identity Apps repo and run the following commands from the command line in the project root directory (where the `package.json` is located) to build all the packages with dependencies. _(Note:- Not necessary if you have already done above identity apps build steps)_
 
     ```bash
+    # `npm run bootstrap` will install npm dependencies and bootstrap lerna modules.
     npm run bootstrap && npm run build
     ```
 
     or
     
     ```bash
+    # This will run `npm run bootstrap && npm run build` in the background.
     npm run build:dev
     ```
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,17 @@ If you are building [product-is](https://github.com/wso2/product-is), the built 
     regexp=(https://localhost:9443/console/login|https://localhost:9443/console/logout|https://localhost:9001/console/login|https://localhost:9001/console/logout)
     ```
 
-8. Open cloned or downloaded Identity Apps repo and Run `npm run build` from the command line in the project root directory (where the `package.json` is located) to build all the packages with dependencies. _(Note:- Not necessary if you have already done above identity apps build steps)_
+8. Open cloned or downloaded Identity Apps repo and run the following commands from the command line in the project root directory (where the `package.json` is located) to build all the packages with dependencies. _(Note:- Not necessary if you have already done above identity apps build steps)_
+
+    ```bash
+    npm run bootstrap && npm run build
+    ```
+
+    or
+    
+    ```bash
+    npm run build:dev
+    ```
 
    > **_Note:-_** 
    >  

--- a/package-lock.json
+++ b/package-lock.json
@@ -12855,6 +12855,15 @@
                 }
             }
         },
+        "eslint-plugin-cypress": {
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.2.tgz",
+            "integrity": "sha512-1SergF1sGbVhsf7MYfOLiBhdOg6wqyeV9pXUAIDIffYTGMN3dTBQS9nFAzhLsHhO+Bn0GaVM1Ecm71XUidQ7VA==",
+            "dev": true,
+            "requires": {
+                "globals": "^11.12.0"
+            }
+        },
         "eslint-plugin-import": {
             "version": "2.22.1",
             "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "test:integration:smoke": "npx lerna run test:smoke --scope @wso2is/integration-tests",
         "test:integration:interactive": "npx lerna run test:interactive --scope @wso2is/integration-tests",
         "update-version": "node scripts/update-version.js",
-        "lint": "eslint --ext .js,.jsx,.ts,.tsx ."
+        "lint": "eslint -c .eslintrc.js --ext .js,.jsx,.ts,.tsx .",
+        "lint:ci": "eslint -c .eslintrc.js $(git diff --diff-filter=d --name-only | grep -E \"(.js$|.ts$|.jsx$|.tsx$)\")"
     },
     "author": "WSO2",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
         "css-loader": "^1.0.0",
         "eslint": "^6.8.0",
         "eslint-loader": "^3.0.3",
+        "eslint-plugin-cypress": "^2.11.2",
         "eslint-plugin-import": "^2.20.2",
         "eslint-plugin-react": "^7.18.3",
         "eslint-plugin-react-hooks": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     ],
     "repository": "https://github.com/wso2/identity-apps.git",
     "scripts": {
-        "prebuild": "npm install && npx lerna bootstrap",
-        "build:dev": "npm run build",
+        "bootstrap": "npm install && npx lerna bootstrap",
         "build": "npx lerna run build --stream",
+        "build:dev": "npm run bootstrap && npm run build",
         "build:external": "npx lerna run build --stream --ignore '{@wso2is/console,@wso2is/myaccount}' && npx lerna run build:external --stream --scope '{@wso2is/console,@wso2is/myaccount}'",
         "clean": "npx lerna run clean --stream",
         "clean-all": "npm run remove-package-lock && npm run remove-maven-folders && npm run remove-node-modules",

--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
                             <executable>npm</executable>
                             <arguments>
                                 <argument>run</argument>
-                                <argument>lint</argument>
+                                <argument>lint:ci</argument>
                             </arguments>
                             <skip>${lint.exec.skip}</skip>
                             <workingDirectory>${basedir}</workingDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -555,6 +555,22 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>run-linter</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>lint</argument>
+                            </arguments>
+                            <skip>${lint.exec.skip}</skip>
+                            <workingDirectory>${basedir}</workingDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>npm run build (compile)</id>
                         <goals>
                             <goal>exec</goal>
@@ -669,5 +685,7 @@
         <json.wso2.version>3.0.0.wso2v1</json.wso2.version>
         <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
         <apache.tomcat-catalina.version>9.0.11</apache.tomcat-catalina.version>
+
+        <lint.exec.skip>true</lint.exec.skip>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -549,7 +549,8 @@
                         <configuration>
                             <executable>npm</executable>
                             <arguments>
-                                <argument>install</argument>
+                                <argument>run</argument>
+                                <argument>bootstrap</argument>
                             </arguments>
                             <workingDirectory>${basedir}</workingDirectory>
                         </configuration>

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -3566,9 +3566,9 @@
             }
         },
         "eslint-plugin-cypress": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.1.tgz",
-            "integrity": "sha512-MxMYoReSO5+IZMGgpBZHHSx64zYPSPTpXDwsgW7ChlJTF/sA+obqRbHplxD6sBStE+g4Mi0LCLkG4t9liu//mQ==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.11.2.tgz",
+            "integrity": "sha512-1SergF1sGbVhsf7MYfOLiBhdOg6wqyeV9pXUAIDIffYTGMN3dTBQS9nFAzhLsHhO+Bn0GaVM1Ecm71XUidQ7VA==",
             "dev": true,
             "requires": {
                 "globals": "^11.12.0"

--- a/tests/package.json
+++ b/tests/package.json
@@ -49,7 +49,7 @@
         "@typescript-eslint/parser": "^2.19.2",
         "cypress": "^5.2.0",
         "eslint": "^7.4.0",
-        "eslint-plugin-cypress": "^2.11.1",
+        "eslint-plugin-cypress": "^2.11.2",
         "eslint-plugin-import": "^2.20.2",
         "rimraf": "^3.0.2",
         "run-script-os": "^1.0.7",


### PR DESCRIPTION
## Purpose
$subject

## Goals
Address https://github.com/wso2-enterprise/asgardeo-product/issues/2518

## Approach
1. Add arg to `pom` to exec linter. `lint.exec.skip` is set to `true` by default.

```sh
mvn clean install -Dlint.exec.skip=false  
```

2. Add node script to run `eslint` on only staged files.

```node
npm run lint:ci
```