### PR TITLE
Remove URL encoding from the URLs shown in the Application config UIs

### DIFF
--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -425,7 +425,7 @@ export const console: ConsoleNS = {
                 heading: "Insecure URL"
             },
             unrecognizedURL: {
-                description: "The entered URL neither HTTP nor HTTPS. Please proceed with caution.",
+                description: "The entered URL is neither HTTP nor HTTPS. Please proceed with caution.",
                 heading: "Unrecognized URL"
             }
         }

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -560,7 +560,9 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                     />
                 ) : <span>{ protocol }</span> }
                 <span>://</span>
-                <span>{ onlyOrigin ? host : pathWithoutProtocol }</span>
+                <span className="decoded-path">
+                    { onlyOrigin ? decodeURIComponent(host) : decodeURIComponent(pathWithoutProtocol) }
+                </span>
             </span>
         );
     };

--- a/modules/theme/src/themes/default/collections/grid.overrides
+++ b/modules/theme/src/themes/default/collections/grid.overrides
@@ -198,6 +198,10 @@
                 margin-top: @SmallMargin;
                 margin-bottom: @SmallMargin;
                 padding: @ZeroPadding;
+
+                .decoded-path {
+                    white-space: pre;
+                }
            }
 
            &.flex-row {


### PR DESCRIPTION
## Purpose
In Application configuration section of the Console displays the URLs (Authorized redirect URIs) with URL encoding. This PR removed URL encoding from UI, hence the displayed URLs will be shown without URL encoding.

![image](https://user-images.githubusercontent.com/25479743/105999268-7dcec180-60d3-11eb-991d-092f182ce9b4.png)

