### PR TITLE
Create a dedicated form for Google authenticator

### DIFF
--- a/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
@@ -79,11 +79,11 @@ interface FacebookAuthenticatorFormInitialValuesInterface {
     /**
      * Facebook Authenticator callback URL field value.
      */
-    callbackUrl: string;
+    callBackUrl: string;
     /**
      * Facebook Authenticator scopes field value.
      */
-    scope: string;
+    Scope: string;
     /**
      * Facebook Authenticator client id field value.
      */

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
@@ -357,7 +357,7 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
             {
                 formFields?.Scope?.value
                 && formFields.Scope.value.split
-                && formFields.Scope.value.split(" ").length > 0
+                && formFields.Scope.value.split(",").length > 0
                 && (
                     <FormSection
                         heading={

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
@@ -18,14 +18,11 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Form } from "@wso2is/form";
-import { Code, FormSection, GenericIcon, Heading, Hint } from "@wso2is/react-components";
-import camelCase from "lodash-es/camelCase";
-import get from "lodash-es/get";
+import { Code, FormSection, GenericIcon, Hint } from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
-import toUpper from "lodash-es/toUpper";
 import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { Divider, Grid, Icon, SemanticICONS } from "semantic-ui-react";
+import { Icon, SemanticICONS } from "semantic-ui-react";
 import { IdentityProviderManagementConstants } from "../../../constants";
 import {
     CommonAuthenticatorFormFieldInterface,
@@ -135,20 +132,6 @@ interface ScopeMetaInterface {
      * Scope icon.
      */
     icon: SemanticICONS
-}
-
-/**
- * User Info UI displaying interface.
- */
-interface UserInfoMetaInterface {
-    /**
-     * Scope description.
-     */
-    description: string;
-    /**
-     * Scope display name.
-     */
-    displayName: ReactNode;
 }
 
 /**

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/google-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/google-authenticator-form.tsx
@@ -1,0 +1,480 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestableComponentInterface } from "@wso2is/core/models";
+import { Field, Form } from "@wso2is/form";
+import { Code, FormSection, GenericIcon, Hint } from "@wso2is/react-components";
+import isEmpty from "lodash-es/isEmpty";
+import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { Icon, SemanticICONS } from "semantic-ui-react";
+import { IdentityProviderManagementConstants } from "../../../constants";
+import {
+    CommonAuthenticatorFormFieldInterface,
+    CommonAuthenticatorFormFieldMetaInterface,
+    CommonAuthenticatorFormInitialValuesInterface,
+    CommonAuthenticatorFormMetaInterface,
+    CommonAuthenticatorFormPropertyInterface
+} from "../../../models";
+
+/**
+ * Interface for Google Authenticator Form props.
+ */
+interface GoogleAuthenticatorFormPropsInterface extends TestableComponentInterface {
+    /**
+     * Google Authenticator metadata.
+     */
+    metadata: CommonAuthenticatorFormMetaInterface;
+    /**
+     * Google Authenticator configured initial values.
+     */
+    initialValues: CommonAuthenticatorFormInitialValuesInterface;
+    /**
+     * Callback for form submit.
+     * @param {CommonAuthenticatorFormInitialValuesInterface} values - Resolved Form Values.
+     */
+    onSubmit: (values: CommonAuthenticatorFormInitialValuesInterface) => void;
+    /**
+     * Is readonly.
+     */
+    readOnly?: boolean;
+    /**
+     * Flag to trigger form submit externally.
+     */
+    triggerSubmit: boolean;
+    /**
+     * Flag to enable/disable form submit button.
+     */
+    enableSubmitButton: boolean;
+    /**
+     * Flag to show/hide custom properties.
+     * @remarks Not implemented ATM. Do this when needed.
+     */
+    showCustomProperties: boolean;
+}
+
+/**
+ * Form initial values interface.
+ */
+interface GoogleAuthenticatorFormInitialValuesInterface {
+    /**
+     * Google Authenticator client secret field value.
+     */
+    AdditionalQueryParameters: string;
+    /**
+     * Google Authenticator client secret field value.
+     */
+    ClientSecret: string;
+    /**
+     * Google Authenticator callback URL field value.
+     */
+    callbackUrl: string;
+    /**
+     * Google Authenticator client id field value.
+     */
+    ClientId: string;
+}
+
+/**
+ * Form fields interface.
+ */
+interface GoogleAuthenticatorFormFieldsInterface {
+    /**
+     * Google Authenticator client secret field value.
+     */
+    AdditionalQueryParameters: CommonAuthenticatorFormFieldInterface;
+    /**
+     * Google Authenticator client secret field.
+     */
+    ClientSecret: CommonAuthenticatorFormFieldInterface;
+    /**
+     * Google Authenticator callback URL field.
+     */
+    callbackUrl: CommonAuthenticatorFormFieldInterface;
+    /**
+     * Google Authenticator client id field value.
+     */
+    ClientId: CommonAuthenticatorFormFieldInterface;
+}
+
+/**
+ * Scopes UI displaying interface.
+ */
+interface ScopeMetaInterface {
+    /**
+     * Scope description.
+     */
+    description: string;
+    /**
+     * Scope display name.
+     */
+    displayName: ReactNode;
+    /**
+     * Scope icon.
+     */
+    icon: SemanticICONS
+}
+
+/**
+ * Google Authenticator Form.
+ *
+ * @param {GoogleAuthenticatorFormPropsInterface} props - Props injected to the component.
+ *
+ * @return {React.ReactElement}
+ */
+export const GoogleAuthenticatorForm: FunctionComponent<GoogleAuthenticatorFormPropsInterface> = (
+    props: GoogleAuthenticatorFormPropsInterface
+): ReactElement => {
+
+    const {
+        metadata,
+        initialValues: originalInitialValues,
+        onSubmit,
+        readOnly,
+        [ "data-testid" ]: testId
+    } = props;
+
+    const { t } = useTranslation();
+
+    const [ formFields, setFormFields ] = useState<GoogleAuthenticatorFormFieldsInterface>(undefined);
+    const [ initialValues, setInitialValues ] = useState<GoogleAuthenticatorFormInitialValuesInterface>(undefined);
+
+    /**
+     * Flattens and resolved form initial values and field metadata.
+     */
+    useEffect(() => {
+
+        if (isEmpty(originalInitialValues?.properties)) {
+            return;
+        }
+
+        let resolvedFormFields: GoogleAuthenticatorFormFieldsInterface = null;
+        let resolvedInitialValues: GoogleAuthenticatorFormInitialValuesInterface = null;
+
+        originalInitialValues.properties.map((value: CommonAuthenticatorFormPropertyInterface) => {
+            const meta: CommonAuthenticatorFormFieldMetaInterface = metadata?.properties
+                .find((meta) => meta.key === value.key);
+
+            resolvedFormFields = {
+                ...resolvedFormFields,
+                [ value.key ]: {
+                    meta,
+                    value: value.value
+                }
+            };
+
+            resolvedInitialValues = {
+                ...resolvedInitialValues,
+                [ value.key ]: value.value
+            };
+        });
+
+        setFormFields(resolvedFormFields);
+        setInitialValues(resolvedInitialValues);
+    }, [ originalInitialValues ]);
+
+    /**
+     * Prepare form values for submitting.
+     *
+     * @param values - Form values.
+     *
+     * @return {CommonAuthenticatorFormInitialValuesInterface} Sanitized form values.
+     */
+    const getUpdatedConfigurations = (values: GoogleAuthenticatorFormInitialValuesInterface)
+        : CommonAuthenticatorFormInitialValuesInterface => {
+
+        const properties = [];
+
+        for (const [ key, value ] of Object.entries(values)) {
+            if (key !== undefined) {
+                properties.push({
+                    key: key,
+                    value: value
+                });
+            }
+        }
+
+        return {
+            ...originalInitialValues,
+            properties
+        };
+    };
+
+    /**
+     * Resolve metadata for UI rendering of scopes.
+     *
+     * @param {string} scope - Input scope.
+     *
+     * @return {ScopeMetaInterface}
+     */
+    const resolveScopeMetadata = (scope: string): ScopeMetaInterface => {
+
+        if (scope === IdentityProviderManagementConstants.GOOGLE_SCOPE_DICTIONARY.EMAIL) {
+            return {
+                description: t("console:develop.features.authenticationProvider.forms" +
+                    ".authenticatorSettings.google.scopes.list.email.description"),
+                displayName: (
+                    <Code compact withBackground={ false } fontSize="inherit" fontColor="inherit">
+                        { IdentityProviderManagementConstants.GOOGLE_SCOPE_DICTIONARY.EMAIL }
+                    </Code>
+                ),
+                icon: "envelope outline"
+            };
+        }
+
+        if (scope === IdentityProviderManagementConstants.GOOGLE_SCOPE_DICTIONARY.OPENID) {
+            return {
+                description: t("console:develop.features.authenticationProvider.forms" +
+                    ".authenticatorSettings.google.scopes.list.openid.description"),
+                displayName: (
+                    <Code compact withBackground={ false } fontSize="inherit" fontColor="inherit">
+                        { IdentityProviderManagementConstants.GOOGLE_SCOPE_DICTIONARY.OPENID }
+                    </Code>
+                ),
+                icon: "openid"
+            };
+        }
+
+        if (scope === IdentityProviderManagementConstants.GOOGLE_SCOPE_DICTIONARY.PROFILE) {
+            return {
+                description: t("console:develop.features.authenticationProvider.forms" +
+                    ".authenticatorSettings.google.scopes.list.profile.description"),
+                displayName: (
+                    <Code compact withBackground={ false } fontSize="inherit" fontColor="inherit">
+                        { IdentityProviderManagementConstants.GOOGLE_SCOPE_DICTIONARY.PROFILE }
+                    </Code>
+                ),
+                icon: "user outline"
+            };
+        }
+
+        return {
+            description: "",
+            displayName: scope,
+            icon: "key"
+        };
+    };
+
+    /**
+     * Extracts scopes as an array.
+     * 
+     * Input - "scope=openid email profile"
+     * Output - [ "openid", "email", "profile" ]
+     * 
+     * @param {string} rawScopes - Raw String.
+     *
+     * @return {string[]}
+     */
+    const extractScopes = (rawScopes: string): string[] => {
+
+        let scopes: string[] = [];
+
+        try {
+            scopes = rawScopes.split("scope=")[1].split(" ");
+        } catch(e) {
+            // Silent any issues occurred when trying to scroll.
+            // Add debug logs here one a logger is added.
+            // Tracked here https://github.com/wso2/product-is/issues/11650.
+        }
+
+        return scopes;
+    };
+
+    return (
+        <Form
+            onSubmit={ (values) => onSubmit(getUpdatedConfigurations(values)) }
+            initialValues={ initialValues }
+        >
+            <Field.Input
+                ariaLabel="Google authenticator client ID"
+                inputType="default"
+                name="ClientId"
+                label={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".google.clientId.label")
+                }
+                placeholder={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".google.clientId.placeholder")
+                }
+                hint={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".google.clientId.hint")
+                }
+                required={ formFields?.ClientId?.meta?.isMandatory }
+                readOnly={ formFields?.ClientId?.meta?.readOnly }
+                value={ formFields?.ClientId?.value }
+                maxLength={ formFields?.ClientId?.meta?.maxLength }
+                minLength={
+                    IdentityProviderManagementConstants
+                        .AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS.CLIENT_ID_MIN_LENGTH as number
+                }
+                width={ 16 }
+                data-testid={ `${ testId }-client-id` }
+            />
+            <Field.Input
+                ariaLabel="Google authenticator client secret"
+                inputType="password"
+                type="password"
+                name="ClientSecret"
+                label={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".google.clientSecret.label")
+                }
+                placeholder={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".google.clientSecret.placeholder")
+                }
+                hint={
+                    <Trans
+                        i18nKey={
+                            "console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                            ".google.clientSecret.hint"
+                        }
+                    >
+                        The <Code>App secret</Code> value of the Google application.
+                    </Trans>
+                }
+                required={ formFields?.ClientSecret?.meta?.isMandatory }
+                readOnly={ formFields?.ClientSecret?.meta?.readOnly }
+                value={ formFields?.ClientSecret?.value }
+                maxLength={ formFields?.ClientSecret?.meta?.maxLength }
+                minLength={
+                    IdentityProviderManagementConstants
+                        .AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS.CLIENT_SECRET_MIN_LENGTH as number
+                }
+                width={ 16 }
+                data-testid={ `${ testId }-client-secret` }
+            />
+            <Field.Input
+                ariaLabel="Google authenticator authorized redirect URL"
+                inputType="copy_input"
+                name="callbackUrl"
+                label={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".google.callbackUrl.label")
+                }
+                placeholder={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".google.callbackUrl.placeholder")
+                }
+                hint={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".google.callbackUrl.hint")
+                }
+                required={ formFields?.callbackUrl?.meta?.isMandatory }
+                value={ formFields?.callbackUrl?.value }
+                readOnly={ formFields?.callbackUrl?.meta?.readOnly }
+                maxLength={ formFields?.callbackUrl?.meta?.maxLength }
+                minLength={
+                    IdentityProviderManagementConstants
+                        .AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS.CALLBACK_URL_MIN_LENGTH as number
+                }
+                width={ 16 }
+                data-testid={ `${ testId }-authorized-redirect-url` }
+            />
+            {
+                (formFields?.AdditionalQueryParameters?.value
+                    && !isEmpty(extractScopes(formFields.AdditionalQueryParameters.value))) && (
+                    <FormSection
+                        heading={
+                            t("console:develop.features.authenticationProvider.forms" +
+                                ".authenticatorSettings.google.scopes.heading")
+                        }
+                    >
+                        <div className="authenticator-dynamic-properties">
+                            {
+                                extractScopes(formFields.AdditionalQueryParameters.value)
+                                    .map((scope: string, index: number) => {
+
+                                        const scopeMeta: ScopeMetaInterface = resolveScopeMetadata(scope);
+
+                                        return (
+                                            <div
+                                                key={ index }
+                                                className="authenticator-dynamic-property"
+                                                data-testid={ scope }
+                                            >
+                                                <div className="authenticator-dynamic-property-name-container">
+                                                    <GenericIcon
+                                                        square
+                                                        inline
+                                                        transparent
+                                                        icon={ <Icon name={ scopeMeta.icon }/> }
+                                                        size="micro"
+                                                        className="scope-icon"
+                                                        spaced="right"
+                                                        verticalAlign="top"
+                                                    />
+                                                    <div data-testid={ `${ scope }-name` }>
+                                                        { scopeMeta.displayName }
+                                                    </div>
+                                                </div>
+                                                <div
+                                                    className="authenticator-dynamic-property-description"
+                                                    data-testid={ `${ scope }-description` }
+                                                >
+                                                    { scopeMeta.description }
+                                                </div>
+                                            </div>
+                                        );
+                                    })
+                            }
+                        </div>
+                        <Hint compact>
+                            <Trans
+                                i18nKey={
+                                    "console:develop.features.authenticationProvider.forms" +
+                                    ".authenticatorSettings.google.scopes.hint"
+                                }
+                            >
+                                Scopes provide a way for connected apps to access data from Google.
+                                Click <a
+                                href={
+                                    "https://developers.google.com/identity/protocols/oauth2/" +
+                                    "openid-connect#scope-param"
+                                }
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >here</a> to learn more.
+                            </Trans>
+                        </Hint>
+                    </FormSection>
+                )
+            }
+            <Field.Button
+                size="small"
+                buttonType="primary_btn"
+                ariaLabel="Google authenticator update button"
+                name="update-button"
+                data-testid={ `${ testId }-submit-button` }
+                disabled={ false }
+                label={ t("common:update") }
+                hidden={ readOnly }
+            />
+        </Form>
+    );
+};
+
+/**
+ * Default props for the component.
+ */
+GoogleAuthenticatorForm.defaultProps = {
+    "data-testid": "google-authenticator-form",
+    enableSubmitButton: true
+};

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/index.ts
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/index.ts
@@ -19,3 +19,4 @@
 export * from "./common-authenticator-form";
 export * from "./facebook-authenticator-form";
 export * from "./github-authenticator-form";
+export * from "./google-authenticator-form";

--- a/apps/console/src/features/identity-providers/components/forms/factories/authenticator-form-factory.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/factories/authenticator-form-factory.tsx
@@ -20,7 +20,12 @@ import { TestableComponentInterface } from "@wso2is/core/models";
 import React, { FunctionComponent, ReactElement } from "react";
 import { IdentityProviderManagementConstants } from "../../../constants";
 import { FederatedAuthenticatorListItemInterface, FederatedAuthenticatorMetaInterface } from "../../../models";
-import { CommonAuthenticatorForm, FacebookAuthenticatorForm, GithubAuthenticatorForm } from "../authenticators";
+import {
+    CommonAuthenticatorForm,
+    FacebookAuthenticatorForm,
+    GithubAuthenticatorForm,
+    GoogleAuthenticatorForm
+} from "../authenticators";
 
 /**
  * Proptypes for the authenticator form factory component.
@@ -60,6 +65,18 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
     } = props;
 
     switch (type) {
+        case IdentityProviderManagementConstants.GOOGLE_OIDC_AUTHENTICATOR_ID:
+            return (
+                <GoogleAuthenticatorForm
+                    initialValues={ initialValues }
+                    metadata={ metadata }
+                    onSubmit={ onSubmit }
+                    triggerSubmit={ triggerSubmit }
+                    enableSubmitButton={ enableSubmitButton }
+                    data-testid={ testId }
+                    showCustomProperties={ showCustomProperties }
+                />
+            );
         case IdentityProviderManagementConstants.FACEBOOK_AUTHENTICATOR_ID:
             return (
                 <FacebookAuthenticatorForm

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -585,67 +585,6 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     identityProvider.federatedAuthenticators.defaultAuthenticatorId === authenticator.id
                 ));
 
-            // TODO: Need to update below values in the Google authenticator metadata API
-            // Set additional meta data if the authenticator is Google
-            if (authenticator.id === "R29vZ2xlT0lEQ0F1dGhlbnRpY2F0b3I") {
-                authenticator.meta.properties.map(prop => {
-                    if (prop.key === "ClientId") {
-                        prop.displayName = "Client ID";
-                        prop.description = "The client identifier value of the Google identity provider.";
-                        prop.maxLength = GOOGLE_CLIENT_ID_SECRET_MAX_LENGTH;
-                    } else if (prop.key === "ClientSecret") {
-                        prop.displayName = "Client secret";
-                        prop.description = "The client secret value of the Google identity provider.";
-                        prop.maxLength = GOOGLE_CLIENT_ID_SECRET_MAX_LENGTH;
-                    } else if (prop.key === "callbackUrl") {
-                        prop.readOnly = true;
-                        prop.description = "The authorized redirect URL used to obtain Google credentials.";
-                        prop.displayName = "Authorized redirect URL";
-                    }
-                });
-
-                // Remove additional query params
-                removeElementFromProps(authenticator.data.properties, "AdditionalQueryParameters");
-                removeElementFromProps(authenticator.meta.properties, "AdditionalQueryParameters");
-
-                // Inject scopes
-                const scopesData = {
-                    key: "scopes",
-                    value: "openid email profile"
-                };
-                authenticator.data.properties.push(scopesData);
-                const scopesMeta: CommonPluggableComponentMetaPropertyInterface = {
-                    defaultValue: "",
-                    description: "The scopes sent to Google to retrieve email address and basic profile " +
-                        "information of the user.",
-                    displayName: "Scopes",
-                    displayOrder: 4,
-                    isConfidential: false,
-                    isMandatory: false,
-                    key: "scopes",
-                    options: [],
-                    properties: {
-                        email: {
-                            description: "Allows to view user's email address",
-                            icon: <Icon className={ "mr-0" } name="envelope outline" />
-                        },
-                        openid: {
-                            description: "Allows to authenticate using OpenID Connect",
-                            icon: <Icon className={ "mr-0" } name="openid" />
-                        },
-                        profile: {
-                            description: "Allows to view user's basic profile info",
-                            icon: <Icon className={ "mr-0" } name="user outline" />
-                        }
-                    },
-                    readOnly: true,
-                    regex: ".*",
-                    subProperties: [],
-                    type: "STRING"
-                };
-                authenticator.meta.properties.push(scopesMeta);
-            }
-
             // TODO: Need to update below values in the OIDC authenticator metadata API
             // Set additional meta data if the authenticator is OIDC
             if (authenticator.id === IdentityProviderManagementConstants.OIDC_AUTHENTICATOR_ID) {

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -105,6 +105,16 @@ export class IdentityProviderManagementConstants {
     };
 
     /**
+     * Google Scope mappings.
+     * @type {Record<string, string>}
+     */
+    public static readonly GOOGLE_SCOPE_DICTIONARY: Record<string, string> = {
+        EMAIL: "email",
+        OPENID: "openid",
+        PROFILE: "profile"
+    };
+
+    /**
      * GitHub Scope mappings.
      * @type {Record<string, string>}
      */

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -2956,7 +2956,7 @@ export const console: ConsoleNS = {
                                 }
                             },
                             clientId: {
-                                hint: "The <1>Client ID</> you received from Google for your OAuth app.",
+                                hint: "The <1>Client ID</1> you received from Google for your OAuth app.",
                                 label: "Client ID",
                                 placeholder: "Enter Client ID from Google application.",
                                 validations: {


### PR DESCRIPTION
### Purpose
ATM, we are rendering the Google Authenticator form using `CommonAuthenticatorForm` which makes it hard to have customized fields for certain attributes.

This PR adds a dedicated form for Google Authenticator. 

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
