### PR TITLE
Fix application help panel appearing and then disappearing when an application is newly created

### DIFF
--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -440,7 +440,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
      * TODO: IMPORTANT - Refactor this code.
      */
     useEffect(() => {
-        if (isExtensionsAvailable == undefined) {
+        if (isExtensionsAvailable === undefined) {
             return;
         }
 

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -133,7 +133,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
         setApplicationTemplateRequestLoadingStatus
     ] = useState<boolean>(false);
     const [ tabsActiveIndex, setTabsActiveIndex ] = useState<number>(0);
-    const [ isExtensionsAvailable, setIsExtensionsAvailable ] = useState<boolean>(false);
+    const [ isExtensionsAvailable, setIsExtensionsAvailable ] = useState<boolean>(undefined);
     const [ defaultActiveIndex, setDefaultActiveIndex ] = useState<number>(0);
     const [ inboundProtocolList, setInboundProtocolList ] = useState<string[]>(undefined);
     const [ inboundProtocolConfigs, setInboundProtocolConfigs ] = useState<object>(undefined);
@@ -440,6 +440,10 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
      * TODO: IMPORTANT - Refactor this code.
      */
     useEffect(() => {
+        if (isExtensionsAvailable == undefined) {
+            return;
+        }
+
         if (!urlSearchParams.get(ApplicationManagementConstants.APP_STATE_URL_SEARCH_PARAM_KEY)) {
             if (isExtensionsAvailable) {
                 setDefaultActiveIndex(1);


### PR DESCRIPTION
## Purpose
This fixes the help panel from being appeared right after an application is created from the Console, and then being disappeared. 