### PR TITLE
Fix unable to update address claims from the console and myaccount

### DIFF
--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -348,6 +348,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             op: "replace",
             value: {}
         };
+        let addressExistsInValue = false;
 
         profileSchema.forEach((schema: ProfileSchemaInterface) => {
 
@@ -363,12 +364,13 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                 if (values.get(schema.name) !== undefined && values.get(schema.name).toString() !== undefined) {
 
                     if (ProfileUtils.isMultiValuedSchemaAttribute(profileSchema, schemaNames[0]) ||
-                        schemaNames[0] === "phoneNumbers") {
+                        schemaNames[0] === "phoneNumbers" || schemaNames[0] === "addresses") {
 
                         const attributeValues = [];
                         const attValues: Map<string, string | string []> = new Map();
 
-                        if (schemaNames.length === 1 || schema.name === "phoneNumbers.mobile") {
+                        if (schemaNames.length === 1 || schema.name === "phoneNumbers.mobile"
+                            || (schemaNames[0] === "addresses" && !addressExistsInValue)) {
 
                             // Extract the sub attributes from the form values.
                             for (const value of values.keys()) {
@@ -386,10 +388,18 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                     if (attribute.length === 1) {
                                         attributeValues.push(value);
                                     } else {
-                                        attributeValues.push({
-                                            type: attribute[1],
-                                            value: value
-                                        });
+                                        if (schemaNames[0] === "addresses") {
+                                            attributeValues.push({
+                                                type: attribute[1],
+                                                formatted: value
+                                            });
+                                            addressExistsInValue = true;
+                                        } else {
+                                            attributeValues.push({
+                                                type: attribute[1],
+                                                value: value
+                                            });
+                                        }
                                     }
                                 }
                             }

--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -348,7 +348,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             op: "replace",
             value: {}
         };
-        let addressExistsInValue = false;
+        let addressExistsInValue: boolean = false;
 
         profileSchema.forEach((schema: ProfileSchemaInterface) => {
 

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -220,7 +220,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
         const schemaNames = formName.split(".");
 
         if (ProfileUtils.isMultiValuedSchemaAttribute(profileSchema, schemaNames[0]) ||
-            schemaNames[0] === "phoneNumbers") {
+            schemaNames[0] === "phoneNumbers" || schemaNames[0] === "addresses") {
             const attributeValues = [];
 
             if (schemaNames.length === 1) {
@@ -250,6 +250,37 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                         [ProfileConstants.SCIM2_ENT_USER_SCHEMA]: {
                             "verifyEmail": true
                         }
+                    };
+                }
+            } else if (schemaNames[0] === "addresses") {
+                const attributeValues = [];
+                // List of sub attributes.
+                const subValues = profileDetails.profileInfo[schemaNames[0]]
+                    && profileDetails.profileInfo[schemaNames[0]]
+                        .filter((subAttribute) => typeof subAttribute ===  "object");
+
+                if (subValues && subValues.length > 0) {
+                    subValues.map((value) => {
+                        if (value.type !== schemaNames[1]) {
+                            const subAttributeEntry = {
+                                type: value.type,
+                                formatted: value.value
+                            };
+                            attributeValues.push(subAttributeEntry);
+                        }
+                    });
+                }
+                // This is required as the api doesn't support
+                // patching the address attributes at the sub attribute level.
+                if (schemaNames[0] === "addresses") {
+                    value = {
+                        [schemaNames[0]]: [
+                            ...attributeValues,
+                            {
+                                type: schemaNames[1],
+                                formatted: values.get(formName)
+                            }
+                        ]
                     };
                 }
             } else {


### PR DESCRIPTION
### Purpose
> Currently, only the `urn:ietf:params:scim:schemas:core:2.0:User:addresses.home` (mapped to local claim `http://wso2.org/claims/addresses.locality`) and the `urn:ietf:params:scim:schemas:core:2.0:User:addresses.work` (mapped to local claim `http://wso2.org/claims/region`) can be updated via SCIM. (`urn:ietf:params:scim:schemas:core:2.0:User:addresses` claim which is mapped to `http://wso2.org/claims/addresses` cannot be update due to a limitation of SCIM). The existing patch request format to update the above supported scim address claims is incorrect [1]. This is to fix that incorrect payload format.


### Related Issues
- [1] https://github.com/wso2-enterprise/asgardeo-product/issues/2726#issuecomment-825505592

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
