### PR TITLE
Stop sending empty string as OIDC id token audience and validate for duplicates

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -514,7 +514,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
             },
             grantTypes: values.get("grant"),
             idToken: {
-                audience: [ values.get("audience") ],
+                audience: values.get("audience") !== "" ? [ values.get("audience") ] : [],
                 encryption: {
                     algorithm: isEncryptionEnabled ?
                         values.get("algorithm") : metadata.idTokenEncryptionAlgorithm.defaultValue,
@@ -708,6 +708,23 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 }));
             }
         }
+    };
+
+    /**
+     * Check if audiences contain duplicates.
+     *
+     * @param {string []} audiences - array of audiences.
+     * @return {boolean} if audience list contains duplicates.
+     */
+    const containsDuplicateAudiences = (audiences: string []): boolean => {
+        const uniqueAudiences = [];
+        for (let i = 0; i < audiences.length; ++i) {
+            if (uniqueAudiences.includes(audiences[i])) {
+                return true;
+            }
+            uniqueAudiences.push(audiences[i]);
+        }
+        return false;
     };
 
     /**
@@ -1258,6 +1275,15 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 ".fields.audience.placeholder")
                         }
                         value={ initialValues?.idToken?.audience.toString() }
+                        validation={ (value: string, validation: Validation) => {
+                            if (value && containsDuplicateAudiences(value.split(","))) {
+                                validation.isValid = false;
+                                validation.errorMessages.push((
+                                    t("console:develop.features.applications.forms.inboundOIDC.sections.idToken" +
+                                        ".fields.audience.validations.duplicate")
+                                ));
+                            }
+                        } }
                         type="textarea"
                         readOnly={ readOnly }
                         data-testid={ `${ testId }-audience-textarea` }

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1201,7 +1201,8 @@ export const console: ConsoleNS = {
                                         label: "Audience",
                                         placeholder: "Enter Audience",
                                         validations: {
-                                            empty: "Please fill the audience"
+                                            empty: "Please fill the audience",
+                                            duplicate: "Audience contains duplicate values"
                                         }
                                     },
                                     encryption: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1198,7 +1198,8 @@ export const console: ConsoleNS = {
                                         label: "Audience",
                                         placeholder: "Saisir l'audience",
                                         validations: {
-                                            empty: "Veuillez remplir le public"
+                                            empty: "Veuillez remplir le public",
+                                            duplicate: "L'audience contient des valeurs en double"
                                         }
                                     },
                                     encryption: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1195,7 +1195,7 @@ export const console: ConsoleNS = {
                                         label: "ප්‍රේක්ෂකයෝ",
                                         placeholder: "ප්‍රේක්ෂකයින් ඇතුළත් කරන්න",
                                         validations: {
-                                            empty: "කරුණාකර සබය පුරවන්න",
+                                            empty: "කරුණාකර audience පුරවන්න",
                                             duplicate: "Audience හි අනුපිටපත් අගයන් අඩංගු වේ"
                                         }
                                     },

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1195,7 +1195,8 @@ export const console: ConsoleNS = {
                                         label: "ප්‍රේක්ෂකයෝ",
                                         placeholder: "ප්‍රේක්ෂකයින් ඇතුළත් කරන්න",
                                         validations: {
-                                            empty: "කරුණාකර සබය පුරවන්න"
+                                            empty: "කරුණාකර සබය පුරවන්න",
+                                            duplicate: "Audience හි අනුපිටපත් අගයන් අඩංගු වේ"
                                         }
                                     },
                                     encryption: {


### PR DESCRIPTION
This PR does the following two modification.
- stops sending empty string as OIDC id token audience when updating the console's application protocol configuration.
- add a validation to avoid having duplicates in the audience.

Resolves : https://github.com/wso2/product-is/issues/11080
Related backend PR : https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1533

![image](https://user-images.githubusercontent.com/25479743/105988346-7f918880-60c5-11eb-887a-e2e33d1c06ca.png)
