### PR TITLE
Fix commonauth url issue when tenanted qualified url is enabled for smsotp

### DIFF
--- a/apps/sms-otp-authentication-portal/src/main/webapp/smsotp.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/smsotp.jsp
@@ -96,7 +96,7 @@
                     <% } %>
                     <div class="error-msg"></div>
                     <div class="segment-form">
-                        <form class="ui large form" id="pin_form" name="pin_form" action="../../commonauth"  method="POST">
+                        <form class="ui large form" id="pin_form" name="pin_form" action="../commonauth"  method="POST">
                             <%
                                 String loginFailed = request.getParameter("authFailure");
                                 if (loginFailed != null && "true".equals(loginFailed)) {


### PR DESCRIPTION
## Purpose
Part of https://github.com/wso2/product-is/issues/11363

This fixes the issue with submitting the form to commonauth endpoint when tenant qualified url is enabled.
This works for both flows.

