### PR TITLE
Remove obsolete attribute config property

### DIFF
--- a/apps/console/src/extensions/configs/attribute.ts
+++ b/apps/console/src/extensions/configs/attribute.ts
@@ -109,7 +109,6 @@ export const attributeConfig: AttributeConfig = {
             checkSCIMAvailability: false,
             customWIzard: false,
             identifyAsCustomAttrib: false,
-            showAttributeMapping: true,
             showDisplayOrder: true,
             showReadOnlyAttribute: true,
             showRegularExpression: true,

--- a/apps/console/src/extensions/configs/models/attribute.ts
+++ b/apps/console/src/extensions/configs/models/attribute.ts
@@ -66,7 +66,6 @@ export interface AttributeConfig {
             showDisplayOrder: boolean;
             showRegularExpression: boolean;
             showReadOnlyAttribute: boolean;
-            showAttributeMapping: boolean;
             showSummary: boolean;
             identifyAsCustomAttrib: boolean;
         }

--- a/apps/console/src/features/claims/components/add/add-local-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-local-claim.tsx
@@ -223,7 +223,7 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
             
         }
 
-        if (!attributeConfig.localAttributes.createWizard.showAttributeMapping && !showMapAttributes) {
+        if (!showMapAttributes) {
             tempData.attributeMapping = [
                 {
                     mappedAttribute: tempData.claimURI.split("/").pop(),

--- a/apps/console/src/features/claims/components/add/add-local-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-local-claim.tsx
@@ -270,7 +270,7 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
             icon: getAddLocalClaimWizardStepIcons().general,
             title: t("console:manage.features.claims.local.wizard.steps.general")
         },
-        ( attributeConfig.localAttributes.createWizard.showAttributeMapping && showMapAttributes ?
+        ( showMapAttributes ?
             {
                 content: (
                     <MappedAttributes


### PR DESCRIPTION
### Purpose
This will remove the obsolete property `showAttributeMapping` from the attributes configuration

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
