### PR TITLE
fix: SAML authn setting checkboxes toggle lag

### DIFF
--- a/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
@@ -20,7 +20,7 @@ import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Form } from "@wso2is/form";
 import { Code, FormInputLabel, FormSection } from "@wso2is/react-components";
 import React, { FunctionComponent, PropsWithChildren, ReactElement, useEffect, useMemo, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider, Grid, SemanticWIDTHS } from "semantic-ui-react";
 import { AppState, ConfigReducerStateInterface } from "../../../../core";
@@ -321,7 +321,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                     <SectionRow>
                         <Field.Checkbox
                             name="IsSLORequestAccepted"
-                            value={ isSLORequestAccepted }
+                            initialValue={ isSLORequestAccepted }
                             ariaLabel={ t(`${ I18N_TARGET_KEY }.IsSLORequestAccepted.ariaLabel`) }
                             data-testid={ `${ testId }-IsSLORequestAccepted-field` }
                             label={ (
@@ -341,7 +341,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                         <Field.Checkbox
                             required={ false }
                             name="IsLogoutEnabled"
-                            value={ isLogoutEnabled }
+                            initialValue={ isLogoutEnabled }
                             ariaLabel={ t(`${ I18N_TARGET_KEY }.IsLogoutEnabled.ariaLabel`) }
                             data-testid={ `${ testId }-IsLogoutEnabled-field` }
                             label={ (
@@ -405,7 +405,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                         <Field.Checkbox
                             required={ false }
                             name="IsLogoutReqSigned"
-                            value={ isLogoutReqSigned }
+                            initialValue={ isLogoutReqSigned }
                             ariaLabel={ t(`${ I18N_TARGET_KEY }.IsLogoutReqSigned.ariaLabel`) }
                             data-testid={ `${ testId }-IsLogoutReqSigned-field` }
                             label={ (
@@ -423,7 +423,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                         <Field.Checkbox
                             required={ false }
                             name="ISAuthnReqSigned"
-                            value={ isAuthnReqSigned }
+                            initialValue={ isAuthnReqSigned }
                             ariaLabel={ t(`${ I18N_TARGET_KEY }.ISAuthnReqSigned.ariaLabel`) }
                             data-testid={ `${ testId }-ISAuthnReqSigned-field` }
                             label={ (
@@ -485,7 +485,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                         <Field.Checkbox
                             required={ false }
                             name="IncludeProtocolBinding"
-                            value={ includeProtocolBinding }
+                            initialValue={ includeProtocolBinding }
                             ariaLabel={ t(`${ I18N_TARGET_KEY }.IncludeProtocolBinding.ariaLabel`) }
                             data-testid={ `${ testId }-IncludeProtocolBinding-field` }
                             label={ (
@@ -501,7 +501,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                         <Field.Checkbox
                             required={ false }
                             name="IsUserIdInClaims"
-                            value={ isUserIdInClaims }
+                            initialValue={ isUserIdInClaims }
                             ariaLabel={ t(`${ I18N_TARGET_KEY }.IsUserIdInClaims.ariaLabel`) }
                             data-testid={ `${ testId }-IsUserIdInClaims-field` }
                             label={ (

--- a/apps/console/src/features/identity-providers/components/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/components/common-pluggable-component-form.tsx
@@ -217,65 +217,8 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
 
     const triggerAlgorithmSelectionDropdowns = (key: string, values: Map<string, FormValue>) => {
 
-        /**
-         * Hold on! before you ask why? Just READ this!
-         * --
-         *
-         * let X be two checkboxes. Form keys:  "IsLogoutReqSigned", "ISAuthnReqSigned"
-         * let Y be a dropdown.     Form Key:   "SignatureAlgorithm"
-         * let Z be a dropdown.     Form Key:   "DigestAlgorithm"
-         *
-         * Say Y & Z depends on X's state:-
-         *
-         *    Requirement is that Y and Z should be enabled only when one of X is enabled.
-         *    In the initial form render we need to disable the fields based on the above
-         *    condition. The fun part is based on X's state how can we trigger Y, Z
-         *    state? Ha! you've come to the wrong place but you are in the right place NOW?!
-         *
-         * So, do we have a solution?
-         * --
-         *
-         * We can listen the change and check whether X has been changed and its current
-         * value. If X's is enabled then we need to dynamically enable the dropdown fields.
-         * {@link handleParentPropertyChange} calls when a field has been changed but not
-         * in the initial run. In order to get it working we need to do some unorthodox
-         * wizardry that is even unacceptable by dear god.
-         *
-         * Why include this logic here instead of above component?
-         * --
-         *
-         * Good question! I also keep asking this from others and myself. Good luck out
-         * there mate! But you may ask, why can't you take the state and events up
-         * to the component tree? Ha! funny enough all IdPs depends on this component
-         * to render it's authenticator settings. Taking state and events upwards
-         * will make this more complicated. So, feel free to explore...
-         *
-         * Currently, these fields are being auto generated and programmed to handle state
-         * only one-way. The only proper solution to this is to, separate the concerns
-         * and make an individual idp do only one thing correctly. Instead of depending
-         * on common components. These components didn't chose the bug life but the bug
-         * life chose them xD.
-         *
-         * List of unknown things?!
-         * --
-         *      - Can user update the form it self only by enabling the checkbox?
-         *      - What happens when there's no default value to the field?
-         *      - But can we assign a default value to the meta prop object?
-         *      - Can we ensure the state will refresh and re-render after a metadata update?
-         *      - Why form state represents API's structure?
-         *
-         * This is what happens when you abstract things to the point where you can't
-         * implement a basic logical condition that was invented in 1918. Below this point
-         * you will see a specific logic tied to SAML protocol fields. But this is the
-         * only way we can ensure that values have the proper state in the form based on
-         * the current state.
-         *
-         * PS: np thank me later! append(:joy)
-         */
-
         if (key === "IsLogoutReqSigned" || key === "ISAuthnReqSigned") {
 
-            // I'm easing your life to navigate this append(:poop)
             const enableField = (formKey: string): void => {
                 const props = metadata
                     .properties
@@ -290,7 +233,6 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                 if (props) props.isDisabled = true;
             };
 
-            // See? how simple! even torvalds would love this! xD
             const isChecked = (value: FormValue): boolean =>
                 value &&
                 (Array.isArray(value) && value.length > 0) ||

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
@@ -36,7 +36,7 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
             <Heading as="h5">Service provider entity ID</Heading>
             <p>
                 This value will be used as the <Code>&lt;saml2:Issuer&gt;</Code> in the SAML requests initiated from
-                { config.ui.productName } to external Identity Provider (IdP). You need to provide a unique value
+                {" "}{ config.ui.productName } to external Identity Provider (IdP). You need to provide a unique value
                 as the service provider entity id.
             </p>
             <Divider/>

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
@@ -37,7 +37,7 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
             <p>
                 This value will be used as the <Code>&lt;saml2:Issuer&gt;</Code> in the SAML requests initiated from
                 {" "}{ config.ui.productName } to external Identity Provider (IdP). You need to provide a unique value
-                as the service provider entity id.
+                as the service provider entity ID.
             </p>
             <Divider/>
             <Heading as="h5">Identity provider entity ID</Heading>


### PR DESCRIPTION
### Purpose
> Please note $subject. Removed value binding from the checkboxes to prevent toggle lag. This is due to migration from the `CheckboxLegacy` component.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
