### PR TITLE
Fix attribute selection mandatory checkbox state

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
@@ -118,7 +118,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
 
     useEffect(() => {
         setMandatory(initialMandatory);
-    }, [initialMandatory]);
+    }, []);
 
     useEffect(() => {
         setRequested(initialRequested);
@@ -191,6 +191,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                     trigger={
                         (
                             <Checkbox
+                                checked={ mandatory || subject }
                                 defaultChecked={ initialMandatory }
                                 onClick={ handleMandatoryCheckChange }
                                 disabled={ mappingOn ? !requested : false }
@@ -210,7 +211,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                     }
                     inverted
                     disabled={
-                        readOnly
+                        subject ? false : readOnly
                             ? true
                             : mappingOn
                                 ? !requested


### PR DESCRIPTION
## Purpose
> Fix state related issue when adding popup to the attribute selection mandatory checkbox. Previously the checkbox **checked** state was not changing when selected as mandatory via subject attribute.

## Approach
> Changed the state change related to checkbox