### PR TITLE
Fix to show delete icon for selected connections

### DIFF
--- a/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
+++ b/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
@@ -109,6 +109,10 @@ interface AuthenticatorGridPropsInterface extends LoadableComponentInterface, Te
      * Show list item actions.
      */
     showListItemActions?: boolean;
+    /**
+     * On authenticators list update callback.
+     */
+    onUpdate?: () => void;
 }
 
 /**
@@ -131,6 +135,7 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
         onItemClick,
         onSearchQueryClear,
         searchQuery,
+        onUpdate,
         [ "data-testid" ]: testId
     } = props;
 
@@ -222,6 +227,7 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
 
         deleteIdentityProvider(id)
             .then(() => {
+                onUpdate();
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider." +
                         "notifications.deleteIDP.success.description"),

--- a/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
+++ b/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
@@ -334,6 +334,10 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                         const isIdP: boolean = IdentityProviderManagementUtils
                             .isConnectorIdentityProvider(authenticator);
 
+                        const isIdPDeletable: boolean = IdentityProviderManagementUtils
+                            .isConnectorIdentityProvider(authenticator) ||
+                            authenticator.type === "FEDERATED";
+
                         return (
                             <Fragment key={ index }>
                                 <ResourceGrid.Card
@@ -354,7 +358,7 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                                     showActions={ true }
                                     showResourceEdit={ true }
                                     showResourceDelete={
-                                        isIdP && !IdentityProviderManagementConstants.DELETING_FORBIDDEN_IDPS
+                                        isIdPDeletable && !IdentityProviderManagementConstants.DELETING_FORBIDDEN_IDPS
                                             .includes(authenticator.name)
                                     }
                                     isResourceComingSoon={ authenticatorConfig?.isComingSoon }

--- a/apps/console/src/features/identity-providers/pages/identity-providers.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-providers.tsx
@@ -99,6 +99,7 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (
     ] = useState<boolean>(undefined);
     const [ triggerClearQuery, setTriggerClearQuery ] = useState<boolean>(false);
     const [ filterTags, setFilterTags ] = useState<string[]>([]);
+    const [ selectedFilterTags, setSelectedFilterTags ] = useState<string[]>([]);
     const [ showFilteredList, setShowFilteredList ] = useState<boolean>(false);
     const [ isPaginating, setIsPaginating ] = useState<boolean>(false);
     const [ useNewConnectionsView, setUseNewConnectionsView ] = useState<boolean>(undefined);
@@ -327,6 +328,8 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (
 
         // Update the internal state to manage placeholders etc.
         setSearchQuery(query);
+        // Update the state of selected filters.
+        setSelectedFilterTags(selectedFilters);
         // Filter out the templates.
         getAllAuthenticators(IdentityProviderManagementUtils.buildAuthenticatorsFilterQuery(query, selectedFilters));
 
@@ -335,6 +338,15 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (
         } else {
             setShowFilteredList(true);
         }
+    };
+
+    /**
+     * Handles the `onUpdate` callback action.
+     */
+    const onUpdate = (): void => {
+
+        getAllAuthenticators(IdentityProviderManagementUtils.buildAuthenticatorsFilterQuery(
+            searchQuery, selectedFilterTags));
     };
 
     /**
@@ -526,6 +538,7 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (
                                 onIdentityProviderDelete={ handleIdentityProviderDelete }
                                 onSearchQueryClear={ handleSearchQueryClear }
                                 searchQuery={ searchQuery }
+                                onUpdate={ onUpdate }
                                 data-testid={ `${ testId }-list` }
                             />
                         </GridLayout>


### PR DESCRIPTION
### Purpose
In connections, when we hover over connections, it shows the delete icon. But when filters are selected, delete icon was not shown previously.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
