### PR TITLE
Fix SPA add wizard Authorized URL validation, naming and error handling

### DIFF
--- a/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -25,7 +25,7 @@ import isEmpty from "lodash/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Grid, Icon, Label, Message } from "semantic-ui-react";
+import { Grid, Icon, Message } from "semantic-ui-react";
 import { AppState, ConfigReducerStateInterface } from "../../../../features/core";
 import { getAuthProtocolMetadata } from "../../api";
 import SinglePageApplicationTemplate
@@ -440,8 +440,8 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                                         urlState={ callBackUrls }
                                         setURLState={ setCallBackUrls }
                                         labelName={
-                                            t("console:develop.features.applications.forms.inboundOIDC." +
-                                                "fields.callBackUrls.label")
+                                            t("console:develop.features.applications.forms." +
+                                                "spaProtocolSettingsWizard.fields.callBackUrls.label")
                                         }
                                         placeholder={
                                             t("console:develop.features.applications.forms.inboundOIDC." +
@@ -449,26 +449,21 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                                                 ".placeholder")
                                         }
                                         validationErrorMsg={
-                                            t("console:develop.features.applications.forms.inboundOIDC." +
-                                                "fields.callBackUrls.validations.empty")
+                                            t("console:develop.features.applications.forms." +
+                                                "spaProtocolSettingsWizard.fields.callBackUrls.validations.invalid")
                                         }
                                         validation={ (value: string) => {
+                                            if (!(URLUtils.isURLValid(value, true) && (URLUtils.isHttpUrl(value) ||
+                                                URLUtils.isHttpsUrl(value)))) {
 
-                                            let label: ReactElement = null;
-
-                                            if (!URLUtils.isHttpsOrHttpUrl(value)) {
-                                                label = (
-                                                    <Label basic color="orange" className="mt-2">
-                                                        { t("console:common.validations.unrecognizedURL.description") }
-                                                    </Label>
-                                                );
+                                                return false;
                                             }
 
                                             if (!URLUtils.isMobileDeepLink(value)) {
                                                 return false;
                                             }
 
-                                            setCallbackURLsErrorLabel(label);
+                                            setCallbackURLsErrorLabel(null);
 
                                             return true;
                                         } }

--- a/apps/console/src/features/applications/data/application-templates/templates/single-page-application/create-wizard-help.tsx
+++ b/apps/console/src/features/applications/data/application-templates/templates/single-page-application/create-wizard-help.tsx
@@ -55,9 +55,9 @@ const SinglePageApplicationCreateWizardHelp: FunctionComponent<SinglePageApplica
             <Divider />
 
             <React.Fragment>
-                <Heading as="h5">Authorized redirect URIs</Heading>
+                <Heading as="h5">Authorized redirect URLs</Heading>
                 <p>
-                    The redirect URL determines where the authorization code is sent to
+                    The Authorized URL determines where the authorization code is sent to
                     once the user is authenticated, and where the user is redirected to
                     once the logout is complete.
                 </p>

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -807,6 +807,11 @@ export interface ConsoleNS {
                             userstoreDomain: FormAttributes;
                         };
                     };
+                    spaProtocolSettingsWizard: {
+                        fields: {
+                            callBackUrls: FormAttributes;
+                        };
+                    };
                 };
                 helpPanel: HelpPanelInterface;
                 list: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1771,6 +1771,16 @@ export const console: ConsoleNS = {
                                 label: "Provisioning userstore domain"
                             }
                         }
+                    },
+                    spaProtocolSettingsWizard:{
+                        fields: {
+                            callBackUrls: {
+                                label: "Authorized URLs",
+                                validations: {
+                                    invalid: "The entered URL is neither HTTP nor HTTPS. Please add a valid URL."
+                                }
+                            }
+                        }
                     }
                 },
                 helpPanel: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1785,6 +1785,16 @@ export const console: ConsoleNS = {
                                 label: "Approvisionnement du domaine utilisateur"
                             }
                         }
+                    },
+                    spaProtocolSettingsWizard:{
+                        fields: {
+                            callBackUrls: {
+                                label: "URL autorisées",
+                                validations: {
+                                    invalid: "L'URL saisie n'est ni HTTP ni HTTPS. Veuillez ajouter un URI valide."
+                                }
+                            }
+                        }
                     }
                 },
                 helpPanel: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1766,6 +1766,16 @@ export const console: ConsoleNS = {
                                 label: "පරිශීලක වෙළඳසැල් වසම සැපයීම"
                             }
                         }
+                    },
+                    spaProtocolSettingsWizard:{
+                        fields: {
+                            callBackUrls: {
+                                label: "බලයලත් URL",
+                                validations: {
+                                    invalid: "ඇතුළත් කළ URL එක HTTP හෝ HTTPS නොවේ. කරුණාකර වලංගු URI එකක් එක් කරන්න."
+                                }
+                            }
+                        }
                     }
                 },
                 helpPanel: {

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -512,8 +512,12 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
      * @return {boolean} origin allowed or not
      */
     const isOriginIsKnownAndAllowed = (url: string): boolean => {
+        const urlComponents = URLUtils.urlComponents(url);
+        if (!urlComponents) {
+            return false;
+        }
         // `origin` contains <scheme>://<host>:<port> (port if exists)
-        const { origin: checkingOrigin } = URLUtils.urlComponents(url);
+        const { origin: checkingOrigin } = urlComponents;
         // This is just a "make sure" operation that cleans out any attached
         // paths from the url. Also, if theres any trailing slashes it will
         // even out with the checkingOrigin vice versa. + We need it because


### PR DESCRIPTION
## Purpose
> Fix URL validation, renaming URI to URL and error handling on URL add in SPA adding wizard

## Approach
> Following fixes were done
- URL validation on adding
- Handling error of adding non URL inputs
- Change of URI to URL

![Screenshot from 2021-02-17 16-13-58](https://user-images.githubusercontent.com/25344622/108195330-a2034880-713d-11eb-8cfb-90bf97779877.png)
