### PR TITLE
Fix 'Something went wrong' displayed when 'Username' column is removed from the users list view

### DIFF
--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -323,7 +323,9 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 attArray.push(attribute);
             }
         }
-
+        if (!attArray.includes(UserManagementConstants.SCIM2_SCHEMA_DICTIONARY.get("USERNAME"))) {
+            attArray.push(UserManagementConstants.SCIM2_SCHEMA_DICTIONARY.get("USERNAME"));
+        }
         return attArray.toString();
     };
 


### PR DESCRIPTION
## Purpose

Fix username not being added to the required attributes of the SCIM2 users list request when 'Username' column is removed from the users list view.

Resolves : https://github.com/wso2-enterprise/asgardeo-product/issues/1638