### PR TITLE
Removed help panel toggle arrow icon temporarily

### DIFF
--- a/modules/react-components/src/components/help-panel/help-panel.tsx
+++ b/modules/react-components/src/components/help-panel/help-panel.tsx
@@ -227,34 +227,36 @@ export const HelpPanel: ForwardRefExoticComponent<PropsWithoutRef<HelpPanelCompo
                     {
                         sidebarMiniEnabled && !visible && (
                             <div className="sidebar-mini-menu">
-                                <Menu.Item
-                                    as="a"
-                                    onClick={ onSidebarToggle }
-                                    data-testid={ `${ testId }-visibility-toggle` }
-                                >
-                                    <Tooltip
-                                        compact
-                                        trigger={ (
-                                            <div>
-                                                <GenericIcon
-                                                    link
-                                                    hoverable
-                                                    defaultIcon
-                                                    transparent
-                                                    icon={ CaretLeftIcon }
-                                                    size="default"
-                                                    hoverType="circular"
-                                                    data-testid={ `${ testId }-visibility-toggle-icon` }
-                                                />
-                                            </div>
-                                        ) }
-                                        content={ sidebarToggleTooltip }
-                                        size="mini"
-                                    />
-                                </Menu.Item>
+                                {/* Commented the CaretLeftIcon temporarily as help panel contains a single tab. */}
+                                {/*<Menu.Item*/}
+                                {/*    as="a"*/}
+                                {/*    onClick={ onSidebarToggle }*/}
+                                {/*    data-testid={ `${ testId }-visibility-toggle` }*/}
+                                {/*>*/}
+                                {/*    <Tooltip*/}
+                                {/*        compact*/}
+                                {/*        trigger={ (*/}
+                                {/*            <div>*/}
+                                {/*                <GenericIcon*/}
+                                {/*                    link*/}
+                                {/*                    hoverable*/}
+                                {/*                    defaultIcon*/}
+                                {/*                    transparent*/}
+                                {/*                    icon={ CaretLeftIcon }*/}
+                                {/*                    size="default"*/}
+                                {/*                    hoverType="circular"*/}
+                                {/*                    data-testid={ `${ testId }-visibility-toggle-icon` }*/}
+                                {/*                />*/}
+                                {/*            </div>*/}
+                                {/*        ) }*/}
+                                {/*        content={ sidebarToggleTooltip }*/}
+                                {/*        size="mini"*/}
+                                {/*    />*/}
+                                {/*</Menu.Item>*/}
                                 {
                                     tabPanes && tabPanes instanceof Array && tabPanes.length > 0 && (
                                         tabPanes.map((pane, index) => (
+                                            // <></>
                                             <Menu.Item
                                                 as="a"
                                                 key={ index }

--- a/modules/react-components/src/components/help-panel/help-panel.tsx
+++ b/modules/react-components/src/components/help-panel/help-panel.tsx
@@ -227,36 +227,38 @@ export const HelpPanel: ForwardRefExoticComponent<PropsWithoutRef<HelpPanelCompo
                     {
                         sidebarMiniEnabled && !visible && (
                             <div className="sidebar-mini-menu">
-                                {/* Commented the CaretLeftIcon temporarily as help panel contains a single tab. */}
-                                {/*<Menu.Item*/}
-                                {/*    as="a"*/}
-                                {/*    onClick={ onSidebarToggle }*/}
-                                {/*    data-testid={ `${ testId }-visibility-toggle` }*/}
-                                {/*>*/}
-                                {/*    <Tooltip*/}
-                                {/*        compact*/}
-                                {/*        trigger={ (*/}
-                                {/*            <div>*/}
-                                {/*                <GenericIcon*/}
-                                {/*                    link*/}
-                                {/*                    hoverable*/}
-                                {/*                    defaultIcon*/}
-                                {/*                    transparent*/}
-                                {/*                    icon={ CaretLeftIcon }*/}
-                                {/*                    size="default"*/}
-                                {/*                    hoverType="circular"*/}
-                                {/*                    data-testid={ `${ testId }-visibility-toggle-icon` }*/}
-                                {/*                />*/}
-                                {/*            </div>*/}
-                                {/*        ) }*/}
-                                {/*        content={ sidebarToggleTooltip }*/}
-                                {/*        size="mini"*/}
-                                {/*    />*/}
-                                {/*</Menu.Item>*/}
+                                {
+                                    tabPanes && tabPanes instanceof Array && tabPanes.length > 1 && (
+                                        <Menu.Item
+                                            as="a"
+                                            onClick={ onSidebarToggle }
+                                            data-testid={ `${ testId }-visibility-toggle` }
+                                        >
+                                            <Tooltip
+                                                compact
+                                                trigger={ (
+                                                    <div>
+                                                        <GenericIcon
+                                                            link
+                                                            hoverable
+                                                            defaultIcon
+                                                            transparent
+                                                            icon={ CaretLeftIcon }
+                                                            size="default"
+                                                            hoverType="circular"
+                                                            data-testid={ `${ testId }-visibility-toggle-icon` }
+                                                        />
+                                                    </div>
+                                                ) }
+                                                content={ sidebarToggleTooltip }
+                                                size="mini"
+                                            />
+                                        </Menu.Item>
+                                    )
+                                }
                                 {
                                     tabPanes && tabPanes instanceof Array && tabPanes.length > 0 && (
                                         tabPanes.map((pane, index) => (
-                                            // <></>
                                             <Menu.Item
                                                 as="a"
                                                 key={ index }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/wso2-enterprise/asgardeo-product/issues/2729
As the help panel contains a single tab, appearance of the help panel toggle arrow icon along with the tab icon which also toggles the help panel causes confusion.

## Approach 
![Screenshot from 2021-03-23 15-22-44](https://user-images.githubusercontent.com/10112625/112127942-f04bb180-8beb-11eb-8b2e-809bebed245f.png)
