### PR TITLE
Adding Identifiable Component Interface and Deprecating Testable Component Interface

### DIFF
--- a/modules/core/src/models/core.ts
+++ b/modules/core/src/models/core.ts
@@ -100,12 +100,23 @@ export interface RuntimeConfigInterface {
 
 /**
  * Common interface to extend testable components.
+ * @deprecated
  */
 export interface TestableComponentInterface {
     /**
      * Unit test id.
      */
     "data-testid"?: string;
+}
+
+/**
+ * Common interface to extend identifiable components.
+*/
+export interface IdentifiableComponentInterface {
+    /**
+     * Unique component id.
+    */
+   "data-componentid"?: string;
 }
 
 /**


### PR DESCRIPTION
### Purpose
Adding Identifiable Component Interface and deprecating Testable Component Interface. This new interface should contain a optional human readable component identifier.

Example Usage
```
interface Example extends IdentifiableComponentInterface {

}
```

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/5366

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
