### PR TITLE
Remove Confirm Password from MyAccount

### DIFF
--- a/apps/myaccount/src/components/change-password/change-password.tsx
+++ b/apps/myaccount/src/components/change-password/change-password.tsx
@@ -17,7 +17,7 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Field, FormValue, Forms, Validation, useTrigger } from "@wso2is/forms";
+import { Field, FormValue, Forms, useTrigger } from "@wso2is/forms";
 import React, { FunctionComponent, Suspense, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -312,38 +312,6 @@ export const ChangePassword: FunctionComponent<ChangePasswordProps> = (props: Ch
                             />
                         </Suspense>
                     </Form.Field>
-                    <Field
-                        data-testid={ `${testId}-new-password-confirm-field` }
-                        hidePassword={ t("common:hidePassword") }
-                        label={ t(
-                            "myAccount:components.changePassword.forms.passwordResetForm.inputs"
-                            + ".confirmPassword.label"
-                        ) }
-                        name="confirmPassword"
-                        placeholder={ t(
-                            "myAccount:components.changePassword.forms.passwordResetForm.inputs." +
-                            "confirmPassword.placeholder"
-                        ) }
-                        required={ true }
-                        requiredErrorMessage={ t(
-                            "myAccount:components.changePassword.forms.passwordResetForm." +
-                            "inputs.confirmPassword.validations.empty"
-                        ) }
-                        showPassword={ t("common:showPassword") }
-                        type="password"
-                        validation={ (value: string, validation: Validation, formValues) => {
-                            if (formValues.get("newPassword") !== value) {
-                                validation.isValid = false;
-                                validation.errorMessages.push(
-                                    t(
-                                        "myAccount:components.changePassword.forms.passwordResetForm.inputs" +
-                                        ".confirmPassword.validations.mismatch"
-                                    )
-                                );
-                            }
-                        } }
-                        width={ 9 }
-                    />
                     <Field
                         hidden={ true }
                         type="divider"


### PR DESCRIPTION
### Purpose
"Confirm Password" field was removed from MyAccount.

### Related Issues
- Issue #1

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Related PRs
- Related PR #1

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
