### PR TITLE
UI issue in forms

### DIFF
--- a/modules/theme/src/themes/default/collections/form.overrides
+++ b/modules/theme/src/themes/default/collections/form.overrides
@@ -47,6 +47,10 @@
 
 .ui.form {
     .field {
+        label::after {
+            position: absolute;
+        }
+        
         &.hidden {
             display: none;
         }


### PR DESCRIPTION
### Purpose
Solved the UI issue in forms which caused the required (`*`) to be in the next line.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
