### PR TITLE
Fix incorrect required error shown even though the field is populated.

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
@@ -127,7 +127,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
     }, [initialRequested]);
 
     useEffect(() => {
-        if (isEmpty(mapping?.applicationClaim)) {
+        if (isEmpty(mapping?.applicationClaim) && isEmpty(mapping)) {
             setErrorInClaimMapping(claimMappingError);
         }
     }, [claimMappingError]);


### PR DESCRIPTION
### Purpose
> This PR fixes : SAML attribute section's mapped attribute field being marked in red even though is is populated with a value if any of the other mapped attribute fields are empty.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
