### PR TITLE
Remove WSO2 dialect from OIDC scope

### DIFF
--- a/apps/console/src/features/oidc-scopes/components/edit-oidc-scope.tsx
+++ b/apps/console/src/features/oidc-scopes/components/edit-oidc-scope.tsx
@@ -235,10 +235,7 @@ export const EditOIDCScope: FunctionComponent<EditScopePropsInterface> = (
                 render: (claim: ExternalClaim): ReactNode => (
                     <Header image as="h6" className="header-with-icon" data-testid={ `${ testId }-item-heading` }>
                         <Header.Content>
-                            { claim.localClaimDisplayName }
-                            <Header.Subheader>
-                                <code>{ claim.mappedLocalClaimURI }</code>
-                            </Header.Subheader>
+                            { claim.claimURI }
                         </Header.Content>
                     </Header>
                 ),


### PR DESCRIPTION
### Purpose
> Remove WSO2 dialect from OIDC scope. And the display name is removed as it is related to the local claims.


### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
