### PR TITLE
Enable email as username when hosting Authentication Endpoint and Recovery Endpoint on a different server. 

### DIFF
--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -69,7 +69,7 @@
     boolean isSaaSApp = Boolean.parseBoolean(request.getParameter("isSaaSApp"));
     String callback = Encode.forHtmlAttribute(request.getParameter("callback"));
     String emailUsernameEnable = application.getInitParameter("EnableEmailUserName");
-    if (StringUtils.isNotBlank(emailUsernameEnable) && emailUsernameEnable.equals("true")) {
+    if (StringUtils.isNotBlank(emailUsernameEnable) && Boolean.parseBoolean(emailUsernameEnable)) {
         if (StringUtils.countMatches(username, "@") == 1) {
             username = username + "@" + tenantDomain;
         }

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -70,8 +70,8 @@
     String callback = Encode.forHtmlAttribute(request.getParameter("callback"));
     String emailUsernameEnable = application.getInitParameter("EnableEmailUserName");
     if (StringUtils.isNotBlank(emailUsernameEnable) && Boolean.parseBoolean(emailUsernameEnable)) {
-        if (StringUtils.countMatches(username, "@") == 1) {
-            username = username + "@" + tenantDomain;
+        if (StringUtils.countMatches(username, IdentityManagementEndpointConstants.TENANT_DOMAIN_SEPARATOR) == 1) {
+            username = username + IdentityManagementEndpointConstants.TENANT_DOMAIN_SEPARATOR + tenantDomain;
         }
     }
     User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain, isSaaSApp);

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -68,6 +68,12 @@
     boolean isPasswordProvisionEnabled = Boolean.parseBoolean(request.getParameter("passwordProvisionEnabled"));
     boolean isSaaSApp = Boolean.parseBoolean(request.getParameter("isSaaSApp"));
     String callback = Encode.forHtmlAttribute(request.getParameter("callback"));
+    String emailUsernameEnable = application.getInitParameter("EnableEmailUserName");
+    if (StringUtils.isNotBlank(emailUsernameEnable) && emailUsernameEnable.equals("true")) {
+        if (StringUtils.countMatches(username, "@") == 1) {
+            username = username + "@" + tenantDomain;
+        }
+    }
     User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain, isSaaSApp);
 
     if (skipSignUpEnableCheck) {


### PR DESCRIPTION

### Purpose
> Fix the issues observed when email as username is enabled, when Authentication Endpoint and Recovery Endpoint are hosted on a different server.

### Related Issues
- https://github.com/wso2/product-is/issues/12265
