### PR TITLE
Mark previously selected Gravatar profile picture by default

### DIFF
--- a/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
+++ b/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
@@ -199,6 +199,7 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
     const [ gravatarURLs, setGravatarURLs ] = useState<Map<string, string>>(undefined);
     const [ selectedAvatarType, setSelectedAvatarType ] = useState<AvatarTypes>(undefined);
     const [ hostedURL, setHostedURL ] = useState<string>(undefined);
+    const [isGravatarUrl, setIsGravatarUrl] = useState<boolean>(false);
     const [ hostedURLError, setHostedURLError ] = useState<LabelProps>(undefined);
     const [
         outputURL,
@@ -283,14 +284,37 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
         setGravatarURLs(urls);
     }, [ selectedGravatarEmail, isGravatarQualified ]);
 
+    /**
+     * Set the Avatar types based on imageUrl.
+     */
     useEffect(() => {
         if (imageUrl) {
-            setOutputURL(imageUrl);
-            setSelectedAvatarType(AvatarTypes.GRAVATAR);
+            if (isGravatarUrl) {
+                setOutputURL(imageUrl);
+                setSelectedAvatarType(AvatarTypes.GRAVATAR);
+            } else {
+                setHostedURL(imageUrl);
+                setSelectedAvatarType(AvatarTypes.URL);
+            }
         } else {
             setSelectedAvatarType(AvatarTypes.SYSTEM_GENERATED);
         }
-    }, [ imageUrl ]);
+    }, [ imageUrl , isGravatarUrl ]);
+
+    /**
+     * Check the type of imageUrl.
+     */
+    useEffect(() => {
+
+        if (gravatarURLs) {
+            gravatarURLs.forEach((value: string, key: string) => {
+                if (imageUrl.localeCompare(value) == 0) {
+                    setIsGravatarUrl(true);
+                }
+            })
+
+        }
+    }, [ gravatarURLs ]);
 
     /**
      * Handles selected gravatar email change.

--- a/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
+++ b/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
@@ -199,7 +199,7 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
     const [ gravatarURLs, setGravatarURLs ] = useState<Map<string, string>>(undefined);
     const [ selectedAvatarType, setSelectedAvatarType ] = useState<AvatarTypes>(undefined);
     const [ hostedURL, setHostedURL ] = useState<string>(undefined);
-    const [isGravatarUrl, setIsGravatarUrl] = useState<boolean>(false);
+    const [ isGravatarUrl, setIsGravatarUrl ] = useState<boolean>(false);
     const [ hostedURLError, setHostedURLError ] = useState<LabelProps>(undefined);
     const [
         outputURL,

--- a/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
+++ b/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
@@ -307,11 +307,13 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
     useEffect(() => {
 
         if (gravatarURLs) {
-            gravatarURLs.forEach((value: string, key: string) => {
+            for (const [ key, value ] of gravatarURLs) {
                 if (imageUrl.localeCompare(value) == 0) {
                     setIsGravatarUrl(true);
+
+                    break;
                 }
-            })
+            }
         }
     }, [ gravatarURLs ]);
 

--- a/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
+++ b/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
@@ -285,8 +285,8 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
 
     useEffect(() => {
         if (imageUrl) {
-            setHostedURL(imageUrl);
-            setSelectedAvatarType(AvatarTypes.URL);
+            setOutputURL(imageUrl);
+            setSelectedAvatarType(AvatarTypes.GRAVATAR);
         } else {
             setSelectedAvatarType(AvatarTypes.SYSTEM_GENERATED);
         }

--- a/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
+++ b/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
@@ -312,7 +312,6 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
                     setIsGravatarUrl(true);
                 }
             })
-
         }
     }, [ gravatarURLs ]);
 


### PR DESCRIPTION
### Purpose
> The Gravatar selected in the previous profile picture update should be marked by default when updating it again.

### Checklist
- [x] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
