### PR TITLE
Revamp copyright templating strategy

### DIFF
--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -150,8 +150,8 @@ export class Config {
         return {
             announcements: window["AppUtils"].getConfig().ui.announcements,
             appCopyright: window["AppUtils"].getConfig().ui.appCopyright
-                .replace("{{copyright}}", "\u00A9")
-                .replace("{{year}}", new Date().getFullYear()),
+                .replace("${copyright}", "\u00A9")
+                .replace("${year}", new Date().getFullYear()),
             appName: window["AppUtils"].getConfig().ui.appName,
             applicationTemplateLoadingStrategy: window["AppUtils"].getConfig().ui.applicationTemplateLoadingStrategy,
             identityProviderTemplateLoadingStrategy:

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -54,7 +54,7 @@
     },
     "tenantResolutionStrategy": "id_token",
     "ui": {
-        "appCopyright": "WSO2 Identity Server {{copyright}} {{year}}",
+        "appCopyright": "WSO2 Identity Server ${copyright} ${year}",
         "appTitle": "Console | WSO2 Identity Server",
         "appName": "Console",
         "applicationTemplateLoadingStrategy": "LOCAL",

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -122,8 +122,8 @@ export class Config {
             appName: window["AppUtils"].getConfig().ui.appName,
             authenticatorApp: window["AppUtils"].getConfig().ui.authenticatorApp,
             copyrightText: window["AppUtils"].getConfig().ui.appCopyright
-                .replace("{{copyright}}", "\u00A9")
-                .replace("{{year}}", new Date().getFullYear()),
+                .replace("${copyright}", "\u00A9")
+                .replace("${year}", new Date().getFullYear()),
             features: window["AppUtils"].getConfig().ui.features,
             i18nConfigs: window["AppUtils"].getConfig().ui.i18nConfigs,
             productName: window["AppUtils"].getConfig().ui.productName,

--- a/apps/myaccount/src/public/deployment.config.json
+++ b/apps/myaccount/src/public/deployment.config.json
@@ -30,7 +30,7 @@
     },
     "tenantResolutionStrategy": "id_token",
     "ui": {
-        "appCopyright": "WSO2 Identity Server {{copyright}} {{year}}",
+        "appCopyright": "WSO2 Identity Server ${copyright} ${year}",
         "appTitle": "My Account | WSO2 Identity Server",
         "appName": "My Account",
         "appLogoPath": "/assets/images/logo.svg",


### PR DESCRIPTION
## Purpose
Double braces `{{` were interfering with some environments like `helm`.

## Goals
Fixes $purpose

## Approach
Use `${` instead of `{{`.