### PR TITLE
feat: add static configuration for disabling/coming-soon `operation add` for attribute dialects.

### DIFF
--- a/apps/console/src/extensions/configs/attribute.ts
+++ b/apps/console/src/extensions/configs/attribute.ts
@@ -45,6 +45,14 @@ export const attributeConfig: AttributeConfig = {
         return true;
     },
     editAttributeMappings: {
+        /**
+         * Disables and marks the dialect add new attribute button as a
+         * coming soon feature.
+         * - @param dialectID: string
+         */
+        markAddExternalAttributeButtonAsAComingSoonFeature() {
+            return false;
+        },
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         showAddExternalAttributeButton: (dialectID: string): boolean => {
             return true;

--- a/apps/console/src/extensions/configs/models/attribute.ts
+++ b/apps/console/src/extensions/configs/models/attribute.ts
@@ -39,6 +39,7 @@ export interface AttributeConfig {
     attributesPlaceholderAddButton: (attributeType: string) => boolean;
     editAttributeMappings: {
         showAddExternalAttributeButton: (dialectID: string) => boolean;
+        markAddExternalAttributeButtonAsAComingSoonFeature: (dialectID: string) => boolean;
     };
     editAttributes: {
         getDisplayOrder: (existingDisplayOrder: number, newDisplayOrder: string) => number;


### PR DESCRIPTION
### Purpose
> Please note subject. Disabling feature for adding SCIM attribute mappings to any dialect through a static configuration >> `markAddExternalAttributeButtonAsAComingSoonFeature`.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
