### PR TITLE
 Modify delete confirmation modal for collaborators

### DIFF
--- a/apps/console/src/extensions/configs/common.ts
+++ b/apps/console/src/extensions/configs/common.ts
@@ -24,6 +24,7 @@ export const commonConfig: CommonConfig = {
     },
     checkForUIResourceScopes: false,
     userEditSection: {
+        isGuestUser: false,
         showEmail: true
     }
 };

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -22,6 +22,7 @@ export interface CommonConfig {
     };
     checkForUIResourceScopes: boolean;
     userEditSection: {
+        isGuestUser: boolean;
         showEmail: boolean;
     };
 }

--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -994,11 +994,17 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                             attached
                             warning
                          >
-                            { t("console:manage.features.user.deleteUser.confirmationModal.message") }
+                            { commonConfig.userEditSection.isGuestUser
+                                ? t("extensions:manage.guest.deleteUser.confirmationModal.message")
+                                : t("console:manage.features.user.deleteUser.confirmationModal.message")
+                            }
                         </ConfirmationModal.Message>
                         <ConfirmationModal.Content>
                             <div className="modal-alert-wrapper"> { alert && alertComponent }</div>
-                            { t("console:manage.features.user.deleteUser.confirmationModal.content") }
+                            { commonConfig.userEditSection.isGuestUser
+                                ? t("extensions:manage.guest.deleteUser.confirmationModal.content")
+                                : t("console:manage.features.user.deleteUser.confirmationModal.content")
+                            }
                         </ConfirmationModal.Content>
                     </ConfirmationModal>
                 )


### PR DESCRIPTION
### Purpose
> Here the when deleting a collaborative user only the association of the is removed from the tenant. But the user is not permanently deleted from the asgardeo account. Hence the confirmation message is modified.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
