### PR TITLE
Add support to host authentication portal and recovery portal in different sub-domain

### DIFF
--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -76,6 +76,7 @@
                         $.ajax({
                             type: "GET",
                             url: "<%=loginContextRequestUrl%>",
+                            xhrFields: { withCredentials: true },
                             success: function (data) {
                                 if (data && data.status == 'redirect' && data.redirectUrl && data.redirectUrl.length > 0) {
                                     window.location.href = data.redirectUrl;

--- a/apps/authentication-portal/src/main/webapp/fido2-uaf.jsp
+++ b/apps/authentication-portal/src/main/webapp/fido2-uaf.jsp
@@ -132,6 +132,7 @@
                     url: "/api/users/v1/me/webauthn/start-authentication?username=admin&" +
                         "tenantDomain=carbon.super&storeDomain=PRIMARY&appId=https://localhost:9443&" +
                         "sessionDataKey="+getParameterByName("sessionDataKey"),
+                    xhrFields: { withCredentials: true },
                     success: function (data) {
                         if (data) {
                             console.log(data);

--- a/apps/authentication-portal/src/main/webapp/identifierauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/identifierauth.jsp
@@ -66,6 +66,7 @@
             $.ajax({
                 type: "GET",
                 url: "<%=loginContextRequestUrl%>",
+                xhrFields: { withCredentials: true },
                 success: function (data) {
                     if (data && data.status === "redirect" && data.redirectUrl && data.redirectUrl.length > 0) {
                         window.location.href = data.redirectUrl;

--- a/apps/authentication-portal/src/main/webapp/js/scripts.js
+++ b/apps/authentication-portal/src/main/webapp/js/scripts.js
@@ -47,6 +47,7 @@ function requestTOTPToken() {
 		url: endpointURL,
 		type: "GET",
 		data: "&sessionDataKey=" + document.getElementById("sessionDataKey").value + "&sendToken=true",
+		xhrFields: { withCredentials: true },
 		success: function(response) {
 			if (response == "") {
 				alert("Verification is code sent to your email address");

--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -423,6 +423,7 @@
             $.ajax({
                 type: "GET",
                 url: "<%=loginContextRequestUrl%>",
+                xhrFields: { withCredentials: true },
                 success: function (data) {
                     if (data && data.status == 'redirect' && data.redirectUrl && data.redirectUrl.length > 0) {
                         window.location.href = data.redirectUrl;

--- a/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -52,10 +52,12 @@
     <!-- *************** End of Global configurations ********************** -->
 
     <!-- *************** Account Recovery Endpoint Context URL Configuration ********************** -->
-    <!--context-param>
+    {% if authenticationendpoint.account_recovery_endpoint_url is defined %}
+    <context-param>
        <param-name>IdentityManagementEndpointContextURL</param-name>
-       <param-value>https://localhost:9443/accountrecoveryendpoint</param-value>
-   </context-param-->
+       <param-value>{{ authenticationendpoint.account_recovery_endpoint_url }}</param-value>
+   </context-param>
+   {% endif %}
     <context-param>
        <param-name>AccountRecoveryRESTEndpointURL</param-name>
        <param-value>/t/tenant-domain/api/identity/user/v1.0/</param-value>
@@ -78,10 +80,12 @@
 
     <!-- *************** End of Account Recovery Endpoint Context URL Configuration ********************** -->
     <!-- *************** Identity Server Endpoint URL Configuration ********************** -->
-    <!--context-param>
+    {% if authenticationendpoint.identity_server_endpoint_url is defined %}
+    <context-param>
         <param-name>IdentityServerEndpointContextURL</param-name>
-        <param-value>https://localhost:9443</param-value>
-    </context-param-->
+        <param-value>{{ authenticationendpoint.identity_server_endpoint_url }}</param-value>
+    </context-param>
+    {% endif %}
     <!-- *************** End of Identity Server Endpoint URL Configuration ********************** -->
     <!--context-param>
         <param-name>EnableAuthenticationWithAuthenticationRESTAPI</param-name>
@@ -150,7 +154,7 @@
     </filter-mapping>
 
     <filter>
-        <filter-name>ContentTypeBasedCachePreventionFilter</filter-name>    
+        <filter-name>ContentTypeBasedCachePreventionFilter</filter-name>
         <filter-class>
            org.wso2.carbon.ui.filters.cache.ContentTypeBasedCachePreventionFilter
         </filter-class>


### PR DESCRIPTION
### Purpose
> Following property needs to be enabled to support cross-domain ajax requests when authentication-portal is hosted in a different domain.
> The XMLHttpRequest.withCredentials property is a Boolean that indicates whether or not cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates. Setting withCredentials has no effect on same-site requests.
> https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials