### PR TITLE
Add ability to change copyright symbol & year appearance in copyright text

### DIFF
--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -149,7 +149,9 @@ export class Config {
     public static getUIConfig(): UIConfigInterface {
         return {
             announcements: window["AppUtils"].getConfig().ui.announcements,
-            appCopyright: `${window["AppUtils"].getConfig().ui.appCopyright} \u00A9 ${ new Date().getFullYear() }`,
+            appCopyright: window["AppUtils"].getConfig().ui.appCopyright
+                .replace("{{copyright}}", "\u00A9")
+                .replace("{{year}}", new Date().getFullYear()),
             appName: window["AppUtils"].getConfig().ui.appName,
             applicationTemplateLoadingStrategy: window["AppUtils"].getConfig().ui.applicationTemplateLoadingStrategy,
             identityProviderTemplateLoadingStrategy:

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -54,7 +54,7 @@
     },
     "tenantResolutionStrategy": "id_token",
     "ui": {
-        "appCopyright": "WSO2 Identity Server",
+        "appCopyright": "WSO2 Identity Server {{copyright}} {{year}}",
         "appTitle": "Console | WSO2 Identity Server",
         "appName": "Console",
         "applicationTemplateLoadingStrategy": "LOCAL",

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -121,7 +121,9 @@ export class Config {
             announcements: window["AppUtils"].getConfig().ui.announcements,
             appName: window["AppUtils"].getConfig().ui.appName,
             authenticatorApp: window["AppUtils"].getConfig().ui.authenticatorApp,
-            copyrightText: `${window["AppUtils"].getConfig().ui.appCopyright} \u00A9 ${new Date().getFullYear()}`,
+            copyrightText: window["AppUtils"].getConfig().ui.appCopyright
+                .replace("{{copyright}}", "\u00A9")
+                .replace("{{year}}", new Date().getFullYear()),
             features: window["AppUtils"].getConfig().ui.features,
             i18nConfigs: window["AppUtils"].getConfig().ui.i18nConfigs,
             productName: window["AppUtils"].getConfig().ui.productName,

--- a/apps/myaccount/src/public/deployment.config.json
+++ b/apps/myaccount/src/public/deployment.config.json
@@ -30,7 +30,7 @@
     },
     "tenantResolutionStrategy": "id_token",
     "ui": {
-        "appCopyright": "WSO2 Identity Server",
+        "appCopyright": "WSO2 Identity Server {{copyright}} {{year}}",
         "appTitle": "My Account | WSO2 Identity Server",
         "appName": "My Account",
         "appLogoPath": "/assets/images/logo.svg",


### PR DESCRIPTION
## Purpose
ATM, copyright text has a fixed position for `copyright symbol` & `year`. This has to be configurable.

## Goals
Fixes $purpose

## Approach
Use `{{copyright}}` & `{{year}}` template literals in the copyright config so the app will replace accordingly.

## Related PRs
Framework - https://github.com/wso2/carbon-identity-framework/pull/3354
