### PR TITLE
Downgrade the SDK version back to version 0.1.2

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -227,7 +227,6 @@ export const initializeAuthentication = () => (dispatch) => {
                 ?? responseModeFallback,
             scope: window["AppUtils"].getConfig().idpConfigs?.scope
                 ?? [ TokenConstants.SYSTEM_SCOPE ],
-            sendCookiesInRequests: true,
             serverOrigin: window["AppUtils"].getConfig().idpConfigs?.serverOrigin
                 ?? window["AppUtils"].getConfig().idpConfigs.serverOrigin,
             sessionState: response?.data?.sessionState,

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -324,7 +324,6 @@ export const initializeAuthentication = () =>(dispatch)=> {
                 ?? responseModeFallback,
             scope: window["AppUtils"].getConfig().idpConfigs?.scope
                 ?? [ TokenConstants.SYSTEM_SCOPE ],
-            sendCookiesInRequests: true,
             serverOrigin: window["AppUtils"].getConfig().idpConfigs?.serverOrigin
                 ?? window["AppUtils"].getConfig().idpConfigs.serverOrigin,
             sessionState: response?.data?.sessionState,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@types/react-redux": "^7.1.1",
         "@types/react-router-dom": "^5.1.3",
         "@types/ua-parser-js": "^0.7.33",
-        "@wso2/identity-oidc-js": "^0.1.3",
+        "@wso2/identity-oidc-js": "0.1.2",
         "await-semaphore": "^0.1.3",
         "axios": "^0.21.1",
         "babel-jest": "^26.3.0",


### PR DESCRIPTION
### Purpose
> Downgrade the SDK back to version "0.1.2" temporarily. 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
