### PR TITLE
Handle SP&IdP role mapping

### DIFF
--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -167,6 +167,7 @@ export class Config {
             isDefaultDialectEditingEnabled: window["AppUtils"].getConfig().ui.isDefaultDialectEditingEnabled,
             isDialectAddingEnabled: window["AppUtils"].getConfig().ui.isDialectAddingEnabled,
             isGroupAndRoleSeparationEnabled: window["AppUtils"].getConfig().ui.isGroupAndRoleSeparationEnabled,
+            isGroupAndRoleSeparationImprovementsEnabled: window["AppUtils"].getConfig().ui.isGroupAndRoleSeparationImprovementsEnabled,
             isLeftNavigationCategorized: window["AppUtils"].getConfig().ui.isLeftNavigationCategorized,
             isRequestPathAuthenticationEnabled: window["AppUtils"].getConfig().ui.isRequestPathAuthenticationEnabled,
             isSignatureValidationCertificateAliasEnabled: window["AppUtils"].getConfig().ui

--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -178,6 +178,10 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      */
     isGroupAndRoleSeparationEnabled?: boolean;
     /**
+     * Enable roles and groups separation improvements.
+     */
+    isGroupAndRoleSeparationImprovementsEnabled?: boolean;
+    /**
      * Is Request path section enabled in applications.
      */
     isRequestPathAuthenticationEnabled?: boolean;

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -313,6 +313,7 @@
             "showLanguageSwitcher": false
         },
         "isGroupAndRoleSeparationEnabled": true,
+        "isGroupAndRoleSeparationImprovementsEnabled": true,
         "isSignatureValidationCertificateAliasEnabled" : false,
         "isClientSecretHashEnabled": false,
         "isDefaultDialectEditingEnabled": false,

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -515,6 +515,7 @@
         "isDialectAddingEnabled": {{ console.ui.is_dialect_adding_enabled }},
         {% endif %}
         "isGroupAndRoleSeparationEnabled": {{ authorization_manager.properties.GroupAndRoleSeparationEnabled }},
+        "isGroupAndRoleSeparationImprovementsEnabled": {{ authorization_manager.properties.isGroupAndRoleSeparationImprovementsEnabled }},
         {% if console.ui.is_request_path_authentication_enabled is defined %}
         "isRequestPathAuthenticationEnabled": {{ console.ui.is_request_path_authentication_enabled }},
         {% endif %}


### PR DESCRIPTION
Fixes wso2/product-is#11330.

If group role separation config is enabled,

- List roles in the IdP role mapping section.
- Append the `Internal` prefix to the plain role name when submitting the role mapping.