### PR TITLE
Add Event Publishing to Console IDP Section and http Interceptor

### DIFF
--- a/apps/console/src/features/applications/components/application-list.tsx
+++ b/apps/console/src/features/applications/components/application-list.tsx
@@ -20,6 +20,7 @@ import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
 import {
     AlertLevels,
+    IdentifiableComponentInterface,
     LoadableComponentInterface,
     SBACInterface,
     TestableComponentInterface
@@ -45,6 +46,7 @@ import { Container, Header, Icon, Label, SemanticICONS } from "semantic-ui-react
 import {
     AppConstants,
     AppState,
+    EventPublisher,
     FeatureConfigInterface,
     UIConfigInterface,
     UIConstants,
@@ -66,7 +68,7 @@ import { ApplicationTemplateManagementUtils } from "../utils";
  * Proptypes for the applications list component.
  */
 interface ApplicationListPropsInterface extends SBACInterface<FeatureConfigInterface>, LoadableComponentInterface,
-    TestableComponentInterface {
+    TestableComponentInterface, IdentifiableComponentInterface {
 
     /**
      * Advanced Search component.
@@ -144,7 +146,8 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
         showListItemActions,
         isSetStrongerAuth,
         isRenderedOnPortal,
-        [ "data-testid" ]: testId
+        [ "data-testid" ]: testId,
+        [ "data-componentid" ]: componentId
     } = props;
 
     const { t } = useTranslation();
@@ -164,6 +167,8 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
     ] = useState<boolean>(false);
 
     const [ alert, setAlert, alertComponent ] = useConfirmationModalAlert();
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     /**
      * Fetch the application templates if list is not available in redux.
@@ -418,7 +423,10 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                     className={ !isRenderedOnPortal ? "list-placeholder" : "" }
                     action={ onEmptyListPlaceholderActionClick && (
                         <Show when={ AccessControlConstants.APPLICATION_WRITE }>
-                            <PrimaryButton onClick={ onEmptyListPlaceholderActionClick }>
+                            <PrimaryButton onClick={ () => {
+                                eventPublisher.publish(componentId + "-click-new-application-button");
+                                onEmptyListPlaceholderActionClick();
+                            } }>
                                 <Icon name="add"/>
                                 { t("console:develop.features.applications.placeholders.emptyList.action") }
                             </PrimaryButton>
@@ -512,6 +520,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
  * Default props for the component.
  */
 ApplicationList.defaultProps = {
+    "data-componentid": "application",
     "data-testid": "application-list",
     selection: true,
     showListItemActions: true

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -360,14 +360,13 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                         onApplicationDelete={ handleApplicationDelete }
                         onEmptyListPlaceholderActionClick={
                             () => {
-                                eventPublisher.publish("application-click-new-application-button");
-                            
                                 history.push(AppConstants.getPaths().get("APPLICATION_TEMPLATES"));
                             }
                         }
                         onSearchQueryClear={ handleSearchQueryClear }
                         searchQuery={ searchQuery }
                         data-testid={ `${ testId }-list` }
+                        data-componentid="application"
                     />
                 </ListLayout>
                 { showWizard && (

--- a/apps/console/src/features/core/utils/http-utils.ts
+++ b/apps/console/src/features/core/utils/http-utils.ts
@@ -19,6 +19,7 @@
 import { AppConstants as AppConstantsCore } from "@wso2is/core/constants";
 import { hideAJAXTopLoadingBar, showAJAXTopLoadingBar } from "@wso2is/core/store";
 import { AuthenticateUtils } from "@wso2is/core/utils";
+import { EventPublisher } from "./event-publisher";
 import { AppConstants } from "../constants";
 import { history } from "../helpers";
 import { store } from "../store";
@@ -64,6 +65,15 @@ export class HttpUtils {
      * @param error - Http error.
      */
     public static onHttpRequestError(error: any): void {
+        /**
+         * Publish an event on the http request error.
+        */
+        EventPublisher.getInstance().publish("console-error-http-request-error", {
+            "type": "error-response",
+            "response": error.response ? error.response : "",
+            "status": error.response ? error.response.status ? error.response.status : "" : ""
+        });
+
         // Terminate the session if the token endpoint returns a bad request(400)
         // The token binding feature will return a 400 status code when the session
         // times out.

--- a/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
+++ b/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
@@ -47,6 +47,7 @@ import { ApplicationBasicInterface } from "../../applications/models";
 import {
     AppConstants,
     AppState,
+    EventPublisher,
     FeatureConfigInterface,
     getEmptyPlaceholderIllustrations,
     history
@@ -158,6 +159,8 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     /**
      * Redirects to the authenticator edit page when the edit button is clicked.
@@ -360,9 +363,38 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                                     onEdit={ (e: MouseEvent<HTMLButtonElement>) => {
                                         // If edit flow override is defined, set the custom edit view flag to true.
                                         if (authenticatorConfig?.editFlowOverrides) {
+                                            eventPublisher.publish("connections-click-template-connect", { "type":
+                                                isIdP 
+                                                    ? AuthenticatorMeta.getAuthenticatorTemplateName(
+                                                        (authenticator as IdentityProviderInterface)
+                                                            .federatedAuthenticators?.defaultAuthenticatorId)
+                                                        ? AuthenticatorMeta.getAuthenticatorTemplateName(
+                                                            (authenticator as IdentityProviderInterface)
+                                                                .federatedAuthenticators?.defaultAuthenticatorId) 
+                                                        : "other"
+                                                    : AuthenticatorMeta.getAuthenticatorTemplateName(authenticator.id)
+                                                        ? AuthenticatorMeta
+                                                            .getAuthenticatorTemplateName(authenticator.id) 
+                                                        : ""
+                                            });
+
                                             setShowCustomEditView(true);
                                             return;
                                         }
+
+                                        eventPublisher.publish("connections-click-template-setup", { "type":
+                                            isIdP 
+                                                ? AuthenticatorMeta.getAuthenticatorTemplateName(
+                                                    (authenticator as IdentityProviderInterface)
+                                                        .federatedAuthenticators?.defaultAuthenticatorId)
+                                                    ? AuthenticatorMeta.getAuthenticatorTemplateName(
+                                                        (authenticator as IdentityProviderInterface)
+                                                            .federatedAuthenticators?.defaultAuthenticatorId) 
+                                                    : "other"
+                                                : AuthenticatorMeta.getAuthenticatorTemplateName(authenticator.id)
+                                                    ? AuthenticatorMeta.getAuthenticatorTemplateName(authenticator.id) 
+                                                    : ""
+                                        });
 
                                         handleGridItemOnClick(e, authenticator);
                                     } }

--- a/apps/console/src/features/identity-providers/components/wizards/authenticator-create-wizard-factory.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/authenticator-create-wizard-factory.tsx
@@ -281,6 +281,7 @@ export const AuthenticatorCreateWizardFactory: FunctionComponent<AuthenticatorCr
                             onWizardClose();
                         } }
                         template={ selectedTemplateWithUniqueName }
+                        data-componentid={ selectedTemplate?.templateId }
                         { ...rest }
                     />
                 )
@@ -298,6 +299,7 @@ export const AuthenticatorCreateWizardFactory: FunctionComponent<AuthenticatorCr
                             onWizardClose();
                         } }
                         template={ selectedTemplateWithUniqueName }
+                        data-componentid={ selectedTemplate?.templateId }
                         { ...rest }
                     />
                 )
@@ -315,6 +317,7 @@ export const AuthenticatorCreateWizardFactory: FunctionComponent<AuthenticatorCr
                             onWizardClose();
                         } }
                         template={ selectedTemplateWithUniqueName }
+                        data-componentid={ selectedTemplate?.templateId }
                         { ...rest }
                     />
                 )
@@ -332,6 +335,7 @@ export const AuthenticatorCreateWizardFactory: FunctionComponent<AuthenticatorCr
                             onWizardClose();
                         } }
                         template={ selectedTemplateWithUniqueName }
+                        data-componentid={ selectedTemplate?.templateId }
                         { ...rest }
                     />
                 )
@@ -349,6 +353,7 @@ export const AuthenticatorCreateWizardFactory: FunctionComponent<AuthenticatorCr
                             onWizardClose();
                         } }
                         template={ selectedTemplateWithUniqueName }
+                        data-componentid={ selectedTemplate?.templateId }
                         { ...rest }
                     />
                 )

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -16,7 +16,11 @@
  * under the License.
  */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { 
+    AlertLevels,
+    IdentifiableComponentInterface,
+    TestableComponentInterface
+} from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Wizard2, WizardPage } from "@wso2is/form";
 import {
@@ -37,6 +41,7 @@ import {
 import { FormValidation } from "@wso2is/validation";
 import cloneDeep from "lodash-es/cloneDeep";
 import isEmpty from "lodash-es/isEmpty";
+import kebabCase from "lodash-es/kebabCase";
 
 import React, {
     FC,
@@ -52,7 +57,13 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dimmer, Divider, Grid, Icon } from "semantic-ui-react";
-import { AppConstants, ModalWithSidePanel, getCertificateIllustrations, store } from "../../../core";
+import { 
+    AppConstants,
+    EventPublisher,
+    ModalWithSidePanel,
+    getCertificateIllustrations,
+    store
+} from "../../../core";
 import { createIdentityProvider, getIdentityProviderList } from "../../api";
 import { getIdPIcons, getIdentityProviderWizardStepIcons } from "../../configs";
 import { IdentityProviderManagementConstants } from "../../constants";
@@ -68,7 +79,7 @@ import { handleGetIDPListCallError } from "../utils";
  * creation wizard component.
  */
 interface EnterpriseIDPCreateWizardProps extends TestableComponentInterface,
-    GenericIdentityProviderCreateWizardPropsInterface {
+    GenericIdentityProviderCreateWizardPropsInterface, IdentifiableComponentInterface {
 }
 
 /**
@@ -108,7 +119,8 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
         title,
         subTitle,
         template,
-        [ "data-testid" ]: testId
+        [ "data-testid" ]: testId,
+        [ "data-componentid" ]: componentId
     } = props;
 
     const wizardRef = useRef(null);
@@ -134,6 +146,8 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
 
     const dispatch = useDispatch();
     const { t } = useTranslation();
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     useEffect(() => {
         setIsIDPListLoading(true);
@@ -316,6 +330,10 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
 
         createIdentityProvider(identityProvider)
             .then((response) => {
+                eventPublisher.publish("connections-finish-adding-connection", {
+                    "type": componentId + "-" + kebabCase(selectedProtocol)
+                });
+
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider.notifications." +
                         "addIDP.success.description"),
@@ -946,6 +964,7 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
  */
 EnterpriseIDPCreateWizard.defaultProps = {
     currentStep: 0,
+    "data-componentid": "enterprise-idp",
     "data-testid": "enterprise-idp-create-wizard"
 };
 

--- a/apps/console/src/features/identity-providers/components/wizards/facebook/facebook-authentication-provider-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/facebook/facebook-authentication-provider-create-wizard.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertLevels, IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { GenericIcon, Heading, LinkButton, PrimaryButton, useWizardAlert } from "@wso2is/react-components";
 import { ContentLoader } from "@wso2is/react-components/src/components/loader/content-loader";
@@ -33,6 +33,7 @@ import {
     AppConstants,
     AppState,
     ConfigReducerStateInterface,
+    EventPublisher,
     ModalWithSidePanel
 } from "../../../../../features/core";
 import { createIdentityProvider } from "../../../api";
@@ -48,7 +49,7 @@ import {
  * Proptypes for the Facebook Authentication Provider Create Wizard.
  */
 interface FacebookAuthenticationProviderCreateWizardPropsInterface extends TestableComponentInterface,
-    GenericIdentityProviderCreateWizardPropsInterface {
+    GenericIdentityProviderCreateWizardPropsInterface, IdentifiableComponentInterface {
 }
 
 /**
@@ -111,7 +112,8 @@ export const FacebookAuthenticationProviderCreateWizard: FunctionComponent<
         title,
         subTitle,
         template,
-        [ "data-testid" ]: testId
+        [ "data-testid" ]: testId,
+        [ "data-componentid" ]: componentId
     } = props;
 
     const dispatch = useDispatch();
@@ -125,6 +127,8 @@ export const FacebookAuthenticationProviderCreateWizard: FunctionComponent<
     const [ currentWizardStep, setCurrentWizardStep ] = useState<number>(currentStep);
     const [ wizStep, setWizStep ] = useState<number>(0);
     const [ totalStep, setTotalStep ] = useState<number>(0);
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     /**
      * Track wizard steps from wizard component.
@@ -146,6 +150,10 @@ export const FacebookAuthenticationProviderCreateWizard: FunctionComponent<
 
         createIdentityProvider(identityProvider)
             .then((response) => {
+                eventPublisher.publish("connections-finish-adding-connection", {
+                    "type": componentId
+                });
+
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider.notifications.addIDP." +
                         "success.description"),
@@ -464,5 +472,6 @@ export const FacebookAuthenticationProviderCreateWizard: FunctionComponent<
  */
 FacebookAuthenticationProviderCreateWizard.defaultProps = {
     currentStep: 1,
+    "data-componentid": "facebook-idp",
     "data-testid": "facebook-idp-create-wizard"
 };

--- a/apps/console/src/features/identity-providers/components/wizards/github/github-authentication-provider-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/github/github-authentication-provider-create-wizard.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertLevels, IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { GenericIcon, Heading, LinkButton, PrimaryButton, useWizardAlert } from "@wso2is/react-components";
 import { ContentLoader } from "@wso2is/react-components/src/components/loader/content-loader";
@@ -33,6 +33,7 @@ import {
     AppConstants,
     AppState,
     ConfigReducerStateInterface,
+    EventPublisher,
     ModalWithSidePanel
 } from "../../../../../features/core";
 import { createIdentityProvider } from "../../../api";
@@ -48,7 +49,7 @@ import {
  * Proptypes for the GitHub Authentication Provider Create Wizard.
  */
 interface GitHubAuthenticationProviderCreateWizardPropsInterface extends TestableComponentInterface,
-    GenericIdentityProviderCreateWizardPropsInterface {
+    GenericIdentityProviderCreateWizardPropsInterface, IdentifiableComponentInterface {
 }
 
 /**
@@ -111,7 +112,8 @@ export const GitHubAuthenticationProviderCreateWizard: FunctionComponent<
         title,
         subTitle,
         template,
-        [ "data-testid" ]: testId
+        [ "data-testid" ]: testId,
+        [ "data-componentid" ]: componentId
     } = props;
 
     const dispatch = useDispatch();
@@ -125,6 +127,8 @@ export const GitHubAuthenticationProviderCreateWizard: FunctionComponent<
     const [ currentWizardStep, setCurrentWizardStep ] = useState<number>(currentStep);
     const [ wizStep, setWizStep ] = useState<number>(0);
     const [ totalStep, setTotalStep ] = useState<number>(0);
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     /**
      * Track wizard steps from wizard component.
@@ -146,6 +150,10 @@ export const GitHubAuthenticationProviderCreateWizard: FunctionComponent<
 
         createIdentityProvider(identityProvider)
             .then((response) => {
+                eventPublisher.publish("connections-finish-adding-connection", {
+                    "type": componentId
+                });
+
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider.notifications.addIDP." +
                         "success.description"),
@@ -462,5 +470,6 @@ export const GitHubAuthenticationProviderCreateWizard: FunctionComponent<
  */
 GitHubAuthenticationProviderCreateWizard.defaultProps = {
     currentStep: 1,
+    "data-componentid": "github-idp",
     "data-testid": "github-idp-create-wizard"
 };

--- a/apps/console/src/features/identity-providers/components/wizards/google/google-authentication-provider-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/google/google-authentication-provider-create-wizard.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertLevels, IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { useTrigger } from "@wso2is/forms";
 import {
@@ -36,7 +36,13 @@ import { Grid } from "semantic-ui-react";
 import {
     GoogleAuthenticationProviderCreateWizardContent
 } from "./google-authentication-provider-create-wizard-content";
-import { AppConstants, AppState, ModalWithSidePanel, store } from "../../../../../features/core";
+import {
+    AppConstants,
+    AppState,
+    EventPublisher,
+    ModalWithSidePanel,
+    store
+} from "../../../../../features/core";
 import {
     createIdentityProvider,
     getFederatedAuthenticatorMetadata
@@ -56,7 +62,7 @@ import { handleGetFederatedAuthenticatorMetadataAPICallError } from "../../utils
  * Proptypes for the identity provider creation wizard component.
  */
 interface MinimalAuthenticationProviderCreateWizardPropsInterface extends TestableComponentInterface,
-    GenericIdentityProviderCreateWizardPropsInterface {
+    GenericIdentityProviderCreateWizardPropsInterface, IdentifiableComponentInterface {
 }
 
 /**
@@ -78,7 +84,8 @@ export const GoogleAuthenticationProviderCreateWizard: FunctionComponent<
         title,
         subTitle,
         template,
-        [ "data-testid" ]: testId
+        [ "data-testid" ]: testId,
+        [ "data-componentid" ]: componentId
     } = props;
 
     const [ currentWizardStep, setCurrentWizardStep ] = useState<number>(currentStep);
@@ -98,6 +105,8 @@ export const GoogleAuthenticationProviderCreateWizard: FunctionComponent<
     const [ wizStep, setWizStep ] = useState<number>(0);
     const [ totalStep, setTotalStep ] = useState<number>(0);
 
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
+
     /**
      * Creates a new identity provider.
      *
@@ -108,6 +117,10 @@ export const GoogleAuthenticationProviderCreateWizard: FunctionComponent<
         // identityProvider.templateId = template.id
         createIdentityProvider(identityProvider)
             .then((response) => {
+                eventPublisher.publish("connections-finish-adding-connection", {
+                    "type": componentId
+                });
+
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider.notifications.addIDP." +
                         "success.description"),
@@ -443,5 +456,6 @@ export const GoogleAuthenticationProviderCreateWizard: FunctionComponent<
  */
 GoogleAuthenticationProviderCreateWizard.defaultProps = {
     currentStep: 1,
+    "data-componentid": "google-idp",
     "data-testid": "idp-edit-idp-create-wizard"
 };

--- a/apps/console/src/features/identity-providers/components/wizards/oidc-authentication-provider-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/oidc-authentication-provider-create-wizard.tsx
@@ -16,7 +16,11 @@
  * under the License.
  */
 
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import {
+    AlertLevels,
+    IdentifiableComponentInterface,
+    TestableComponentInterface
+} from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { useTrigger } from "@wso2is/forms";
 import { GenericIcon, LinkButton, PrimaryButton, useWizardAlert } from "@wso2is/react-components";
@@ -27,7 +31,13 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Grid, Header } from "semantic-ui-react";
 import { OidcAuthenticationWizardFrom } from "./oidc-authentication-wizard-page";
-import { AppConstants, AppState, ModalWithSidePanel, store } from "../../../../features/core";
+import {
+    AppConstants,
+    AppState,
+    EventPublisher,
+    ModalWithSidePanel,
+    store
+} from "../../../../features/core";
 import {
     createIdentityProvider,
     getFederatedAuthenticatorMetadata
@@ -46,7 +56,7 @@ import {
  * Proptypes for the identity provider creation wizard component.
  */
 interface MinimalAuthenticationProviderCreateWizardPropsInterface extends TestableComponentInterface,
-    GenericIdentityProviderCreateWizardPropsInterface { }
+    GenericIdentityProviderCreateWizardPropsInterface, IdentifiableComponentInterface { }
 
 /**
  * Identity provider creation wizard component.
@@ -65,7 +75,8 @@ export const OidcAuthenticationProviderCreateWizard: FunctionComponent<MinimalAu
         title,
         subTitle,
         template,
-        [ "data-testid" ]: testId
+        [ "data-testid" ]: testId,
+        [ "data-componentid" ]: componentId
     } = props;
 
     const [ currentWizardStep, setCurrentWizardStep ] = useState<number>(currentStep);
@@ -88,6 +99,8 @@ export const OidcAuthenticationProviderCreateWizard: FunctionComponent<MinimalAu
     const [ wizStep, setWizStep ] = useState<number>(0);
     const [ totalStep, setTotalStep ] = useState<number>(0);
 
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
+
     /**
      * Creates a new identity provider.
      *
@@ -98,6 +111,10 @@ export const OidcAuthenticationProviderCreateWizard: FunctionComponent<MinimalAu
         // identityProvider.templateId = template.id
         createIdentityProvider(identityProvider)
             .then((response) => {
+                eventPublisher.publish("connections-finish-adding-connection", {
+                    "type": componentId
+                });
+
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider.notifications.addIDP." +
                         "success.description"),
@@ -398,5 +415,6 @@ export const OidcAuthenticationProviderCreateWizard: FunctionComponent<MinimalAu
  */
 OidcAuthenticationProviderCreateWizard.defaultProps = {
     currentStep: 1,
+    "data-componentid": "oidc-idp",
     "data-testid": "idp-edit-idp-create-wizard"
 };

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/groups/enterprise-idp-template-group.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/groups/enterprise-idp-template-group.json
@@ -9,5 +9,6 @@
     "services": [],
     "disabled": false,
     "type": "ENTERPRISE",
-    "tags": [ "OIDC", "SAML" ]
+    "tags": [ "OIDC", "SAML" ],
+    "templateId": "enterprise-idp"
 }

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/enterprise-identity-provider/enterprise-identity-provider.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/enterprise-identity-provider/enterprise-identity-provider.json
@@ -34,5 +34,6 @@
     "name": "Enterprise",
     "services": [],
     "disabled": false,
+    "templateId": "enterprise-idp",
     "type": "ENTERPRISE"
 }

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/enterprise-identity-provider/enterprise-oidc-idp-provider.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/enterprise-identity-provider/enterprise-oidc-idp-provider.json
@@ -91,5 +91,6 @@
     "image": "oidc",
     "name": "OpenID Connect",
     "services": [],
-    "disabled": false
+    "disabled": false,
+    "templateId": "enterprise-oidc-idp"
 }

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/facebook/facebook.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/facebook/facebook.json
@@ -198,5 +198,6 @@
             ]
         }
     },
-    "type": "SOCIAL"
+    "type": "SOCIAL",
+    "templateId": "facebook-idp"
 }

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/github/github.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/github/github.json
@@ -121,5 +121,6 @@
             ]
         }
     },
-    "type": "SOCIAL"
+    "type": "SOCIAL",
+    "templateId": "github-idp"
 }

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/google/google.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/google/google.json
@@ -82,5 +82,6 @@
             ]
         }
     },
-    "type": "SOCIAL"
+    "type": "SOCIAL",
+    "templateId": "google-idp"
 }

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/oidc-identity-provider/enterprise-oidc-identity-provider.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/oidc-identity-provider/enterprise-oidc-identity-provider.json
@@ -94,5 +94,6 @@
     "image": "enterprise",
     "name": "OpenID Connect",
     "services": [],
-    "disabled": false
+    "disabled": false,
+    "templateId": "enterprise-oidc-idp"
 }

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/enterprise-saml-identity-provider.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/enterprise-saml-identity-provider.json
@@ -140,5 +140,6 @@
     "image": "enterprise",
     "name": "SAML",
     "services": [],
-    "disabled": false
+    "disabled": false,
+    "templateId": "enterprise-saml-idp"
 }

--- a/apps/console/src/features/identity-providers/meta/authenticator-meta.ts
+++ b/apps/console/src/features/identity-providers/meta/authenticator-meta.ts
@@ -220,4 +220,29 @@ export class AuthenticatorMeta {
             AuthenticatorLabels.SAML
         ];
     }
+
+    /**
+     * Get Authenticator template name.
+     *
+     * @param {string} authenticatorId - Authenticator ID.
+     *
+     * @return {string}
+     */
+    public static getAuthenticatorTemplateName(authenticatorId: string): string {
+        
+        return get({
+            [ IdentityProviderManagementConstants.BASIC_AUTHENTICATOR ]: "username-and-password",
+            [ IdentityProviderManagementConstants.BASIC_AUTHENTICATOR_ID ]: "username-and-password",
+            [ IdentityProviderManagementConstants.FIDO_AUTHENTICATOR_ID ]: "fido",
+            [ IdentityProviderManagementConstants.TOTP_AUTHENTICATOR_ID ]: "totp",
+            [ IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID ]: "email-otp",
+            [ IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR_ID ]: "identifier-first",
+            [ IdentityProviderManagementConstants.GOOGLE_OIDC_AUTHENTICATOR_ID ]: "google",
+            [ IdentityProviderManagementConstants.GITHUB_AUTHENTICATOR_ID ]: "github",
+            [ IdentityProviderManagementConstants.FACEBOOK_AUTHENTICATOR_ID ]: "facebook",
+            [ IdentityProviderManagementConstants.TWITTER_AUTHENTICATOR_ID ]: "twitter",
+            [ IdentityProviderManagementConstants.OIDC_AUTHENTICATOR_ID ]: "enterprise-oidc",
+            [ IdentityProviderManagementConstants.SAML_AUTHENTICATOR_ID ]: "enterprise-saml"
+        }, authenticatorId);
+    }
 }

--- a/apps/console/src/features/identity-providers/models/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/models/identity-provider.ts
@@ -212,6 +212,10 @@ export interface IdentityProviderTemplateItemInterface {
     templateGroup?: string;
     subTemplates?: IdentityProviderTemplateItemInterface[];
     subTemplatesSectionTitle?: string;
+    /**
+     * Template identifier.
+    */
+    templateId?: string;
 }
 
 /**

--- a/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
@@ -38,6 +38,7 @@ import {
     AppConstants,
     AppState,
     ConfigReducerStateInterface,
+    EventPublisher,
     getEmptyPlaceholderIllustrations,
     history
 } from "../../core";
@@ -103,6 +104,8 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
     const [ filterTags, setFilterTags ] = useState<string[]>([]);
     const [ searchQuery, setSearchQuery ] = useState<string>("");
     const [ useNewConnectionsView, setUseNewConnectionsView ] = useState<boolean>(undefined);
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     /**
      * Checks if the listing view defined in the config is the new connections view.
@@ -237,6 +240,10 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
 
         if (selectedTemplate) {
             setSelectedTemplate(selectedTemplate);
+
+            eventPublisher.publish("connections-select-template", {
+                "type": selectedTemplate.templateId
+            });
         }
 
         setTemplateType(id);

--- a/apps/console/src/features/identity-providers/pages/identity-providers.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-providers.tsx
@@ -25,7 +25,7 @@ import React, { FunctionComponent, MouseEvent, ReactElement, SyntheticEvent, use
 import { useTranslation } from "react-i18next";
 import { DropdownItemProps, DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
 import { AuthenticatorExtensionsConfigInterface, identityProviderConfig } from "../../../extensions/configs";
-import { AdvancedSearchWithBasicFilters, AppConstants, UIConstants, history } from "../../core";
+import { AdvancedSearchWithBasicFilters, AppConstants, EventPublisher, UIConstants, history } from "../../core";
 import { getAuthenticatorTags, getAuthenticators, getIdentityProviderList } from "../api";
 import { AuthenticatorGrid, IdentityProviderList, handleGetIDPListCallError } from "../components";
 import { AuthenticatorMeta } from "../meta";
@@ -103,6 +103,8 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (
     const [ showFilteredList, setShowFilteredList ] = useState<boolean>(false);
     const [ isPaginating, setIsPaginating ] = useState<boolean>(false);
     const [ useNewConnectionsView, setUseNewConnectionsView ] = useState<boolean>(undefined);
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     /**
      * Checks if the listing view defined in the config is the new connections view.
@@ -419,6 +421,8 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (
                         <Show when={ AccessControlConstants.IDP_WRITE }>
                             <PrimaryButton
                                 onClick={ (): void => {
+                                    eventPublisher.publish("connections-click-new-connection-button");
+
                                     history.push(AppConstants.getPaths().get("IDP_TEMPLATES"));
                                 } }
                                 data-testid={ `${ testId }-add-button` }
@@ -531,6 +535,8 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (
                                         : idpList?.identityProviders
                                 }
                                 onEmptyListPlaceholderActionClick={ () => {
+                                    eventPublisher.publish("connections-click-new-connection-button");
+                                    
                                     history.push(AppConstants.getPaths().get("IDP_TEMPLATES"));
                                 } }
                                 isFiltering={ showFilteredList }


### PR DESCRIPTION
### Purpose
- Adding event publishing function call in console IDP section click events.
- Adding templateIds to idp templates jsons.
- Adding event publishing to console http interceptor errors.

### Related Issues
- https://github.com/wso2/product-is/issues/12310

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
