### PR TITLE
Fix default props hoisting issue

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -44,7 +44,6 @@ import {
     ApplicationTemplateListItemInterface,
     CertificateInterface,
     CertificateTypeInterface,
-    emptyOIDCConfig,
     GrantTypeInterface,
     GrantTypeMetaDataInterface,
     MetadataPropertyInterface,
@@ -2497,5 +2496,23 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
  */
 InboundOIDCForm.defaultProps = {
     "data-testid": "inbound-oidc-form",
-    initialValues: emptyOIDCConfig
+    initialValues: {
+        accessToken: undefined,
+        allowedOrigins: [],
+        callbackURLs: [],
+        clientId: "",
+        clientSecret: "",
+        grantTypes: [],
+        idToken: undefined,
+        logout: undefined,
+        refreshToken: undefined,
+        pkce: {
+            mandatory: false,
+            supportPlainTransformAlgorithm: false
+        },
+        publicClient: false,
+        scopeValidators: [],
+        state: undefined,
+        validateRequestObjectSignature: undefined
+    }
 };

--- a/apps/console/src/features/applications/models/application-inbound.ts
+++ b/apps/console/src/features/applications/models/application-inbound.ts
@@ -123,26 +123,6 @@ export interface OIDCDataInterface {
     scopeValidators?: string[];
 }
 
-export const emptyOIDCConfig: OIDCDataInterface = ({
-    accessToken: undefined,
-    allowedOrigins: [],
-    callbackURLs: [],
-    clientId: "",
-    clientSecret: "",
-    grantTypes: [],
-    pkce: {
-        mandatory: false,
-        supportPlainTransformAlgorithm: false
-    },
-    publicClient: false,
-    state: undefined,
-    idToken: undefined,
-    logout: undefined,
-    refreshToken: undefined,
-    scopeValidators: [],
-    validateRequestObjectSignature: undefined,
-});
-
 /**
  * Enum for the supported auth protocol types.
  *


### PR DESCRIPTION
## Purpose
`emptyOIDCConfig` usage in default props was causing runtime issues due to hoisting issues.