### PR TITLE
Add warning icons to 'implicit' and 'password' grant types

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -96,6 +96,16 @@ interface InboundOIDCFormPropsInterface extends TestableComponentInterface {
 }
 
 /**
+ * Interface for grant icons.
+ */
+interface GrantIconInterface {
+    label: string | ReactElement;
+    value: string;
+    hint?: any;
+    disabled?: boolean;
+}
+
+/**
  * Inbound OIDC protocol configurations form.
  *
  * @param {InboundOIDCFormPropsInterface} props - Props injected to the component.
@@ -586,7 +596,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                  * as optional because not all children have hint/description
                  * popups. {@see modules > forms > CheckboxChild}
                  */
-                const grant: { label: any; value: string; hint?: any; disabled?: boolean } = {
+                const grant: GrantIconInterface = {
                     label: modifyGrantTypeLabels(name, displayName),
                     value: name
                 };

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -24,6 +24,7 @@ import {
     Code,
     ConfirmationModal,
     CopyInputField,
+    GenericIcon,
     Heading,
     Hint,
     LinkButton,
@@ -61,6 +62,7 @@ import {
 } from "../../models";
 import { ApplicationManagementUtils } from "../../utils";
 import { CertificateFormFieldModal } from "../modals";
+import { getGeneralIcons } from "../../configs";
 
 /**
  * Proptypes for the inbound OIDC form component.
@@ -498,21 +500,30 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     };
 
     /**
-     * Modifies the grant type label string value. For now we only concatenate
-     * some extra value to the `implicit` field. If you need to do the same for
-     * other checkboxes label then add a condition and bind the values.
+     * Modifies the grant type label. For `implicit` and `password` fields,
+     * a warning icon is concatenated with the label.
      *
      * @param value {string} checkbox key {@link TEMPLATE_WISE_ALLOWED_GRANT_TYPES}
      * @param label {string} mapping label for value
      */
-    const modifyGrantTypeLabels = (value: string, label: string): string => {
-        if (value === ApplicationManagementConstants.IMPLICIT_GRANT) {
-            return t("console:develop.features.applications.forms.inboundOIDC.fields.grant.children.implicit.label",
-                { grantType: label });
-        }
-        if (value === ApplicationManagementConstants.PASSWORD) {
-            return t("console:develop.features.applications.forms.inboundOIDC.fields.grant.children.password.label",
-                { grantType: label });
+    const modifyGrantTypeLabels = (value: string, label: string) => {
+        if (value === ApplicationManagementConstants.IMPLICIT_GRANT ||
+            value === ApplicationManagementConstants.PASSWORD) {
+            return (
+                <>
+                    <label>
+                        { label }
+                        <GenericIcon
+                            icon={ getGeneralIcons().warning }
+                            defaultIcon
+                            colored
+                            transparent
+                            spaced="left"
+                            floated="right"
+                        />
+                    </label>
+                </>
+            );
         }
         return label;
     };
@@ -575,7 +586,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                  * as optional because not all children have hint/description
                  * popups. {@see modules > forms > CheckboxChild}
                  */
-                const grant: { label: string; value: string; hint?: any; disabled?: boolean } = {
+                const grant: { label: any; value: string; hint?: any; disabled?: boolean } = {
                     label: modifyGrantTypeLabels(name, displayName),
                     value: name
                 };

--- a/apps/console/src/features/applications/configs/ui.ts
+++ b/apps/console/src/features/applications/configs/ui.ts
@@ -126,6 +126,7 @@ import { ReactComponent as JWTLogo } from "../../../themes/default/assets/images
 import { ReactComponent as MicrosoftLogo } from "../../../themes/default/assets/images/third-party/microsoft-logo.svg";
 import { ReactComponent as Office365Logo } from "../../../themes/default/assets/images/third-party/office-365-logo.svg";
 import { ReactComponent as YahooLogo } from "../../../themes/default/assets/images/third-party/yahoo-logo.svg";
+import { ReactComponent as WarningIcon } from "../../../themes/default/assets/images/icons/warning-icon.svg";
 
 export const getInboundProtocolLogos = () => {
 
@@ -224,7 +225,8 @@ export const getGeneralIcons = () => {
     return {
         addCircleOutline: AddCircleOutlineIcon,
         plusIcon: PlusIcon,
-        predefined: ProtocolPredefined
+        predefined: ProtocolPredefined,
+        warning: WarningIcon
     };
 };
 


### PR DESCRIPTION
### Purpose
Instead of mentioning `not recommended` in the checkbox label, added a warning icon to the labels in traditional and custom OIDC applications.

![image](https://user-images.githubusercontent.com/36252940/127210579-652676a8-fd2c-4175-8bef-fb47634f7cc4.png)

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
