### PR TITLE
[Console] Imporve confirmation modal deletion onpress Enter key

### DIFF
--- a/modules/react-components/src/components/modal/confirmation-modal/confirmation-modal.tsx
+++ b/modules/react-components/src/components/modal/confirmation-modal/confirmation-modal.tsx
@@ -160,6 +160,16 @@ export const ConfirmationModal: FunctionComponent<ConfirmationModalPropsInterfac
     };
 
     /**
+     * Handler for the enter key press down.
+     */
+    const handleKeyDown = (k: KeyboardEvent, e: MouseEvent<HTMLButtonElement> ) => {
+        if (k.key === "Enter" && confirmed) {
+            setAssertionInput("");        
+            onPrimaryActionClick(e);
+        }
+    };
+
+    /**
      * Resolves the animated icon.
      *
      * @param {string} type - Type of the modal.
@@ -270,6 +280,7 @@ export const ConfirmationModal: FunctionComponent<ConfirmationModalPropsInterfac
                     <Input
                         data-testid={ `${ testId }-assertion-input` }
                         onChange={ (e: ChangeEvent<HTMLInputElement>): void => setAssertionInput(e.target?.value) }
+                        onKeyDown={ handleKeyDown }
                         value={ assertionInput }
                         fluid
                     />


### PR DESCRIPTION
## Purpose
POC fix for https://github.com/wso2/product-is/issues/11187

## Goals
After this fix, the user can press enter on the delete after entering successful confirmation input.

## Approach
 Since Change Event doesn't trigger on pressing enter, I added the OnChange attribute and create a prop to handle call back URL for keyboard event (Enter Key press).

Current PR is for POC for application deletion, we can replicate them for other modals.
![Fix](https://user-images.githubusercontent.com/25488962/106991546-76c34580-679c-11eb-963b-61f30e35b227.gif)
