### PR TITLE
Make certificate required when ID token encryption is enabled

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1670,7 +1670,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             t("console:develop.features.applications.forms.advancedConfig" +
                                                 ".sections.certificate.fields.pemValue.label")
                                         }
-                                        required={ false }
+                                        required={ isEncryptionEnabled }
                                         requiredErrorMessage={
                                             t("console:develop.features.applications.forms.advancedConfig" +
                                                 ".sections.certificate.fields.pemValue.validations.empty")
@@ -1723,7 +1723,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             t("console:develop.features.applications.forms.advancedConfig" +
                                                 ".sections.certificate.fields.jwksValue.label")
                                         }
-                                        required={ false }
+                                        required={ isEncryptionEnabled }
                                         requiredErrorMessage={
                                             t("console:develop.features.applications.forms.advancedConfig" +
                                                 ".sections.certificate.fields.jwksValue.validations.empty")


### PR DESCRIPTION
## Purpose
This PR is to make 'certificate' a required field when ID token encryption is enabled. 

Resolves : https://github.com/wso2-enterprise/asgardeo-product/issues/1588