### PR TITLE
Bump identity-oidc-js SDK version

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -227,6 +227,7 @@ export const initializeAuthentication = () => (dispatch) => {
                 ?? responseModeFallback,
             scope: window["AppUtils"].getConfig().idpConfigs?.scope
                 ?? [ TokenConstants.SYSTEM_SCOPE ],
+            sendCookiesInRequests: true,
             serverOrigin: window["AppUtils"].getConfig().idpConfigs?.serverOrigin
                 ?? window["AppUtils"].getConfig().idpConfigs.serverOrigin,
             sessionState: response?.data?.sessionState,

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -324,6 +324,7 @@ export const initializeAuthentication = () =>(dispatch)=> {
                 ?? responseModeFallback,
             scope: window["AppUtils"].getConfig().idpConfigs?.scope
                 ?? [ TokenConstants.SYSTEM_SCOPE ],
+            sendCookiesInRequests: true,
             serverOrigin: window["AppUtils"].getConfig().idpConfigs?.serverOrigin
                 ?? window["AppUtils"].getConfig().idpConfigs.serverOrigin,
             sessionState: response?.data?.sessionState,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@types/react-redux": "^7.1.1",
         "@types/react-router-dom": "^5.1.3",
         "@types/ua-parser-js": "^0.7.33",
-        "@wso2/identity-oidc-js": "^0.1.2",
+        "@wso2/identity-oidc-js": "^0.1.3",
         "await-semaphore": "^0.1.3",
         "axios": "^0.21.1",
         "babel-jest": "^26.3.0",


### PR DESCRIPTION
### Purpose
Bump identity-oidc-js SDK version to 0.1.3 and set `sendCookiesInRequests` to true to enable sending cookie headers with the internal requests sent from the SDK.

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/3540

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
- https://github.com/asgardeo/asgardeo-auth-js-sdk/pull/131

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
