### PR TITLE
Bump commons-io dependency version

### DIFF
--- a/apps/x509-certificate-authentication-portal/pom.xml
+++ b/apps/x509-certificate-authentication-portal/pom.xml
@@ -50,6 +50,10 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>jstl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -664,7 +664,7 @@
         <identity.governance.version>1.4.97</identity.governance.version>
         <totp.authenticator.version>3.0.18</totp.authenticator.version>
 
-        <commons-io.wso2.version>2.4.0.wso2v1</commons-io.wso2.version>
+        <commons-io.wso2.version>2.7.0.wso2v1</commons-io.wso2.version>
         <commons-lang.wso2.version>2.6.0.wso2v1</commons-lang.wso2.version>
         <servlet-api.version>2.5</servlet-api.version>
         <javax.jsp-api.version>2.0</javax.jsp-api.version>


### PR DESCRIPTION
Related Issues: wso2/product-is#12485
### Purpose
> Bump commons-io dependency version to 2.7.0.wso2v1
> Exclude commons-io from x509-certificate-authentication-portal webapps