### PR TITLE
Fix tenanted myaccount URL format

### DIFF
--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -323,8 +323,7 @@ export const AppUtils = (function() {
             return ((this.getTenantPrefix() !== "") && (this.getTenantName() !== "")) ?
                 _config.accountAppOrigin + 
                 "/" + this.getTenantPrefix() + 
-                "/" + this.getTenantName() + 
-                "/myaccount" : "";
+                "/" + this.getTenantName() : "";
         },
 
         /**


### PR DESCRIPTION
### Purpose
This PR changes the tenanted myaccount URL to return the correct URL **without** the `myaccount` suffix. The change was made in `apps/console/src/init/app-utils.ts` file.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR - https://github.com/wso2/identity-apps/pull/2239

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
