### PR TITLE
Defined error messages for Traditional OIDC application PEM Certificate validation

### DIFF
--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1020,8 +1020,8 @@ export const console: ConsoleNS = {
                                         description: "The text value of the certificate in PEM format.",
                                         placeholder: "Certificate in PEM format.",
                                         validations: {
-                                            empty: "This is a required field."
-                                        }
+                                            empty: "This is a required field.",
+                                            invalid: "Enter a valid certificate in PEM format"                                        }
                                     },
                                     type: {
                                         children: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1024,8 +1024,8 @@ export const console: ConsoleNS = {
                                         placeholder: "Certificat au format PEM.",
                                         description: "La valeur texte du certificat au format PEM.",
                                         validations: {
-                                            empty: "Ceci est un champ obligatoire."
-                                        }
+                                            empty: "Ceci est un champ obligatoire.",
+                                            invalid: "Entrez un certificat valide au format PEM"                                        }
                                     },
                                     type: {
                                         children: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1023,8 +1023,8 @@ export const console: ConsoleNS = {
                                         placeholder: "PEM ආකෘතියෙන් සහතිකය.",
                                         description: "සහතිකයේ පෙළ අගය PEM ආකෘතියෙන්.",
                                         validations: {
-                                            empty: "මෙය අත්‍යවශ්‍ය ක්ෂේත්‍රයකි."
-                                        }
+                                            empty: "මෙය අත්‍යවශ්‍ය ක්ෂේත්‍රයකි.",
+                                            invalid: "PEM ආකෘතියෙන් වලංගු සහතිකයක් ඇතුළත් කරන්න"                                        }
                                     },
                                     type: {
                                         children: {


### PR DESCRIPTION
## Purpose
> Resources to resolve https://github.com/issues/assigned

## Goals
> Clear and concise error message values defined for invalid PEM format in the certification entered by the user.

## Approach
> Error messages were defined to invalid key to display on validation error for PEM format certification.
