### PR TITLE
fix(console): make `name-id` value default for user assertion

### DIFF
--- a/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
@@ -154,7 +154,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
             IsLogoutEnabled: findPropVal<boolean>({ defaultValue: false, key: "IsLogoutEnabled" }),
             IsLogoutReqSigned: findPropVal<boolean>({ defaultValue: false, key: "IsLogoutReqSigned" }),
             IsSLORequestAccepted: findPropVal<boolean>({ defaultValue: false, key: "IsSLORequestAccepted" }),
-            IsUserIdInClaims: findPropVal<boolean>({ defaultValue: true, key: "IsUserIdInClaims" })
+            IsUserIdInClaims: findPropVal<boolean>({ defaultValue: false, key: "IsUserIdInClaims" })
         } as SamlPropertiesInterface;
 
     }, []);

--- a/apps/console/src/features/identity-providers/components/utils/saml-idp-utils.ts
+++ b/apps/console/src/features/identity-providers/components/utils/saml-idp-utils.ts
@@ -29,27 +29,28 @@ type SamlIdPListItemOption = {
     value: string;
 };
 
+export const supportedSchemes: string[] = [
+    "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
+    "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+    "urn:oasis:names:tc:SAML:2.0:nameid-format:entity",
+    "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+    "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+    "urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted",
+    "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
+    "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
+    "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos"
+];
+
+export const DEFAULT_NAME_ID_FORMAT = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
+
 /**
  * Returns the available nameid formats with the correct urn scheme.
  */
 export const getAvailableNameIDFormats = (): Array<SamlIdPListItemOption> => {
-    const schemes: string[] = [
-        "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
-        "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-        "urn:oasis:names:tc:SAML:2.0:nameid-format:entity",
-        "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-        "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-        "urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted",
-        "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
-        "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
-        "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos"
-    ];
-    return schemes.map((scheme: string, index: number) => ({
+    return supportedSchemes.map((scheme: string, index: number) => ({
         key: index, text: scheme, value: scheme
     }));
 };
-
-export const DEFAULT_NAME_ID_FORMAT = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified";
 
 /**
  * Returns the supported protocol binding types.

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -255,7 +255,7 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                     { key: "SPEntityId", value: values.SPEntityId },
                     { key: "SSOUrl", value: values.SSOUrl },
                     { key: "SelectMode", value: "Manual Configuration" },
-                    { key: "IsUserIdInClaims", value: "true" },
+                    { key: "IsUserIdInClaims", value: "false" },
                     { key: "IsSLORequestAccepted", value: "false" },
                     { key: "SignatureAlgorithm", value: "RSA with SHA1" },
                     { key: "DigestAlgorithm", value: "SHA1" }
@@ -265,7 +265,7 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                     { key: "SPEntityId", value: values.SPEntityId },
                     { key: "meta_data_saml", value: xmlBase64String ?? EMPTY_STRING },
                     { key: "SelectMode", value: "Metadata File Configuration" },
-                    { key: "IsUserIdInClaims", value: "true" },
+                    { key: "IsUserIdInClaims", value: "false" },
                     { key: "IsSLORequestAccepted", value: "false" }
                 ];
             }

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -62,6 +62,7 @@ import {
     StrictIdentityProviderInterface
 } from "../../models";
 import { handleGetIDPListCallError } from "../utils";
+import { getAvailableNameIDFormats, getAvailableProtocolBindingTypes } from "../utils/saml-idp-utils";
 
 /**
  * Proptypes for the enterprise identity provider
@@ -186,33 +187,6 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                 title: "Certificates"
             }
         ] as WizardStepInterface[];
-    };
-
-    const getAvailableNameIDFormats = () => {
-
-        const schemes = [
-            "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-            "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
-            "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-            "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
-            "urn:oasis:names:tc:SAML:1.1:nameid-format:X509SubjectName",
-            "urn:oasis:names:tc:SAML:1.1:nameid-format:WindowsDomainQualifiedName",
-            "urn:oasis:names:tc:SAML:2.0:nameid-format:kerberos",
-            "urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
-        ];
-
-        return schemes.map((scheme: string, index: number) => ({
-            key: index, text: scheme, value: scheme
-        }));
-
-    };
-
-    const getAvailableProtocolBindingTypes = () => {
-        return [
-            { key: 1, text: "HTTP Redirect", value: "redirect" },
-            { key: 2, text: "HTTP Post", value: "post" },
-            { key: 3, text: "As Per Request", value: "as_request" }
-        ];
     };
 
     const isIdpNameAlreadyTaken = (userInput: string): boolean => {


### PR DESCRIPTION
### Purpose
> Please note $subject. Makes `IsUserIdInClaims` value `false` by default It prevents searching for the user id in SAML authn response using configured claim mappings.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
