### PR TITLE
Fix sign-on method script editor width

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/script-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/script-based-flow.tsx
@@ -141,18 +141,29 @@ export const ScriptBasedFlow: FunctionComponent<AdaptiveScriptsPropsInterface> =
             });
     }, []);
 
+    const setScriptEditorWidth = () => {
+        let width = "100%";
+
+        if (showAuthTemplatesSidePanel) {
+            width = `calc(100% - ${ authTemplatesSidePanelRef?.current?.ref?.current?.offsetWidth }px)`;
+        }
+
+        scriptEditorSectionRef.current.style.width = width;
+    };
+
     /**
      * Triggered on `showAuthenticatorsSidePanel` change.
      */
     useEffect(() => {
-        let width = "100%";
-
-        if (showAuthTemplatesSidePanel) {
-            width = `calc(100% - ${ authTemplatesSidePanelRef?.current?.ref?.current?.clientWidth }px)`;
-        }
-
-        scriptEditorSectionRef.current.style.width = width;
+        setScriptEditorWidth();
     }, [ showAuthTemplatesSidePanel ]);
+
+    /**
+     * Triggered after component mounted change.
+     */
+    useEffect(() => {
+        setScriptEditorWidth();
+    });
 
     /**
      * Triggered on steps and script change.


### PR DESCRIPTION
## Purpose
> Fix application edit -> sign-on method -> Script-based configuration script editor width. Previously the hamburger icon and scroll bar for editor was hidden

![2021-03-17_15-42](https://user-images.githubusercontent.com/25344622/111451909-f1866580-8737-11eb-95ff-19c3787031d3.png)
