### PR TITLE
Improvements to the sign-on-method page.

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -206,7 +206,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                                 content={ (
                                     <>
                                         <Label attached="top">
-                                            <Icon name="warning sign" /> Warning
+                                            <Icon name="info circle" /> Info
                                         </Label>
                                         { resolvePopupContent() }
                                     </>

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -200,8 +200,12 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
 
     useEffect(() => {
 
-        const shouldEnable = hasSpecificFactorsInSteps(
+        let shouldEnable = hasSpecificFactorsInSteps(
             ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS, [ ...authenticationSteps ]);
+
+        if (authenticationSteps.length === 1) {
+            shouldEnable = false;
+        }
 
         setSecondFactorAuthenticators(
             secondFactorAuthenticators.map((authenticator) => {


### PR DESCRIPTION
## Purpose

 Fix activating the TOTP authenticator upon adding and removing a new step.
Change the warning message showing when hover over totp authenticator to a info.

![Peek 2021-03-08 11-40](https://user-images.githubusercontent.com/25428696/110281698-36f1b700-8003-11eb-9b3d-7c0a1d45ca3d.gif)
