### PR TITLE
revert(Styles): Revert portal switch color

### DIFF
--- a/modules/theme/src/themes/default/collections/menu.variables
+++ b/modules/theme/src/themes/default/collections/menu.variables
@@ -55,7 +55,7 @@
 @appHeaderSecondaryPanelPortalSwitchesLeftSpacing: 14px;
 
 @appHeaderSecondaryPanelPortalSwitchBackground: inherit;
-@appHeaderSecondaryPanelPortalSwitchColor: @mutedTextColor;
+@appHeaderSecondaryPanelPortalSwitchColor: @lightTextColor;
 @appHeaderSecondaryPanelPortalSwitchBorderBottom: 3px solid transparent;
 
 @appHeaderSecondaryPanelPortalSwitchActiveBackground: inherit;
@@ -66,7 +66,7 @@
 @appHeaderSecondaryPanelContainerHeight: 100%;
 
 @appHeaderPortalSwitchExtensionBackgroundColor: transparent !important;
-@appHeaderPortalSwitchExtensionColor: @mutedTextColor !important;
+@appHeaderPortalSwitchExtensionColor: @lightTextColor !important;
 @appHeaderPortalSwitchExtensionActiveColor: @textColor !important;
 @appHeaderPortalSwitchExtensionActiveBorderBottom: 3px solid @primaryColor;
 


### PR DESCRIPTION
## Purpose
> Reverts the portal inactive switch back to the original color. Reduced opacity to 40% from 60%. Reference commit 78c57122ccf815b96c37b781d0962596330ad82f
