### PR TITLE
Set description height to fit content

### DIFF
--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -1421,7 +1421,7 @@ body {
                         text-overflow: ellipsis;
                         word-wrap: break-word;
                         overflow: hidden;
-                        max-height: 3.6em;
+                        max-height: fit-content;
                         line-height: 1.8em;
                     }
                 }


### PR DESCRIPTION
## Purpose
This PR will change the approach on showing the message in the notification box to adjust the box height to fit the content of the message.

<img width="419" alt="Screenshot 2021-03-17 at 11 57 38" src="https://user-images.githubusercontent.com/11191791/111425075-9f821780-8718-11eb-8b79-cfd76da037d3.png">

fixes - https://github.com/wso2-enterprise/asgardeo-product/issues/2699

## Approach
Change `description` class `max-height` property to `fit-content` rather than having a fixed height. This will allow to show lengthy messages without cropping.

