### PR TITLE
Fix step component re-generate issues

### DIFF
--- a/modules/react-components/src/components/step/steps.tsx
+++ b/modules/react-components/src/components/step/steps.tsx
@@ -86,7 +86,7 @@ export const Steps: FunctionComponent<PropsWithChildren<StepsPropsInterface>> & 
 
     useEffect(() => {
         setFilteredChildren(React.Children.toArray(children).filter((child) => !!child));
-    }, []);
+    }, [ children ]);
 
     return (
         <div className={ classes } style={ style } data-testid={ testId }>


### PR DESCRIPTION
## Purpose
Steps component doesn't regenerate when the `children` changes.
