### PR TITLE
Add schema id to profile schema object

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -298,21 +298,23 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         data-testid={ `${ testId }-form-description-input` }
                         hint={ t("console:manage.features.claims.local.forms.descriptionHint") }
                     />
-                    <Field.Input
-                        ariaLabel="regularExpression"
-                        inputType="resourceName"
-                        name="regularExpression"
-                        label={ t("console:manage.features.claims.local.forms.regEx.label") }
-                        required={ false }
-                        requiredErrorMessage=""
-                        placeholder={ t("console:manage.features.claims.local.forms.regEx.placeholder") }
-                        value={ claim?.regEx }
-                        ref={ regExField }
-                        data-testid={ `${ testId }-form-regex-input` }
-                        maxLength={ 50 }
-                        minLength={ 3 }
-                        hint={ t("console:manage.features.claims.local.forms.regExHint") }
-                    />
+                    { attributeConfig.localAttributes.createWizard.showRegularExpression && 
+                        <Field.Input
+                            ariaLabel="regularExpression"
+                            inputType="resourceName"
+                            name="regularExpression"
+                            label={ t("console:manage.features.claims.local.forms.regEx.label") }
+                            required={ false }
+                            requiredErrorMessage=""
+                            placeholder={ t("console:manage.features.claims.local.forms.regEx.placeholder") }
+                            value={ claim?.regEx }
+                            ref={ regExField }
+                            data-testid={ `${ testId }-form-regex-input` }
+                            maxLength={ 50 }
+                            minLength={ 3 }
+                            hint={ t("console:manage.features.claims.local.forms.regExHint") }
+                        />
+                    }
                     {
                         claim &&
                         <Field.Checkbox

--- a/apps/console/src/features/claims/components/wizard/local-claim/basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/wizard/local-claim/basic-details-local-claims.tsx
@@ -97,35 +97,6 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
         setClaimID(values?.get("claimURI").toString());
     }, [ values ]);
 
-    /**
-     * Check the availability of custom OIDC attribute names.
-     * TODO: Move constants to extension constants file
-     */
-    useEffect(() => {
-        if (!oidcMapping && !( oidcMapping === "" || claimID === oidcMapping ) ) {
-            return;
-        }
-
-        attributeConfig.localAttributes.checkAttributeNameAvailability(
-            oidcMapping, "OIDC").then(response => {
-                setNoUniqueOIDCAttrib(response.get("OIDC"));
-        });
-    }, [ oidcMapping ]);
-
-    /**
-     * Check the availability of custom SCIM attribute names.
-     * TODO: Move constants to extension constants file
-     */
-     useEffect(() => {
-        if (!scimMapping && !( scimMapping === "" || claimID === scimMapping ) ) {
-            return;
-        }
-
-        attributeConfig.localAttributes.checkAttributeNameAvailability(
-            scimMapping, "SCIM").then(response => {
-                setNoUniqueSCIMAttrib(response.get("SCIM"));
-        });
-    }, [ scimMapping ]);
 
     /**
      * This shows a popup with a delay of 500 ms.
@@ -314,6 +285,11 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                                         <InlineEditInput
                                                             text={ oidcMapping } 
                                                             onChangesSaved={ (value: string) => {
+                                                                attributeConfig.localAttributes
+                                                                    .checkAttributeNameAvailability(
+                                                                        oidcMapping, "OIDC").then(response => {
+                                                                        setNoUniqueOIDCAttrib(response.get("OIDC"));
+                                                                });
                                                                 setOidcMapping(value);
                                                             } }
                                                         />
@@ -339,6 +315,11 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                                         <InlineEditInput
                                                             textPrefix="urn:scim:custom:schema:"
                                                             onChangesSaved={ (value: string) => {
+                                                                attributeConfig.localAttributes
+                                                                    .checkAttributeNameAvailability(
+                                                                        scimMapping, "SCIM").then(response => {
+                                                                        setNoUniqueSCIMAttrib(response.get("SCIM"));
+                                                                });
                                                                 setScimMapping(value);
                                                             } }
                                                             text={ scimMapping } 

--- a/modules/core/src/api/profile.ts
+++ b/modules/core/src/api/profile.ts
@@ -250,10 +250,10 @@ export const getProfileSchemas = (): Promise<ProfileSchemaInterface[]> => {
                             attribute.subAttributes.map((subAttribute) => {
                                 modifiedSubAttributes.push({ ...subAttribute,  extended: true});
                             }
-                        )
+                        );
                         attribute.subAttributes = modifiedSubAttributes;
                         }
-                        schemaAttributes.push({ ...attribute, extended: true });
+                        schemaAttributes.push({ ...attribute, extended: true, schemaId: schema.id });
                         return;
                     }
                     schemaAttributes.push(attribute);

--- a/modules/core/src/constants/profile-constants.ts
+++ b/modules/core/src/constants/profile-constants.ts
@@ -34,6 +34,7 @@ export class ProfileConstants {
     public static readonly SCIM2_CORE_USER_SCHEMA: string = "urn:ietf:params:scim:schemas:core:2.0:User";
     public static readonly SCIM2_ENT_USER_SCHEMA: string = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User";
     public static readonly SCIM2_WSO2_USER_SCHEMA: string = "urn:scim:wso2:schema:User";
+    public static readonly SCIM2_WSO2_CUSTOM_SCHEMA: string = "urn:scim:wso2:schema";
 
     // API errors
     public static readonly SCHEMA_FETCH_REQUEST_INVALID_RESPONSE_CODE_ERROR: string = "Received an invalid status " +

--- a/modules/core/src/models/profile.ts
+++ b/modules/core/src/models/profile.ts
@@ -187,6 +187,10 @@ export interface ProfileSchemaInterface {
      */
     extended?: boolean;
     /**
+     * Store ID to identify schema of the attribute
+     */
+    schemaId?: string;
+    /**
      * Regular expression to validate field.
      */
     regEx?: string;


### PR DESCRIPTION
### Purpose
This will add schema id to the profile schema object so that, we could identify which schema the attribute belongs to.

This PR will also fix API request on each character input in attributes wizard.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
