### PR TITLE
[MyAccount] Have seperate sub title in Porfile Info for non linked account profiles

### DIFF
--- a/apps/myaccount/src/pages/personal-info.tsx
+++ b/apps/myaccount/src/pages/personal-info.tsx
@@ -49,7 +49,10 @@ const PersonalInfoPage = (): ReactElement => {
     return (
         <InnerPageLayout
             pageTitle={ t("myAccount:pages.personalInfo.title") }
-            pageDescription={ t("myAccount:pages.personalInfo.subTitle") }
+            pageDescription={ isFeatureEnabled(accessConfig?.personalInfo,
+                AppConstants.FEATURE_DICTIONARY.get("PROFILEINFO_LINKED_ACCOUNTS")) ?
+                t("myAccount:pages.personalInfo.subTitle"):
+                t("myAccount:pages.personalInfoWithoutLinkedAccounts.subTitle") }
         >
             <Divider hidden/>
             <Grid>

--- a/modules/i18n/src/models/namespaces/myaccount-ns.ts
+++ b/modules/i18n/src/models/namespaces/myaccount-ns.ts
@@ -726,6 +726,7 @@ export interface MyAccountNS {
         applications: Page;
         overview: Page;
         personalInfo: Page;
+        personalInfoWithoutLinkedAccounts: Page;
         privacy: Page;
         security: Page;
     };

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -1290,6 +1290,10 @@ export const myAccount: MyAccountNS = {
             subTitle: "Edit or export your personal profile and manage linked accounts",
             title: "Personal Info"
         },
+        personalInfoWithoutLinkedAccounts: {
+            subTitle: "Edit or export your personal profile",
+            title: "Personal Info"
+        },
         privacy: {
             subTitle: "",
             title: "WSO2 Identity Server Privacy Policy"

--- a/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
@@ -1294,6 +1294,10 @@ export const myAccount: MyAccountNS = {
             subTitle: "Modifier ou exporter votre profil personnel et gérer vos comptes associés",
             title: "Données personnelles"
         },
+        personalInfoWithoutLinkedAccounts: {
+            subTitle: "Modifier ou exporter votre profil personnel",
+            title: "Données personnelles"
+        },
         privacy: {
             subTitle: "",
             title: "Politique de confidentialité de WSO2 Identity Server"

--- a/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
@@ -1272,6 +1272,10 @@ export const myAccount: MyAccountNS = {
             subTitle: "Edite ou exporte seu perfil pessoal e gerencie contas vinculadas",
             title: "Informação pessoal"
         },
+        personalInfoWithoutLinkedAccounts: {
+            subTitle: "Edite ou exporte o seu perfil pessoal",
+            title: "Informação pessoal"
+        },
         privacy: {
             subTitle: "",
             title: "Política de Privacidade do Servidor de Identidade WSO2"

--- a/modules/i18n/src/translations/si-LK/portals/myaccount.ts
+++ b/modules/i18n/src/translations/si-LK/portals/myaccount.ts
@@ -1283,6 +1283,10 @@ export const myAccount: MyAccountNS = {
                 "ඔබගේ පුද්ගලික පැතිකඩ සංස්කරණය කරන්න හෝ අපනයනය කරන්න සහ සම්බන්ධිත ගිණුම් කළමනාකරණය කරන්න",
             title: "පෞද්ගලික තොරතුරු"
         },
+        personalInfoWithoutLinkedAccounts: {
+            subTitle: "ඔබගේ පුද්ගලික පැතිකඩ සංස්කරණය කරන්න හෝ අපනයනය කරන්න",
+            title: "පෞද්ගලික තොරතුරු"
+        },
         privacy: {
             subTitle: "",
             title: "WSO2 හැඳුනුම් සේවාදායක රහස්‍යතා ප්‍රතිපත්තිය"

--- a/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
@@ -1320,6 +1320,10 @@ export const myAccount: MyAccountNS = {
                 "நிர்வகிக்கவும்",
             title: "பயனர் விபரம்"
         },
+        personalInfoWithoutLinkedAccounts: {
+            subTitle: "உங்கள் தனிப்பட்ட சுயவிவரத்தைத் திருத்தவும் அல்லது ஏற்றுமதி செய்யவும்",
+            title: "பயனர் விபரம்"
+        },
         privacy: {
             subTitle: "",
             title: "WSO2 Identity Server தனியுரிமைக் கொள்கை"


### PR DESCRIPTION
## Purpose
In the My Account application, we can remove the Linked account feature by configuration. This fix helps to fix the subtitle of the description when the Linked account feature turned off.

##Fix 

![fix](https://user-images.githubusercontent.com/25488962/109471131-56826000-7a96-11eb-815c-d137d3808008.png)
