### PR TITLE
fix(console): Trigger validation for SP Entity Id on file-mode

### DIFF
--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -413,38 +413,33 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
     const samlConfigurationPage = () => (
         <WizardPage validate={ (values) => {
             const errors: FormErrors = {};
-            if (showAsStandaloneIdentityProvider) {
-                errors.name = composeValidators(required, length(IDP_NAME_LENGTH))(values.name);
-                if (isIdpNameAlreadyTaken(values.name)) {
-                    errors.name = t("console:develop.features.authenticationProvider." +
-                        "forms.generalDetails.name.validations.duplicate");
-                }
-            }
             errors.SPEntityId = composeValidators(required, length(SP_EID_LENGTH))(values.SPEntityId);
-            errors.NameIDType = composeValidators(required)(values.NameIDType);
-            errors.SSOUrl = composeValidators(required, length(SSO_URL_LENGTH), isUrl)(values.SSOUrl);
-            errors.IdPEntityId = composeValidators(required, length(IDP_EID_LENGTH))(values.IdPEntityId);
-            errors.RequestMethod = composeValidators(required)(values.RequestMethod);
             if (selectedSamlConfigMode === "file") {
-                setNextShouldBeDisabled(!xmlBase64String);
+                setNextShouldBeDisabled(ifFieldsHave(errors) || !xmlBase64String);
             } else {
+                errors.NameIDType = composeValidators(required)(values.NameIDType);
+                errors.SSOUrl = composeValidators(required, length(SSO_URL_LENGTH), isUrl)(values.SSOUrl);
+                errors.IdPEntityId = composeValidators(required, length(IDP_EID_LENGTH))(values.IdPEntityId);
+                errors.RequestMethod = composeValidators(required)(values.RequestMethod);
                 setNextShouldBeDisabled(ifFieldsHave(errors));
             }
             return errors;
         } }>
-            { showAsStandaloneIdentityProvider ? (<Field.Input
-                data-testid={ `${ testId }-form-wizard-idp-name` }
-                ariaLabel="name"
-                inputType="name"
-                name="name"
-                placeholder="Enter a name for the identity provider"
-                label="Identity provider name"
-                initialValue={ initialValues.name }
-                maxLength={ IDP_NAME_LENGTH.max }
-                minLength={ IDP_NAME_LENGTH.min }
-                required={ true }
-                width={ 15 }
-            />) : (<></>) }
+            { showAsStandaloneIdentityProvider && (
+                <Field.Input
+                    data-testid={ `${ testId }-form-wizard-idp-name` }
+                    ariaLabel="name"
+                    inputType="name"
+                    name="name"
+                    placeholder="Enter a name for the identity provider"
+                    label="Identity provider name"
+                    initialValue={ initialValues.name }
+                    maxLength={ IDP_NAME_LENGTH.max }
+                    minLength={ IDP_NAME_LENGTH.min }
+                    required={ true }
+                    width={ 15 }
+                />)
+            }
             <Field.Input
                 ariaLabel="Service provider entity id"
                 inputType="default"

--- a/modules/react-components/src/components/file-picker/file-picker.tsx
+++ b/modules/react-components/src/components/file-picker/file-picker.tsx
@@ -374,7 +374,7 @@ export const FilePicker: FC<FilePickerProps> = (props: FilePickerPropsAlias): Re
         menuItem: "Upload",
         render: () => {
             const previewPlaceholder = (
-                <Segment placeholder color="green">
+                <Segment placeholder>
                     <Segment textAlign="center" basic>
                         <GenericIcon
                             inline


### PR DESCRIPTION
### Purpose

- In file-based mode, now the user cannot proceed to the next steps without providing a value for Service provider entity ID.
- Remove the green colour segment colour since it's a bit off with the current UI UX experience.

### Related Issues
(None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
(none)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
