### PR TITLE
Adding Revoke Endpoint in Info Tab

### DIFF
--- a/apps/console/src/features/applications/api/application.ts
+++ b/apps/console/src/features/applications/api/application.ts
@@ -761,6 +761,7 @@ export const getOIDCApplicationConfigurations = (): Promise<OIDCApplicationConfi
                 introspectionEndpoint: response.data.introspection_endpoint,
                 jwksEndpoint: response.data.jwks_uri,
                 tokenEndpoint: response.data.token_endpoint,
+                tokenRevocationEndpoint: response.data.revocation_endpoint,
                 userEndpoint: response.data.userinfo_endpoint,
                 wellKnownEndpoint: store.getState().config.endpoints.wellKnown
             };

--- a/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
+++ b/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
@@ -144,6 +144,31 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                 <Grid.Row columns={ 2 }>
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
                         <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.revoke }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-token-revoke-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.revoke") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.tokenRevocationEndpoint }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-token-revoke-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
                             icon={ getHelpPanelIcons().endpoints.userInfo }
                             size="micro"
                             square

--- a/apps/console/src/features/applications/configs/ui.ts
+++ b/apps/console/src/features/applications/configs/ui.ts
@@ -53,6 +53,7 @@ import { ReactComponent as SLOIcon } from "../../../themes/default/assets/images
 import { ReactComponent as SpinWheelIcon } from "../../../themes/default/assets/images/icons/spin-wheel-icon.svg";
 import { ReactComponent as SSOIcon } from "../../../themes/default/assets/images/icons/sso.svg";
 import { ReactComponent as TokenIcon } from "../../../themes/default/assets/images/icons/token.svg";
+import { ReactComponent as RevokeTokenIcon } from "../../../themes/default/assets/images/icons/revoke.svg";
 import { ReactComponent as UserInfoIcon } from "../../../themes/default/assets/images/icons/userInfo.svg";
 import GithubIdPIcon from "../../../themes/default/assets/images/identity-providers/github-idp-illustration.svg";
 import {
@@ -199,6 +200,7 @@ export const getHelpPanelIcons = () => {
             samlSLO: SLOIcon,
             samlSSO: SSOIcon,
             token: TokenIcon,
+            revoke: RevokeTokenIcon,
             userInfo: UserInfoIcon,
             wellKnown: WellKnownIcon
         },

--- a/apps/console/src/features/applications/configs/ui.ts
+++ b/apps/console/src/features/applications/configs/ui.ts
@@ -53,7 +53,7 @@ import { ReactComponent as SLOIcon } from "../../../themes/default/assets/images
 import { ReactComponent as SpinWheelIcon } from "../../../themes/default/assets/images/icons/spin-wheel-icon.svg";
 import { ReactComponent as SSOIcon } from "../../../themes/default/assets/images/icons/sso.svg";
 import { ReactComponent as TokenIcon } from "../../../themes/default/assets/images/icons/token.svg";
-import { ReactComponent as RevokeTokenIcon } from "../../../themes/default/assets/images/icons/revoke.svg";
+import { ReactComponent as RevokeTokenIcon } from "../../../themes/default/assets/images/icons/outline-icons/revoke-outline.svg";
 import { ReactComponent as UserInfoIcon } from "../../../themes/default/assets/images/icons/userInfo.svg";
 import GithubIdPIcon from "../../../themes/default/assets/images/identity-providers/github-idp-illustration.svg";
 import {

--- a/apps/console/src/features/applications/models/application.ts
+++ b/apps/console/src/features/applications/models/application.ts
@@ -578,6 +578,7 @@ export interface OIDCApplicationConfigurationInterface {
     endSessionEndpoint: string;
     introspectionEndpoint: string;
     tokenEndpoint: string;
+    tokenRevocationEndpoint: string;
     userEndpoint: string;
     jwksEndpoint: string;
     wellKnownEndpoint: string;
@@ -600,6 +601,7 @@ export const emptyOIDCAppConfiguration = (): OIDCApplicationConfigurationInterfa
     introspectionEndpoint: "",
     jwksEndpoint: "",
     tokenEndpoint: "",
+    tokenRevocationEndpoint: "",
     userEndpoint: "",
     wellKnownEndpoint: ""
 });

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -2119,6 +2119,7 @@ export const console: ConsoleNS = {
                                         keystore: "Key Set",
                                         jwks: "JWKS",
                                         token: "Token",
+                                        revoke: "Revoke",
                                         userInfo: "UserInfo",
                                         wellKnown: "Discovery"
                                     }

--- a/modules/theme/src/themes/default/assets/images/icons/outline-icons/revoke-outline.svg
+++ b/modules/theme/src/themes/default/assets/images/icons/outline-icons/revoke-outline.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<svg id="revoke-icon" class="icon" xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 14 14" xml:space="preserve" >
+  <g id="revoke_1" data-name="revoke token">
+    <path id="revoke-outline" d="M.292,14A.292.292,0,0,1,0,13.708V11.375a.291.291,0,0,1,.086-.206l1.081-1.082V9.625a.292.292,0,0,1,.292-.292h.463l.16-.159.011.034L2.1,9.176l.4,1.21,1.27.186.013.029.024,0-.016.016.479,1.08-.005.072.067.642-1.5,1.5A.294.294,0,0,1,2.625,14ZM1.75,10.209a.292.292,0,0,1-.085.206L.583,11.5v1.921H2.5l1.156-1.155v-.374l-.305-.793-.033,0L2.247,12.164a.291.291,0,0,1-.412-.412L2.583,11,2.1,10.948,1.756,9.916H1.75ZM5.442,11.3l-.016-.186-.467-1.2L3.709,9.77,3.294,8.247l-.073-.214L3.5,7.754V7.292A.292.292,0,0,1,3.792,7h.463l.292-.292-.377-.377a.291.291,0,0,1,.076-.467L4.766,5.6a4.664,4.664,0,1,1,4.6,3.732,4.746,4.746,0,0,1-.971-.1l-.26.521a.29.29,0,0,1-.214.158.3.3,0,0,1-.049,0,.292.292,0,0,1-.2-.085l-.377-.377L5.444,11.3l0,0ZM5.375,9.4l.338.812L7.086,8.835a.291.291,0,0,1,.412,0l.3.3.183-.365a.293.293,0,0,1,.261-.161.279.279,0,0,1,.073.009,4.249,4.249,0,0,0,1.057.136A4.107,4.107,0,1,0,5.385,5.689a.3.3,0,0,1-.152.334L4.867,6.2l.3.3a.291.291,0,0,1,0,.412L4.581,7.5a.291.291,0,0,1-.206.086H4.083v.292A.291.291,0,0,1,4,8.081l-.162.162h.008l.26.966.239.035L5.918,7.669a.291.291,0,1,1,.412.412L5.062,9.35ZM9.333,3.209a1.458,1.458,0,1,1,1.458,1.458A1.46,1.46,0,0,1,9.333,3.209Zm.583,0a.875.875,0,1,0,.875-.875A.876.876,0,0,0,9.916,3.209Z" fill="#666"/>
+  </g>
+</svg>


### PR DESCRIPTION
### Purpose
> This PR adds Revoke Token Endpoint info to the Info Tab of applications. 
![Screenshot from 2021-07-26 11-52-54](https://user-images.githubusercontent.com/32198547/126943217-ca8a112f-7f62-4dc3-bcb3-aa86c2d400ca.png)


### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
