### PR TITLE
Fix IDP create wizard NPE

### DIFF
--- a/apps/console/src/features/identity-providers/components/wizards/authenticator-create-wizard-factory.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/authenticator-create-wizard-factory.tsx
@@ -133,8 +133,19 @@ export const AuthenticatorCreateWizardFactory: FunctionComponent<AuthenticatorCr
      */
     useEffect(() => {
 
-        if (!showWizard) return;
-        if (!possibleListOfDuplicateIDPs) return;
+        if (!showWizard) {
+            return;
+        }
+
+        if (!possibleListOfDuplicateIDPs) {
+            return;
+        }
+
+        // WHen the wizard is closed by pressing `esc`, bellow code block is executed
+        // hitting NPE. Better, to terminate execution if `selectedTemplate` is undefined.
+        if (!selectedTemplate) {
+            return;
+        }
 
         if (selectedTemplate.idp?.name) {
             /**


### PR DESCRIPTION
### Purpose
IDP wizard is hitting a NPE when `esc` is pressed.

<img width="368" alt="Screen Shot 2021-06-14 at 12 24 25 PM" src="https://user-images.githubusercontent.com/25959096/121851220-7f5bf780-cd0b-11eb-8c95-76aba7496c7a.png">

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
