### PR TITLE
Improve the login page idle timeout screen

### DIFF
--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -192,7 +192,7 @@
 </head>
 <body class="login-portal layout authentication-portal-layout" onload="checkSessionKey()">
 
-    <% request.setAttribute("pageName", "login"); %>
+    <% request.setAttribute("pageName", "sign-in"); %>
     <% if (new File(getServletContext().getRealPath("extensions/timeout.jsp")).exists()) { %>
         <jsp:include page="extensions/timeout.jsp"/>
     <% } else { %>

--- a/apps/authentication-portal/src/main/webapp/util/modal.jsp
+++ b/apps/authentication-portal/src/main/webapp/util/modal.jsp
@@ -18,8 +18,26 @@
 
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
-<div class="ui modal mini notify" id="asg-modal-0">
-    <div class="content">
+<div class="ui modal tiny notify" id="asg-modal-0">
+    <div class="animated-icon text-center">
+        <div class="svg-box" data-testid="session-timeout-modal-warning-animated-icon">
+            <svg class="circular warning-stroke">
+                <circle class="path" cx="75" cy="75" r="50" fill="none" stroke-width="2" stroke-miterlimit="10">
+                </circle>
+            </svg>
+            <svg class="warning-icon warning-stroke">
+                <g transform="matrix(1,0,0,1,-615.516,-257.346)">
+                    <g transform="matrix(0.56541,-0.56541,0.56541,0.56541,93.7153,495.69)">
+                        <path class="line" d="M634.087,300.805L673.361,261.53" fill="none"></path>
+                    </g>
+                    <g transform="matrix(2.27612,-2.46519e-32,0,2.27612,-792.339,-404.147)">
+                        <circle class="dot" cx="621.52" cy="316.126" r="1.318"></circle>
+                    </g>
+                </g>
+            </svg>
+        </div>
+    </div>
+    <div class="content text-center">
         <div class="description">
             <div class="ui header" id="asg-modal-0-title">
                 <b>${param.title}</b>
@@ -35,7 +53,7 @@
         </div>
         <c:if test="${not empty param.action_button_text}">
             <div class="ui primary button" id="asg-modal-0-action-button">
-                    ${param.action_button_text}
+                ${param.action_button_text}
             </div>
         </c:if>
     </div>

--- a/apps/authentication-portal/src/main/webapp/util/timeout.jsp
+++ b/apps/authentication-portal/src/main/webapp/util/timeout.jsp
@@ -28,12 +28,16 @@
 <jsp:include page="countdown.jsp"/>
 
 <%--Include the reusable modal component--%>
+<%
+    String description = "You've been idle in this page for too long. For security reasons," +
+        "you need to start over or you will be redirected to the sign-in page";
+%>
 <jsp:include page="modal.jsp">
-    <jsp:param name="title" value="This login instance is about to timeout!"/>
+    <jsp:param name="title" value="This sign-in instance is about to timeout!"/>
     <jsp:param
             name="description"
-            value="You have been idle in this page for too long. You need to try signing in again."/>
-    <jsp:param name="action_button_text" value="Got it"/>
+            value="<%=description%>"/>
+    <jsp:param name="action_button_text" value="Start over"/>
     <jsp:param name="cancel_button_text" value="Dismiss"/>
 </jsp:include>
 
@@ -166,9 +170,9 @@
             function onTick(time) {
                 if (time.total < Countdown.minutes(PROPS.notifyOnMinute)) {
                     modal.changeDescriptionAsHTML(
-                        "You have been idle in" + SPACE_CHAR + PROPS.pageName + SPACE_CHAR +
-                        "page for too long. You need to try signing in again" + SPACE_CHAR +
-                        "<b>" + Countdown.timeToReadable(time) + "</b>."
+                    "You have been idle in" + SPACE_CHAR + PROPS.pageName + SPACE_CHAR +
+                    "page for too long. For security reasons, you need to start over or you will be redirected " +
+                    "to the sign-in page"  + SPACE_CHAR + "<b>" + Countdown.timeToReadable(time) + "</b>."
                     );
                 }
                 if (time.total === Countdown.minutes(PROPS.notifyOnMinute)) {

--- a/apps/authentication-portal/src/main/webapp/util/timeout.jsp
+++ b/apps/authentication-portal/src/main/webapp/util/timeout.jsp
@@ -29,7 +29,7 @@
 
 <%--Include the reusable modal component--%>
 <jsp:include page="modal.jsp">
-    <jsp:param name="title" value="Heads Up!"/>
+    <jsp:param name="title" value="This login instance is about to timeout!"/>
     <jsp:param
             name="description"
             value="You have been idle in this page for too long. You need to try signing in again."/>
@@ -138,53 +138,56 @@
         totalTimeoutMinutes: <%= totalTimeoutMinutes %>,
         notifyOnMinute: <%= notifyOnMinute %>,
         appAccessUrlEncoded: "<%= appAccessUrlEncoded %>",
-        pageName: "<%= pageName %>"
+        pageName: "<%= pageName %>",
+        showModal: <%= isNotEmpty(appAccessUrlEncoded) %>
     };
 
-    $(document).ready(function () {
+    if(PROPS.showModal) {
+        $(document).ready(function () {
 
-        const SPACE_CHAR = " ";
-        const timeout = Countdown.minutes(PROPS.totalTimeoutMinutes);
-        const countdown = new Countdown(timeout, onDone, onTick);
+            const SPACE_CHAR = " ";
+            const timeout = Countdown.minutes(PROPS.totalTimeoutMinutes);
+            const countdown = new Countdown(timeout, onDone, onTick);
 
-        const modal = new ModalRef(function (/*Modal onAction*/) {
-            // Once the modal action button clicked, the user will be redirected
-            // to the specified URL immediately. If the url is not available then
-            // it will not redirect or do anything.
-            if (PROPS.appAccessUrlEncoded) {
+            const modal = new ModalRef(function (/*Modal onAction*/) {
+                // Once the modal action button clicked, the user will be redirected
+                // to the specified URL immediately. If the url is not available then
+                // it will not redirect or do anything.
+                if (PROPS.appAccessUrlEncoded) {
+                    window.location = PROPS.appAccessUrlEncoded;
+                }
+            });
+
+            /**
+             * This function will be called everytime when time ticks.
+             *
+             * @param time {{total: number, hours: number, seconds: number, minutes: number, days: number}}
+             */
+            function onTick(time) {
+                if (time.total < Countdown.minutes(PROPS.notifyOnMinute)) {
+                    modal.changeDescriptionAsHTML(
+                        "You have been idle in" + SPACE_CHAR + PROPS.pageName + SPACE_CHAR +
+                        "page for too long. You need to try signing in again" + SPACE_CHAR +
+                        "<b>" + Countdown.timeToReadable(time) + "</b>."
+                    );
+                }
+                if (time.total === Countdown.minutes(PROPS.notifyOnMinute)) {
+                    modal.show();
+                }
+            }
+
+            /**
+             * Once the timer is finished, this method will be
+             * invoked to execute the target action.
+             */
+            function onDone() {
+                // Once the countdown is over, the user will be redirected
+                // to the access URL immediately.
                 window.location = PROPS.appAccessUrlEncoded;
             }
+
+            countdown.start();
         });
-
-        /**
-         * This function will be called everytime when time ticks.
-         *
-         * @param time {{total: number, hours: number, seconds: number, minutes: number, days: number}}
-         */
-        function onTick(time) {
-            if (time.total < Countdown.minutes(PROPS.notifyOnMinute)) {
-                modal.changeDescriptionAsHTML(
-                    "You have been idle in" + SPACE_CHAR + PROPS.pageName + SPACE_CHAR +
-                    "page for too long. You need to try signing in again" + SPACE_CHAR +
-                    "<b>" + Countdown.timeToReadable(time) + "</b>."
-                );
-            }
-            if (time.total === Countdown.minutes(PROPS.notifyOnMinute)) {
-                modal.show();
-            }
-        }
-
-        /**
-         * Once the timer is finished, this method will be
-         * invoked to execute the target action.
-         */
-        function onDone() {
-            modal.hideDismissButton();
-            modal.show();
-        }
-
-        countdown.start();
-
-    });
+    }
 
 </script>

--- a/apps/authentication-portal/src/main/webapp/util/timeout.jsp
+++ b/apps/authentication-portal/src/main/webapp/util/timeout.jsp
@@ -29,7 +29,7 @@
 
 <%--Include the reusable modal component--%>
 <%
-    String description = "You've been idle in this page for too long. For security reasons," +
+    String description = "You have been idle in this page for too long. For security reasons," +
         "you need to start over or you will be redirected to the sign-in page";
 %>
 <jsp:include page="modal.jsp">
@@ -115,7 +115,7 @@
     try {
 
         String _serviceProvider = request.getParameter("sp");
-        String _userTenantDomain = request.getParameter("ut");
+        String _userTenantDomain = request.getParameter("t");
         String _tenantDomain = getTenantDomainFromContext();
         ApplicationDataRetrievalClient _client = new ApplicationDataRetrievalClient();
         String _accessUrl = _client.getApplicationAccessURL(_tenantDomain, _serviceProvider);


### PR DESCRIPTION
### Purpose

1. Updated the look and feel of the modal
2. User will be automatically redirected once the countdown is completed
3. If the access URL is not defined, this will not pop up at all

### Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/3394

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
