### PR TITLE
Enlarge clickable area for list action icons

### DIFF
--- a/modules/react-components/src/components/table/data-table/data-table.tsx
+++ b/modules/react-components/src/components/table/data-table/data-table.tsx
@@ -529,7 +529,7 @@ export const DataTable = <T extends object = {}>(
                     trigger={ (
                         <Icon
                             link={ actionLink && actionLink(item) }
-                            className="list-icon"
+                            className="list-icon data-table-list-icon"
                             disabled={ actionDisabled }
                             size="small"
                             color="grey"

--- a/modules/theme/src/themes/default/elements/icon.overrides
+++ b/modules/theme/src/themes/default/elements/icon.overrides
@@ -25,6 +25,16 @@ i.icon {
     &.list-icon {
         font-size: 1em;
         margin-right: 8px;
+
+        &.data-table-list-icon {
+            min-width: @dataTableListIconMinWidth;
+            min-height: @dataTableListIconMinHeight;
+            padding-top: @dataTableListIconTopPadding;
+
+            &:hover {
+                background: rgba(0,0,0,.1);
+            }
+        }
     }
 
     &.bordered {

--- a/modules/theme/src/themes/default/elements/icon.variables
+++ b/modules/theme/src/themes/default/elements/icon.variables
@@ -1,3 +1,7 @@
 /*******************************
         Icon Variables
 *******************************/
+
+@dataTableListIconMinHeight: 2em;
+@dataTableListIconMinWidth: 2em;
+@dataTableListIconTopPadding: 0.5em;


### PR DESCRIPTION
## Purpose
> Increase clickable area of action icons in lists. Previously the clickable area was too small

![Peek 2021-03-24 11-46](https://user-images.githubusercontent.com/25344622/112264276-a7046c00-8c96-11eb-8262-a72c62743996.gif)