### PR TITLE
Make subject attribute mandatory when it is included in requested claims

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -612,6 +612,7 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
     const submitUpdateRequest = (claimMappingFinal) => {
         let isSubjectSelectedWithoutMapping = false;
         const RequestedClaims = [];
+        const subjectClaim = advanceSettingValues?.subject?.claim;
         if (selectedDialect.localDialect) {
             selectedClaims.map((claim: ExtendedClaimInterface) => {
                 // If claim mapping is there then check whether claim is requested or not.
@@ -623,7 +624,9 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                             claim: {
                                 uri: claimMappingURI
                             },
-                            mandatory: claim.mandatory
+                            mandatory: (subjectClaim && claimMappingURI === subjectClaim.toString())
+                                ? applicationConfig.attributeSettings.makeSubjectMandatory
+                                : claim.mandatory
                         };
                         RequestedClaims.push(requestedClaim);
                     }
@@ -632,7 +635,9 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                         claim: {
                             uri: claim.claimURI
                         },
-                        mandatory: claim.mandatory
+                        mandatory: (subjectClaim && claim.claimURI === subjectClaim.toString())
+                            ? applicationConfig.attributeSettings.makeSubjectMandatory
+                            : claim.mandatory
                     };
                     RequestedClaims.push(requestedClaim);
                 }
@@ -650,18 +655,8 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
         }
 
         if (claimMappingFinal.findIndex(mapping => mapping.localClaim.uri === DefaultSubjectAttribute) < 0
-            && advanceSettingValues?.subject.claim.toString() === DefaultSubjectAttribute) {
+            && subjectClaim && subjectClaim.toString() === DefaultSubjectAttribute) {
             isSubjectSelectedWithoutMapping = true;
-        }
-
-        // Make the subject attribute mandatory by default.
-        if (applicationConfig.attributeSettings.makeSubjectMandatory && !isSubjectSelectedWithoutMapping) {
-            RequestedClaims.push({
-                claim: {
-                    uri: advanceSettingValues?.subject.claim
-                },
-                mandatory: true
-            });
         }
 
         if (claimMappingFinal.length > 0 && isSubjectSelectedWithoutMapping) {


### PR DESCRIPTION
### Purpose
When the config to make subject attribute mandatory by default, and the subject attribute is in the requested claims, the requested claims list contains subject attribute twice. This PR is to fix that issue.

### Related Issues
- https://github.com/wso2/product-is/issues/11940

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
