### PR TITLE
Update pr-builder.yml

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-        maven-version: [3.5.2]
+        maven-version: [3.6.x]
 
     steps:
     - name: Checkout

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -31,6 +31,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4
+      id: mvn-setup
+      with:
         maven-version: ${{ matrix.maven-version }}
     - name: Get npm cache directory
       id: cache-npm-modules

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-        maven-version: [3.6.x]
+        maven-version: [3.6.3]
 
     steps:
     - name: Checkout

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
+        maven-version: [3.5.2]
 
     steps:
     - name: Checkout
@@ -30,6 +31,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+        maven-version: ${{ matrix.maven-version }}
     - name: Get npm cache directory
       id: cache-npm-modules
       uses: actions/cache@v2


### PR DESCRIPTION
### Purpose
Maven version has been updated in Github action's ubuntu container(3.8.1) and this version blocks http links in the POM.

```bash
Error:  Failed to execute goal on project authentication-portal: Could not resolve dependencies for project org.wso2.identity.apps:authentication-portal:war:1.2.179-SNAPSHOT: Failed to collect dependencies at commons-io.wso2:commons-io:jar:2.4.0.wso2v1: Failed to read artifact descriptor for commons-io.wso2:commons-io:jar:2.4.0.wso2v1: Could not transfer artifact commons-io.wso2:commons-io:pom:2.4.0.wso2v1 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [wso2-nexus (http://maven.wso2.org/nexus/content/groups/wso2-public/, default, releases+snapshots), wso2.releases (http://maven.wso2.org/nexus/content/repositories/releases/, default, releases+snapshots), wso2.snapshots (http://maven.wso2.org/nexus/content/repositories/snapshots/, default, snapshots)] -> [Help 1]
```

### Related Issues
- Issue #1

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
- Related PR #1

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
