### PR TITLE
Fix `400` error in IDP rest API PUT due to `tags`

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -149,6 +149,13 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
             removeElementFromProps(props, "scopes");
         }
 
+        /**
+         * `tags` were added to the IDP Rest API with https://github.com/wso2/product-is/issues/11985.
+         * But ATM, updating them is not allowed. So to avoid `400` errors in the PUT request, 
+         * `tags` has to be removed.
+         */
+        values?.tags && delete values.tags;
+
         updateFederatedAuthenticator(identityProvider.id, values)
             .then(() => {
                 dispatch(addAlert({

--- a/apps/console/src/features/identity-providers/models/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/models/identity-provider.ts
@@ -131,6 +131,10 @@ export interface FederatedAuthenticatorInterface extends CommonPluggableComponen
     name?: string;
     isEnabled?: boolean;
     isDefault?: boolean;
+    /**
+     * The list of tags that the authenticator can be categorized under.
+     */
+    tags?: string[];
 }
 
 export interface FederatedAuthenticatorWithMetaInterface {


### PR DESCRIPTION
### Purpose
`tags` were added to the IDP Rest API with https://github.com/wso2/product-is/issues/11985. But ATM, updating them is not allowed. So to avoid `400` errors in the PUT request, `tags` has to be removed.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
