### PR TITLE
Publish Updated State with Application Sign-in Method Update Button Click

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -321,17 +321,23 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
             setIsDefaultScript(true);
         }
 
-        const eventPublisherProperties = {
+        const eventPublisherProperties : {
+            "script-based": boolean,
+            "step-based": Array<Record<number, string>>
+        } = {
             "script-based": !AdaptiveScriptUtils.isDefaultScript(adaptiveScript, steps),
             "step-based": []
         };
 
         updatedSteps.forEach((updatedStep) => {
-            const step = {};
-            updatedStep.options.forEach((element,id) => {
-                step[id] = kebabCase(element?.authenticator);
-            });
-            eventPublisherProperties["step-based"].push(step);
+            const step : Record<number, string> = {};
+
+            if (Array.isArray(updatedStep?.options) && updatedStep.options.length > 0) {
+                updatedStep.options.forEach((element,id) => {
+                    step[id] = kebabCase(element?.authenticator);
+                });
+                eventPublisherProperties["step-based"].push(step);
+            }
         });
 
         eventPublisher.publish("application-sign-in-method-click-update-button", {

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -20,6 +20,7 @@ import { AlertLevels, SBACInterface, TestableComponentInterface } from "@wso2is/
 import { addAlert } from "@wso2is/core/store";
 import { Field, Forms } from "@wso2is/forms";
 import { Heading, Hint, LinkButton, PrimaryButton } from "@wso2is/react-components";
+import kebabCase from "lodash-es/kebabCase";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -116,6 +117,7 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
     const [ steps, setSteps ] = useState<number>(1);
     const [ isDefaultScript, setIsDefaultScript ] = useState<boolean>(true);
     const [ isButtonDisabled, setIsButtonDisabled ] = useState<boolean>(false);
+    const [ updatedSteps, setUpdatedSteps ] = useState<AuthenticationStepInterface[]>();
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
@@ -314,12 +316,28 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
      * Handles the update button click event.
      */
     const handleUpdateClick = (): void => {
-        eventPublisher.publish("application-sign-in-method-click-update-button");
-        
         if (AdaptiveScriptUtils.isEmptyScript(adaptiveScript)) {
             setAdaptiveScript(AdaptiveScriptUtils.generateScript(steps + 1).join("\n"));
             setIsDefaultScript(true);
         }
+
+        const eventPublisherProperties = {
+            "script-based": !AdaptiveScriptUtils.isDefaultScript(adaptiveScript, steps),
+            "step-based": []
+        };
+
+        updatedSteps.forEach((updatedStep) => {
+            const step = {};
+            updatedStep.options.forEach((element,id) => {
+                step[id] = kebabCase(element?.authenticator);
+            });
+            eventPublisherProperties["step-based"].push(step);
+        });
+
+        eventPublisher.publish("application-sign-in-method-click-update-button", {
+            "type": eventPublisherProperties
+        });
+
         setUpdateTrigger(true);
     };
 
@@ -447,7 +465,10 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
                 data-testid={ `${ testId }-step-based-flow` }
                 updateSteps={ updateSteps }
                 onIDPCreateWizardTrigger={ onIDPCreateWizardTrigger }
-                onAuthenticationSequenceChange={ handleButtonDisabledStateChange }
+                onAuthenticationSequenceChange={ (isDisabled, updatedSteps) => {
+                    handleButtonDisabledStateChange(isDisabled);
+                    setUpdatedSteps(updatedSteps);
+                } }
             />
             <Divider className="x2"/>
             <ScriptBasedFlow

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -98,7 +98,7 @@ interface AuthenticationFlowPropsInterface extends TestableComponentInterface {
     /**
      * Callback to update the button disable state change.
      */
-    onAuthenticationSequenceChange: (isDisabled: boolean) => void;
+    onAuthenticationSequenceChange: (isDisabled: boolean, updatedSteps: AuthenticationStepInterface[]) => void;
 }
 
 /**
@@ -266,10 +266,10 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
         const hasStepsWithOptions: boolean = steps.some((step: AuthenticationStepInterface) => !isEmpty(step.options));
 
         if (hasStepsWithOptions) {
-            onAuthenticationSequenceChange(false);
+            onAuthenticationSequenceChange(false, authenticationSteps);
             return;
         }
-        onAuthenticationSequenceChange(true);
+        onAuthenticationSequenceChange(true, authenticationSteps);
     }, [ authenticationSteps ]);
 
     /**


### PR DESCRIPTION
### Purpose
Currently only the Update button click is published for event publishing. But requires the user updated details to have a better analysis. This required in below pages.

- Application sign-in method edit page.

### Related Issues
- https://github.com/wso2/product-is/issues/12487

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
