### PR TITLE
Show a different account lock error message for admin initiated account lock

### DIFF
--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -220,3 +220,4 @@ error.user.not.found=User not found in the directory. Cannot proceed further wit
 error.user.account.locked=User account is locked. Please retry later.
 error.user.account.temporarly.locked=User account is locked. Please retry after %s minutes.
 error.user.account.locked.incorrect.login.attempts=Your account has been temporarily locked due to multiple failed login attempts. Please check your email for more details.
+error.user.account.locked.admin.initiated=Your account is locked. Please contact your system administrator.

--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -186,11 +186,17 @@
 %>
 
 <% if (StringUtils.equals(request.getParameter("errorCode"), IdentityCoreConstants.USER_ACCOUNT_LOCKED_ERROR_CODE) &&
-        StringUtils.equals(request.getParameter("remainingAttempts"), "0") ) { %>
-<div class="ui visible negative message" id="error-msg" data-testid="login-page-error-message">
-    <%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.account.locked.incorrect.login.attempts")%>
-</div>
-<% } else if (Boolean.parseBoolean(loginFailed) &&
+        StringUtils.equals(request.getParameter("remainingAttempts"), "0") ) {
+    if (StringUtils.equals(request.getParameter("lockedReason"), "AdminInitiated")) { %>
+        <div class="ui visible negative message" lockedReasonid="error-msg" data-testid="login-page-error-message">
+            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.account.locked.admin.initiated")%>
+        </div>
+    <% } else { %>
+        <div class="ui visible negative message" lockedReasonid="error-msg" data-testid="login-page-error-message">
+            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.account.locked.incorrect.login.attempts")%>
+        </div>
+    <% }
+} else if (Boolean.parseBoolean(loginFailed) &&
         !errorCode.equals(IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE)) { %>
 <div class="ui visible negative message" id="error-msg" data-testid="login-page-error-message">
     <%= AuthenticationEndpointUtil.i18n(resourceBundle, errorMessage) %>


### PR DESCRIPTION
### Purpose
Currently, the error message shown when a user tries to login to an locked account is as follows (even though the account is locked by admin, but not locked due to reaching the maximum failed login attempts allowed)

![image](https://user-images.githubusercontent.com/25479743/130608588-2721960c-c002-45cf-b720-df167f5f08b2.png)

With this PR, the error message is changed as follows when the account is locked by the admin.

![image](https://user-images.githubusercontent.com/25479743/130608475-7efb2461-1b92-4040-a151-a93096eca742.png)

### Related Issues
- https://github.com/wso2/product-is/issues/12355

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/101

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
