### PR TITLE
Temporary removal of application revoke option

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -561,6 +561,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
     /**
      * Show Revoke confirmation.
+     * TODO - Currently revoke functionality is disabled until proper backend support is provided for disabling
+     * @link https://github.com/wso2/product-is/issues/11453
      *
      * @param event Button click event.
      */
@@ -2354,6 +2356,9 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                                     value={ initialValues?.clientId }
                                                     data-testid={ `${ testId }-client-id-readonly-input` }
                                                 />
+                                                {/*TODO - Application revoke is disabled until proper
+                                                backend support for application disabling is provided
+                                                @link https://github.com/wso2/product-is/issues/11453
                                                 {
                                                     (!readOnly
                                                         && initialValues?.clientSecret
@@ -2367,7 +2372,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                                             { t("common:revoke") }
                                                         </Button>
                                                     )
-                                                }
+                                                }*/}
                                             </div>
                                         </Form.Field>
                                         { ((initialValues?.state !== State.REVOKED) &&

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -842,7 +842,9 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                 title={ (
                     <>
                         <span>{ application.name }</span>
-                        { resolveApplicationStatusLabel() }
+                        {/*TODO - Application status is not shown until the backend support for disabling is given
+                        @link https://github.com/wso2/product-is/issues/11453
+                        { resolveApplicationStatusLabel() }*/}
                     </>
                 ) }
                 contentTopMargin={ true }


### PR DESCRIPTION
## Purpose
> Remove application revoke option as it does not properly disable the application from backend. The feature is disabled until proper backend support is provided for disabling application for all protocols: Resolves https://github.com/wso2/product-is/issues/11453

## Approach
> Removed **Revoke* button from application protocols page next  to `ClientId` and removed the application status indicator as from current fix application disabling is avoided

![2021-03-16_10-25](https://user-images.githubusercontent.com/25344622/111258153-6bd4be00-8642-11eb-9058-f41c37743031.png)
![2021-03-16_10-25_1](https://user-images.githubusercontent.com/25344622/111258167-70997200-8642-11eb-8f7f-86fe535d07f7.png)
