### PR TITLE
Hide `Active`, `External ID`, `Resource Type`, `User Metadata - Version`  SCIM attributes in MyAccount Profile

### DIFF
--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -1098,6 +1098,9 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("USER_SOURCE_ID")
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("IDP_TYPE")
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("LOCAL_CREDENTIAL_EXISTS")
+                            || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("ACTIVE")
+                            || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("RESROUCE_TYPE")
+                            || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("EXTERNAL_ID")
                             || (!commonConfig.userProfilePage.showEmail &&
                                 schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("EMAILS"))
                         )) {

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -1101,6 +1101,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("ACTIVE")
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("RESROUCE_TYPE")
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("EXTERNAL_ID")
+                            || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("META_DATA")
                             || (!commonConfig.userProfilePage.showEmail &&
                                 schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("EMAILS"))
                         )) {

--- a/modules/core/src/constants/profile-constants.ts
+++ b/modules/core/src/constants/profile-constants.ts
@@ -19,7 +19,7 @@
 /**
  * Class containing profile operation constants.
  */
- export class ProfileConstants {
+export class ProfileConstants {
 
     /**
      * Private constructor to avoid object instantiation from outside
@@ -78,6 +78,7 @@
         .set("ACTIVE", "active")
         .set("RESROUCE_TYPE", "ResourceType")
         .set("EXTERNAL_ID", "ExternalID")
+        .set("META_DATA", "MetaData")
         .set("IDP_TYPE", "idpType");
 
     /**

--- a/modules/core/src/constants/profile-constants.ts
+++ b/modules/core/src/constants/profile-constants.ts
@@ -19,7 +19,7 @@
 /**
  * Class containing profile operation constants.
  */
-export class ProfileConstants {
+ export class ProfileConstants {
 
     /**
      * Private constructor to avoid object instantiation from outside
@@ -75,6 +75,9 @@ export class ProfileConstants {
         .set("DOB", "dateOfBirth")
         .set("LOCAL_CREDENTIAL_EXISTS", "localCredentialExists")
         .set("USER_SOURCE_ID", "userSourceId")
+        .set("ACTIVE", "active")
+        .set("RESROUCE_TYPE", "ResourceType")
+        .set("EXTERNAL_ID", "ExternalID")
         .set("IDP_TYPE", "idpType");
 
     /**


### PR DESCRIPTION
### Purpose
This will hide the following attributes from showing in the my account profile view.

`Active`, `External ID`, `Resource Type`, `User Metadata - Version` ( The latter three doesn't contain a SCIM mapping by default hence even if the mapping is added, they will not show up in the my account profile.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
