### PR TITLE
Fix the alignment issue when adding an authenticatior to the authentication steps.

### DIFF
--- a/modules/theme/src/theme-core/definitions/apps/developer-portal.less
+++ b/modules/theme/src/theme-core/definitions/apps/developer-portal.less
@@ -184,6 +184,7 @@
                      overflow: @signOnMethodsAuthStepOverflow;
                      flex-direction: @signOnMethodsAuthStepFlexDirection;
                      min-height: @signOnMethodsAuthStepMinHeight;
+                     max-height: @signOnMethodsAuthStepMinHeight;
                      flex-wrap: wrap;
                  }
  


### PR DESCRIPTION

## Purpose
Fix _When dropping an authenticator to a second step, step box alignments breaks - P1_ in https://github.com/wso2-enterprise/asgardeo-product/issues/2068.

## Approach
 Set max height to be equal to min height in authentication-step container

![Peek 2021-02-17 12-32](https://user-images.githubusercontent.com/25428696/108168567-85efaf00-711d-11eb-97a3-9359710dcf14.gif)
