### PR TITLE
Prevent Group/Role creation without the required scopes and add deployment config to handle multiple scopes

### DIFF
--- a/apps/console/src/features/groups/components/group-list.tsx
+++ b/apps/console/src/features/groups/components/group-list.tsx
@@ -132,18 +132,6 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
     const [ currentDeletedGroup, setCurrentDeletedGroup ] = useState<GroupsInterface>();
 
     const handleGroupEdit = (group: GroupsInterface) => {
-        const userStore = group?.displayName?.split("/").length > 1
-            ? group?.displayName?.split("/")[ 0 ]
-            : "PRIMARY";
-
-        if (!isFeatureEnabled(featureConfig?.groups,
-            GroupConstants.FEATURE_DICTIONARY.get("GROUP_UPDATE"))
-            || readOnlyUserStores?.includes(userStore.toString())
-            || !hasRequiredScopes(featureConfig?.groups,
-                featureConfig?.groups?.scopes?.update, allowedScopes)) {
-            return;
-        }
-
         history.push(AppConstants.getPaths().get("GROUP_EDIT").replace(":id", group?.id));
     };
 

--- a/apps/console/src/features/groups/pages/groups.tsx
+++ b/apps/console/src/features/groups/pages/groups.tsx
@@ -17,6 +17,7 @@
  */
 
 import { getUserStoreList } from "@wso2is/core/api";
+import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertInterface, AlertLevels, RolesInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import {
@@ -74,6 +75,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     const { t } = useTranslation();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
 
     const [ listItemLimit, setListItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);
     const [ listOffset, setListOffset ] = useState<number>(0);
@@ -350,6 +352,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
         <PageLayout
             action={
                 (isGroupsListRequestLoading || !(!searchQuery && paginatedGroups?.length <= 0))
+                && hasRequiredScopes(featureConfig?.groups, featureConfig?.groups?.scopes?.create, allowedScopes)
                 && (
                     <PrimaryButton
                         data-testid="group-mgt-groups-list-add-button"

--- a/apps/console/src/features/roles/pages/role.tsx
+++ b/apps/console/src/features/roles/pages/role.tsx
@@ -17,15 +17,16 @@
  */
 
 import { getRolesList, getUserStoreList } from "@wso2is/core/api";
+import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertInterface, AlertLevels, RoleListInterface, RolesInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ListLayout, PageLayout, PrimaryButton } from "@wso2is/react-components";
 import find from "lodash-es/find";
 import React, { ReactElement, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Dropdown, DropdownItemProps, DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
-import { AdvancedSearchWithBasicFilters, UIConstants } from "../../core";
+import { AdvancedSearchWithBasicFilters, AppState, FeatureConfigInterface, UIConstants } from "../../core";
 import { CreateRoleWizard, RoleList } from "../../roles";
 import { deleteRoleById, searchRoleList } from "../api";
 import { APPLICATION_DOMAIN, INTERNAL_DOMAIN } from "../constants";
@@ -94,6 +95,9 @@ const RolesPage = (): ReactElement => {
     const [ paginatedRoles, setPaginatedRoles ] = useState<RoleListInterface>();
 
     const [ listSortingStrategy, setListSortingStrategy ] = useState<DropdownItemProps>(ROLES_SORTING_OPTIONS[ 0 ]);
+
+    const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
+    const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
     useEffect(() => {
         if (searchQuery == "") {
@@ -319,6 +323,7 @@ const RolesPage = (): ReactElement => {
         <PageLayout
             action={
                 (isRoleListFetchRequestLoading || !(!searchQuery && paginatedRoles?.Resources?.length <= 0))
+                && hasRequiredScopes(featureConfig?.roles, featureConfig?.roles?.scopes?.create, allowedScopes)
                 && (
                     <PrimaryButton
                         data-testid="role-mgt-roles-list-add-button"

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -458,7 +458,9 @@
                     {% endfor %}
                     {% endif %}
                 ],
-                "enabled": {{ console.manage_getting_started.enabled }},
+                "enabled":{% if console.manage_getting_started.scopes is defined %} {{ console.manage_getting_started.enabled }},
+                    {% else %} true,
+                    {% endif %}
                 "scopes": {
                     {% if console.manage_getting_started.scopes is defined %}
                     {% for operation, scopes in console.manage_getting_startedscopes.items() %}

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -162,6 +162,19 @@
                         "update": [],
                         "delete": []
                     {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.applications.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.applications.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
+                    {% endif %}
                 }
             },
             "approvals": {
@@ -187,6 +200,19 @@
                         "read": [],
                         "update": [],
                         "delete": []
+                    {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.approvals.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.approvals.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
                     {% endif %}
                 }
             },
@@ -214,6 +240,19 @@
                         "update": [],
                         "delete": []
                     {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.attribute_dialects.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.attribute_dialects.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
+                    {% endif %}
                 }
             },
             "certificates": {
@@ -239,6 +278,19 @@
                         "read": [],
                         "update": [],
                         "delete": []
+                    {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.certificates.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.certificates.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
                     {% endif %}
                 }
             },
@@ -266,6 +318,19 @@
                         "update": [],
                         "delete": []
                     {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.email_templates.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.email_templates.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
+                    {% endif %}
                 }
             },
             "generalConfigurations": {
@@ -291,6 +356,19 @@
                         "read": [],
                         "update": [],
                         "delete": []
+                    {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.general_configurations.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.general_configurations.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
                     {% endif %}
                 }
             },
@@ -318,6 +396,19 @@
                         "update": [],
                         "delete": []
                     {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.groups.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.groups.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
+                    {% endif %}
                 }
             },
             "identityProviders": {
@@ -343,6 +434,58 @@
                         "read": [],
                         "update": [],
                         "delete": []
+                    {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.identity_providers.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.identity_providers.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
+                    {% endif %}
+                }
+            },
+            "manageGettingStarted": {
+                "disabledFeatures": [
+                    {% if console.manage_getting_started.disabled_features is defined %}
+                    {% for feature in console.manage_getting_started.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {{ console.manage_getting_started.enabled }},
+                "scopes": {
+                    {% if console.manage_getting_started.scopes is defined %}
+                    {% for operation, scopes in console.manage_getting_startedscopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "read": [],
+                        "update": [],
+                        "delete": []
+                    {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.manage_getting_started.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.manage_getting_started.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
                     {% endif %}
                 }
             },
@@ -370,6 +513,19 @@
                         "update": [],
                         "delete": []
                     {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.oidc_scopes.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.oidc_scopes.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
+                    {% endif %}
                 }
             },
             "remoteFetchConfig": {
@@ -395,6 +551,19 @@
                         "read": [],
                         "update": [],
                         "delete": []
+                    {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.remote_fetch.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.remote_fetch.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
                     {% endif %}
                 }
             },
@@ -422,6 +591,19 @@
                         "update": [],
                         "delete": []
                     {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.roles.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.roles.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
+                    {% endif %}
                 }
             },
             "users": {
@@ -448,6 +630,19 @@
                         "update": [],
                         "delete": []
                     {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.users.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.users.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
+                    {% endif %}
                 }
             },
             "userStores": {
@@ -473,6 +668,19 @@
                         "read": [],
                         "update": [],
                         "delete": []
+                    {% endif %}
+                },
+                "shouldHaveAllScopes": {
+                    {% if console.user_stores.shouldHaveAllScopes is defined %}
+                    {% for operation, flag in console.user_stores.shouldHaveAllScopes.items() %}
+                    "{{ operation }}": "{{ flag }}"
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": true,
+                        "read": true,
+                        "update": true,
+                        "delete": true
                     {% endif %}
                 }
             }
@@ -549,7 +757,7 @@
                 {% for value in console.system_apps_identifiers %}
                 "{{ value }}"{{ "," if not loop.last }}
                 {% endfor %}
-            {% endif %} 
+            {% endif %}
         ],
         "theme": {
             "name": "{{ console.theme }}"

--- a/modules/core/src/helpers/access-control.ts
+++ b/modules/core/src/helpers/access-control.ts
@@ -58,7 +58,10 @@ export const isFeatureEnabled = (feature: FeatureAccessConfigInterface, key: str
  * @return {boolean} True is scopes are enough and false if not.
  */
 export const hasRequiredScopes = (
-    feature: FeatureAccessConfigInterface, scopes: string[], allowedScopes: string
+    feature: FeatureAccessConfigInterface,
+    scopes: string[],
+    allowedScopes: string,
+    shouldAllScopesBePresent: boolean = true
 ): boolean => {
     const isDefined = feature?.scopes && !isEmpty(feature.scopes) && scopes && !isEmpty(scopes);
 
@@ -67,7 +70,17 @@ export const hasRequiredScopes = (
     }
 
     if (scopes instanceof Array) {
-        return scopes.every((scope) => AuthenticateUtils.hasScope(scope, allowedScopes));
+        if (shouldAllScopesBePresent) {
+            return scopes.every((scope) => AuthenticateUtils.hasScope(scope, allowedScopes));
+        } else {
+            for (const scope of scopes) {
+                if (AuthenticateUtils.hasScope(scope, allowedScopes)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     return true;
@@ -135,6 +148,10 @@ export const hasRequiredScopesForAdminView = (featureConfig: any, allowedScopes:
             }
 
             isAllowed = hasRequiredManageScopes(feature, feature.scopes?.read, allowedScopes);
+        }
+
+        if (isAllowed) {
+            break;
         }
     }
 

--- a/modules/core/src/models/config.ts
+++ b/modules/core/src/models/config.ts
@@ -218,7 +218,7 @@ export interface AppThemeConfigInterface {
      */
     name: string;
     /**
-     * App theme path. Used to override the default theme path defined in the source. 
+     * App theme path. Used to override the default theme path defined in the source.
      * ex: "https://cdn.wso2.com/is/assets/theme.min.css".
      */
     path?: string;
@@ -315,6 +315,29 @@ export interface FeatureAccessConfigInterface {
      * Enable the feature.
      */
     enabled?: boolean;
+    /**
+     * Determines if all the scopes should be allowed or just one of them.
+     */
+    shouldHaveAllScopes?: ShouldHaveAllScopesInterface;
+}
+
+export interface ShouldHaveAllScopesInterface {
+    /**
+     * Determines if all the create scopes should be allowed.
+     */
+    create?: boolean;
+    /**
+     * Determines if all the read scopes should be allowed.
+     */
+    read?: boolean;
+    /**
+     * Determines if all the update scopes should be allowed.
+     */
+    update?: boolean;
+    /**
+     * Determines if all the delete scopes should be allowed.
+     */
+    delete?: boolean;
 }
 
 /**

--- a/modules/core/src/utils/route-utils.ts
+++ b/modules/core/src/utils/route-utils.ts
@@ -46,7 +46,7 @@ export class RouteUtils {
      */
     public static filterEnabledRoutes<T>(routes: RouteInterface[],
                                          featureConfig: T,
-                                         allowedScopes: string): RouteInterface[] { 
+                                         allowedScopes: string): RouteInterface[] {
 
         // Filters features based on scope requirements.
         const filter = (routeArr: RouteInterface[] | ChildRouteInterface[], allowedScopes: string) => {
@@ -69,7 +69,8 @@ export class RouteUtils {
                     return true;
                 }
 
-                return hasRequiredScopes(feature, feature?.scopes?.read, allowedScopes);
+                return hasRequiredScopes(feature, feature?.scopes?.read, allowedScopes,
+                    feature?.shouldHaveAllScopes?.read);
             });
         };
 

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -554,8 +554,8 @@ export const console: ConsoleNS = {
                     addSocialLogin: {
                         content : "To add a new social login, we will need to route you to a different page and " +
                             "any unsaved changes in this page will be lost. Please confirm.",
-                        header: "Are you sure?",
-                        subHeader: "This action is irreversible."
+                        header: "Do you want to continue?",
+                        subHeader: "You will lose any unsaved changes."
                     },
                     clientSecretHashDisclaimer: {
                         forms: {


### PR DESCRIPTION
## Purpose
>  Prevent Group/Role creation without the required scopes.
> Add `shouldHaveAllScopes` attribute to deployment config to set if all the scopes should be present or not.
> Example:
```json
"some-feature": {
      "enabled": true,
      "disabledFeatures": [],
      "scopes":{
            "read": [
                  "internal_role_mgt_create",
                  "internal_user_mgt_create"
             ]
       },
       "shouldHaveAllScopes":{
             "read": false
       }
},
```