### PR TITLE
Skip sending a logout request when the myaccount/console session times out due to inactivity.

### DIFF
--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -34,6 +34,7 @@ import { I18nextProvider } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect, Route, Router, Switch } from "react-router-dom";
 import { initializeAuthentication } from "./features/authentication";
+import { AuthenticateUtils } from "./features/authentication/utils/authenticate-utils";
 import { ProtectedRoute } from "./features/core/components";
 import { Config, getBaseRoutes } from "./features/core/configs";
 import { AppConstants } from "./features/core/constants";
@@ -181,6 +182,7 @@ export const App: FunctionComponent<{}> = (): ReactElement => {
                                         <SessionManagementProvider
                                             onSessionTimeoutAbort={ handleSessionTimeoutAbort }
                                             onSessionLogout={ handleSessionLogout }
+                                            onLoginAgain={ AuthenticateUtils.endUserSession }
                                             modalOptions={ {
                                                 description: I18n.instance.t("console:common.modals" +
                                                     ".sessionTimeoutModal.description"),
@@ -188,7 +190,13 @@ export const App: FunctionComponent<{}> = (): ReactElement => {
                                                 primaryButtonText: I18n.instance.t("console:common.modals" +
                                                     ".sessionTimeoutModal.primaryButton"),
                                                 secondaryButtonText: I18n.instance.t("console:common.modals" +
-                                                    ".sessionTimeoutModal.secondaryButton")
+                                                    ".sessionTimeoutModal.secondaryButton"),
+                                                sessionTimedOutHeadingI18nKey: "console:common:modals" +
+                                                    ".sessionTimeoutModal.sessionTimedOutHeading",
+                                                loginAgainButtonText: I18n.instance.t("console:common:modals" +
+                                                    ".sessionTimeoutModal.loginAgainButton"),
+                                                sessionTimedOutDescription: I18n.instance.t("console:common:modals" +
+                                                    ".sessionTimeoutModal.sessionTimedOutDescription"),
                                             } }
                                         >
                                             <>

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -34,7 +34,7 @@ import { I18nextProvider } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect, Route, Router, Switch } from "react-router-dom";
 import { initializeAuthentication } from "./features/authentication";
-import { AuthenticateUtils } from "./features/authentication/utils/authenticate-utils";
+import { AuthenticateUtils } from "./features/authentication/utils";
 import { ProtectedRoute } from "./features/core/components";
 import { Config, getBaseRoutes } from "./features/core/configs";
 import { AppConstants } from "./features/core/constants";

--- a/apps/console/src/init/init.ts
+++ b/apps/console/src/init/init.ts
@@ -141,18 +141,7 @@ if (state !== null && state === "Y2hlY2tTZXNzaW9u") {
         _idleSecondsCounter++;
         _sessionAgeCounter++;
 
-        // Logout user if idle
-        if (_idleSecondsCounter >= IDLE_TIMEOUT) {
-
-            let logoutPath = config.clientOrigin + config.appBaseWithTenant + config.routes.logout;
-
-            // SaaS app paths already contains the tenant and basename.
-            if (config.isSaas) {
-                logoutPath = config.clientOrigin + config.routes.logout;
-            }
-
-            window.top.location.href = logoutPath;
-        } else if (_idleSecondsCounter === IDLE_WARNING_TIMEOUT) {
+        if (_idleSecondsCounter === IDLE_WARNING_TIMEOUT || _idleSecondsCounter >= IDLE_TIMEOUT) {
             const warningSearchParamKey = "session_timeout_warning";
             const currentURL = new URL(window.location.href);
 

--- a/apps/myaccount/src/app.tsx
+++ b/apps/myaccount/src/app.tsx
@@ -46,7 +46,7 @@ import {
 } from "./models";
 import { AppState } from "./store";
 import { initializeAuthentication } from "./store/actions";
-import { filterRoutes } from "./utils";
+import { endUserSession, filterRoutes } from "./utils";
 
 /**
  * Main App component.
@@ -178,6 +178,7 @@ export const App = (): ReactElement => {
                                         <SessionManagementProvider
                                             onSessionTimeoutAbort={ handleSessionTimeoutAbort }
                                             onSessionLogout={ handleSessionLogout }
+                                            onLoginAgain={ endUserSession }
                                             modalOptions={ {
                                                 description: I18n.instance.t("myAccount:modals" +
                                                     ".sessionTimeoutModal.description"),
@@ -185,7 +186,13 @@ export const App = (): ReactElement => {
                                                 primaryButtonText: I18n.instance.t("myAccount:modals" +
                                                     ".sessionTimeoutModal.primaryButton"),
                                                 secondaryButtonText: I18n.instance.t("myAccount:modals" +
-                                                    ".sessionTimeoutModal.secondaryButton")
+                                                    ".sessionTimeoutModal.secondaryButton"),
+                                                sessionTimedOutHeadingI18nKey: "myAccount:modals" +
+                                                    ".sessionTimeoutModal.sessionTimedOutHeading",
+                                                loginAgainButtonText: I18n.instance.t("myAccount:modals" +
+                                                    ".sessionTimeoutModal.loginAgainButton"),
+                                                sessionTimedOutDescription: I18n.instance.t("myAccount:modals" +
+                                                    ".sessionTimeoutModal.sessionTimedOutDescription"),
                                             } }
                                         >
                                             <>

--- a/apps/myaccount/src/init/init.ts
+++ b/apps/myaccount/src/init/init.ts
@@ -141,18 +141,7 @@ if (state !== null && state === "Y2hlY2tTZXNzaW9u") {
             _idleSecondsCounter++;
             _sessionAgeCounter++;
 
-            // Logout user if idle
-            if (_idleSecondsCounter >= IDLE_TIMEOUT) {
-
-                let logoutPath = config.clientOrigin + config.appBaseWithTenant + config.routes.logout;
-
-                // SaaS app paths already contains the tenant and basename.
-                if (config.isSaas) {
-                    logoutPath = config.clientOrigin + config.routes.logout;
-                }
-
-                window.top.location.href = logoutPath;
-            } else if (_idleSecondsCounter === IDLE_WARNING_TIMEOUT) {
+            if (_idleSecondsCounter >= IDLE_TIMEOUT || _idleSecondsCounter === IDLE_WARNING_TIMEOUT) {
                 const warningSearchParamKey = "session_timeout_warning";
                 const currentURL = new URL(window.location.href);
 

--- a/modules/i18n/src/models/common.ts
+++ b/modules/i18n/src/models/common.ts
@@ -172,6 +172,7 @@ export interface ModalInterface {
     content?: object;
     primaryButton: string;
     secondaryButton: string;
+    [ key: string ]: any;
 }
 
 /**

--- a/modules/i18n/src/models/common.ts
+++ b/modules/i18n/src/models/common.ts
@@ -172,7 +172,6 @@ export interface ModalInterface {
     content?: object;
     primaryButton: string;
     secondaryButton: string;
-    [ key: string ]: any;
 }
 
 /**

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -84,7 +84,16 @@ export interface ConsoleNS {
         };
         modals: {
             editAvatarModal: ModalInterface;
-            sessionTimeoutModal: ModalInterface;
+            sessionTimeoutModal: {
+                description: string;
+                heading: string;
+                content?: object;
+                primaryButton: string;
+                secondaryButton: string;
+                loginAgainButton: string;
+                sessionTimedOutHeading: string;
+                sessionTimedOutDescription: string;
+            };
         };
         notifications: {
             invalidPEMFile: Notification;

--- a/modules/i18n/src/models/namespaces/myaccount-ns.ts
+++ b/modules/i18n/src/models/namespaces/myaccount-ns.ts
@@ -711,7 +711,16 @@ export interface MyAccountNS {
     };
     modals: {
         editAvatarModal: ModalInterface;
-        sessionTimeoutModal: ModalInterface;
+        sessionTimeoutModal: {
+            description: string;
+            heading: string;
+            content?: object;
+            primaryButton: string;
+            secondaryButton: string;
+            loginAgainButton: string;
+            sessionTimedOutHeading: string;
+            sessionTimedOutDescription: string;
+        };
     };
     pages: {
         applications: Page;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -113,11 +113,14 @@ export const console: ConsoleNS = {
                 secondaryButton: "Cancel"
             },
             sessionTimeoutModal: {
-                description: "You will be logged out of the current session due to inactivity." +
+                description: "You will be logged out of the current session due to inactivity. " +
                     "Please choose Stay logged in if you would like to continue the session.",
                 heading: "You will be logged out in <1>{{ time }}</1>.",
                 primaryButton: "Stay logged in",
-                secondaryButton: "Logout"
+                secondaryButton: "Logout",
+                loginAgainButton: "Login again",
+                sessionTimedOutHeading: "Your session has expired due to inactivity.",
+                sessionTimedOutDescription: "Please log in again to continue from where you left off."
             }
         },
         notifications: {

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -1267,11 +1267,14 @@ export const myAccount: MyAccountNS = {
             secondaryButton: "Cancel"
         },
         sessionTimeoutModal: {
-            description: "You will be logged out of the current session due to inactivity." +
+            description: "You will be logged out of the current session due to inactivity. " +
                 "Please choose Stay logged in if you would like to continue the session.",
             heading: "You will be logged out in <1>{{ time }}</1>.",
             primaryButton: "Stay logged in",
-            secondaryButton: "Logout"
+            secondaryButton: "Logout",
+            loginAgainButton: "Login again",
+            sessionTimedOutHeading: "Your session has expired due to inactivity.",
+            sessionTimedOutDescription: "Please log in again to continue from where you left off."
         }
     },
     pages: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -117,7 +117,10 @@ export const console: ConsoleNS = {
                     "Veuillez choisir 'Rester connecté' si vous souhaitez poursuivre la session.",
                 heading: "Vous serez déconnecté(e) dans <1>{{ time }}</1>.",
                 primaryButton: "Rester connecté",
-                secondaryButton: "Déconnexion"
+                secondaryButton: "Déconnexion",
+                loginAgainButton: "Connectez-vous à nouveau",
+                sessionTimedOutHeading: "Votre session a expiré en raison d'une inactivité.",
+                sessionTimedOutDescription: "Veuillez vous reconnecter pour reprendre là où vous vous étiez arrêté."
             }
         },
         notifications: {

--- a/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
@@ -1274,7 +1274,10 @@ export const myAccount: MyAccountNS = {
                 "Sélectionnez <1>Rester connecté<1> pour poursuivre la session.",
             heading: "Vous serez déconnecté(e) dans <1>{{ time }}</1>.",
             primaryButton: "Rester connecté",
-            secondaryButton: "Se déconnecter"
+            secondaryButton: "Se déconnecter",
+            loginAgainButton: "Connectez-vous à nouveau",
+            sessionTimedOutHeading: "Votre session a expiré en raison d'une inactivité.",
+            sessionTimedOutDescription: "Veuillez vous reconnecter pour reprendre là où vous vous étiez arrêté."
         }
     },
     pages: {

--- a/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
@@ -1253,7 +1253,10 @@ export const myAccount: MyAccountNS = {
                 "Selecione Permanecer conectado se desejar continuar a sessão.",
             heading: "Você será desconectado em <1>{{ time }}</1>.",
             primaryButton: "Permaneça logado",
-            secondaryButton: "Sair"
+            secondaryButton: "Sair",
+            loginAgainButton: "Entrar novamente",
+            sessionTimedOutHeading: "Sua sessão expirou devido à inatividade.",
+            sessionTimedOutDescription: "Faça login novamente para continuar de onde parou."
         }
     },
     pages: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -117,7 +117,10 @@ export const console: ConsoleNS = {
                     "කරුණාකර ඔබ සැසිය දිගටම කරගෙන යාමට කැමති නම් ලොග් වී සිටින්න තෝරන්න.",
                 heading: "ඔබ <1>{{ time }}</1> න් ඉවත් වනු ඇත.",
                 primaryButton: "පුරනය වී සිටින්න",
-                secondaryButton: "ඉවත් වන්න"
+                secondaryButton: "ඉවත් වන්න",
+                loginAgainButton: "නැවත පුරනය වන්න",
+                sessionTimedOutHeading: "අක්‍රියතාවය හේතුවෙන් ඔබගේ සැසිය කල් ඉකුත්වී ඇත.",
+                sessionTimedOutDescription: "ඔබ නතර කළ ස්ථානයෙන් ඉදිරියට යාමට කරුණාකර නැවත ලොග් වන්න."
             }
         },
         notifications: {

--- a/modules/i18n/src/translations/si-LK/portals/myaccount.ts
+++ b/modules/i18n/src/translations/si-LK/portals/myaccount.ts
@@ -1263,7 +1263,10 @@ export const myAccount: MyAccountNS = {
                 "නම් කරුණාකර රැඳී සිටින්න තෝරන්න.",
             heading: "තත්පර <1>{{ time }}</1> කින් ඔබ ඉවත් වනු ඇත.",
             primaryButton: "පුරනය වී සිටින්න",
-            secondaryButton: "වරන්න"
+            secondaryButton: "වරන්න",
+            loginAgainButton: "නැවත පුරනය වන්න",
+            sessionTimedOutHeading: "අක්‍රියතාවය හේතුවෙන් ඔබගේ සැසිය කල් ඉකුත්වී ඇත.",
+            sessionTimedOutDescription: "ඔබ නතර කළ ස්ථානයෙන් ඉදිරියට යාමට කරුණාකර නැවත ලොග් වන්න."
         }
     },
     pages: {

--- a/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
@@ -1300,7 +1300,10 @@ export const myAccount: MyAccountNS = {
                 "நீங்கள் அமர்வைத் தொடர விரும்பினால் உள்நுழைந்திருப்பதைத் தேர்வுசெய்க.",
             heading: "நீங்கள் <1>{{ time }}</1> இல் வெளியேறுவீர்கள்.",
             primaryButton: "உள்நுழைந்திருங்கள்",
-            secondaryButton: "வெளியேறு"
+            secondaryButton: "வெளியேறு",
+            loginAgainButton: "மீண்டும் உள்நுழைக",
+            sessionTimedOutHeading: "செயலற்ற தன்மை காரணமாக உங்கள் அமர்வு காலாவதியானது.",
+            sessionTimedOutDescription: "நீங்கள் நிறுத்திய இடத்திலிருந்து தொடர தயவுசெய்து மீண்டும் உள்நுழைக."
         }
     },
     pages: {

--- a/modules/react-components/src/providers/session-management/session-management-provider.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-provider.tsx
@@ -171,6 +171,10 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
      * Handles session timeout abort.
      */
     const handleSessionTimeoutAbort = (): void => {
+        if (sessionTimedOut) {
+            handleLoginAgain();
+            return;
+        }
         const parsedURL: URL = new URL(sessionTimeoutEventState.url);
 
         if (parsedURL && parsedURL.searchParams) {

--- a/modules/react-components/src/providers/session-management/session-management-provider.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-provider.tsx
@@ -272,8 +272,10 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
                     >
                     </Trans>
                 }
-                description={ sessionTimedOut ? modalOptions?.sessionTimedOutDescription : modalOptions?.description }
-                primaryButtonText={ sessionTimedOut ? modalOptions?.loginAgainButtonText : modalOptions?.primaryButtonText }
+                description={ sessionTimedOut ? modalOptions?.sessionTimedOutDescription
+                    : modalOptions?.description }
+                primaryButtonText={ sessionTimedOut ? modalOptions?.loginAgainButtonText
+                    : modalOptions?.primaryButtonText }
                 secondaryButtonText={ modalOptions?.secondaryButtonText }
             />
         </>


### PR DESCRIPTION
## Purpose
This fix is to skip sending a logout request when the myaccount/console session times out due to inactivity. Instead of that the below message is shown after the idle session time out timer times up.

Resolves : https://github.com/wso2-enterprise/asgardeo-product/issues/1667

![pr](https://user-images.githubusercontent.com/25479743/107883435-f4155580-6f14-11eb-815e-30a753294930.gif)

