### PR TITLE
Hide `show on profile`  in username claim edit

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -317,7 +317,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         />
                     }
                     {
-                        claim && claim.displayName !== ClaimManagementConstants.USER_ID &&
+                        //Hides on user_id and username claims
+                        claim && claim.displayName !== ClaimManagementConstants.USER_ID 
+                            && claim.displayName !== ClaimManagementConstants.USER_NAME &&
                         (
                             <Field.CheckboxLegacy
                                 ariaLabel="supportedByDefault"
@@ -368,7 +370,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             />
                     }
                     {
-                        claim && claim.displayName !== ClaimManagementConstants.USER_ID &&
+                        //Hides on user_id and username claims
+                        claim && claim.displayName !== ClaimManagementConstants.USER_ID 
+                            && claim.displayName !== ClaimManagementConstants.USER_NAME &&
                         (
                             <Field.CheckboxLegacy
                                 ariaLabel="readOnly"

--- a/apps/console/src/features/claims/constants/claim-management-constants.ts
+++ b/apps/console/src/features/claims/constants/claim-management-constants.ts
@@ -134,5 +134,10 @@ export class ClaimManagementConstants {
         { name: "Core 1.0 Schema", uri: SCIMConfigs.scim.core1Schema }
     ]
 
+    /**
+     * Display names of User Id & Username to 
+     * identify.
+     */
     public static readonly USER_ID: string = "User ID";
+    public static readonly USER_NAME: string = "Username";
 }


### PR DESCRIPTION
### Purpose
This PR will hide the following options from edit attribute view for attribute `Username`.

- `Display this attribute on the user's profile`
- `Make this attribute read-only on the user's profile`

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
