### PR TITLE
Increase notification time to 15s

### DIFF
--- a/apps/console/src/features/core/constants/ui-constants.ts
+++ b/apps/console/src/features/core/constants/ui-constants.ts
@@ -55,7 +55,7 @@ export class UIConstants {
      * @constant
      * @type {number}
      */
-    public static readonly ALERT_DISMISS_INTERVAL: number = 5;
+    public static readonly ALERT_DISMISS_INTERVAL: number = 15; //Increased dismiss interval to 15s
 
     /**
      * AJAX top loading bar height.

--- a/apps/console/src/features/core/constants/ui-constants.ts
+++ b/apps/console/src/features/core/constants/ui-constants.ts
@@ -55,7 +55,7 @@ export class UIConstants {
      * @constant
      * @type {number}
      */
-    public static readonly ALERT_DISMISS_INTERVAL: number = 15; //Increased dismiss interval to 15s
+    public static readonly ALERT_DISMISS_INTERVAL: number = 15;
 
     /**
      * AJAX top loading bar height.

--- a/apps/myaccount/src/components/shared/alert.tsx
+++ b/apps/myaccount/src/components/shared/alert.tsx
@@ -139,5 +139,5 @@ export const Alert: FunctionComponent<AlertProps> = (props: AlertProps): JSX.Ele
 Alert.defaultProps =  {
     alertsPosition: "br",
     "data-testid": "alert",
-    dismissInterval: 5
+    dismissInterval: 15
 };

--- a/modules/react-components/src/components/alert/alert.tsx
+++ b/modules/react-components/src/components/alert/alert.tsx
@@ -194,7 +194,7 @@ Alert.defaultProps = {
     absolute: false,
     alertsPosition: "br",
     "data-testid": "alert",
-    dismissInterval: 5,
+    dismissInterval: 15,
     dismissible: true,
     withIcon: true
 };


### PR DESCRIPTION
## Purpose
This PR will increase the fadeout time of the notification to 15s.

## Goals
By increasing the fadeout time, the user will have more time to grasp the message
