### PR TITLE
Add pre-loader loading page to be replaced with a replace component when extending

### DIFF
--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -26,7 +26,7 @@ import {
 } from "@wso2is/core/store";
 import { LocalStorageUtils } from "@wso2is/core/utils";
 import { I18n, I18nModuleOptionsInterface } from "@wso2is/i18n";
-import { ContentLoader, SessionManagementProvider, ThemeContext } from "@wso2is/react-components";
+import { SessionManagementProvider, ThemeContext } from "@wso2is/react-components";
 import _ from "lodash";
 import React, { FunctionComponent, ReactElement, Suspense, useContext, useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
@@ -35,6 +35,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Redirect, Route, Router, Switch } from "react-router-dom";
 import { initializeAuthentication } from "./features/authentication";
 import { AuthenticateUtils } from "./features/authentication/utils";
+import { PreLoader } from "./features/core"
 import { ProtectedRoute } from "./features/core/components";
 import { Config, getBaseRoutes } from "./features/core/configs";
 import { AppConstants } from "./features/core/constants";
@@ -178,7 +179,7 @@ export const App: FunctionComponent<{}> = (): ReactElement => {
                         <Router history={ history }>
                             <div className="container-fluid">
                                 <I18nextProvider i18n={ I18n.instance }>
-                                    <Suspense fallback={ <ContentLoader dimmer/> }>
+                                    <Suspense fallback={ <PreLoader /> }>
                                         <SessionManagementProvider
                                             onSessionTimeoutAbort={ handleSessionTimeoutAbort }
                                             onSessionLogout={ handleSessionLogout }
@@ -264,7 +265,7 @@ export const App: FunctionComponent<{}> = (): ReactElement => {
                             </div>
                         </Router>
                     )
-                    : <ContentLoader dimmer/>
+                    : <PreLoader />
             }
         </>
     );

--- a/apps/console/src/features/authentication/pages/sign-in.tsx
+++ b/apps/console/src/features/authentication/pages/sign-in.tsx
@@ -18,9 +18,10 @@
 
 import { AppConstants as AppConstantsCore } from "@wso2is/core/constants";
 import { AuthenticateUtils } from "@wso2is/core/utils";
-import { FunctionComponent, ReactElement, useEffect } from "react";
+import React, { FunctionComponent, ReactElement, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router";
+import { PreLoader } from "../../core";
 import { AppConstants } from "../../core/constants";
 import { history } from "../../core/helpers";
 import { AppState } from "../../core/store";
@@ -75,7 +76,7 @@ const SignIn: FunctionComponent<RouteComponentProps> = (
         loginSuccessRedirect();
     }, [ isAuthenticated, isInitialized ]);
 
-    return null;
+    return <PreLoader />;
 };
 
 /**

--- a/apps/console/src/features/authentication/pages/sign-out.tsx
+++ b/apps/console/src/features/authentication/pages/sign-out.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import { FunctionComponent, ReactElement, useEffect } from "react";
+import React, { FunctionComponent, ReactElement, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { AppState } from "../../core";
+import { AppState, PreLoader } from "../../core";
 import { handleSignOut } from "../store/actions";
 
 /**
@@ -38,7 +38,7 @@ const SignOut: FunctionComponent<{}> = (): ReactElement => {
         }
     }, [ logoutInit, isInitialized ]);
 
-    return null;
+    return <PreLoader />;
 };
 
 /**

--- a/apps/console/src/features/core/components/index.ts
+++ b/apps/console/src/features/core/components/index.ts
@@ -26,3 +26,4 @@ export * from "./upload-certificate";
 export * from "./groups";
 export * from "./roles";
 export * from "./attribute-select-list";
+export * from "./pre-loader";

--- a/apps/console/src/features/core/components/pre-loader.tsx
+++ b/apps/console/src/features/core/components/pre-loader.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestableComponentInterface } from "@wso2is/core/models";
+import { ContentLoader } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
+
+type OverviewPageInterface = TestableComponentInterface;
+
+export const PreLoader: FunctionComponent<OverviewPageInterface> = (
+    props: OverviewPageInterface
+): ReactElement => {
+
+    const {
+        ["data-testid"]: testId
+    } = props;
+
+    return(
+        <div className={ "pre-loader-wrapper" }>
+            <ContentLoader dimmer data-testid={ testId }/>
+        </div>
+    );
+};
+
+PreLoader.defaultProps = {
+    "data-testid": "pre-loader"
+};

--- a/apps/console/src/layouts/app.tsx
+++ b/apps/console/src/layouts/app.tsx
@@ -20,7 +20,6 @@ import { RouteInterface } from "@wso2is/core/models";
 import { CommonUtils } from "@wso2is/core/utils";
 import {
     AppLayout as AppLayoutSkeleton,
-    ContentLoader,
     EmptyPlaceholder,
     ErrorBoundary,
     LinkButton
@@ -28,6 +27,7 @@ import {
 import React, { FunctionComponent, ReactElement, Suspense, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Redirect, Route, Switch } from "react-router-dom";
+import { PreLoader } from "../features/core";
 import { ProtectedRoute } from "../features/core/components";
 import { getAppLayoutRoutes, getEmptyPlaceholderIllustrations } from "../features/core/configs";
 import { AppConstants } from "../features/core/constants";
@@ -71,7 +71,7 @@ export const AppLayout: FunctionComponent<{}> = (): ReactElement => {
                     />
                 ) }
             >
-                <Suspense fallback={ <ContentLoader dimmer/> }>
+                <Suspense fallback={ <PreLoader /> }>
                     <Switch>
                         {
                             appRoutes.map((route, index) => (

--- a/apps/console/src/layouts/auth.tsx
+++ b/apps/console/src/layouts/auth.tsx
@@ -17,9 +17,10 @@
  */
 
 import { RouteInterface } from "@wso2is/core/models";
-import { AuthLayout as AuthLayoutSkeleton, ContentLoader } from "@wso2is/react-components";
+import { AuthLayout as AuthLayoutSkeleton } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, Suspense, useEffect, useState } from "react";
 import { Redirect, Route, Switch } from "react-router-dom";
+import { PreLoader } from "../features/core";
 import { ProtectedRoute } from "../features/core/components";
 import { getAuthLayoutRoutes } from "../features/core/configs";
 import { AppConstants } from "../features/core/constants";
@@ -59,7 +60,7 @@ export const AuthLayout: FunctionComponent<AuthLayoutPropsInterface> = (
 
     return (
         <AuthLayoutSkeleton fluid={ fluid }>
-            <Suspense fallback={ <ContentLoader dimmer/> }>
+            <Suspense fallback={ <PreLoader /> }>
                 <Switch>
                     {
                         authLayoutRoutes.map((route, index) => (

--- a/apps/console/src/views/full-screen-view.tsx
+++ b/apps/console/src/views/full-screen-view.tsx
@@ -41,6 +41,7 @@ import {
     AppConstants,
     AppState,
     FeatureConfigInterface,
+    PreLoader,
     ProtectedRoute,
     RouteUtils,
     getEmptyPlaceholderIllustrations,
@@ -180,7 +181,7 @@ export const FullScreenView: FunctionComponent<FullScreenViewPropsInterface> = (
                     />
                 ) }
             >
-                <Suspense fallback={ <ContentLoader dimmer/> }>
+                <Suspense fallback={ <PreLoader /> }>
                     <Switch>
                         { resolveRoutes() }
                     </Switch>

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -1906,4 +1906,18 @@ code {
     }
 }
 
+/*-------------------------------
+          Pre-Loader
+--------------------------------*/
+.pre-loader-wrapper {
+    background-color: @preLoaderWrapperBackgroundColor;
+    min-height: 100vh;
+    align-items: center;
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    background-image: @preLoaderWrapperBackgroundImage;
+}
+
 .loadUIOverrides();

--- a/modules/theme/src/themes/default/globals/product.variables
+++ b/modules/theme/src/themes/default/globals/product.variables
@@ -209,3 +209,10 @@
 @inlineCodeBlockColor: #5c666f;
 @inlineCodeBlockBgColor: #eef0f1;
 @inlineCodeBlockBorder: 1px solid #c7ced1;
+
+/*-------------------------------
+        Preloader
+--------------------------------*/
+
+@preLoaderWrapperBackgroundColor: @white;
+@preLoaderWrapperBackgroundImage: none;


### PR DESCRIPTION
## Purpose
> Add loading page component that can be used to replace when extending

## Approach
> Added Custom loader page which uses default ```ContentLoader``` component, but gives the ability to be replaced and customized when extending