### PR TITLE
Fix `deployement.config` not loading issue

### DIFF
--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -36,7 +36,7 @@
         <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.min.css" rel="stylesheet" type="text/css"/>
 
         <script>
-            var contextPathGlobal = "<%= htmlWebpackPlugin.options.contextPath %>";
+            var contextPathGlobal = "<%= htmlWebpackPlugin.options.publicPath %>";
             var serverOriginGlobal = "<%= htmlWebpackPlugin.options.serverUrl %>";
             var superTenantGlobal = "<%= htmlWebpackPlugin.options.superTenantConstant %>";
             var tenantPrefixGlobal = "<%= htmlWebpackPlugin.options.tenantPrefix %>";


### PR DESCRIPTION
## Purpose
`htmlWebpackPlugin.options.context` is no longer defined in webpack. This causes 
