### PR TITLE
Skip updating read only attributes in the user profile

### DIFF
--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -321,6 +321,11 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         };
 
         profileSchema.forEach((schema: ProfileSchemaInterface) => {
+
+            if (schema.mutability === ProfileConstants.READONLY_SCHEMA) {
+                return;
+            }
+
             let opValue = {};
 
             const schemaNames = schema.name.split(".");


### PR DESCRIPTION
## Purpose

Skip updating the read only attributes (the claims which are defined as read-only in the profile schema) when updating the user profile.

Partially resolves- https://github.com/wso2-enterprise/asgardeo-product/issues/1421