### PR TITLE
Included the date format for the birthdate field placeholder in myaccount

### DIFF
--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -475,6 +475,17 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
             const fieldName = t("myAccount:components.profile.fields." + schema.name.replace(".", "_"),
                 { defaultValue: schema.displayName }
             );
+
+            // Define the field placeholder for text fields.
+            let innerPlaceholder = t("myAccount:components.profile.forms.generic." +
+                "inputs.placeholder",
+                {
+                    fieldName: fieldName.toLowerCase()
+                } );
+            // Concatenate the date format for the birth date field.
+            if (schema.name === ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("DOB")) {
+                innerPlaceholder += " in the format YYYY-MM-DD";
+            }
             return (
                 isFeatureEnabled(
                     featureConfig?.personalInfo,
@@ -594,10 +605,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                                                 autoFocus={ true }
                                                 label=""
                                                 name={ schema.name }
-                                                placeholder={ t("myAccount:components.profile.forms.generic.inputs." +
-                                                    "placeholder", {
-                                                    fieldName: fieldName.toLowerCase()
-                                                }) }
+                                                placeholder={ innerPlaceholder }
                                                 required={ schema.required }
                                                 requiredErrorMessage={ t(
                                                     "myAccount:components.profile.forms.generic.inputs.validations.empty",
@@ -619,7 +627,8 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                                                                 "myAccount:components.profile.forms.mobileChangeForm." +
                                                                 "inputs.mobile.validations.invalidFormat"
                                                             ));
-                                                        } else if (checkSchemaType(schema.name, "dateOfBirth")) {
+                                                        } else if (checkSchemaType(schema.name,
+                                                            ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("DOB"))) {
                                                             validation.errorMessages.push(t(
                                                                 "myAccount:components.profile.forms.dateChangeForm." +
                                                                 "inputs.date.validations.invalidFormat", { fieldName }

--- a/modules/core/src/constants/profile-constants.ts
+++ b/modules/core/src/constants/profile-constants.ts
@@ -69,7 +69,8 @@ export class ProfileConstants {
         .set("PROFILE_URL", "profileUrl")
         .set("ACCOUNT_LOCKED", "accountLocked")
         .set("ACCOUNT_DISABLED", "accountDisabled")
-        .set("ONETIME_PASSWORD", "oneTimePassword");
+        .set("ONETIME_PASSWORD", "oneTimePassword")
+        .set("DOB", "dateOfBirth");
 
     /**
      * States if the SCIM schema is mutable.


### PR DESCRIPTION
### Purpose
> Indicate the date format in the date of birth placeholder in my account. Currently the invalid error message indicates the format but the user will not know which format before they see the error message on wrong input. 

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
