### PR TITLE
fix account-recovery loading

### DIFF
--- a/apps/myaccount/src/components/account-recovery/account-recovery.tsx
+++ b/apps/myaccount/src/components/account-recovery/account-recovery.tsx
@@ -18,10 +18,11 @@
 
 import { hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
 import { SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
+import { EmphasizedSegment } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { List } from "semantic-ui-react";
+import { List, Placeholder } from "semantic-ui-react";
 import { EmailRecovery, SecurityQuestionsComponent } from "./options";
 import { getPreference } from "../../api";
 import { AppConstants } from "../../constants";
@@ -69,12 +70,13 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
     const [ isQsRecoveryEnabled, setIsQsRecoveryEnabled ] = useState<boolean>(false);
     const [ isNotificationRecoveryEnabled, setIsNotificationRecoveryEnabled ] = useState<boolean>(false);
     const [ isUsernameRecoveryEnabled, setIsUsernameRecoveryEnabled ] = useState<boolean>(false);
+    const [ isAccountRecoveryDetailsLoading, setIsAccountRecoveryDetailsLoading ] = useState<boolean>(false);
 
     /**
      * The following method gets the preference for account recovery.
      */
     const getPreferences = (): void => {
-
+        setIsAccountRecoveryDetailsLoading(true);
         const recoveryConnector: PreferenceRequest[] = [
             {
                 "connector-name": RECOVERY_CONNECTOR,
@@ -140,6 +142,9 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
                         "myAccount:sections.accountRecovery.preference.notifications.genericError.message"
                     )
                 });
+            })
+            .finally(() => {
+                setIsAccountRecoveryDetailsLoading(false);
             });
     };
 
@@ -150,7 +155,7 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
         getPreferences();
     }, []);
 
-    return (
+    return (!isAccountRecoveryDetailsLoading? (
         <>
             {
                 ( isQsRecoveryEnabled || isNotificationRecoveryEnabled || isUsernameRecoveryEnabled ) ?
@@ -213,6 +218,20 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
                     : null
             }
         </>
+            ) :
+            <EmphasizedSegment padded="very">
+                <Placeholder fluid>
+                    <Placeholder.Header image>
+                        <Placeholder.Line />
+                        <Placeholder.Line />
+                    </Placeholder.Header>
+                    <Placeholder.Paragraph>
+                        <Placeholder.Line />
+                        <Placeholder.Line />
+                        <Placeholder.Line />
+                    </Placeholder.Paragraph>
+                </Placeholder>
+            </EmphasizedSegment>
     );
 };
 

--- a/apps/myaccount/src/components/account-recovery/account-recovery.tsx
+++ b/apps/myaccount/src/components/account-recovery/account-recovery.tsx
@@ -77,6 +77,7 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
      */
     const getPreferences = (): void => {
         setIsAccountRecoveryDetailsLoading(true);
+
         const recoveryConnector: PreferenceRequest[] = [
             {
                 "connector-name": RECOVERY_CONNECTOR,
@@ -165,14 +166,13 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
                     placeholder={
                         !isAccountRecoveryDetailsLoading &&
                         !(isQsRecoveryEnabled || isNotificationRecoveryEnabled || isUsernameRecoveryEnabled) ?
-                            "No Account recovery options enabled"
+                            "No Account Recovery options enabled"
                             : null
                     }
                 >
                     { (!isAccountRecoveryDetailsLoading ?
 
                             <List divided={ true } verticalAlign="middle" className="main-content-inner" >
-                                <>
                                     <List.Item className="inner-list-item">
                                         {hasRequiredScopes(
                                             featureConfig?.security,
@@ -210,24 +210,25 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
                                         )
                                         : null}
                                 </List.Item>
-                                </>
                             </List>
-                            : <EmphasizedSegment>
-                                <Placeholder fluid>
-                                    <Placeholder.Header image>
-                                        <Placeholder.Line />
-                                        <Placeholder.Line />
-                                    </Placeholder.Header>
-                                    <Placeholder.Header image>
-                                        <Placeholder.Line />
-                                        <Placeholder.Line />
-                                    </Placeholder.Header>
-                                    <Placeholder.Header image>
-                                        <Placeholder.Line />
-                                        <Placeholder.Line />
-                                    </Placeholder.Header>
-                                </Placeholder>
-                            </EmphasizedSegment>
+                    : (
+                        <EmphasizedSegment>
+                            <Placeholder fluid>
+                                <Placeholder.Header image>
+                                    <Placeholder.Line />
+                                    <Placeholder.Line />
+                                </Placeholder.Header>
+                                <Placeholder.Header image>
+                                    <Placeholder.Line />
+                                    <Placeholder.Line />
+                                </Placeholder.Header>
+                                <Placeholder.Header image>
+                                    <Placeholder.Line />
+                                    <Placeholder.Line />
+                                </Placeholder.Header>
+                            </Placeholder>
+                        </EmphasizedSegment>
+                     )
                     )
                     }
                 </SettingsSection>

--- a/apps/myaccount/src/components/account-recovery/account-recovery.tsx
+++ b/apps/myaccount/src/components/account-recovery/account-recovery.tsx
@@ -170,7 +170,7 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
                             : null
                     }
                 >
-                    { (!isAccountRecoveryDetailsLoading ?
+                    { !isAccountRecoveryDetailsLoading ?
 
                             <List divided={ true } verticalAlign="middle" className="main-content-inner" >
                                     <List.Item className="inner-list-item">
@@ -211,8 +211,7 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
                                         : null}
                                 </List.Item>
                             </List>
-                    : (
-                        <EmphasizedSegment>
+                    :   <EmphasizedSegment>
                             <Placeholder fluid>
                                 <Placeholder.Header image>
                                     <Placeholder.Line />
@@ -228,8 +227,6 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
                                 </Placeholder.Header>
                             </Placeholder>
                         </EmphasizedSegment>
-                     )
-                    )
                     }
                 </SettingsSection>
             }

--- a/apps/myaccount/src/components/account-recovery/account-recovery.tsx
+++ b/apps/myaccount/src/components/account-recovery/account-recovery.tsx
@@ -155,20 +155,26 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
         getPreferences();
     }, []);
 
-    return (!isAccountRecoveryDetailsLoading? (
+    return (
         <>
             {
-                ( isQsRecoveryEnabled || isNotificationRecoveryEnabled || isUsernameRecoveryEnabled ) ?
-                    (
-                        <SettingsSection
-                            data-testid={ `${testId}-settings-section` }
-                            description={ t("myAccount:sections.accountRecovery.description") }
-                            header={ t("myAccount:sections.accountRecovery.heading") }
-                        >
-                            <List divided={ true } verticalAlign="middle" className="main-content-inner">
-                                <List.Item className="inner-list-item">
-                                    {
-                                        hasRequiredScopes(
+                <SettingsSection
+                    data-testid={ `${testId}-settings-section` }
+                    description={ t("myAccount:sections.accountRecovery.description") }
+                    header={ t("myAccount:sections.accountRecovery.heading") }
+                    placeholder={
+                        !isAccountRecoveryDetailsLoading &&
+                        !(isQsRecoveryEnabled || isNotificationRecoveryEnabled || isUsernameRecoveryEnabled) ?
+                            "No Account recovery options enabled"
+                            : null
+                    }
+                >
+                    { (!isAccountRecoveryDetailsLoading ?
+
+                            <List divided={ true } verticalAlign="middle" className="main-content-inner" >
+                                <>
+                                    <List.Item className="inner-list-item">
+                                        {hasRequiredScopes(
                                             featureConfig?.security,
                                             featureConfig?.security?.scopes?.read,
                                             allowedScopes
@@ -181,57 +187,52 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
                                         isQsRecoveryEnabled
                                             ? (
                                                 <SecurityQuestionsComponent
-                                                    onAlertFired=
-                                                        { onAlertFired }
-                                                    data-testid=
-                                                        { `${testId}-settings-section-security-questions-component` }
-                                                />
+                                                    onAlertFired={onAlertFired}
+                                                    data-testid={`${testId}-settings-section-security-questions-component`}/>
                                             )
-                                            : null
-                                    }
+                                            : null}
+                                    </List.Item><List.Item className="inner-list-item">
+                                    {hasRequiredScopes(
+                                        featureConfig?.security,
+                                        featureConfig?.security?.scopes?.read,
+                                        allowedScopes
+                                    ) &&
+                                    isFeatureEnabled(
+                                        featureConfig?.security,
+                                        AppConstants.FEATURE_DICTIONARY
+                                            .get("SECURITY_ACCOUNT_RECOVERY_EMAIL_RECOVERY")
+                                    ) &&
+                                    (isNotificationRecoveryEnabled || isUsernameRecoveryEnabled)
+                                        ? (
+                                            <EmailRecovery
+                                                onAlertFired={onAlertFired}
+                                                data-testid={`${testId}-settings-section-email-recovery`}/>
+                                        )
+                                        : null}
                                 </List.Item>
-                                <List.Item className="inner-list-item">
-                                    {
-                                        hasRequiredScopes(
-                                            featureConfig?.security,
-                                            featureConfig?.security?.scopes?.read,
-                                            allowedScopes
-                                        ) &&
-                                        isFeatureEnabled(
-                                            featureConfig?.security,
-                                            AppConstants.FEATURE_DICTIONARY
-                                                .get("SECURITY_ACCOUNT_RECOVERY_EMAIL_RECOVERY")
-                                        ) &&
-                                        (isNotificationRecoveryEnabled || isUsernameRecoveryEnabled)
-                                            ? (
-                                                <EmailRecovery
-                                                    onAlertFired={ onAlertFired }
-                                                    data-testid={ `${testId}-settings-section-email-recovery` }
-                                                />
-                                            )
-                                            : null
-                                    }
-                                </List.Item>
+                                </>
                             </List>
-                        </SettingsSection>
+                            : <EmphasizedSegment>
+                                <Placeholder fluid>
+                                    <Placeholder.Header image>
+                                        <Placeholder.Line />
+                                        <Placeholder.Line />
+                                    </Placeholder.Header>
+                                    <Placeholder.Header image>
+                                        <Placeholder.Line />
+                                        <Placeholder.Line />
+                                    </Placeholder.Header>
+                                    <Placeholder.Header image>
+                                        <Placeholder.Line />
+                                        <Placeholder.Line />
+                                    </Placeholder.Header>
+                                </Placeholder>
+                            </EmphasizedSegment>
                     )
-                    : null
+                    }
+                </SettingsSection>
             }
         </>
-            ) :
-            <EmphasizedSegment padded="very">
-                <Placeholder fluid>
-                    <Placeholder.Header image>
-                        <Placeholder.Line />
-                        <Placeholder.Line />
-                    </Placeholder.Header>
-                    <Placeholder.Paragraph>
-                        <Placeholder.Line />
-                        <Placeholder.Line />
-                        <Placeholder.Line />
-                    </Placeholder.Paragraph>
-                </Placeholder>
-            </EmphasizedSegment>
     );
 };
 


### PR DESCRIPTION
### Purpose
> Fix account recovery loading

#### Reason for this fix:
Since the Account Recovery is loaded as a component into security page has to employ placeholder loader.

#### After Fix 
- For at least one account recovery options

https://user-images.githubusercontent.com/32198547/129915964-a11c7029-d1c9-4b3a-be39-343c4b9eada7.mp4

- For no options available 

https://user-images.githubusercontent.com/32198547/129915475-75859c16-e181-4bf4-973a-bc811aa30c1a.mp4

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
