### PR TITLE
Change application role mapping to use groups

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
@@ -150,7 +150,7 @@ export const RoleMapping: FunctionComponent<RoleMappingPropsInterface> = (
                                 const finalData: RoleMappingInterface[] = data.map(mapping => {
                                     return {
                                         applicationRole: mapping.value,
-                                        localRole: mapping.key.includes("/") ? mapping.key : "Internal/" + mapping.key
+                                        localRole: mapping.key
                                     };
                                 });
                                 onSubmit(finalData);

--- a/modules/core/src/api/roles.ts
+++ b/modules/core/src/api/roles.ts
@@ -47,7 +47,7 @@ export const getRolesList = (domain: string): Promise<RoleListInterface | any> =
         params: {
             domain
         },
-        url: CommonServiceResourcesEndpoints(ContextUtils.getRuntimeConfig().serverHost).roles
+        url: CommonServiceResourcesEndpoints(ContextUtils.getRuntimeConfig().serverHost).groups
     };
 
     return httpClient(requestConfig)


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/11330.

In the role mapping section of an application,

List down groups instead of roles.

<img width="1401" alt="Screenshot 2021-02-23 at 00 13 05" src="https://user-images.githubusercontent.com/22551445/108754414-e80c4200-756b-11eb-9d44-6173952cb85c.png">

How to change the `Enter a Local Role` to `Enter a Local Group`?
Need to persist b/c via a config('cause BE behaviour will change according to the config so UI should follow the same approach)
