### PR TITLE
fix(console): Add `idp` name validation on keystroke

### DIFF
--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -350,7 +350,8 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
             const errors: FormErrors = {};
             errors.name = composeValidators(required, length(IDP_NAME_LENGTH))(values.name);
             if (isIdpNameAlreadyTaken(values.name)) {
-                errors.name = "An identity provider already exists with this name.";
+                errors.name = t("console:develop.features.authenticationProvider." +
+                    "forms.generalDetails.name.validations.duplicate");
             }
             setNextShouldBeDisabled(ifFieldsHave(errors));
             return errors;
@@ -412,7 +413,8 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
             if (showAsStandaloneIdentityProvider) {
                 errors.name = composeValidators(required, length(IDP_NAME_LENGTH))(values.name);
                 if (isIdpNameAlreadyTaken(values.name)) {
-                    errors.name = "An identity provider already exists with this name.";
+                    errors.name = t("console:develop.features.authenticationProvider." +
+                        "forms.generalDetails.name.validations.duplicate");
                 }
             }
             errors.SPEntityId = composeValidators(required, length(SP_EID_LENGTH))(values.SPEntityId);
@@ -557,7 +559,8 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                         length(IDP_NAME_LENGTH)
                     )(values.name);
                     if (isIdpNameAlreadyTaken(values.name)) {
-                        errors.name = "An identity provider already exists with this name.";
+                        errors.name = t("console:develop.features.authenticationProvider." +
+                            "forms.generalDetails.name.validations.duplicate");
                     }
                 }
                 errors.clientId = composeValidators(

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -849,8 +849,8 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                         className="content-container"
                         data-testid={ `${ testId }-modal-content-2` }>
                         { alert && alertComponent }
-                        { !isIDPListLoading ?
-                            <Wizard2
+                        { !isIDPListLoading
+                            ? <Wizard2
                                 ref={ wizardRef }
                                 initialValues={ initialValues }
                                 onSubmit={ handleFormSubmit }
@@ -858,8 +858,8 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                                 pageChanged={ (index: number) => setCurrentWizardStep(index) }
                                 data-testid={ testId }>
                                 { resolveWizardPages() }
-                            </Wizard2> :
-                            <ContentLoader text="Loading identity providers"/>
+                            </Wizard2>
+                            : <ContentLoader text="Loading identity providers"/>
                         }
                     </ModalWithSidePanel.Content>
                 </React.Fragment>

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -127,13 +127,16 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
 
     useEffect(() => {
         setIsIDPListLoading(true);
-        getIdentityProviderList(null, null, null).then((response) => {
-            setIdPList(response.identityProviders);
-        }).catch((error) => {
-            handleGetIDPListCallError(error);
-        }).finally(() => {
-            setIsIDPListLoading(false);
-        });
+        getIdentityProviderList(null, null, null)
+            .then((response) => {
+                setIdPList(response.identityProviders);
+            })
+            .catch((error) => {
+                handleGetIDPListCallError(error);
+            })
+            .finally(() => {
+                setIsIDPListLoading(false);
+            });
     }, []);
 
     useEffect(() => {

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -34,18 +34,19 @@ import {
 import { addAlert } from "@wso2is/core/store";
 
 import React, { FC, PropsWithChildren, ReactElement, Suspense, useEffect, useMemo, useRef, useState } from "react";
-import { IdentityProviderTemplateInterface } from "../../models";
+import { IdentityProviderTemplateInterface, StrictIdentityProviderInterface } from "../../models";
 import { AppConstants, getCertificateIllustrations, history, ModalWithSidePanel, store } from "../../../core";
 import { getIdentityProviderWizardStepIcons, getIdPIcons } from "../../configs";
 import { Divider, Grid, Icon } from "semantic-ui-react";
 import { useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { Field, Wizard2, WizardPage } from "@wso2is/form";
-import { createIdentityProvider } from "../../api";
+import { createIdentityProvider, getIdentityProviderList } from "../../api";
 import isEmpty from "lodash-es/isEmpty";
 import { IdentityProviderManagementConstants } from "../../constants";
 import cloneDeep from "lodash-es/cloneDeep";
 import { FormValidation } from "@wso2is/validation";
+import { handleGetIDPListCallError } from "../utils";
 
 /**
  * Proptypes for the enterprise identity provider
@@ -118,9 +119,23 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
 
     // Dynamic UI state
     const [ nextShouldBeDisabled, setNextShouldBeDisabled ] = useState<boolean>(true);
+    const [ idpList, setIdPList ] = useState<StrictIdentityProviderInterface[]>([]);
+    const [ isIDPListLoading, setIsIDPListLoading ] = useState<boolean>(false);
 
     const dispatch = useDispatch();
     const { t } = useTranslation();
+
+    useEffect(() => {
+        setIsIDPListLoading(true);
+        getIdentityProviderList(null, null, null)
+            .then((response) => {
+                setIdPList(response.identityProviders);
+            }).catch((error) => {
+            handleGetIDPListCallError(error);
+        }).finally(() => {
+            setIsIDPListLoading(false);
+        });
+    }, []);
 
     useEffect(() => {
         if (showAsStandaloneIdentityProvider) {
@@ -144,7 +159,7 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
     }, [ selectedProtocol ]);
 
     const initialValues = useMemo(() => ({
-        name: template?.name,
+        name: EMPTY_STRING, // This must be filled by the user.
         RequestMethod: "post",
         NameIDType: "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
     }), []);
@@ -196,6 +211,15 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
             { key: 2, text: "HTTP Post", value: "post" },
             { key: 3, text: "As Per Request", value: "as_request" }
         ]
+    };
+
+    const isIdpNameAlreadyTaken = (userInput: string): boolean => {
+        if (idpList?.length > 0) {
+            return idpList
+                .reduce((set, { name }) => set.add(name), new Set<string>())
+                .has(userInput);
+        }
+        return false;
     };
 
     // Wizard
@@ -326,6 +350,9 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
         <WizardPage validate={ (values: any) => {
             const errors: FormErrors = {};
             errors.name = composeValidators(required, length(IDP_NAME_LENGTH))(values.name);
+            if (isIdpNameAlreadyTaken(values.name)) {
+                errors.name = "An identity provider already exists with this name.";
+            }
             setNextShouldBeDisabled(ifFieldsHave(errors));
             return errors;
         } }>
@@ -385,6 +412,9 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
             const errors: FormErrors = {};
             if (showAsStandaloneIdentityProvider) {
                 errors.name = composeValidators(required, length(IDP_NAME_LENGTH))(values.name);
+                if (isIdpNameAlreadyTaken(values.name)) {
+                    errors.name = "An identity provider already exists with this name.";
+                }
             }
             errors.SPEntityId = composeValidators(required, length(SP_EID_LENGTH))(values.SPEntityId);
             errors.NameIDType = composeValidators(required)(values.NameIDType);
@@ -527,6 +557,9 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                         required,
                         length(IDP_NAME_LENGTH)
                     )(values.name);
+                    if (isIdpNameAlreadyTaken(values.name)) {
+                        errors.name = "An identity provider already exists with this name.";
+                    }
                 }
                 errors.clientId = composeValidators(
                     required,
@@ -814,15 +847,18 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                         className="content-container"
                         data-testid={ `${ testId }-modal-content-2` }>
                         { alert && alertComponent }
-                        <Wizard2
-                            ref={ wizardRef }
-                            initialValues={ initialValues }
-                            onSubmit={ handleFormSubmit }
-                            uncontrolledForm={ true }
-                            pageChanged={ (index: number) => setCurrentWizardStep(index) }
-                            data-testid={ testId }>
-                            { resolveWizardPages() }
-                        </Wizard2>
+                        { !isIDPListLoading ?
+                            <Wizard2
+                                ref={ wizardRef }
+                                initialValues={ initialValues }
+                                onSubmit={ handleFormSubmit }
+                                uncontrolledForm={ true }
+                                pageChanged={ (index: number) => setCurrentWizardStep(index) }
+                                data-testid={ testId }>
+                                { resolveWizardPages() }
+                            </Wizard2> :
+                            <ContentLoader text="Loading identity providers"/>
+                        }
                     </ModalWithSidePanel.Content>
                 </React.Fragment>
                 { /*Modal actions*/ }

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -127,10 +127,9 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
 
     useEffect(() => {
         setIsIDPListLoading(true);
-        getIdentityProviderList(null, null, null)
-            .then((response) => {
-                setIdPList(response.identityProviders);
-            }).catch((error) => {
+        getIdentityProviderList(null, null, null).then((response) => {
+            setIdPList(response.identityProviders);
+        }).catch((error) => {
             handleGetIDPListCallError(error);
         }).finally(() => {
             setIsIDPListLoading(false);


### PR DESCRIPTION
### Purpose
> Please note $subject. Implement the IDP name validation on the input keystroke level. It will have the same behaviour as google authenticator but the name will not autocomplete at first. Instead, the user needs to fill it by themselves.

### Related Issues
(None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
(None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
