### PR TITLE
Fix header typo and translation of social login add confirm dialog

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticator-side-panel.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticator-side-panel.tsx
@@ -163,20 +163,19 @@ export const AuthenticatorSidePanel: FunctionComponent<AuthenticatorSidePanelPro
                 <ConfirmationModal.Header
                     data-testid={ `${ testId }-delete-confirmation-modal-header` }
                 >
-                    Confirm You Action
+                     { t("console:develop.features.applications.confirmations.addSocialLogin.header") }
                 </ConfirmationModal.Header>
                 <ConfirmationModal.Message
                     attached
                     warning
                     data-testid={ `${ testId }-delete-confirmation-modal-message` }
                 >
-                    This action is irreversible.
+                    { t("console:develop.features.applications.confirmations.addSocialLogin.subHeader") }
                 </ConfirmationModal.Message>
                 <ConfirmationModal.Content
                     data-testid={ `${ testId }-delete-confirmation-modal-content` }
                 >
-                    To add a new social login we will need to route you to a different page and any unsaved
-                    changes in this page will be lost. Please confirm.
+                    { t("console:develop.features.applications.confirmations.addSocialLogin.content") }
                 </ConfirmationModal.Content>
             </ConfirmationModal>
         );

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -363,6 +363,7 @@ export interface ConsoleNS {
                     placeholder: string;
                 };
                 confirmations: {
+                    addSocialLogin: Popup;
                     deleteApplication: Confirmation;
                     deleteOutboundProvisioningIDP: Confirmation;
                     deleteProtocol: Confirmation;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -545,6 +545,12 @@ export const console: ConsoleNS = {
                     placeholder: "Search by application name"
                 },
                 confirmations: {
+                    addSocialLogin: {
+                        content : "To add a new social login we will need to route you to a different page and " +
+                            "any unsaved changes in this page will be lost. Please confirm.",
+                        header: "Confirm Your Action",
+                        subHeader: "This action is irreversible."
+                    },
                     clientSecretHashDisclaimer: {
                         forms: {
                             clientIdSecretForm: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -541,6 +541,13 @@ export const console: ConsoleNS = {
                     placeholder: "Chercher par nom d'application"
                 },
                 confirmations: {
+                    addSocialLogin: {
+                        content : "Pour ajouter une nouvelle connexion sociale, nous devrons vous diriger " +
+                            "vers une autre page et toutes les modifications non enregistrées de cette page " +
+                            "seront perdues. Veuillez confirmer.",
+                        header: "Confirmez votre action",
+                        subHeader: "Cette action est irréversible."
+                    },
                     clientSecretHashDisclaimer: {
                         forms: {
                             clientIdSecretForm: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -549,6 +549,12 @@ export const console: ConsoleNS = {
                     placeholder: "යෙදුම් නාමයෙන් සොයන්න"
                 },
                 confirmations: {
+                    addSocialLogin: {
+                        content : "නව සමාජ පිවිසුමක් එක් කිරීම සඳහා අපි ඔබව වෙනත් පිටුවකට යොමු කළ යුතු අතර මෙම පිටුවෙහි " +
+                            "කිසියම් සුරකින ලද වෙනස්කම් නැති වනු ඇත. කරුණාකර තහවුරු කරන්න.",
+                        header: "ඔබේ ක්‍රියාව තහවුරු කරන්න",
+                        subHeader: "මෙම ක්‍රියාව ආපසු හැරවිය නොහැක."
+                    },
                     clientSecretHashDisclaimer: {
                         forms: {
                             clientIdSecretForm: {


### PR DESCRIPTION
## Purpose
> Fix header typo and content translation of social login add confirmation dialog

## Approach
> Added translation content to translation files and used in the ```authenticator-side-panel.tsx``` while correcting typo