### PR TITLE
Fix updates in the protocol page not being reflected immediately

### DIFF
--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -211,6 +211,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                 }));
 
                 onAllowedOriginsUpdate();
+                onUpdate(appId);
             })
             .catch((error) => {
                 if (error?.response?.data?.description) {
@@ -244,8 +245,6 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         updateApplicationDetails({ id: appId, ...values.general })
             .then(() => {
                 handleInboundConfigFormSubmit(values.inbound, selectedProtocol);
-
-                onUpdate(appId);
             })
             .catch((error) => {
                 if (error.response && error.response.data && error.response.data.description) {


### PR DESCRIPTION
### Purpose
> When updating the inbound authentication configurations, the onUpdate GET request is sent before the PUT request is successfully executed and the configs are properly persisted in the backend. Therefore, the changes done by the update is not reflected immediately. This PR fixes this issue by calling the onUpdate after the response for the PUT request is received.

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/3750

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
- Related PR #1

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
