### PR TITLE
Fix responive issues in application protocol page.

### DIFF
--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -463,7 +463,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         }
 
         return (
-            <EmphasizedSegment className="protocol-settings-section" padded="very">
+            <EmphasizedSegment className="protocol-settings-section form-wrapper with-max-height" padded="very">
                 {
                     Object.values(SupportedAuthProtocolTypes).includes(selectedProtocol as SupportedAuthProtocolTypes)
                         ? (

--- a/modules/theme/src/theme-core/definitions/apps/developer-portal.less
+++ b/modules/theme/src/theme-core/definitions/apps/developer-portal.less
@@ -731,3 +731,21 @@
         }
     }
 }
+
+/*-------------------------------
+      Form Container Styles
+--------------------------------*/
+.form-wrapper {
+    &.with-max-height {
+        max-height: @formWrapperMaxHeight;
+        overflow: auto;
+    }
+}
+.form-container {
+    &.with-max-width {
+        max-width: @formContainerMaxWidth;
+    }
+    &.subject-attribute-selection {
+        max-width: @applicationSubjectSelectWidth;
+    }
+}

--- a/modules/theme/src/themes/default/apps/developer-portal.variables
+++ b/modules/theme/src/themes/default/apps/developer-portal.variables
@@ -68,3 +68,11 @@
 --------------------------------*/
 
 @idpTemplateGridPaddingTop: 1.5em;
+
+/*----------------------------------
+          Form Container
+------------------------------------*/
+
+@formContainerMaxWidth: 750px;
+@formWrapperMaxHeight: 55vh;
+@applicationSubjectSelectWidth: 820px;

--- a/modules/theme/src/themes/default/collections/grid.overrides
+++ b/modules/theme/src/themes/default/collections/grid.overrides
@@ -365,15 +365,3 @@
         }
     }
 }
-
-/*----------------------------------
-          Form Grids
-------------------------------------*/
-
-.ui.grid {
-    &.form-container {
-        &.with-max-width {
-            max-width: @formGridContainerMaxWidth;
-        }
-    }
-}


### PR DESCRIPTION
## Purpose

This fixes the issue where scrolling to the bottom of the Protocol section makes a large empty area in the side panel. 
For longer pages, this would define a max height to the form wrapper and overflow.

![Peek 2021-04-09 23-20](https://user-images.githubusercontent.com/25428696/114221591-2084a580-998b-11eb-9220-c426ff996b32.gif)


