### PR TITLE
[MyAccount]  Improve Session timeout mesage

### DIFF
--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -122,7 +122,7 @@ export const console: ConsoleNS = {
                 primaryButton: "Stay logged in",
                 secondaryButton: "Logout",
                 loginAgainButton: "Login again",
-                sessionTimedOutHeading: "Your session has expired due to inactivity.",
+                sessionTimedOutHeading: "User session has expired due to inactivity.",
                 sessionTimedOutDescription: "Please log in again to continue from where you left off."
             }
         },

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -1273,7 +1273,7 @@ export const myAccount: MyAccountNS = {
             primaryButton: "Stay logged in",
             secondaryButton: "Logout",
             loginAgainButton: "Login again",
-            sessionTimedOutHeading: "Your session has expired due to inactivity.",
+            sessionTimedOutHeading: "User session has expired due to inactivity.",
             sessionTimedOutDescription: "Please log in again to continue from where you left off."
         }
     },

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -122,7 +122,7 @@ export const console: ConsoleNS = {
                 primaryButton: "Rester connecté",
                 secondaryButton: "Déconnexion",
                 loginAgainButton: "Connectez-vous à nouveau",
-                sessionTimedOutHeading: "Votre session a expiré en raison d'une inactivité.",
+                sessionTimedOutHeading: "La session utilisateur a expiré en raison d'une inactivité.",
                 sessionTimedOutDescription: "Veuillez vous reconnecter pour reprendre là où vous vous étiez arrêté."
             }
         },

--- a/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
@@ -1276,7 +1276,7 @@ export const myAccount: MyAccountNS = {
             primaryButton: "Rester connecté",
             secondaryButton: "Se déconnecter",
             loginAgainButton: "Connectez-vous à nouveau",
-            sessionTimedOutHeading: "Votre session a expiré en raison d'une inactivité.",
+            sessionTimedOutHeading: "La session utilisateur a expiré en raison d'une inactivité.",
             sessionTimedOutDescription: "Veuillez vous reconnecter pour reprendre là où vous vous étiez arrêté."
         }
     },

--- a/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
@@ -1255,7 +1255,7 @@ export const myAccount: MyAccountNS = {
             primaryButton: "Permaneça logado",
             secondaryButton: "Sair",
             loginAgainButton: "Entrar novamente",
-            sessionTimedOutHeading: "Sua sessão expirou devido à inatividade.",
+            sessionTimedOutHeading: "A sessão do usuário expirou devido à inatividade.",
             sessionTimedOutDescription: "Faça login novamente para continuar de onde parou."
         }
     },

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -122,7 +122,7 @@ export const console: ConsoleNS = {
                 primaryButton: "පුරනය වී සිටින්න",
                 secondaryButton: "ඉවත් වන්න",
                 loginAgainButton: "නැවත පුරනය වන්න",
-                sessionTimedOutHeading: "අක්‍රියතාවය හේතුවෙන් ඔබගේ සැසිය කල් ඉකුත්වී ඇත.",
+                sessionTimedOutHeading: "අක්‍රියතාවය හේතුවෙන් පරිශීලක සැසිය කල් ඉකුත්වී ඇත.",
                 sessionTimedOutDescription: "ඔබ නතර කළ ස්ථානයෙන් ඉදිරියට යාමට කරුණාකර නැවත ලොග් වන්න."
             }
         },

--- a/modules/i18n/src/translations/si-LK/portals/myaccount.ts
+++ b/modules/i18n/src/translations/si-LK/portals/myaccount.ts
@@ -1265,7 +1265,7 @@ export const myAccount: MyAccountNS = {
             primaryButton: "පුරනය වී සිටින්න",
             secondaryButton: "වරන්න",
             loginAgainButton: "නැවත පුරනය වන්න",
-            sessionTimedOutHeading: "අක්‍රියතාවය හේතුවෙන් ඔබගේ සැසිය කල් ඉකුත්වී ඇත.",
+            sessionTimedOutHeading: "අක්‍රියතාවය හේතුවෙන් පරිශීලක සැසිය කල් ඉකුත්වී ඇත.",
             sessionTimedOutDescription: "ඔබ නතර කළ ස්ථානයෙන් ඉදිරියට යාමට කරුණාකර නැවත ලොග් වන්න."
         }
     },

--- a/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
@@ -1302,7 +1302,7 @@ export const myAccount: MyAccountNS = {
             primaryButton: "உள்நுழைந்திருங்கள்",
             secondaryButton: "வெளியேறு",
             loginAgainButton: "மீண்டும் உள்நுழைக",
-            sessionTimedOutHeading: "செயலற்ற தன்மை காரணமாக உங்கள் அமர்வு காலாவதியானது.",
+            sessionTimedOutHeading: "செயலற்ற தன்மை காரணமாக பயனர் அமர்வு காலாவதியானது.",
             sessionTimedOutDescription: "நீங்கள் நிறுத்திய இடத்திலிருந்து தொடர தயவுசெய்து மீண்டும் உள்நுழைக."
         }
     },

--- a/modules/react-components/src/components/modal/session-timeout-modal/session-timeout-modal.tsx
+++ b/modules/react-components/src/components/modal/session-timeout-modal/session-timeout-modal.tsx
@@ -26,6 +26,11 @@ import { ConfirmationModal } from "../confirmation-modal";
  * Session Management Modal props interface.
  */
 export interface SessionTimeoutModalPropsInterface extends ModalProps, TestableComponentInterface {
+
+    /**
+     * Check whether session timeout modal or session timer modal.
+     */
+    sessionTimeOut?: boolean;
     /**
      * Modal description.
      */
@@ -65,6 +70,7 @@ export const SessionTimeoutModal: FunctionComponent<SessionTimeoutModalPropsInte
     const {
         description,
         heading,
+        sessionTimeOut,
         onSecondaryActionClick,
         onPrimaryActionClick,
         primaryButtonText,
@@ -79,8 +85,8 @@ export const SessionTimeoutModal: FunctionComponent<SessionTimeoutModalPropsInte
             type="warning"
             textAlign="center"
             primaryAction={ primaryButtonText }
-            secondaryAction={ secondaryButtonText }
-            onSecondaryActionClick={ onSecondaryActionClick }
+            secondaryAction={ sessionTimeOut? null: secondaryButtonText }
+            onSecondaryActionClick={ sessionTimeOut ? null: onSecondaryActionClick }
             onPrimaryActionClick={ onPrimaryActionClick }
             data-testid={ testId }
             { ...rest }

--- a/modules/react-components/src/providers/session-management/session-management-provider.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-provider.tsx
@@ -262,6 +262,7 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
                 onClose={ handleSessionTimeoutAbort }
                 onPrimaryActionClick={ handlePrimaryActionClick }
                 onSecondaryActionClick={ handleSessionLogout }
+                sessionTimeOut = { sessionTimedOut }
                 heading={
                     <Trans
                         i18nKey={ !sessionTimedOut?

--- a/modules/theme/src/themes/default/globals/site.variables
+++ b/modules/theme/src/themes/default/globals/site.variables
@@ -192,6 +192,12 @@
 @readOnlyFieldCursor: default;
 
 /*-------------------
+    Site Colors
+--------------------*/
+
+@warningColor: #EBA91C;
+
+/*-------------------
        Layouts
 --------------------*/
 


### PR DESCRIPTION
space

## Purpose
Earlier Session Time out has two buttons but used for the same functionality, So we are removing the logout button after the session timed out. We are also changing **Your session** to **User sessions** to remove ambiguity.



Earlier
![msg](https://user-images.githubusercontent.com/25488962/110321146-468af300-8037-11eb-9670-41c833ecd174.png)


Now
![#F2C037](https://user-images.githubusercontent.com/25488962/110321168-4d196a80-8037-11eb-92bd-ffaff80e413b.png)



