### PR TITLE
[MyAccount][TOTP Authenticator] Remove cancel button at the end

### DIFF
--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
@@ -322,7 +322,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                 </Modal.Content>
                 <Modal.Actions data-testid={ `${ testId }-modal-actions` }>
                     {
-                        step !== 3
+                        step !== 1
                             ? (
                                 < Button onClick={ () => { setOpenWizard(false); } } className="link-button">
                                     { t("common:cancel") }


### PR DESCRIPTION
## Purpose
Since there is no purpose of having a Cancel button there we are removing it from the UI (Last step).

## After
![fix](https://user-images.githubusercontent.com/25488962/109487871-d1557600-7aaa-11eb-9f35-38d5115a4639.gif)

## Methodology
Limit the appearance of the cancel button to step 1 only.