### PR TITLE
Disable update button when no authentication methods selected

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -113,6 +113,7 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
     const [ selectedRequestPathAuthenticators, setSelectedRequestPathAuthenticators ] = useState<any>(undefined);
     const [ steps, setSteps ] = useState<number>(1);
     const [ isDefaultScript, setIsDefaultScript ] = useState<boolean>(true);
+    const [ isButtonDisabled, setIsButtonDisabled ] = useState<boolean>(false);
 
     /**
      * Toggles the update trigger.
@@ -353,6 +354,13 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
     );
 
     /**
+     * Handles the update button disable state.
+     */
+    const handleButtonDisabledStateChange = (buttonStateDisabled: boolean): void => {
+        setIsButtonDisabled(buttonStateDisabled);
+    };
+
+    /**
      * Renders update button.
      *
      * @return {React.ReactElement}
@@ -369,6 +377,7 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
                 <PrimaryButton
                     onClick={ handleUpdateClick }
                     data-testid={ `${ testId }-update-button` }
+                    disabled={ isButtonDisabled }
                 >
                     { t("common:update") }
                 </PrimaryButton>
@@ -428,6 +437,7 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
                 data-testid={ `${ testId }-step-based-flow` }
                 updateSteps={ updateSteps }
                 onIDPCreateWizardTrigger={ onIDPCreateWizardTrigger }
+                onAuthenticationSequenceChange={ handleButtonDisabledStateChange }
             />
             <Divider className="x2"/>
             <ScriptBasedFlow

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -96,6 +96,10 @@ interface AuthenticationFlowPropsInterface extends TestableComponentInterface {
      * Update authentication steps.
      */
     updateSteps: (add: boolean) => void;
+    /**
+     * Callback to update the button disable state change.
+     */
+    onAuthenticationSequenceChange: (buttonStateDisabled: boolean) => void;
 }
 
 /**
@@ -117,6 +121,7 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
         readOnly,
         triggerUpdate,
         updateSteps,
+        onAuthenticationSequenceChange,
         [ "data-testid" ]: testId
     } = props;
 
@@ -240,6 +245,20 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
             // Add debug logs here one a logger is added.
             // Tracked here https://github.com/wso2/product-is/issues/11650.
         }
+    }, [ authenticationSteps ]);
+
+    /**
+     * Change button disable state when authentication Steps are changed.
+     */
+    useEffect(() => {
+
+        const noOptionsSelected = authenticationSteps.length === 1 && authenticationSteps[ 0 ].options?.length === 0;
+
+        if (noOptionsSelected) {
+            onAuthenticationSequenceChange(true);
+            return;
+        }
+        onAuthenticationSequenceChange(false);
     }, [ authenticationSteps ]);
 
     /**

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -99,7 +99,7 @@ interface AuthenticationFlowPropsInterface extends TestableComponentInterface {
     /**
      * Callback to update the button disable state change.
      */
-    onAuthenticationSequenceChange: (buttonStateDisabled: boolean) => void;
+    onAuthenticationSequenceChange: (isDisabled: boolean) => void;
 }
 
 /**
@@ -252,7 +252,8 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
      */
     useEffect(() => {
 
-        const noOptionsSelected = authenticationSteps.length === 1 && authenticationSteps[ 0 ].options?.length === 0;
+        const noOptionsSelected: boolean = authenticationSteps.length === 1
+            && authenticationSteps[ 0 ].options?.length === 0;
 
         if (noOptionsSelected) {
             onAuthenticationSequenceChange(true);


### PR DESCRIPTION
### Purpose
"Update" button is disabled when there is only one authentication step and there are no authentication options selected in that step.

### Related Issues
- [https://github.com/wso2/product-is/issues/11854](https://github.com/wso2/product-is/issues/11854)

### Checklist
- [x] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
