### PR TITLE
Show seperate info tabs for custom application

### DIFF
--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -256,12 +256,11 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
         }
         setSAMLConfigsLoading(true);
 
-        if (application?.templateId === SAMLApplicationTemplate.id) {
-            ApplicationManagementUtils.getSAMLApplicationMeta()
-                .finally(() => {
-                    setSAMLConfigsLoading(false);
+
+        ApplicationManagementUtils.getSAMLApplicationMeta()
+            .finally(() => {
+                setSAMLConfigsLoading(false);
             });
-        }
     }, [ samlConfigurations, inboundProtocolConfig ]);
 
     useEffect(() => {
@@ -679,8 +678,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 });
             }
             if (isFeatureEnabled(featureConfig?.applications,
-                ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_INFO"))
-                && inboundProtocolList.length !== 0) {
+                ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_INFO"))) {
 
                 panes.push({
                     menuItem: {

--- a/apps/console/src/features/applications/components/settings/info.tsx
+++ b/apps/console/src/features/applications/components/settings/info.tsx
@@ -31,6 +31,7 @@ import {
     SAMLApplicationConfigurationInterface
 } from "../../models";
 import { OIDCConfigurations, SAMLConfigurations } from "../help-panel";
+import { ApplicationManagementConstants } from "../../constants";
 
 /**
  * Proptypes for the server endpoints details component.
@@ -107,7 +108,8 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                     <Grid.Row>
                         <Grid.Column>
 
-                            { (isOIDC || templateId === CustomApplicationTemplate.id) && (
+                            { (isOIDC || templateId === CustomApplicationTemplate.id
+                                || templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC) && (
                                 <>
                                     <Heading ellipsis as="h4">
                                         { t("console:develop.features.applications.edit.sections.info." +
@@ -126,7 +128,7 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                                     <Divider className="x2" hidden/>
                                 </>
                             ) : null }
-                            { isSAML && (
+                            { (isSAML || templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_SAML) && (
                                 <>
                                     <Heading ellipsis as="h4">
                                         { t("console:develop.features.applications.edit.sections.info." +


### PR DESCRIPTION
### Purpose
> show separate info tabs for custom application SAML & OIDC before the protocol is configured.

### Related Issues
- Issue Issue wso2/product-is#11935

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
