### PR TITLE
Add support to remove userstore domain appended to the username in user active sessions

### DIFF
--- a/apps/console/src/extensions/configs/models/userstores.ts
+++ b/apps/console/src/extensions/configs/models/userstores.ts
@@ -33,4 +33,7 @@ export interface UserstoresConfig {
     userstoreList: {
         allowAddingUserstores: boolean;
     };
+    userstoreDomain: {
+        appendToUsername: boolean;
+    };
 }

--- a/apps/console/src/extensions/configs/userstores.tsx
+++ b/apps/console/src/extensions/configs/userstores.tsx
@@ -34,5 +34,8 @@ export const userstoresConfig: UserstoresConfig = {
     },
     userstoreList: {
         allowAddingUserstores: true
+    },
+    userstoreDomain: {
+        appendToUsername: true
     }
 };

--- a/apps/console/src/features/users/components/user-sessions.tsx
+++ b/apps/console/src/features/users/components/user-sessions.tsx
@@ -53,6 +53,7 @@ import { FeatureConfigInterface, getEmptyPlaceholderIllustrations, history } fro
 import { getUserSessions, terminateAllUserSessions, terminateUserSession } from "../api";
 import { ApplicationSessionInterface, UserSessionInterface, UserSessionsInterface } from "../models";
 import { Show, AccessControlConstants } from "@wso2is/access-control";
+
 /**
  * Proptypes for the user sessions component.
  */

--- a/apps/console/src/features/users/components/user-sessions.tsx
+++ b/apps/console/src/features/users/components/user-sessions.tsx
@@ -48,12 +48,11 @@ import React, {
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Grid, Icon, Label, List, SemanticICONS } from "semantic-ui-react";
+import { userstoresConfig } from "../../../extensions";
 import { FeatureConfigInterface, getEmptyPlaceholderIllustrations, history } from "../../core";
 import { getUserSessions, terminateAllUserSessions, terminateUserSession } from "../api";
 import { ApplicationSessionInterface, UserSessionInterface, UserSessionsInterface } from "../models";
-import { CONSUMER_USERSTORE } from "../../userstores";
 import { Show, AccessControlConstants } from "@wso2is/access-control";
-
 /**
  * Proptypes for the user sessions component.
  */
@@ -293,18 +292,25 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
     };
 
     /**
-     * Returns username without the "CONSUMER" domain reference.
+     * Processes the username according to userstore configurations.
      *
-     * @param userName
-     * @return userName without CONSUMER domain name
+     * @param {string} applicationSubject
+     * @return {string}
      */
-    const getUserNameWithoutDomain = (userName: string): string => {
+    const getUsername = (applicationSubject: string): string => {
 
-        const splitComponents = userName.split("/");
-        if (splitComponents.length > 1 && splitComponents[0] === CONSUMER_USERSTORE) {
-            return splitComponents[1];
+        const splitComponents = applicationSubject.split("/");
+        let username = applicationSubject;
+
+        if (splitComponents.length > 1 && !userstoresConfig.userstoreDomain.appendToUsername) {
+            username = splitComponents[1];
         }
-        return userName;
+        if (username.split("@").length > 1) {
+
+            return username.split("@")[0].concat("@").concat(username.split("@")[1]);
+        }
+
+        return username.split("@")[0];
     };
 
     /**
@@ -428,7 +434,6 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                                 {
                                                     session.applications.map((application: ApplicationSessionInterface,
                                                                               index: number) => (
-
                                                         <List.Description className="pb-2" key={ index }>
                                                             <Label
                                                                 className="micro spaced-right"
@@ -443,14 +448,7 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                                                 }
                                                                 tOptions={ {
                                                                     app: application.appName,
-                                                                    user: getUserNameWithoutDomain(application.subject).
-                                                                    split("@").length > 1
-                                                                        ? getUserNameWithoutDomain(application.subject).
-                                                                        split("@")[ 0 ].concat("@")
-                                                                        .concat(getUserNameWithoutDomain(application.subject).
-                                                                        split("@")[ 1 ])
-                                                                        : getUserNameWithoutDomain(application.subject)
-                                                                            .split("@")[ 0 ]
+                                                                    user: getUsername(application.subject)
                                                                 } }
                                                             >
                                                                 { "Logged in on " }
@@ -548,7 +546,7 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                         "genericError.message"
                     )
                 }));
-            })
+            });
     };
 
     /**
@@ -725,7 +723,7 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                         showSessionTerminateConfirmationModal
                                         || showAllSessionsTerminateConfirmationModal
                                     }
-                                    assertion={ getUserNameWithoutDomain(user.userName) }
+                                    assertion={ getUsername(user.userName) }
                                     assertionHint={ (
                                         <p>
                                             <Trans
@@ -736,9 +734,9 @@ export const UserSessions: FunctionComponent<UserSessionsPropsInterface> = (
                                                         : "console:manage.features.users.confirmations." +
                                                         "terminateAllSessions.assertionHint"
                                                 }
-                                                tOptions={ { name: getUserNameWithoutDomain(user.userName) } }
+                                                tOptions={ { name: getUsername(user.userName) } }
                                             >
-                                                Please type <strong>{ getUserNameWithoutDomain(user.userName) }</strong> to confirm.
+                                                Please type <strong>{ getUsername(user.userName) }</strong> to confirm.
                                             </Trans>
                                         </p>
                                     ) }


### PR DESCRIPTION
### Purpose
> Introduced a new configuration to append or remove userstore domain from the username in user active sessions.

### Related Issues
- Issue  (None)

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR  (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
