### PR TITLE
Add documentation link tag UI component

### DIFF
--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -22,7 +22,7 @@ import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { I18n } from "@wso2is/i18n";
 import {
-    DocumentationLinkTag,
+    DocumentationLink,
     GridLayout,
     ListLayout,
     PageLayout,
@@ -281,11 +281,11 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
             description={ 
                 <p>
                     { t("console:develop.pages.applications.subTitle") }
-                    <DocumentationLinkTag
+                    <DocumentationLink
                         link={ getLink("develop.applications.learnMore") }
                     >
                         { t("common:learnMore") }
-                    </DocumentationLinkTag>
+                    </DocumentationLink>
                 </p> 
             }
             data-testid={ `${ testId }-page-layout` }

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -283,8 +283,9 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                     { t("console:develop.pages.applications.subTitle") }
                     <DocumentationLinkTag
                         link={ getLink("develop.applications.learnMore") }
-                        text={ t("common:learnMore") }
-                    />
+                    >
+                        { t("common:learnMore") }
+                    </DocumentationLinkTag>
                 </p> 
             }
             data-testid={ `${ testId }-page-layout` }

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -22,10 +22,12 @@ import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { I18n } from "@wso2is/i18n";
 import {
+    DocumentationLinkTag,
     GridLayout,
     ListLayout,
     PageLayout,
-    PrimaryButton
+    PrimaryButton,
+    useDocumentation
 } from "@wso2is/react-components";
 import find from "lodash-es/find";
 import React, {
@@ -106,6 +108,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
     } = props;
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const dispatch = useDispatch();
 
@@ -275,7 +278,15 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                 )
             }
             title={ t("console:develop.pages.applications.title") }
-            description={ t("console:develop.pages.applications.subTitle") }
+            description={ 
+                <p>
+                    { t("console:develop.pages.applications.subTitle") }
+                    <DocumentationLinkTag
+                        link={ getLink("develop.applications.learnMore") }
+                        text={ t("common:learnMore") }
+                    />
+                </p> 
+            }
             data-testid={ `${ testId }-page-layout` }
         >
         { !isLoading? (

--- a/modules/i18n/src/models/namespaces/common-ns.ts
+++ b/modules/i18n/src/models/namespaces/common-ns.ts
@@ -91,6 +91,7 @@ export interface CommonNS {
     lastModified: string;
     lastSeen: string;
     lastUpdatedOn: string;
+    learnMore: string;
     lightMode: string;
     loading: string;
     loginTime: string;

--- a/modules/i18n/src/translations/en-US/portals/common.ts
+++ b/modules/i18n/src/translations/en-US/portals/common.ts
@@ -97,6 +97,7 @@ export const common: CommonNS = {
     lastModified: "Last modified",
     lastSeen: "Last seen",
     lastUpdatedOn: "Last updated on",
+    learnMore: "Learn More",
     lightMode: "Light mode",
     loading: "Loading",
     loginTime: "Login time",

--- a/modules/i18n/src/translations/fr-FR/portals/common.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/common.ts
@@ -98,6 +98,7 @@ export const common: CommonNS = {
     lastModified: "Dernière modification",
     lastSeen: "Dernier vu",
     lastUpdatedOn: "Dernière mise à jour le",
+    learnMore: "Apprendre encore plus",
     lightMode: "Mode lumière",
     loading: "Chargement",
     loginTime: "Heure de connexion",

--- a/modules/i18n/src/translations/pt-BR/portals/common.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/common.ts
@@ -97,6 +97,7 @@ export const common: CommonNS = {
     lastModified: "Última modificação",
     lastSeen: "Visto pela última vez",
     lastUpdatedOn: "Última atualização em",
+    learnMore: "Saber mais",
     lightMode: "Modo claro",
     loading: "Carregando",
     loginTime: "Hora de início de sessão",

--- a/modules/i18n/src/translations/si-LK/portals/common.ts
+++ b/modules/i18n/src/translations/si-LK/portals/common.ts
@@ -97,6 +97,7 @@ export const common: CommonNS = {
     lastModified: "අවසන් වෙනස් කළ දිනය",
     lastSeen: "අවසන් වරට",
     lastUpdatedOn: "අවසන් වරට යාවත්කාලීන කළ දිනය",
+    learnMore: "තවත් හදාරන්න",
     lightMode: "දීප්තිමත් තේමාව",
     loading: "පූරණය වෙමින් පවතී",
     loginTime: "පිවිසුම් කාලය",

--- a/modules/i18n/src/translations/ta-IN/portals/common.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/common.ts
@@ -97,6 +97,7 @@ export const common: CommonNS = {
     lastModified: "கடைசியாக மாற்றியமைக்கப்பட்டது",
     lastSeen: "இறுதி நுழைவு",
     lastUpdatedOn: "கடைசியாக புதுப்பிக்கப்பட்ட தேதி",
+    learnMore: "மேலும் அறிக",
     lightMode: "ஒளி தீம்",
     loading: "ஏற்றுகிறது",
     loginTime: "நுழைந்த நேரம்",

--- a/modules/react-components/src/components/documentation/documentation-link.tsx
+++ b/modules/react-components/src/components/documentation/documentation-link.tsx
@@ -16,13 +16,12 @@
  * under the License.
  */
 
-import { TestableComponentInterface } from "@wso2is/core/models";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
 import { Icon } from "semantic-ui-react";
 /**
  * DocumentationLinkTag component Prop types.
  */
-export interface DocumentationLinkTagPropsInterface extends  TestableComponentInterface { 
+interface DocumentationLinkTagPropsInterface { 
     /**
      * Documentation URL.
      */
@@ -31,49 +30,47 @@ export interface DocumentationLinkTagPropsInterface extends  TestableComponentIn
      * Documentation URL target property. Opens in a new window by default.
      */
     target?: string;
-    /**
-     * Text on the anchor tag. Defaults to Learn More.
-     */
-    text?: string;
 }
 
 /**
  * Documentation link anchor tag component.
  *
- * @param {DocumentationLinkTagPropsInterface} props - Props injected to the component.
+ * @param {React.PropsWithChildren<DocumentationLinkTagPropsInterface>} props - Props injected to the component.
  *
  * @return {React.ReactElement}
  */
-export const DocumentationLinkTag: FunctionComponent<DocumentationLinkTagPropsInterface> = (
-    props: DocumentationLinkTagPropsInterface
+export const DocumentationLinkTag: FunctionComponent<PropsWithChildren<DocumentationLinkTagPropsInterface>> = (
+    props: PropsWithChildren<DocumentationLinkTagPropsInterface>
 ): ReactElement => {
 
     const { 
+        children,
         link,
-        target,
-        text
+        target
     } = props;
 
+    if (link === undefined) {
+        return null;
+    }
+
     return (
-        (link === undefined) ?
-            null :
-            <strong>
-                <a
-                    href={ link }
-                    target={ target }
-                    rel="noopener noreferrer"
-                    className="link external no-wrap"
-                > { text }
-                    <Icon className="ml-7" name="caret right"/>
-                </a>
-            </strong> 
+        <strong>
+            <a
+                href={ link }
+                target={ target }
+                rel="noopener noreferrer"
+                className="link external no-wrap"
+            >
+                { children }
+                <Icon className="ml-7" name="caret right"/>
+            </a>
+        </strong>
     );
 };
 
 /**
  * Prop types for the DocumentationLinkTag component.
  */
- DocumentationLinkTag.defaultProps = {
-    target: "_blank",
-    text: "Learn More"
+DocumentationLinkTag.defaultProps = {
+    target: "_blank"
 };

--- a/modules/react-components/src/components/documentation/documentation-link.tsx
+++ b/modules/react-components/src/components/documentation/documentation-link.tsx
@@ -59,7 +59,7 @@ export const DocumentationLinkTag: FunctionComponent<PropsWithChildren<Documenta
                 href={ link }
                 target={ target }
                 rel="noopener noreferrer"
-                className="link external no-wrap"
+                className="ml-1 link external no-wrap"
             >
                 { children }
                 <Icon className="ml-7" name="caret right"/>

--- a/modules/react-components/src/components/documentation/documentation-link.tsx
+++ b/modules/react-components/src/components/documentation/documentation-link.tsx
@@ -19,9 +19,9 @@
 import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
 import { Icon } from "semantic-ui-react";
 /**
- * DocumentationLinkTag component Prop types.
+ * DocumentationLink component Prop types.
  */
-interface DocumentationLinkTagPropsInterface { 
+interface DocumentationLinkPropsInterface { 
     /**
      * Documentation URL.
      */
@@ -35,12 +35,12 @@ interface DocumentationLinkTagPropsInterface {
 /**
  * Documentation link anchor tag component.
  *
- * @param {React.PropsWithChildren<DocumentationLinkTagPropsInterface>} props - Props injected to the component.
+ * @param {React.PropsWithChildren<DocumentationLinkPropsInterface>} props - Props injected to the component.
  *
  * @return {React.ReactElement}
  */
-export const DocumentationLinkTag: FunctionComponent<PropsWithChildren<DocumentationLinkTagPropsInterface>> = (
-    props: PropsWithChildren<DocumentationLinkTagPropsInterface>
+export const DocumentationLink: FunctionComponent<PropsWithChildren<DocumentationLinkPropsInterface>> = (
+    props: PropsWithChildren<DocumentationLinkPropsInterface>
 ): ReactElement => {
 
     const { 
@@ -69,8 +69,8 @@ export const DocumentationLinkTag: FunctionComponent<PropsWithChildren<Documenta
 };
 
 /**
- * Prop types for the DocumentationLinkTag component.
+ * Prop types for the DocumentationLink component.
  */
-DocumentationLinkTag.defaultProps = {
+DocumentationLink.defaultProps = {
     target: "_blank"
 };

--- a/modules/react-components/src/components/documentation/documentation-link.tsx
+++ b/modules/react-components/src/components/documentation/documentation-link.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestableComponentInterface } from "@wso2is/core/models";
+import React, { FunctionComponent, ReactElement } from "react";
+import { Icon } from "semantic-ui-react";
+/**
+ * DocumentationLinkTag component Prop types.
+ */
+export interface DocumentationLinkTagPropsInterface extends  TestableComponentInterface { 
+    /**
+     * Documentation URL.
+     */
+    link: string;
+    /**
+     * Documentation URL target property. Opens in a new window by default.
+     */
+    target?: string;
+    /**
+     * Text on the anchor tag. Defaults to Learn More.
+     */
+    text?: string;
+}
+
+/**
+ * Documentation link anchor tag component.
+ *
+ * @param {DocumentationLinkTagPropsInterface} props - Props injected to the component.
+ *
+ * @return {React.ReactElement}
+ */
+export const DocumentationLinkTag: FunctionComponent<DocumentationLinkTagPropsInterface> = (
+    props: DocumentationLinkTagPropsInterface
+): ReactElement => {
+
+    const { 
+        link,
+        target,
+        text
+    } = props;
+
+    return (
+        (link === undefined) ?
+            null :
+            <strong>
+                <a
+                    href={ link }
+                    target={ target }
+                    rel="noopener noreferrer"
+                    className="link external no-wrap"
+                > { text }
+                    <Icon className="ml-7" name="caret right"/>
+                </a>
+            </strong> 
+    );
+};
+
+/**
+ * Prop types for the DocumentationLinkTag component.
+ */
+ DocumentationLinkTag.defaultProps = {
+    target: "_blank",
+    text: "Learn More"
+};

--- a/modules/react-components/src/components/documentation/index.ts
+++ b/modules/react-components/src/components/documentation/index.ts
@@ -17,5 +17,6 @@
  *
  */
 
+export * from "./documentation-link";
 export * from "./documentation-provider";
 export * from "./use-documentation";


### PR DESCRIPTION
### Purpose
This PR adds a reusable UI component which contains the `Learn More` anchor tag. This is to be used along with the documentation link context hook for better reusability.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- https://github.com/wso2/identity-apps/pull/2418

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
