### PR TITLE
Application create wizard related fixes

### DIFF
--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -366,6 +366,10 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         document.getElementById("notification-div").scrollIntoView({ behavior: "smooth" });
     };
 
+    const isNameValid = (name: string) => {
+        return name && !!name.match(ApplicationManagementConstants.FORM_FIELD_CONSTRAINTS.APP_NAME_PATTERN);
+    };
+
     /**
      * Resolves to the applicable content of an application template.
      *
@@ -409,6 +413,19 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                                 type="text"
                                 data-testid={ `${ testId }-application-name-input` }
                                 validation={ async (value: FormValue, validation: Validation) => {
+                                    if(!isNameValid(value.toString())) {
+                                        validation.isValid = false;
+                                        validation.errorMessages.push(
+                                            t("console:develop.features.applications.forms." +
+                                                "spaProtocolSettingsWizard.fields.name.validations.invalid",
+                                                { appName: value.toString(),
+                                                    characterLimit: ApplicationManagementConstants
+                                                        .FORM_FIELD_CONSTRAINTS.APP_NAME_MAX_LENGTH }
+                                            )
+                                        );
+
+                                        return;
+                                    }
                                     let response: ApplicationListInterface = null;
                                     try {
                                         response = await getApplicationList(null, null, "name eq " + value.toString());

--- a/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -452,6 +452,10 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                                             t("console:develop.features.applications.forms." +
                                                 "spaProtocolSettingsWizard.fields.callBackUrls.validations.invalid")
                                         }
+                                        emptyErrorMessage={
+                                            t("console:develop.features.applications.forms." +
+                                                "spaProtocolSettingsWizard.fields.callBackUrls.validations.empty")
+                                        }
                                         validation={ (value: string) => {
                                             if (!(URLUtils.isURLValid(value, true) && (URLUtils.isHttpUrl(value) ||
                                                 URLUtils.isHttpsUrl(value)))) {
@@ -491,8 +495,8 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                                                 <Icon name="info" size="mini" />
                                                 <Message.Content> {
                                                     <Trans
-                                                    i18nKey="console:develop.features.applications.forms.
-                                                    inboundOIDC.fieldscallBackUrls.info"
+                                                    i18nKey={ "console:develop.features.applications.forms." +
+                                                        "inboundOIDC.fields.callBackUrls.info" }
                                                     tOptions={ { callBackURLFromTemplate: callBackURLFromTemplate  } }
                                                     >
                                                         Don’t have an app? Try out a sample app

--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -338,6 +338,7 @@ export class ApplicationManagementConstants {
      * @type {{APP_NAME_MAX_LENGTH: number}}
      */
     public static readonly FORM_FIELD_CONSTRAINTS = {
-        APP_NAME_MAX_LENGTH: 50
+        APP_NAME_MAX_LENGTH: 50,
+        APP_NAME_PATTERN: new RegExp("^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$")
     }
 }

--- a/apps/console/src/features/applications/data/application-templates/templates/oidc-web-application/create-wizard-help.tsx
+++ b/apps/console/src/features/applications/data/application-templates/templates/oidc-web-application/create-wizard-help.tsx
@@ -45,7 +45,6 @@ const OIDCWebApplicationCreateWizardHelp: FunctionComponent<OIDCWebApplicationCr
             <Heading as="h5">Name</Heading>
             <p>A unique name to identify your application.</p>
             <p>E.g., My App</p>
-
             <>
                 <Divider/>
                 <Heading as="h5">Protocol</Heading>
@@ -57,9 +56,9 @@ const OIDCWebApplicationCreateWizardHelp: FunctionComponent<OIDCWebApplicationCr
             <Divider />
 
             <React.Fragment>
-                <Heading as="h5">Authorized URIs</Heading>
+                <Heading as="h5">Authorized redirect URLs</Heading>
                 <p>
-                    The authorized redirect URIs determine where the authorization code
+                    The authorized redirect URLs determine where the authorization code
                     is sent to once the user is authenticated, and where the user is
                     redirected to once the logout is complete.
                 </p>

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -813,6 +813,7 @@ export interface ConsoleNS {
                     spaProtocolSettingsWizard: {
                         fields: {
                             callBackUrls: FormAttributes;
+                            name: FormAttributes;
                         };
                     };
                 };

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1133,7 +1133,7 @@ export const console: ConsoleNS = {
                             callBackUrls: {
                                 hint: "The authorized redirect URL determines where the authorization code is sent " +
                                     "to upon user authentication, and where the user is redirected to upon user " +
-                                    "logout. The client app should specify the authorization redirect URL in the " +
+                                    "logout. The client app should specify the authorized redirect URL in the " +
                                     "authorization or logout request and {{productName}} will validate it against the " +
                                     "authorized redirect URLs entered here.",
                                 label: "Authorized redirect URLs",

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1131,21 +1131,21 @@ export const console: ConsoleNS = {
                                 }
                             },
                             callBackUrls: {
-                                hint: "The redirect URI determines where the authorization code is sent to upon " +
-                                    "user authentication, and where the user is redirected to upon user logout." +
-                                    "The client app should specify the redirect URI in the authorization or logout " +
-                                    "request and {{productName}} will validate it against the redirect URIs " +
-                                    "entered here.",
-                                label: "Authorized URIs",
+                                hint: "The authorized redirect URL determines where the authorization code is sent " +
+                                    "to upon user authentication, and where the user is redirected to upon user " +
+                                    "logout. The client app should specify the authorization redirect URL in the " +
+                                    "authorization or logout request and {{productName}} will validate it against the " +
+                                    "authorized redirect URLs entered here.",
+                                label: "Authorized redirect URLs",
                                 placeholder: "https://myapp.io/login",
                                 validations: {
-                                    empty: "Please add a valid URI.",
+                                    empty: "Please add a valid URL.",
                                     required: "This field is required for a functional app. " +
                                         "However, if you are planning to try the sample app, " +
                                         "this field can be ignored."
                                 },
                                 info: "Don’t have an app? Try out a sample app using {{callBackURLFromTemplate}} " +
-                                "as the Authorized URL."
+                                "as the authorized redirect URL."
                             },
                             clientID: {
                                 label: "Client ID"
@@ -1781,7 +1781,16 @@ export const console: ConsoleNS = {
                             callBackUrls: {
                                 label: "Authorized redirect URLs",
                                 validations: {
+                                    empty: "This is a required field.",
                                     invalid: "The entered URL is neither HTTP nor HTTPS. Please add a valid URL."
+                                }
+                            },
+                            name: {
+                                label: "Name",
+                                validations: {
+                                    invalid: "{{appName}} is not a valid name. It can contain up to " +
+                                        "{{characterLimit}} characters, including alphanumerics, periods (.), " +
+                                        "dashes (-), underscores (_), and spaces ( )."
                                 }
                             }
                         }

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1793,7 +1793,14 @@ export const console: ConsoleNS = {
                             callBackUrls: {
                                 label: "URL autorisées",
                                 validations: {
+                                    empty: "Ceci est un champ obligatoire",
                                     invalid: "L'URL saisie n'est ni HTTP ni HTTPS. Veuillez ajouter un URI valide."
+                                }
+                            },
+                            name: {
+                                label: "Name",
+                                validations: {
+                                    invalid: "The application name should contain letters, numbers."
                                 }
                             }
                         }

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1776,7 +1776,14 @@ export const console: ConsoleNS = {
                             callBackUrls: {
                                 label: "බලයලත් URL",
                                 validations: {
+                                    empty: "මෙය අත්‍යවශ්‍ය ක්ෂේත්‍රයකි",
                                     invalid: "ඇතුළත් කළ URL එක HTTP හෝ HTTPS නොවේ. කරුණාකර වලංගු URI එකක් එක් කරන්න."
+                                }
+                            },
+                            name: {
+                                label: "Name",
+                                validations: {
+                                    invalid: "The application name should contain letters, numbers."
                                 }
                             }
                         }

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -28,6 +28,7 @@ import { Hint } from "../typography";
 export interface URLInputPropsInterface extends TestableComponentInterface {
     addURLTooltip?: string;
     duplicateURLErrorMessage: string;
+    emptyErrorMessage?: string;
     urlState: string;
     setURLState: any;
     placeholder?: string;
@@ -123,6 +124,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
         restrictSecondaryContent,
         customLabel,
         duplicateURLErrorMessage,
+        emptyErrorMessage,
         isAllowEnabled,
         allowedOrigins,
         handleAddAllowedOrigin,
@@ -470,6 +472,14 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
      * @return {React.ReactElement | React.ReactNode}
      */
     const resolveValidationLabel = (): ReactElement | ReactNode => {
+        if(!validURL && !changeUrl && emptyErrorMessage) {
+            return (
+                <Label basic color="red" pointing>
+                    { emptyErrorMessage }
+                </Label>
+            );
+        }
+
         if (!validURL) {
             return (
                 <Label basic color="red" pointing>


### PR DESCRIPTION
## Purpose
> SPA and traditional app creation wizard related minor fixes

## Approach
> Following issues were fixed

- Changed all places to be consistent with name `authorized redirect URL`
- Added application name validation
- Handled redirect URL input field's empty scenario to provide different error message

![Screenshot from 2021-03-03 06-37-36](https://user-images.githubusercontent.com/25344622/109737213-a9216080-7beb-11eb-9040-ce7100a342ae.png)

![Screenshot from 2021-03-03 06-38-01](https://user-images.githubusercontent.com/25344622/109737257-b9d1d680-7beb-11eb-9557-76925a8f8f80.png)
