### PR TITLE
Removed Help subtitle and fixed alignment in Application Create Wizard

### DIFF
--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -530,12 +530,10 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
 
         return (
             <ModalWithSidePanel.SidePanel>
-                <ModalWithSidePanel.Header className="wizard-header muted">
-                    { t("console:develop.features.applications.wizards.minimalAppCreationWizard.help.heading") }
-                    <Heading as="h6">
-                        { t("console:develop.features.applications.wizards.minimalAppCreationWizard.help" +
-                            ".subHeading") }
-                    </Heading>
+                <ModalWithSidePanel.Header className="wizard-header help-panel-header muted">
+                    <div className="help-panel-header-text">
+                        { t("console:develop.features.applications.wizards.minimalAppCreationWizard.help.heading") }
+                    </div>
                 </ModalWithSidePanel.Header>
                 <ModalWithSidePanel.Content>
                     <Suspense fallback={ <ContentLoader /> }>

--- a/modules/theme/src/themes/default/modules/modal.overrides
+++ b/modules/theme/src/themes/default/modules/modal.overrides
@@ -226,6 +226,14 @@
                 white-space: nowrap;
                 overflow: hidden;
             }
+             &.help-panel-header {
+                display: flex;
+
+                .help-panel-header-text {
+                    margin: auto 0;
+                    display: inline-block;
+                }
+             }
         }
         .steps-container {
             background: @wizardStepsContainerBgColor;
@@ -465,7 +473,7 @@
                     display: flex;
                     align-items: center;
                     right: 30px;
-                    top: 30px;
+                    top: 20px;
                     z-index: 99;
                     width: 100%;
                     justify-content: flex-end;

--- a/modules/theme/src/themes/default/modules/modal.variables
+++ b/modules/theme/src/themes/default/modules/modal.variables
@@ -48,7 +48,7 @@
 @sidePanelModalHeaderFontWeight: @headerFontWeight;
 @sidePanelModalHeaderFontSize: @headerFontSize;
 @sidePanelModalHeaderPadding: @headerPadding;
-@sidePanelModalHeaderHeight: 90px;
+@sidePanelModalHeaderHeight: 75px;
 @sidePanelModalHeaderBorderBottom: @defaultBorderWidth solid @borderColor;
 
 @sidePanelModalContentPadding: 30px;


### PR DESCRIPTION
## Purpose
> Fixes _Remove refer to the guide below_ issue in https://github.com/wso2-enterprise/asgardeo-product/issues/2169

## Goals
> Removed reference text to guide on Help sidebar in Application Create Wizard
> Fixed alignment issues once refer text removed

## Approach
> ![Screenshot from 2021-02-22 23-08-35](https://user-images.githubusercontent.com/10112625/108746955-f4d86800-7562-11eb-9b3c-7d12928522ad.png)


