### PR TITLE
Add `Link` component

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -23,6 +23,7 @@
         "start": "npx run-script-os",
         "start:win32": "..\\..\\node_modules\\.bin\\webpack serve --mode development --inline --hot --open --env NODE_ENV=development",
         "start:default": "../../node_modules/.bin/webpack serve --mode development --inline --hot --open --env NODE_ENV=development",
+        "start:lite": "npm run start --env DISABLE_ESLINT_PLUGIN=true",
         "test": "npx jest --passWithNoTests",
         "test:watch": "npm run test -- --watch",
         "compile:i18n": "npx run-script-os",

--- a/apps/console/webpack.config.js
+++ b/apps/console/webpack.config.js
@@ -73,6 +73,8 @@ module.exports = (env) => {
     const isDevServerHostCheckDisabled = env.DISABLE_DEV_SERVER_HOST_CHECK === "true";
 
     const shouldCopyLessDistribution = env.SHOULD_COPY_LESS_DISTRIBUTION === "true";
+    
+    const isESLintPluginDisabled = env.DISABLE_ESLINT_PLUGIN === "true";
 
     // Log level.
     const logLevel = env.LOG_LEVEL
@@ -501,7 +503,7 @@ module.exports = (env) => {
                 test: /\.(js|css|html|svg)$/,
                 threshold: 10240
             }),
-            new ESLintPlugin({
+            !isESLintPluginDisabled && new ESLintPlugin({
                 cache: true,
                 cacheLocation: path.resolve(
                     PATHS.appNodeModules,

--- a/apps/myaccount/package.json
+++ b/apps/myaccount/package.json
@@ -23,6 +23,7 @@
         "start": "npx run-script-os",
         "start:win32": "..\\..\\node_modules\\.bin\\webpack serve --mode development --inline --hot --open --env NODE_ENV=development",
         "start:default": "../../node_modules/.bin/webpack serve --mode development --inline --hot --open --env NODE_ENV=development",
+        "start:lite": "npm run start --env DISABLE_ESLINT_PLUGIN=true",
         "start:profile": "npm run start -- --env ENABLE_BUILD_PROFILER=true",
         "start:verbose": "npm run start -- --env LOG_LEVEL=verbose",
         "test": "npx jest --passWithNoTests",

--- a/apps/myaccount/webpack.config.js
+++ b/apps/myaccount/webpack.config.js
@@ -72,6 +72,8 @@ module.exports = (env) => {
     // Dev Server Options.
     const isDevServerHostCheckDisabled = env.DISABLE_DEV_SERVER_HOST_CHECK === "true";
 
+    const isESLintPluginDisabled = env.DISABLE_ESLINT_PLUGIN === "true";
+
     // Log level.
     const logLevel = env.LOG_LEVEL
         ? env.LOG_LEVEL
@@ -476,7 +478,7 @@ module.exports = (env) => {
                 test: /\.(js|css|html|svg)$/,
                 threshold: 10240
             }),
-            new ESLintPlugin({
+            !isESLintPluginDisabled && new ESLintPlugin({
                 cache: true,
                 cacheLocation: path.resolve(
                     PATHS.appNodeModules,

--- a/modules/react-components/src/components/index.ts
+++ b/modules/react-components/src/components/index.ts
@@ -40,6 +40,7 @@ export * from "./icon";
 export * from "./input";
 export * from "./label";
 export * from "./language-switcher";
+export * from "./links";
 export * from "./list";
 export * from "./loader";
 export * from "./message";

--- a/modules/react-components/src/components/links/index.ts
+++ b/modules/react-components/src/components/links/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./link";

--- a/modules/react-components/src/components/links/link.tsx
+++ b/modules/react-components/src/components/links/link.tsx
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import classNames from "classnames";
+import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
+import { Icon, SemanticICONS } from "semantic-ui-react";
+
+/**
+ * Link component Prop types interface.
+ */
+interface LinkPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * Does the link point to an external source.
+     */
+    external?: boolean;
+    /**
+     * Icon to be displayed.
+     */
+    icon?: SemanticICONS;
+    /**
+     * Icon position.
+     */
+    iconPosition?: "left" | "right";
+    /**
+     * Documentation URL.
+     */
+    link: string;
+    /**
+     * Documentation URL target property. Opens in a new window by default.
+     */
+    target?: string;
+}
+
+/**
+ * Link component.
+ *
+ * @param {React.PropsWithChildren<LinkPropsInterface>} props - Props injected to the component.
+ * @return {React.ReactElement}
+ */
+export const Link: FunctionComponent<PropsWithChildren<LinkPropsInterface>> = (
+    props: PropsWithChildren<LinkPropsInterface>
+): ReactElement => {
+
+    const {
+        children,
+        external,
+        icon,
+        iconPosition,
+        link,
+        target
+    } = props;
+
+    const classes = classNames(
+        "link pointing",
+        {
+            external
+        }
+    );
+
+    if (!link) {
+        return null;
+    }
+
+    return (
+        <a
+            href={ link }
+            target={ target }
+            rel="noopener noreferrer"
+            className={ classes }
+        >
+            { icon && iconPosition === "left" && <Icon className="mr-1" name={ icon } /> }
+            { children }
+            { icon && iconPosition === "right" && <Icon className="ml-1" name={ icon } /> }
+        </a>
+    );
+};
+
+/**
+ * Prop types for the component.
+ */
+Link.defaultProps = {
+    "data-componentid": "link",
+    external: true,
+    icon: "external",
+    iconPosition: "right",
+    target: "_blank"
+};


### PR DESCRIPTION
### Purpose
Add reusable component to add `Hyperlinks` in the UI.

```jsx
<Link
   link={ <LINK> }
   icon="github"
   iconPosition="left"
>
    documentation
</Link>
```
### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
