### PR TITLE
Add support to send user back to signing url during authentication flow failure

### DIFF
--- a/apps/authentication-portal/src/main/webapp/retry.jsp
+++ b/apps/authentication-portal/src/main/webapp/retry.jsp
@@ -18,13 +18,20 @@
 
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApplicationDataRetrievalClient" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApplicationDataRetrievalClientException" %>
+<%@ page import="java.util.regex.Pattern" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="includes/localize.jsp" %>
+<%@include file="includes/init-url.jsp" %>
 
 <%
     String stat = request.getParameter("status");
     String statusMessage = request.getParameter("statusMsg");
+    String sp = request.getParameter("sp");
+    String urlWithoutEncoding = null;
     if (stat == null || statusMessage == null) {
         stat = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.error");
         statusMessage =  AuthenticationEndpointUtil.i18n(resourceBundle,
@@ -34,6 +41,15 @@
         statusMessage = AuthenticationEndpointUtil.customi18n(resourceBundle, statusMessage);
     }
     session.invalidate();
+
+    try {
+        ApplicationDataRetrievalClient applicationDataRetrievalClient = new ApplicationDataRetrievalClient();
+        urlWithoutEncoding = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain,
+                sp);
+        urlWithoutEncoding = replaceURLPlaceholders(urlWithoutEncoding, request, tenantDomain);
+    } catch (ApplicationDataRetrievalClientException e) {
+        //ignored and fallback to login page url
+    }
 %>
 
 <!doctype html>
@@ -68,6 +84,9 @@
                     <div class="ui visible negative message">
                         <div class="header"><%=Encode.forHtmlContent(stat)%></div>
                         <p><%=Encode.forHtmlContent(statusMessage)%></p>
+                        <% if (StringUtils.isNotBlank(urlWithoutEncoding)) { %>
+                        <i class="caret left icon orange"></i><a href="<%= IdentityManagementEndpointUtil.getURLEncodedCallback(urlWithoutEncoding)%>">Back to sign in</a>
+                        <% } %>
                     </div>
                 </div>
             </div>
@@ -93,5 +112,30 @@
     <% } else { %>
         <jsp:include page="includes/footer.jsp"/>
     <% } %>
+    <%!
+        private String replaceURLPlaceholders (String accessURL, HttpServletRequest request, String tenantDomain) {
+
+            if (StringUtils.isBlank(accessURL)) {
+                return accessURL;
+            }
+            if (!accessURL.contains("${UserTenantHint}")) {
+                return accessURL;
+            }
+            String userTenantHint = request.getParameter("ut");
+            if (StringUtils.isBlank(userTenantHint)) {
+                userTenantHint = request.getParameter("t");
+            }
+            if (StringUtils.isBlank(userTenantHint)) {
+                if (StringUtils.isNotBlank(tenantDomain)) {
+                    userTenantHint = tenantDomain;
+                } else {
+                    userTenantHint = "carbon.super";
+                }
+            }
+
+            return accessURL.replaceAll(Pattern.quote("${UserTenantHint}"), userTenantHint)
+                    .replaceAll(Pattern.quote("/t/carbon.super/"), "/");
+        }
+    %>
 </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/retry.jsp
+++ b/apps/authentication-portal/src/main/webapp/retry.jsp
@@ -31,7 +31,7 @@
     String stat = request.getParameter("status");
     String statusMessage = request.getParameter("statusMsg");
     String sp = request.getParameter("sp");
-    String urlWithoutEncoding = null;
+    String applicationAccessURLWithoutEncoding = null;
     if (stat == null || statusMessage == null) {
         stat = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.error");
         statusMessage =  AuthenticationEndpointUtil.i18n(resourceBundle,
@@ -44,9 +44,9 @@
 
     try {
         ApplicationDataRetrievalClient applicationDataRetrievalClient = new ApplicationDataRetrievalClient();
-        urlWithoutEncoding = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain,
+        applicationAccessURLWithoutEncoding = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain,
                 sp);
-        urlWithoutEncoding = replaceURLPlaceholders(urlWithoutEncoding, request, tenantDomain);
+        applicationAccessURLWithoutEncoding = replaceURLPlaceholders(applicationAccessURLWithoutEncoding, request, tenantDomain);
     } catch (ApplicationDataRetrievalClientException e) {
         //ignored and fallback to login page url
     }
@@ -84,8 +84,8 @@
                     <div class="ui visible negative message">
                         <div class="header"><%=Encode.forHtmlContent(stat)%></div>
                         <p><%=Encode.forHtmlContent(statusMessage)%></p>
-                        <% if (StringUtils.isNotBlank(urlWithoutEncoding)) { %>
-                        <i class="caret left icon orange"></i><a href="<%= IdentityManagementEndpointUtil.getURLEncodedCallback(urlWithoutEncoding)%>">Back to sign in</a>
+                        <% if (StringUtils.isNotBlank(applicationAccessURLWithoutEncoding)) { %>
+                        <i class="caret left icon orange"></i><a href="<%= IdentityManagementEndpointUtil.getURLEncodedCallback(applicationAccessURLWithoutEncoding)%>">Back to sign in</a>
                         <% } %>
                     </div>
                 </div>

--- a/pom.xml
+++ b/pom.xml
@@ -641,7 +641,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.19.14</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.19.21</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.oauth.version>6.4.98</carbon.identity.oauth.version>
         <carbon.identity.oauth.imp.pkg.version.range>[6.1.0, 7.0.0)</carbon.identity.oauth.imp.pkg.version.range>


### PR DESCRIPTION
## Purpose
- Introduce a new link to `retry.jsp` to redirect user back to signing page. 
- Application's `Access URL` is used as the link to **Signing In** page. If the `Access URL` is not configured for the application link will be hidden.
- Fixing https://github.com/wso2-enterprise/asgardeo-product/issues/1643
- Depends on https://github.com/wso2/carbon-identity-framework/pull/3373