### PR TITLE
Fix duplicated success message in SAML IdP attributes

### DIFF
--- a/apps/console/src/features/identity-providers/components/utils/attribute-settings-utils.tsx
+++ b/apps/console/src/features/identity-providers/components/utils/attribute-settings-utils.tsx
@@ -163,58 +163,58 @@ export const initSubjectAndRoleURIs = (initialClaims, setSubjectClaimUri, setRol
 export const handleAttributeSettingsFormSubmit = (idpId: string, values: IdentityProviderClaimsInterface,
                                                   roleMapping: IdentityProviderRoleMappingInterface[],
                                                   onUpdate: (idpId: string) => void): void => {
-    updateClaimsConfigs(idpId, values)
-        .then(() => {
-            store.dispatch(addAlert({
-                description: I18n.instance.t("console:develop.features.authenticationProvider.notifications." +
-                    "updateClaimsConfigs.success.description"),
-                level: AlertLevels.SUCCESS,
-                message: I18n.instance.t("console:develop.features.authenticationProvider." +
-                    "notifications.updateClaimsConfigs." +
-                    "success.message")
-            }));
-            onUpdate(idpId);
-        })
-        .catch((error) => {
-            if (error.response && error.response.data && error.response.data.description) {
+    
+    Promise.all([
+        new Promise<void>((resolve, reject) => updateClaimsConfigs(idpId, values)
+            .then(() => {
+                onUpdate(idpId);
+                resolve();
+            })
+            .catch((error) => {
+                if (error.response && error.response.data && error.response.data.description) {
+                    store.dispatch(addAlert({
+                        description: I18n.instance.t("console:develop.features.authenticationProvider.notifications." +
+                            "updateClaimsConfigs.error.description",
+                            { description: error.response.data.description }),
+                        level: AlertLevels.ERROR,
+                        message: I18n.instance.t("console:develop.features.authenticationProvider" +
+                            ".notifications.updateClaimsConfigs." +
+                            "error.message")
+                    }));
+                }
+
                 store.dispatch(addAlert({
                     description: I18n.instance.t("console:develop.features.authenticationProvider.notifications." +
-                        "updateClaimsConfigs.error.description",
-                        { description: error.response.data.description }),
+                        "updateClaimsConfigs.genericError.description"),
                     level: AlertLevels.ERROR,
-                    message: I18n.instance.t("console:develop.features.authenticationProvider" +
-                        ".notifications.updateClaimsConfigs." +
-                        "error.message")
+                    message: I18n.instance.t("console:develop.features.authenticationProvider.notifications." +
+                        "updateClaimsConfigs.genericError.message")
                 }));
-            }
-
-            store.dispatch(addAlert({
-                description: I18n.instance.t("console:develop.features.authenticationProvider.notifications." +
-                    "updateClaimsConfigs.genericError.description"),
-                level: AlertLevels.ERROR,
-                message: I18n.instance.t("console:develop.features.authenticationProvider.notifications." +
-                    "updateClaimsConfigs.genericError.message")
-            }));
-        });
-
-    updateIDPRoleMappings(idpId, {
-            mappings: roleMapping,
-            outboundProvisioningRoles: [""]
-        } as IdentityProviderRolesInterface
-    ).then(() => {
-        store.dispatch(addAlert(
-            {
-                description: I18n.instance.t("console:develop.features.authenticationProvider.notifications." +
-                    "updateIDPRoleMappings.success.description"),
-                level: AlertLevels.SUCCESS,
-                message: I18n.instance.t("console:develop.features.authenticationProvider" +
-                    ".notifications.updateIDPRoleMappings" +
-                    ".success.message")
-            }
-        ));
-        onUpdate(idpId);
-    }).catch(error => {
-        handleUpdateIDPRoleMappingsError(error);
+                reject();
+            })
+        ),
+        new Promise<void>((resolve, reject) => updateIDPRoleMappings(idpId, {
+                    mappings: roleMapping,
+                    outboundProvisioningRoles: [""]
+                } as IdentityProviderRolesInterface
+            ).then(() => {
+                onUpdate(idpId);
+                resolve();
+            }).catch(error => {
+                handleUpdateIDPRoleMappingsError(error);
+                reject();
+            })
+        )
+    ]).then(() => {
+        // Show single alert message when both requests are successfully completed.
+        store.dispatch(addAlert({
+            description: I18n.instance.t("console:develop.features.authenticationProvider.notifications." +
+                "updateAttributes.success.description"),
+            level: AlertLevels.SUCCESS,
+            message: I18n.instance.t("console:develop.features.authenticationProvider." +
+                "notifications.updateAttributes." +
+                "success.message")
+        }));
     });
 };
 

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1495,6 +1495,7 @@ export interface ConsoleNS {
                     submitAttributeSettings: Notification;
                     deleteDefaultAuthenticator: Notification;
                     deleteDefaultConnector: Notification;
+                    updateAttributes: Notification;
                     updateClaimsConfigs: Notification;
                     updateFederatedAuthenticator: Notification;
                     updateFederatedAuthenticators: Notification;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -3677,6 +3677,20 @@ export const console: ConsoleNS = {
                             message: ""
                         }
                     },
+                    updateAttributes: {
+                        error: {
+                            description: "{{ description }}",
+                            message: "Update error"
+                        },
+                        genericError: {
+                            description: "An error occurred while updating Identity Provider attributes.",
+                            message: "Update error"
+                        },
+                        success: {
+                            description: "Successfully updated Identity Provider attributes.",
+                            message: "Update successful"
+                        }
+                    },
                     updateClaimsConfigs: {
                         error: {
                             description: "{{ description }}",

--- a/modules/react-components/src/components/documentation/documentation-link.tsx
+++ b/modules/react-components/src/components/documentation/documentation-link.tsx
@@ -60,14 +60,14 @@ export const DocumentationLink: FunctionComponent<PropsWithChildren<Documentatio
         return null;
     }
 
-    const classes = classNames("documentation-link", className);
+    const classes = classNames("documentation-link ml-1 link external no-wrap", className);
 
     return (
         <a
             href={ link }
             target={ target }
             rel="noopener noreferrer"
-            className="ml-1 link external no-wrap"
+            className={ classes }
         >
             { children }
             <Icon className="ml-1" name="external alternate"/>

--- a/modules/react-components/src/components/documentation/documentation-link.tsx
+++ b/modules/react-components/src/components/documentation/documentation-link.tsx
@@ -54,17 +54,15 @@ export const DocumentationLink: FunctionComponent<PropsWithChildren<Documentatio
     }
 
     return (
-        <strong>
-            <a
-                href={ link }
-                target={ target }
-                rel="noopener noreferrer"
-                className="ml-1 link external no-wrap"
-            >
-                { children }
-                <Icon className="ml-1" name="external alternate"/>
-            </a>
-        </strong>
+        <a
+            href={ link }
+            target={ target }
+            rel="noopener noreferrer"
+            className="ml-1 link external no-wrap"
+        >
+            { children }
+            <Icon className="ml-1" name="external alternate"/>
+        </a>
     );
 };
 


### PR DESCRIPTION
### Purpose
This PR will fix the appearance of two success texts when the Attributes section of the SAML IdPs are updated successfully. Now it will return one common success text when the Attributes are updated.

**Before Fix:**
<img width="1438" alt="Screenshot 2021-09-16 at 16 48 06" src="https://user-images.githubusercontent.com/42619922/133603004-9abf6948-07cf-4247-92d9-8d78c317e756.png">

**After Fix:**
<img width="1438" alt="Screenshot 2021-09-16 at 16 47 45" src="https://user-images.githubusercontent.com/42619922/133603012-d2bef811-00e3-4991-a531-0328d8aaa8f7.png">

### Related Issues
- None

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
