### PR TITLE
Fix requested claims issue in Facebook IDP

### DIFF
--- a/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
@@ -108,7 +108,7 @@ interface FacebookAuthenticatorFormFieldsInterface {
     /**
      * Facebook Authenticator scopes field.
      */
-    scope: CommonAuthenticatorFormFieldInterface;
+    Scope: CommonAuthenticatorFormFieldInterface;
     /**
      * Facebook User Info field.
      */
@@ -372,9 +372,9 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
                 data-testid={ `${ testId }-authorized-redirect-url` }
             />
             {
-                formFields?.scope?.value
-                && formFields.scope.value.split
-                && formFields.scope.value.split(" ").length > 0
+                formFields?.Scope?.value
+                && formFields.Scope.value.split
+                && formFields.Scope.value.split(" ").length > 0
                 && (
                     <FormSection
                         heading={
@@ -384,8 +384,8 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
                     >
                         <div className="authenticator-dynamic-properties">
                             {
-                                formFields.scope.value
-                                    .split(" ")
+                                formFields.Scope.value
+                                    .split(",")
                                     .map((scope: string, index: number) => {
 
                                         const scopeMeta: ScopeMetaInterface = resolveScopeMetadata(scope);

--- a/apps/console/src/features/identity-providers/components/wizards/facebook/facebook-authentication-provider-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/facebook/facebook-authentication-provider-create-wizard.tsx
@@ -248,8 +248,8 @@ export const FacebookAuthenticationProviderCreateWizard: FunctionComponent<
                 "value": config.deployment.serverHost + "/commonauth"
             },
             {
-                "key": "scope",
-                "value": IdentityProviderManagementConstants.FACEBOOK_AUTHENTICATOR_REQUESTED_SCOPES.join(" ")
+                "key": "Scope",
+                "value": IdentityProviderManagementConstants.FACEBOOK_AUTHENTICATOR_REQUESTED_SCOPES.join(",")
             },
             {
                 "key": "UserInfoFields",

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/facebook/facebook.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/facebook/facebook.json
@@ -19,16 +19,73 @@
         "alias": "https://localhost:9444/oauth2/token",
         "claims": {
             "userIdClaim": {
-                "uri": "http://wso2.org/claims/username"
+                "uri": "email"
             },
             "roleClaim": {
                 "uri": "http://wso2.org/claims/role"
             },
+            "mappings": [
+                {
+                    "idpClaim": "email",
+                    "localClaim": {
+                        "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9lbWFpbGFkZHJlc3M",
+                        "uri": "http://wso2.org/claims/emailaddress",
+                        "displayName": "Email"
+                    }
+                },
+                {
+                    "idpClaim": "gender",
+                    "localClaim": {
+                        "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9nZW5kZXI",
+                        "uri": "http://wso2.org/claims/gender",
+                        "displayName": "Gender"
+                    }
+                },
+                {
+                    "idpClaim": "name",
+                    "localClaim": {
+                        "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9mdWxsbmFtZQ",
+                        "uri": "http://wso2.org/claims/fullname",
+                        "displayName": "Full Name"
+                    }
+                },
+                {
+                    "idpClaim": "first_name",
+                    "localClaim": {
+                        "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9naXZlbm5hbWU",
+                        "uri": "http://wso2.org/claims/givenname",
+                        "displayName": "First Name"
+                    }
+                },
+                {
+                    "idpClaim": "last_name",
+                    "localClaim": {
+                        "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9sYXN0bmFtZQ",
+                        "uri": "http://wso2.org/claims/lastname",
+                        "displayName": "Last Name"
+                    }
+                },
+                {
+                    "idpClaim": "age_range",
+                    "localClaim": {
+                        "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy9kb2I",
+                        "uri": "http://wso2.org/claims/dob",
+                        "displayName": "Birth Date"
+                    }
+                },
+                {
+                    "idpClaim": "link",
+                    "localClaim": {
+                        "id": "aHR0cDovL3dzbzIub3JnL2NsYWltcy91cmw",
+                        "uri": "http://wso2.org/claims/url",
+                        "displayName": "URL"
+                    }
+                }
+            ],
             "provisioningClaims": []
         },
         "roles": {
-            "mappings": [],
-            "outboundProvisioningRoles": []
+            "mappings": []
         },
         "federatedAuthenticators": {
             "defaultAuthenticatorId": "RmFjZWJvb2tBdXRoZW50aWNhdG9y",


### PR DESCRIPTION
### Purpose

User Attributes were not displaying when logging with Facebook Credentials. This was happening due to the usage of `scope` instead of `Scope` (https://github.com/wso2-extensions/identity-outbound-auth-facebook/blob/master/components/org.wso2.carbon.identity.application.authenticator.facebook/src/main/java/org/wso2/carbon/identity/application/authenticator/facebook/FacebookAuthenticatorConstants.java#L34)

**After fix**

<img width="1919" alt="Screen Shot 2021-06-16 at 10 55 23 AM" src="https://user-images.githubusercontent.com/25959096/122163213-6af63700-ce92-11eb-9b02-f7870c32937f.png">

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
