### PR TITLE
Fix overflowed text hiding in myaccount subheadings/descriptions

### DIFF
--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -846,7 +846,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                 ) }
                 contentTopMargin={ true }
                 description={ (
-                    <div className="with-label">
+                    <div className="with-label ellipsis">
                         { applicationTemplate?.name && <Label size="small">{ applicationTemplate.name }</Label> }
                         { application.description }
                     </div>
@@ -875,8 +875,9 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                 } }
                 titleTextAlign="left"
                 bottomMargin={ false }
-                pageHeaderMaxWidth={ false }
+                pageHeaderMaxWidth={ true }
                 data-testid={ `${ testId }-page-layout` }
+                truncateContent={ true }
             >
                 <EditApplication
                     application={ application }

--- a/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
@@ -273,6 +273,8 @@ const IdentityProviderEditPage: FunctionComponent<IDPEditPagePropsInterface> = (
                 titleTextAlign="left"
                 bottomMargin={ false }
                 data-testid={ `${ testId }-page-layout` }
+                pageHeaderMaxWidth={ true }
+                truncateContent={ true }
             >
                 <EditIdentityProvider
                     identityProvider={ identityProvider }

--- a/apps/myaccount/src/layouts/inner.tsx
+++ b/apps/myaccount/src/layouts/inner.tsx
@@ -17,7 +17,7 @@
  */
 
 import { CommonUtils } from "@wso2is/core/utils";
-import { ErrorBoundary, LinkButton } from "@wso2is/react-components";
+import { ErrorBoundary, LinkButton, PageLayout } from "@wso2is/react-components";
 import React, { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Responsive } from "semantic-ui-react";
@@ -27,7 +27,6 @@ import {
     EmptyPlaceholder,
     GlobalLoader,
     Header,
-    PageHeader,
     SidePanelWrapper
 } from "../components";
 import { getEmptyPlaceholderIllustrations } from "../configs";
@@ -115,12 +114,16 @@ export const InnerPageLayout: React.FunctionComponent<InnerPageLayoutProps> = (
                             />
                         ) }
                     >
-                        <PageHeader
-                            title={ pageTitle }
+                        
+                        <PageLayout
                             description={ pageDescription }
+                            pageHeaderMaxWidth={ false }
+                            title={ pageTitle }
                             titleTextAlign={ pageTitleTextAlign }
-                        />
-                        { children }
+                            truncateContent={ false }
+                        >
+                            { children }
+                        </PageLayout>
                     </ErrorBoundary>
                 </SidePanelWrapper>
             </div>

--- a/modules/react-components/src/components/page-header/page-header.tsx
+++ b/modules/react-components/src/components/page-header/page-header.tsx
@@ -82,6 +82,10 @@ export interface PageHeaderPropsInterface extends LoadableComponentInterface, Te
      * Title text alignment.
      */
     titleTextAlign?: "left" | "center" | "right" | "justified";
+    /**
+     * Truncate content
+     */
+    truncateContent?: boolean;
 }
 
 /**
@@ -125,6 +129,7 @@ export const PageHeader: React.FunctionComponent<PageHeaderPropsInterface> = (
         titleAs,
         titleTextAlign,
         pageHeaderMaxWidth,
+        truncateContent,
         [ "data-testid" ]: testId
     } = props;
 
@@ -152,12 +157,20 @@ export const PageHeader: React.FunctionComponent<PageHeaderPropsInterface> = (
     );
 
     const headerContentClasses = classNames(
-        "page-header ellipsis",
+        "page-header",
         {
+            "ellipsis": truncateContent,
             "no-max-width": !pageHeaderMaxWidth
         }
     );
-    
+
+    const subHeaderContentClasses = classNames(
+        "sub-header",
+        {
+            "ellipsis": truncateContent
+        }
+    );
+
     const headingContent = (
         <div className={ innerClasses }>
             { image && (
@@ -211,7 +224,7 @@ export const PageHeader: React.FunctionComponent<PageHeaderPropsInterface> = (
                             </span>
                             { description && (
                                 <Header.Subheader
-                                    className="sub-header ellipsis"
+                                    className={ subHeaderContentClasses }
                                     data-testid={ `${ testId }-sub-title` }
                                 >
                                     { description }

--- a/modules/theme/src/themes/default/elements/header.overrides
+++ b/modules/theme/src/themes/default/elements/header.overrides
@@ -31,15 +31,13 @@ h6.ui.header .sub.header {
 
 .ui.header {
     &.page-header {
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-
         .sub-header {
             margin-top: @pageHeaderInnerMargin;
         }
 
-        max-width: 50%;
+        &:not(.no-max-width) {
+            max-width: 50%;
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose
> To fix the hiding overflow text of MyAccount subheadings/descriptions

![Screenshot from 2021-02-11 08-29-44](https://user-images.githubusercontent.com/25344622/107598375-8da5e400-6c43-11eb-817e-23c2ae5e3256.png)

## Approach
> Replaced Header component with PageLayout component and used a custom prop to specify whether the truncate should happen or not

High resolution
![Screenshot from 2021-02-11 08-41-28](https://user-images.githubusercontent.com/25344622/107598877-f93c8100-6c44-11eb-87a9-c1209ef26c79.png)
Low resolution
![Screenshot from 2021-02-11 08-42-28](https://user-images.githubusercontent.com/25344622/107598952-196c4000-6c45-11eb-9c17-a9067e13e5d5.png)
