### PR TITLE
fix(secrets-management): bind `access-control` scopes to UI

### DIFF
--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -103,6 +103,10 @@ export interface FeatureConfigInterface {
      * User management feature.
      */
     users?: FeatureAccessConfigInterface;
+    /**
+     * Secret Management Feature UI Access Scopes.
+     */
+    secretsManagement?: FeatureAccessConfigInterface;
 }
 
 /**

--- a/apps/console/src/features/secrets/components/add-secret-wizard.tsx
+++ b/apps/console/src/features/secrets/components/add-secret-wizard.tsx
@@ -27,7 +27,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Grid, Message, Modal } from "semantic-ui-react";
 import { AppState, ConfigReducerStateInterface } from "../../core";
 import { createSecret, getSecretList } from "../api/secret";
-import { EMPTY_JSON_OBJECT_STRING, FEATURE_LOCAL_STORAGE_KEY } from "../constants/secrets.common";
+import { EMPTY_JSON_OBJECT_STRING, EMPTY_STRING, FEATURE_LOCAL_STORAGE_KEY } from "../constants/secrets.common";
 import { EditSecretLocalStorage } from "../models/common";
 import { SecretModel } from "../models/secret";
 import {
@@ -58,8 +58,6 @@ type FieldDropDownOption = {
  * This wizard is sorely responsible for adding a new `secret` for a
  * given `secret-type`.
  *
- * Known Issue TODO: https://github.com/wso2/product-is/issues/12447
- *                   Need to add access-control and event-publishers
  * @param props {AddSecretWizardProps}
  * @constructor
  * @return {ReactElement}
@@ -102,12 +100,12 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
         fetchSecretTypes()
             .then(async (response) => {
                 setSecretTypes(response);
-                const initialSecretType = response.length ? response[0].value : "";
+                const initialSecretType = response.length ? response[0].value : EMPTY_STRING;
                 setInitialFormValues({
-                    secret_description: "",
-                    secret_name: "",
+                    secret_description: EMPTY_STRING,
+                    secret_name: EMPTY_STRING,
                     secret_type: initialSecretType,
-                    secret_value: ""
+                    secret_value: EMPTY_STRING
                 });
                 /**
                  * If we have a initial secret type then, go ahead and fetch
@@ -146,7 +144,7 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
     }, []);
 
     useEffect(() => {
-            checkAndRenderInfoMessage();
+        checkAndRenderInfoMessage();
     }, []);
 
     /**
@@ -322,8 +320,6 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
                         ariaLabel={ t("console:develop.features.secrets.wizards" +
                             ".addSecret.form.secretTypeField.ariaLabel") }
                         hint={ t("console:develop.features.secrets.wizards.addSecret.form.secretTypeField.hint") }
-                        // TODO: implement validation here if above improvement added.
-                        // https://github.com/wso2/product-is/issues/12447
                     />
                     <Field.Input
                         required

--- a/apps/console/src/features/secrets/components/empty-secret-list-placeholder.tsx
+++ b/apps/console/src/features/secrets/components/empty-secret-list-placeholder.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { EmptyPlaceholder, LinkButton, PrimaryButton } from "@wso2is/react-components";
 import React, { FC, ReactElement } from "react";
@@ -37,7 +38,6 @@ export type EmptySecretListPlaceholderProps = {
  * added to it. It can be either adaptive script secrets or custom
  * created secret-types.
  *
- * TODO: https://github.com/wso2/product-is/issues/12447
  * @constructor
  * @return {ReactElement}
  */
@@ -86,12 +86,16 @@ export const EmptySecretListPlaceholder: FC<EmptySecretListPlaceholderProps> = (
     return (
         <EmptyPlaceholder
             action={
-                <PrimaryButton
-                    aria-label={ t("console:develop.features.secrets.emptyPlaceholders.buttons.addSecret.ariaLabel") }
-                    onClick={ onAddNewSecret }>
-                    <Icon name="add"/>
-                    { t("console:develop.features.secrets.emptyPlaceholders.buttons.addSecret.label") }
-                </PrimaryButton>
+                <Show when={ AccessControlConstants.SECRET_WRITE }>
+                    <PrimaryButton
+                        aria-label={
+                            t("console:develop.features.secrets.emptyPlaceholders.buttons.addSecret.ariaLabel")
+                        }
+                        onClick={ onAddNewSecret }>
+                        <Icon name="add"/>
+                        { t("console:develop.features.secrets.emptyPlaceholders.buttons.addSecret.label") }
+                    </PrimaryButton>
+                </Show>
             }
             image={ getEmptyPlaceholderIllustrations().newList }
             imageSize="tiny"

--- a/apps/console/src/features/secrets/components/secret-description-form.tsx
+++ b/apps/console/src/features/secrets/components/secret-description-form.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/form";
@@ -23,7 +24,6 @@ import cloneDeep from "lodash-es/cloneDeep";
 import React, { FC, Fragment, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Grid } from "semantic-ui-react";
 import { patchSecret } from "../api/secret";
 import { SecretModel } from "../models/secret";
 import { SECRET_DESCRIPTION_LENGTH } from "../utils/secrets.validation.utils";
@@ -124,7 +124,7 @@ const SecretDescriptionForm: FC<SecretDescriptionFormProps> = (
 
     return (
         <Fragment>
-            <Form uncontrolledForm={ false } onSubmit={ updateSecretDescription }>
+            <Form uncontrolledForm={ true } onSubmit={ updateSecretDescription }>
                 <Field.Textarea
                     data-componentid={ `${ testId }-description-field` }
                     ariaLabel={
@@ -141,15 +141,17 @@ const SecretDescriptionForm: FC<SecretDescriptionFormProps> = (
                     maxLength={ SECRET_DESCRIPTION_LENGTH.max }
                     listen={ (value: string): void => setSecretDescription(value) }
                 />
-                <Field.Button
-                    data-componentid={ `${ testId }-update-button` }
-                    loading={ loading }
-                    disabled={ !canUpdateDescription || loading }
-                    type="submit"
-                    buttonType="primary_btn"
-                    ariaLabel={ t("console:develop.features.secrets.forms.actions.submitButton.ariaLabel") }
-                    label={ t("console:develop.features.secrets.forms.actions.submitButton.label") }
-                    name="submit"/>
+                <Show when={ AccessControlConstants.SECRET_EDIT }>
+                    <Field.Button
+                        data-componentid={ `${ testId }-update-button` }
+                        loading={ loading }
+                        disabled={ !canUpdateDescription || loading }
+                        type="submit"
+                        buttonType="primary_btn"
+                        ariaLabel={ t("console:develop.features.secrets.forms.actions.submitButton.ariaLabel") }
+                        label={ t("console:develop.features.secrets.forms.actions.submitButton.label") }
+                        name="submit"/>
+                </Show>
             </Form>
         </Fragment>
     );

--- a/apps/console/src/features/secrets/pages/secret-edit.tsx
+++ b/apps/console/src/features/secrets/pages/secret-edit.tsx
@@ -23,7 +23,6 @@ import React, { FC, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { RouteComponentProps } from "react-router";
-import { Label } from "semantic-ui-react";
 import { AppConstants, getSecretManagementIllustrations, history } from "../../core";
 import { getSecret } from "../api/secret";
 import EditSecret from "../components/edit-secret";
@@ -37,10 +36,7 @@ import { SecretModel } from "../models/secret";
 export type SecretEditProps = RouteComponentProps & IdentifiableComponentInterface;
 
 /**
- * TODO: Need to implement access-control and event publishers
- *  https://github.com/wso2/product-is/issues/12447
- *
- * @param props
+ * @param props {SecretEditProps}
  * @constructor
  */
 const SecretEdit: FC<SecretEditProps> = (props: SecretEditProps): ReactElement => {
@@ -55,7 +51,7 @@ const SecretEdit: FC<SecretEditProps> = (props: SecretEditProps): ReactElement =
     const [ loading, setLoading ] = useState<boolean>(true);
     const [ resourceNotFound, setResourceNotFound ] = useState<boolean>(false);
     const [ editingSecret, setEditingSecret ] = useState<SecretModel>(undefined);
-    const [ secretType, setSecretType ] = useState<string>();
+    const [ , setSecretType ] = useState<string>();
     const [ secretName, setSecretName ] = useState<string>();
 
     /**

--- a/apps/console/src/features/secrets/pages/secret-edit.tsx
+++ b/apps/console/src/features/secrets/pages/secret-edit.tsx
@@ -51,7 +51,6 @@ const SecretEdit: FC<SecretEditProps> = (props: SecretEditProps): ReactElement =
     const [ loading, setLoading ] = useState<boolean>(true);
     const [ resourceNotFound, setResourceNotFound ] = useState<boolean>(false);
     const [ editingSecret, setEditingSecret ] = useState<SecretModel>(undefined);
-    const [ , setSecretType ] = useState<string>();
     const [ secretName, setSecretName ] = useState<string>();
 
     /**
@@ -62,7 +61,6 @@ const SecretEdit: FC<SecretEditProps> = (props: SecretEditProps): ReactElement =
         const { secretType, secretName } = extractDataFromPath();
 
         setSecretName(secretName);
-        setSecretType(secretType);
 
         getSecret({ params: { secretName, secretType } })
             .then(({ data }) => {

--- a/apps/console/src/features/secrets/pages/secrets.tsx
+++ b/apps/console/src/features/secrets/pages/secrets.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { PageLayout, PrimaryButton } from "@wso2is/react-components";
@@ -37,8 +38,9 @@ export type SecretsPageProps = IdentifiableComponentInterface;
 
 /**
  * There are couple of things missing in this component:
- * TODO: https://github.com/wso2/product-is/issues/12447
  * The secrets list of page.
+ *
+ * @param props {SecretsPageProps}
  * @constructor
  */
 const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElement => {
@@ -132,20 +134,24 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
             title={ t("console:develop.features.secrets.page.title") }
             description={ t("console:develop.features.secrets.page.description") }
             action={ secretList?.length > 0 && (
-                <PrimaryButton
-                    onClick={ onAddNewSecretButtonClick }
-                    data-testid={ `${ testId }-add-button` }>
-                    <Icon name="add"/>
-                    { t("console:develop.features.secrets.page.primaryActionButtonText") }
-                </PrimaryButton>
+                <Show when={ AccessControlConstants.SECRET_WRITE }>
+                    <PrimaryButton
+                        onClick={ onAddNewSecretButtonClick }
+                        data-testid={ `${ testId }-add-button` }>
+                        <Icon name="add"/>
+                        { t("console:develop.features.secrets.page.primaryActionButtonText") }
+                    </PrimaryButton>
+                </Show>
             ) }>
-            <SecretsList
-                whenSecretDeleted={ whenSecretDeleted }
-                isSecretListLoading={ isSecretListLoading }
-                secretList={ secretList }
-                selectedSecretType={ selectedSecretType }
-                onAddNewSecretButtonClick={ onAddNewSecretButtonClick }
-            />
+            <Show when={ AccessControlConstants.SECRET_READ }>
+                <SecretsList
+                    whenSecretDeleted={ whenSecretDeleted }
+                    isSecretListLoading={ isSecretListLoading }
+                    secretList={ secretList }
+                    selectedSecretType={ selectedSecretType }
+                    onAddNewSecretButtonClick={ onAddNewSecretButtonClick }
+                />
+            </Show>
             { showAddSecretModal && (
                 <AddSecretWizard
                     onClose={ whenAddNewSecretModalClosed }

--- a/modules/access-control/src/access-control-constants.ts
+++ b/modules/access-control/src/access-control-constants.ts
@@ -212,4 +212,24 @@ export class AccessControlConstants {
      */
     public static readonly FULL_UI_SCOPE: string = "console:full";
 
+    /**
+     * Secret Management Write/Create Scope.
+     */
+    public static readonly SECRET_WRITE: string = "internal_secret_mgt_add";
+
+    /**
+     * Secret Management Read Scope.
+     */
+    public static readonly SECRET_READ: string = "internal_secret_mgt_view";
+
+    /**
+     * Secret Management Edit/Update Scope.
+     */
+    public static readonly SECRET_EDIT: string = "internal_secret_mgt_update";
+
+    /**
+     * Secret Management Delete/Remove Scope.
+     */
+    public static readonly SECRET_DELETE: string = "internal_secret_mgt_delete";
+
 }

--- a/modules/access-control/src/access-control-context-provider.tsx
+++ b/modules/access-control/src/access-control-context-provider.tsx
@@ -136,7 +136,28 @@ export const AccessControlContext: FunctionComponent<PropsWithChildren<AccessCon
                 [ AccessControlConstants.USER_EDIT ] : hasRequiredScopes(featureConfig.users,
                     featureConfig.users.scopes.update, allowedScopes),
                 [ AccessControlConstants.USER_DELETE ] : hasRequiredScopes(featureConfig.users,
-                    featureConfig.users.scopes.delete, allowedScopes)
+                    featureConfig.users.scopes.delete, allowedScopes),
+
+                [AccessControlConstants.SECRET_WRITE]: hasRequiredScopes(
+                    featureConfig.secretsManagement,
+                    featureConfig.secretsManagement.scopes.create,
+                    allowedScopes
+                ),
+                [AccessControlConstants.SECRET_READ]: hasRequiredScopes(
+                    featureConfig.secretsManagement,
+                    featureConfig.secretsManagement.scopes.read,
+                    allowedScopes
+                ),
+                [AccessControlConstants.SECRET_EDIT]: hasRequiredScopes(
+                    featureConfig.secretsManagement,
+                    featureConfig.secretsManagement.scopes.update,
+                    allowedScopes
+                ),
+                [AccessControlConstants.SECRET_DELETE]: hasRequiredScopes(
+                    featureConfig.secretsManagement,
+                    featureConfig.secretsManagement.scopes.delete,
+                    allowedScopes
+                )
             }
         });
 


### PR DESCRIPTION
### Purpose
> Please note $subject.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
