### PR TITLE
Add loader for local claims list

### DIFF
--- a/apps/console/src/features/claims/components/edit/external-dialect/edit-external-claim.tsx
+++ b/apps/console/src/features/claims/components/edit/external-dialect/edit-external-claim.tsx
@@ -104,12 +104,14 @@ export const EditExternalClaim: FunctionComponent<EditExternalClaimsPropsInterfa
     const [ localClaims, setLocalClaims ] = useState<Claim[]>();
     const [ claim, setClaim ] = useState<ExternalClaim>(null);
     const [ filteredLocalClaims, setFilteredLocalClaims ] = useState<Claim[]>();
+    const [ isClaimsLoading, setIsClaimsLoading ] = useState<boolean>(false); 
 
     const dispatch = useDispatch();
 
     const { t } = useTranslation();
 
     useEffect(() => {
+        setIsClaimsLoading(true);
         const params: ClaimsGetParams = {
             "exclude-identity-claims": true,
             filter: null,
@@ -118,6 +120,7 @@ export const EditExternalClaim: FunctionComponent<EditExternalClaimsPropsInterfa
             sort: null
         };
         getAllLocalClaims(params).then(response => {
+            setIsClaimsLoading(false);
             setLocalClaims(sortList(response, "displayName", true));
         }).catch(error => {
             dispatch(addAlert(
@@ -278,6 +281,7 @@ export const EditExternalClaim: FunctionComponent<EditExternalClaimsPropsInterfa
                                 "localAttribute.requiredErrorMessage") }
                             placeholder={ t("console:manage.features.claims.external.forms.attributeURI.placeholder") }
                             search
+                            loading={ isClaimsLoading }
                             value={ wizard ? addedClaim.mappedLocalClaimURI : claim?.mappedLocalClaimURI }
                             children={
                                 filteredLocalClaims?.map((claim: Claim, index) => {


### PR DESCRIPTION
### Purpose
This PR will introduce a loader for the local claims list until it is loaded on to UI in the edit view of add claim mapping.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
