### PR TITLE
Show an error message when there is a network timeout

### DIFF
--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -259,11 +259,11 @@ export const App: FunctionComponent<{}> = (): ReactElement => {
                                                     </style>
                                                 </Helmet>
                                                 <NetworkErrorModal
-                                                    heading="Something went wrong"
-                                                    description={
-                                                        "Try reloading the app to see if that resolves the issue."
-                                                    }
-                                                    primaryActionText="Reload the App"
+                                                    heading={ I18n.instance.t("common:networkErrorMessage.heading") }
+                                                    description={ I18n.instance.t("common:networkErrorMessage" +
+                                                        ".description") }
+                                                    primaryActionText={ I18n.instance.t("common:networkErrorMessage" +
+                                                        ".primaryActionText") }
                                                 />
                                                 <Switch>
                                                     <Redirect

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -26,7 +26,13 @@ import {
 } from "@wso2is/core/store";
 import { LocalStorageUtils } from "@wso2is/core/utils";
 import { I18n, I18nModuleOptionsInterface } from "@wso2is/i18n";
-import { Code, SessionManagementProvider, SessionTimeoutModalTypes, ThemeContext } from "@wso2is/react-components";
+import {
+    Code,
+    NetworkErrorModal,
+    SessionManagementProvider,
+    SessionTimeoutModalTypes,
+    ThemeContext
+} from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, Suspense, useContext, useEffect, useState } from "react";
 import { Helmet } from "react-helmet";
@@ -252,6 +258,13 @@ export const App: FunctionComponent<{}> = (): ReactElement => {
                                                         { state.css }
                                                     </style>
                                                 </Helmet>
+                                                <NetworkErrorModal
+                                                    heading="Something went wrong"
+                                                    description={
+                                                        "Try reloading the app to see if that resolves the issue."
+                                                    }
+                                                    primaryActionText="Reload the App"
+                                                />
                                                 <Switch>
                                                     <Redirect
                                                         exact={ true }

--- a/apps/console/src/features/core/utils/http-utils.ts
+++ b/apps/console/src/features/core/utils/http-utils.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { AppConstants as AppConstantsCore } from "@wso2is/core/constants";
 import { hideAJAXTopLoadingBar, showAJAXTopLoadingBar } from "@wso2is/core/store";
 import { AuthenticateUtils } from "@wso2is/core/utils";
 import { AppConstants } from "../constants";
@@ -87,11 +88,12 @@ export class HttpUtils {
             return;
         }
 
-        // Terminate the session if the requests returns an un-authorized status code (401)
+        // Dispatch a `network_error_event` Event when the requests returns an un-authorized status code (401)
+        // or are timed out.
         // NOTE: Axios is unable to handle 401 errors. `!error.response` will usually catch
         // the `401` error. Check the link in the doc comment.
         if (!error.response || error.response.status === 401) {
-            history.push(window["AppUtils"].getConfig().routes.logout);
+            dispatchEvent(new Event(AppConstantsCore.NETWORK_ERROR_EVENT));
         }
     }
 

--- a/apps/myaccount/src/app.tsx
+++ b/apps/myaccount/src/app.tsx
@@ -29,6 +29,7 @@ import { I18n, I18nModuleOptionsInterface } from "@wso2is/i18n";
 import {
     Code,
     ContentLoader,
+    NetworkErrorModal,
     SessionManagementProvider,
     SessionTimeoutModalTypes,
     ThemeContext
@@ -253,6 +254,13 @@ export const App = (): ReactElement => {
                                                         { state.css }
                                                     </style>
                                                 </Helmet>
+                                                <NetworkErrorModal
+                                                    heading="Something went wrong"
+                                                    description={
+                                                        "Try reloading the app to see if that resolves the issue."
+                                                    }
+                                                    primaryActionText="Reload the App"
+                                                />
                                                 <Switch>
                                                     <Redirect
                                                         exact={ true }

--- a/apps/myaccount/src/app.tsx
+++ b/apps/myaccount/src/app.tsx
@@ -255,11 +255,11 @@ export const App = (): ReactElement => {
                                                     </style>
                                                 </Helmet>
                                                 <NetworkErrorModal
-                                                    heading="Something went wrong"
-                                                    description={
-                                                        "Try reloading the app to see if that resolves the issue."
-                                                    }
-                                                    primaryActionText="Reload the App"
+                                                    heading={ I18n.instance.t("common:networkErrorMessage.heading") }
+                                                    description={ I18n.instance.t("common:networkErrorMessage" +
+                                                        ".description") }
+                                                    primaryActionText={ I18n.instance.t("common:networkErrorMessage" +
+                                                        ".primaryActionText") }
                                                 />
                                                 <Switch>
                                                     <Redirect

--- a/apps/myaccount/src/utils/http-utils.ts
+++ b/apps/myaccount/src/utils/http-utils.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import { AppConstants as AppConstantsCore } from "@wso2is/core/constants";
 import { AuthenticateUtils } from "@wso2is/core/utils";
 import { AppConstants } from "../constants";
 import { history } from "../helpers";
@@ -74,11 +75,12 @@ export const onHttpRequestError = (error: any): null => {
         return;
     }
 
-    // Terminate the session if the requests return an un-authorized status code (401)
+    // Dispatch a `network_error_event` Event when the requests returns an un-authorized status code (401)
+    // or are timed out.
     // or a forbidden status code (403). NOTE: Axios is unable to handle 401 errors.
     // `!error.response` will usually catch the `401` error. Check the link in the doc comment.
     if (!error.response || error.response.status === 403 || error.response.status === 401) {
-        history.push(AppConstants.getAppLogoutPath());
+        dispatchEvent(new Event(AppConstantsCore.NETWORK_ERROR_EVENT));
     }
 };
 

--- a/modules/core/src/constants/app-constants.ts
+++ b/modules/core/src/constants/app-constants.ts
@@ -62,4 +62,12 @@ export class AppConstants {
      * @default
      */
     public static readonly MY_ACCOUNT_APP: string = "my_account";
+
+    /**
+     * The name of the event dispatched when a network error occurs.
+     * @constant
+     * @type {string}
+     * @default
+     */
+    public static readonly NETWORK_ERROR_EVENT: string = "network_error_event";
 }

--- a/modules/i18n/src/models/namespaces/common-ns.ts
+++ b/modules/i18n/src/models/namespaces/common-ns.ts
@@ -150,4 +150,9 @@ export interface CommonNS {
     disabled: string;
     enable: string;
     disable: string;
+    networkErrorMessage: {
+        heading: string;
+        description: string;
+        primaryActionText: string;
+    }
 }

--- a/modules/i18n/src/translations/en-US/portals/common.ts
+++ b/modules/i18n/src/translations/en-US/portals/common.ts
@@ -31,8 +31,8 @@ export const common: CommonNS = {
     approvalStatus: "Approval Status",
     approve: "Approve",
     assignees: "Assignees",
-    authenticator: "Authenticator",
     authentication: "Authentication",
+    authenticator: "Authenticator",
     // eslint-disable-next-line @typescript-eslint/camelcase
     authenticator_plural: "Authenticators",
     back: "Back",
@@ -49,8 +49,8 @@ export const common: CommonNS = {
     confirm: "Confirm",
     contains: "Contains",
     continue: "Continue",
-    createdOn: "Created on",
     create: "Create",
+    createdOn: "Created on",
     dangerZone: "Danger Zone",
     delete: "Delete",
     description: "Description",
@@ -94,6 +94,11 @@ export const common: CommonNS = {
     more: "More",
     myAccount: "My Account",
     name: "Name",
+    networkErrorMessage: {
+        description: "Please try reloading the app.",
+        heading: "Something went wrong",
+        primaryActionText: "Reload the App"
+    },
     next: "Next",
     okay: "Okay",
     operatingSystem: "Operating System",

--- a/modules/i18n/src/translations/fr-FR/portals/common.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/common.ts
@@ -94,6 +94,11 @@ export const common: CommonNS = {
     more: "Plus",
     myAccount: "Mon compte",
     name: "Nom",
+    networkErrorMessage:{
+        description: "Veuillez essayer de recharger l'application.",
+        heading: "Quelque chose s'est mal passé",
+        primaryActionText: "Recharger l'application"
+    },
     next: "Suivant",
     okay: "d'accord",
     operatingSystem: "Système d'exploitation",

--- a/modules/i18n/src/translations/pt-BR/portals/common.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/common.ts
@@ -31,8 +31,8 @@ export const common: CommonNS = {
     approvalStatus: "Status de aprovação",
     approve: "Approve",
     assignees: "Cessionárias",
-    authenticator: "Autenticador",
     authentication: "Autenticação",
+    authenticator: "Autenticador",
     // eslint-disable-next-line @typescript-eslint/camelcase
     authenticator_plural: "Autenticadores",
     back: "Voltar",
@@ -49,8 +49,8 @@ export const common: CommonNS = {
     confirm: "Confirme",
     contains: "Contém",
     continue: "Continuar",
-    createdOn: "Criado em",
     create: "Crio",
+    createdOn: "Criado em",
     dangerZone: "Zona de perigo",
     delete: "Excluir",
     description: "Descrição",
@@ -94,6 +94,11 @@ export const common: CommonNS = {
     more: "Mais",
     myAccount: "Minha conta",
     name: "Nome",
+    networkErrorMessage: {
+        description: "Tente recarregar o aplicativo.",
+        heading: "Quelque chose s'est mal passé",
+        primaryActionText: "Recarregue o aplicativo"
+    },
     next: "Próximo",
     okay: "OK",
     operatingSystem: "Sistema operacional",

--- a/modules/i18n/src/translations/si-LK/portals/common.ts
+++ b/modules/i18n/src/translations/si-LK/portals/common.ts
@@ -31,8 +31,8 @@ export const common: CommonNS = {
     approvalStatus: "අනුමත කිරීමේ තත්වය",
     approve: "අනුමත කරන්න",
     assignees: "පැවරුම්කරුවන්",
-    authenticator: "සත්‍යාපකය",
     authentication: "සත්‍යාපනය",
+    authenticator: "සත්‍යාපකය",
     // eslint-disable-next-line @typescript-eslint/camelcase
     authenticator_plural: "සත්‍යාපක",
     back: "ආපසු",
@@ -49,8 +49,8 @@ export const common: CommonNS = {
     confirm: "තහවුරු කරන්න",
     contains: "අඩංගු වේ",
     continue: "පවත්වාගෙන යන්න",
-    createdOn: "නිර්මාණය කරන ලද්දේ",
     create: "සාදන්න",
+    createdOn: "නිර්මාණය කරන ලද්දේ",
     dangerZone: "අන්තරා කලාපය",
     delete: "මකන්න",
     description: "විස්තරය",
@@ -94,6 +94,11 @@ export const common: CommonNS = {
     more: "තව",
     myAccount: "පුද්ගලික ගිණුම",
     name: "නම",
+    networkErrorMessage: {
+        description: "කරුණාකර යෙදුම නැවත පූරණය කිරීමට උත්සාහ කරන්න.",
+        heading: "මොකක්හරි වැරැද්දක් වෙලා",
+        primaryActionText: "යෙදුම නැවත පූරණය කරන්න"
+    },
     next: "ඊළඟ ",
     okay: "හරි",
     operatingSystem: "මෙහෙයුම් පද්ධතිය",

--- a/modules/i18n/src/translations/ta-IN/portals/common.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/common.ts
@@ -31,8 +31,8 @@ export const common: CommonNS = {
     approvalStatus: "அனுமதி நிலை",
     approve: "அனுமதி",
     assignees: "அளிக்கப்பட்டவர்கள்",
-    authenticator: "அங்கீகார",
     authentication: "அங்கீகார",
+    authenticator: "அங்கீகார",
     // eslint-disable-next-line @typescript-eslint/camelcase
     authenticator_plural: "அங்கீகாரிகள்",
     back: "மீண்டும்",
@@ -49,8 +49,8 @@ export const common: CommonNS = {
     confirm: "உறுதிப்படுத்தவும்",
     contains: "கொண்டுள்ளது",
     continue: "தொடர்",
-    createdOn: "உருவாக்கப்பட்ட தினம்",
     create: "உருவாக்கு",
+    createdOn: "உருவாக்கப்பட்ட தினம்",
     dangerZone: "ஆபத்து மண்டலம்",
     delete: "அழி",
     description: "விபரம்",
@@ -94,6 +94,11 @@ export const common: CommonNS = {
     more: "மேலும்",
     myAccount: "என் கணக்கு",
     name: "பெயர்",
+    networkErrorMessage: {
+        description: "பயன்பாட்டை மீண்டும் ஏற்ற முயற்சிக்கவும்.",
+        heading: "ஏதோ தவறு நடந்துவிட்டது",
+        primaryActionText: "பயன்பாட்டை மீண்டும் ஏற்றவும்"
+    },
     next: "அடுத்தது",
     okay: "சரி",
     operatingSystem: "இயங்கு தளம்",

--- a/modules/react-components/src/components/modal/index.ts
+++ b/modules/react-components/src/components/modal/index.ts
@@ -20,3 +20,4 @@
 export * from "./confirmation-modal";
 export * from "./edit-avatar-modal";
 export * from "./session-timeout-modal";
+export * from "./network-error-modal";

--- a/modules/react-components/src/components/modal/network-error-modal/index.ts
+++ b/modules/react-components/src/components/modal/network-error-modal/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./network-error-modal";

--- a/modules/react-components/src/components/modal/network-error-modal/network-error-modal.tsx
+++ b/modules/react-components/src/components/modal/network-error-modal/network-error-modal.tsx
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AppConstants } from "@wso2is/core/constants";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { Heading } from "../../typography";
+import { ConfirmationModal } from "../confirmation-modal";
+
+/**
+ * Prop type of the `NetworkErrorModal` component.
+ */
+interface NetworkErrorModalPropTypes {
+    heading: string;
+    description: string;
+    primaryActionText: string;
+}
+
+/**
+ * This component listens to the `network_error_event` Event and pops up a modal
+ * when this Event is dispatched.
+ *
+ * This is used to show an error message when an API call fails due to a `401` error
+ * or a network-timeout error.
+ *
+ * @param {NetworkErrorModalPropTypes} props - The props passed into the component.
+ *
+ * @return {ReactElement} - The component that pops up a modal when there is a network error.
+ */
+export const NetworkErrorModal: FunctionComponent<NetworkErrorModalPropTypes> = (
+    props: NetworkErrorModalPropTypes
+): ReactElement => {
+    const { heading, description, primaryActionText } = props;
+
+    const [ showModal, setShowModal ] = useState(false);
+
+    /**
+     * Show modal.
+     */
+    const showErrorModal = () => {
+        setShowModal(true);
+    };
+
+    /**
+     * Called on mount and unmount to add/remove the event listener.
+     */
+    useEffect(() => {
+        addEventListener(AppConstants.NETWORK_ERROR_EVENT, showErrorModal);
+
+        return () => {
+            removeEventListener(AppConstants.NETWORK_ERROR_EVENT, showErrorModal);
+        };
+    }, []);
+
+    return (
+        <ConfirmationModal
+            animated
+            type="warning"
+            textAlign="center"
+            primaryAction={ primaryActionText }
+            onPrimaryActionClick={ () => {
+                location.reload();
+            } }
+            data-testid={ "network-error-modal" }
+            open={ showModal }
+        >
+            <ConfirmationModal.Content>
+                <Heading as="h3">{ heading }</Heading>
+                <p>{ description }</p>
+            </ConfirmationModal.Content>
+        </ConfirmationModal>
+    );
+};


### PR DESCRIPTION
### Purpose
> Pop up a network error message when there is a network timeout. 

This PR resolves the issue of automatic logout when a network request is timed out. The user was logged out following a timeout because, when there is a timeout, the error object that is passed as an argument to the catch callback doesn't contain the response attribute. Whenever the error object doesn't contain a response attribute, the previous logic logged the user out. This was done to log the user out in case of a 401 error. The 401 error also returns an error object without the response attribute. Since there is no way by which we can distinguish between a 401 error and a network timeout(since both return an error object without the response attribute), we decided to show the below modal. 

![image](https://user-images.githubusercontent.com/20745428/122738494-a8e2c900-d29f-11eb-824e-de820f0adab8.png)

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)


### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
