### PR TITLE
Logouturl key changed for OIDC IDP edit

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -684,8 +684,8 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                         prop.description = "These  will be sent to the identity provider as query parameters in the " +
                             "authentication request. \nE.g., loginHint=hint1";
                     } else if (prop.key === "IsBasicAuthEnabled") {
-                        prop.description = "Specify whether to enable HTTP basic authentication for authenticating " +
-                            "clients. If unchecked, client credentials will be included in the request body";
+                        prop.description = "Specify whether to enable HTTP basic authentication or send " +
+                            "client credentials in the request body";
                     }
                 });
 

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -682,13 +682,13 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     } else if (prop.key === "commonAuthQueryParams") {
                         prop.displayName = "Additional query parameters";
                         prop.description = "These  will be sent to the identity provider as query parameters in the " +
-                            "authentication request. \nE.g., loginHint=hint1";
-                    } else if (prop.key === "IsBasicAuthEnabled") {
-                        prop.description = "Specify whether to enable HTTP basic authentication or send " +
-                            "client credentials in the request body";
+                            "authentication request. \nE.g., loginHint=hint1"
                     }
                 });
 
+                // Remove additional query params
+                removeElementFromProps(authenticator.data.properties, "IsBasicAuthEnabled");
+                removeElementFromProps(authenticator.meta.properties, "IsBasicAuthEnabled");
                 //Temporarily removed until sub attributes are available
                 removeElementFromProps(authenticator.meta.properties, "IsUserIdInClaims" )
 

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -682,19 +682,19 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     } else if (prop.key === "commonAuthQueryParams") {
                         prop.displayName = "Additional query parameters";
                         prop.description = "These  will be sent to the identity provider as query parameters in the " +
-                            "authentication request. \nE.g., loginHint=hint1"
+                            "authentication request. \nE.g., loginHint=hint1";
+                    } else if (prop.key === "IsBasicAuthEnabled") {
+                        prop.description = "Specify whether to enable HTTP basic authentication for authenticating " +
+                            "clients. If unchecked, client credentials will be included in the request body";
                     }
                 });
 
-                // Remove additional query params
-                removeElementFromProps(authenticator.data.properties, "IsBasicAuthEnabled");
-                removeElementFromProps(authenticator.meta.properties, "IsBasicAuthEnabled");
                 //Temporarily removed until sub attributes are available
                 removeElementFromProps(authenticator.meta.properties, "IsUserIdInClaims" )
 
                 // Inject logout url
                 const logoutUrlData = {
-                    key: "LogoutUrl"
+                    key: "OIDCLogoutEPUrl"
                 };
                 authenticator.data.properties.push(logoutUrlData);
                 const logoutUrlMeta: CommonPluggableComponentMetaPropertyInterface = {
@@ -704,7 +704,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     displayOrder: 7,
                     isConfidential: false,
                     isMandatory: false,
-                    key: "LogoutUrl",
+                    key: "OIDCLogoutEPUrl",
                     options: [],
                     subProperties: [],
                     type: "URL"


### PR DESCRIPTION
### Purpose
> The key of the key value mapping for sending the logout URL of the OIDC enterprise Identity provider has been updated from frontend to match the backend accepted key.

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
