### PR TITLE
Update oidc discovery ep to conform with the spec

### DIFF
--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -139,7 +139,7 @@ export class Config {
             // TODO: Remove this endpoint and use ID token to get the details
             me: `${this.getDeploymentConfig().serverHost}/scim2/Me`,
             saml2Meta: `${this.getDeploymentConfig().serverHost}/identity/metadata/saml2`,
-            wellKnown: `${this.getDeploymentConfig().serverHost}/oauth2/oidcdiscovery/.well-known/openid-configuration`
+            wellKnown: `${this.getDeploymentConfig().serverHost}/oauth2/token/.well-known/openid-configuration`
         };
     }
 


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/11484

The OIDC Discovery spec states the discovery url should be in the following format

```
issuer/.well-known/openid-configuration
```

Since the IS issuer is `https://localhost:9443/t/tenant/oauth2/token`, the discovery URL should be,
```
https://localhost:9443/t/tenant/oauth2/token/.well-known/openid-configuration
```

Ref:
https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest