### PR TITLE
Make restrict imports an error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,8 +90,21 @@ module.exports = {
             {
                 paths: [
                     {
-                        message: "Please use import foo from 'lodash/foo' instead.",
+                        message: "Please use import foo from 'lodash-es/foo' instead.",
                         name: "lodash"
+                    },
+                    {
+                        message: "Avoid using chain since it is non tree-shakable. Try out flow instead.",
+                        name: "lodash-es/chain"
+                    },
+                    {
+                        importNames: [ "chain" ],
+                        message: "Avoid using chain since it is non tree-shakable. Try out flow instead.",
+                        name: "lodash-es"
+                    },
+                    {
+                        message: "Please use import foo from 'lodash-es/foo' instead.",
+                        name: "lodash-es"
                     }
                 ],
                 patterns: [ "@wso2is/**/dist/**", "lodash/**", "lodash/fp/**" ]

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,7 +94,7 @@ module.exports = {
                         name: "lodash"
                     }
                 ],
-                patterns: [ "@wso2is/**/dist/**" ]
+                patterns: [ "@wso2is/**/dist/**", "lodash/**", "lodash/fp/**" ]
             }
         ],
         "semi": 1,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,10 +86,7 @@ module.exports = {
         "no-console": "warn",
         "no-duplicate-imports": "warn",
         "no-restricted-imports": [
-            // `chain` doesn't play nice with cherry pick imports.
-            // TODO: Fix this issue and make the rule as `error`.
-            // @see {@link https://github.com/lodash/lodash/issues/3298 }
-            "warn",
+            "error",
             {
                 paths: [
                     {


### PR DESCRIPTION
## Purpose
1. Set `no-restricted-imports` to `error`.
2. Restrict `lodash/*` and `lodash/fp/*` patterns infavour of `lodash-es`.
3. Restrict the use of `chain` function.