### PR TITLE
Disable required on claim when read-only checked

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -81,6 +81,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     const [ isShowDisplayOrder, setIsShowDisplayOrder ] = useState(false);
     const [ confirmDelete, setConfirmDelete ] = useState(false);
+    const [ isClaimReadOnly , setIsClaimReadOnly ] = useState<boolean>(false);
 
     const nameField = useRef<HTMLElement>(null);
     const regExField = useRef<HTMLElement>(null);
@@ -96,6 +97,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
     useEffect(() => {
         if (claim?.supportedByDefault) {
             setIsShowDisplayOrder(true);
+        }
+        if (claim?.readOnly) {
+            setIsClaimReadOnly(true);
         }
     }, [ claim ]);
 
@@ -206,7 +210,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
             properties: claim.properties,
             readOnly: values?.readOnly !== undefined ? !!values.readOnly : claim?.readOnly,
             regEx:  values?.regularExpression !== undefined ? values.regularExpression?.toString() : claim?.regEx,
-            required: values?.required !== undefined ? !!values.required : claim?.required,
+            required: values?.required !== undefined && !values?.readOnly ? !!values.required : claim?.required,
             supportedByDefault: values?.supportedByDefault !== undefined
                 ? !!values.supportedByDefault : claim?.supportedByDefault
         };
@@ -377,7 +381,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                 defaultValue={ claim?.required }
                                 data-testid={ `${ testId }-form-required-checkbox` }
                                 readOnly={ isReadOnly }
+                                value={ !isClaimReadOnly }
                                 hint={ t("console:manage.features.claims.local.forms.requiredHint") }
+                                disabled={ isClaimReadOnly }
                             />
                     }
                     {
@@ -395,6 +401,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                 data-testid={ `${ testId }-form-readonly-checkbox` }
                                 readOnly={ isReadOnly }
                                 hint={ t("console:manage.features.claims.local.forms.readOnlyHint") }
+                                listen={ (value) => {
+                                    setIsClaimReadOnly(value);
+                                } }
                             />
                         )
                     }

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -81,7 +81,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     const [ isShowDisplayOrder, setIsShowDisplayOrder ] = useState(false);
     const [ confirmDelete, setConfirmDelete ] = useState(false);
-    const [ isClaimReadOnly , setIsClaimReadOnly ] = useState<boolean>(false);
+    const [ isClaimReadOnly, setIsClaimReadOnly ] = useState<boolean>(false);
 
     const nameField = useRef<HTMLElement>(null);
     const regExField = useRef<HTMLElement>(null);


### PR DESCRIPTION
### Purpose
This PR will add the following functionality.

- If `Make this attribute read-only on the user's profile` is checked, the `Make this attribute required on the user's profile` will be disabled.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
