### PR TITLE
Enabling Collaborator delete

### DIFF
--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -70,6 +70,10 @@ interface UserProfilePropsInterface extends TestableComponentInterface, SBACInte
      */
     isReadOnly?: boolean;
     /**
+     * Allow if the user is deletable.
+     */
+    allowDeleteOnly?: boolean;
+    /**
      * Password reset connector properties
      */
     connectorProperties: ConnectorPropertyInterface[];
@@ -102,6 +106,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         user,
         handleUserUpdate,
         isReadOnly,
+        allowDeleteOnly,
         featureConfig,
         connectorProperties,
         isReadOnlyUserStoresLoading,
@@ -638,14 +643,14 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             <>
                 {
                     (hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.delete,
-                        allowedScopes) && !isReadOnly &&
-                        (user.userName !== tenantAdmin || user.userName !== "admin") &&
-                        user.userName !== authenticatedUser) && (
+                        allowedScopes) && (!isReadOnly || allowDeleteOnly) &&
+                        !(user.userName === tenantAdmin || user.userName === "admin") &&
+                        !authenticatedUser.includes(user.userName)) && (
                         <DangerZoneGroup
                             sectionHeader={ t("console:manage.features.user.editUser.dangerZoneGroup.header") }
                         >
                             {
-                                configSettings?.accountDisable === "true" && (
+                                !allowDeleteOnly && configSettings?.accountDisable === "true" && (
                                     <DangerZone
                                         data-testid={ `${ testId }-danger-zone` }
                                         actionTitle={ t("console:manage.features.user.editUser.dangerZoneGroup." +
@@ -666,7 +671,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                 )
                             }
                             {
-                                configSettings?.accountLock === "true" && (
+                                !allowDeleteOnly && configSettings?.accountLock === "true" && (
                                     <DangerZone
                                         data-testid={ `${ testId }-danger-zone` }
                                         actionTitle={ t("console:manage.features.user.editUser.dangerZoneGroup." +


### PR DESCRIPTION
### Purpose
> This PR enables **collaborator deletion** given the role has permissions in the profile-view of a user. Deletion from User List view is already enabled. This PR also ensures that deletion will not be enabled for owner or logged in user.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- https://github.com/wso2-enterprise/asgardeo-app-extensions/pull/953

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
