### PR TITLE
Add a new tab named Info to include server endpoints details in the application view

### DIFF
--- a/apps/console/src/extensions/configs/application.tsx
+++ b/apps/console/src/extensions/configs/application.tsx
@@ -79,22 +79,7 @@ export const applicationConfig: ApplicationConfig = {
         disabledGrantTypes: []
     },
     infoSettings: {
-        renderInfoTabExtension: () => {
-            return (
-                <Grid className="form-container with-max-width">
-                    <Grid.Row>
-                        <Grid.Column>
-                            <Heading ellipsis as="h4">
-                                <strong>
-                                    Try out application
-                                </strong>
-                            </Heading>
-                            <AddUserStepContent/>
-                        </Grid.Column>
-                    </Grid.Row>
-                </Grid>
-            );
-        }
+        renderInfoTabExtension: () => null
     },
     templates: {
         android: true,

--- a/apps/console/src/extensions/configs/application.tsx
+++ b/apps/console/src/extensions/configs/application.tsx
@@ -16,13 +16,16 @@
  * under the License.
  */
 
-import { ReactNode } from "react";
+import React, { ReactNode } from "react";
 import { ApplicationConfig } from "./models";
 import {
     ExtendedClaimInterface,
     ExtendedExternalClaimInterface,
     SelectedDialectInterface
 } from "../../features/applications/components/settings";
+import { Grid } from "semantic-ui-react";
+import { Heading } from "@wso2is/react-components";
+import {AddUserStepContent} from "../application-templates/shared/components";
 
 export const applicationConfig: ApplicationConfig = {
     advancedConfigurations: {
@@ -74,6 +77,24 @@ export const applicationConfig: ApplicationConfig = {
         showCertificates: true,
         showReturnAuthenticatedIdPList: true,
         disabledGrantTypes: []
+    },
+    infoSettings: {
+        renderInfoTabExtension: () => {
+            return (
+                <Grid className="form-container with-max-width">
+                    <Grid.Row>
+                        <Grid.Column>
+                            <Heading ellipsis as="h4">
+                                <strong>
+                                    Try out application
+                                </strong>
+                            </Heading>
+                            <AddUserStepContent/>
+                        </Grid.Column>
+                    </Grid.Row>
+                </Grid>
+            );
+        }
     },
     templates: {
         android: true,

--- a/apps/console/src/extensions/configs/application.tsx
+++ b/apps/console/src/extensions/configs/application.tsx
@@ -16,16 +16,13 @@
  * under the License.
  */
 
-import React, { ReactNode } from "react";
+import { ReactNode } from "react";
 import { ApplicationConfig } from "./models";
 import {
     ExtendedClaimInterface,
     ExtendedExternalClaimInterface,
     SelectedDialectInterface
 } from "../../features/applications/components/settings";
-import { Grid } from "semantic-ui-react";
-import { Heading } from "@wso2is/react-components";
-import {AddUserStepContent} from "../application-templates/shared/components";
 
 export const applicationConfig: ApplicationConfig = {
     advancedConfigurations: {

--- a/apps/console/src/extensions/configs/models/application.ts
+++ b/apps/console/src/extensions/configs/models/application.ts
@@ -65,6 +65,9 @@ export interface ApplicationConfig {
         showReturnAuthenticatedIdPList: boolean;
         disabledGrantTypes: string[];
     };
+    infoSettings: {
+        renderInfoTabExtension: () => ReactNode
+    };
     templates: {
         android: boolean;
         oidc: boolean;

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -171,6 +171,14 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
     };
 
     /**
+     * Called when the defaultActiveIndex updates.
+     */
+    useEffect( () => {
+        setActiveTabIndex(defaultActiveIndex);
+
+    },[defaultActiveIndex]);
+
+    /**
      * Fetch the allowed origins list whenever there's an update.
      */
     useEffect(() => {
@@ -282,8 +290,8 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 onApplicationUpdate: () => {
                     onUpdate(application?.id);
                 },
-                onTriggerTabUpdate: (Type: string) => {
-                    setActiveTabIndex(6);
+                onTriggerTabUpdate: (tabIndex: number) => {
+                    setActiveTabIndex(tabIndex);
                 },
                 template: template
             },

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -709,7 +709,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
     /**
      * Handles the tab change.
      */
-    const handleTabChange = (e, { activeIndex }) => {
+    const handleTabChange = (e, { activeIndex }): void => {
         setActiveTabIndex(activeIndex);
     };
 

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -282,7 +282,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 onApplicationUpdate: () => {
                     onUpdate(application?.id);
                 },
-                onTriggerTabUpdate: (type: string) => {
+                onTriggerTabUpdate: (Type: string) => {
                     setActiveTabIndex(6);
                 },
                 template: template
@@ -696,6 +696,13 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
     };
 
     /**
+     * Handles the tab change.
+     */
+    const handleTabChange = (e, { activeIndex }) => {
+        setActiveTabIndex(activeIndex);
+    };
+
+    /**
      * Renders the client secret hash disclaimer modal.
      * @return {React.ReactElement}
      */
@@ -820,9 +827,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                         defaultActiveIndex={
                             application?.templateId === CustomApplicationTemplate.id ?
                                 (defaultActiveIndex - 1) : defaultActiveIndex }
-                        onTabChange={ (event, { activeIndex } ) => {
-                            setActiveTabIndex((parseInt(activeIndex.toString())));
-                        } }
+                        onTabChange={ handleTabChange }
                         panes= { resolveTabPanes() }
                     />
                     { showClientSecretHashDisclaimerModal && renderClientSecretHashDisclaimerModal() }

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -241,7 +241,6 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
             .finally(() => {
                 setOIDCConfigsLoading(false);
             });
-
     }, [oidcConfigurations, inboundProtocolConfig]);
 
     useEffect(() => {
@@ -620,7 +619,6 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                     render: ConnectionDetailsTabPane
                 });
             }
-
 
             return panes;
         }

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -41,8 +41,10 @@ import { AppState, CORSOriginsListInterface, FeatureConfigInterface, getCORSOrig
 import { getInboundProtocolConfig } from "../api";
 import { ApplicationManagementConstants } from "../constants";
 import {
-    ApplicationInterface, ApplicationTemplateInterface,
-    AuthProtocolMetaListItemInterface, OIDCApplicationConfigurationInterface,
+    ApplicationInterface,
+    ApplicationTemplateInterface,
+    AuthProtocolMetaListItemInterface,
+    OIDCApplicationConfigurationInterface,
     OIDCDataInterface,
     SAMLApplicationConfigurationInterface,
     SupportedAuthProtocolTypes
@@ -581,6 +583,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 inboundProtocols={ application?.inboundProtocols }
                 isOIDCConfigLoading={ isOIDCConfigsLoading }
                 isSAMLConfigLoading={ isSAMLConfigsLoading }
+                data-testid={ `${ testId }-server-endpoints` }
             />
         </ResourceTab.Pane>
     );

--- a/apps/console/src/features/applications/components/settings/connection-details.tsx
+++ b/apps/console/src/features/applications/components/settings/connection-details.tsx
@@ -68,7 +68,6 @@ export const ConnectionDetails: FunctionComponent<ConnectionDetailsPropsInterfac
                 }
             });
         }
-
     }, [inboundProtocols]);
 
     return (

--- a/apps/console/src/features/applications/components/settings/connection-details.tsx
+++ b/apps/console/src/features/applications/components/settings/connection-details.tsx
@@ -31,7 +31,7 @@ import {
 import { OIDCConfigurations, SAMLConfigurations } from "../help-panel";
 
 /**
- * Proptypes for the connection details settings component.
+ * Proptypes for the connection details component.
  */
 interface ConnectionDetailsPropsInterface extends LoadableComponentInterface, TestableComponentInterface {
     inboundProtocols: InboundProtocolListItemInterface[];

--- a/apps/console/src/features/applications/components/settings/connection-details.tsx
+++ b/apps/console/src/features/applications/components/settings/connection-details.tsx
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestableComponentInterface, LoadableComponentInterface } from "@wso2is/core/models";
+import { EmphasizedSegment, Heading, Hint } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import { Divider, Grid } from "semantic-ui-react";
+import { AppState } from "../../../core";
+import {
+    InboundProtocolListItemInterface,
+    OIDCApplicationConfigurationInterface,
+    SAMLApplicationConfigurationInterface
+} from "../../models";
+import { OIDCConfigurations, SAMLConfigurations } from "../help-panel";
+
+/**
+ * Proptypes for the connection details settings component.
+ */
+interface ConnectionDetailsPropsInterface extends LoadableComponentInterface, TestableComponentInterface {
+    inboundProtocols: InboundProtocolListItemInterface[];
+    isSAMLConfigLoading: boolean;
+    isOIDCConfigLoading: boolean;
+}
+export const ConnectionDetails: FunctionComponent<ConnectionDetailsPropsInterface> = (
+    props: ConnectionDetailsPropsInterface
+): ReactElement => {
+
+    const { inboundProtocols, isOIDCConfigLoading, isSAMLConfigLoading  } = props;
+    const oidcConfigurations: OIDCApplicationConfigurationInterface = useSelector(
+        (state: AppState) => state.application.oidcConfigurations);
+    const samlConfigurations: SAMLApplicationConfigurationInterface = useSelector(
+        (state: AppState) => state.application.samlConfigurations);
+    const { t } = useTranslation();
+    const [isOIDC, setIsOIDC] = useState<boolean>(false);
+    const [isSAML, setIsSAML] = useState<boolean>(false);
+    const [ isLoading, setIsLoading ] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (inboundProtocols == undefined) {
+            return;
+        }
+
+        if (inboundProtocols.length > 0) {
+            inboundProtocols.map((protocol) => {
+                if (protocol.type == "oauth2") {
+                    setIsOIDC(true);
+                    setIsLoading(isOIDCConfigLoading);
+                } else if (protocol.type == "samlsso") {
+                    setIsSAML(true);
+                    setIsLoading(isSAMLConfigLoading);
+                }
+            });
+        }
+
+    }, [inboundProtocols]);
+
+    return (
+        <EmphasizedSegment loading={ isLoading } padded="very">
+        { !isLoading ? (
+            <Grid className="form-container with-max-width">
+                <Grid.Row>
+                    <Grid.Column>
+                        <Heading ellipsis as="h5">
+                            <strong>
+                                { t("console:develop.features.applications.helpPanel.tabs.start.content.endpoints."
+                                    + "title") }
+                            </strong>
+                        </Heading>
+                        <Hint>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content.endpoints." +
+                                        "subTitle") }
+                        </Hint>
+                        <Divider hidden/>
+                        { isOIDC && (
+                            <OIDCConfigurations oidcConfigurations={ oidcConfigurations }/>
+                        ) }
+                        { isOIDC && isSAML ? (
+                            <>
+                                <Divider hidden/>
+                                <Divider/>
+                                <Divider hidden/>
+                            </>
+                        ) : null }
+                        { isSAML && (
+                            <SAMLConfigurations samlConfigurations={ samlConfigurations }/>
+                        ) }
+                    </Grid.Column>
+                </Grid.Row>
+            </Grid>
+        ) : null }
+        </EmphasizedSegment>
+    );
+};

--- a/apps/console/src/features/applications/components/settings/info.tsx
+++ b/apps/console/src/features/applications/components/settings/info.tsx
@@ -66,6 +66,7 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
         isSAMLConfigLoading,
         [ "data-testid" ]: testId
     } = props;
+    
     const oidcConfigurations: OIDCApplicationConfigurationInterface = useSelector(
         (state: AppState) => state.application.oidcConfigurations);
     const samlConfigurations: SAMLApplicationConfigurationInterface = useSelector(

--- a/apps/console/src/features/applications/components/settings/info.tsx
+++ b/apps/console/src/features/applications/components/settings/info.tsx
@@ -16,12 +16,13 @@
  * under the License.
  */
 
-import { TestableComponentInterface, LoadableComponentInterface } from "@wso2is/core/models";
-import { EmphasizedSegment, Heading, Hint } from "@wso2is/react-components";
+import { LoadableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
+import { ContentLoader, EmphasizedSegment, Heading } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider, Grid } from "semantic-ui-react";
+import { AddUserStepContent } from "../../../../extensions/application-templates/shared/components";
 import { AppState } from "../../../core";
 import {
     InboundProtocolListItemInterface,
@@ -31,15 +32,15 @@ import {
 import { OIDCConfigurations, SAMLConfigurations } from "../help-panel";
 
 /**
- * Proptypes for the connection details component.
+ * Proptypes for the server endpoints details component.
  */
-interface ConnectionDetailsPropsInterface extends LoadableComponentInterface, TestableComponentInterface {
+interface InfoPropsInterface extends LoadableComponentInterface, TestableComponentInterface {
     inboundProtocols: InboundProtocolListItemInterface[];
     isSAMLConfigLoading: boolean;
     isOIDCConfigLoading: boolean;
 }
-export const ConnectionDetails: FunctionComponent<ConnectionDetailsPropsInterface> = (
-    props: ConnectionDetailsPropsInterface
+export const Info: FunctionComponent<InfoPropsInterface> = (
+    props: InfoPropsInterface
 ): ReactElement => {
 
     const { inboundProtocols, isOIDCConfigLoading, isSAMLConfigLoading  } = props;
@@ -71,39 +72,54 @@ export const ConnectionDetails: FunctionComponent<ConnectionDetailsPropsInterfac
     }, [inboundProtocols]);
 
     return (
-        <EmphasizedSegment loading={ isLoading } padded="very">
-        { !isLoading ? (
-            <Grid className="form-container with-max-width">
-                <Grid.Row>
-                    <Grid.Column>
-                        <Heading ellipsis as="h5">
-                            <strong>
-                                { t("console:develop.features.applications.helpPanel.tabs.start.content.endpoints."
-                                    + "title") }
-                            </strong>
-                        </Heading>
-                        <Hint>
+        !isLoading ? (
+            <EmphasizedSegment loading={ isLoading } padded="very">
+                <Grid className="form-container with-max-width">
+                    <Grid.Row>
+                        <Grid.Column>
+                            <Heading ellipsis as="h4">
+                                <strong>
+                                    { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                        "endpoints." + "title") }
+                                </strong>
+                            </Heading>
+
                             { t("console:develop.features.applications.helpPanel.tabs.start.content.endpoints." +
-                                        "subTitle") }
-                        </Hint>
-                        <Divider hidden/>
-                        { isOIDC && (
-                            <OIDCConfigurations oidcConfigurations={ oidcConfigurations }/>
-                        ) }
-                        { isOIDC && isSAML ? (
-                            <>
-                                <Divider hidden/>
-                                <Divider/>
-                                <Divider hidden/>
-                            </>
-                        ) : null }
-                        { isSAML && (
-                            <SAMLConfigurations samlConfigurations={ samlConfigurations }/>
-                        ) }
-                    </Grid.Column>
-                </Grid.Row>
-            </Grid>
-        ) : null }
-        </EmphasizedSegment>
+                                            "subTitle") }
+
+                            <Divider hidden/>
+                            { isOIDC && (
+                                <OIDCConfigurations oidcConfigurations={ oidcConfigurations }/>
+                            ) }
+                            { isOIDC && isSAML ? (
+                                <>
+                                    <Divider hidden/>
+                                    <Divider/>
+                                    <Divider hidden/>
+                                </>
+                            ) : null }
+                            { isSAML && (
+                                <SAMLConfigurations samlConfigurations={ samlConfigurations }/>
+                            ) }
+                        </Grid.Column>
+                    </Grid.Row>
+                </Grid>
+                <Divider hidden/>
+                <Divider hidden/>
+                <Grid className="form-container with-max-width">
+                    <Grid.Row>
+                        <Grid.Column>
+                            <Heading ellipsis as="h4">
+                                <strong>
+                                    Try out application
+                                </strong>
+                            </Heading>
+                            <AddUserStepContent/>
+                        </Grid.Column>
+                    </Grid.Row>
+                </Grid>
+            </EmphasizedSegment>
+        )
+        : <ContentLoader/>
     );
 };

--- a/apps/console/src/features/applications/components/settings/info.tsx
+++ b/apps/console/src/features/applications/components/settings/info.tsx
@@ -22,7 +22,7 @@ import React, { FunctionComponent, ReactElement, useEffect, useState } from "rea
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider, Grid } from "semantic-ui-react";
-import { AddUserStepContent } from "../../../../extensions/application-templates/shared/components";
+import { applicationConfig } from "../../../../extensions";
 import { AppState } from "../../../core";
 import {
     InboundProtocolListItemInterface,
@@ -106,18 +106,7 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                 </Grid>
                 <Divider hidden/>
                 <Divider hidden/>
-                <Grid className="form-container with-max-width">
-                    <Grid.Row>
-                        <Grid.Column>
-                            <Heading ellipsis as="h4">
-                                <strong>
-                                    Try out application
-                                </strong>
-                            </Heading>
-                            <AddUserStepContent/>
-                        </Grid.Column>
-                    </Grid.Row>
-                </Grid>
+                { applicationConfig.infoSettings.renderInfoTabExtension() }
             </EmphasizedSegment>
         )
         : <ContentLoader/>

--- a/apps/console/src/features/applications/components/settings/info.tsx
+++ b/apps/console/src/features/applications/components/settings/info.tsx
@@ -35,22 +35,44 @@ import { OIDCConfigurations, SAMLConfigurations } from "../help-panel";
  * Proptypes for the server endpoints details component.
  */
 interface InfoPropsInterface extends LoadableComponentInterface, TestableComponentInterface {
+    /**
+     *  Currently configured inbound protocols.
+     */
     inboundProtocols: InboundProtocolListItemInterface[];
+    /**
+     * Is the SAML configuration still loading.
+     */
     isSAMLConfigLoading: boolean;
+    /**
+     * Is the OIDC configuration still loading.
+     */
     isOIDCConfigLoading: boolean;
 }
+
+/**
+ * Component to include server endpoints details of the application.
+ *
+ * @param {InfoPropsInterface} props - Props injected to the component.
+ *
+ * @return {ReactElement}
+ */
 export const Info: FunctionComponent<InfoPropsInterface> = (
     props: InfoPropsInterface
 ): ReactElement => {
 
-    const { inboundProtocols, isOIDCConfigLoading, isSAMLConfigLoading  } = props;
+    const {
+        inboundProtocols,
+        isOIDCConfigLoading,
+        isSAMLConfigLoading,
+        [ "data-testid" ]: testId
+    } = props;
     const oidcConfigurations: OIDCApplicationConfigurationInterface = useSelector(
         (state: AppState) => state.application.oidcConfigurations);
     const samlConfigurations: SAMLApplicationConfigurationInterface = useSelector(
         (state: AppState) => state.application.samlConfigurations);
     const { t } = useTranslation();
-    const [isOIDC, setIsOIDC] = useState<boolean>(false);
-    const [isSAML, setIsSAML] = useState<boolean>(false);
+    const [ isOIDC, setIsOIDC ] = useState<boolean>(false);
+    const [ isSAML, setIsSAML ] = useState<boolean>(false);
     const [ isLoading, setIsLoading ] = useState<boolean>(false);
 
     useEffect(() => {
@@ -73,7 +95,7 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
 
     return (
         !isLoading ? (
-            <EmphasizedSegment loading={ isLoading } padded="very">
+            <EmphasizedSegment loading={ isLoading } padded="very" data-testid={ testId }>
                 <Grid className="form-container with-max-width">
                     <Grid.Row>
                         <Grid.Column>
@@ -93,9 +115,7 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                             ) }
                             { isOIDC && isSAML ? (
                                 <>
-                                    <Divider hidden/>
-                                    <Divider/>
-                                    <Divider hidden/>
+                                    <Divider className="x2" hidden/>
                                 </>
                             ) : null }
                             { isSAML && (
@@ -104,11 +124,17 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                         </Grid.Column>
                     </Grid.Row>
                 </Grid>
-                <Divider hidden/>
-                <Divider hidden/>
+                <Divider className="x2" hidden/>
                 { applicationConfig.infoSettings.renderInfoTabExtension() }
             </EmphasizedSegment>
         )
         : <ContentLoader/>
     );
+};
+
+/**
+ * Default props for the server endpoints details component.
+ */
+Info.defaultProps = {
+    "data-testid": "application-server-endpoints"
 };

--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -58,7 +58,7 @@ export class ApplicationManagementConstants {
         .set("APPLICATION_EDIT_SIGN_ON_METHOD_CONFIG", "applications.edit.signOnMethodConfiguration")
         .set("APPLICATION_EDIT_PROVISIONING_SETTINGS", "applications.edit.provisioningSettings")
         .set("APPLICATION_EDIT_ADVANCED_SETTINGS", "applications.edit.advancedSettings")
-        .set("APPLICATION_CONNECTION_DETAILS_SETTINGS", "applications.edit.connectionDetails");
+        .set("APPLICATION_EDIT_INFO", "applications.edit.info");
 
     /**
      * Key for the `Edit Application` tag in the docs structure object.

--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -57,7 +57,8 @@ export class ApplicationManagementConstants {
         .set("APPLICATION_EDIT_ATTRIBUTE_MAPPING", "applications.edit.attributeMapping")
         .set("APPLICATION_EDIT_SIGN_ON_METHOD_CONFIG", "applications.edit.signOnMethodConfiguration")
         .set("APPLICATION_EDIT_PROVISIONING_SETTINGS", "applications.edit.provisioningSettings")
-        .set("APPLICATION_EDIT_ADVANCED_SETTINGS", "applications.edit.advancedSettings");
+        .set("APPLICATION_EDIT_ADVANCED_SETTINGS", "applications.edit.advancedSettings")
+        .set("APPLICATION_CONNECTION_DETAILS_SETTINGS", "applications.edit.connectionDetails");
 
     /**
      * Key for the `Edit Application` tag in the docs structure object.

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -887,7 +887,8 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
 
     return (
         <HelpPanelLayout
-            activeIndex={ tabsActiveIndex }
+            enabled={ false }
+            visible={ false }
             sidebarDirection="right"
             sidebarMiniEnabled={ true }
             tabs={ helpPanelTabs }
@@ -902,7 +903,6 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             pinButtonTooltip={ t("console:develop.features.helpPanel.actions.pin") }
             unpinButtonTooltip={ t("console:develop.features.helpPanel.actions.unPin") }
             onHelpPanelVisibilityChange={ (isVisible: boolean) => dispatch(toggleHelpPanelVisibility(isVisible)) }
-            visible={ helpPanelVisibilityGlobalState }
         >
             <PageLayout
                 isLoading={ isApplicationRequestLoading }

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -498,7 +498,7 @@ export interface ConsoleNS {
                             };
                             tabName: string;
                         };
-                        connectionDetails: {
+                        info: {
                             tabName: string;
                         };
                         general: {

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -498,6 +498,9 @@ export interface ConsoleNS {
                             };
                             tabName: string;
                         };
+                        connectionDetails: {
+                            tabName: string;
+                        };
                         general: {
                             tabName: string;
                         };

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -818,8 +818,8 @@ export const console: ConsoleNS = {
                             },
                             tabName: "User Attributes"
                         },
-                        connectionDetails: {
-                            tabName: "Connection Details"
+                        info: {
+                            tabName: "Info"
                         },
                         general: {
                             tabName: "General"

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -818,6 +818,9 @@ export const console: ConsoleNS = {
                             },
                             tabName: "User Attributes"
                         },
+                        connectionDetails: {
+                            tabName: "Connection Details"
+                        },
                         general: {
                             tabName: "General"
                         },

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -822,8 +822,8 @@ export const console: ConsoleNS = {
                             },
                             tabName: "Attributs"
                         },
-                        connectionDetails: {
-                            tabName: "Détails de connexion"
+                        info: {
+                            tabName: "Info"
                         },
                         general: {
                             tabName: "Général"

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -822,6 +822,9 @@ export const console: ConsoleNS = {
                             },
                             tabName: "Attributs"
                         },
+                        connectionDetails: {
+                            tabName: "Détails de connexion"
+                        },
                         general: {
                             tabName: "Général"
                         },

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -819,6 +819,9 @@ export const console: ConsoleNS = {
                             },
                             tabName: "පරිශීලක ගුණාංග"
                         },
+                        connectionDetails: {
+                            tabName: "සම්බන්ධතා විස්තර"
+                        },
                         general: {
                             tabName: "ජනරාල්"
                         },

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -819,8 +819,8 @@ export const console: ConsoleNS = {
                             },
                             tabName: "පරිශීලක ගුණාංග"
                         },
-                        connectionDetails: {
-                            tabName: "සම්බන්ධතා විස්තර"
+                        info: {
+                            tabName: "තොරතුරු"
                         },
                         general: {
                             tabName: "ජනරාල්"


### PR DESCRIPTION
### Purpose
Added a new tab named **Info** to include the server endpoints details
Removed help panel in the application view as its content is now contained in the **Info** tab.

![Screenshot from 2021-05-29 22-27-04](https://user-images.githubusercontent.com/36721128/120078407-16e70680-c0cd-11eb-9de3-c0d110fbefb1.png)

### Related Issues
- Issue [wso2-enterprise/asgardeo-produc#3582](https://github.com/wso2-enterprise/asgardeo-product/issues/3582)
- Issue [wso2-enterprise/asgardeo-produc#2743](https://github.com/wso2-enterprise/asgardeo-product/issues/2743)
- Issue [wso2-enterprise/asgardeo-produc#2080](https://github.com/wso2-enterprise/asgardeo-product/issues/2080)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
