### PR TITLE
Disable configuring TOTP for federated users

### DIFF
--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -357,8 +357,7 @@ export class ApplicationManagementConstants {
 
     // Authenticators that can handle TOTP.
     public static readonly TOTP_HANDLERS = [
-        ...ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS,
-        ...ApplicationManagementConstants.SOCIAL_AUTHENTICATORS
+        ...ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS
     ];
 
     /**


### PR DESCRIPTION
### Purpose
As per the issue: wso2-enterprise/asgardeo-product#3972, disable configuring TOTP for federated users from UI.