### PR TITLE
Make requested attributes readonly and mandatory if set as the subject

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
@@ -610,13 +610,23 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                                                                         isDefaultMappingChanged={
                                                                             setIsDefaultMappingChanged
                                                                         }
-                                                                        initialMandatory={ claim.mandatory }
+                                                                        initialMandatory={
+                                                                            (claimConfigurations?.subject?.claim?.uri
+                                                                                === claim.claimURI)
+                                                                                ? true
+                                                                                : claim.mandatory
+                                                                        }
                                                                         initialRequested={ claim.requested }
                                                                         selectMandatory={ updateMandatory }
                                                                         selectRequested={ updateRequested }
                                                                         claimMappingOn={ claimMappingOn }
                                                                         claimMappingError={ claimMappingError }
-                                                                        readOnly={ readOnly }
+                                                                        readOnly={
+                                                                            (claimConfigurations?.subject?.claim?.uri
+                                                                                === claim.claimURI)
+                                                                                ? true
+                                                                                : readOnly
+                                                                        }
                                                                         data-testid={ claim.claimURI }
                                                                     />
                                                                 );
@@ -678,11 +688,21 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                                                                         displayName={ claim.claimURI }
                                                                         mappedURI={ claim.mappedLocalClaimURI }
                                                                         localDialect={ false }
-                                                                        initialMandatory={ claim.mandatory }
+                                                                        initialMandatory={
+                                                                            (claimConfigurations?.subject?.claim?.uri
+                                                                                === claim.mappedLocalClaimURI)
+                                                                                ? true
+                                                                                : claim.mandatory
+                                                                        }
                                                                         selectMandatory={ updateMandatory }
                                                                         initialRequested={ claim.requested }
                                                                         data-testid={ claim.claimURI }
-                                                                        readOnly={ readOnly }
+                                                                        readOnly={
+                                                                            (claimConfigurations?.subject?.claim?.uri
+                                                                                === claim.mappedLocalClaimURI)
+                                                                                ? true
+                                                                                : readOnly
+                                                                        }
                                                                         localClaimDisplayName={
                                                                             claim.localClaimDisplayName
                                                                         }

--- a/modules/theme/src/themes/default/modules/checkbox.overrides
+++ b/modules/theme/src/themes/default/modules/checkbox.overrides
@@ -5,7 +5,7 @@
 .ui.checkbox {
     &.read-only {
         label:before {
-            background-color: @readOnlyFormFieldBgColor;
+            background-color: @readOnlyFormFieldBgColor !important;
             cursor: @readOnlyFieldCursor;
         }
     }


### PR DESCRIPTION
## Purpose
If a different attribute selected as the subject attribute, it should be added to the requested attributes and mark it as mandatory during the update and the mandatory checkbox should be readonly until the admin change the subject attribute
