### PR TITLE
Adding Compute Function to Event Publisher

### DIFF
--- a/apps/console/src/extensions/configs/analytics.ts
+++ b/apps/console/src/extensions/configs/analytics.ts
@@ -20,6 +20,7 @@ import { AnalyticsConfig } from "./models/analytics";
  
 export const analyticsConfig: AnalyticsConfig = {
     EventPublisherExtension: {
+        compute: (computation) => null,
         init: () => null,
         publish: (eventId, customProperties?) => null
     }

--- a/apps/console/src/extensions/configs/models/analytics.ts
+++ b/apps/console/src/extensions/configs/models/analytics.ts
@@ -18,6 +18,7 @@
 
 export interface AnalyticsConfig {
     EventPublisherExtension: {
+        compute: (computation: () => void) => void;
         init: () => void;
         publish: (eventId: string, customProperties?: { [key: string]: string | Record<string, unknown> }) => void;
     }

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -420,9 +420,11 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
      * @param {React.SyntheticEvent} e - Click event.
      * @param {TabProps} data - 
      */
-     const handleTabChange = (e: SyntheticEvent, data: TabProps): void => {
-        eventPublisher.publish("application-switch-edit-application-tabs", {
-            "type": data.panes[data.activeIndex].componentId
+    const handleTabChange = (e: SyntheticEvent, data: TabProps): void => {
+        eventPublisher.compute(() => {
+            eventPublisher.publish("application-switch-edit-application-tabs", {
+                "type": data.panes[data.activeIndex].componentId
+            });
         });
 
         handleActiveTabIndexChange(data.activeIndex as number);

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -321,27 +321,29 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
             setIsDefaultScript(true);
         }
 
-        const eventPublisherProperties : {
-            "script-based": boolean,
-            "step-based": Array<Record<number, string>>
-        } = {
-            "script-based": !AdaptiveScriptUtils.isDefaultScript(adaptiveScript, steps),
-            "step-based": []
-        };
-
-        updatedSteps.forEach((updatedStep) => {
-            const step : Record<number, string> = {};
-
-            if (Array.isArray(updatedStep?.options) && updatedStep.options.length > 0) {
-                updatedStep.options.forEach((element,id) => {
-                    step[id] = kebabCase(element?.authenticator);
-                });
-                eventPublisherProperties["step-based"].push(step);
-            }
-        });
-
-        eventPublisher.publish("application-sign-in-method-click-update-button", {
-            "type": eventPublisherProperties
+        eventPublisher.compute(() => {
+            const eventPublisherProperties : {
+                "script-based": boolean,
+                "step-based": Array<Record<number, string>>
+            } = {
+                "script-based": !AdaptiveScriptUtils.isDefaultScript(adaptiveScript, steps),
+                "step-based": []
+            };
+    
+            updatedSteps.forEach((updatedStep) => {
+                const step : Record<number, string> = {};
+    
+                if (Array.isArray(updatedStep?.options) && updatedStep.options.length > 0) {
+                    updatedStep.options.forEach((element,id) => {
+                        step[id] = kebabCase(element?.authenticator);
+                    });
+                    eventPublisherProperties["step-based"].push(step);
+                }
+            });
+    
+            eventPublisher.publish("application-sign-in-method-click-update-button", {
+                "type": eventPublisherProperties
+            });
         });
 
         setUpdateTrigger(true);

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
@@ -254,9 +254,11 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
      */
     const handleModalSubmit = (): void => {
 
-        selectedAuthenticators.forEach(element => {
-            eventPublisher.publish("application-sign-in-method-add-new-authenticator", {
-                "type": kebabCase(element["defaultAuthenticator"]["name"])
+        eventPublisher.compute(() => {
+            selectedAuthenticators.forEach(element => {
+                eventPublisher.publish("application-sign-in-method-add-new-authenticator", {
+                    "type": kebabCase(element["defaultAuthenticator"]["name"])
+                });
             });
         });
 

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -237,15 +237,17 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         }
         createApplication(application)
             .then((response) => {
-                if (selectedTemplate.id === CustomApplicationTemplate.id) {
-                    eventPublisher.publish("application-register-new-application", {
-                        "type": application.templateId
-                    });
-                } else {
-                    eventPublisher.publish("application-register-new-application", {
-                        "type": selectedTemplate.templateId
-                    });
-                }
+                eventPublisher.compute(() => {
+                    if (selectedTemplate.id === CustomApplicationTemplate.id) {
+                        eventPublisher.publish("application-register-new-application", {
+                            "type": application.templateId
+                        });
+                    } else {
+                        eventPublisher.publish("application-register-new-application", {
+                            "type": selectedTemplate.templateId
+                        });
+                    }
+                });
                 
                 dispatch(
                     addAlert({

--- a/apps/console/src/features/core/utils/event-publisher.ts
+++ b/apps/console/src/features/core/utils/event-publisher.ts
@@ -52,6 +52,16 @@ export class EventPublisher {
     }
 
     /**
+     * Function to perform event publisher related computations.
+     * 
+     * @param {any} computation - Computation to perform.
+    */
+    public compute = (computation: () => void): void => {
+        analyticsConfig.EventPublisherExtension.compute &&
+            analyticsConfig.EventPublisherExtension.compute(computation);
+    }
+
+    /**
      * Function to publish event logs.
      * 
      * @param {string} eventId - Publishing event identifier.

--- a/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
+++ b/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
@@ -363,7 +363,30 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                                     onEdit={ (e: MouseEvent<HTMLButtonElement>) => {
                                         // If edit flow override is defined, set the custom edit view flag to true.
                                         if (authenticatorConfig?.editFlowOverrides) {
-                                            eventPublisher.publish("connections-click-template-connect", { "type":
+                                            eventPublisher.compute(() => {
+                                                eventPublisher.publish("connections-click-template-connect", { "type":
+                                                    isIdP 
+                                                        ? AuthenticatorMeta.getAuthenticatorTemplateName(
+                                                            (authenticator as IdentityProviderInterface)
+                                                                .federatedAuthenticators?.defaultAuthenticatorId)
+                                                            ? AuthenticatorMeta.getAuthenticatorTemplateName(
+                                                                (authenticator as IdentityProviderInterface)
+                                                                    .federatedAuthenticators?.defaultAuthenticatorId) 
+                                                            : "other"
+                                                        : AuthenticatorMeta
+                                                            .getAuthenticatorTemplateName(authenticator.id)
+                                                            ? AuthenticatorMeta
+                                                                .getAuthenticatorTemplateName(authenticator.id) 
+                                                            : ""
+                                                });
+                                            });
+
+                                            setShowCustomEditView(true);
+                                            return;
+                                        }
+
+                                        eventPublisher.compute(() => {
+                                            eventPublisher.publish("connections-click-template-setup", { "type":
                                                 isIdP 
                                                     ? AuthenticatorMeta.getAuthenticatorTemplateName(
                                                         (authenticator as IdentityProviderInterface)
@@ -373,27 +396,10 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                                                                 .federatedAuthenticators?.defaultAuthenticatorId) 
                                                         : "other"
                                                     : AuthenticatorMeta.getAuthenticatorTemplateName(authenticator.id)
-                                                        ? AuthenticatorMeta
-                                                            .getAuthenticatorTemplateName(authenticator.id) 
+                                                        ? AuthenticatorMeta.
+                                                            getAuthenticatorTemplateName(authenticator.id) 
                                                         : ""
                                             });
-
-                                            setShowCustomEditView(true);
-                                            return;
-                                        }
-
-                                        eventPublisher.publish("connections-click-template-setup", { "type":
-                                            isIdP 
-                                                ? AuthenticatorMeta.getAuthenticatorTemplateName(
-                                                    (authenticator as IdentityProviderInterface)
-                                                        .federatedAuthenticators?.defaultAuthenticatorId)
-                                                    ? AuthenticatorMeta.getAuthenticatorTemplateName(
-                                                        (authenticator as IdentityProviderInterface)
-                                                            .federatedAuthenticators?.defaultAuthenticatorId) 
-                                                    : "other"
-                                                : AuthenticatorMeta.getAuthenticatorTemplateName(authenticator.id)
-                                                    ? AuthenticatorMeta.getAuthenticatorTemplateName(authenticator.id) 
-                                                    : ""
                                         });
 
                                         handleGridItemOnClick(e, authenticator);

--- a/apps/myaccount/src/extensions/configs/analytics.ts
+++ b/apps/myaccount/src/extensions/configs/analytics.ts
@@ -20,6 +20,7 @@ import { AnalyticsConfig } from "./models/analytics";
   
 export const analyticsConfig: AnalyticsConfig = {
     EventPublisherExtension: {
+        compute: (computation) => null,
         init: () => null,
         publish: (eventId, customProperties?) => null
     }

--- a/apps/myaccount/src/extensions/configs/models/analytics.ts
+++ b/apps/myaccount/src/extensions/configs/models/analytics.ts
@@ -18,6 +18,7 @@
 
 export interface AnalyticsConfig {
     EventPublisherExtension: {
+        compute: (computation: () => void) => void;
         init: () => void;
         publish: (eventId: string, customProperties?: { [key: string]: string | Record<string, unknown> }) => void;
     }

--- a/apps/myaccount/src/utils/event-publisher.ts
+++ b/apps/myaccount/src/utils/event-publisher.ts
@@ -53,6 +53,16 @@ export class EventPublisher {
     }
 
     /**
+     * Function to perform event publisher related computations.
+     * 
+     * @param {any} computation - Computation to perform.
+    */
+    public compute = (computation: () => void): void => {
+        analyticsConfig.EventPublisherExtension.compute &&
+            analyticsConfig.EventPublisherExtension.compute(computation);
+    }
+
+    /**
      * Function to publish event logs.
      * 
      * @param {string} eventId - Publishing event identifier.


### PR DESCRIPTION
### Purpose
As for the current implementation, event publishing related computations are performed nevertheless event publishing is enabled or disabled. But for few cases there may be some sort of computation (i.e. might have to perform a set of if-else conditions or loop through an array) which could impact the overall browser performance. But these computations should not perform when the event publishing is being disabled (i.e. in on-prem setups).

### Related Issues
- https://github.com/wso2/product-is/issues/12507

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
