### PR TITLE
Change the behaviour of the subject attribute dropdown for SAML IdPs

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/uri-attributes-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/uri-attributes-settings.tsx
@@ -17,7 +17,7 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Heading, Hint } from "@wso2is/react-components";
+import { Code, Heading, Hint } from "@wso2is/react-components";
 import find from "lodash-es/find";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
@@ -34,6 +34,10 @@ interface AdvanceAttributeSettingsPropsInterface extends TestableComponentInterf
      * this {@code false}.
      */
     claimMappingOn: boolean;
+    /**
+     * Specifies if the IdP Attribute Mappings are available.
+     */  
+    isMappingEmpty: boolean;
     updateRole: (roleUri: string) => void;
     updateSubject: (subjectUri: string) => void;
     roleError?: boolean;
@@ -58,6 +62,7 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
         roleError,
         subjectError,
         isReadOnly,
+        isMappingEmpty,
         [ "data-testid" ]: testId
     } = props;
 
@@ -109,11 +114,14 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
                                 pointing: "above"
                             } }
                             readOnly={ isReadOnly }
-                            disabled={ !claimMappingOn }
+                            disabled={ isMappingEmpty }
                         />
                     </Form>
                     <Hint>
-                        { t("console:develop.features.authenticationProvider.forms.uriAttributeSettings.subject.hint") }
+                        The attribute that identifies the user at the enterprise identity provider. 
+                        When attributes are configured based on the authentication response of this IdP connection, 
+                        you can use one of them as the subject. Otherwise, the default <Code>SAML:Subject</Code> in 
+                        the SAML response is used as the subject attribute.
                     </Hint>
                 </Grid.Column>
             </Grid.Row>

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/uri-attributes-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/uri-attributes-settings.tsx
@@ -78,9 +78,16 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
                     <Divider hidden/>
                     <Form>
                         <Form.Select
-                            required
                             fluid
-                            options={ dropDownOptions }
+                            options={ 
+                                dropDownOptions.concat(
+                                    {
+                                        key: "default_subject",
+                                        text: "Default Subject",
+                                        value: ""
+                                    } as DropdownOptionsInterface 
+                                )
+                            }
                             value={ getValidatedInitialValue(initialSubjectUri) }
                             placeholder={ t("console:develop.features.authenticationProvider.forms." +
                                 "uriAttributeSettings.subject." +
@@ -102,6 +109,7 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
                                 pointing: "above"
                             } }
                             readOnly={ isReadOnly }
+                            disabled={ !claimMappingOn }
                         />
                     </Form>
                     <Hint>

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/uri-attributes-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/uri-attributes-settings.tsx
@@ -20,7 +20,7 @@ import { TestableComponentInterface } from "@wso2is/core/models";
 import { Code, Heading, Hint } from "@wso2is/react-components";
 import find from "lodash-es/find";
 import React, { FunctionComponent, ReactElement } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { Divider, Form, Grid } from "semantic-ui-react";
 import { DropdownOptionsInterface } from "../attribute-settings";
 
@@ -88,7 +88,9 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
                                 dropDownOptions.concat(
                                     {
                                         key: "default_subject",
-                                        text: "Default Subject",
+                                        text: t("console:develop.features.authenticationProvider.forms." +
+                                            "uriAttributeSettings.subject." +
+                                            "placeHolder"),
                                         value: ""
                                     } as DropdownOptionsInterface 
                                 )
@@ -118,10 +120,17 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
                         />
                     </Form>
                     <Hint>
-                        The attribute that identifies the user at the enterprise identity provider. 
-                        When attributes are configured based on the authentication response of this IdP connection, 
-                        you can use one of them as the subject. Otherwise, the default <Code>SAML:Subject</Code> in 
-                        the SAML response is used as the subject attribute.
+                        <Trans
+                            i18nKey={
+                                "console:console:develop.features.authenticationProvider.forms.uriAttributeSettings" +
+                                ".subject.hint"
+                            }
+                        >
+                            The attribute that identifies the user at the enterprise identity provider. 
+                            When attributes are configured based on the authentication response of this IdP connection, 
+                            you can use one of them as the subject. Otherwise, the 
+                            default <Code>saml2:Subject</Code> in the SAML response is used as the subject attribute.
+                        </Trans>
                     </Hint>
                 </Grid.Column>
             </Grid.Row>

--- a/apps/console/src/features/identity-providers/components/settings/attribute-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-settings.tsx
@@ -272,14 +272,6 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
             });
         }
 
-        // Prepare subject for submission.
-        if (isEmpty(subjectClaimUri)) {
-            // Trigger form field validation on the empty subject uri.
-            setSubjectError(true);
-            canSubmit = false;
-        } else {
-            setSubjectError(false);
-        }
 
         const matchingLocalClaim = availableLocalClaims.find(element => element.uri === subjectClaimUri);
         claimConfigurations["userIdClaim"] = matchingLocalClaim ? matchingLocalClaim : { uri: subjectClaimUri } as
@@ -298,6 +290,8 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                 const matchingLocalClaim = availableLocalClaims.find(element => element.uri === roleClaimUri);
                 claimConfigurations[ "roleClaim" ] = matchingLocalClaim ? matchingLocalClaim : { uri: roleClaimUri } as
                     IdentityProviderClaimInterface;
+            } else {
+                claimConfigurations[ "roleClaim" ] = { uri: "" } as IdentityProviderClaimInterface;
             }
         }
 

--- a/apps/console/src/features/identity-providers/components/settings/attribute-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-settings.tsx
@@ -359,6 +359,7 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                             roleError={ isSubmitting && roleError && !roleClaimUri }
                             subjectError={ isSubmitting && subjectError && !subjectClaimUri }
                             isReadOnly={ isReadOnly }
+                            isMappingEmpty={ isEmpty(selectedClaimsWithMapping) }
                         /> }
 
                         { /* Select attributes for provisioning. */ }

--- a/apps/console/src/features/identity-providers/components/settings/attribute-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-settings.tsx
@@ -156,9 +156,6 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
     // Sets role URI error.
     const [ roleError, setRoleError ] = useState<boolean>(false);
 
-    // Sets subject URI error.
-    const [ subjectError, setSubjectError ] = useState<boolean>(false);
-
     // Selected role mapping.
     const [roleMapping, setRoleMapping] = useState<IdentityProviderRoleMappingInterface[]>(undefined);
 
@@ -356,7 +353,7 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                             updateSubject={ setSubjectClaimUri }
                             data-testid={ `${ testId }-uri-attribute-settings` }
                             roleError={ isSubmitting && roleError && !roleClaimUri }
-                            subjectError={ isSubmitting && subjectError && !subjectClaimUri }
+                            subjectError={ isSubmitting && !subjectClaimUri }
                             isReadOnly={ isReadOnly }
                             isMappingEmpty={ isEmpty(selectedClaimsWithMapping) }
                         /> }

--- a/apps/console/src/features/identity-providers/components/settings/attribute-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-settings.tsx
@@ -272,7 +272,6 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
             });
         }
 
-
         const matchingLocalClaim = availableLocalClaims.find(element => element.uri === subjectClaimUri);
         claimConfigurations["userIdClaim"] = matchingLocalClaim ? matchingLocalClaim : { uri: subjectClaimUri } as
             IdentityProviderClaimInterface;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -3293,7 +3293,7 @@ export const console: ConsoleNS = {
                             heading: "Subject",
                             hint: "Specifies the attribute that identifies the user at the identity provider",
                             label: "Subject Attribute",
-                            placeHolder: "Select Attribute",
+                            placeHolder: "Default Subject",
                             validation: {
                                 empty: "Please select an attribute for subject"
                             }

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -3291,7 +3291,11 @@ export const console: ConsoleNS = {
                         },
                         subject: {
                             heading: "Subject",
-                            hint: "Specifies the attribute that identifies the user at the identity provider",
+                            hint: "The attribute that identifies the user at the enterprise identity provider. " +
+                                "When attributes are configured based on the authentication response of " +
+                                "this IdP connection, you can use one of them as the subject. " +
+                                "Otherwise, the default <1>saml2:Subject</1> in the SAML response is used " +
+                                "as the subject attribute.",
                             label: "Subject Attribute",
                             placeHolder: "Default Subject",
                             validation: {


### PR DESCRIPTION
### Purpose
- This PR will disable the subject attribute dropdown in SAML IdPs when there are no attribute mappings are present. It will consider the default subject attribute when there are no mappings.
<img width="1438" alt="Screenshot 2021-09-21 at 13 43 10" src="https://user-images.githubusercontent.com/42619922/134136214-8581cb0b-aa20-47a3-9d2c-09b37ddc22a4.png">

- The dropdown will be enabled when the attribute mappings are present.
<img width="1438" alt="Screenshot 2021-09-21 at 13 45 07" src="https://user-images.githubusercontent.com/42619922/134136295-b441113a-7b23-49b3-9070-56d2ea60080b.png">

- This PR also fixes the issue where attribute settings are not properly updated at times by making 2 parallel API calls to occur sequentially.


### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
