### PR TITLE
Fix search params duplication issues in templated IDP URLs

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -374,9 +374,15 @@ export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overridde
     const parsedURL: URL = new URL(originalURL);
     const parsedOverrideURL: URL = new URL(overriddenURL);
 
-    // If the override URL has search params, adjust the params of the original URL accordingly.
-    if (parsedOverrideURL.search) {
-        return overriddenURL + parsedURL.search.replace(parsedURL.search.charAt(0), "&");
+    // If the override URL & original URL has search params, try to moderate the URL.
+    if (parsedOverrideURL.search && parsedURL.search) {
+        for (const [ key, value ] of parsedURL.searchParams.entries()) {
+            if (parsedOverrideURL.searchParams.has(key)) {
+                parsedURL.searchParams.append(key, value);
+            }
+        }
+
+        return parsedURL.toString();
     }
 
     return overriddenURL + parsedURL.search;

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -371,21 +371,21 @@ export const initializeAuthentication = () => (dispatch) => {
  */
 export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overriddenURL: string): string => {
 
-    const parsedURL: URL = new URL(originalURL);
+    const parsedOriginalURL: URL = new URL(originalURL);
     const parsedOverrideURL: URL = new URL(overriddenURL);
 
     // If the override URL & original URL has search params, try to moderate the URL.
-    if (parsedOverrideURL.search && parsedURL.search) {
-        for (const [ key, value ] of parsedURL.searchParams.entries()) {
-            if (parsedOverrideURL.searchParams.has(key)) {
-                parsedURL.searchParams.append(key, value);
+    if (parsedOverrideURL.search && parsedOriginalURL.search) {
+        for (const [ key, value ] of parsedOriginalURL.searchParams.entries()) {
+            if (!parsedOverrideURL.searchParams.has(key)) {
+                parsedOverrideURL.searchParams.append(key, value);
             }
         }
 
-        return parsedURL.toString();
+        return parsedOverrideURL.toString();
     }
 
-    return overriddenURL + parsedURL.search;
+    return overriddenURL + parsedOriginalURL.search;
 };
 
 /**

--- a/apps/console/src/init/rpIFrame-script.ts
+++ b/apps/console/src/init/rpIFrame-script.ts
@@ -97,17 +97,18 @@ function receiveMessage(e) {
     } else {
         // [RP] session state has changed. Sending prompt=none request...
         const promptNoneIFrame: HTMLIFrameElement = document.getElementById("promptNoneIFrame") as HTMLIFrameElement;
-        promptNoneIFrame.src =
-            getItemFromSessionStorage("authorization_endpoint") +
-            "?response_type=code" +
-            "&client_id=" +
-            clientId +
-            "&scope=openid" +
-            "&redirect_uri=" +
-            redirectUri +
-            "&state=Y2hlY2tTZXNzaW9u" +
-            "&prompt=none" +
-            "&code_challenge_method=S256&code_challenge=" +
-            getRandomPKCEChallenge();
+
+        const parsedAuthorizationEndpointURL: URL = new URL(getItemFromSessionStorage("authorization_endpoint"));
+
+        parsedAuthorizationEndpointURL.searchParams.append("response_type", "code");
+        parsedAuthorizationEndpointURL.searchParams.append("client_id", clientId);
+        parsedAuthorizationEndpointURL.searchParams.append("scope", "openid");
+        parsedAuthorizationEndpointURL.searchParams.append("redirect_uri", redirectUri);
+        parsedAuthorizationEndpointURL.searchParams.append("state", "Y2hlY2tTZXNzaW9u");
+        parsedAuthorizationEndpointURL.searchParams.append("prompt", "none");
+        parsedAuthorizationEndpointURL.searchParams.append("code_challenge_method", "S256");
+        parsedAuthorizationEndpointURL.searchParams.append("code_challenge", getRandomPKCEChallenge());
+
+        promptNoneIFrame.src = parsedAuthorizationEndpointURL.toString();
     }
 }

--- a/apps/myaccount/src/init/rpIFrame-script.ts
+++ b/apps/myaccount/src/init/rpIFrame-script.ts
@@ -97,17 +97,18 @@ function receiveMessage(e) {
     } else {
         // [RP] session state has changed. Sending prompt=none request...
         const promptNoneIFrame: HTMLIFrameElement = document.getElementById("promptNoneIFrame") as HTMLIFrameElement;
-        promptNoneIFrame.src =
-            getItemFromSessionStorage("authorization_endpoint") +
-            "?response_type=code" +
-            "&client_id=" +
-            clientId +
-            "&scope=openid" +
-            "&redirect_uri=" +
-            redirectUri +
-            "&state=Y2hlY2tTZXNzaW9u" +
-            "&prompt=none" +
-            "&code_challenge_method=S256&code_challenge=" +
-            getRandomPKCEChallenge();
+
+        const parsedAuthorizationEndpointURL: URL = new URL(getItemFromSessionStorage("authorization_endpoint"));
+
+        parsedAuthorizationEndpointURL.searchParams.append("response_type", "code");
+        parsedAuthorizationEndpointURL.searchParams.append("client_id", clientId);
+        parsedAuthorizationEndpointURL.searchParams.append("scope", "openid");
+        parsedAuthorizationEndpointURL.searchParams.append("redirect_uri", redirectUri);
+        parsedAuthorizationEndpointURL.searchParams.append("state", "Y2hlY2tTZXNzaW9u");
+        parsedAuthorizationEndpointURL.searchParams.append("prompt", "none");
+        parsedAuthorizationEndpointURL.searchParams.append("code_challenge_method", "S256");
+        parsedAuthorizationEndpointURL.searchParams.append("code_challenge", getRandomPKCEChallenge());
+
+        promptNoneIFrame.src = parsedAuthorizationEndpointURL.toString();
     }
 }

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -461,21 +461,21 @@ export const initializeAuthentication = () =>(dispatch)=> {
  */
 export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overriddenURL: string): string => {
 
-    const parsedURL: URL = new URL(originalURL);
+    const parsedOriginalURL: URL = new URL(originalURL);
     const parsedOverrideURL: URL = new URL(overriddenURL);
 
     // If the override URL & original URL has search params, try to moderate the URL.
-    if (parsedOverrideURL.search && parsedURL.search) {
-        for (const [ key, value ] of parsedURL.searchParams.entries()) {
-            if (parsedOverrideURL.searchParams.has(key)) {
-                parsedURL.searchParams.append(key, value);
+    if (parsedOverrideURL.search && parsedOriginalURL.search) {
+        for (const [ key, value ] of parsedOriginalURL.searchParams.entries()) {
+            if (!parsedOverrideURL.searchParams.has(key)) {
+                parsedOverrideURL.searchParams.append(key, value);
             }
         }
 
-        return parsedURL.toString();
+        return parsedOverrideURL.toString();
     }
 
-    return overriddenURL + parsedURL.search;
+    return overriddenURL + parsedOriginalURL.search;
 };
 
 /**

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -464,9 +464,15 @@ export const resolveIdpURLSAfterTenantResolves = (originalURL: string, overridde
     const parsedURL: URL = new URL(originalURL);
     const parsedOverrideURL: URL = new URL(overriddenURL);
 
-    // If the override URL has search params, adjust the params of the original URL accordingly.
-    if (parsedOverrideURL.search) {
-        return overriddenURL + parsedURL.search.replace(parsedURL.search.charAt(0), "&");
+    // If the override URL & original URL has search params, try to moderate the URL.
+    if (parsedOverrideURL.search && parsedURL.search) {
+        for (const [ key, value ] of parsedURL.searchParams.entries()) {
+            if (parsedOverrideURL.searchParams.has(key)) {
+                parsedURL.searchParams.append(key, value);
+            }
+        }
+
+        return parsedURL.toString();
     }
 
     return overriddenURL + parsedURL.search;


### PR DESCRIPTION
## Purpose
Templated IDP URLs contained duplicated search parameters.

```bash
<SERVER_HOST>/t/carbon.super/oauth2/authorize?ut=brionmario&ut=carbon.super
```

Here `ut` is duplicated.

## Goals
Removes duplicated params.

## Approach
Only add the params if the overridden URL already doesn't contain them.
