### PR TITLE
[Console] Add warning on selecting Refresh token without selecting any other recomended Grant types

### DIFF
--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -186,7 +186,27 @@ export class ApplicationManagementConstants {
     public static readonly AUTHORIZATION_CODE_GRANT: string = "authorization_code";
     public static readonly REFRESH_TOKEN_GRANT: string = "refresh_token";
     public static readonly IMPLICIT_GRANT: string = "implicit";
+    public static readonly PASSWORD: string = "password";
+    public static readonly SAML2_BEARER: string = "urn:ietf:params:oauth:grant-type:saml2-bearer";
+    public static readonly JWT_BEARER: string = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+    public static readonly IWA_NTLM: string = "iwa:ntlm";
+    public static readonly UMA_TICKET: string = "urn:ietf:params:oauth:grant-type:uma-ticket";
 
+    /**
+     * Currently refresh grant type is recommended to use atleast one of below.
+     * We need to get information from backend rather than hard code.
+     * This isssue is track via https://github.com/wso2-enterprise/asgardeo-product/issues/1852.
+     */
+    public static readonly IS_REFRESH_TOKEN_GRANT_TYPE_ALLOWED = [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.IMPLICIT_GRANT,
+            ApplicationManagementConstants.PASSWORD,
+            ApplicationManagementConstants.SAML2_BEARER,
+            ApplicationManagementConstants.IWA_NTLM,
+            ApplicationManagementConstants.JWT_BEARER,
+            ApplicationManagementConstants.UMA_TICKET
+    ];
+    
     /**
      * Set of grant types allowed for certain templates.
      * @constant

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1148,7 +1148,8 @@ export const console: ConsoleNS = {
                                     empty: "Select at least a  grant type"
                                 },
                                 validation: {
-                                    refreshToken:"Refresh token grant type should be selected along with the Code grant type."
+                                    refreshToken:"Refresh token grant type should only be selected along with " +
+                                    "grant types that provide a refresh token."
                                 }
                             },
                             public: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1151,8 +1151,9 @@ export const console: ConsoleNS = {
                                 validations: {
                                     empty: "Sélectionnez au minimum un grant type"
                                 },
-                                validation: {
-                                    refreshToken:"Le type d'octroi Refresh token doit être sélectionné avec le type d'octroi code."
+                                vvalidation: {
+                                    refreshToken:"Le type d'octroi Refresh token doit être sélectionné uniquement " +
+                                    "avec les types d'octroi qui fournissent un jeton d'actualisation."
                                 }
                             },
                             public: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1154,7 +1154,8 @@ export const console: ConsoleNS = {
                                     empty: "අවම වශයෙන් ප්‍රදාන වර්ගයක් තෝරන්න"
                                 },
                                 validation: {
-                                    refreshToken:"Code grant වර්ගය සමඟ Refresh token grant type තෝරා ගත යුතුය."
+                                    refreshToken:"Refresh token ප්‍රදාන වර්ගය තෝරා ගත යුත්තේ ප්‍රබෝධවත් ටෝකනයක් " +
+                                    "සපයන ප්‍රදාන වර්ග සමඟ පමණි."
                                 }
                             },
                             public: {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/11236

- Added Recommended grant types for the refresh token

After firx
![Finalfix](https://user-images.githubusercontent.com/25488962/107474680-c76de080-6b98-11eb-8fad-213db341ee44.gif)

**Please review the content of the warning and approve.**
Content: 
Refresh token grant type should be selected along with grant types that provide refresh token.
CC: @sherenewso2 