### PR TITLE
Remove user store domain from username shown in overview page heading

### DIFF
--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -18,7 +18,8 @@
 
 import { updateProfileImageURL } from "@wso2is/core/api";
 import { ProfileConstants } from "@wso2is/core/constants";
-import { isFeatureEnabled, resolveUserDisplayName, resolveUserEmails } from "@wso2is/core/helpers";
+import { isFeatureEnabled, resolveUserDisplayName, resolveUserEmails,
+    getUserNameWithoutDomain } from "@wso2is/core/helpers";
 import { SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { ProfileUtils } from "@wso2is/core/utils";
 import { Field, Forms, Validation } from "@wso2is/forms";
@@ -37,7 +38,6 @@ import { AppState } from "../../store";
 import { getProfileInformation, setActiveForm } from "../../store/actions";
 import { EditSection, SettingsSection } from "../shared";
 import { MobileUpdateWizard } from "../shared/mobile-update-wizard";
-import { getUserNameWithoutDomain } from "../../helpers";
 
 /**
  * Prop types for the basic details component.

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -37,6 +37,7 @@ import { AppState } from "../../store";
 import { getProfileInformation, setActiveForm } from "../../store/actions";
 import { EditSection, SettingsSection } from "../shared";
 import { MobileUpdateWizard } from "../shared/mobile-update-wizard";
+import { getUserNameWithoutDomain } from "../../helpers";
 
 /**
  * Prop types for the basic details component.
@@ -381,12 +382,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
          * USER-STORE/userNameString => userNameString
          */
         if (schema.name === "userName") {
-            if (schemaFormValue?.indexOf("/") > -1) {
-                const fragments = schemaFormValue.split("/");
-                if (fragments?.length > 1) {
-                    schemaFormValue = fragments[1];
-                }
-            }
+            schemaFormValue = getUserNameWithoutDomain(schemaFormValue);
         }
 
         return schemaFormValue;

--- a/apps/myaccount/src/helpers/user.ts
+++ b/apps/myaccount/src/helpers/user.ts
@@ -17,6 +17,7 @@
  */
 
 import { isEmpty } from "lodash";
+import { getUserNameWithoutDomain } from "@wso2is/core/helpers";
 import { AppConstants } from "../constants";
 import { AuthStateInterface } from "../models";
 
@@ -85,21 +86,4 @@ export const resolveUserStoreEmbeddedUsername = (username: string): string => {
     }
 
     return username;
-};
-
-/**
- * This function returns the username without the user store domain prefix.
- *
- * @param {string} userNameWithDomain - Username of the user with the userStore domain.
- * @return {string} User name without domain.
- */
-export const getUserNameWithoutDomain = (userNameWithDomain: string): string => {
-
-    if (userNameWithDomain.indexOf("/") > -1) {
-        const fragments = userNameWithDomain.split("/");
-        if (fragments?.length > 1) {
-            return fragments[1];
-        }
-    }
-    return userNameWithDomain;
 };

--- a/apps/myaccount/src/helpers/user.ts
+++ b/apps/myaccount/src/helpers/user.ts
@@ -35,11 +35,11 @@ export const resolveUserDisplayName = (state: AuthStateInterface): string => {
         const familyName = isEmpty(state.profileInfo.name.familyName) ? "" : state.profileInfo.name.familyName;
         return givenName + familyName;
     } else if (state.profileInfo.userName) {
-        return state.profileInfo.userName;
+        return getUserNameWithoutDomain(state.profileInfo.userName);
     } else if (state.displayName) {
         return state.displayName;
     } else if (state.username) {
-        return state.username;
+        return getUserNameWithoutDomain(state.username);
     }
 
     return null;
@@ -85,4 +85,21 @@ export const resolveUserStoreEmbeddedUsername = (username: string): string => {
     }
 
     return username;
+};
+
+/**
+ * This function returns the username without the user store domain prefix.
+ *
+ * @param {string} userNameWithDomain - Username of the user with the userStore domain.
+ * @return {string} User name without domain.
+ */
+export const getUserNameWithoutDomain = (userNameWithDomain: string): string => {
+
+    if (userNameWithDomain.indexOf("/") > -1) {
+        const fragments = userNameWithDomain.split("/");
+        if (fragments?.length > 1) {
+            return fragments[1];
+        }
+    }
+    return userNameWithDomain;
 };

--- a/modules/core/src/helpers/profile.ts
+++ b/modules/core/src/helpers/profile.ts
@@ -39,15 +39,11 @@ export const resolveUserDisplayName = (profileInfo: ProfileInfoInterface,
         const familyName = isEmpty(profileInfo.name.familyName) ? "" : profileInfo.name.familyName;
         return givenName + familyName;
     } else if (profileInfo.userName) {
-        let userName = "";
-        profileInfo.userName.split("/").length > 1
-            ?  userName = profileInfo?.userName.split("/")[1]
-            : userName = profileInfo?.userName;
-        return userName;
+        return getUserNameWithoutDomain(profileInfo.userName);
     } else if (authState && authState.displayName) {
         return authState.displayName;
     } else if (authState && authState.username) {
-        return authState.username;
+        return getUserNameWithoutDomain(authState.username);
     }
 
     return fallback;
@@ -116,4 +112,21 @@ export const resolveUserEmails = (emails: (string | MultiValueAttributeInterface
 
         return email as string;
     });
+};
+
+/**
+ * This function returns the username without the user store domain prefix.
+ *
+ * @param {string} userNameWithDomain - Username of the user with the userStore domain.
+ * @return {string} User name without domain.
+ */
+export const getUserNameWithoutDomain = (userNameWithDomain: string): string => {
+
+    if (userNameWithDomain.indexOf("/") > -1) {
+        const fragments = userNameWithDomain.split("/");
+        if (fragments?.length > 1) {
+            return fragments[1];
+        }
+    }
+    return userNameWithDomain;
 };


### PR DESCRIPTION
## Purpose

If the user's first and(or) last name is not defined in the profile, the welcome heading in the My-Account overview page displays user name along with the user store domain prefix for secondary user store users. This PR is to hide the user store domain from user name displayed in the welcome message of the overview section.
