### PR TITLE
Add function to parse strings to boolean

### DIFF
--- a/modules/core/src/utils/common-utils.ts
+++ b/modules/core/src/utils/common-utils.ts
@@ -208,4 +208,15 @@ export class CommonUtils {
 
         return countryDropDown;
     }
+
+    /**
+     * Returns boolean value for both boolean strings and primitive boolean value.
+     *
+     * @param {any} booleanResult - Result that needs to be converted to boolean. 
+     * Can be a string or a boolean value.
+     * @return {boolean}
+     */
+    public static parseBoolean(booleanResult: any): boolean {
+        return (String(booleanResult).toLowerCase() == "true");
+    }
 }

--- a/modules/core/src/utils/common-utils.ts
+++ b/modules/core/src/utils/common-utils.ts
@@ -217,6 +217,6 @@ export class CommonUtils {
      * @return {boolean}
      */
     public static parseBoolean(booleanResult: any): boolean {
-        return (String(booleanResult).toLowerCase() == "true");
+        return (String(booleanResult).toLowerCase() === "true");
     }
 }


### PR DESCRIPTION
### Purpose
This PR will introduce a function which parse string boolean values to primitive boolean values. The function is case insensitive. Therefore, String "True" regardless of their case, will return boolean `true`.

**Usage:**
`parseBoolean("True")` returns `true`
`parseBoolean(true)` returns `true`
`parseBoolean("true")` returns `true`

It works similarly to `false` Strings as well.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
