### PR TITLE
Fix cyclic dependency issue.

### DIFF
--- a/apps/console/src/extensions/configs/index.ts
+++ b/apps/console/src/extensions/configs/index.ts
@@ -21,6 +21,4 @@ export * from "./application";
 export * from "./identity-provider";
 export * from "./common";
 export * from "./server-configuration";
-export * from "./userstores"
-//Do not import scim here cause cyclic dependency
-// export * from "./scim";
+export * from "./userstores";

--- a/apps/console/src/extensions/configs/index.ts
+++ b/apps/console/src/extensions/configs/index.ts
@@ -21,5 +21,6 @@ export * from "./application";
 export * from "./identity-provider";
 export * from "./common";
 export * from "./server-configuration";
-export * from "./userstores";
-export * from "./scim";
+export * from "./userstores"
+//Do not import scim here cause cyclic dependency
+// export * from "./scim";

--- a/apps/console/src/features/claims/constants/claim-management-constants.ts
+++ b/apps/console/src/features/claims/constants/claim-management-constants.ts
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 // Keep statement as this to avoid cyclic dependency. Do not import from config index.
 import { SCIMConfigs } from "../../../extensions/configs/scim";
 

--- a/apps/console/src/features/claims/constants/claim-management-constants.ts
+++ b/apps/console/src/features/claims/constants/claim-management-constants.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { SCIMConfigs } from "../../../extensions/configs";
+import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**
  * Class containing claim constants.

--- a/apps/console/src/features/claims/constants/claim-management-constants.ts
+++ b/apps/console/src/features/claims/constants/claim-management-constants.ts
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
+//keep the import statement as this in order to avoid cyclic dependency
 import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**

--- a/apps/console/src/features/claims/constants/claim-management-constants.ts
+++ b/apps/console/src/features/claims/constants/claim-management-constants.ts
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-//keep the import statement as this in order to avoid cyclic dependency
+// Keep statement as this to avoid cyclic dependency. Do not import from config index.
 import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**

--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -29,7 +29,7 @@ import { useDispatch } from "react-redux";
 import { Grid, Icon, Modal } from "semantic-ui-react";
 import { RolePermissions } from "./user-role-permissions";
 import { AddUserWizardSummary } from "./wizard-summary";
-import { SCIMConfigs } from "../../../../extensions/configs";
+import { SCIMConfigs } from "../../../../extensions/configs/scim";
 import { AppConstants } from "../../../core/constants";
 import { history } from "../../../core/helpers";
 import { getGroupList, updateGroupDetails } from "../../../groups/api";

--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -29,7 +29,8 @@ import { useDispatch } from "react-redux";
 import { Grid, Icon, Modal } from "semantic-ui-react";
 import { RolePermissions } from "./user-role-permissions";
 import { AddUserWizardSummary } from "./wizard-summary";
-import { SCIMConfigs } from "../../../../extensions/configs/scim"; //keep statement as this to avoid cyclic dependency
+// Keep statement as this to avoid cyclic dependency. Do not import from config index.
+import { SCIMConfigs } from "../../../../extensions/configs/scim";
 import { AppConstants } from "../../../core/constants";
 import { history } from "../../../core/helpers";
 import { getGroupList, updateGroupDetails } from "../../../groups/api";

--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -29,7 +29,7 @@ import { useDispatch } from "react-redux";
 import { Grid, Icon, Modal } from "semantic-ui-react";
 import { RolePermissions } from "./user-role-permissions";
 import { AddUserWizardSummary } from "./wizard-summary";
-import { SCIMConfigs } from "../../../../extensions/configs/scim";
+import { SCIMConfigs } from "../../../../extensions/configs/scim"; //keep statement as this to avoid cyclic dependency
 import { AppConstants } from "../../../core/constants";
 import { history } from "../../../core/helpers";
 import { getGroupList, updateGroupDetails } from "../../../groups/api";

--- a/apps/console/src/features/users/constants/user-management-constants.ts
+++ b/apps/console/src/features/users/constants/user-management-constants.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { SCIMConfigs } from "../../../extensions/configs";
+import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**
  * Class containing app constants which can be used across several applications.

--- a/apps/console/src/features/users/constants/user-management-constants.ts
+++ b/apps/console/src/features/users/constants/user-management-constants.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+//keep the import statement as this in order to avoid cyclic dependency
 import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**

--- a/apps/console/src/features/users/constants/user-management-constants.ts
+++ b/apps/console/src/features/users/constants/user-management-constants.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-//keep the import statement as this in order to avoid cyclic dependency
+// Keep statement as this to avoid cyclic dependency. Do not import from config index.
 import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**

--- a/apps/console/src/features/users/models/user.ts
+++ b/apps/console/src/features/users/models/user.ts
@@ -17,6 +17,7 @@
  */
 
 import { LinkInterface, MultiValueAttributeInterface, NameInterface, RolesInterface } from "@wso2is/core/models";
+//keep the import statement as this in order to avoid cyclic dependency
 import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**

--- a/apps/console/src/features/users/models/user.ts
+++ b/apps/console/src/features/users/models/user.ts
@@ -17,7 +17,7 @@
  */
 
 import { LinkInterface, MultiValueAttributeInterface, NameInterface, RolesInterface } from "@wso2is/core/models";
-import { SCIMConfigs } from "../../../extensions/configs";
+import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**
  * Captures meta details of the user.

--- a/apps/console/src/features/users/models/user.ts
+++ b/apps/console/src/features/users/models/user.ts
@@ -17,7 +17,7 @@
  */
 
 import { LinkInterface, MultiValueAttributeInterface, NameInterface, RolesInterface } from "@wso2is/core/models";
-//keep the import statement as this in order to avoid cyclic dependency
+// Keep statement as this to avoid cyclic dependency. Do not import from config index.
 import { SCIMConfigs } from "../../../extensions/configs/scim";
 
 /**

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -18,7 +18,7 @@
 
 import { I18nModuleOptionsInterface } from "@wso2is/i18n";
 import { I18nConstants } from "../constants";
-import { SCIMConfigs } from "../extensions/configs/scim";
+import { SCIMConfigs } from "../extensions/configs/scim"; //keep statement as this in order to avoid cyclic dependency
 import { DeploymentConfigInterface, ServiceResourceEndpointsInterface, UIConfigInterface } from "../models";
 
 /**

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -18,7 +18,8 @@
 
 import { I18nModuleOptionsInterface } from "@wso2is/i18n";
 import { I18nConstants } from "../constants";
-import { SCIMConfigs } from "../extensions/configs/scim"; //keep statement as this in order to avoid cyclic dependency
+// Keep statement as this to avoid cyclic dependency. Do not import from config index.
+import { SCIMConfigs } from "../extensions/configs/scim";
 import { DeploymentConfigInterface, ServiceResourceEndpointsInterface, UIConfigInterface } from "../models";
 
 /**

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -18,7 +18,7 @@
 
 import { I18nModuleOptionsInterface } from "@wso2is/i18n";
 import { I18nConstants } from "../constants";
-import { SCIMConfigs } from "../extensions/configs";
+import { SCIMConfigs } from "../extensions/configs/scim";
 import { DeploymentConfigInterface, ServiceResourceEndpointsInterface, UIConfigInterface } from "../models";
 
 /**

--- a/apps/myaccount/src/extensions/configs/index.ts
+++ b/apps/myaccount/src/extensions/configs/index.ts
@@ -17,4 +17,5 @@
  */
 
 export * from "./common";
-export * from "./scim";
+//Do not import scim.ts here caused cyclic dependency
+// export * from "./scim";

--- a/apps/myaccount/src/extensions/configs/index.ts
+++ b/apps/myaccount/src/extensions/configs/index.ts
@@ -17,5 +17,3 @@
  */
 
 export * from "./common";
-//Do not import scim.ts here caused cyclic dependency
-// export * from "./scim";

--- a/apps/myaccount/src/models/profile.ts
+++ b/apps/myaccount/src/models/profile.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
- import { SCIMConfigs } from "../extensions/configs";
+ import { SCIMConfigs } from "../extensions/configs/scim";
 
 /**
   * Multi-valued attribute model

--- a/apps/myaccount/src/models/profile.ts
+++ b/apps/myaccount/src/models/profile.ts
@@ -16,7 +16,8 @@
  * under the License.
  */
 
- import { SCIMConfigs } from "../extensions/configs/scim";
+//keep the import statement as this in order to avoid cyclic dependency
+import { SCIMConfigs } from "../extensions/configs/scim";
 
 /**
   * Multi-valued attribute model

--- a/apps/myaccount/src/models/profile.ts
+++ b/apps/myaccount/src/models/profile.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-//keep the import statement as this in order to avoid cyclic dependency
+// Keep statement as this to avoid cyclic dependency. Do not import from config index.
 import { SCIMConfigs } from "../extensions/configs/scim";
 
 /**

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -43,7 +43,7 @@ import { AuthAction, authenticateActionTypes } from "./types";
 import { getProfileInfo, getUserReadOnlyStatus, switchAccount } from "../../api";
 import { Config } from "../../configs";
 import { AppConstants, CommonConstants } from "../../constants";
-// keep statement as this to avoid cyclic dependency
+// Keep statement as this to avoid cyclic dependency. Do not import from config index.
 import { SCIMConfigs } from "../../extensions/configs/scim"; 
 import { history } from "../../helpers";
 import {

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -43,7 +43,7 @@ import { AuthAction, authenticateActionTypes } from "./types";
 import { getProfileInfo, getUserReadOnlyStatus, switchAccount } from "../../api";
 import { Config } from "../../configs";
 import { AppConstants, CommonConstants } from "../../constants";
-import { SCIMConfigs } from "../../extensions/configs/scim";
+import { SCIMConfigs } from "../../extensions/configs/scim"; //keep statement as this to avoid cyclic dependency
 import { history } from "../../helpers";
 import {
     AlertLevels,

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -43,7 +43,7 @@ import { AuthAction, authenticateActionTypes } from "./types";
 import { getProfileInfo, getUserReadOnlyStatus, switchAccount } from "../../api";
 import { Config } from "../../configs";
 import { AppConstants, CommonConstants } from "../../constants";
-import { SCIMConfigs } from "../../extensions/configs";
+import { SCIMConfigs } from "../../extensions/configs/scim";
 import { history } from "../../helpers";
 import {
     AlertLevels,

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -43,7 +43,8 @@ import { AuthAction, authenticateActionTypes } from "./types";
 import { getProfileInfo, getUserReadOnlyStatus, switchAccount } from "../../api";
 import { Config } from "../../configs";
 import { AppConstants, CommonConstants } from "../../constants";
-import { SCIMConfigs } from "../../extensions/configs/scim"; //keep statement as this to avoid cyclic dependency
+// keep statement as this to avoid cyclic dependency
+import { SCIMConfigs } from "../../extensions/configs/scim"; 
 import { history } from "../../helpers";
 import {
     AlertLevels,


### PR DESCRIPTION
### Purpose
This PR is sent to solve the cyclic dependency issue raised by the import statement as follows
 ```import { SCIMConfigs } from "../../../extensions/configs";```,
Importing the scim config by exporting in index.ts causes this issue.  This problem is solved by removing the export from index.ts and directly importing the SCIMConfigs as follows 
```import { SCIMConfigs } from "../../../extensions/configs/scim";```