### PR TITLE
fix(console): remove obsolete `logoutUrl` field manual validation

### DIFF
--- a/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
@@ -391,14 +391,6 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                             ) }
                             maxLength={ LOGOUT_URL_LENGTH.max }
                             minLength={ LOGOUT_URL_LENGTH.min }
-                            validate={ (value) => {
-                                return (formValues?.IsLogoutEnabled && value)
-                                    ? composeValidators(
-                                        isUrl,
-                                        hasLength(LOGOUT_URL_LENGTH)
-                                    )(value)
-                                    : undefined;
-                            } }
                             hint={ t(`${ I18N_TARGET_KEY }.LogoutReqUrl.hint`) }
                             readOnly={ readOnly }
                         />


### PR DESCRIPTION
### Purpose
> Please note $subject. Removing the `validation` prop from the field input that manually overrides default validation of `url` now the field validates and checks for lengths as expected.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
