### PR TITLE
Check deployment.config.json configuration when filtering the routes of side panel items

### DIFF
--- a/apps/console/src/views/admin.tsx
+++ b/apps/console/src/views/admin.tsx
@@ -138,21 +138,23 @@ export const AdminView: FunctionComponent<AdminViewPropsInterface> = (
             const feature = featureConfig[route.id];
             if (feature) {
                 let shouldShowRoute: boolean = false;
-                for (const [ key, value ] of Object.entries(feature?.scopes)) {
-                    if (value && value instanceof Array) {
-                        if (AuthenticateUtils.hasScopes(value, allowedScopes)) {
-                            shouldShowRoute = true;
+                if (feature?.enabled) {
+                    for (const [ key, value ] of Object.entries(feature?.scopes)) {
+                        if (value && value instanceof Array) {
+                            if (AuthenticateUtils.hasScopes(value, allowedScopes)) {
+                                shouldShowRoute = true;
+                            }
                         }
                     }
                 }
-    
+
                 if (route.showOnSidePanel && shouldShowRoute) {
                     controlledRoutes.push(route);
                 }
             } else {
                 controlledRoutes.push(route);
             }
-            
+
         });
 
         // TODO : Temporary fix for access controlled routes
@@ -180,7 +182,7 @@ export const AdminView: FunctionComponent<AdminViewPropsInterface> = (
 
     useEffect(() => {
         setSelectedRoute(CommonRouteUtils.getInitialActiveRoute(location.pathname, filteredRoutes));
-        
+
         if (governanceConnectorsEvaluated === true) {
             RouteUtils.gracefullyHandleRouting(filteredRoutes,
                 AppConstants.getAdminViewBasePath(),
@@ -230,7 +232,7 @@ export const AdminView: FunctionComponent<AdminViewPropsInterface> = (
 
         if (!(governanceConnectorCategories !== undefined && governanceConnectorCategories.length > 0)) {
             GovernanceConnectorUtils.getGovernanceConnectors();
-            
+
             return;
         }
 

--- a/apps/console/src/views/developer.tsx
+++ b/apps/console/src/views/developer.tsx
@@ -127,29 +127,31 @@ export const DeveloperView: FunctionComponent<DeveloperViewPropsInterface> = (
             const feature = featureConfig[route.id];
             if (feature) {
                 let shouldShowRoute: boolean = false;
-                for (const [ key, value ] of Object.entries(feature?.scopes)) {
-                    if (value && value instanceof Array) {
-                        if (AuthenticateUtils.hasScopes(value, allowedScopes)) {
-                            shouldShowRoute = true;
+                if (feature?.enabled) {
+                    for (const [key, value] of Object.entries(feature?.scopes)) {
+                        if (value && value instanceof Array) {
+                            if (AuthenticateUtils.hasScopes(value, allowedScopes)) {
+                                shouldShowRoute = true;
+                            }
                         }
                     }
                 }
-    
+
                 if (route.showOnSidePanel && shouldShowRoute) {
                     controlledRoutes.push(route);
                 }
             } else {
                 controlledRoutes.push(route);
             }
-            
+
         });
 
         if (controlledRoutes.length !== 1 && controlledRoutes[0].id !== "developer-getting-started") {
-            setAccessControlledRoutes(controlledRoutes); 
+            setAccessControlledRoutes(controlledRoutes);
         } else {
             dispatch(setDeveloperVisibility(false));
         }
-        
+
     }, [ allowedScopes ]);
 
     /**
@@ -178,19 +180,19 @@ export const DeveloperView: FunctionComponent<DeveloperViewPropsInterface> = (
 
         // TODO : Temporary fix for access control module
         if (routes.length === 3) {
-            if (routes.filter(route => route.id === "developer-getting-started").length > 0 
-                && routes.filter(route => route.id === "identityProviders").length > 0 
+            if (routes.filter(route => route.id === "developer-getting-started").length > 0
+                && routes.filter(route => route.id === "identityProviders").length > 0
                 && routes.filter(route => route.id === "404").length > 0) {
-                    if (hasRequiredScopes(featureConfig?.identityProviders, 
-                            featureConfig?.identityProviders?.scopes?.read, allowedScopes) 
-                            && !hasRequiredScopes(featureConfig?.applications, 
+                    if (hasRequiredScopes(featureConfig?.identityProviders,
+                            featureConfig?.identityProviders?.scopes?.read, allowedScopes)
+                            && !hasRequiredScopes(featureConfig?.applications,
                                 featureConfig?.applications?.scopes?.read,  allowedScopes)) {
                         routes = routes.filter(route => route.id === "404");
                         dispatch(setDeveloperVisibility(false));
-                    } 
+                    }
             }
-        } else if (routes.length === 2 
-            && routes.filter(route => route.id === "developer-getting-started").length > 0 
+        } else if (routes.length === 2
+            && routes.filter(route => route.id === "developer-getting-started").length > 0
                 && routes.filter(route => route.id === "404").length > 0) {
             routes = routes.filter(route => route.id === "404");
             dispatch(setDeveloperVisibility(false));


### PR DESCRIPTION
### Purpose
> Even though a feature is disabled from the deployment.config.json, the route to the feature is still available from the side panel. This PR is to fix this, by checking the `enabled` configuration in deployment.config.json when showing the items in the side panel. 

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/3804

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)


### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
