### PR TITLE
Display User ID attribute in console and myaccount/profile

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -317,18 +317,20 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         />
                     }
                     {
-                        claim &&
-                        <Field.CheckboxLegacy
-                            ariaLabel="supportedByDefault"
-                            name="supportedByDefault"
-                            label={ t("console:manage.features.claims.local.forms.supportedByDefault.label") }
-                            required={ false }
-                            value={ claim?.supportedByDefault ? ["supportedByDefault"] : [] }
-                            listen={ (values) => {
-                                setIsShowDisplayOrder(!!values?.supportedByDefault);
-                            } }
-                            data-testid={ `${testId}-form-supported-by-default-input` }
-                        />
+                        claim && claim.displayName !== ClaimManagementConstants.USER_ID &&
+                        (
+                            <Field.CheckboxLegacy
+                                ariaLabel="supportedByDefault"
+                                name="supportedByDefault"
+                                label={ t("console:manage.features.claims.local.forms.supportedByDefault.label") }
+                                required={ false }
+                                value={ claim?.supportedByDefault ? ["supportedByDefault"] : [] }
+                                listen={ (values) => {
+                                    setIsShowDisplayOrder(!!values?.supportedByDefault);
+                                } }
+                                data-testid={ `${testId}-form-supported-by-default-input` }
+                            />
+                        )
                     }
                     {
                         attributeConfig.editAttributes.showDisplayOrderInput && isShowDisplayOrder
@@ -366,16 +368,18 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             />
                     }
                     {
-                        claim &&
-                        <Field.CheckboxLegacy
-                            ariaLabel="readOnly"
-                            name="readOnly"
-                            required={ false }
-                            label={ t("console:manage.features.claims.local.forms.readOnly.label") }
-                            requiredErrorMessage=""
-                            value={ claim?.readOnly ? [ "readOnly" ] : [] }
-                            data-testid={ `${ testId }-form-readonly-checkbox` }
-                        />
+                        claim && claim.displayName !== ClaimManagementConstants.USER_ID &&
+                        (
+                            <Field.CheckboxLegacy
+                                ariaLabel="readOnly"
+                                name="readOnly"
+                                required={ false }
+                                label={ t("console:manage.features.claims.local.forms.readOnly.label") }
+                                requiredErrorMessage=""
+                                value={ claim?.readOnly ? [ "readOnly" ] : [] }
+                                data-testid={ `${ testId }-form-readonly-checkbox` }
+                            />
+                        )
                     }
                     <Field.Button
                         ariaLabel="submit"

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -317,7 +317,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         />
                     }
                     {
-                        claim && (
+                        claim &&
                             <Field.CheckboxLegacy
                                 ariaLabel="supportedByDefault"
                                 name="supportedByDefault"
@@ -329,7 +329,6 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                 } }
                                 data-testid={ `${testId}-form-supported-by-default-input` }
                             />
-                        )
                     }
                     {
                         attributeConfig.editAttributes.showDisplayOrderInput && isShowDisplayOrder
@@ -367,7 +366,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             />
                     }
                     {
-                        claim && (
+                        claim &&
                             <Field.CheckboxLegacy
                                 ariaLabel="readOnly"
                                 name="readOnly"
@@ -377,7 +376,6 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                 value={ claim?.readOnly ? [ "readOnly" ] : [] }
                                 data-testid={ `${ testId }-form-readonly-checkbox` }
                             />
-                        )
                     }
                     <Field.Button
                         ariaLabel="submit"

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -318,17 +318,17 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                     }
                     {
                         claim &&
-                            <Field.CheckboxLegacy
-                                ariaLabel="supportedByDefault"
-                                name="supportedByDefault"
-                                label={ t("console:manage.features.claims.local.forms.supportedByDefault.label") }
-                                required={ false }
-                                value={ claim?.supportedByDefault ? ["supportedByDefault"] : [] }
-                                listen={ (values) => {
-                                    setIsShowDisplayOrder(!!values?.supportedByDefault);
-                                } }
-                                data-testid={ `${testId}-form-supported-by-default-input` }
-                            />
+                        <Field.CheckboxLegacy
+                            ariaLabel="supportedByDefault"
+                            name="supportedByDefault"
+                            label={ t("console:manage.features.claims.local.forms.supportedByDefault.label") }
+                            required={ false }
+                            value={ claim?.supportedByDefault ? ["supportedByDefault"] : [] }
+                            listen={ (values) => {
+                                setIsShowDisplayOrder(!!values?.supportedByDefault);
+                            } }
+                            data-testid={ `${testId}-form-supported-by-default-input` }
+                        />
                     }
                     {
                         attributeConfig.editAttributes.showDisplayOrderInput && isShowDisplayOrder
@@ -367,15 +367,15 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                     }
                     {
                         claim &&
-                            <Field.CheckboxLegacy
-                                ariaLabel="readOnly"
-                                name="readOnly"
-                                required={ false }
-                                label={ t("console:manage.features.claims.local.forms.readOnly.label") }
-                                requiredErrorMessage=""
-                                value={ claim?.readOnly ? [ "readOnly" ] : [] }
-                                data-testid={ `${ testId }-form-readonly-checkbox` }
-                            />
+                        <Field.CheckboxLegacy
+                            ariaLabel="readOnly"
+                            name="readOnly"
+                            required={ false }
+                            label={ t("console:manage.features.claims.local.forms.readOnly.label") }
+                            requiredErrorMessage=""
+                            value={ claim?.readOnly ? [ "readOnly" ] : [] }
+                            data-testid={ `${ testId }-form-readonly-checkbox` }
+                        />
                     }
                     <Field.Button
                         ariaLabel="submit"

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -42,6 +42,7 @@ import { useDispatch } from "react-redux";
 import { Divider, Grid , Form as SemanticForm } from "semantic-ui-react";
 import { attributeConfig } from "../../../../../extensions";
 import { AppConstants, history } from "../../../../core";
+import { ClaimManagementConstants } from "../../../constants";
 import { deleteAClaim, updateAClaim } from "../../../api";
 
 /**
@@ -316,8 +317,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         />
                     }
                     {
-                        claim &&
-                        <Field.CheckboxLegacy
+                        claim && claim.displayName !== ClaimManagementConstants.USER_ID &&
+                        <Field.Checkbox
                             ariaLabel="supportedByDefault"
                             name="supportedByDefault"
                             label={ t("console:manage.features.claims.local.forms.supportedByDefault.label") } 
@@ -365,8 +366,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             />
                     }
                     {
-                        claim &&
-                        <Field.CheckboxLegacy
+                        claim && claim.displayName !== ClaimManagementConstants.USER_ID &&
+                        <Field.Checkbox
                             ariaLabel="readOnly"
                             name="readOnly"
                             required={ false }

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -317,8 +317,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         />
                     }
                     {
-                        claim && claim.displayName !== ClaimManagementConstants.USER_ID && (
-                            <Field.Checkbox
+                        claim && (
+                            <Field.CheckboxLegacy
                                 ariaLabel="supportedByDefault"
                                 name="supportedByDefault"
                                 label={ t("console:manage.features.claims.local.forms.supportedByDefault.label") }
@@ -367,8 +367,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             />
                     }
                     {
-                        claim && claim.displayName !== ClaimManagementConstants.USER_ID && (
-                            <Field.Checkbox
+                        claim && (
+                            <Field.CheckboxLegacy
                                 ariaLabel="readOnly"
                                 name="readOnly"
                                 required={ false }

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -317,18 +317,19 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         />
                     }
                     {
-                        claim && claim.displayName !== ClaimManagementConstants.USER_ID &&
-                        <Field.Checkbox
-                            ariaLabel="supportedByDefault"
-                            name="supportedByDefault"
-                            label={ t("console:manage.features.claims.local.forms.supportedByDefault.label") } 
-                            required={ false }
-                            value={ claim?.supportedByDefault ? ["supportedByDefault"] : [] }
-                            listen={ (values) => {
-                                setIsShowDisplayOrder(!!values?.supportedByDefault);
-                            } }
-                            data-testid={ `${testId}-form-supported-by-default-input` }
-                        />
+                        claim && claim.displayName !== ClaimManagementConstants.USER_ID && (
+                            <Field.Checkbox
+                                ariaLabel="supportedByDefault"
+                                name="supportedByDefault"
+                                label={ t("console:manage.features.claims.local.forms.supportedByDefault.label") }
+                                required={ false }
+                                value={ claim?.supportedByDefault ? ["supportedByDefault"] : [] }
+                                listen={ (values) => {
+                                    setIsShowDisplayOrder(!!values?.supportedByDefault);
+                                } }
+                                data-testid={ `${testId}-form-supported-by-default-input` }
+                            />
+                        )
                     }
                     {
                         attributeConfig.editAttributes.showDisplayOrderInput && isShowDisplayOrder
@@ -366,16 +367,17 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             />
                     }
                     {
-                        claim && claim.displayName !== ClaimManagementConstants.USER_ID &&
-                        <Field.Checkbox
-                            ariaLabel="readOnly"
-                            name="readOnly"
-                            required={ false }
-                            label={ t("console:manage.features.claims.local.forms.readOnly.label") }
-                            requiredErrorMessage=""
-                            value={ claim?.readOnly ? [ "readOnly" ] : [] }
-                            data-testid={ `${ testId }-form-readonly-checkbox` }
-                        />
+                        claim && claim.displayName !== ClaimManagementConstants.USER_ID && (
+                            <Field.Checkbox
+                                ariaLabel="readOnly"
+                                name="readOnly"
+                                required={ false }
+                                label={ t("console:manage.features.claims.local.forms.readOnly.label") }
+                                requiredErrorMessage=""
+                                value={ claim?.readOnly ? [ "readOnly" ] : [] }
+                                data-testid={ `${ testId }-form-readonly-checkbox` }
+                            />
+                        )
                     }
                     <Field.Button
                         ariaLabel="submit"

--- a/apps/console/src/features/claims/constants/claim-management-constants.ts
+++ b/apps/console/src/features/claims/constants/claim-management-constants.ts
@@ -134,5 +134,5 @@ export class ClaimManagementConstants {
         { name: "Core 1.0 Schema", uri: SCIMConfigs.scim.core1Schema }
     ]
 
-    public static readonly USER_ID = "User ID";
+    public static readonly USER_ID: string = "User ID";
 }

--- a/apps/console/src/features/claims/constants/claim-management-constants.ts
+++ b/apps/console/src/features/claims/constants/claim-management-constants.ts
@@ -134,4 +134,5 @@ export class ClaimManagementConstants {
         { name: "Core 1.0 Schema", uri: SCIMConfigs.scim.core1Schema }
     ]
 
+    public static readonly USER_ID = "User ID";
 }

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -80,10 +80,19 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
     const [ profileInfo, setProfileInfo ] = useState(new Map<string, string>());
     const [ profileSchema, setProfileSchema ] = useState<ProfileSchema[]>();
     const [ isEmailPending, setEmailPending ] = useState<boolean>(false);
+    const [ userId, setUserId ] = useState<string>(null);
     const [ showEditAvatarModal, setShowEditAvatarModal ] = useState<boolean>(false);
     const [ showMobileUpdateWizard, setShowMobileUpdateWizard ] = useState<boolean>(false);
     const [ countryList, setCountryList ] = useState<DropdownItemProps[]>([]);
     const allowedScopes: string = useSelector((state: AppState) => state?.authenticationInformation?.scope);
+
+    /**
+     * Set the userId.
+     */
+    useEffect(() => {
+
+        setUserId(profileDetails.profileInfo.id);
+    }, [profileDetails])
 
     /**
      * Set the if the email verification is pending.
@@ -1017,6 +1026,28 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
             <List divided={ true } verticalAlign="middle"
                   className="main-content-inner"
                   data-testid={ `${testId}-schema-list` }>
+                {
+                    isProfileInfoLoading || profileSchemaLoader
+                        ? null : (
+                            <List.Item key={profileSchema.length} className="inner-list-item"
+                                       data-testid={`${testId}-schema-list-item`}>
+                                <Grid padded={true}>
+                                    <Grid.Row columns={3}>
+                                        < Grid.Column mobile={6} tablet={6} computer={4} className="first-column">
+                                            <List.Content> User Id </List.Content>
+                                        </Grid.Column>
+                                        <Grid.Column mobile={8} tablet={8} computer={10}>
+                                            <List.Content>
+                                                <List.Description>
+                                                    { userId }
+                                                </List.Description>
+                                            </List.Content>
+                                        </Grid.Column>
+                                    </Grid.Row>
+                                </Grid>
+                            </List.Item>
+                        )
+                }
                 {
                     profileSchema && profileSchema.map((schema: ProfileSchema, index: number) => {
                         if (!(schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("ROLES_DEFAULT")

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -1028,7 +1028,8 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): J
                   data-testid={ `${testId}-schema-list` }>
                 {
                     isProfileInfoLoading || profileSchemaLoader
-                        ? null : (
+                        ? null
+                        : (
                             <List.Item key={profileSchema.length} className="inner-list-item"
                                        data-testid={`${testId}-schema-list-item`}>
                                 <Grid padded={true}>

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -1632,6 +1632,9 @@ body {
                             margin-left: 0;
                             margin-right: 8px;
                         }
+                        .with-description {
+                             margin-bottom: 5px;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Purpose
>Display User ID attribute (readonly) in user-edit section in console and profile in myaccount
>Hide the configuration option for Enabling user ID in the profile and made it readonly at the attribute configuration

### Related Issues
- INone

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
