### PR TITLE
Restrict typing non-numeric characters in the "number" input fields

### DIFF
--- a/modules/forms/src/components/field.tsx
+++ b/modules/forms/src/components/field.tsx
@@ -194,6 +194,28 @@ export const InnerField = React.forwardRef((props: InnerFieldPropsInterface, ref
                         onKeyPress={ (event: React.KeyboardEvent) => {
                             event.key === ENTER_KEY && handleBlur(event, inputField.name);
                         } }
+                        onKeyDown={ inputField.type === "number" ?
+                            ((event: React.KeyboardEvent) => {
+                                const isNumber = /^[0-9]$/i.test(event.key);
+                                const isAllowed = ((event.key === "a" || event.key === "v" ||
+                                    event.key === "c" || event.key === "x")
+                                    && (event.ctrlKey === true || event.metaKey === true)) ||
+                                    (event.key === "ArrowRight" || event.key == "ArrowLeft") ||
+                                    (event.key === "Delete" || event.key === "Backspace");
+                                !isNumber && !isAllowed && event.preventDefault();
+                            }) : (): void => {
+                                return;
+                            }
+                        }
+                        onPaste={ inputField.type === "number" ?
+                            ((event: React.ClipboardEvent) => {
+                                const data = event.clipboardData.getData("Text") ;
+                                const isNumber = /^[0-9]+$/i.test(data);
+                                !isNumber && event.preventDefault();
+                            }) : (): void => {
+                                return;
+                            }
+                        }
                     />
                 );
             }


### PR DESCRIPTION
### Purpose
Currently, the 'number' input field in Chrome allows the characters - `e, E, -, +, .` and the Firefox browser allows any character to be typed. However, even though they are allowed to be typed, both these browsers set the typed value as empty ("") when those non-numeric characters are typed. Therefore, instead of the validation message, the fields show the required message when non-numeric characters are typed. This PR is to override this default behavior of the "number" input field and disallow typing any non-numeric character in the input fields.

![image](https://user-images.githubusercontent.com/25479743/118488945-e355c500-b739-11eb-9699-cfb52d7322ed.png)

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/3170
-
### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
