### PR TITLE
Fix IDP certificate functionality issues

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
@@ -116,13 +116,13 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesPropsInterface> =
      * @param certType
      */
     const handleCertificateTypeChange = (certType: string) => {
-        if (certType === "PEM") {
+        if (certType === "PEM" && editingIDP?.certificate?.jwksUri) {
             dispatch(addAlert({
                 description: t("console:develop.features.idp.notifications.changeCertType.pem.description"),
                 level: AlertLevels.WARNING,
                 message: t("console:develop.features.idp.notifications.changeCertType.pem.message")
             }));
-        } else {
+        } else if (certType === "JWKS" && editingIDP?.certificate?.certificates){
             dispatch(addAlert({
                 description: t("console:develop.features.idp.notifications.changeCertType.jwks" +
                     ".description"),

--- a/apps/console/src/features/identity-providers/components/wizards/steps/add-certificate-steps/add-certificate-form.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/steps/add-certificate-steps/add-certificate-form.tsx
@@ -17,6 +17,7 @@
  */
 
 import { Certificate, TestableComponentInterface } from "@wso2is/core/models";
+import { CertificateManagementUtils } from "@wso2is/core/utils";
 import { Forms } from "@wso2is/forms";
 import * as forge from "node-forge";
 import React, { ReactElement, useEffect, useState } from "react";
@@ -58,7 +59,7 @@ export const AddIDPCertificateFormComponent: React.FunctionComponent<AddIDPCerti
             return;
         }
         onSubmit({ certificate: certString });
-    }, [ certString, onSubmit ]);
+    }, [ certString ]);
 
     /**
      * This is called when the first step is submitted.
@@ -87,7 +88,7 @@ export const AddIDPCertificateFormComponent: React.FunctionComponent<AddIDPCerti
         setFileDecoded(fileDecoded);
         setFile(file);
         setCertificate(forgeCertificate);
-        setCertString(data.certificate);
+        setCertString(btoa(CertificateManagementUtils.enclosePem(data.certificate)));
     };
 
     const addIDPCertificateForm = (): ReactElement => (

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1073,6 +1073,7 @@ export interface ConsoleNS {
                             message: string;
                         };
                     };
+                    deleteCertificate: Notification;
                     deleteIDP: Notification;
                     disableAuthenticator: Notification;
                     disableOutboundProvisioningConnector: Notification;

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1407,6 +1407,7 @@ export interface ConsoleNS {
                             message: string;
                         };
                     };
+                    deleteCertificate: Notification;
                     deleteIDP: Notification;
                     disableAuthenticator: Notification;
                     disableOutboundProvisioningConnector: Notification;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -2600,14 +2600,28 @@ export const console: ConsoleNS = {
                     },
                     changeCertType: {
                         jwks: {
-                            description: "Please note that if you have added a certificate it'll be overridden " +
+                            description: "Please note that the certificates will be overridden " +
                                 "by the the JWKS endpoint.",
                             message: "Warning!"
                         },
                         pem: {
-                            description: "Please note that if you have added a JWKS endpoint it'll be overridden " +
-                                "by the certificate.",
+                            description: "Please note that the JWKS endpoint will be overridden " +
+                                "by the certificates.",
                             message: "Warning!"
+                        }
+                    },
+                    deleteCertificate: {
+                        error: {
+                            description: "{{ description }}",
+                            message: "Certificate delete error"
+                        },
+                        genericError: {
+                            description: "An error occurred while deleting the certificate.",
+                            message: "Certificate delete error"
+                        },
+                        success: {
+                            description: "Successfully deleted the certificate.",
+                            message: "Delete successful"
                         }
                     },
                     deleteDefaultAuthenticator: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -3432,14 +3432,28 @@ export const console: ConsoleNS = {
                     },
                     changeCertType: {
                         jwks: {
-                            description: "Please note that if you have added a certificate it'll be overridden " +
+                            description: "Please note that the certificates will be overridden " +
                                 "by the the JWKS endpoint.",
                             message: "Warning!"
                         },
                         pem: {
-                            description: "Please note that if you have added a JWKS endpoint it'll be overridden " +
-                                "by the certificate.",
+                            description: "Please note that the JWKS endpoint will be overridden " +
+                                "by the certificates.",
                             message: "Warning!"
+                        }
+                    },
+                    deleteCertificate: {
+                        error: {
+                            description: "{{ description }}",
+                            message: "Certificate delete error"
+                        },
+                        genericError: {
+                            description: "An error occurred while deleting the certificate.",
+                            message: "Certificate delete error"
+                        },
+                        success: {
+                            description: "Successfully deleted the certificate.",
+                            message: "Delete successful"
                         }
                     },
                     deleteDefaultAuthenticator: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -2606,14 +2606,28 @@ export const console: ConsoleNS = {
                     },
                     changeCertType: {
                         jwks: {
-                            description: "Veuillez noter que si vous avez ajouté un certificat, il sera remplacé " +
-                                "par l'adresse JWKS.",
+                            description: "Veuillez noter que les certificats seront remplacés par le point de " +
+                                "terminaison JWKS.",
                             message: "Attention !"
                         },
                         pem: {
-                            description: "Veuillez noter que si vous avez ajouté une adresse JWKS, elle sera remplacée " +
-                                "par le certificat.",
+                            description: "Veuillez noter que le point de terminaison JWKS sera remplacé par " +
+                                "les certificats.",
                             message: "Attention !"
+                        }
+                    },
+                    deleteCertificate: {
+                        error: {
+                            description: "{{ description }}",
+                            message: "Erreur de suppression de certificat"
+                        },
+                        genericError: {
+                            description: "Une erreur s'est produite lors de la suppression du certificat.",
+                            message: "Erreur de suppression de certificat"
+                        },
+                        success: {
+                            description: "Le certificat a bien été supprimé.",
+                            message: "Suppression réussie"
                         }
                     },
                     deleteDefaultAuthenticator: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -2598,14 +2598,26 @@ export const console: ConsoleNS = {
                     },
                     changeCertType: {
                         jwks: {
-                            description: "ඔබ සහතිකයක් එකතු කර ඇත්නම් එය JWKS අන්ත ලක්ෂ්‍යය මගින් අභිබවා යනු " +
-                                "ඇති බව කරුණාවෙන් සලකන්න.",
+                            description: "JWKS අවසාන ලක්ෂ්‍යය මගින් සහතික අභිබවා යන බව කරුණාවෙන් සලකන්න.",
                             message: "අවවාදයයි!"
                         },
                         pem: {
-                            description: "ඔබ JWKS අන්ත ලක්ෂ්‍යයක් එකතු කර ඇත්නම් එය සහතිකය මගින් අභිබවා " +
-                                "යනු ඇති බව කරුණාවෙන් සලකන්න.",
+                            description: "JWKS endpoint සහතික මගින් අභිබවා යන බව කරුණාවෙන් සලකන්න.",
                             message: "අවවාදයයි!"
+                        }
+                    },
+                    deleteCertificate: {
+                        error: {
+                            description: "{{ description }}",
+                            message: "සහතිකය මකාදැමීමේ දෝෂයකි"
+                        },
+                        genericError: {
+                            description: "සහතිකය මකාදැමීමේදී දෝෂයක් සිදුවිය.",
+                            message: "සහතිකය මකාදැමීමේ දෝෂයකි"
+                        },
+                        success: {
+                            description: "සහතිකය සාර්ථකව මකා දමන ලදි.",
+                            message: "මකාදැමීම සාර්ථකයි"
                         }
                     },
                     deleteDefaultAuthenticator: {


### PR DESCRIPTION
## Purpose
This PR fixes,
- not being able to add more than one certificate for the IdP.
- sending multiple API patch calls to add a single certificate.
- not being able to delete an added certificate.
- warning message about overwriting the added certificate/JWKS endpoint being displayed even though a certificate/JWKS endpoint is not added.
Resolves : https://github.com/wso2/product-is/issues/11150
Related PR : https://github.com/wso2/identity-api-server/pull/265