### PR TITLE
Updated external logins section in MyAccount to show only if at least one external login is available

### DIFF
--- a/apps/myaccount/src/components/federated-associations/federated-associations.tsx
+++ b/apps/myaccount/src/components/federated-associations/federated-associations.tsx
@@ -224,20 +224,21 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
     };
 
     return (
-        <SettingsSection
-            data-testid={ `${testId}-settings-section` }
-            description={ t("myAccount:sections.federatedAssociations.description") }
-            header={ t("myAccount:sections.federatedAssociations.heading") }
-            icon={ getSettingsSectionIcons().federatedAssociations }
-            iconMini={ getSettingsSectionIcons().federatedAssociationsMini }
-            iconSize="auto"
-            iconStyle="colored"
-            iconFloated="right"
-            showActionBar={ true }
-        >
-            { deleteConfirmation() }
-            { federatedAssociationsList() }
-        </SettingsSection>
+        federatedAssociations.length > 0 &&
+            <SettingsSection
+                data-testid={ `${testId}-settings-section` }
+                description={ t("myAccount:sections.federatedAssociations.description") }
+                header={ t("myAccount:sections.federatedAssociations.heading") }
+                icon={ getSettingsSectionIcons().federatedAssociations }
+                iconMini={ getSettingsSectionIcons().federatedAssociationsMini }
+                iconSize="auto"
+                iconStyle="colored"
+                iconFloated="right"
+                showActionBar={ true }
+            >
+                { deleteConfirmation() }
+                { federatedAssociationsList() }
+            </SettingsSection>
     );
 };
 


### PR DESCRIPTION
### Purpose
> External Logins section is visible even when no external logins are available. External logins section should only be visible when there is at least one external login, in the Profile Info section.

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
