### PR TITLE
Fix description limit

### DIFF
--- a/apps/console/src/features/oidc-scopes/pages/oidc-scopes-edit.tsx
+++ b/apps/console/src/features/oidc-scopes/pages/oidc-scopes-edit.tsx
@@ -115,6 +115,7 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
 
         const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
         const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+        const SCOPE_DESCRIPTION_MAX_LENGTH: number = 100;
 
         const isReadOnly = useMemo(() => (
             !hasRequiredScopes(
@@ -467,7 +468,7 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
                                             ) }
                                             value={ scope.description }
                                             required={ false }
-                                            maxLength={ 300 }
+                                            maxLength={ SCOPE_DESCRIPTION_MAX_LENGTH }
                                             minLength={ 3 }
                                             readOnly={ isReadOnly }
                                         />


### PR DESCRIPTION
### Purpose
> Change the description limit to 100 character at `edit form` similar to that `add form`

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
