### PR TITLE
[HotFix][v1.2.295] Fix initial subject claim shown in the dropdown is set to default value instead of the initial value

### DIFF
--- a/apps/authentication-portal/pom.xml
+++ b/apps/authentication-portal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/apps/console/pom.xml
+++ b/apps/console/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -72,7 +72,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
 
     const { t } = useTranslation();
 
-    const [ selectedSubjectValue, setSelectedSubjectValue ] = useState<string>(initialSubject?.claim?.uri);
+    const [ selectedSubjectValue, setSelectedSubjectValue ] = useState<string>();
     const [ selectedSubjectValueLocalClaim, setSelectedSubjectValueLocalClaim ] =
         useState<string>();
 
@@ -99,7 +99,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                     setSelectedSubjectValue(selectedSubjectValue);
                 }
             } else {
-                setSelectedSubjectValue(dropDownOptions[ 0 ]?.value);
+                setSelectedSubjectValue(initialSubject?.claim?.uri || dropDownOptions[ 0 ]?.value);
             }
         } else if (selectedSubjectValue) {
             if (dropDownOptions && dropDownOptions.length > 0 &&

--- a/apps/myaccount/pom.xml
+++ b/apps/myaccount/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/apps/recovery-portal/pom.xml
+++ b/apps/recovery-portal/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/apps/sms-otp-authentication-portal/pom.xml
+++ b/apps/sms-otp-authentication-portal/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/apps/x509-certificate-authentication-portal/pom.xml
+++ b/apps/x509-certificate-authentication-portal/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.identity.apps.common/pom.xml
+++ b/components/org.wso2.identity.apps.common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/theme/pom.xml
+++ b/components/theme/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.identity.apps.authentication.portal.server.feature/pom.xml
+++ b/features/org.wso2.identity.apps.authentication.portal.server.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.identity.apps.common.server.feature/pom.xml
+++ b/features/org.wso2.identity.apps.common.server.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.identity.apps.console.server.feature/pom.xml
+++ b/features/org.wso2.identity.apps.console.server.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.identity.apps.feature/pom.xml
+++ b/features/org.wso2.identity.apps.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.identity.apps.myaccount.server.feature/pom.xml
+++ b/features/org.wso2.identity.apps.myaccount.server.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.identity.apps.recovery.portal.server.feature/pom.xml
+++ b/features/org.wso2.identity.apps.recovery.portal.server.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.wso2.identity.apps</groupId>
     <artifactId>identity-apps</artifactId>
     <packaging>pom</packaging>
-    <version>1.2.295</version>
+    <version>1.2.295.1</version>
     <name>WSO2 Identity Server Apps - Parent</name>
     <description>WSO2 Identity Server Web Apps</description>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.identity.apps</groupId>
         <artifactId>identity-apps</artifactId>
-        <version>1.2.295</version>
+        <version>1.2.295.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### Purpose
Fix initial subject claim shown in the drop-down is set to default value instead of the initial value.


### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- https://github.com/wso2/identity-apps/pull/2176

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
