### PR TITLE
Remove duplicated eye icon in password fields for Edge browser

### DIFF
--- a/modules/theme/src/themes/default/elements/input.overrides
+++ b/modules/theme/src/themes/default/elements/input.overrides
@@ -91,3 +91,11 @@
         }
     }
 }
+
+/*-------------------------------
+ Remove Duplicated Eye-Icon for Password Fields in MS Edge Browser
+--------------------------------*/
+input[type=password]::-ms-reveal, input[type=password]::-ms-clear {
+    display: none;
+}
+


### PR DESCRIPTION
### Purpose
This PR removes the duplicated eye icon in password fields (globally) applied by the Edge browser as there is a password reveal icon already built into the theme.

Tested in:
- Microsoft Edge (92.0.902.73)
- Mozilla Firefox (91.0)


**Before Fix**:
<img width="1678" alt="Screen Shot 2021-08-16 at 3 34 01 PM" src="https://user-images.githubusercontent.com/42619922/129547097-29735df0-3919-4c82-81ec-97584276c4cb.png">

**After Fix**:
<img width="1678" alt="Screen Shot 2021-08-16 at 3 20 10 PM" src="https://user-images.githubusercontent.com/42619922/129546852-1a31e047-58ce-4c03-9457-36333672fd93.png">

### Related Issues
- None

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
