### PR TITLE
Fix non-formatted error message displayed as the scope name validation error

### DIFF
--- a/apps/console/src/features/oidc-scopes/components/wizards/add-oidc-scope-form.tsx
+++ b/apps/console/src/features/oidc-scopes/components/wizards/add-oidc-scope-form.tsx
@@ -75,7 +75,7 @@ let triggerPreviousForm: () => void;
             description: initialValues?.description
         } }
         onSubmit={ (values) => {
-            onSubmit(getFormValues(values)); 
+            onSubmit(getFormValues(values));
         } }
         triggerSubmit={ (submitFunction) => triggerSubmission(submitFunction) }
         triggerPrevious={ (previousFunction: () => void) => {
@@ -95,8 +95,8 @@ let triggerPreviousForm: () => void;
         >
             <Field.Input
                 data-testid={ `${ testId }-oidc-scope-form-name-input` }
-                ariaLabel="scopeName" 
-                inputType="name" 
+                ariaLabel="scopeName"
+                inputType="name"
                 name="scopeName"
                 label={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs.scopeName.label") }
                 required={ true }
@@ -106,7 +106,7 @@ let triggerPreviousForm: () => void;
                     "scopeName.placeholder") }
                 validation={ (value: string) => {
                     if (!value.toString().match(/^[\w.-]+$/)) {
-                        return t("console:manage.features.oidcScopes. forms.addScopeForm.inputs." +
+                        return t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
                             "scopeName.validations.invalid");
                     }
                 } }
@@ -116,7 +116,7 @@ let triggerPreviousForm: () => void;
             />
             <Field.Input
                 ariaLabel="displayName"
-                inputType="resourceName" 
+                inputType="resourceName"
                 data-testid={ `${ testId }-oidc-scope-form-name-input` }
                 name="displayName"
                 label={ t("console:manage.features.oidcScopes.forms.addScopeForm." +
@@ -133,7 +133,7 @@ let triggerPreviousForm: () => void;
             <Field.Input
                 data-testid={ `${ testId }-oidc-scope-form-name-input` }
                 ariaLabel="description"
-                inputType="resourceName" 
+                inputType="resourceName"
                 name="description"
                 label={ t("console:manage.features.oidcScopes.forms.addScopeForm." +
                     "inputs.description.label") }


### PR DESCRIPTION
### Purpose
Fixed below non-formatted validation error message.
Old:
![old](https://user-images.githubusercontent.com/25479743/119319969-aee18c00-bc98-11eb-982e-57260b232d08.png)

Fixed:
![correct](https://user-images.githubusercontent.com/25479743/119319984-b3a64000-bc98-11eb-8b8d-7d2958798644.png)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
