### PR TITLE
Handle role mapping in SP & IdP based on group vs role separation

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
@@ -27,7 +27,7 @@ import { Grid } from "semantic-ui-react";
 import { RoleMappingInterface } from "../../../models";
 import { AppState } from "../../../../core/store";
 import { getGroupList } from "../../../../groups/api";
-import {GroupListInterface, GroupsInterface} from "../../../../groups/models";
+import { GroupListInterface, GroupsInterface } from "../../../../groups/models";
 
 interface RoleMappingPropsInterface extends TestableComponentInterface {
     /**

--- a/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
@@ -79,6 +79,23 @@ export const RoleMapping: FunctionComponent<RoleMappingPropsInterface> = (
     const isGroupAndRoleSeparationEnabled: boolean = useSelector(
         (state: AppState) => state?.config?.ui?.isGroupAndRoleSeparationEnabled);
 
+    const isGroupAndRoleSeparationImprovementsEnabledFlag = useSelector((state: AppState) =>
+        state?.config?.ui?.isGroupAndRoleSeparationImprovementsEnabled);
+
+    const getGroupAndRoleSeparationImprovementsEnabled = (
+        groupRoleSeparationEnabledFlag: boolean, groupRoleSeparationImprovementsEnabledFlag: boolean): boolean => {
+        return groupRoleSeparationEnabledFlag ? groupRoleSeparationImprovementsEnabledFlag : false;
+    }
+
+    const isGroupAndRoleSeparationImprovementsEnabled = getGroupAndRoleSeparationImprovementsEnabled(
+        isGroupAndRoleSeparationEnabled, isGroupAndRoleSeparationImprovementsEnabledFlag);
+
+    const roleOrGroupMapping = isGroupAndRoleSeparationImprovementsEnabled ? "groupMapping" : "roleMapping";
+
+    const applicationRoleOrGroup = isGroupAndRoleSeparationImprovementsEnabled ? "applicationGroup" : "applicationRole";
+
+    const localRoleOrGroup = isGroupAndRoleSeparationImprovementsEnabled ? "localGroup" : "localRole";
+
     /**
      * Filter out Application related and Internal roles
      */
@@ -109,7 +126,7 @@ export const RoleMapping: FunctionComponent<RoleMappingPropsInterface> = (
     };
 
     useEffect(() => {
-        isGroupAndRoleSeparationEnabled ?
+        isGroupAndRoleSeparationImprovementsEnabled ?
             getGroupList(null)
                 .then((response) => {
                     if (response.status === 200) {
@@ -139,7 +156,8 @@ export const RoleMapping: FunctionComponent<RoleMappingPropsInterface> = (
             <Grid.Row columns={ 2 }>
                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
                     <Heading as="h4">
-                        { t("console:develop.features.applications.edit.sections.attributes.roleMapping.heading") }
+                        { t("console:develop.features.applications.edit.sections.attributes." + roleOrGroupMapping
+                            + ".heading") }
                     </Heading>
                     <DynamicField
                         data={
@@ -152,28 +170,28 @@ export const RoleMapping: FunctionComponent<RoleMappingPropsInterface> = (
                                 }) : []
                         }
                         keyType="dropdown"
-                        keyData={ isGroupAndRoleSeparationEnabled ?
+                        keyData={ isGroupAndRoleSeparationImprovementsEnabled ?
                             (groupList ? getGroups() : []) : (roleList ? getFilteredRoles() : [])
                         }
                         keyName={
                             t("console:develop.features.applications.edit.sections.attributes.forms.fields.dynamic" +
-                                ".localRole.label")
+                                "." + localRoleOrGroup + ".label")
                         }
                         valueName={
                             t("console:develop.features.applications.edit.sections.attributes.forms.fields.dynamic" +
-                                ".applicationRole.label")
+                                "." + applicationRoleOrGroup + ".label")
                         }
                         keyRequiredMessage={
                             t("console:develop.features.applications.edit.sections.attributes.forms.fields.dynamic" +
-                                ".localRole.validations.empty")
+                                "." + localRoleOrGroup + ".validations.empty")
                         }
                         valueRequiredErrorMessage={
                             t("console:develop.features.applications.edit.sections.attributes.forms.fields.dynamic" +
-                                ".applicationRole.validations.empty")
+                                "." + applicationRoleOrGroup + ".validations.empty")
                         }
                         duplicateKeyErrorMsg={
                             t("console:develop.features.applications.edit.sections.attributes.forms.fields.dynamic" +
-                                ".applicationRole.validations.duplicate")
+                                "." + applicationRoleOrGroup + ".validations.duplicate")
                         }
                         submit={ submitState }
                         update={ (data) => {
@@ -181,7 +199,7 @@ export const RoleMapping: FunctionComponent<RoleMappingPropsInterface> = (
                                 const finalData: RoleMappingInterface[] = data.map(mapping => {
                                     return {
                                         applicationRole: mapping.value,
-                                        localRole: isGroupAndRoleSeparationEnabled || mapping.key.includes("/") ?
+                                        localRole: isGroupAndRoleSeparationImprovementsEnabled || mapping.key.includes("/") ?
                                             mapping.key : "Internal/" + mapping.key
                                     };
                                 });

--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -166,6 +166,7 @@ export class Config {
             isDefaultDialectEditingEnabled: window["AppUtils"].getConfig().ui.isDefaultDialectEditingEnabled,
             isDialectAddingEnabled: window["AppUtils"].getConfig().ui.isDialectAddingEnabled,
             isGroupAndRoleSeparationEnabled: window["AppUtils"].getConfig().ui.isGroupAndRoleSeparationEnabled,
+            isGroupAndRoleSeparationImprovementsEnabled: window["AppUtils"].getConfig().ui.isGroupAndRoleSeparationImprovementsEnabled,
             isLeftNavigationCategorized: window["AppUtils"].getConfig().ui.isLeftNavigationCategorized,
             isRequestPathAuthenticationEnabled: window["AppUtils"].getConfig().ui.isRequestPathAuthenticationEnabled,
             isSignatureValidationCertificateAliasEnabled: window["AppUtils"].getConfig().ui

--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -174,6 +174,10 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      */
     isGroupAndRoleSeparationEnabled?: boolean;
     /**
+     * Enable roles and groups separation improvements.
+     */
+    isGroupAndRoleSeparationImprovementsEnabled?: boolean;
+    /**
      * Is Request path section enabled in applications.
      */
     isRequestPathAuthenticationEnabled?: boolean;

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/role-mapping-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/role-mapping-settings.tsx
@@ -16,18 +16,18 @@
  * under the License.
  */
 
-import {getRolesList} from "@wso2is/core/api";
-import {RoleListInterface, RolesInterface, TestableComponentInterface} from "@wso2is/core/models";
-import {DynamicField, Heading, Hint} from "@wso2is/react-components";
-import React, {FunctionComponent, ReactElement, useEffect, useState} from "react";
-import {useTranslation} from "react-i18next";
-import {Grid} from "semantic-ui-react";
-import {getGroupList} from "../../../../groups/api";
-import {IdentityProviderRoleMappingInterface} from "../../../models";
-import {GroupListInterface, GroupsInterface} from "../../../../groups/models";
-import {useSelector} from "react-redux";
-import {AppState} from "../../../../core/store";
-import {handleGetRoleListError} from "../../utils";
+import { getRolesList } from "@wso2is/core/api";
+import { RoleListInterface, RolesInterface, TestableComponentInterface } from "@wso2is/core/models";
+import { DynamicField, Heading, Hint } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Grid } from "semantic-ui-react";
+import { getGroupList } from "../../../../groups/api";
+import { IdentityProviderRoleMappingInterface } from "../../../models";
+import { GroupListInterface, GroupsInterface } from "../../../../groups/models";
+import { useSelector } from "react-redux";
+import { AppState } from "../../../../core/store";
+import { handleGetRoleListError } from "../../utils";
 
 /**
  * Proptypes for the identity providers settings component.

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/role-mapping-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/role-mapping-settings.tsx
@@ -16,18 +16,18 @@
  * under the License.
  */
 
-import { getRolesList } from "@wso2is/core/api";
-import { RoleListInterface, RolesInterface, TestableComponentInterface } from "@wso2is/core/models";
-import { DynamicField, Heading, Hint } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { Grid } from "semantic-ui-react";
-import { getGroupList } from "../../../../groups/api";
-import { IdentityProviderRoleMappingInterface } from "../../../models";
-import { GroupListInterface, GroupsInterface } from "../../../../groups/models";
-import { useSelector } from "react-redux";
-import { AppState } from "../../../../core/store";
-import { handleGetRoleListError } from "../../utils";
+import {getRolesList} from "@wso2is/core/api";
+import {RoleListInterface, RolesInterface, TestableComponentInterface} from "@wso2is/core/models";
+import {DynamicField, Heading, Hint} from "@wso2is/react-components";
+import React, {FunctionComponent, ReactElement, useEffect, useState} from "react";
+import {useTranslation} from "react-i18next";
+import {Grid} from "semantic-ui-react";
+import {getGroupList} from "../../../../groups/api";
+import {IdentityProviderRoleMappingInterface} from "../../../models";
+import {GroupListInterface, GroupsInterface} from "../../../../groups/models";
+import {useSelector} from "react-redux";
+import {AppState} from "../../../../core/store";
+import {handleGetRoleListError} from "../../utils";
 
 /**
  * Proptypes for the identity providers settings component.
@@ -66,6 +66,19 @@ export const RoleMappingSettings: FunctionComponent<RoleMappingSettingsPropsInte
     const isGroupAndRoleSeparationEnabled: boolean = useSelector(
         (state: AppState) => state?.config?.ui?.isGroupAndRoleSeparationEnabled);
 
+    const isGroupAndRoleSeparationImprovementsEnabledFlag = useSelector((state: AppState) =>
+        state?.config?.ui?.isGroupAndRoleSeparationImprovementsEnabled);
+
+    const getGroupAndRoleSeparationImprovementsEnabled = (
+        groupRoleSeparationEnabledFlag: boolean, groupRoleSeparationImprovementsEnabledFlag: boolean): boolean => {
+        return groupRoleSeparationEnabledFlag ? groupRoleSeparationImprovementsEnabledFlag : false;
+    }
+
+    const isGroupAndRoleSeparationImprovementsEnabled = getGroupAndRoleSeparationImprovementsEnabled(
+        isGroupAndRoleSeparationEnabled, isGroupAndRoleSeparationImprovementsEnabledFlag);
+
+    const roleOrGroupMapping = isGroupAndRoleSeparationImprovementsEnabled ? "groupMapping" : "roleMapping";
+
     const {
         onSubmit,
         triggerSubmit,
@@ -99,7 +112,7 @@ export const RoleMappingSettings: FunctionComponent<RoleMappingSettingsPropsInte
     };
 
     useEffect(() => {
-        isGroupAndRoleSeparationEnabled ?
+        isGroupAndRoleSeparationImprovementsEnabled ?
             getGroupList(null)
                 .then((response) => {
                     if (response.status === 200) {
@@ -124,7 +137,7 @@ export const RoleMappingSettings: FunctionComponent<RoleMappingSettingsPropsInte
         <>
             <Grid.Row>
                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                    <Heading as="h4">{ t("console:develop.features.idp.forms.roleMapping.heading") }</Heading>
+                    <Heading as="h4">{ t("console:develop.features.idp.forms." + roleOrGroupMapping + ".heading") }</Heading>
                     <DynamicField
                         bottomMargin={ false }
                         data={
@@ -137,18 +150,18 @@ export const RoleMappingSettings: FunctionComponent<RoleMappingSettingsPropsInte
                                 }) : []
                         }
                         keyType="dropdown"
-                        keyData={ isGroupAndRoleSeparationEnabled ?
+                        keyData={ isGroupAndRoleSeparationImprovementsEnabled ?
                             ( groupList ? getGroups() : [] )
                             :
                             ( roleList ? getRoles() : [] )
                         }
-                        keyName={ t("console:develop.features.idp.forms.roleMapping.keyName") }
-                        valueName={ t("console:develop.features.idp.forms.roleMapping.valueName") }
-                        keyRequiredMessage={ t("console:develop.features.idp.forms.roleMapping." +
+                        keyName={ t("console:develop.features.idp.forms." + roleOrGroupMapping + ".keyName") }
+                        valueName={ t("console:develop.features.idp.forms." + roleOrGroupMapping + ".valueName") }
+                        keyRequiredMessage={ t("console:develop.features.idp.forms." + roleOrGroupMapping + "." +
                             "validation.keyRequiredMessage") }
-                        valueRequiredErrorMessage={ t("console:develop.features.idp.forms.roleMapping." +
+                        valueRequiredErrorMessage={ t("console:develop.features.idp.forms." + roleOrGroupMapping + "." +
                             "validation.valueRequiredErrorMessage") }
-                        duplicateKeyErrorMsg={ t("console:develop.features.idp.forms.roleMapping." +
+                        duplicateKeyErrorMsg={ t("console:develop.features.idp.forms." + roleOrGroupMapping + "." +
                             "validation.duplicateKeyErrorMsg") }
                         submit={ triggerSubmit }
                         update={ (data) => {
@@ -166,7 +179,7 @@ export const RoleMappingSettings: FunctionComponent<RoleMappingSettingsPropsInte
                         } }
                         data-testid={ testId }
                     />
-                    <Hint>{ t("console:develop.features.idp.forms.roleMapping.hint") }</Hint>
+                    <Hint>{ t("console:develop.features.idp.forms." + roleOrGroupMapping + ".hint") }</Hint>
                 </Grid.Column>
             </Grid.Row>
         </>

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -313,6 +313,7 @@
             "showLanguageSwitcher": false
         },
         "isGroupAndRoleSeparationEnabled": true,
+        "isGroupAndRoleSeparationImprovementsEnabled": true,
         "isSignatureValidationCertificateAliasEnabled" : false,
         "isClientSecretHashEnabled": false,
         "isDefaultDialectEditingEnabled": false,

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -509,6 +509,7 @@
         "isDialectAddingEnabled": {{ console.ui.is_dialect_adding_enabled }},
         {% endif %}
         "isGroupAndRoleSeparationEnabled": {{ authorization_manager.properties.GroupAndRoleSeparationEnabled }},
+        "isGroupAndRoleSeparationImprovementsEnabled": {{ authorization_manager.properties.isGroupAndRoleSeparationImprovementsEnabled }},
         {% if console.ui.is_request_path_authentication_enabled is defined %}
         "isRequestPathAuthenticationEnabled": {{ console.ui.is_request_path_authentication_enabled }},
         {% endif %}

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -432,6 +432,8 @@ export interface ConsoleNS {
                                     dynamic: {
                                         localRole: FormAttributes;
                                         applicationRole: FormAttributes;
+                                        localGroup: FormAttributes;
+                                        applicationGroup: FormAttributes;
                                     };
                                 };
                             };
@@ -483,6 +485,9 @@ export interface ConsoleNS {
                             };
                             attributeMappingChange: Notification;
                             roleMapping: {
+                                heading: string;
+                            };
+                            groupMapping: {
                                 heading: string;
                             };
                             tabName: string;
@@ -1028,6 +1033,17 @@ export interface ConsoleNS {
                         };
                         hint: string;
                     };
+                    groupMapping: {
+                        heading: string;
+                        keyName: string;
+                        valueName: string;
+                        validation: {
+                            keyRequiredMessage: string;
+                            valueRequiredErrorMessage: string;
+                            duplicateKeyErrorMsg: string;
+                        };
+                        hint: string;
+                    };
                     uriAttributeSettings: {
                         subject: {
                             heading: string;
@@ -1354,6 +1370,17 @@ export interface ConsoleNS {
                         };
                     };
                     roleMapping: {
+                        heading: string;
+                        keyName: string;
+                        valueName: string;
+                        validation: {
+                            keyRequiredMessage: string;
+                            valueRequiredErrorMessage: string;
+                            duplicateKeyErrorMsg: string;
+                        };
+                        hint: string;
+                    };
+                    groupMapping: {
                         heading: string;
                         keyName: string;
                         valueName: string;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -723,12 +723,28 @@ export const console: ConsoleNS = {
                                             validations: {
                                                 empty: "Please enter the local role"
                                             }
+                                        },
+                                        applicationGroup: {
+                                            label: "Application Group",
+                                            validations: {
+                                                duplicate: "This group is already mapped. Please select another group",
+                                                empty: "Please enter an attribute to map to"
+                                            }
+                                        },
+                                        localGroup: {
+                                            label: "Local Group",
+                                            validations: {
+                                                empty: "Please enter the local group"
+                                            }
                                         }
                                     }
                                 }
                             },
                             roleMapping: {
                                 heading: "Role Mapping"
+                            },
+                            groupMapping: {
+                                heading: "Group Mapping"
                             },
                             selection: {
                                 addWizard: {
@@ -2636,6 +2652,17 @@ export const console: ConsoleNS = {
                         },
                         valueName: "Identity Provider Role"
                     },
+                    groupMapping: {
+                        heading: "Group Mapping",
+                        hint: "Map local groups with the Identity Provider groups",
+                        keyName: "Local Group",
+                        validation: {
+                            duplicateKeyErrorMsg: "This group is already mapped. Please select another group",
+                            keyRequiredMessage: "Please enter the local group",
+                            valueRequiredErrorMessage: "Please enter an IDP group to map to"
+                        },
+                        valueName: "Identity Provider Group"
+                    },
                     uriAttributeSettings: {
                         role: {
                             heading: "Role",
@@ -3489,6 +3516,17 @@ export const console: ConsoleNS = {
                             valueRequiredErrorMessage: "Please enter an IDP role to map to"
                         },
                         valueName: "Identity Provider Role"
+                    },
+                    groupMapping: {
+                        heading: "Group Mapping",
+                        hint: "Map local groups with the Identity Provider groups",
+                        keyName: "Local Group",
+                        validation: {
+                            duplicateKeyErrorMsg: "This group is already mapped. Please select another group",
+                            keyRequiredMessage: "Please enter the local group",
+                            valueRequiredErrorMessage: "Please enter an IDP group to map to"
+                        },
+                        valueName: "Identity Provider Group"
                     },
                     uriAttributeSettings: {
                         role: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -725,12 +725,28 @@ export const console: ConsoleNS = {
                                             validations: {
                                                 empty: "Veuillez entrer le rôle local"
                                             }
+                                        },
+                                        applicationGroup: {
+                                            label: "Groupe d'applications",
+                                            validations: {
+                                                duplicate: "Ce groupe est déjà mappé. Veuillez sélectionner un autre groupe",
+                                                empty: "Veuillez saisir un attribut auquel mapper"
+                                            }
+                                        },
+                                        localGroup: {
+                                            label: "Groupe local",
+                                            validations: {
+                                                empty: "Veuillez entrer le groupe local"
+                                            }
                                         }
                                     }
                                 }
                             },
                             roleMapping: {
                                 heading: "Association des rôles"
+                            },
+                            groupMapping: {
+                                heading: "Mappage de groupe"
                             },
                             selection: {
                                 addWizard: {
@@ -2648,6 +2664,17 @@ export const console: ConsoleNS = {
                             valueRequiredErrorMessage: "Veuillez renseigner un rôle de l'IDP à associer à"
                         },
                         valueName: "Rôle du fournisseur d'identité"
+                    },
+                    groupMapping: {
+                        heading: "Mappage de groupe",
+                        hint: "Mapper les groupes locaux avec les groupes de fournisseur d'identité",
+                        keyName: "Groupe local",
+                        validation: {
+                            duplicateKeyErrorMsg: "Ce groupe est déjà mappé. Veuillez sélectionner un autre groupe",
+                            keyRequiredMessage: "Veuillez entrer le groupe local",
+                            valueRequiredErrorMessage: "Veuillez saisir un groupe IDP auquel mapper"
+                        },
+                        valueName: "Groupe de fournisseurs d'identité"
                     },
                     uriAttributeSettings: {
                         role: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -728,12 +728,28 @@ export const console: ConsoleNS = {
                                             validations: {
                                                 empty: "කරුණාකර දේශීය භූමිකාව ඇතුළත් කරන්න"
                                             }
+                                        },
+                                        applicationGroup: {
+                                            label: "යෙදුම් කණ්ඩායම",
+                                            validations: {
+                                                duplicate: "මෙම කණ්ඩායම දැනටමත් සිතියම් ගත කර ඇත. කරුණාකර වෙනත් කණ්ඩායමක් තෝරන්න",
+                                                empty: "කරුණාකර සිතියම සඳහා ලක්ෂණයක් ඇතුළත් කරන්න"
+                                            }
+                                        },
+                                        localGroup: {
+                                            label: "දේශීය කණ්ඩායම",
+                                            validations: {
+                                                empty: "කරුණාකර ප්‍රාදේශීය කණ්ඩායමට ඇතුළු වන්න"
+                                            }
                                         }
                                     }
                                 }
                             },
                             roleMapping: {
                                 heading: "භූමිකාව සිතියම්ගත කිරීම"
+                            },
+                            groupMapping: {
+                                heading: "කණ්ඩායම් සිතියම්කරණය"
                             },
                             selection: {
                                 addWizard: {
@@ -2626,6 +2642,17 @@ export const console: ConsoleNS = {
                                 + " භූමිකාවක් ඇතුළත් කරන්න"
                         },
                         valueName: "හැඳුනුම්පත් සපයන්නාගේ කාර්යභාරය"
+                    },
+                    groupMapping: {
+                        heading: "කණ්ඩායම් සිතියම්කරණය",
+                        hint: "අනන්‍යතා සැපයුම් කණ්ඩායම් සමඟ දේශීය කණ්ඩායම් සිතියම් ගත කරන්න",
+                        keyName: "දේශීය කණ්ඩායම",
+                        validation: {
+                            duplicateKeyErrorMsg: "මෙම කණ්ඩායම දැනටමත් සිතියම් ගත කර ඇත. කරුණාකර වෙනත් කණ්ඩායමක් තෝරන්න",
+                            keyRequiredMessage: "කරුණාකර ප්‍රාදේශීය කණ්ඩායමට ඇතුළු වන්න",
+                            valueRequiredErrorMessage: "සිතියම් ගත කිරීමට කරුණාකර අවතැන්වූවන් කණ්ඩායමක් ඇතුළත් කරන්න"
+                        },
+                        valueName: "අනන්‍යතා සැපයුම් කණ්ඩායම"
                     },
                     uriAttributeSettings: {
                         role: {


### PR DESCRIPTION
Fixes wso2/product-is#11330.

If group role separation config is enabled,

- [x] List groups instead of roles under SP role mapping
- [x] List groups instead of roles under IdP role mapping

Review comments:
 - [x] Need to change the header and the naming from roles to groups
 - [x] Need to switch to the new config for backward compatibility