### PR TITLE
[DO NOT MERGE] Add ability to template IDP URLs using placeholders

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -271,9 +271,24 @@ export const initializeAuthentication = () => (dispatch) => {
         ContextUtils.setRuntimeConfig(Config.getDeploymentConfig());
 
         // Update post_logout_redirect_uri of logout_url with tenant qualified url
-        if (!window["AppUtils"].getConfig().accountApp.commonPostLogoutUrl && sessionStorage.getItem(LOGOUT_URL)) {
+        if (sessionStorage.getItem(LOGOUT_URL)) {
             let logoutUrl = sessionStorage.getItem(LOGOUT_URL);
             logoutUrl = logoutUrl.replace(window["AppUtils"].getAppBase() , window["AppUtils"].getAppBaseWithTenant());
+
+            // If an override URL is defined in config, use that instead.
+            if (window["AppUtils"].getConfig().idpConfigs?.logoutEndpointURL) {
+                const parsedURL: URL = new URL(logoutUrl);
+                const parsedOverrideURL: URL = new URL(window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL);
+
+                // If the override URL has search params, adjust the params of the original URL accordingly.
+                if (parsedOverrideURL.search) {
+                    logoutUrl =  window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL
+                        + parsedURL.search.replace(parsedURL.search.charAt(0), "&");
+                } else {
+                    logoutUrl =  window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL + parsedURL.search;
+                }
+            }
+
             sessionStorage.setItem(LOGOUT_URL, logoutUrl);
         }
 

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -213,10 +213,6 @@ export const initializeAuthentication = () => (dispatch) => {
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             clockTolerance: window["AppUtils"].getConfig().idpConfigs?.clockTolerance,
-            customParams: {
-                o: window["AppUtils"].getSuperTenant(),
-                t: window["AppUtils"].getTenantName(true)
-            },
             enablePKCE: window["AppUtils"].getConfig().idpConfigs?.enablePKCE ?? true,
             endpoints: {
                 authorize: window["AppUtils"].getConfig().idpConfigs?.authorizeEndpointURL,

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -277,16 +277,8 @@ export const initializeAuthentication = () => (dispatch) => {
 
             // If an override URL is defined in config, use that instead.
             if (window["AppUtils"].getConfig().idpConfigs?.logoutEndpointURL) {
-                const parsedURL: URL = new URL(logoutUrl);
-                const parsedOverrideURL: URL = new URL(window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL);
-
-                // If the override URL has search params, adjust the params of the original URL accordingly.
-                if (parsedOverrideURL.search) {
-                    logoutUrl =  window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL
-                        + parsedURL.search.replace(parsedURL.search.charAt(0), "&");
-                } else {
-                    logoutUrl =  window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL + parsedURL.search;
-                }
+                logoutUrl = resolveIdpURLSAfterTenantResolves(logoutUrl,
+                    window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL);
             }
 
             sessionStorage.setItem(LOGOUT_URL, logoutUrl);
@@ -316,9 +308,32 @@ export const initializeAuthentication = () => (dispatch) => {
 
         auth.getServiceEndpoints()
             .then((response: ServiceResourcesType) => {
-                sessionStorage.setItem(AUTHORIZATION_ENDPOINT, response.authorize);
-                sessionStorage.setItem(OIDC_SESSION_IFRAME_ENDPOINT, response.oidcSessionIFrame);
-                sessionStorage.setItem(TOKEN_ENDPOINT, response.token);
+
+                let authorizationEndpoint: string = response.authorize;
+                let oidcSessionIframeEndpoint: string = response.oidcSessionIFrame;
+                let tokenEndpoint: string = response.token;
+
+                // If `authorize` endpoint is overridden, save that in the session.
+                if (window["AppUtils"].getConfig().idpConfigs?.authorizeEndpointURL) {
+                    authorizationEndpoint = resolveIdpURLSAfterTenantResolves(authorizationEndpoint,
+                        window[ "AppUtils" ].getConfig().idpConfigs.authorizeEndpointURL);
+                }
+
+                // If `oidc session iframe` endpoint is overridden, save that in the session.
+                if (window[ "AppUtils" ].getConfig().idpConfigs?.oidcSessionIFrameEndpointURL) {
+                    oidcSessionIframeEndpoint = resolveIdpURLSAfterTenantResolves(oidcSessionIframeEndpoint,
+                        window[ "AppUtils" ].getConfig().idpConfigs.oidcSessionIFrameEndpointURL);
+                }
+
+                // If `token` endpoint is overridden, save that in the session.
+                if (window["AppUtils"].getConfig().idpConfigs?.tokenEndpointURL) {
+                    tokenEndpoint = resolveIdpURLSAfterTenantResolves(tokenEndpoint,
+                        window["AppUtils"].getConfig().idpConfigs.tokenEndpointURL);
+                }
+
+                sessionStorage.setItem(AUTHORIZATION_ENDPOINT, authorizationEndpoint);
+                sessionStorage.setItem(OIDC_SESSION_IFRAME_ENDPOINT, oidcSessionIframeEndpoint);
+                sessionStorage.setItem(TOKEN_ENDPOINT, tokenEndpoint);
 
                 const rpIFrame: HTMLIFrameElement = document.getElementById("rpIFrame") as HTMLIFrameElement;
                 rpIFrame?.contentWindow.postMessage("loadTimer", location.origin);
@@ -330,6 +345,26 @@ export const initializeAuthentication = () => (dispatch) => {
         dispatch(getProfileInformation(Config.getServiceResourceEndpoints().me,
             window[ "AppUtils" ].getConfig().clientOriginWithTenant));
     });
+};
+
+/**
+ * Resolves IDP URLs when the tenant resolves. Returns
+ *
+ * @param {string} originalURL - Original URL.
+ * @param {string} overriddenURL - Overridden URL from config.
+ * @return {string}
+ */
+export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overriddenURL: string) => {
+
+    const parsedURL: URL = new URL(originalURL);
+    const parsedOverrideURL: URL = new URL(overriddenURL);
+
+    // If the override URL has search params, adjust the params of the original URL accordingly.
+    if (parsedOverrideURL.search) {
+        return overriddenURL + parsedURL.search.replace(parsedURL.search.charAt(0), "&");
+    }
+
+    return overriddenURL + parsedURL.search;
 };
 
 /**

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -354,7 +354,7 @@ export const initializeAuthentication = () => (dispatch) => {
  * @param {string} overriddenURL - Overridden URL from config.
  * @return {string}
  */
-export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overriddenURL: string) => {
+export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overriddenURL: string): string => {
 
     const parsedURL: URL = new URL(originalURL);
     const parsedOverrideURL: URL = new URL(overriddenURL);

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -397,49 +397,63 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
+                                : this.getSuperTenant()),
                 jwksEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.jwksEndpointURL
                         && _config.idpConfigs.jwksEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
+                                : this.getSuperTenant()),
                 logoutEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.logoutEndpointURL
                         && _config.idpConfigs.logoutEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
+                                : this.getSuperTenant()),
                 oidcSessionIFrameEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.oidcSessionIFrameEndpointURL
                         && _config.idpConfigs.oidcSessionIFrameEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
+                                : this.getSuperTenant()),
                 tokenEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.tokenEndpointURL
                         && _config.idpConfigs.tokenEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
+                                : this.getSuperTenant()),
                 tokenRevocationEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.tokenRevocationEndpointURL
                         && _config.idpConfigs.tokenRevocationEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
+                                : this.getSuperTenant()),
                 wellKnownEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.wellKnownEndpointURL
                         && _config.idpConfigs.wellKnownEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName())
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
+                            : this.getSuperTenant())
             };
         },
 

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -70,6 +70,11 @@ export const AppUtils = (function() {
     const isSaasFallback = true;
     const tenantResolutionStrategyFallback = "id_token";
 
+    const SERVER_ORIGIN_IDP_URL_PLACEHOLDER = "${serverOrigin}";
+    const TENANT_PREFIX_IDP_URL_PLACEHOLDER = "${tenantPrefix}";
+    const USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER = "${userTenantDomain}";
+    const SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER = "${superTenantDomain}";
+
     return {
         /**
          * Constructs a basename to be used by the History API.
@@ -374,7 +379,67 @@ export const AppUtils = (function() {
                 serverOrigin: this.isSaas()
                         ? _config.serverOrigin
                         : _config.serverOrigin + this.getTenantPath(true),
-                ..._config.idpConfigs
+                ..._config.idpConfigs,
+                ...this.resolveURLs()
+            };
+        },
+
+        /**
+         * Resolves IDP URLs by resolving the placeholders.
+         * ex: /t/{userTenantDomain}/common/oauth2/authz?t={superTenantDomain} ->
+         * /t/wso2.com/common/oauth2/authz?t=carbon.super
+         */
+        resolveURLs: function() {
+            return {
+                authorizeEndpointURL: (_config.idpConfigs
+                        && _config.idpConfigs.authorizeEndpointURL
+                        && _config.idpConfigs.authorizeEndpointURL)
+                            .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                jwksEndpointURL: (_config.idpConfigs
+                        && _config.idpConfigs.jwksEndpointURL
+                        && _config.idpConfigs.jwksEndpointURL)
+                            .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                logoutEndpointURL: (_config.idpConfigs
+                        && _config.idpConfigs.logoutEndpointURL
+                        && _config.idpConfigs.logoutEndpointURL)
+                            .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                oidcSessionIFrameEndpointURL: (_config.idpConfigs
+                        && _config.idpConfigs.oidcSessionIFrameEndpointURL
+                        && _config.idpConfigs.oidcSessionIFrameEndpointURL)
+                            .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                tokenEndpointURL: (_config.idpConfigs
+                        && _config.idpConfigs.tokenEndpointURL
+                        && _config.idpConfigs.tokenEndpointURL)
+                            .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                tokenRevocationEndpointURL: (_config.idpConfigs
+                        && _config.idpConfigs.tokenRevocationEndpointURL
+                        && _config.idpConfigs.tokenRevocationEndpointURL)
+                            .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
+                wellKnownEndpointURL: (_config.idpConfigs
+                        && _config.idpConfigs.wellKnownEndpointURL
+                        && _config.idpConfigs.wellKnownEndpointURL)
+                            .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName())
             };
         },
 

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -397,8 +397,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                                ? this.getTenantName(true)
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
                                 : this.getSuperTenant()),
                 jwksEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.jwksEndpointURL
@@ -406,8 +406,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                                ? this.getTenantName(true)
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
                                 : this.getSuperTenant()),
                 logoutEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.logoutEndpointURL
@@ -415,8 +415,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                                ? this.getTenantName(true)
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
                                 : this.getSuperTenant()),
                 oidcSessionIFrameEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.oidcSessionIFrameEndpointURL
@@ -424,8 +424,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                                ? this.getTenantName(true)
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
                                 : this.getSuperTenant()),
                 tokenEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.tokenEndpointURL
@@ -433,8 +433,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                                ? this.getTenantName(true)
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
                                 : this.getSuperTenant()),
                 tokenRevocationEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.tokenRevocationEndpointURL
@@ -442,8 +442,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                                ? this.getTenantName(true)
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                                ? this.getTenantName()
                                 : this.getSuperTenant()),
                 wellKnownEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.wellKnownEndpointURL
@@ -451,8 +451,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                            ? this.getTenantName(true)
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
                             : this.getSuperTenant())
             };
         },

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -397,8 +397,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                                ? this.getTenantName()
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                                ? this.getTenantName(true)
                                 : this.getSuperTenant()),
                 jwksEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.jwksEndpointURL
@@ -406,8 +406,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                                ? this.getTenantName()
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                                ? this.getTenantName(true)
                                 : this.getSuperTenant()),
                 logoutEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.logoutEndpointURL
@@ -415,8 +415,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                                ? this.getTenantName()
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                                ? this.getTenantName(true)
                                 : this.getSuperTenant()),
                 oidcSessionIFrameEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.oidcSessionIFrameEndpointURL
@@ -424,8 +424,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                                ? this.getTenantName()
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                                ? this.getTenantName(true)
                                 : this.getSuperTenant()),
                 tokenEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.tokenEndpointURL
@@ -433,8 +433,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                                ? this.getTenantName()
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                                ? this.getTenantName(true)
                                 : this.getSuperTenant()),
                 tokenRevocationEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.tokenRevocationEndpointURL
@@ -442,8 +442,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                                ? this.getTenantName()
+                            .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                                ? this.getTenantName(true)
                                 : this.getSuperTenant()),
                 wellKnownEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.wellKnownEndpointURL
@@ -451,8 +451,8 @@ export const AppUtils = (function() {
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                            ? this.getTenantName()
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                            ? this.getTenantName(true)
                             : this.getSuperTenant())
             };
         },

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -391,51 +391,51 @@ export const AppUtils = (function() {
          */
         resolveURLs: function() {
             return {
-                authorizeEndpointURL: (_config.idpConfigs
+                authorizeEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.authorizeEndpointURL
-                        && _config.idpConfigs.authorizeEndpointURL)
+                        && _config.idpConfigs.authorizeEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
-                jwksEndpointURL: (_config.idpConfigs
+                jwksEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.jwksEndpointURL
-                        && _config.idpConfigs.jwksEndpointURL)
+                        && _config.idpConfigs.jwksEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
-                logoutEndpointURL: (_config.idpConfigs
+                logoutEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.logoutEndpointURL
-                        && _config.idpConfigs.logoutEndpointURL)
+                        && _config.idpConfigs.logoutEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
-                oidcSessionIFrameEndpointURL: (_config.idpConfigs
+                oidcSessionIFrameEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.oidcSessionIFrameEndpointURL
-                        && _config.idpConfigs.oidcSessionIFrameEndpointURL)
+                        && _config.idpConfigs.oidcSessionIFrameEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
-                tokenEndpointURL: (_config.idpConfigs
+                tokenEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.tokenEndpointURL
-                        && _config.idpConfigs.tokenEndpointURL)
+                        && _config.idpConfigs.tokenEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
-                tokenRevocationEndpointURL: (_config.idpConfigs
+                tokenRevocationEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.tokenRevocationEndpointURL
-                        && _config.idpConfigs.tokenRevocationEndpointURL)
+                        && _config.idpConfigs.tokenRevocationEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()),
-                wellKnownEndpointURL: (_config.idpConfigs
+                wellKnownEndpointURL: _config.idpConfigs
                         && _config.idpConfigs.wellKnownEndpointURL
-                        && _config.idpConfigs.wellKnownEndpointURL)
+                        && _config.idpConfigs.wellKnownEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                             .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                             .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -70,6 +70,11 @@ export const AppUtils = (function() {
     const isSaasFallback = true;
     const tenantResolutionStrategyFallback = "id_token";
 
+    const SERVER_ORIGIN_IDP_URL_PLACEHOLDER = "${serverOrigin}";
+    const TENANT_PREFIX_IDP_URL_PLACEHOLDER = "${tenantPrefix}";
+    const USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER = "${userTenantDomain}";
+    const SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER = "${superTenantDomain}";
+
     return {
         /**
          * Constructs a basename to be used by the History API.
@@ -340,7 +345,81 @@ export const AppUtils = (function() {
                 serverOrigin: this.isSaas()
                     ? _config.serverOrigin
                     : _config.serverOrigin + this.getTenantPath(true),
-                ..._config.idpConfigs
+                ..._config.idpConfigs,
+                ...this.resolveURLs()
+            };
+        },
+
+        /**
+         * Resolves IDP URLs by resolving the placeholders.
+         * ex: /t/{userTenantDomain}/common/oauth2/authz?t={superTenantDomain} ->
+         * /t/wso2.com/common/oauth2/authz?t=carbon.super
+         */
+        resolveURLs: function() {
+            return {
+                authorizeEndpointURL: _config.idpConfigs
+                    && _config.idpConfigs.authorizeEndpointURL
+                    && _config.idpConfigs.authorizeEndpointURL
+                        .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
+                            : this.getSuperTenant()),
+                jwksEndpointURL: _config.idpConfigs
+                    && _config.idpConfigs.jwksEndpointURL
+                    && _config.idpConfigs.jwksEndpointURL
+                        .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
+                            : this.getSuperTenant()),
+                logoutEndpointURL: _config.idpConfigs
+                    && _config.idpConfigs.logoutEndpointURL
+                    && _config.idpConfigs.logoutEndpointURL
+                        .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
+                            : this.getSuperTenant()),
+                oidcSessionIFrameEndpointURL: _config.idpConfigs
+                    && _config.idpConfigs.oidcSessionIFrameEndpointURL
+                    && _config.idpConfigs.oidcSessionIFrameEndpointURL
+                        .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
+                            : this.getSuperTenant()),
+                tokenEndpointURL: _config.idpConfigs
+                    && _config.idpConfigs.tokenEndpointURL
+                    && _config.idpConfigs.tokenEndpointURL
+                        .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
+                            : this.getSuperTenant()),
+                tokenRevocationEndpointURL: _config.idpConfigs
+                    && _config.idpConfigs.tokenRevocationEndpointURL
+                    && _config.idpConfigs.tokenRevocationEndpointURL
+                        .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
+                            : this.getSuperTenant()),
+                wellKnownEndpointURL: _config.idpConfigs
+                    && _config.idpConfigs.wellKnownEndpointURL
+                    && _config.idpConfigs.wellKnownEndpointURL
+                        .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
+                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
+                            : this.getSuperTenant())
             };
         },
 

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -363,8 +363,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                            ? this.getTenantName(true)
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
                             : this.getSuperTenant()),
                 jwksEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.jwksEndpointURL
@@ -372,8 +372,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                            ? this.getTenantName(true)
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
                             : this.getSuperTenant()),
                 logoutEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.logoutEndpointURL
@@ -381,8 +381,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                            ? this.getTenantName(true)
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
                             : this.getSuperTenant()),
                 oidcSessionIFrameEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.oidcSessionIFrameEndpointURL
@@ -390,8 +390,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                            ? this.getTenantName(true)
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
                             : this.getSuperTenant()),
                 tokenEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.tokenEndpointURL
@@ -399,8 +399,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                            ? this.getTenantName(true)
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
                             : this.getSuperTenant()),
                 tokenRevocationEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.tokenRevocationEndpointURL
@@ -408,8 +408,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                            ? this.getTenantName(true)
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
                             : this.getSuperTenant()),
                 wellKnownEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.wellKnownEndpointURL
@@ -417,8 +417,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
-                            ? this.getTenantName(true)
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
+                            ? this.getTenantName()
                             : this.getSuperTenant())
             };
         },

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -363,8 +363,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                            ? this.getTenantName()
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                            ? this.getTenantName(true)
                             : this.getSuperTenant()),
                 jwksEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.jwksEndpointURL
@@ -372,8 +372,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                            ? this.getTenantName()
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                            ? this.getTenantName(true)
                             : this.getSuperTenant()),
                 logoutEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.logoutEndpointURL
@@ -381,8 +381,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                            ? this.getTenantName()
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                            ? this.getTenantName(true)
                             : this.getSuperTenant()),
                 oidcSessionIFrameEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.oidcSessionIFrameEndpointURL
@@ -390,8 +390,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                            ? this.getTenantName()
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                            ? this.getTenantName(true)
                             : this.getSuperTenant()),
                 tokenEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.tokenEndpointURL
@@ -399,8 +399,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                            ? this.getTenantName()
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                            ? this.getTenantName(true)
                             : this.getSuperTenant()),
                 tokenRevocationEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.tokenRevocationEndpointURL
@@ -408,8 +408,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                            ? this.getTenantName()
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                            ? this.getTenantName(true)
                             : this.getSuperTenant()),
                 wellKnownEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.wellKnownEndpointURL
@@ -417,8 +417,8 @@ export const AppUtils = (function() {
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
                         .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
                         .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenant())
-                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
-                            ? this.getTenantName()
+                        .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName(true)
+                            ? this.getTenantName(true)
                             : this.getSuperTenant())
             };
         },

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -368,6 +368,21 @@ export const initializeAuthentication = () =>(dispatch)=> {
         if (sessionStorage.getItem(LOGOUT_URL)) {
             let logoutUrl = sessionStorage.getItem(LOGOUT_URL);
             logoutUrl = logoutUrl.replace(window["AppUtils"].getAppBase() , window["AppUtils"].getAppBaseWithTenant());
+
+            // If an override URL is defined in config, use that instead.
+            if (window["AppUtils"].getConfig().idpConfigs?.logoutEndpointURL) {
+                const parsedURL: URL = new URL(logoutUrl);
+                const parsedOverrideURL: URL = new URL(window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL);
+
+                // If the override URL has search params, adjust the params of the original URL accordingly.
+                if (parsedOverrideURL.search) {
+                    logoutUrl =  window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL
+                        + parsedURL.search.replace(parsedURL.search.charAt(0), "&");
+                } else {
+                    logoutUrl =  window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL + parsedURL.search;
+                }
+            }
+
             sessionStorage.setItem(LOGOUT_URL, logoutUrl);
         }
 

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -440,7 +440,7 @@ export const initializeAuthentication = () =>(dispatch)=> {
  * @param {string} overriddenURL - Overridden URL from config.
  * @return {string}
  */
-export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overriddenURL: string) => {
+export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overriddenURL: string): string => {
 
     const parsedURL: URL = new URL(originalURL);
     const parsedOverrideURL: URL = new URL(overriddenURL);

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -305,10 +305,6 @@ export const initializeAuthentication = () =>(dispatch)=> {
             clientHost: window["AppUtils"].getConfig().clientOriginWithTenant,
             clientID: window["AppUtils"].getConfig().clientID,
             clockTolerance: window["AppUtils"].getConfig().idpConfigs?.clockTolerance,
-            customParams: {
-                o: window["AppUtils"].getSuperTenant(),
-                t : window["AppUtils"].getTenantName(true)
-            },
             enablePKCE: window["AppUtils"].getConfig().idpConfigs?.enablePKCE
                 ?? true,
             endpoints: {


### PR DESCRIPTION
## Purpose
Currently, IDP urls can be overridden with absolute paths. But there is no way to change these dynamically in different environments.

## Goals
Add placeholders to make IDP URLs dynamic. 

## Approach
```toml
[console]
idp_configs.authorizeEndpointURL = "${serverOrigin}/${tenantPrefix}/${userTenantDomain}/oauth2/authorize"
```

## Related PRs
SDK - https://github.com/asgardeo/asgardeo-auth-js-sdk