### PR TITLE
Disable enable authorization checkbox from applications

### DIFF
--- a/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
+++ b/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
@@ -144,6 +144,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 value={ config?.enableAuthorization ? ["enableAuthorization"] : [] }
                 readOnly={ readOnly }
                 data-testid={ `${testId}-enable-authorization-checkbox` }
+                hidden={ !applicationConfig.advancedConfigurations.showEnableAuthorization }
                 hint={ t("console:develop.features.applications.forms.advancedConfig.fields.enableAuthorization.hint") }
             />
             <Field.Button


### PR DESCRIPTION
### Purpose
> Added the missing hidden prop for Advanced Configuration Form `Field.Checkbox` element. Since it is already disabled from the application configuration. Resolves https://github.com/wso2-enterprise/asgardeo-product/issues/3534

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/3534

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
(None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
