### PR TITLE
Fix create custom dialect on slow networks

### DIFF
--- a/apps/console/src/features/claims/components/add/add-local-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-local-claim.tsx
@@ -115,7 +115,7 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
 
         if ( attributeConfig.localAttributes.createCustomDialect ) {
 
-            attributeConfig.localAttributes.isSCIMCustomDialectAvailable().then(available => {
+            await attributeConfig.localAttributes.isSCIMCustomDialectAvailable().then(available => {
                 if (available === "") {
                     addDialect(attributeConfig.localAttributes.customDialectURI);
                 }


### PR DESCRIPTION
### Purpose
This will fix the random issue where the scim custom dialect is created after the claim is created, making the auto mapping of new scim attribute to fail. 

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
