### PR TITLE
Make certificate inputs optional in wizard.

### DIFF
--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -689,7 +689,7 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                          * invalid content to the picker we can't enable next because it's invalid.
                          */
                         setNextShouldBeDisabled(
-                            (result?.pastedContent?.length || result?.file) > 0 &&
+                            (result?.pastedContent?.length > 0 || result?.file) &&
                             !result.serialized &&
                             !result.valid
                         );


### PR DESCRIPTION
### Purpose
> Please note $subject. Now the user can continue without the certificate input step. It has been marked optional but the
validation will be strict if the user tries to enter one of the available inputs.

### Related Issues
(None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
(None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
