### PR TITLE
Add ability to filter user permissions tree

### DIFF
--- a/apps/console/src/features/roles/components/wizard/role-permission.tsx
+++ b/apps/console/src/features/roles/components/wizard/role-permission.tsx
@@ -44,6 +44,10 @@ interface PermissionListProp extends  TestableComponentInterface {
     initialValues?: TreeNode[];
     isRole?: boolean;
     isReadOnly?: boolean;
+    /**
+     * Permissions to hide.
+     */
+    permissionsToHide?: string[];
 }
 
 /**
@@ -62,6 +66,7 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
         isEdit,
         initialValues,
         isRole,
+        permissionsToHide,
         [ "data-testid" ]: testId
     } = props;
 
@@ -77,12 +82,13 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
     useEffect(() => {
         const checkedNodes: TreeNode[] = [];
 
-        RoleManagementUtils.getAllPermissions().then((permissionTree: TreeNode[]) => {
-            disableSuperAdminTreeNode(isSuperAdmin, permissionTree);
-            setPermissions(permissionTree);
-            setDefaultExpandKeys( [permissionTree[0].key.toString()] );
-            setIsPermissionsLoading(false);
-        });
+        RoleManagementUtils.getAllPermissions(permissionsToHide)
+            .then((permissionTree: TreeNode[]) => {
+                disableSuperAdminTreeNode(isSuperAdmin, permissionTree);
+                setPermissions(permissionTree);
+                setDefaultExpandKeys([ permissionTree[ 0 ].key.toString() ]);
+                setIsPermissionsLoading(false);
+            });
         checkIsSuperAdmin();
 
         if ( initialValues && initialValues.length > 0 ) {

--- a/apps/console/src/features/users/components/user-role-permissions.tsx
+++ b/apps/console/src/features/users/components/user-role-permissions.tsx
@@ -32,6 +32,10 @@ interface UserRolePermissionsInterface extends TestableComponentInterface {
     openRolePermissionModal: boolean;
     handleCloseRolePermissionModal: () => void;
     roleId: string;
+    /**
+     * Permissions to hide.
+     */
+    permissionsToHide?: string[];
 }
 
 /**
@@ -48,6 +52,7 @@ export const UserRolePermissions: FunctionComponent<UserRolePermissionsInterface
         openRolePermissionModal,
         handleCloseRolePermissionModal,
         roleId,
+        permissionsToHide,
         [ "data-testid" ]: testId
     } = props;
 
@@ -113,6 +118,7 @@ export const UserRolePermissions: FunctionComponent<UserRolePermissionsInterface
                             isReadOnly={ true }
                             emphasize={ false }
                             isEdit={ false }
+                            permissionsToHide={ permissionsToHide }
                             isRole
                             roleObject={ role }
                         />

--- a/apps/console/src/features/users/components/user-roles-edit.tsx
+++ b/apps/console/src/features/users/components/user-roles-edit.tsx
@@ -76,6 +76,10 @@ interface UserRolesPropsInterface {
      * Show/ Hide domain
      */
     showDomain?: boolean;
+    /**
+     * Permissions to hide.
+     */
+    permissionsToHide?: string[];
 }
 
 export const UserRolesList: FunctionComponent<UserRolesPropsInterface> = (
@@ -88,7 +92,8 @@ export const UserRolesList: FunctionComponent<UserRolesPropsInterface> = (
         handleUserUpdate,
         isReadOnly,
         isGroupAndRoleSeparationEnabled,
-        showDomain
+        showDomain,
+        permissionsToHide
     } = props;
 
     const { t } = useTranslation();
@@ -750,6 +755,7 @@ export const UserRolesList: FunctionComponent<UserRolesPropsInterface> = (
                 openRolePermissionModal={ showRolePermissionModal }
                 handleCloseRolePermissionModal={ handleCloseRolePermissionModal }
                 roleId={ selectedRoleId }
+                permissionsToHide={ permissionsToHide }
             />
         );
     };


### PR DESCRIPTION
## Purpose
Role permissions view is filterable but ATM users permissions list is not.

## Goals
Added `permissionsToHide` prop to user permissions list.
