### PR TITLE
Disable update button when there are no authentication options selected in any authentication step

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -256,15 +256,15 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
     }, [ groupedIDPTemplates, addNewAuthenticatorClicked ]);
 
     /**
-     * Change button disable state when authentication Steps are changed.
+     * Disable button when there are no authentication options selected.
      */
     useEffect(() => {
 
         const steps: AuthenticationStepInterface[] = [ ...authenticationSteps ];
 
-        const optionsSelected = steps.find((step) => !isEmpty(step.options));
+        const hasStepsWithOptions: boolean = steps.some((step: AuthenticationStepInterface) => !isEmpty(step.options));
 
-        if (optionsSelected) {
+        if (hasStepsWithOptions) {
             onAuthenticationSequenceChange(false);
             return;
         }

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -260,14 +260,15 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
      */
     useEffect(() => {
 
-        const noOptionsSelected: boolean = authenticationSteps.length === 1
-            && authenticationSteps[ 0 ].options?.length === 0;
+        const steps: AuthenticationStepInterface[] = [ ...authenticationSteps ];
 
-        if (noOptionsSelected) {
-            onAuthenticationSequenceChange(true);
+        const optionsSelected = steps.find((step) => !isEmpty(step.options));
+
+        if (optionsSelected) {
+            onAuthenticationSequenceChange(false);
             return;
         }
-        onAuthenticationSequenceChange(false);
+        onAuthenticationSequenceChange(true);
     }, [ authenticationSteps ]);
 
     /**

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -2238,7 +2238,7 @@ export const console: ConsoleNS = {
                     },
                     emptyAuthenticationStep: {
                         genericError: {
-                            description: "There is an empty authentication step. Please remove it or add " +
+                            description: "There are empty authentication steps. Please remove them or add " +
                                 "authenticators to proceed.",
                             message: "Update error"
                         }

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -2252,8 +2252,8 @@ export const console: ConsoleNS = {
                     },
                     emptyAuthenticationStep: {
                         genericError: {
-                            description: "Il y a une étape d'authentification vide.Veuillez la supprimer ou ajouter des " +
-                                "authentificateurs pour continuer.",
+                            description: "Il y a des étapes d'authentification vides. Veuillez les supprimer ou" +
+                                " ajouter des authentifiants pour continuer.",
                             message: "Erreur de mise à jour"
                         }
                     },

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -2208,8 +2208,8 @@ export const console: ConsoleNS = {
                     },
                     emptyAuthenticationStep: {
                         genericError: {
-                            description: "හිස් සත්‍යාපන පියවරක් ඇත. කරුණාකර එය ඉවත් කරන්න හෝ " +
-                                "ඉදිරියට යාමට සත්‍යාපක එකතු කරන්න.",
+                            description: "හිස් සත්‍යාපන පියවර තිබේ. කරුණාකර ඒවා ඉවත් කරන්න හෝ ඉදිරියට යාමට සත්‍යාපක එකතු" +
+                                " කරන්න.",
                             message: "යාවත්කාලීන දෝෂයකි"
                         }
                     },


### PR DESCRIPTION
### Purpose
"Update" button was disabled when there are no authentication options selected in any authentication step.

### Related Issues
- https://github.com/wso2/product-is/issues/11854

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
