### PR TITLE
Display a modal to handle chunk load error

### DIFF
--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -262,9 +262,10 @@ export const App: FunctionComponent<{}> = (): ReactElement => {
                                                         ".primaryActionText") }
                                                 />
                                                 <ChunkErrorModal
-                                                    heading={ I18n.instance.t("common:networkErrorMessage.heading") }
-                                                    description="An error occurred in serving the requested application. Please try reloading the app."
-                                                    primaryActionText={ I18n.instance.t("common:networkErrorMessage" +
+                                                    heading={ I18n.instance.t("common:chunkLoadErrorMessage.heading") }
+                                                    description={ I18n.instance.t("common:chunkLoadErrorMessage" +
+                                                        ".description") }
+                                                    primaryActionText={ I18n.instance.t("common:chunkLoadErrorMessage" +
                                                         ".primaryActionText") }
                                                 />
                                                 <Switch>

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -28,6 +28,7 @@ import { LocalStorageUtils } from "@wso2is/core/utils";
 import { I18n, I18nModuleOptionsInterface } from "@wso2is/i18n";
 import {
     Code,
+    ChunkErrorModal,
     NetworkErrorModal,
     SessionManagementProvider,
     SessionTimeoutModalTypes
@@ -257,6 +258,12 @@ export const App: FunctionComponent<{}> = (): ReactElement => {
                                                     heading={ I18n.instance.t("common:networkErrorMessage.heading") }
                                                     description={ I18n.instance.t("common:networkErrorMessage" +
                                                         ".description") }
+                                                    primaryActionText={ I18n.instance.t("common:networkErrorMessage" +
+                                                        ".primaryActionText") }
+                                                />
+                                                <ChunkErrorModal
+                                                    heading={ I18n.instance.t("common:networkErrorMessage.heading") }
+                                                    description="An error occurred in serving the requested application. Please try reloading the app."
                                                     primaryActionText={ I18n.instance.t("common:networkErrorMessage" +
                                                         ".primaryActionText") }
                                                 />

--- a/apps/console/src/extensions/component-extension.tsx
+++ b/apps/console/src/extensions/component-extension.tsx
@@ -21,7 +21,7 @@ import { EmptyPlaceholder, ErrorBoundary } from "@wso2is/react-components";
 import React, { Suspense, lazy } from "react";
 import { Placeholder } from "semantic-ui-react";
 import { ExtensionsManager } from "./extensions-manager";
-import { getEmptyPlaceholderIllustrations } from "../features/core";
+import { AppUtils, getEmptyPlaceholderIllustrations } from "../features/core";
 
 interface ComponentExtensionInterface {
     component?: string;
@@ -68,6 +68,7 @@ export const ComponentExtensionPlaceholder = (args: ComponentExtensionInterface)
                     menuItem: I18n.instance.t(pane.title),
                     render: () => (
                         <ErrorBoundary
+                            onChunkLoadError={ AppUtils.onChunkLoadError }
                             fallback={ (
                                 <EmptyPlaceholder
                                     image={ getEmptyPlaceholderIllustrations().genericError }

--- a/apps/console/src/extensions/extension.tsx
+++ b/apps/console/src/extensions/extension.tsx
@@ -21,7 +21,7 @@ import React, { ReactElement, Suspense, lazy, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { Placeholder } from "semantic-ui-react";
 import { ExtensionsManager } from "./extensions-manager";
-import {AppUtils, getEmptyPlaceholderIllustrations} from "../features/core";
+import { AppUtils, getEmptyPlaceholderIllustrations } from "../features/core";
 
 /**
  * Extension Interface.

--- a/apps/console/src/extensions/extension.tsx
+++ b/apps/console/src/extensions/extension.tsx
@@ -21,7 +21,7 @@ import React, { ReactElement, Suspense, lazy, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { Placeholder } from "semantic-ui-react";
 import { ExtensionsManager } from "./extensions-manager";
-import { getEmptyPlaceholderIllustrations } from "../features/core";
+import {AppUtils, getEmptyPlaceholderIllustrations} from "../features/core";
 
 /**
  * Extension Interface.
@@ -60,6 +60,7 @@ export const ComponentPlaceholder = (props: ExtensionInterface): ReactElement =>
 
     return (
         <ErrorBoundary
+                onChunkLoadError={ AppUtils.onChunkLoadError }
                 fallback={ (
                     <EmptyPlaceholder
                         image={ getEmptyPlaceholderIllustrations().genericError }

--- a/apps/console/src/features/core/utils/app-utils.ts
+++ b/apps/console/src/features/core/utils/app-utils.ts
@@ -123,9 +123,8 @@ export class AppUtils {
     /**
      * Callback to be fired on every chunk load error.
      */
-    public static onChunkLoadError(status: boolean): void {
-        if (status) {
-            dispatchEvent(new Event(AppConstants.CHUNK_LOAD_ERROR_EVENT));
-        }
+    public static onChunkLoadError(): void {
+
+        dispatchEvent(new Event(AppConstants.CHUNK_LOAD_ERROR_EVENT));
     }
 }

--- a/apps/console/src/features/core/utils/app-utils.ts
+++ b/apps/console/src/features/core/utils/app-utils.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { AppConstants } from "@wso2is/core/constants";
 import { StorageIdentityAppsSettingsInterface } from "@wso2is/core/models";
 import { LocalStorageUtils } from "@wso2is/core/utils";
 import cloneDeep from "lodash-es/cloneDeep";
@@ -117,5 +118,14 @@ export class AppUtils {
         newPref.identityAppsSettings.devPortal.hiddenRoutes = [ ...hiddenRoutes, routeId ];
 
         this.setUserPreferences(newPref);
+    }
+
+    /**
+     * Callback to be fired on every chunk load error.
+     */
+    public static onChunkLoadError(status: boolean): void {
+        if (status) {
+            dispatchEvent(new Event(AppConstants.CHUNK_LOAD_ERROR_EVENT));
+        }
     }
 }

--- a/apps/console/src/layouts/app.tsx
+++ b/apps/console/src/layouts/app.tsx
@@ -29,7 +29,7 @@ import React, { FunctionComponent, ReactElement, Suspense, useEffect, useState }
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Redirect, Route, Switch } from "react-router-dom";
-import { AppState, PreLoader } from "../features/core";
+import { AppState, AppUtils, PreLoader } from "../features/core";
 import { ProtectedRoute } from "../features/core/components";
 import { getAppLayoutRoutes, getEmptyPlaceholderIllustrations } from "../features/core/configs";
 import { AppConstants } from "../features/core/constants";
@@ -58,6 +58,7 @@ export const AppLayout: FunctionComponent<{}> = (): ReactElement => {
     return (
         <AppLayoutSkeleton>
             <ErrorBoundary
+                onChunkLoadError={ AppUtils.onChunkLoadError }
                 fallback={ (
                     <EmptyPlaceholder
                         action={ (

--- a/apps/console/src/views/admin.tsx
+++ b/apps/console/src/views/admin.tsx
@@ -431,6 +431,7 @@ export const AdminView: FunctionComponent<AdminViewPropsInterface> = (
                 ) }
             >
                 <ErrorBoundary
+                    onChunkLoadError={ AppUtils.onChunkLoadError }
                     fallback={ (
                         <EmptyPlaceholder
                             action={ (

--- a/apps/console/src/views/developer.tsx
+++ b/apps/console/src/views/developer.tsx
@@ -343,6 +343,7 @@ export const DeveloperView: FunctionComponent<DeveloperViewPropsInterface> = (
                 ) }
             >
                 <ErrorBoundary
+                    onChunkLoadError={ AppUtils.onChunkLoadError }
                     fallback={ (
                         <EmptyPlaceholder
                             action={ (

--- a/apps/console/src/views/full-screen-view.tsx
+++ b/apps/console/src/views/full-screen-view.tsx
@@ -45,7 +45,8 @@ import {
     ProtectedRoute,
     RouteUtils,
     getEmptyPlaceholderIllustrations,
-    getFullScreenViewRoutes, AppUtils
+    getFullScreenViewRoutes,
+    AppUtils
 } from "../features/core";
 
 /**

--- a/apps/console/src/views/full-screen-view.tsx
+++ b/apps/console/src/views/full-screen-view.tsx
@@ -45,7 +45,7 @@ import {
     ProtectedRoute,
     RouteUtils,
     getEmptyPlaceholderIllustrations,
-    getFullScreenViewRoutes
+    getFullScreenViewRoutes, AppUtils
 } from "../features/core";
 
 /**
@@ -164,6 +164,7 @@ export const FullScreenView: FunctionComponent<FullScreenViewPropsInterface> = (
     return (
         <FullScreenLayoutSkeleton>
             <ErrorBoundary
+                onChunkLoadError={ AppUtils.onChunkLoadError }
                 fallback={ (
                     <EmptyPlaceholder
                         action={ (

--- a/apps/myaccount/src/app.tsx
+++ b/apps/myaccount/src/app.tsx
@@ -27,6 +27,7 @@ import {
 import { LocalStorageUtils } from "@wso2is/core/utils";
 import { I18n, I18nModuleOptionsInterface } from "@wso2is/i18n";
 import {
+    ChunkErrorModal,
     Code,
     ContentLoader,
     NetworkErrorModal,
@@ -252,6 +253,13 @@ export const App = (): ReactElement => {
                                                     <title>{ appTitle }</title>
                                                 </Helmet>
                                                 <NetworkErrorModal
+                                                    heading={ I18n.instance.t("common:networkErrorMessage.heading") }
+                                                    description={ I18n.instance.t("common:networkErrorMessage" +
+                                                        ".description") }
+                                                    primaryActionText={ I18n.instance.t("common:networkErrorMessage" +
+                                                        ".primaryActionText") }
+                                                />
+                                                <ChunkErrorModal
                                                     heading={ I18n.instance.t("common:networkErrorMessage.heading") }
                                                     description={ I18n.instance.t("common:networkErrorMessage" +
                                                         ".description") }

--- a/apps/myaccount/src/app.tsx
+++ b/apps/myaccount/src/app.tsx
@@ -260,10 +260,10 @@ export const App = (): ReactElement => {
                                                         ".primaryActionText") }
                                                 />
                                                 <ChunkErrorModal
-                                                    heading={ I18n.instance.t("common:networkErrorMessage.heading") }
-                                                    description={ I18n.instance.t("common:networkErrorMessage" +
+                                                    heading={ I18n.instance.t("common:chunkLoadErrorMessage.heading") }
+                                                    description={ I18n.instance.t("common:chunkLoadErrorMessage" +
                                                         ".description") }
-                                                    primaryActionText={ I18n.instance.t("common:networkErrorMessage" +
+                                                    primaryActionText={ I18n.instance.t("common:chunkLoadErrorMessage" +
                                                         ".primaryActionText") }
                                                 />
                                                 <Switch>

--- a/apps/myaccount/src/layouts/inner.tsx
+++ b/apps/myaccount/src/layouts/inner.tsx
@@ -32,6 +32,7 @@ import {
 } from "../components";
 import { getEmptyPlaceholderIllustrations } from "../configs";
 import { AppState } from "../store";
+import {AppUtils} from "../utils";
 
 /**
  * Inner page layout component Prop types.
@@ -102,6 +103,7 @@ export const InnerPageLayout: React.FunctionComponent<InnerPageLayoutProps> = (
                     onSidePanelPusherClick={ handleSidePanelPusherClick }
                 >
                     <ErrorBoundary
+                        onChunkLoadError={ AppUtils.onChunkLoadError }
                         fallback={ (
                             <EmptyPlaceholder
                                 action={ (

--- a/apps/myaccount/src/layouts/inner.tsx
+++ b/apps/myaccount/src/layouts/inner.tsx
@@ -32,7 +32,7 @@ import {
 } from "../components";
 import { getEmptyPlaceholderIllustrations } from "../configs";
 import { AppState } from "../store";
-import {AppUtils} from "../utils";
+import { AppUtils } from "../utils";
 
 /**
  * Inner page layout component Prop types.

--- a/apps/myaccount/src/utils/app-utils.ts
+++ b/apps/myaccount/src/utils/app-utils.ts
@@ -82,9 +82,8 @@ export class AppUtils {
     /**
      * Callback to be fired on every chunk load error.
      */
-    public static onChunkLoadError(status: boolean): void {
-        if (status) {
-            dispatchEvent(new Event(AppConstants.CHUNK_LOAD_ERROR_EVENT));
-        }
+    public static onChunkLoadError(): void {
+
+        dispatchEvent(new Event(AppConstants.CHUNK_LOAD_ERROR_EVENT));
     }
 }

--- a/apps/myaccount/src/utils/app-utils.ts
+++ b/apps/myaccount/src/utils/app-utils.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import { AppConstants } from "@wso2is/core/constants";
 import { StorageIdentityAppsSettingsInterface } from "@wso2is/core/models";
 import { LocalStorageUtils } from "@wso2is/core/utils";
 import get from "lodash-es/get";
@@ -76,5 +77,14 @@ export class AppUtils {
             ...JSON.parse(LocalStorageUtils.getValueFromLocalStorage(tenantName)),
             [ username ]: preferences
         }));
+    }
+
+    /**
+     * Callback to be fired on every chunk load error.
+     */
+    public static onChunkLoadError(status: boolean): void {
+        if (status) {
+            dispatchEvent(new Event(AppConstants.CHUNK_LOAD_ERROR_EVENT));
+        }
     }
 }

--- a/modules/core/src/constants/app-constants.ts
+++ b/modules/core/src/constants/app-constants.ts
@@ -70,4 +70,12 @@ export class AppConstants {
      * @default
      */
     public static readonly NETWORK_ERROR_EVENT: string = "network_error_event";
+
+    /**
+     * The name of the event dispatched when a chunk load error occurs.
+     * @constant
+     * @type {string}
+     * @default
+     */
+    public static readonly CHUNK_LOAD_ERROR_EVENT: string = "chunk_load_error_event";
 }

--- a/modules/i18n/src/models/namespaces/common-ns.ts
+++ b/modules/i18n/src/models/namespaces/common-ns.ts
@@ -41,6 +41,11 @@ export interface CommonNS {
     close: string;
     challengeQuestionNumber: string;
     change: string;
+    chunkLoadErrorMessage: {
+        heading: string;
+        description: string;
+        primaryActionText: string;
+    }
     claim: string;
     clear: string;
     comingSoon: string;

--- a/modules/i18n/src/translations/en-US/portals/common.ts
+++ b/modules/i18n/src/translations/en-US/portals/common.ts
@@ -40,6 +40,11 @@ export const common: CommonNS = {
     cancel: "Cancel",
     challengeQuestionNumber: "Challenge Question {{number}}",
     change: "Change",
+    chunkLoadErrorMessage: {
+        description: "An error occurred when serving the requested application. Please try reloading the app.",
+        heading: "Something went wrong",
+        primaryActionText: "Reload the App"
+    },
     claim: "Claim",
     clear: "Clear",
     close: "Close",

--- a/modules/i18n/src/translations/fr-FR/portals/common.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/common.ts
@@ -40,6 +40,12 @@ export const common: CommonNS = {
     cancel: "Annuler",
     challengeQuestionNumber: "Question de sécurité {{number}}",
     change: "Modifier",
+    chunkLoadErrorMessage: {
+        description: "Une erreur s'est produite lors de la diffusion de l'application demandée. Veuillez essayer " +
+            "de recharger l'application.",
+        heading: "Quelque chose s'est mal passé",
+        primaryActionText: "Recharger l'application"
+    },
     claim: "Claim",
     clear: "Effacer",
     close: "Fermer",

--- a/modules/i18n/src/translations/pt-BR/portals/common.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/common.ts
@@ -40,6 +40,11 @@ export const common: CommonNS = {
     cancel: "Cancelar",
     challengeQuestionNumber: "Questão Desafio {{number}}",
     change: "Mudança",
+    chunkLoadErrorMessage: {
+        description: "Ocorreu um erro ao servir o aplicativo solicitado. Tente recarregar o aplicativo.",
+        heading: "Quelque chose s'est mal passé",
+        primaryActionText: "Recarregue o aplicativo"
+    },
     claim: "Afirmação",
     clear: "Apagar",
     close: "Fechar",

--- a/modules/i18n/src/translations/si-LK/portals/common.ts
+++ b/modules/i18n/src/translations/si-LK/portals/common.ts
@@ -40,6 +40,11 @@ export const common: CommonNS = {
     cancel: "අවලංගු කරන්න",
     challengeQuestionNumber: "අභියෝගාත්මක ප්\u200Dරශ්නය {{number}}",
     change: "වෙනස් කරන්න",
+    chunkLoadErrorMessage: {
+        description: "ඉල්ලූ යෙදුමට සේවය කිරීමේදී දෝෂයක් ඇතිවිය. කරුණාකර යෙදුම නැවත පූරණය කිරීමට උත්සාහ කරන්න.",
+        heading: "මොකක්හරි වැරැද්දක් වෙලා",
+        primaryActionText: "යෙදුම නැවත පූරණය කරන්න"
+    },
     claim: "හිමිකම",
     clear: "මකන්න",
     close: "වසන්න",

--- a/modules/i18n/src/translations/ta-IN/portals/common.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/common.ts
@@ -40,6 +40,11 @@ export const common: CommonNS = {
     cancel: "இரத்து செய்",
     challengeQuestionNumber: "சவால் வினா {{number}}",
     change: "மாற்று",
+    chunkLoadErrorMessage: {
+        description: "கோரப்பட்ட பயன்பாட்டிற்கு சேவை செய்யும் போது பிழை ஏற்பட்டது. பயன்பாட்டை மீண்டும் ஏற்ற முயற்சிக்கவும்.",
+        heading: "ஏதோ தவறு நடந்துவிட்டது",
+        primaryActionText: "பயன்பாட்டை மீண்டும் ஏற்றவும்"
+    },
     claim: "கோர்",
     clear: "அழிக்கவும்",
     close: "நெருக்கமான",

--- a/modules/react-components/src/components/error/error-boundary.tsx
+++ b/modules/react-components/src/components/error/error-boundary.tsx
@@ -31,7 +31,7 @@ interface ErrorBoundaryState {
  */
 interface ErrorBoundaryProps {
     fallback: React.ReactNode;
-    onChunkLoadError: (state: boolean) => void;
+    onChunkLoadError: () => void;
 }
 
 /**
@@ -57,8 +57,9 @@ export class ErrorBoundary extends React.Component<PropsWithChildren<ErrorBounda
     componentDidCatch(error, errorInfo) {
 
         const { onChunkLoadError } = this.props;
+
         if (error.name === 'ChunkLoadError') {
-            onChunkLoadError && onChunkLoadError(true);
+            onChunkLoadError && onChunkLoadError();
         }
         // Catch errors in any components below and re-render with error message
         this.setState({

--- a/modules/react-components/src/components/error/error-boundary.tsx
+++ b/modules/react-components/src/components/error/error-boundary.tsx
@@ -31,6 +31,7 @@ interface ErrorBoundaryState {
  */
 interface ErrorBoundaryProps {
     fallback: React.ReactNode;
+    onChunkLoadError: (state: boolean) => void;
 }
 
 /**
@@ -43,7 +44,7 @@ interface ErrorBoundaryProps {
  * @param {PlaceholderProps} props - Props injected in to the placeholder component.
  * @return {JSX.Element}
  */
-export class ErrorBoundary extends React.Component<PropsWithChildren<ErrorBoundaryProps>, ErrorBoundaryState> {
+export class ErrorBoundary extends React.Component<PropsWithChildren<ErrorBoundaryProps>, ErrorBoundaryState, ErrorBoundaryProps> {
 
     constructor(props) {
         super(props);
@@ -54,6 +55,11 @@ export class ErrorBoundary extends React.Component<PropsWithChildren<ErrorBounda
     }
 
     componentDidCatch(error, errorInfo) {
+
+        const { onChunkLoadError } = this.props;
+        if (error.name === 'ChunkLoadError') {
+            onChunkLoadError && onChunkLoadError(true);
+        }
         // Catch errors in any components below and re-render with error message
         this.setState({
             error,

--- a/modules/react-components/src/components/modal/chunk-error-modal/chunk-error-modal.tsx
+++ b/modules/react-components/src/components/modal/chunk-error-modal/chunk-error-modal.tsx
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AppConstants } from "@wso2is/core/constants";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { Heading } from "../../typography";
+import { ConfirmationModal } from "../confirmation-modal";
+
+/**
+ * Prop type of the `ChunkErrorModal` component.
+ */
+interface ChunkModalPropTypes {
+    heading: string;
+    description: string;
+    primaryActionText: string;
+}
+
+/**
+ * This component listens to the `chunk load error` and pops up a modal
+ * when this error is occurred.
+ */
+export const ChunkErrorModal: FunctionComponent<ChunkModalPropTypes> = (
+    props: ChunkModalPropTypes
+): ReactElement => {
+    const { heading, description, primaryActionText } = props;
+
+    const [ showModal, setShowModal ] = useState(false);
+
+    /**
+     * Show modal.
+     */
+    const showErrorModal = () => {
+        setShowModal(true);
+    };
+
+    /**
+     * Called on mount and unmount to add/remove the event listener.
+     */
+    useEffect(() => {
+        addEventListener(AppConstants.CHUNK_LOAD_ERROR_EVENT, showErrorModal);
+
+        return () => {
+            removeEventListener(AppConstants.CHUNK_LOAD_ERROR_EVENT, showErrorModal);
+        };
+    }, []);
+
+    return (
+        <ConfirmationModal
+            animated
+            type="warning"
+            textAlign="center"
+            primaryAction={ primaryActionText }
+            onPrimaryActionClick={ () => {
+                location.reload();
+            } }
+            data-testid={ "chunk-error-modal" }
+            open={ showModal }
+        >
+            <ConfirmationModal.Content>
+                <Heading as="h3">{ heading }</Heading>
+                <p>{ description }</p>
+            </ConfirmationModal.Content>
+        </ConfirmationModal>
+    );
+};

--- a/modules/react-components/src/components/modal/chunk-error-modal/chunk-error-modal.tsx
+++ b/modules/react-components/src/components/modal/chunk-error-modal/chunk-error-modal.tsx
@@ -24,7 +24,7 @@ import { ConfirmationModal } from "../confirmation-modal";
 /**
  * Prop type of the `ChunkErrorModal` component.
  */
-interface ChunkModalPropTypes {
+interface ChunkModalPropsInterface {
     heading: string;
     description: string;
     primaryActionText: string;
@@ -34,28 +34,22 @@ interface ChunkModalPropTypes {
  * This component listens to the `chunk load error` and pops up a modal
  * when this error is occurred.
  */
-export const ChunkErrorModal: FunctionComponent<ChunkModalPropTypes> = (
-    props: ChunkModalPropTypes
+export const ChunkErrorModal: FunctionComponent<ChunkModalPropsInterface> = (
+    props: ChunkModalPropsInterface
 ): ReactElement => {
+
     const { heading, description, primaryActionText } = props;
 
     const [ showModal, setShowModal ] = useState(false);
 
     /**
-     * Show modal.
-     */
-    const showErrorModal = () => {
-        setShowModal(true);
-    };
-
-    /**
      * Called on mount and unmount to add/remove the event listener.
      */
     useEffect(() => {
-        addEventListener(AppConstants.CHUNK_LOAD_ERROR_EVENT, showErrorModal);
+        addEventListener(AppConstants.CHUNK_LOAD_ERROR_EVENT, () => setShowModal(true));
 
         return () => {
-            removeEventListener(AppConstants.CHUNK_LOAD_ERROR_EVENT, showErrorModal);
+            removeEventListener(AppConstants.CHUNK_LOAD_ERROR_EVENT, () => setShowModal(true));
         };
     }, []);
 

--- a/modules/react-components/src/components/modal/chunk-error-modal/index.ts
+++ b/modules/react-components/src/components/modal/chunk-error-modal/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -14,11 +14,6 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
-export * from "./confirmation-modal";
-export * from "./edit-avatar-modal";
-export * from "./session-timeout-modal";
-export * from "./network-error-modal";
 export * from "./chunk-error-modal";


### PR DESCRIPTION
### Purpose
> Console & My Account are sometimes hitting error boundaries due to chunk loading issues when there are new rollouts. We have to show a modal to the users and they can reload the app. 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
