### PR TITLE
Change group list component in add user wizard

### DIFF
--- a/apps/console/src/features/users/components/add-user-groups.tsx
+++ b/apps/console/src/features/users/components/add-user-groups.tsx
@@ -59,25 +59,11 @@ export const AddUserGroup: FunctionComponent<AddUserGroupPropsInterface> = (
     const { t } = useTranslation();
 
     const [ checkedUnassignedListItems, setCheckedUnassignedListItems ] = useState<RolesInterface[]>([]);
-    const [ checkedAssignedListItems, setCheckedAssignedListItems ] = useState<RolesInterface[]>([]);
     const [ isSelectUnassignedGroupsAllRolesChecked, setIsSelectUnassignedAllGroupsChecked ] = useState(false);
-    const [ isSelectAssignedAllGroupsChecked, setIsSelectAssignedAllGroupsChecked ] = useState(false);
 
     useEffect(() => {
-        if (isSelectAssignedAllGroupsChecked) {
-            setCheckedAssignedListItems(initialValues?.tempGroupList);
-        } else {
-            setCheckedAssignedListItems([]);
-        }
-    }, [ isSelectAssignedAllGroupsChecked ]);
-
-    useEffect(() => {
-        if (isSelectUnassignedGroupsAllRolesChecked) {
-            setCheckedUnassignedListItems(initialValues?.groupList);
-        } else {
-            setCheckedUnassignedListItems([]);
-        }
-    }, [ isSelectUnassignedGroupsAllRolesChecked ]);
+        setCheckedUnassignedListItems(initialValues?.tempGroupList);
+    }, [ initialValues?.tempGroupList ]);
 
     /**
      * The following method handles the onChange event of the
@@ -94,7 +80,7 @@ export const AddUserGroup: FunctionComponent<AddUserGroupPropsInterface> = (
         if (!_.isEmpty(value)) {
             const re = new RegExp(_.escapeRegExp(value), "i");
 
-            initialValues.groupList && initialValues.groupList.map((group) => {
+            initialValues.initialGroupList && initialValues.initialGroupList.map((group) => {
                 isMatch = re.test(group.displayName);
                 if (isMatch) {
                     filteredGroupList.push(group);
@@ -106,78 +92,18 @@ export const AddUserGroup: FunctionComponent<AddUserGroupPropsInterface> = (
         }
     };
 
-    const handleSelectedListSearch = (e, { value }) => {
-        let isMatch = false;
-        const filteredGroupList = [];
-
-        if (!_.isEmpty(value)) {
-            const re = new RegExp(_.escapeRegExp(value), "i");
-
-            initialValues.tempGroupList && initialValues.tempGroupList.map((group) => {
-                isMatch = re.test(group.displayName);
-                if (isMatch) {
-                    filteredGroupList.push(group);
-                    handleTempListChange(filteredGroupList);
-                }
-            });
-        } else {
-            handleTempListChange(initialValues?.initialTempGroupList);
-        }
-    };
-
     /**
      * The following function enables the user to select all the roles at once.
      */
     const selectAllUnAssignedList = () => {
+        if (!isSelectUnassignedGroupsAllRolesChecked) {
+            setCheckedUnassignedListItems(initialValues?.groupList);
+            handleTempListChange(initialValues?.groupList);
+        } else {
+            setCheckedUnassignedListItems([]);
+        }
+
         setIsSelectUnassignedAllGroupsChecked(!isSelectUnassignedGroupsAllRolesChecked);
-    };
-
-    /**
-     * The following function enables the user to deselect all the roles at once.
-     */
-    const selectAllAssignedList = () => {
-        setIsSelectAssignedAllGroupsChecked(!isSelectAssignedAllGroupsChecked);
-    };
-
-    /**
-     * The following method handles adding list items checked in the initial
-     * roles list to the assigned roles list.
-     */
-    const addGroups = () => {
-        const addedGroups = [ ...initialValues?.tempGroupList ];
-        if (checkedUnassignedListItems?.length > 0) {
-            checkedUnassignedListItems.map((group) => {
-                if (!(initialValues?.tempGroupList?.includes(group))) {
-                    addedGroups.push(group);
-                }
-            });
-        }
-        handleTempListChange(addedGroups);
-        handleInitialTempListChange(addedGroups);
-        handleGroupListChange(initialValues.groupList.filter(x => !addedGroups.includes(x)));
-        handleInitialGroupListChange(initialValues.groupList.filter(x => !addedGroups.includes(x)));
-        setIsSelectUnassignedAllGroupsChecked(false);
-    };
-
-    /**
-     * The following method handles removing list items checked in the assigned
-     * roles list to the initial role list.
-     */
-    const removeGroups = () => {
-        const removedGroups = [ ...initialValues?.groupList ];
-        if (checkedAssignedListItems?.length > 0) {
-            checkedAssignedListItems.map((group) => {
-                if (!(initialValues?.groupList?.includes(group))) {
-                    removedGroups.push(group);
-                }
-            });
-        }
-        handleGroupListChange(removedGroups);
-        handleInitialGroupListChange(removedGroups);
-        handleTempListChange(initialValues?.tempGroupList?.filter(x => !removedGroups.includes(x)));
-        handleInitialTempListChange(initialValues?.tempGroupList?.filter(x => !removedGroups.includes(x)));
-        setCheckedUnassignedListItems([]);
-        setIsSelectAssignedAllGroupsChecked(false);
     };
 
     /**
@@ -189,26 +115,16 @@ export const AddUserGroup: FunctionComponent<AddUserGroupPropsInterface> = (
 
         if (checkedGroups?.includes(group)) {
             checkedGroups.splice(checkedGroups.indexOf(group), 1);
-            setCheckedUnassignedListItems(checkedGroups);
         } else {
             checkedGroups.push(group);
-            setCheckedUnassignedListItems(checkedGroups);
         }
-    };
+        handleTempListChange(checkedGroups);
+        handleInitialTempListChange(checkedGroups);
 
-    /**
-     * The following method handles the onChange event of the
-     * checkbox field of an assigned item.
-     */
-    const handleAssignedItemCheckboxChange = (group) => {
-        const checkedGroups = [ ...checkedAssignedListItems ];
-
-        if (checkedGroups?.includes(group)) {
-            checkedGroups.splice(checkedGroups.indexOf(group), 1);
-            setCheckedAssignedListItems(checkedGroups);
+        if (initialValues?.groupList?.length === checkedGroups.length) {
+            setIsSelectUnassignedAllGroupsChecked(true);
         } else {
-            checkedGroups.push(group);
-            setCheckedAssignedListItems(checkedGroups);
+            setIsSelectUnassignedAllGroupsChecked(false);
         }
     };
 
@@ -234,12 +150,10 @@ export const AddUserGroup: FunctionComponent<AddUserGroupPropsInterface> = (
             submitState={ triggerSubmit }
         >
             <TransferComponent
+                selectionComponent
                 searchPlaceholder={ t("console:manage.features.transferList.searchPlaceholder",
                     { type: "Groups" }) }
-                addItems={ addGroups }
-                removeItems={ removeGroups }
                 handleUnelectedListSearch={ handleUnselectedListSearch }
-                handleSelectedListSearch={ handleSelectedListSearch }
                 data-testid="user-mgt-add-user-wizard-modal"
             >
                 <TransferList
@@ -270,38 +184,6 @@ export const AddUserGroup: FunctionComponent<AddUserGroupPropsInterface> = (
                                     showSecondaryActions={ false }
                                     handleOpenPermissionModal={ () => handleSetGroupId(group.id) }
                                     data-testid="user-mgt-add-user-wizard-modal-unselected-groups"
-                                />
-                            );
-                        })
-                    }
-                </TransferList>
-                <TransferList
-                    isListEmpty={ !(initialValues.tempGroupList.length > 0) }
-                    listType="selected"
-                    listHeaders={ [
-                        t("console:manage.features.transferList.list.headers.0"),
-                        t("console:manage.features.transferList.list.headers.1")
-                    ] }
-                    handleHeaderCheckboxChange={ selectAllAssignedList }
-                    isHeaderCheckboxChecked={ isSelectAssignedAllGroupsChecked }
-                    emptyPlaceholderContent={ t("console:manage.features.transferList.list.emptyPlaceholders.users." +
-                        "roles.selected", { type: "groups" }) }
-                    data-testid="user-mgt-add-user-wizard-modal-selected-groups-select-all-checkbox"
-                >
-                    {
-                        initialValues?.tempGroupList?.map((group, index)=> {
-                            const groupName = group?.displayName?.split("/");
-                            return (
-                                <TransferListItem
-                                    handleItemChange={ () => handleAssignedItemCheckboxChange(group) }
-                                    key={ index }
-                                    listItem={ groupName?.length > 1 ? groupName[1] : group?.displayName }
-                                    listItemId={ group.id }
-                                    listItemIndex={ index }
-                                    listItemTypeLabel={ createGroupLabel(group?.displayName) }
-                                    isItemChecked={ checkedAssignedListItems.includes(group) }
-                                    showSecondaryActions={ false }
-                                    data-testid="user-mgt-add-user-wizard-modal-selected-groups"
                                 />
                             );
                         })

--- a/apps/console/src/features/users/components/add-user-groups.tsx
+++ b/apps/console/src/features/users/components/add-user-groups.tsx
@@ -102,7 +102,6 @@ export const AddUserGroup: FunctionComponent<AddUserGroupPropsInterface> = (
         } else {
             setCheckedUnassignedListItems([]);
         }
-
         setIsSelectUnassignedAllGroupsChecked(!isSelectUnassignedGroupsAllRolesChecked);
     };
 
@@ -120,12 +119,7 @@ export const AddUserGroup: FunctionComponent<AddUserGroupPropsInterface> = (
         }
         handleTempListChange(checkedGroups);
         handleInitialTempListChange(checkedGroups);
-
-        if (initialValues?.groupList?.length === checkedGroups.length) {
-            setIsSelectUnassignedAllGroupsChecked(true);
-        } else {
-            setIsSelectUnassignedAllGroupsChecked(false);
-        }
+        setIsSelectUnassignedAllGroupsChecked(initialValues?.groupList?.length === checkedGroups.length)
     };
 
     /**

--- a/apps/console/src/features/users/components/user-groups-edit.tsx
+++ b/apps/console/src/features/users/components/user-groups-edit.tsx
@@ -23,6 +23,7 @@ import {
     RolesMemberInterface
 } from "@wso2is/core/models";
 import {
+    ContentLoader,
     EmphasizedSegment,
     EmptyPlaceholder,
     Heading,
@@ -84,16 +85,13 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
 
     const [ showAddNewRoleModal, setAddNewRoleModalView ] = useState(false);
     const [ groupList, setGroupList ] = useState<any>([]);
-    const [ tempGroupList, setTempGroupList ] = useState([]);
+    const [ selectedGroupsList, setSelectedGroupList ] = useState([]);
     const [ initialGroupList, setInitialGroupList ] = useState([]);
-    const [ initialTempGroupList, setInitialTempGroupList ] = useState([]);
     const [ primaryGroups, setPrimaryGroups ] = useState(undefined);
     const [ primaryGroupsList, setPrimaryGroupsList ] = useState<Map<string, string>>(undefined);
-    const [ checkedUnassignedListItems, setCheckedUnassignedListItems ] = useState<RolesMemberInterface[]>([]);
-    const [ checkedAssignedListItems, setCheckedAssignedListItems ] = useState<RolesMemberInterface[]>([]);
-    const [ isSelectUnassignedRolesAllRolesChecked, setIsSelectUnassignedAllRolesChecked ] = useState(false);
-    const [ isSelectAssignedAllRolesChecked, setIsSelectAssignedAllRolesChecked ] = useState(false);
+    const [ isSelectAllGroupsChecked, setIsSelectAllGroupsChecked ] = useState(false);
     const [ assignedGroups, setAssignedGroups ] = useState<RolesMemberInterface[]>([]);
+    const [ isPrimaryGroupsLoading, setPrimaryGroupsLoading ] = useState<boolean>(false);
 
     useEffect(() => {
         if (!(user)) {
@@ -102,22 +100,6 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
         mapUserGroups();
         setAssignedGroups(user.groups);
     }, []);
-
-    useEffect(() => {
-        if (isSelectAssignedAllRolesChecked) {
-            setCheckedAssignedListItems(tempGroupList);
-        } else {
-            setCheckedAssignedListItems([]);
-        }
-    }, [ isSelectAssignedAllRolesChecked ]);
-
-    useEffect(() => {
-        if (isSelectUnassignedRolesAllRolesChecked) {
-            setCheckedUnassignedListItems(groupList);
-        } else {
-            setCheckedUnassignedListItems([]);
-        }
-    }, [ isSelectUnassignedRolesAllRolesChecked ]);
 
     /**
      * The following useEffect will be triggered when the
@@ -132,15 +114,26 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     }, [ user ]);
 
     useEffect(() => {
+        if (!(user.groups)) {
+            return;
+        }
+        setInitialLists();
+    }, [ user.groups && primaryGroups ]);
+
+    useEffect(() => {
         let domain = "Primary";
         const domainName: string[] = user?.userName?.split("/");
 
         if (domainName.length > 1) {
             domain = domainName[0];
         }
+        setPrimaryGroupsLoading(true)
         getGroupList(domain)
             .then((response) => {
                 setPrimaryGroups(response.data.Resources);
+            })
+            .finally(() => {
+                setPrimaryGroupsLoading(false);
             });
     }, []);
 
@@ -162,36 +155,15 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     };
 
     /**
-     * The following function remove already assigned roles from the initial roles.
-     */
-    const removeExistingRoles = () => {
-        const groupListCopy = primaryGroups ? [ ...primaryGroups ] : [];
-
-        const addedGroups = [];
-        _.forEachRight(groupListCopy, (group) => {
-            if (primaryGroupsList?.has(group.displayName)) {
-                addedGroups.push(group);
-                groupListCopy.splice(groupListCopy.indexOf(group), 1);
-            }
-        });
-        setTempGroupList(addedGroups);
-        setInitialTempGroupList(addedGroups);
-        setGroupList(groupListCopy);
-        setInitialGroupList(groupListCopy);
-    };
-
-    /**
      * The following function enables the user to select all the roles at once.
      */
-    const selectAllUnAssignedList = () => {
-        setIsSelectUnassignedAllRolesChecked(!isSelectUnassignedRolesAllRolesChecked);
-    };
-
-    /**
-     * The following function enables the user to deselect all the roles at once.
-     */
-    const selectAllAssignedList = () => {
-        setIsSelectAssignedAllRolesChecked(!isSelectAssignedAllRolesChecked);
+    const selectAllGroups = () => {
+        if (!isSelectAllGroupsChecked) {
+            setSelectedGroupList(groupList);
+        } else {
+            setSelectedGroupList([]);
+        }
+        setIsSelectAllGroupsChecked(!isSelectAllGroupsChecked);
     };
 
     /**
@@ -199,77 +171,43 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
      * checkbox field of an unassigned item.
      */
     const handleUnassignedItemCheckboxChange = (group) => {
-        const checkedGroups = [ ...checkedUnassignedListItems ];
+        const checkedGroups = [ ...selectedGroupsList ];
 
         if (checkedGroups?.includes(group)) {
             checkedGroups.splice(checkedGroups.indexOf(group), 1);
-            setCheckedUnassignedListItems(checkedGroups);
+            setSelectedGroupList(checkedGroups);
         } else {
             checkedGroups.push(group);
-            setCheckedUnassignedListItems(checkedGroups);
+            setSelectedGroupList(checkedGroups);
         }
-    };
 
-    /**
-     * The following method handles the onChange event of the
-     * checkbox field of an assigned item.
-     *
-     * @param group
-     */
-    const handleAssignedItemCheckboxChange = (group) => {
-        const checkedGroups = [ ...checkedAssignedListItems ];
-
-        if (checkedGroups?.includes(group)) {
-            checkedGroups.splice(checkedGroups.indexOf(group), 1);
-            setCheckedAssignedListItems(checkedGroups);
+        if (checkedGroups.length !== groupList.length) {
+            setIsSelectAllGroupsChecked(false);
         } else {
-            checkedGroups.push(group);
-            setCheckedAssignedListItems(checkedGroups);
+            setIsSelectAllGroupsChecked(true);
         }
     };
 
-    const addGroups = () => {
-        const addedRoles = [ ...tempGroupList ];
-
-        if (checkedUnassignedListItems?.length > 0) {
-            checkedUnassignedListItems.map((role) => {
-                if (!(tempGroupList?.includes(role))) {
-                    addedRoles.push(role);
-                }
-            });
-        }
-        setTempGroupList(addedRoles);
-        setInitialTempGroupList(addedRoles);
-        setGroupList(groupList.filter(x => !addedRoles?.includes(x)));
-        setInitialGroupList(groupList.filter(x => !addedRoles?.includes(x)));
-        setCheckedAssignedListItems([]);
-        setIsSelectUnassignedAllRolesChecked(false);
-    };
-
-    const removeGroups = () => {
-        const removedRoles = [ ...groupList ];
-
-        if (checkedAssignedListItems?.length > 0) {
-            checkedAssignedListItems.map((role) => {
-                if (!(groupList?.includes(role))) {
-                    removedRoles.push(role);
-                }
-            });
-        }
-        setGroupList(removedRoles);
-        setInitialGroupList(removedRoles);
-        setTempGroupList(tempGroupList?.filter(x => !removedRoles?.includes(x)));
-        setInitialTempGroupList(tempGroupList?.filter(x => !removedRoles?.includes(x)));
-        setCheckedUnassignedListItems([]);
-        setIsSelectAssignedAllRolesChecked(false);
+    const setInitialLists = () => {
+        const groupListCopy = primaryGroups ? [ ...primaryGroups ] : [];
+        const addedGroups = [];
+        _.forEachRight(groupListCopy, (group) => {
+            if (primaryGroupsList?.has(group.displayName)) {
+                addedGroups.push(group);
+            }
+        });
+        setSelectedGroupList(addedGroups);
+        setGroupList(groupListCopy);
+        setInitialGroupList(groupListCopy);
     };
 
     const handleOpenAddNewGroupModal = () => {
-        removeExistingRoles();
+        setInitialLists();
         setAddNewRoleModalView(true);
     };
 
     const handleCloseAddNewGroupModal = () => {
+        setIsSelectAllGroupsChecked(false);
         setAddNewRoleModalView(false);
     };
 
@@ -289,25 +227,6 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
             });
         } else {
             setGroupList(initialGroupList);
-        }
-    };
-
-    const handleSelectedListSearch = (e, { value }) => {
-        let isMatch = false;
-        const filteredGroupList = [];
-
-        if (!_.isEmpty(value)) {
-            const re = new RegExp(_.escapeRegExp(value), "i");
-
-            tempGroupList && tempGroupList?.map((role) => {
-                isMatch = re.test(role.displayName);
-                if (isMatch) {
-                    filteredGroupList.push(role);
-                    setTempGroupList(filteredGroupList);
-                }
-            });
-        } else {
-            setTempGroupList(initialTempGroupList);
         }
     };
 
@@ -382,7 +301,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
             removeOperations.map((operation) => {
                 bulkData.Operations.push(operation);
             });
-        } 
+        }
 
         if (groupIds && groupIds?.length > 0) {
             groupIds.map((id) => {
@@ -491,82 +410,49 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
                 </Heading>
             </Modal.Header>
                 <Modal.Content image>
-                    <TransferComponent
-                        searchPlaceholder={ t("console:manage.features.transferList.searchPlaceholder",
-                            { type: "Groups" }) }
-                        addItems={ addGroups }
-                        removeItems={ removeGroups }
-                        handleUnelectedListSearch={ handleUnselectedListSearch }
-                        handleSelectedListSearch={ handleSelectedListSearch }
-                        data-testid="user-mgt-update-groups-modal"
-                    >
-                        <TransferList
-                            isListEmpty={ !(groupList.length > 0) }
-                            listType="unselected"
-                            listHeaders={ [
-                                t("console:manage.features.transferList.list.headers.0"),
-                                t("console:manage.features.transferList.list.headers.1")
-                            ] }
-                            handleHeaderCheckboxChange={ selectAllUnAssignedList }
-                            isHeaderCheckboxChecked={ isSelectUnassignedRolesAllRolesChecked }
-                            emptyPlaceholderContent={ t("console:manage.features.transferList.list." +
-                                "emptyPlaceholders.users.roles.unselected", { type: "groups" }) }
-                            data-testid="user-mgt-update-groups-modal-unselected-groups-select-all-checkbox"
+                    { !isPrimaryGroupsLoading ? (
+                        <TransferComponent
+                            selectionComponent
+                            searchPlaceholder={ t("console:manage.features.transferList.searchPlaceholder",
+                                { type: "Groups" }) }
+                            handleUnelectedListSearch={ handleUnselectedListSearch }
+                            data-testid="user-mgt-update-groups-modal"
                         >
-                            {
-                                groupList?.map((group, index)=> {
-                                    return (
-                                        <TransferListItem
-                                            handleItemChange={
-                                                () => handleUnassignedItemCheckboxChange(group)
-                                            }
-                                            key={ index }
-                                            listItem={ resolveListItem(group?.displayName) }
-                                            listItemId={ group?.id }
-                                            listItemIndex={ index }
-                                            listItemTypeLabel={ resolveListItemLabel(group?.displayName) }
-                                            isItemChecked={ checkedUnassignedListItems.includes(group) }
-                                            showSecondaryActions={ false }
-                                            data-testid="user-mgt-update-groups-modal-unselected-groups"
-                                        />
-                                    );
-                                })
-                            }
-                        </TransferList>
-                        <TransferList
-                            isListEmpty={ !(tempGroupList.length > 0) }
-                            listType="selected"
-                            listHeaders={ [
-                                t("console:manage.features.transferList.list.headers.0"),
-                                t("console:manage.features.transferList.list.headers.1")
-                            ] }
-                            handleHeaderCheckboxChange={ selectAllAssignedList }
-                            isHeaderCheckboxChecked={ isSelectAssignedAllRolesChecked }
-                            emptyPlaceholderContent={ t("console:manage.features.transferList.list." +
-                                "emptyPlaceholders.users.roles.selected", { type: "groups" }) }
-                            data-testid="user-mgt-update-groups-modal-selected-groups-select-all-checkbox"
-                        >
-                            {
-                                tempGroupList?.map((group, index)=> {
-                                    return (
-                                        <TransferListItem
-                                            handleItemChange={
-                                                () => handleAssignedItemCheckboxChange(group)
-                                            }
-                                            key={ index }
-                                            listItem={ resolveListItem(group?.displayName) }
-                                            listItemId={ group?.id }
-                                            listItemIndex={ index }
-                                            listItemTypeLabel={ resolveListItemLabel(group?.displayName) }
-                                            isItemChecked={ checkedAssignedListItems.includes(group) }
-                                            showSecondaryActions={ false }
-                                            data-testid="user-mgt-update-groups-modal-selected-groups"
-                                        />
-                                    );
-                                })
-                            }
-                        </TransferList>
-                    </TransferComponent>
+                            <TransferList
+                                isListEmpty={ !(groupList.length > 0) }
+                                listType="unselected"
+                                listHeaders={ [
+                                    t("console:manage.features.transferList.list.headers.0"),
+                                    t("console:manage.features.transferList.list.headers.1")
+                                ] }
+                                handleHeaderCheckboxChange={ selectAllGroups }
+                                isHeaderCheckboxChecked={ isSelectAllGroupsChecked }
+                                emptyPlaceholderContent={ t("console:manage.features.transferList.list." +
+                                    "emptyPlaceholders.users.roles.unselected", { type: "groups" }) }
+                                data-testid="user-mgt-update-groups-modal-unselected-groups-select-all-checkbox"
+                            >
+                                {
+                                    groupList?.map((group, index)=> {
+                                        return (
+                                            <TransferListItem
+                                                handleItemChange={
+                                                    () => handleUnassignedItemCheckboxChange(group)
+                                                }
+                                                key={ index }
+                                                listItem={ resolveListItem(group?.displayName) }
+                                                listItemId={ group?.id }
+                                                listItemIndex={ index }
+                                                listItemTypeLabel={ resolveListItemLabel(group?.displayName) }
+                                                isItemChecked={ selectedGroupsList.includes(group) }
+                                                showSecondaryActions={ false }
+                                                data-testid="user-mgt-update-groups-modal-unselected-groups"
+                                            />
+                                        );
+                                    })
+                                }
+                            </TransferList>
+                        </TransferComponent>
+                    ) : <ContentLoader/> }
                 </Modal.Content>
             <Modal.Actions>
                 <Grid>
@@ -584,7 +470,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
                             <PrimaryButton
                                 data-testid="user-mgt-update-groups-modal-save-button"
                                 floated="right"
-                                onClick={ () => updateUserGroup(user, tempGroupList) }
+                                onClick={ () => updateUserGroup(user, selectedGroupsList) }
                             >
                                 { t("common:save") }
                             </PrimaryButton>

--- a/apps/console/src/features/users/components/user-groups-edit.tsx
+++ b/apps/console/src/features/users/components/user-groups-edit.tsx
@@ -180,12 +180,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
             checkedGroups.push(group);
             setSelectedGroupList(checkedGroups);
         }
-
-        if (checkedGroups.length !== groupList.length) {
-            setIsSelectAllGroupsChecked(false);
-        } else {
-            setIsSelectAllGroupsChecked(true);
-        }
+        setIsSelectAllGroupsChecked(checkedGroups.length === groupList.length)
     };
 
     const setInitialLists = () => {
@@ -199,6 +194,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
         setSelectedGroupList(addedGroups);
         setGroupList(groupListCopy);
         setInitialGroupList(groupListCopy);
+        setIsSelectAllGroupsChecked(groupListCopy.length === addedGroups.length);
     };
 
     const handleOpenAddNewGroupModal = () => {


### PR DESCRIPTION
## Purpose
The group list component in add user wizard, and user's group tab's edit wizard are changed to a list component.

Earlier view :
![image](https://user-images.githubusercontent.com/25479743/108358955-5e7c0d80-7215-11eb-8f5d-f8f53d6164fc.png)

Current view :
![image](https://user-images.githubusercontent.com/25479743/108358888-44422f80-7215-11eb-94e2-875438bf23f9.png)
