### PR TITLE
Fix invalid key of primary email attribute in the flatted profile info object.

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificate-list.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificate-list.tsx
@@ -164,6 +164,10 @@ export const IdpCertificatesListComponent: FunctionComponent<IdpCertificatesProp
 
     /**
      * Remove the certificate from the certificated list.
+     * The path attribute of the patch request requires the certificate index.
+     * At the moment, the index of the certificate to be deleted is obtained from the indexes of
+     * @see certificates. This may cause unexpected behaviours if the certificates array is manipulated
+     * for some reason.
      *
      * @param certificateIndex
      */

--- a/apps/myaccount/src/utils/profile-utils.ts
+++ b/apps/myaccount/src/utils/profile-utils.ts
@@ -106,6 +106,9 @@ export const flattenProfileInfo = (profileInfo: any, parentAttributeName?: strin
         // append it to the existing attribute key.
         if (parentAttributeName) {
             key = parentAttributeName + "." + key;
+            if (parentAttributeName === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("EMAILS")) {
+                key = parentAttributeName;
+            }
         }
 
         // Check if the value is an array and if it's a string array


### PR DESCRIPTION
## Purpose
Currently, when work/home emails are also available along with the primary email in the user profile schema, the formed flatted profile info object's primary email attribute's key is generated incorrectly. Due to this, the overview section's profile completion calculation cannot identify the primary email attribute as it uses the incorrectly formed flatted profile info object for the profile completion calculations.

This PR is to fix forming an invalid key for primary email attribute in the flatten profile info object. It will resolve 'email' being shown as an incomplete field in the overview's profile completion section even though email is filled.

Resolves part of https://github.com/wso2-enterprise/asgardeo-product/issues/1453