### PR TITLE
Change cookie banner Z-index

### DIFF
--- a/modules/theme/src/themes/default/elements/segment.overrides
+++ b/modules/theme/src/themes/default/elements/segment.overrides
@@ -645,7 +645,7 @@
         color: @cookieConsentBannerColor;
         padding: @cookieConsentBannerPadding;
         border: @cookieConsentBannerBorder;
-        z-index: 999;
+        z-index: @cookieConsentBannerZIndex;
         
         &.aligned {
             &-left {

--- a/modules/theme/src/themes/default/elements/segment.variables
+++ b/modules/theme/src/themes/default/elements/segment.variables
@@ -123,6 +123,7 @@
 @cookieConsentBannerContentMargin: 0 0 1em 0;
 @cookieConsentBannerBorder: none;
 @cookieConsentBannerIconColor: @darkGray;
+@cookieConsentBannerZIndex: 9999;
 
 // Light Mode
 @cookieConsentBannerColor: inherit;


### PR DESCRIPTION
### Purpose
Change the `z-index` of cookie banner to avoid overlapping with other emphasized elements.

### Related Issues
- None

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
