### PR TITLE
Error alert message is removed after updating the certificate

### DIFF
--- a/apps/console/src/features/certificates/components/import-certificate.tsx
+++ b/apps/console/src/features/certificates/components/import-certificate.tsx
@@ -232,6 +232,7 @@ export const ImportCertificate: FunctionComponent<ImportCertificatePropsInterfac
      */
     const previous = (): void => {
         setCurrentWizardStep(currentWizardStep - 1);
+        setAlert(null);
     };
 
     return (


### PR DESCRIPTION
## Purpose
> Fix for : https://github.com/wso2-enterprise/asgardeo-product/issues/1793

## Approach
> The error alert is removed after clicking the previous button.

**Adding same certificate error**
![image](https://user-images.githubusercontent.com/33889049/107611799-cc02c980-6c6a-11eb-8bf0-240e577d3c69.png)



**After clicking previous button**
![Screenshot from 2021-02-11 12-44-10](https://user-images.githubusercontent.com/33889049/107611452-0ae44f80-6c6a-11eb-8b26-667a4b497823.png)
