### PR TITLE
Enable configuring TOTP for federated users

### DIFF
--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -352,12 +352,14 @@ export class ApplicationManagementConstants {
 
     // Authenticators that can handle TOTP.
     public static readonly TOTP_HANDLERS = [
-        ...ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS
+        ...ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS,
+        ...ApplicationManagementConstants.SOCIAL_AUTHENTICATORS
     ];
 
     // Authenticators that can handle Email OTP.
     public static readonly EMAIL_OTP_HANDLERS = [
-        ...ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS
+        ...ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS,
+        ...ApplicationManagementConstants.SOCIAL_AUTHENTICATORS
     ];
 
     /**


### PR DESCRIPTION
Reverts wso2/identity-apps#2289 to enable configuring TOTP for federated users