### PR TITLE
[MyAccount] Validate user input claims using the regex configured with the schema

### DIFF
--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -530,16 +530,28 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                                             type="text"
                                             validation={ (value: string, validation: Validation) => {
                                                 if (!RegExp(schema.regEx).test(value)) {
-                                                    validation.errorMessages.push(
-                                                        t(
-                                                            "myAccount:components.profile.forms." +
-                                                            "generic.inputs.validations.invalidFormat",
-                                                            {
-                                                                fieldName
-                                                            }
-                                                        )
-                                                    );
                                                     validation.isValid = false;
+                                                    if (checkSchemaType(schema.name, "emails")) {
+                                                        validation.errorMessages.push(t(
+                                                            "myAccount:components.profile.forms.emailChangeForm." +
+                                                            "inputs.email.validations.invalidFormat"
+                                                        ));
+                                                    } else if (checkSchemaType(schema.name, "phoneNumbers")) {
+                                                        validation.errorMessages.push(t(
+                                                            "myAccount:components.profile.forms.mobileChangeForm." +
+                                                            "inputs.mobile.validations.invalidFormat"
+                                                        ));
+                                                    } else {
+                                                        validation.errorMessages.push(
+                                                            t(
+                                                                "myAccount:components.profile.forms." +
+                                                                "generic.inputs.validations.invalidFormat",
+                                                                {
+                                                                    fieldName
+                                                                }
+                                                            )
+                                                        );
+                                                    }
                                                 }
                                             } }
                                                 value={ resolveProfileInfoSchemaValue(schema) }

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -529,31 +529,17 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                                             ) }
                                             type="text"
                                             validation={ (value: string, validation: Validation) => {
-                                                if (checkSchemaType(schema.name, "emails")) {
-                                                    if (!FormValidation.email(value)) {
-                                                        validation.errorMessages.push(
-                                                            t(
-                                                                "myAccount:components.profile.forms." +
-                                                                "generic.inputs.validations.invalidFormat",
-                                                                {
-                                                                    fieldName
-                                                                }
-                                                            )
-                                                        );
-                                                        validation.isValid = false;
-                                                    }
-                                                }
-                                                if (checkSchemaType(schema.name, "mobile")) {
-                                                    if (!FormValidation.mobileNumber(value)) {
-                                                        validation.errorMessages.push(t(
+                                                if (!RegExp(schema.regEx).test(value)) {
+                                                    validation.errorMessages.push(
+                                                        t(
                                                             "myAccount:components.profile.forms." +
                                                             "generic.inputs.validations.invalidFormat",
                                                             {
                                                                 fieldName
                                                             }
-                                                        ));
-                                                        validation.isValid = false;
-                                                    }
+                                                        )
+                                                    );
+                                                    validation.isValid = false;
                                                 }
                                             } }
                                                 value={ resolveProfileInfoSchemaValue(schema) }

--- a/apps/myaccount/src/models/profile.ts
+++ b/apps/myaccount/src/models/profile.ts
@@ -110,6 +110,7 @@ export interface ProfileSchema {
     required: boolean;
     subAttributes?: ProfileSchema[];
     extended?: boolean;
+    regEx?: string;
 }
 
 /**

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -966,7 +966,7 @@ export const myAccount: MyAccountNS = {
                             placeholder: "Enter your email address",
                             validations: {
                                 empty: "Email address is a required field",
-                                invalidFormat: "The email address is not of the correct format"
+                                invalidFormat: "Please enter a valid email address"
                             }
                         }
                     }
@@ -992,7 +992,7 @@ export const myAccount: MyAccountNS = {
                             placeholder: "Enter your mobile number",
                             validations: {
                                 empty: "Mobile number is a required field",
-                                invalidFormat: "The mobile number is not of the right format"
+                                invalidFormat: "Please enter a valid mobile number"
                             }
                         }
                     }


### PR DESCRIPTION
## Purpose
This PR adds regex pattern based form validation to user input fields in myaccount profile. It considers the regex returned with the SCIM2 schema for validation. This approach is already being used in the console [1].

[1] https://github.com/wso2/identity-apps/blob/6cabd897f6f8bac1267d5f5e42d20084a971ea8e/apps/console/src/features/users/components/user-profile.tsx#L688

Resolves : https://github.com/wso2-enterprise/asgardeo-product/issues/1650