### PR TITLE
fix(secret-management): add margin right to avoid overlapping dismiss button

### DIFF
--- a/apps/console/src/features/secrets/components/add-secret-wizard.tsx
+++ b/apps/console/src/features/secrets/components/add-secret-wizard.tsx
@@ -375,7 +375,7 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
                                 onDismiss={ onDismissInfoMessageBanner }
                             >
                                 <Message.Content
-                                    className="mt-2"
+                                    className="mr-2"
                                     data-componentid={ `${ testId }-page-message-content` }>
                                     { t(
                                         "console:develop.features.secrets.banners.secretIsHidden.content",


### PR DESCRIPTION
### Purpose
> Please note $subject.

<img width="589" alt="Screenshot 2021-09-27 at 15 06 15" src="https://user-images.githubusercontent.com/25561152/134883987-4e881fa6-f8d0-4d73-a987-f13715b0da89.png">

#### Fix
<img width="589" alt="Screenshot 2021-09-27 at 15 06 37" src="https://user-images.githubusercontent.com/25561152/134884037-bea2ad4f-264a-49f1-bf5b-ee22460c8f04.png">

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
