### PR TITLE
Fix attribute selection hitting an error boundary.

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
@@ -490,7 +490,7 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                             "removeApplicationUserAttribute.content" }
                     >
                         If you remove this, the subject attribute will be set to
-                        the <strong>{ { default: defaultSubjectClaim.displayName } }</strong>
+                        the <strong>{ { default: defaultSubjectClaim?.displayName } }</strong>
                     </Trans>
                 </ConfirmationModal.Content>
             </ConfirmationModal>


### PR DESCRIPTION
## Purpose
Attribute selection tab hits an error boundary intermittently.

<img width="1912" alt="Screen Shot 2021-04-12 at 12 35 02 PM" src="https://user-images.githubusercontent.com/25959096/114359449-9e1a0280-9b91-11eb-90e1-dafa720afe37.png">

<img width="695" alt="Screen Shot 2021-04-12 at 12 35 30 PM" src="https://user-images.githubusercontent.com/25959096/114359475-a5411080-9b91-11eb-9b67-42e4720da58c.png">
