### PR TITLE
Add ACS URL in SAML IdP configuration

### DIFF
--- a/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
@@ -277,7 +277,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                 ariaLabel={ t(`${ I18N_TARGET_KEY }.AuthRedirectUrl.ariaLabel`) }
                 data-testid={ `${ testId }-authorized-redirect-url` }
                 label={ (
-                    <FormInputLabel htmlFor="IdPEntityId" disabled={ true }>
+                    <FormInputLabel htmlFor="AuthRedirectUrl" disabled={ true }>
                         { t(`${ I18N_TARGET_KEY }.AuthRedirectUrl.label`) }
                     </FormInputLabel>
                 ) }

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
@@ -38,6 +38,7 @@ import {
     getDigestAlgorithmOptionsMapped,
     getSignatureAlgorithmOptionsMapped,
     hasLength,
+    IDENTITY_PROVIDER_AUTHORIZED_REDIRECT_URL_LENGTH,
     IDENTITY_PROVIDER_ENTITY_ID_LENGTH,
     isUrl,
     LOGOUT_URL_LENGTH,
@@ -64,6 +65,7 @@ interface SamlSettingsFormPropsInterface extends TestableComponentInterface {
 }
 
 export interface SamlPropertiesInterface {
+    AuthRedirectUrl?: string;
     DigestAlgorithm?: string;
     IdPEntityId?: string;
     LogoutReqUrl?: string;
@@ -109,6 +111,8 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
     const [ isUserIdInClaims, setIsUserIdInClaims ] = useState<boolean>(false);
     const [ isLogoutEnabled, setIsLogoutEnabled ] = useState<boolean>(false);
 
+    const authorizedRedirectURL: string = config?.deployment?.serverHost + "/commonauth" ;
+
     /**
      * ISAuthnReqSigned, IsLogoutReqSigned these two fields states will be used by other
      * fields states. Basically, algorithms fields enable and disable states will be
@@ -128,6 +132,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
         const [ findPropVal, findMeta ] = fastSearch(authenticator);
 
         return {
+            AuthRedirectUrl: findPropVal<string>({ defaultValue: authorizedRedirectURL, key: "AuthRedirectUrl" }),
             DigestAlgorithm: findPropVal<string>({ defaultValue: "SHA1", key: "DigestAlgorithm" }),
             IdPEntityId: findPropVal<string>({ defaultValue: "", key: "IdPEntityId" }),
             NameIDType: findPropVal<string>({
@@ -259,6 +264,26 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                     hasLength(SSO_URL_LENGTH)
                 ) }
                 hint={ t(`${ I18N_TARGET_KEY }.SSOUrl.hint`, {
+                    productName: config.ui.productName
+                }) }
+                readOnly={ readOnly }
+            />
+
+            <Field.Input
+                name="AuthRedirectUrl"
+                value={ formValues?.AuthRedirectUrl }
+                inputType="copy_input"
+                placeholder={ t(`${ I18N_TARGET_KEY }.AuthRedirectUrl.placeholder`) }
+                ariaLabel={ t(`${ I18N_TARGET_KEY }.AuthRedirectUrl.ariaLabel`) }
+                data-testid={ `${ testId }-authorized-redirect-url` }
+                label={ (
+                    <FormInputLabel htmlFor="IdPEntityId" disabled={ true }>
+                        { t(`${ I18N_TARGET_KEY }.AuthRedirectUrl.label`) }
+                    </FormInputLabel>
+                ) }
+                maxLength={ IDENTITY_PROVIDER_AUTHORIZED_REDIRECT_URL_LENGTH.max }
+                minLength={ IDENTITY_PROVIDER_AUTHORIZED_REDIRECT_URL_LENGTH.min }
+                hint={ t(`${ I18N_TARGET_KEY }.AuthRedirectUrl.hint`, {
                     productName: config.ui.productName
                 }) }
                 readOnly={ readOnly }

--- a/apps/console/src/features/identity-providers/components/utils/saml-idp-utils.ts
+++ b/apps/console/src/features/identity-providers/components/utils/saml-idp-utils.ts
@@ -274,6 +274,7 @@ export const SSO_URL_LENGTH: MinMaxLength = { max: 2048, min: 10 };
 export const LOGOUT_URL_LENGTH: MinMaxLength = { max: 2048, min: 10 };
 export const IDENTITY_PROVIDER_ENTITY_ID_LENGTH: MinMaxLength = { max: 2048, min: 5 };
 export const IDENTITY_PROVIDER_NAME_LENGTH: MinMaxLength = { max: 120, min: 3 };
+export const IDENTITY_PROVIDER_AUTHORIZED_REDIRECT_URL_LENGTH: MinMaxLength = { max: 2048, min: 10 };
 
 /**
  * Given a {@link FormErrors} object, it will check whether

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -545,28 +545,6 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                             placeholder={ "Enter SAML 2.0 entity id (saml issuer)" }
                             data-testid={ `${ testId }-form-wizard-saml-idp-entity-id` }
                         />
-                        <Field.Dropdown
-                            ariaLabel="Name ID format"
-                            name="NameIDType"
-                            label="Name ID format"
-                            required={ true }
-                            width={ 15 }
-                            options={ getAvailableNameIDFormats() }
-                            value={ initialValues.NameIDType }
-                            placeholder="Select an available name identifier"
-                            data-testid={ `${ testId }-form-wizard-saml-nameid-format` }
-                        />
-                        <Field.Dropdown
-                            ariaLabel="SAML 2.0 protocol binding"
-                            name="RequestMethod"
-                            label="SAML 2.0 protocol binding"
-                            required={ true }
-                            options={ getAvailableProtocolBindingTypes() }
-                            width={ 15 }
-                            value={ initialValues.RequestMethod }
-                            placeholder={ "Select mode of protocol binding" }
-                            data-testid={ `${ testId }-form-wizard-saml-protocol-binding` }
-                        />
                     </div>
                 )
                 : (

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-file-based-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-file-based-help.tsx
@@ -17,7 +17,7 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Code, CopyInputField, Heading, useDocumentation } from "@wso2is/react-components";
+import { Code, CopyInputField, DocumentationLink, Heading, useDocumentation } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -66,20 +66,18 @@ const SAMLIdPWizardFileBasedHelp: FunctionComponent<Props> = (props: Props): Rea
                             productName: config.ui.productName
                         })
                     }
-                    <br/>
-                    <br/>
-                    { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined ?
-                        null :
-                        <a
-                            href={ getLink("develop.connections.newConnection.enterprise.samlLearnMore") }
-                            target="_blank"
-                            rel="noopener noreferrer">
-                            {
-                                t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
-                                    "preRequisites.configureIdp")
-                            }
-                        </a>
+                    { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined
+                        ? null
+                        : <Divider hidden/>
                     }
+                    <DocumentationLink
+                        link={ getLink("develop.connections.newConnection.enterprise.samlLearnMore") }
+                    >
+                        {
+                            t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                                "preRequisites.configureIdp")
+                        }
+                    </DocumentationLink>
                 </p>
             </Message>
             <Heading as="h5">Service provider entity ID</Heading>

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-file-based-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-file-based-help.tsx
@@ -21,7 +21,7 @@ import { Code, CopyInputField, Heading, useDocumentation } from "@wso2is/react-c
 import React, { FunctionComponent, ReactElement } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Divider, Message } from "semantic-ui-react";
+import { Divider, Icon, Message } from "semantic-ui-react";
 import { AppState, ConfigReducerStateInterface } from "../../../../../core";
 
 /**
@@ -46,12 +46,6 @@ const SAMLIdPWizardFileBasedHelp: FunctionComponent<Props> = (props: Props): Rea
     return (
         <div data-testid={ testId }>
             <Message info>
-                <Heading as="h5" className="mb-3">
-                    {
-                        t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
-                            "preRequisites.heading")
-                    }
-                </Heading>
                 <p>
 
                     <Trans
@@ -66,7 +60,15 @@ const SAMLIdPWizardFileBasedHelp: FunctionComponent<Props> = (props: Props): Rea
                         className="copy-input-dark spaced"
                         value={ config?.deployment?.serverHost + "/commonauth" }
                     />
-                    
+                    <Icon name="info circle" />
+                    {
+                        t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                            "preRequisites.hint", {
+                            productName: config.ui.productName
+                        })
+                    }
+                    <br/>
+                    <br/>
                     { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined ?
                         null :
                         <a
@@ -78,7 +80,7 @@ const SAMLIdPWizardFileBasedHelp: FunctionComponent<Props> = (props: Props): Rea
                                     "preRequisites.configureIdp")
                             }
                         </a>
-                }
+                    }
                 </p>
             </Message>
             <Heading as="h5">Service provider entity ID</Heading>

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-file-based-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-file-based-help.tsx
@@ -17,11 +17,12 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Code, Heading } from "@wso2is/react-components";
+import { Code, CopyInputField, Heading, useDocumentation } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
-import { AppState, ConfigReducerStateInterface } from "../../../../../core";
+import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Divider } from "semantic-ui-react";
+import { Divider, Message } from "semantic-ui-react";
+import { AppState, ConfigReducerStateInterface } from "../../../../../core";
 
 /**
  * No component specific props. Hence unnecessary
@@ -39,8 +40,47 @@ const SAMLIdPWizardFileBasedHelp: FunctionComponent<Props> = (props: Props): Rea
     const { [ "data-testid" ]: testId } = props;
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
+    const { t } = useTranslation();
+    const { getLink } = useDocumentation();
+
     return (
         <div data-testid={ testId }>
+            <Message info>
+                <Heading as="h5" className="mb-3">
+                    {
+                        t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                            "preRequisites.heading")
+                    }
+                </Heading>
+                <p>
+
+                    <Trans
+                        i18nKey={
+                            "console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                            "preRequisites.configureRedirectURL"
+                        }
+                    >
+                        Use the following URL as the <strong>Authorized Redirect URI</strong>.
+                    </Trans>
+                    <CopyInputField
+                        className="copy-input-dark spaced"
+                        value={ config?.deployment?.serverHost + "/commonauth" }
+                    />
+                    
+                    { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined ?
+                        null :
+                        <a
+                            href={ getLink("develop.connections.newConnection.enterprise.samlLearnMore") }
+                            target="_blank"
+                            rel="noopener noreferrer">
+                            {
+                                t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                                    "preRequisites.configureIdp")
+                            }
+                        </a>
+                }
+                </p>
+            </Message>
             <Heading as="h5">Service provider entity ID</Heading>
             <p>
                 This value will be used as the <Code>&lt;saml2:Issuer&gt;</Code> in the SAML requests initiated from

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-file-based-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-file-based-help.tsx
@@ -47,7 +47,6 @@ const SAMLIdPWizardFileBasedHelp: FunctionComponent<Props> = (props: Props): Rea
         <div data-testid={ testId }>
             <Message info>
                 <p>
-
                     <Trans
                         i18nKey={
                             "console:develop.features.authenticationProvider.templates.enterprise.saml." +

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
@@ -17,7 +17,7 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Code, CopyInputField, Heading, useDocumentation } from "@wso2is/react-components";
+import { Code, CopyInputField, DocumentationLink, Heading, useDocumentation } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -63,20 +63,18 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
                             productName: config.ui.productName
                         })
                     }
-                    <br/>
-                    <br/>
-                    { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined ?
-                        null :
-                        <a
-                            href={ getLink("develop.connections.newConnection.enterprise.samlLearnMore") }
-                            target="_blank"
-                            rel="noopener noreferrer">
-                            {
-                                t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
-                                    "preRequisites.configureIdp")
-                            }
-                        </a>
+                    { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined
+                        ? null
+                        : <Divider hidden/>
                     }
+                    <DocumentationLink
+                        link={ getLink("develop.connections.newConnection.enterprise.samlLearnMore") }
+                    >
+                        {
+                            t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                                "preRequisites.configureIdp")
+                        }
+                    </DocumentationLink>
                 </p>
             </Message>
             <Heading as="h5">Service provider entity ID</Heading>

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
@@ -21,7 +21,7 @@ import { Code, CopyInputField, Heading, useDocumentation } from "@wso2is/react-c
 import React, { FunctionComponent, ReactElement } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Divider, Message } from "semantic-ui-react";
+import { Divider, Icon, Message } from "semantic-ui-react";
 import { AppState, ConfigReducerStateInterface } from "../../../../../core";
 
 type Props = TestableComponentInterface;
@@ -43,12 +43,6 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
     return (
         <div data-testid={ testId }>
             <Message info>
-                <Heading as="h5" className="mb-3">
-                    {
-                        t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
-                            "preRequisites.heading")
-                    }
-                </Heading>
                 <p>
 
                     <Trans
@@ -63,7 +57,15 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
                         className="copy-input-dark spaced"
                         value={ config?.deployment?.serverHost + "/commonauth" }
                     />
-                    
+                    <Icon name="info circle" />
+                    {
+                        t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                            "preRequisites.hint", {
+                            productName: config.ui.productName
+                        })
+                    }
+                    <br/>
+                    <br/>
                     { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined ?
                         null :
                         <a
@@ -75,7 +77,7 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
                                     "preRequisites.configureIdp")
                             }
                         </a>
-                }
+                    }
                 </p>
             </Message>
             <Heading as="h5">Service provider entity ID</Heading>
@@ -99,17 +101,6 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
                 organization.
             </p>
             <p>E.g., https://ENTERPRISE_DOMAIN</p>
-            <Divider/>
-            <Heading as="h5">Name ID format</Heading>
-            <p>
-                This specifies the name identifier format that is used to exchange information regarding the user
-                in the SAML assertion sent from the external IdP.
-            </p>
-            <Divider/>
-            <Heading as="h5">Protocol binding</Heading>
-            <p>
-                This specifies the mechanisms to transport SAML messages in communication protocols.
-            </p>
         </div>
     );
 

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
@@ -17,10 +17,11 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Code, Heading } from "@wso2is/react-components";
+import { Code, CopyInputField, Heading, useDocumentation } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
+import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Divider } from "semantic-ui-react";
+import { Divider, Message } from "semantic-ui-react";
 import { AppState, ConfigReducerStateInterface } from "../../../../../core";
 
 type Props = TestableComponentInterface;
@@ -36,8 +37,47 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
 
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
+    const { t } = useTranslation();
+    const { getLink } = useDocumentation();
+
     return (
         <div data-testid={ testId }>
+            <Message info>
+                <Heading as="h5" className="mb-3">
+                    {
+                        t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                            "preRequisites.heading")
+                    }
+                </Heading>
+                <p>
+
+                    <Trans
+                        i18nKey={
+                            "console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                            "preRequisites.configureRedirectURL"
+                        }
+                    >
+                        Use the following URL as the <strong>Authorized Redirect URI</strong>.
+                    </Trans>
+                    <CopyInputField
+                        className="copy-input-dark spaced"
+                        value={ config?.deployment?.serverHost + "/commonauth" }
+                    />
+                    
+                    { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined ?
+                        null :
+                        <a
+                            href={ getLink("develop.connections.newConnection.enterprise.samlLearnMore") }
+                            target="_blank"
+                            rel="noopener noreferrer">
+                            {
+                                t("console:develop.features.authenticationProvider.templates.enterprise.saml." +
+                                    "preRequisites.configureIdp")
+                            }
+                        </a>
+                }
+                </p>
+            </Message>
             <Heading as="h5">Service provider entity ID</Heading>
             <p>
                 This value will be used as the <Code>&lt;saml2:Issuer&gt;</Code> in the SAML requests initiated from

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/saml-identity-provider/saml-idp-wizard-help.tsx
@@ -44,7 +44,6 @@ const SamlIDPWizardHelp: FunctionComponent<Props> = (props: Props): ReactElement
         <div data-testid={ testId }>
             <Message info>
                 <p>
-
                     <Trans
                         i18nKey={
                             "console:develop.features.authenticationProvider.templates.enterprise.saml." +

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1238,6 +1238,7 @@ export interface ConsoleNS {
                             };
                         };
                         saml: {
+                            AuthRedirectUrl: FormAttributes,
                             SPEntityId: FormAttributes;
                             SSOUrl: FormAttributes;
                             IdPEntityId: FormAttributes;
@@ -1420,6 +1421,13 @@ export interface ConsoleNS {
                         }
                     };
                     enterprise?: {
+                        saml?: {
+                            preRequisites: {
+                                configureIdp: string;
+                                configureRedirectURL: string;
+                                heading: string;
+                            }
+                        }
                         validation: {
                             name: string;
                             invalidName: string;

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1426,6 +1426,7 @@ export interface ConsoleNS {
                                 configureIdp: string;
                                 configureRedirectURL: string;
                                 heading: string;
+                                hint: string;
                             }
                         }
                         validation: {

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1238,7 +1238,7 @@ export interface ConsoleNS {
                             };
                         };
                         saml: {
-                            AuthRedirectUrl: FormAttributes,
+                            AuthRedirectUrl: FormAttributes;
                             SPEntityId: FormAttributes;
                             SSOUrl: FormAttributes;
                             IdPEntityId: FormAttributes;

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1427,8 +1427,8 @@ export interface ConsoleNS {
                                 configureRedirectURL: string;
                                 heading: string;
                                 hint: string;
-                            }
-                        }
+                            };
+                        };
                         validation: {
                             name: string;
                             invalidName: string;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -3085,6 +3085,14 @@ export const console: ConsoleNS = {
                             }
                         },
                         saml: {
+                            AuthRedirectUrl: {
+                                ariaLabel: "SAML authorized redirect URL",
+                                hint: "The {{productName}} URL to which the user needs to be redirected after" +
+                                    " completing the authentication at the identity provider. The identity provider" +
+                                    " needs to send the authorization code to this URL upon successful authentication.",
+                                label: "Authorized Redirect URL",
+                                placeholder: "Authorized Redirect URL"
+                            },
                             SPEntityId: {
                                 placeholder: "Enter service provider entity ID",
                                 ariaLabel: "Service provider entity ID",
@@ -3878,6 +3886,20 @@ export const console: ConsoleNS = {
                     }
                 },
                 templates: {
+                    enterprise: {
+                        saml: {
+                            preRequisites: {
+                                configureIdp: "See Asgardeo guide on configuring SAML IdP.",
+                                configureRedirectURL: "Use the following URL as the <1>Authorized Redirect URI</1>.",
+                                heading: "Prerequisite"
+                            }
+                        },
+                        validation: {
+                            invalidName: "{{idpName}} is not a valid name. It should not contain any other" +
+                                " alphanumerics except for periods (.), dashes (-), underscores (_) and spaces.",
+                            name: "Please enter a valid name"
+                        }
+                    },
                     facebook: {
                         wizardHelp: {
                             clientId: {
@@ -3892,9 +3914,9 @@ export const console: ConsoleNS = {
                             },
                             heading: "Help",
                             name: {
-                                idpDescription: "Provide a unique name for the identity provider.",
                                 connectionDescription: "Provide a unique name for the connection.",
-                                heading: "Name"
+                                heading: "Name",
+                                idpDescription: "Provide a unique name for the identity provider."
                             },
                             preRequisites: {
                                 configureOAuthApps: "See Facebooks's guide on configuring apps.",
@@ -3971,13 +3993,6 @@ export const console: ConsoleNS = {
                     quickSetup: {
                         heading: "Quick Setup",
                         subHeading: "Predefined set of templates to speed up your identity provider creation."
-                    },
-                    enterprise: {
-                        validation: {
-                            name: "Please enter a valid name",
-                            invalidName: "{{idpName}} is not a valid name. It should not contain any other" +
-                                " alphanumerics except for periods (.), dashes (-), underscores (_) and spaces."
-                        }
                     }
                 },
                 wizards: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -3086,12 +3086,12 @@ export const console: ConsoleNS = {
                         },
                         saml: {
                             AuthRedirectUrl: {
-                                ariaLabel: "SAML authorized redirect URL",
-                                hint: "The {{productName}} URL to which the user needs to be redirected after" +
-                                    " completing the authentication at the identity provider. The identity provider" +
-                                    " needs to send the authorization code to this URL upon successful authentication.",
-                                label: "Authorized Redirect URL",
-                                placeholder: "Authorized Redirect URL"
+                                ariaLabel: "SAML assertion consumer service URL",
+                                hint: "The Assertion Consumer Service (ACS) URL determines where" +
+                                    " {{productName}} expects the external identity provider to send the" + 
+                                    " SAML response.",
+                                label: "Assertion Consumer Service (ACS) URL",
+                                placeholder: "Assertion Consumer Service (ACS) URL"
                             },
                             SPEntityId: {
                                 placeholder: "Enter service provider entity ID",
@@ -3121,16 +3121,16 @@ export const console: ConsoleNS = {
                                 placeholder: "Select identity provider NameIDFormat",
                                 ariaLabel: "Choose NameIDFormat for SAML 2.0 assertion",
                                 label: "Identity provider NameID format",
-                                hint: "Name ID defines the name identifier formats supported by the external " +
-                                    "IdP. Name identifier is how {{productName}} communicates with" +
-                                    " external IdP regarding a user."
+                                hint: "This specifies the name identifier format that is used to " +
+                                    "exchange information regarding the user in the SAML " +
+                                    "assertion sent from the external IdP."
                             },
                             RequestMethod: {
                                 placeholder: "Select HTTP protocol binding",
                                 ariaLabel: "HTTP protocol for SAML 2.0 bindings",
                                 label: "HTTP protocol binding",
-                                hint: "Protocol binding to use when sending requests. HTTP redirect for simple" +
-                                    " requests or HTTP POST if requests are signed, which is recommended."
+                                hint: "This specifies the mechanisms to transport SAML" +
+                                " messages in communication protocols."
                             },
                             IsSLORequestAccepted: {
                                 ariaLabel: "Specify whether logout is enabled for IdP",
@@ -3890,8 +3890,12 @@ export const console: ConsoleNS = {
                         saml: {
                             preRequisites: {
                                 configureIdp: "See Asgardeo guide on configuring SAML IdP.",
-                                configureRedirectURL: "Use the following URL as the <1>Authorized Redirect URI</1>.",
-                                heading: "Prerequisite"
+                                configureRedirectURL: "Use the following URL as the " + 
+                                    "<1>Assertion Consumer Service (ACS) URL</1>.",
+                                heading: "Prerequisite",
+                                hint: "The Assertion Consumer Service (ACS) URL determines" +
+                                    " where {{productName}} expects the external identity" + 
+                                    " provider to send the SAML response."
                             }
                         },
                         validation: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -3889,7 +3889,7 @@ export const console: ConsoleNS = {
                     enterprise: {
                         saml: {
                             preRequisites: {
-                                configureIdp: "See Asgardeo guide on configuring SAML IdP.",
+                                configureIdp: "See Asgardeo guide on configuring SAML IdP",
                                 configureRedirectURL: "Use the following URL as the " + 
                                     "<1>Assertion Consumer Service (ACS) URL</1>.",
                                 heading: "Prerequisite",


### PR DESCRIPTION
### Purpose
This PR will allow the console to display authorized redirect URL in SAML IdP configuration similar to that of OIDC configuration. It is visible to the user in two places.

**SAML IdP connection creation wizard**
<img width="1438" alt="Screenshot 2021-09-14 at 20 13 12" src="https://user-images.githubusercontent.com/42619922/133279409-d879f9c8-35a8-4238-aa4e-7c11ce1cf118.png">

**SAML IdP settings page**
<img width="1438" alt="Screenshot 2021-09-14 at 20 15 33" src="https://user-images.githubusercontent.com/42619922/133279727-da6f742f-7e7c-4aeb-ace8-3dc7e0505d2a.png">

### Related Issues
- None

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
