### PR TITLE
Advanced search filter and operation set to default values and reset button removed

### DIFF
--- a/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
+++ b/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
@@ -270,6 +270,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
                                         ".validations.empty")
                                 }
                                 type="dropdown"
+                                value={ defaultSearchAttribute }
                                 data-testid={ `${ testId }-filter-attribute-dropdown` }
                             />
                             <Form.Group widths='equal'>
@@ -305,6 +306,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
                                     requiredErrorMessage={ t("console:common.advancedSearch.form.inputs" +
                                         ".filterCondition.validations.empty") }
                                     type="dropdown"
+                                    value={ defaultSearchOperator }
                                     data-testid={ `${ testId }-filter-condition-dropdown` }
                                 />
                                 <Field
@@ -359,5 +361,5 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
 AdvancedSearchWithBasicFilters.defaultProps = {
     "data-testid": "advanced-search",
     dropdownPosition: "bottom left",
-    showResetButton: true
+    showResetButton: false
 };


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2-enterprise/asgardeo-product/issues/2289

## Approach
> Since the dropdown values have been set to default to improve UX and intuition of functionality, a reset button would not be necessary as the dropdown values should not be cleared. Resetting back to default values also would not be necessary as the default values combination cannot be considered more prominent than another, and vice versa, in the advanced search context.

> The Reset button has been hidden and not removed, as it would be useful later if more fields are added to the search window.