### PR TITLE
Adding Component Identifiers to Edit Application Menu and TemplateIds to Application Templates

### DIFF
--- a/apps/console/src/extensions/component-extension.tsx
+++ b/apps/console/src/extensions/component-extension.tsx
@@ -65,6 +65,7 @@ export const ComponentExtensionPlaceholder = (args: ComponentExtensionInterface)
             config.panes.map(pane => {
                 const DynamicLoader = lazy(() => import(`${ pane.path }`));
                 tabPanes.push({
+                    componentId: pane.componentid,
                     menuItem: I18n.instance.t(pane.title),
                     render: () => (
                         <ErrorBoundary

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -422,7 +422,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
      */
      const handleTabChange = (e: SyntheticEvent, data: TabProps): void => {
         eventPublisher.publish("application-switch-edit-application-tabs", {
-            "menuItemName": data.panes[data.activeIndex].menuItem
+            "type": data.panes[data.activeIndex].componentId
         });
 
         handleActiveTabIndexChange(data.activeIndex as number);
@@ -729,6 +729,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_GENERAL_SETTINGS"))) {
 
                 panes.push({
+                    componentId: "general",
                     menuItem: t("console:develop.features.applications.edit.sections.general.tabName"),
                     render: GeneralApplicationSettingsTabPane
                 });
@@ -737,6 +738,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_ACCESS_CONFIG"))) {
 
                 panes.push({
+                    componentId: "protocol",
                     menuItem: t("console:develop.features.applications.edit.sections.access.tabName"),
                     render: ApplicationSettingsTabPane
                 });
@@ -745,6 +747,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_ATTRIBUTE_MAPPING"))) {
 
                 panes.push({
+                    componentId: "user-attributes",
                     menuItem: t("console:develop.features.applications.edit.sections.attributes.tabName"),
                     render: AttributeSettingTabPane
                 });
@@ -753,6 +756,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_SIGN_ON_METHOD_CONFIG"))) {
 
                 panes.push({
+                    componentId: "sign-in-method",
                     menuItem: t("console:develop.features.applications.edit.sections.signOnMethod.tabName"),
                     render: SignOnMethodsTabPane
                 });
@@ -763,6 +767,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                     ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_PROVISIONING_SETTINGS"))) {
 
                 panes.push({
+                    componentId: "provisioning",
                     menuItem: t("console:develop.features.applications.edit.sections.provisioning.tabName"),
                     render: ProvisioningSettingsTabPane
                 });
@@ -771,6 +776,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_ADVANCED_SETTINGS"))) {
 
                 panes.push({
+                    componentId: "advanced",
                     menuItem: t("console:develop.features.applications.edit.sections.advanced.tabName"),
                     render: AdvancedSettingsTabPane
                 });
@@ -779,6 +785,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_INFO"))) {
 
                 panes.push({
+                    componentId: "info",
                     menuItem: {
                         content: t("console:develop.features.applications.edit.sections.info.tabName"),
                         icon: "info circle grey"
@@ -792,30 +799,37 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
 
         return [
             {
+                componentId: "general",
                 menuItem: t("console:develop.features.applications.edit.sections.general.tabName"),
                 render: GeneralApplicationSettingsTabPane
             },
             {
+                componentId: "protocol",
                 menuItem: t("console:develop.features.applications.edit.sections.access.tabName"),
                 render: ApplicationSettingsTabPane
             },
             {
+                componentId: "user-attributes",
                 menuItem: t("console:develop.features.applications.edit.sections.attributes.tabName"),
                 render: AttributeSettingTabPane
             },
             {
+                componentId: "sign-in-method",
                 menuItem: t("console:develop.features.applications.edit.sections.signOnMethod.tabName"),
                 render: SignOnMethodsTabPane
             },
             applicationConfig.editApplication.showProvisioningSettings && {
+                componentId: "provisioning",
                 menuItem: t("console:develop.features.applications.edit.sections.provisioning.tabName"),
                 render: ProvisioningSettingsTabPane
             },
             {
+                componentId: "advanced",
                 menuItem: t("console:develop.features.applications.edit.sections.advanced.tabName"),
                 render: AdvancedSettingsTabPane
             },
             {
+                componentId: "info",
                 menuItem: {
                     content: t("console:develop.features.applications.edit.sections.info.tabName"),
                     icon: "info circle grey"

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -229,10 +229,15 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         }
         createApplication(application)
             .then((response) => {
-                eventPublisher.publish("application-register-new-application", {
-                    "type": title,
-                    "protocol": selectedTemplate.name
-                });
+                if (selectedTemplate.id === CustomApplicationTemplate.id) {
+                    eventPublisher.publish("application-register-new-application", {
+                        "type": application.templateId
+                    });
+                } else {
+                    eventPublisher.publish("application-register-new-application", {
+                        "type": selectedTemplate.templateId
+                    });
+                }
                 
                 dispatch(
                     addAlert({

--- a/apps/console/src/features/applications/data/application-templates/groups/desktop-application-template-group.json
+++ b/apps/console/src/features/applications/data/application-templates/groups/desktop-application-template-group.json
@@ -3,6 +3,7 @@
     "description": "Applications developed to target native desktops.",
     "enabled": true,
     "id": "desktop",
+    "templateId": "desktop-application",
     "displayOrder": 3,
     "image": "windowsNative",
     "name": "Desktop Application",

--- a/apps/console/src/features/applications/data/application-templates/groups/mobile-application-template-group.json
+++ b/apps/console/src/features/applications/data/application-templates/groups/mobile-application-template-group.json
@@ -3,6 +3,7 @@
     "description": "Applications developed to target mobile devices.",
     "enabled": true,
     "id": "mobile",
+    "templateId": "mobile-application",
     "displayOrder": 2,
     "image": "oidcMobile",
     "name": "Mobile Application",

--- a/apps/console/src/features/applications/data/application-templates/groups/web-application-template-group.json
+++ b/apps/console/src/features/applications/data/application-templates/groups/web-application-template-group.json
@@ -4,6 +4,7 @@
     "enabled": true,
     "displayOrder": 1,
     "id": "web-application",
+    "templateId": "traditional-web-application",
     "image": "oidcWebApp",
     "name": "Traditional Web Application",
     "subTemplatesSectionTitle": "Protocol",

--- a/apps/console/src/features/applications/data/application-templates/templates/android-mobile-application/android-mobile-application.json
+++ b/apps/console/src/features/applications/data/application-templates/templates/android-mobile-application/android-mobile-application.json
@@ -1,5 +1,6 @@
 {
     "id": "44a2d9d9-bc0c-4b54-85df-1cf08f4002ec",
+    "templateId": "android-mobile-application",
     "name": "Android",
     "description": "Applications developed to target native Android mobile devices.",
     "image": "android",

--- a/apps/console/src/features/applications/data/application-templates/templates/custom-application/custom-application.json
+++ b/apps/console/src/features/applications/data/application-templates/templates/custom-application/custom-application.json
@@ -1,5 +1,6 @@
 {
     "id": "custom-application",
+    "templateId": "custom-application",
     "name": "Custom Application",
     "description": "Register your application manually.",
     "image": "customApp",

--- a/apps/console/src/features/applications/data/application-templates/templates/oidc-web-application/oidc-web-application.json
+++ b/apps/console/src/features/applications/data/application-templates/templates/oidc-web-application/oidc-web-application.json
@@ -1,5 +1,6 @@
 {
     "id": "b9c5e11e-fc78-484b-9bec-015d247561b8",
+    "templateId": "oidc-web-application",
     "name": "OpenID Connect",
     "description": "Regular web application that uses redirection within the browser.",
     "image": "oidc",

--- a/apps/console/src/features/applications/data/application-templates/templates/saml-web-application/saml-web-application.json
+++ b/apps/console/src/features/applications/data/application-templates/templates/saml-web-application/saml-web-application.json
@@ -1,5 +1,6 @@
 {
     "id": "776a73da-fd8e-490b-84ff-93009f8ede85",
+    "templateId": "saml-web-application",
     "name": "SAML",
     "description": "Regular web application that uses redirection within the browser.",
     "image": "saml",

--- a/apps/console/src/features/applications/data/application-templates/templates/single-page-application/single-page-application.json
+++ b/apps/console/src/features/applications/data/application-templates/templates/single-page-application/single-page-application.json
@@ -1,5 +1,6 @@
 {
     "id": "6a90e4b0-fbff-42d7-bfde-1efd98f07cd7",
+    "templateId": "single-page-application",
     "name": "Single-Page Application",
     "description": "Web applications that perform user interface logic in a web browser.",
     "image": "spa",

--- a/apps/console/src/features/applications/data/application-templates/templates/windows-desktop-application/windows-desktop-application.json
+++ b/apps/console/src/features/applications/data/application-templates/templates/windows-desktop-application/windows-desktop-application.json
@@ -1,5 +1,6 @@
 {
     "id": "df929521-6768-44f5-8586-624126ec3f8b",
+    "templateId": "windows-desktop-application",
     "name": "Windows",
     "description": "Applications developed to target windows desktops.",
     "image": "windows",

--- a/apps/console/src/features/applications/models/application.ts
+++ b/apps/console/src/features/applications/models/application.ts
@@ -247,6 +247,11 @@ export interface ApplicationTemplateListItemInterface {
      * ex: "web-application"
      */
     templateGroup?: string;
+    /**
+     * Template identifier.
+     * ex: "single-page-application"
+    */
+    templateId?: string;
     types?: any[];
     category?: string;
     displayOrder?: number;

--- a/apps/console/src/features/applications/models/application.ts
+++ b/apps/console/src/features/applications/models/application.ts
@@ -298,6 +298,11 @@ export interface ApplicationTemplateGroupInterface {
      * Title for the sub template selection section inside the wizard.
      */
     subTemplatesSectionTitle?: string;
+    /**
+     * Template group identifier.
+     * ex: "traditional-web-application"
+    */
+    templateId?: string;
 }
 
 /**

--- a/apps/console/src/features/applications/pages/application-template.tsx
+++ b/apps/console/src/features/applications/pages/application-template.tsx
@@ -220,7 +220,7 @@ const ApplicationTemplateSelectPage: FunctionComponent<ApplicationTemplateSelect
         }
 
         eventPublisher.publish("application-click-create-new", {
-            "type": selected.name
+            "type": selected.templateId
         });
 
         setSelectedTemplate(selected);
@@ -410,7 +410,7 @@ const ApplicationTemplateSelectPage: FunctionComponent<ApplicationTemplateSelect
                             primary
                             onClick={ () =>  {
                                 eventPublisher.publish("application-click-create-new", {
-                                    "type": "Custom Application"
+                                    "type": "custom-application"
                                 });
                                 
                                 setSelectedTemplate(CustomApplicationTemplate);


### PR DESCRIPTION
### Purpose
Inorder to customize custom property values in event logs, following changes have been made.
- Introduce a component identifier to edit application menu items (panes)
- Introduce template identifiers to application templates
- Alter the relevant event publisher key value pairs

> Note: These identifier values should follow the kebabcase formatting.

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/5366

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation
- [ ] Documentation provided. (Add links)
- [ ] Unit tests provided. (Add links if any)
- [ ] Integration tests provided. (Add links if any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
