### PR TITLE
Make error message displayed when deleting a custom attribute visible 

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -159,6 +159,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         || t("console:manage.features.claims.local.notifications.deleteClaim.genericError.message")
                 }
             ));
+        }).finally(() => {
+            setConfirmDelete(false);
         });
     };
 


### PR DESCRIPTION
### Purpose
> Fix: Error alert displayed during deleting a custom attribute is not visible and it is overlapped with delete confirmation modal. 

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
