### PR TITLE
Fix initial subject claim shown in the dropdown is set to default value instead of the initial value

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -72,7 +72,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
 
     const { t } = useTranslation();
 
-    const [ selectedSubjectValue, setSelectedSubjectValue ] = useState<string>(initialSubject?.claim?.uri);
+    const [ selectedSubjectValue, setSelectedSubjectValue ] = useState<string>();
     const [ selectedSubjectValueLocalClaim, setSelectedSubjectValueLocalClaim ] =
         useState<string>();
 
@@ -99,7 +99,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                     setSelectedSubjectValue(selectedSubjectValue);
                 }
             } else {
-                setSelectedSubjectValue(dropDownOptions[ 0 ]?.value);
+                setSelectedSubjectValue(initialSubject?.claim?.uri || dropDownOptions[ 0 ]?.value);
             }
         } else if (selectedSubjectValue) {
             if (dropDownOptions && dropDownOptions.length > 0 &&
@@ -167,9 +167,14 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
     };
 
     const subjectAttributeChangeListener = (subjectAttributeFieldName: string): void => {
+        console.log("AAAAAAAAAAAAAAAAAAA");
         if(subjectAttributeFieldName) {
+            console.log("BBBBBBBBBBB");
+            console.log(subjectAttributeFieldName?.toString());
             setSelectedSubjectValue(subjectAttributeFieldName?.toString());
         } else {
+            console.log("CCCCCCCCC");
+            console.log(subjectAttributeFieldName);
             setSelectedSubjectValue(subjectAttributeFieldName);
         }
     };

--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -167,14 +167,9 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
     };
 
     const subjectAttributeChangeListener = (subjectAttributeFieldName: string): void => {
-        console.log("AAAAAAAAAAAAAAAAAAA");
         if(subjectAttributeFieldName) {
-            console.log("BBBBBBBBBBB");
-            console.log(subjectAttributeFieldName?.toString());
             setSelectedSubjectValue(subjectAttributeFieldName?.toString());
         } else {
-            console.log("CCCCCCCCC");
-            console.log(subjectAttributeFieldName);
             setSelectedSubjectValue(subjectAttributeFieldName);
         }
     };


### PR DESCRIPTION
### Purpose
> When the application attribute section is loaded, the default subject claim value is shown in the drop-down instead of the persisted subject claim value.

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
