### PR TITLE
Allow password paste in password reset page

### DIFF
--- a/apps/recovery-portal/src/main/webapp/password-reset.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-reset.jsp
@@ -95,7 +95,6 @@
                                         name="reset-password"
                                         type="password"
                                         required=""
-                                        onpaste="return false"
                                     />
                                     <i id="password1ShowHide" class="eye link icon" onclick="password1ShowToggle()"></i>
                                 </div>
@@ -152,7 +151,6 @@
                                         type="password"
                                         data-match="reset-password"
                                         required=""
-                                        onpaste="return false"
                                     />
                                     <i id="password2ShowHide" class="eye link icon" onclick="password2ShowToggle()"></i>
                                 </div>


### PR DESCRIPTION
### Purpose
When the invited user click on the invitation link and proceed with setting user password, it is allowed to paste the password in the password field.

### Related Issues
- https://github.com/wso2/product-is/issues/11891

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
