### PR TITLE
Show account lock error message on the login page

### DIFF
--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -219,3 +219,4 @@ error.emailOTP.disabled=Enable the Email OTP in your Profile. Cannot proceed fur
 error.user.not.found=User not found in the directory. Cannot proceed further without Email OTP authentication.
 error.user.account.locked=User account is locked. Please retry later.
 error.user.account.temporarly.locked=User account is locked. Please retry after %s minutes.
+error.user.account.locked.incorrect.login.attempts=Your account has been temporarily locked due to multiple failed login attempts. Please check your email for more details.

--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -185,7 +185,13 @@
     }
 %>
 
-<% if (Boolean.parseBoolean(loginFailed) && !errorCode.equals(IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE)) { %>
+<% if (StringUtils.equals(request.getParameter("errorCode"), IdentityCoreConstants.USER_ACCOUNT_LOCKED_ERROR_CODE) &&
+        StringUtils.equals(request.getParameter("remainingAttempts"), "0") ) { %>
+<div class="ui visible negative message" id="error-msg" data-testid="login-page-error-message">
+    <%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.account.locked.incorrect.login.attempts")%>
+</div>
+<% } else if (Boolean.parseBoolean(loginFailed) &&
+        !errorCode.equals(IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE)) { %>
 <div class="ui visible negative message" id="error-msg" data-testid="login-page-error-message">
     <%= AuthenticationEndpointUtil.i18n(resourceBundle, errorMessage) %>
 </div>

--- a/pom.xml
+++ b/pom.xml
@@ -657,7 +657,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.20.6</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.126</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.oauth.version>6.5.3</carbon.identity.oauth.version>
         <carbon.identity.oauth.imp.pkg.version.range>[6.1.0, 7.0.0)</carbon.identity.oauth.imp.pkg.version.range>


### PR DESCRIPTION
### Purpose
> There's no indication for the user that his account is locked after reaching the maximum number of failed login attempts.Better to have a way to notify the user when his account is locked.

>With this improvement, the user will be notified with an error message on the login page when his account is locked.

![onprem-toml-true-lock](https://user-images.githubusercontent.com/36721128/126692915-7b900b6f-c6d9-4614-a45d-b95142b12ca5.gif)

Account lock error message:
![Screenshot from 2021-07-23 00-08-02](https://user-images.githubusercontent.com/36721128/126692891-685d3c6e-cb58-49cc-99aa-7bb01cc8fa51.png)

### Related Issues
- Issue  #wso2/product-is/issues/12175

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- wso2-extensions/identity-local-auth-basicauth#113
- wso2/carbon-identity-framework#3622

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
