### PR TITLE
Renaming Customer User Password Option Identifier

### DIFF
--- a/apps/console/src/features/users/components/add-user.tsx
+++ b/apps/console/src/features/users/components/add-user.tsx
@@ -68,7 +68,7 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
     } = props;
 
     const [ userStoreOptions, setUserStoresList ] = useState([]);
-    const [ passwordOption, setPasswordOption ] = useState(initialValues?.passwordOption ?? "createPw");
+    const [ passwordOption, setPasswordOption ] = useState(initialValues?.passwordOption ?? "create-password");
     const [ userStore, setUserStore ] = useState<string>(initialValues?.domain);
     const [ randomPassword, setRandomPassword ] = useState<string>("");
     const [ isPasswordGenerated, setIsPasswordGenerated ] = useState<boolean>(false);
@@ -108,11 +108,11 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
     }, []);
 
     /**
-     * Set the password setup option to 'createPw'.
+     * Set the password setup option to 'create-password'.
      */
     useEffect(() => {
         if (!passwordOption) {
-            setPasswordOption("createPw");
+            setPasswordOption("create-password");
         }
     }, []);
 
@@ -120,12 +120,12 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
         {
             "data-testid": "user-mgt-add-user-form-create-password-option-radio-button",
             label: t("console:manage.features.user.forms.addUserForm.buttons.radioButton.options.createPassword"),
-            value: "createPw"
+            value: "create-password"
         },
         {
             "data-testid": "user-mgt-add-user-form-ask-password-option-radio-button",
             label: t("console:manage.features.user.forms.addUserForm.buttons.radioButton.options.askPassword"),
-            value: "askPw"
+            value: "ask-password"
         }
     ];
 
@@ -254,7 +254,7 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
     };
 
     const handlePasswordOptions = () => {
-        if (passwordOption && passwordOption === "createPw") {
+        if (passwordOption && passwordOption === "create-password") {
             return (
                 <>
                     <Grid.Row columns={ 2 }>
@@ -374,7 +374,7 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
                     </Grid.Row>
                 </>
             );
-        } else if (passwordOption && passwordOption === "askPw") {
+        } else if (passwordOption && passwordOption === "ask-password") {
             return (
                 <>
                     <Grid.Row columns={ 1 }>
@@ -568,10 +568,10 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
                                 type="radio"
                                 label={ t("console:manage.features.user.forms.addUserForm.buttons.radioButton.label") }
                                 name="passwordOption"
-                                default="createPw"
+                                default="create-password"
                                 listen={ (values) => { setPasswordOption(values.get("passwordOption").toString()); } }
                                 children={ passwordOptions }
-                                value={ initialValues?.passwordOption ?? "createPw" }
+                                value={ initialValues?.passwordOption ?? "create-password" }
                                 tabIndex={ 6 }
                             />
                         </Grid.Column>

--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -374,7 +374,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
         let userDetails: UserDetailsInterface = createEmptyUserDetails();
         const password = userInfo.newPassword;
 
-        userInfo.passwordOption && userInfo.passwordOption !== "askPw"
+        userInfo.passwordOption && userInfo.passwordOption !== "ask-password"
             ? (
                 userDetails = {
                     emails:[

--- a/apps/console/src/features/users/components/wizard/wizard-summary.tsx
+++ b/apps/console/src/features/users/components/wizard/wizard-summary.tsx
@@ -188,7 +188,7 @@ export const AddUserWizardSummary: FunctionComponent<AddUserWizardSummaryProps> 
                     </Grid.Column>
                 </Grid.Row>
             ) }
-            { modifiedSummary?.email && modifiedSummary?.passwordOption && modifiedSummary?.passwordOption === "askPw"
+            { modifiedSummary?.email && modifiedSummary?.passwordOption && modifiedSummary?.passwordOption === "ask-password"
                 ? (
                     <Grid.Row className="summary-field" columns={ 2 }>
                         <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">


### PR DESCRIPTION
### Purpose
Previously the customer user password option FE code identifiers were used as `askPw` and `createPw`. As for a requirement of making these identifiers human readable and transforming to kebabcase formatting, these two has been renamed as follows.
- askPw -> ask-password
- createPw -> create-password

### Related Issues
- Issue [#5366](https://github.com/wso2-enterprise/asgardeo-product/issues/5366)

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
