### PR TITLE
Remove user info of readonly schemas from being displayed in the user profile if the value is empty.

### DIFF
--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -50,6 +50,10 @@ interface EditUserPropsInterface extends SBACInterface<FeatureConfigInterface> {
      * Password reset connector properties
      */
     connectorProperties: ConnectorPropertyInterface[];
+    /**
+     * Is read only user stores loading.
+     */
+    isReadOnlyUserStoresLoading?: boolean;
 }
 
 /**
@@ -66,7 +70,8 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
         handleUserUpdate,
         featureConfig,
         readOnlyUserStores,
-        connectorProperties
+        connectorProperties,
+        isReadOnlyUserStoresLoading
     } = props;
 
     const { t } = useTranslation();
@@ -110,6 +115,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                         handleUserUpdate={ handleUserUpdate }
                         isReadOnly={ isReadOnly }
                         connectorProperties={ connectorProperties }
+                        isReadOnlyUserStoresLoading={ isReadOnlyUserStoresLoading }
                     />
                 </ResourceTab.Pane>
             )

--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -31,6 +31,7 @@ import { ProfileUtils } from "@wso2is/core/utils";
 import { Field, Forms, Validation } from "@wso2is/forms";
 import {
     ConfirmationModal,
+    ContentLoader,
     DangerZone,
     DangerZoneGroup,
     EmphasizedSegment,
@@ -72,6 +73,10 @@ interface UserProfilePropsInterface extends TestableComponentInterface, SBACInte
      * Password reset connector properties
      */
     connectorProperties: ConnectorPropertyInterface[];
+    /**
+     * Is read only user stores loading.
+     */
+    isReadOnlyUserStoresLoading?: boolean;
 }
 
 /**
@@ -91,6 +96,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         isReadOnly,
         featureConfig,
         connectorProperties,
+        isReadOnlyUserStoresLoading,
         [ "data-testid" ]: testId
     } = props;
 
@@ -753,6 +759,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
     };
 
     return (
+        !isReadOnlyUserStoresLoading ? (
         <>
             {
                 <Grid>
@@ -1008,6 +1015,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                 handleUserUpdate={ handleUserUpdate }
             />
         </>
+        ) : <ContentLoader dimmer/>
     );
 };
 

--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -695,6 +695,19 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
     };
 
     /**
+     * If the profile schema is read only or the user is read only, the profile detail for a profile schema should
+     * only be displayed in the form only if there is a value for the schema. This function validates whether the
+     * filed should be displayed considering these factors.
+     *
+     * @param {ProfileSchemaInterface} schema
+     * @return {boolean} whether the field for the input schema should be displayed.
+     */
+    const isFieldDisplayable = (schema: ProfileSchemaInterface): boolean => {
+        return (!_.isEmpty(profileInfo.get(schema.name)) ||
+            (!isReadOnly && (schema.mutability !== ProfileConstants.READONLY_SCHEMA)));
+    }
+
+    /**
      * This function generates the user profile details form based on the input Profile Schema
      *
      * @param {ProfileSchemaInterface} schema
@@ -784,7 +797,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                             || schema.name === ProfileConstants?.
                                                 SCIM2_SCHEMA_DICTIONARY.get("ACCOUNT_DISABLED")
                                             || schema.name === ProfileConstants?.
-                                                SCIM2_SCHEMA_DICTIONARY.get("ONETIME_PASSWORD"))){
+                                                SCIM2_SCHEMA_DICTIONARY.get("ONETIME_PASSWORD"))
+                                            && isFieldDisplayable(schema)) {
                                             return (
                                                 generateProfileEditForm(schema, index)
                                             );

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -57,6 +57,7 @@ const UserEditPage = (): ReactElement => {
     const [ readOnlyUserStoresList, setReadOnlyUserStoresList ] = useState<string[]>(undefined);
     const [ showEditAvatarModal, setShowEditAvatarModal ] = useState<boolean>(false);
     const [ connectorProperties, setConnectorProperties ] = useState<ConnectorPropertyInterface[]>(undefined);
+    const [ isReadOnlyUserStoresLoading, setReadOnlyUserStoresLoading ] = useState<boolean>(false);
 
     useEffect(() => {
         const properties: ConnectorPropertyInterface[] = [];
@@ -98,8 +99,11 @@ const UserEditPage = (): ReactElement => {
     }, []);
 
     useEffect(() => {
+        setReadOnlyUserStoresLoading(true);
         SharedUserStoreUtils.getReadOnlyUserStores().then((response) => {
             setReadOnlyUserStoresList(response);
+        }).finally(() => {
+            setReadOnlyUserStoresLoading(false);
         });
     }, [ user ]);
 
@@ -237,6 +241,7 @@ const UserEditPage = (): ReactElement => {
                 handleUserUpdate={ handleUserUpdate }
                 readOnlyUserStores={ readOnlyUserStoresList }
                 connectorProperties={ connectorProperties }
+                isReadOnlyUserStoresLoading={ isReadOnlyUserStoresLoading }
             />
             {
                 showEditAvatarModal && (

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -931,9 +931,8 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                                             : null
                                     }
                                     {
-                                        !isReadOnlyUser &&
-                                        schema.mutability !== ProfileConstants.READONLY_SCHEMA &&
-                                        !isEmpty(profileInfo.get(schema.name))
+                                        !isEmpty(profileInfo.get(schema.name)) ||
+                                        (!isReadOnlyUser && (schema.mutability !== ProfileConstants.READONLY_SCHEMA))
                                             ? (
                                                 <List.Item key={ index } className="inner-list-item"
                                                            data-testid={ `${testId}-schema-list-item` }>

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -113,7 +113,8 @@ export const setInitialized = (flag: boolean): AuthAction => ({
 /**
  * Get SCIM2 schemas
  */
-export const getScimSchemas = (profileInfo: BasicProfileInterface = null) => (dispatch): void => {
+export const getScimSchemas = (profileInfo: BasicProfileInterface = null,
+                               isReadOnlyUser: boolean) => (dispatch): void => {
     dispatch(setProfileSchemaLoader(true));
 
     getProfileSchemas()
@@ -122,7 +123,7 @@ export const getScimSchemas = (profileInfo: BasicProfileInterface = null) => (di
             dispatch(setScimSchemas(response));
 
             if (profileInfo) {
-                dispatch(getProfileCompletion(profileInfo, response));
+                dispatch(getProfileCompletion(profileInfo, response, isReadOnlyUser));
             }
         })
         .catch(() => {
@@ -156,7 +157,8 @@ export const getProfileInformation = (updateProfileCompletion = false) => (dispa
                         // If the schemas in the redux store is empty, fetch the SCIM schemas from the API.
                         if (_.isEmpty(store.getState().authenticationInformation.profileSchemas)) {
                             isCompletionCalculated = true;
-                            dispatch(getScimSchemas(infoResponse));
+                            dispatch(getScimSchemas(infoResponse,
+                                response["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]?.isReadOnlyUser));
                         }
 
                         // If `updateProfileCompletion` flag is enabled, update the profile completion.
@@ -164,7 +166,9 @@ export const getProfileInformation = (updateProfileCompletion = false) => (dispa
                             try {
                                 getProfileCompletion(
                                     infoResponse,
-                                    store.getState().authenticationInformation.profileSchemas
+                                    store.getState().authenticationInformation.profileSchemas,
+                                    response["urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]
+                                        ?.isReadOnlyUser
                                 );
                             } catch (e) {
                                 dispatch(


### PR DESCRIPTION
## Purpose

This PR introduces the following modifications.
- If the user is read only, the user profile will not show the non-empty fields.
- If the user is not read only, the user profile will not show the empty read only (if the schema is immutable) fields.
- If the user is read only, the **myaccount > overview**'s profile completion will be calculated from only the available claims (which makes it 100% all the time)
- If the user is not read only, the **myaccount > overview**'s  profile completion will be calculated from the non-empty fields + empty, non read only claims.
- Shows content loader in the user profile page until readonly user stores are loaded.

Resolves : https://github.com/wso2/product-is/issues/11227
