### PR TITLE
Fix help panel pin/unpin issue

### DIFF
--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -892,7 +892,8 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             isPinned={ HelpPanelUtils.isPanelPinned() }
             icons={ {
                 close: getHelpPanelActionIcons().close,
-                pin: getHelpPanelActionIcons().pin
+                pin: getHelpPanelActionIcons().pin,
+                unpin: getHelpPanelActionIcons().unpin
             } }
             sidebarToggleTooltip={ t("console:develop.features.helpPanel.actions.open") }
             pinButtonTooltip={ t("console:develop.features.helpPanel.actions.pin") }

--- a/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
@@ -341,7 +341,8 @@ const IdentityProviderEditPage: FunctionComponent<IDPEditPagePropsInterface> = (
             isPinned={ HelpPanelUtils.isPanelPinned() }
             icons={ {
                 close: getHelpPanelActionIcons().close,
-                pin: getHelpPanelActionIcons().pin
+                pin: getHelpPanelActionIcons().pin,
+                unpin: getHelpPanelActionIcons().unpin
             } }
             sidebarToggleTooltip={ t("console:develop.features.helpPanel.actions.open") }
             pinButtonTooltip={ t("console:develop.features.helpPanel.actions.pin") }

--- a/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
@@ -455,7 +455,8 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
             isPinned={ HelpPanelUtils.isPanelPinned() }
             icons={ {
                 close: getHelpPanelActionIcons().close,
-                pin: getHelpPanelActionIcons().pin
+                pin: getHelpPanelActionIcons().pin,
+                unpin: getHelpPanelActionIcons().unpin
             } }
             sidebarToggleTooltip={ t("console:develop.features.helpPanel.actions.open") }
             pinButtonTooltip={ t("console:develop.features.helpPanel.actions.pin") }


### PR DESCRIPTION
## Purpose
Fix help panel's unpin icon being missing in some pages.
![helpPin](https://user-images.githubusercontent.com/25479743/115646512-e7134900-a33f-11eb-974b-5df5c43cd8b8.gif)

With this, the issue mentioned in https://github.com/wso2-enterprise/asgardeo-product/issues/3161 is no longer reproducible.