### PR TITLE
fix(auth-portal): increase timeout notification period

### DIFF
--- a/apps/authentication-portal/src/main/webapp/util/timeout.jsp
+++ b/apps/authentication-portal/src/main/webapp/util/timeout.jsp
@@ -33,7 +33,7 @@
     <jsp:param
             name="description"
             value="You have been idle in this page for too long. You need to try signing in again."/>
-    <jsp:param name="action_button_text" value="Start Over"/>
+    <jsp:param name="action_button_text" value="Got it"/>
     <jsp:param name="cancel_button_text" value="Dismiss"/>
 </jsp:include>
 

--- a/apps/authentication-portal/src/main/webapp/util/timeout.jsp
+++ b/apps/authentication-portal/src/main/webapp/util/timeout.jsp
@@ -97,8 +97,8 @@
      * It's serves a default value for the description in the modal. Check the method
      * {@code modal.changeDescriptionAsHTML} in script.
      */
-    int totalTimeoutMinutes = parseRequestAttributeToANumber(request.getAttribute("totalTimeoutMinutes"), 10);
-    int notifyOnMinute = parseRequestAttributeToANumber(request.getAttribute("notifyOnMinute"), 1);
+    int totalTimeoutMinutes = parseRequestAttributeToANumber(request.getAttribute("totalTimeoutMinutes"), 35);
+    int notifyOnMinute = parseRequestAttributeToANumber(request.getAttribute("notifyOnMinute"), 2);
     String pageName = parseRequestAttributeToAString(request.getAttribute("pageName"), "this");
 
     /*


### PR DESCRIPTION
### Purpose
> Please note $subject. Now the notification will trigger after 35 minutes.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
