### PR TITLE
Fix issues in updating certificate in protocol section

### DIFF
--- a/apps/console/src/features/applications/components/settings/certificate/add-certificate-form.tsx
+++ b/apps/console/src/features/applications/components/settings/certificate/add-certificate-form.tsx
@@ -31,6 +31,10 @@ interface AddApplicationCertificateFormProps extends TestableComponentInterface 
     triggerCertificateUpload: boolean;
     triggerSubmit: boolean;
     onSubmit: (values: any) => void;
+    /**
+     * Sets the visibility of the finish button
+     */
+    setShowFinishButton?: (buttonState: boolean) => void;
 }
 
 /**
@@ -44,6 +48,7 @@ export const AddApplicationCertificateFormComponent: React.FunctionComponent<Add
     const {
         triggerCertificateUpload,
         onSubmit,
+        setShowFinishButton,
         ["data-testid"]: testId
     } = props;
 
@@ -108,6 +113,7 @@ export const AddApplicationCertificateFormComponent: React.FunctionComponent<Add
                             forgeCertificateData={ certificate }
                             data-testid={ `${testId}-upload` }
                             hideAliasInput={ true }
+                            setShowFinishButton={ setShowFinishButton }
                         />
                     </Grid.Column>
                 </Grid.Row>

--- a/apps/console/src/features/applications/components/settings/certificate/add-certificate-wizard.tsx
+++ b/apps/console/src/features/applications/components/settings/certificate/add-certificate-wizard.tsx
@@ -58,6 +58,7 @@ export const AddApplicationCertificateWizard: FunctionComponent<AddApplicationCe
 
     const [ partiallyCompletedStep, setPartiallyCompletedStep ] = useState<number>(undefined);
     const [ currentWizardStep, setCurrentWizardStep ] = useState<number>(currentStep);
+    const [ showFinishButton, setShowFinishButton ] = useState<boolean>(false);
 
     const [ alert, setAlert, alertComponent ] = useWizardAlert();
 
@@ -103,6 +104,7 @@ export const AddApplicationCertificateWizard: FunctionComponent<AddApplicationCe
                     triggerCertificateUpload={ triggerUpload }
                     triggerSubmit={ finishSubmit }
                     onSubmit={ handleWizardFormFinish }
+                    setShowFinishButton={ setShowFinishButton }
                 />
             ),
             icon: getAddIDPCertificateWizardStepIcons().general,
@@ -146,6 +148,7 @@ export const AddApplicationCertificateWizard: FunctionComponent<AddApplicationCe
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
                             { currentWizardStep === STEPS.length - 1 && (
                                 <PrimaryButton
+                                    disabled={ !showFinishButton }
                                     floated="right"
                                     onClick={ navigateToNext }
                                     data-testid={ `${testId}-finish-button` }

--- a/apps/console/src/features/core/components/upload-certificate.tsx
+++ b/apps/console/src/features/core/components/upload-certificate.tsx
@@ -18,12 +18,12 @@
 
 import { Certificate, TestableComponentInterface } from "@wso2is/core/models";
 import { CertificateManagementUtils } from "@wso2is/core/utils";
-import { GenericIcon } from "@wso2is/react-components";
+import { GenericIcon, Message } from "@wso2is/react-components";
 import { KJUR, X509 } from "jsrsasign";
 import * as forge from "node-forge";
 import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Divider, Form, Icon, Message, Segment, Tab, TextArea } from "semantic-ui-react";
+import { Button, Divider, Form, Icon, Segment, Tab, TextArea } from "semantic-ui-react";
 import { getCertificateIllustrations } from "../configs";
 
 // This is a polyfill to support `File.arrayBuffer()` in Safari and IE.
@@ -100,6 +100,10 @@ interface UploadCertificatePropsInterface extends TestableComponentInterface {
      * Hides the alias input.
      */
     hideAliasInput?: boolean;
+    /**
+     * Sets the visibility of the finish button
+     */
+    setShowFinishButton?: (buttonState: boolean) => void;
 }
 
 /**
@@ -123,6 +127,7 @@ export const UploadCertificate: FunctionComponent<UploadCertificatePropsInterfac
         fileData,
         forgeCertificateData,
         hideAliasInput,
+        setShowFinishButton,
         [ "data-testid" ]: testId
     } = props;
 
@@ -208,6 +213,17 @@ export const UploadCertificate: FunctionComponent<UploadCertificatePropsInterfac
             setFileError(false);
         }
     }, [ file ]);
+
+    /**
+     * Sets the visibility of the Finish button.
+     */
+    useEffect(() => {
+        if (!file && !pem) {
+            setShowFinishButton(false);
+        } else {
+            setShowFinishButton(true);
+        }
+    }, [file, pem])
 
     /**
      * Gets the forge certificate data from the wizard on coming back from the following step.
@@ -567,12 +583,15 @@ export const UploadCertificate: FunctionComponent<UploadCertificatePropsInterfac
 
             {
                 (fileError || certEmpty) &&
-                <Message error attached="bottom" data-testid={ `${ testId }-error-message` }>
-                    { fileError
-                        ? t("console:manage.features.certificates.keystore.errorCertificate")
-                        : t("console:manage.features.certificates.keystore.errorEmpty")
-                    }
-                </Message>
+                <Message
+                    negative
+                    data-testid={ `${ testId }-error-message` }
+                    content =
+                        { fileError
+                            ? t("console:manage.features.certificates.keystore.errorCertificate")
+                            : t("console:manage.features.certificates.keystore.errorEmpty")
+                        }
+                />
             }
         </>
 


### PR DESCRIPTION
### Purpose
> Enable the `Finish Button` only if certificate file or value is added to the wizard.
> Display an error message when the pem value is invalid.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
