### PR TITLE
Fix inconsistency when updating the grant types

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -369,6 +369,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         if (isHideRefreshTokenGrantType(selectedGrantTypes)) {
             grants = grants.filter(grant => grant != "refresh_token");
         }
+        initialValues.grantTypes = grants;
         setSelectedGrantTypes(grants);
         setGrantChanged(!isGrantChanged);
     };


### PR DESCRIPTION
### Purpose
> When updating the grant types in OIDC protocol page, the updated grant types are not visible(previous values will be displayed) until the page is loaded again.

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/3575

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
