### PR TITLE
Prevent Publishing Entire Request Object in Event Publisher in Console

### DIFF
--- a/apps/console/src/features/core/utils/http-utils.ts
+++ b/apps/console/src/features/core/utils/http-utils.ts
@@ -68,11 +68,17 @@ export class HttpUtils {
         /**
          * Publish an event on the http request error.
         */
-        EventPublisher.getInstance().publish("console-error-http-request-error", {
-            "type": "error-response",
-            "response": error.response ? error.response.data ? error.response.data : "" : "",
-            "status": error.response ? error.response.status ? error.response.status : "" : ""
-        });
+        if(
+                error.response &&
+                error.response.data &&
+                error.response.data.code
+        ) {
+            EventPublisher.getInstance().publish("console-error-http-request-error", {
+                "type": "error-response",
+                "code": error.response.data.code,
+                "status": error.response.status ? error.response.status : ""
+            });
+        }
 
         // Terminate the session if the token endpoint returns a bad request(400)
         // The token binding feature will return a 400 status code when the session

--- a/apps/console/src/features/core/utils/http-utils.ts
+++ b/apps/console/src/features/core/utils/http-utils.ts
@@ -70,7 +70,7 @@ export class HttpUtils {
         */
         EventPublisher.getInstance().publish("console-error-http-request-error", {
             "type": "error-response",
-            "response": error.response ? error.response : "",
+            "response": error.response ? error.response.data ? error.response.data : "" : "",
             "status": error.response ? error.response.status ? error.response.status : "" : ""
         });
 

--- a/apps/console/src/features/core/utils/http-utils.ts
+++ b/apps/console/src/features/core/utils/http-utils.ts
@@ -68,10 +68,10 @@ export class HttpUtils {
         /**
          * Publish an event on the http request error.
         */
-        if(
-                error.response &&
-                error.response.data &&
-                error.response.data.code
+        if (
+            error.response &&
+            error.response.data &&
+            error.response.data.code
         ) {
             EventPublisher.getInstance().publish("console-error-http-request-error", {
                 "type": "error-response",


### PR DESCRIPTION
### Purpose
Prevent Publishing Entire Request Object in Event Publisher in Console

### Related Issues
- https://github.com/wso2/product-is/issues/12357

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
