### PR TITLE
Modify error message shown when adding incorrect redirect urls in custom application types

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1238,8 +1238,11 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             "callBackUrls.placeholder")
                                     }
                                     validationErrorMsg={
-                                        t("console:develop.features.applications.forms.inboundOIDC.fields." +
+                                        CustomApplicationTemplate?.id !== template?.id
+                                        ? t("console:develop.features.applications.forms.inboundOIDC.fields." +
                                             "callBackUrls.validations.invalid")
+                                        : t("console:develop.features.applications.forms.inboundOIDC.messages." +
+                                                "customInvalidMessage")
                                     }
                                     emptyErrorMessage={
                                         t("console:develop.features.applications.forms.inboundOIDC.fields." +

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -802,6 +802,7 @@ export interface ConsoleNS {
                         };
                         messages: {
                             revokeDisclaimer: Message;
+                            customInvalidMessage: string;
                         };
                     };
                     inboundSAML: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1424,7 +1424,9 @@ export const console: ConsoleNS = {
                                 content: "The application has been revoked. Reactivate the application to allow " +
                                     "users to log in.",
                                 heading: "Application is inactive"
-                            }
+                            },
+                            customInvalidMessage: "Please enter a valid URI. Valid formats include HTTP, HTTPS, " +
+                                "or private-use URI scheme."
                         },
                         sections: {
                             accessToken: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1440,10 +1440,12 @@ export const console: ConsoleNS = {
                         },
                         messages: {
                             revokeDisclaimer: {
-                                content: "விண்ணப்பம் ரத்து செய்யப்பட்டது. நீங்கள் பயன்பாட்டை மீண்டும் இயக்க விரும்பினால் " +
-                                    "ரகசியத்தை மீண்டும் உருவாக்கவும்.",
+                                content: "La demande a été révoquée. Réactivez l'application pour permettre " +
+                                    "aux utilisateurs de se connecter.",
                                 heading: "La demande est révoquée"
-                            }
+                            },
+                            customInvalidMessage: "Veuillez saisir un URI valide. Les formats valides incluent " +
+                                "HTTP, HTTPS ou le schéma d'URI à usage privé."
                         },
                         sections: {
                             accessToken: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1338,7 +1338,9 @@ export const console: ConsoleNS = {
                                 content: "යෙදුම අවලංගු කර ඇත. ඔබට යෙදුම නැවත සක්‍රිය කිරීමට අවශ්‍ය නම් " +
                                     "කරුණාකර රහස ජනනය කරන්න.",
                                 heading: "යෙදුම අවලංගු කර ඇත"
-                            }
+                            },
+                            customInvalidMessage: "වලංගු URI එකක් ඇතුළු කරන්න. වලංගු ආකෘති වලට HTTP, HTTPS, හෝ " +
+                                "පුද්ගලික භාවිත URI යෝජනා ක්‍රමය ඇතුළත් වේ."
                         },
                         fields: {
                             allowedOrigins: {

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -414,7 +414,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                 popupSubHeader={
                     <React.Fragment>
                         <Icon name={ positive ? "check" : "times" } color={ positive ? "green" : "red" }/>
-                        { origin !== "null" ? origin : href }
+                        { origin && origin !== "null" ? origin : href }
                     </React.Fragment>
                 }
                 popupContent={

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -414,7 +414,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                 popupSubHeader={
                     <React.Fragment>
                         <Icon name={ positive ? "check" : "times" } color={ positive ? "green" : "red" }/>
-                        { origin }
+                        { origin !== "null" ? origin : href }
                     </React.Fragment>
                 }
                 popupContent={


### PR DESCRIPTION
### Purpose
> Modify error message shown when adding incorrect redirect urls in custom application types to include mobile urls
> Fix for `null` is displayed in popups for mobile urls

### Related Issues
- None

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
