### PR TITLE
Omit Groups from user profile

### DIFF
--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -844,6 +844,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                         if (!(schema.name === ProfileConstants?.
                                                 SCIM2_SCHEMA_DICTIONARY.get("ROLES_DEFAULT")
                                             || schema.name === ProfileConstants?.
+                                                SCIM2_SCHEMA_DICTIONARY.get("GROUPS")
+                                            || schema.name === ProfileConstants?.
                                                 SCIM2_SCHEMA_DICTIONARY.get("PROFILE_URL")
                                             || schema.name === ProfileConstants?.
                                                 SCIM2_SCHEMA_DICTIONARY.get("ACCOUNT_LOCKED")

--- a/modules/core/src/constants/profile-constants.ts
+++ b/modules/core/src/constants/profile-constants.ts
@@ -63,6 +63,7 @@ export class ProfileConstants {
         .set("NAME", "name")
         .set("ADDRESSES", "addresses")
         .set("PHONE_NUMBERS", "phoneNumbers")
+        .set("GROUPS", "groups")
         .set("ROLES", "roles")
         .set("ROLES_DEFAULT", "roles.default")
         .set("PROFILE_URL", "profileUrl")


### PR DESCRIPTION
Fixes https://github.com/wso2-enterprise/asgardeo-product/issues/1799.

With the groups vs roles enabled, the `groups` claim values are visible in the user's profile section under the `groups` attribute. But,

groups should be viewed from the `Groups` panel and should be omitted from the user profile.

Therefore this PR filter our `groups` claim in the same manner as we do with `roles`