### PR TITLE
Add logout URL to server endpoints section in application edit

### DIFF
--- a/apps/console/src/features/applications/api/application.ts
+++ b/apps/console/src/features/applications/api/application.ts
@@ -757,6 +757,7 @@ export const getOIDCApplicationConfigurations = (): Promise<OIDCApplicationConfi
 
             const oidcConfigs = {
                 authorizeEndpoint: response.data.authorization_endpoint,
+                endSessionEndpoint: response.data.end_session_endpoint,
                 introspectionEndpoint: response.data.introspection_endpoint,
                 jwksEndpoint: response.data.jwks_uri,
                 tokenEndpoint: response.data.token_endpoint,

--- a/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
+++ b/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
@@ -23,7 +23,7 @@ import { CopyInputField, GenericIcon } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Grid } from "semantic-ui-react";
+import { Grid, Icon } from "semantic-ui-react";
 import { AppState } from "../../../core/store";
 import { getHelpPanelIcons } from "../../configs";
 import {
@@ -238,6 +238,31 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                             value={ oidcConfigurations?.wellKnownEndpoint  }
                             className="panel-url-input"
                             data-testid={ `${ testId }-introspection-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ <Icon className={ "mr-0" } name="power off" /> }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-logout-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.endSession") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.endSessionEndpoint  }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-logout-readonly-input` }
                         />
                     </Grid.Column>
                 </Grid.Row>

--- a/apps/console/src/features/applications/models/application.ts
+++ b/apps/console/src/features/applications/models/application.ts
@@ -575,6 +575,7 @@ export interface SimpleUserStoreListItemInterface {
  */
 export interface OIDCApplicationConfigurationInterface {
     authorizeEndpoint: string;
+    endSessionEndpoint: string;
     introspectionEndpoint: string;
     tokenEndpoint: string;
     userEndpoint: string;
@@ -595,6 +596,7 @@ export interface SAMLApplicationConfigurationInterface {
 
 export const emptyOIDCAppConfiguration = (): OIDCApplicationConfigurationInterface => ({
     authorizeEndpoint: "",
+    endSessionEndpoint: "",
     introspectionEndpoint: "",
     jwksEndpoint: "",
     tokenEndpoint: "",

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1840,6 +1840,7 @@ export const console: ConsoleNS = {
                                 oidcConfigurations: {
                                     labels: {
                                         authorize: "Authorize",
+                                        endSession: "Logout",
                                         introspection: "Introspection",
                                         keystore: "Key Set",
                                         jwks: "JWKS",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1854,6 +1854,7 @@ export const console: ConsoleNS = {
                                 oidcConfigurations: {
                                     labels: {
                                         authorize: "Authorize",
+                                        endSession: "Se déconnecter",
                                         introspection: "Introspection",
                                         keystore: "Key Set",
                                         jwks: "JWKS",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1835,6 +1835,7 @@ export const console: ConsoleNS = {
                                 oidcConfigurations: {
                                     labels: {
                                         authorize: "අවසරලත්",
+                                        endSession: "පිටතට",
                                         introspection: "ස්වයං විමර්ශනය",
                                         keystore: "යතුරු කට්ටලය",
                                         jwks: "JWKS",


### PR DESCRIPTION
## Purpose
> Add the missing logout URL in server endpoints section of application edit.

![Screenshot from 2021-02-15 13-50-13](https://user-images.githubusercontent.com/25344622/107921619-c96ae180-6f94-11eb-90b0-cb7701d36f8c.png)

## Approach
> Captured ```end_session_endpoint``` when server endpoints are retrieved and used it to display in server endpoints section

