### PR TITLE
Change Parameter Type of Custom Property in Event Publisher

### DIFF
--- a/apps/console/src/extensions/configs/models/analytics.ts
+++ b/apps/console/src/extensions/configs/models/analytics.ts
@@ -19,6 +19,6 @@
 export interface AnalyticsConfig {
     EventPublisherExtension: {
         init: () => void;
-        publish: (eventId: string, customProperties?: { [key: string]: string }) => void;
+        publish: (eventId: string, customProperties?: { [key: string]: string | Record<string, unknown> }) => void;
     }
 }

--- a/apps/console/src/features/core/utils/event-publisher.ts
+++ b/apps/console/src/features/core/utils/event-publisher.ts
@@ -55,9 +55,9 @@ export class EventPublisher {
      * Function to publish event logs.
      * 
      * @param {string} eventId - Publishing event identifier.
-     * @param { {[key: string]: string} } [customProperties] - Any custom properties to be published (optional).
+     * @param { {[key: string]: any} } [customProperties] - Any custom properties to be published (optional).
     */
-    public publish(eventId: string, customProperties?: { [key: string]: string }): void {
+    public publish(eventId: string, customProperties?: { [key: string]: any }): void {
         if(customProperties) {
             /**
              * If you want to do any event logging, do it here.

--- a/apps/console/src/features/core/utils/event-publisher.ts
+++ b/apps/console/src/features/core/utils/event-publisher.ts
@@ -55,9 +55,10 @@ export class EventPublisher {
      * Function to publish event logs.
      * 
      * @param {string} eventId - Publishing event identifier.
-     * @param { {[key: string]: any} } [customProperties] - Any custom properties to be published (optional).
+     * @param { {[key: string]: string | Record<string, unknown>} } [customProperties] 
+     *      - Any custom properties to be published (optional).
     */
-    public publish(eventId: string, customProperties?: { [key: string]: any }): void {
+    public publish(eventId: string, customProperties?: { [key: string]: string | Record<string, unknown> }): void {
         if(customProperties) {
             /**
              * If you want to do any event logging, do it here.

--- a/apps/myaccount/src/extensions/configs/models/analytics.ts
+++ b/apps/myaccount/src/extensions/configs/models/analytics.ts
@@ -19,6 +19,6 @@
 export interface AnalyticsConfig {
     EventPublisherExtension: {
         init: () => void;
-        publish: (eventId: string, customProperties?: { [key: string]: string }) => void;
+        publish: (eventId: string, customProperties?: { [key: string]: string | Record<string, unknown> }) => void;
     }
 }

--- a/apps/myaccount/src/utils/event-publisher.ts
+++ b/apps/myaccount/src/utils/event-publisher.ts
@@ -56,9 +56,10 @@ export class EventPublisher {
      * Function to publish event logs.
      * 
      * @param {string} eventId - Publishing event identifier.
-     * @param { {[key: string]: any} } [customProperties] - Any custom properties to be published (optional).
+     * @param { {[key: string]: string | Record<string, unknown>} } [customProperties] 
+     *      - Any custom properties to be published (optional).
     */
-    public publish(eventId: string, customProperties?: { [key: string]: any }): void {
+    public publish(eventId: string, customProperties?: { [key: string]: string | Record<string, unknown> }): void {
         if(customProperties) {
             /**
              * If you want to do any event logging, do it here.

--- a/apps/myaccount/src/utils/event-publisher.ts
+++ b/apps/myaccount/src/utils/event-publisher.ts
@@ -56,9 +56,9 @@ export class EventPublisher {
      * Function to publish event logs.
      * 
      * @param {string} eventId - Publishing event identifier.
-     * @param { {[key: string]: string} } [customProperties] - Any custom properties to be published (optional).
+     * @param { {[key: string]: any} } [customProperties] - Any custom properties to be published (optional).
     */
-    public publish(eventId: string, customProperties?: { [key: string]: string }): void {
+    public publish(eventId: string, customProperties?: { [key: string]: any }): void {
         if(customProperties) {
             /**
              * If you want to do any event logging, do it here.


### PR DESCRIPTION
### Purpose
- Change parameter type of custom property in event publisher publish() function call in order to allow javascript objects.
- Fixing possible type error in event publisher.

### Related Issues
- https://github.com/wso2/product-is/issues/12327

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
