### PR TITLE
Stop toggling help panel visibility based on the landing page

### DIFF
--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -458,10 +458,6 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
 
             setDefaultActiveIndex(0);
 
-            if (helpPanelVisibilityGlobalState) {
-                dispatch(toggleHelpPanelVisibility(false));
-            }
-
             return;
         }
 


### PR DESCRIPTION
### Purpose
> This is to disable toggling the help panel visibility based on the landing page of the application edit section. 

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
