### PR TITLE
Updated method to extract embedded userstore of user in myaccount

### DIFF
--- a/apps/myaccount/src/helpers/user.ts
+++ b/apps/myaccount/src/helpers/user.ts
@@ -114,7 +114,8 @@ export const resolveUserStoreEmbeddedUsername = (username: string): string => {
  * @return {string}
  */
 export const resolveUserstore= (username: string): string => {
-    const parts = username.split("/");
-
-    return parts[0];
+    // Userstore is index 0 and index 1 is username
+    const USERSTORE = 0;
+    const parts = username?.split("/");
+    return parts[USERSTORE];
 };

--- a/apps/myaccount/src/helpers/user.ts
+++ b/apps/myaccount/src/helpers/user.ts
@@ -63,7 +63,7 @@ export const resolveUserProfileName = (state: AuthStateInterface, isProfileInfoL
         return resolveUserDisplayName(state);
     }
     return null;
-}
+};
 
 /**
  * Same username can exist in two different user stores. This function
@@ -105,4 +105,16 @@ export const resolveUserStoreEmbeddedUsername = (username: string): string => {
     }
 
     return username;
+};
+
+/**
+ * Resolves the user's userstore from the username
+ *
+ * @param {string} username - Username of the user with user store embedded.
+ * @return {string}
+ */
+export const resolveUserstore= (username: string): string => {
+    const parts = username.split("/");
+
+    return parts[0];
 };

--- a/apps/myaccount/src/pages/account-security.tsx
+++ b/apps/myaccount/src/pages/account-security.tsx
@@ -40,12 +40,12 @@ import {
 } from "../components";
 import { AppConstants, CommonConstants } from "../constants";
 import { commonConfig } from "../extensions";
-import { resolveUserStoreEmbeddedUsername } from "../helpers";
+import { SCIMConfigs } from "../extensions/configs/scim";
+import { resolveUserstore } from "../helpers";
 import { InnerPageLayout } from "../layouts";
 import { AlertInterface, AuthStateInterface, FeatureConfigInterface } from "../models";
 import { AppState } from "../store";
 import { addAlert } from "../store/actions";
-import { SCIMConfigs } from "../extensions/configs/scim";
 
 /**
 * Prop types for the Account Security page.
@@ -130,7 +130,7 @@ const AccountSecurityPage: FunctionComponent<AccountSecurityPagePropsInterface>=
      */
     useEffect(() => {
         if (profileDetails?.profileInfo?.userName) {
-            const userstore: string = resolveUserStoreEmbeddedUsername(profileDetails.profileInfo.userName);
+            const userstore: string = resolveUserstore(profileDetails.profileInfo.userName);
             setUserstore(userstore);
         }
     }, [profileDetails?.profileInfo]);


### PR DESCRIPTION
### Purpose
> The method of extracting the userstore from the username was invalid. The userstore was identified invalidly when determining the myaccount contents to be displayed.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
