### PR TITLE
Update the user attributes grid after a successful change of the subject attribute

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
@@ -119,6 +119,25 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
 
     const initValue = useRef(false);
 
+    useEffect(() => {
+        const tempFilterSelectedExternalClaims = [...filterSelectedExternalClaims];
+        claimConfigurations?.claimMappings?.map((claim) => {
+            if (
+                !filterSelectedExternalClaims.find(
+                    (selectedExternalClaim) => selectedExternalClaim.mappedLocalClaimURI === claim.localClaim.uri
+                )
+            ) {
+                tempFilterSelectedExternalClaims.push(
+                    availableExternalClaims.find(
+                        (availableClaim) => availableClaim.mappedLocalClaimURI === claim.localClaim.uri
+                    )
+                );
+            }
+        });
+        setSelectedExternalClaims(tempFilterSelectedExternalClaims);
+        setFilterSelectedExternalClaims(tempFilterSelectedExternalClaims);
+    }, [claimConfigurations]);
+
     const updateMandatory = (claimURI: string, mandatory: boolean) => {
         if (selectedDialect.localDialect) {
             const localClaims = [...selectedClaims];


### PR DESCRIPTION
## Purpose
> Fix to update the **User Attribute Selection** grid after a change and update of **Subject attribute**

## Approach
> A function is added to identify and update the grid according to subject attributes.



https://user-images.githubusercontent.com/33889049/107912677-f44d3980-6f84-11eb-850d-84728c3ac6ee.MP4


