### PR TITLE
Add support for building React artifacts for static servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,16 +167,32 @@ Once the build is complete, execute the following commands in-order to build the
 
 **Console**
 
+###### Deploy on a Java EE server (ex: Tomcat)
+
 ```bash
 npx lerna run build:external --scope @wso2is/console
+```
+
+###### Deploy on a static server.
+
+```bash
+npx lerna run build:external:static --scope @wso2is/console
 ```
 
 Once the build is completed, you can find the build artifacts inside the build folder i.e `apps/console/build`.
 
 **My Account**
 
+###### Deploy on a Java EE server (ex: Tomcat)
+
 ```bash
 npx lerna run build:external --scope @wso2is/myaccount
+```
+
+###### Deploy on a static server.
+
+```bash
+npx lerna run build:external:static --scope @wso2is/myaccount
 ```
 
 Once the build is completed, you can find the build artifacts inside the build folder i.e `apps/myaccount/build`.
@@ -185,9 +201,18 @@ Once the build is completed, you can find the build artifacts inside the build f
 
 You can simply use npm to build the Console and My Account applications for external deployment by just executing the following script.
 
+###### Deploy on a Java EE server (ex: Tomcat)
+
 ```bash
 # From project root
 npm run build:external
+```
+
+###### Deploy on a static server.
+
+```bash
+# From project root
+npm run build:external:static
 ```
 
 The respective build artifacts could be found inside the build folder. (`apps/(myaccount|console)/build`)

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -11,6 +11,7 @@
         "build:analyze:win32": "..\\..\\node_modules\\.bin\\webpack --mode production --env NODE_ENV=production --env ENABLE_ANALYZER=true --env ANALYZER_PORT=8889",
         "build:analyze:default": "../../node_modules/.bin/webpack --mode production --env NODE_ENV=production --env ENABLE_ANALYZER=true --env ANALYZER_PORT=8889",
         "build:external": "npm run build:prod -- --env IS_DEPLOYED_ON_EXTERNAL_SERVER=true",
+        "build:external:static": "npm run build:prod -- --env IS_DEPLOYED_ON_EXTERNAL_SERVER=true SERVER_TYPE=static",
         "build:prod": "run-script-os",
         "build:prod:win32": "..\\..\\node_modules\\.bin\\webpack --mode production --env NODE_ENV=production",
         "build:prod:default": "../../node_modules/.bin/webpack --mode production --env NODE_ENV=production",

--- a/apps/console/webpack.config.js
+++ b/apps/console/webpack.config.js
@@ -78,7 +78,8 @@ module.exports = (env) => {
     // will be removed. Since these resources are only available inside IS runtime, when hosted
     // externally, the server (tomcat etc.) will throw errors when trying to resolve them.
     const isDeployedOnExternalServer = env.IS_DEPLOYED_ON_EXTERNAL_SERVER;
-    // Is deployed on a static server. With this option, all the `jsp` files and java specific folders will be dropped.
+    // Flag to determine if the app is deployed on a static server.
+    // With this option, all the `jsp` files and java specific folders will be dropped.
     const isDeployedOnStaticServer = env.SERVER_TYPE === "static";
 
     // Analyzing mode options.

--- a/apps/console/webpack.config.js
+++ b/apps/console/webpack.config.js
@@ -41,12 +41,13 @@ const isProfilingEnabledInProduction = false;
 const DEVELOPMENT_ESLINT_CONFIG = ".eslintrc.js";
 const PRODUCTION_ESLINT_CONFIG = ".prod.eslintrc.js";
 
-// Build artifacts output path.
-const APP_SOURCE_DIRECTORY = "src";                // App source code directory.
-const APP_NODE_MODULES_DIRECTORY = "node_modules"; // Node modules.
-const OUTPUT_PATH = "build/console";               // Build artifacts output path.
-const CACHE_DIRECTORY = "cache";                   // Output directory for the cache files. Only applicable in dev mode.
-const STATIC_ASSETS_DIRECTORY = "static/media";    // Output directory for static assets i.e .png, .jpg etc.
+// Paths & Folders
+const APP_SOURCE_DIRECTORY = "src";                    // App source code directory.
+const APP_NODE_MODULES_DIRECTORY = "node_modules";     // Node modules.
+const OUTPUT_PATH = "build/console";                   // Build artifacts output path.
+const CACHE_DIRECTORY = "cache";                       // Output directory for the cache files for dev mode.
+const STATIC_ASSETS_DIRECTORY = "static/media";        // Output directory for static assets i.e .png, .jpg etc.
+const JAVA_EE_SERVER_FOLDERS = [ "**/WEB-INF/**/*" ];  // Java EE server specific folders.
 
 // Dev Server Default Configs.
 const DEV_SERVER_PORT = 9001;
@@ -77,6 +78,8 @@ module.exports = (env) => {
     // will be removed. Since these resources are only available inside IS runtime, when hosted
     // externally, the server (tomcat etc.) will throw errors when trying to resolve them.
     const isDeployedOnExternalServer = env.IS_DEPLOYED_ON_EXTERNAL_SERVER;
+    // Is deployed on a static server. With this option, all the `jsp` files and java specific folders will be dropped.
+    const isDeployedOnStaticServer = env.SERVER_TYPE === "static";
 
     // Analyzing mode options.
     const isAnalyzeMode = env.ENABLE_ANALYZER === "true";
@@ -426,9 +429,18 @@ module.exports = (env) => {
                         context: path.join(__dirname, "src"),
                         force: true,
                         from: "public",
+                        // For deployments on static servers, we don't require the Java EE specific
+                        // folders like `WEB_INF` etc.
+                        globOptions: {
+                            ignore: isDeployedOnStaticServer
+                                ? [ ...JAVA_EE_SERVER_FOLDERS ]
+                                : []
+                        },
                         to: "."
                     },
-                    {
+                    // For deployments on static servers, we don't require `auth.jsp` since we can't use
+                    // `form_post` response mode.
+                    !isDeployedOnStaticServer && {
                         context: path.join(__dirname, "src"),
                         force: true,
                         from: "auth.jsp",
@@ -436,7 +448,7 @@ module.exports = (env) => {
                     }
                 ].filter(Boolean)
             }),
-            isProduction
+            isProduction && !isDeployedOnStaticServer
                 ? new HtmlWebpackPlugin({
                     authorizationCode: "<%=request.getParameter(\"code\")%>",
                     contentType: "<%@ page language=\"java\" contentType=\"text/html; charset=UTF-8\" " +

--- a/apps/console/webpack.config.js
+++ b/apps/console/webpack.config.js
@@ -471,6 +471,7 @@ module.exports = (env) => {
                         ? "<%@ page import=\"" +
                         "static org.wso2.carbon.identity.core.util.IdentityUtil.getServerURL\" %>"
                         : "",
+                    minify: false,
                     publicPath: !isRootContext
                         ? publicPath
                         : "/",
@@ -496,6 +497,7 @@ module.exports = (env) => {
                     excludeChunks: [ "rpIFrame" ],
                     filename: path.join(distFolder, "index.html"),
                     hash: true,
+                    minify: false,
                     publicPath: !isRootContext
                         ? publicPath
                         : "/",
@@ -506,6 +508,7 @@ module.exports = (env) => {
                 excludeChunks: [ "main", "init" ],
                 filename: path.join(distFolder, "rpIFrame.html"),
                 hash: true,
+                minify: false,
                 publicPath: !isRootContext
                     ? publicPath
                     : "/",

--- a/apps/myaccount/package.json
+++ b/apps/myaccount/package.json
@@ -11,6 +11,7 @@
         "build:analyze:win32": "..\\..\\node_modules\\.bin\\webpack --mode production --env NODE_ENV=production --env ENABLE_ANALYZER=true --env ANALYZER_PORT=8888",
         "build:analyze:default": "../../node_modules/.bin/webpack --mode production --env NODE_ENV=production --env ENABLE_ANALYZER=true --env ANALYZER_PORT=8888",
         "build:external": "npm run build:prod -- --env IS_DEPLOYED_ON_EXTERNAL_SERVER=true",
+        "build:external:static": "npm run build:prod -- --env IS_DEPLOYED_ON_EXTERNAL_SERVER=true SERVER_TYPE=static",
         "build:prod": "run-script-os",
         "build:prod:win32": "..\\..\\node_modules\\.bin\\webpack --mode production --env NODE_ENV=production",
         "build:prod:default": "../../node_modules/.bin/webpack --mode production --env NODE_ENV=production",

--- a/apps/myaccount/webpack.config.js
+++ b/apps/myaccount/webpack.config.js
@@ -445,6 +445,7 @@ module.exports = (env) => {
                         ? "<%@ page import=\"" +
                         "static org.wso2.carbon.identity.core.util.IdentityUtil.getServerURL\" %>"
                         : "",
+                    minify: false,
                     publicPath: !isRootContext
                         ? publicPath
                         : "/",
@@ -470,6 +471,7 @@ module.exports = (env) => {
                     excludeChunks: [ "rpIFrame" ],
                     filename: path.join(distFolder, "index.html"),
                     hash: true,
+                    minify: false,
                     publicPath: !isRootContext
                         ? publicPath
                         : "/",
@@ -480,6 +482,7 @@ module.exports = (env) => {
                 excludeChunks: [ "main", "init" ],
                 filename: path.join(distFolder, "rpIFrame.html"),
                 hash: true,
+                minify: false,
                 publicPath: !isRootContext
                     ? publicPath
                     : "/",

--- a/apps/myaccount/webpack.config.js
+++ b/apps/myaccount/webpack.config.js
@@ -40,12 +40,13 @@ const isProfilingEnabledInProduction = false;
 const DEVELOPMENT_ESLINT_CONFIG = ".eslintrc.js";
 const PRODUCTION_ESLINT_CONFIG = ".prod.eslintrc.js";
 
-// Paths
-const APP_SOURCE_DIRECTORY = "src";                // App source code directory.
-const APP_NODE_MODULES_DIRECTORY = "node_modules"; // Node modules.
-const OUTPUT_PATH = "build/myaccount";             // Build artifacts output path.
-const CACHE_DIRECTORY = "cache";                   // Output directory for the cache files. Only applicable in dev mode.
-const STATIC_ASSETS_DIRECTORY = "static/media";    // Output directory for static assets i.e .png, .jpg etc.
+// Paths & Folders
+const APP_SOURCE_DIRECTORY = "src";                    // App source code directory.
+const APP_NODE_MODULES_DIRECTORY = "node_modules";     // Node modules.
+const OUTPUT_PATH = "build/myaccount";                 // Build artifacts output path.
+const CACHE_DIRECTORY = "cache";                       // Output directory for the cache files. Only applicable in dev mode.
+const STATIC_ASSETS_DIRECTORY = "static/media";        // Output directory for static assets i.e .png, .jpg etc.
+const JAVA_EE_SERVER_FOLDERS = [ "**/WEB-INF/**/*" ];  // Java EE server specific folders.
 
 // Dev Server Default Configs.
 const DEV_SERVER_PORT = 9000;
@@ -76,6 +77,8 @@ module.exports = (env) => {
     // will be removed. Since these resources are only available inside IS runtime, when hosted
     // externally, the server (tomcat etc.) will throw errors when trying to resolve them.
     const isDeployedOnExternalServer = env.IS_DEPLOYED_ON_EXTERNAL_SERVER;
+    // Is deployed on a static server. With this option, all the `jsp` files and java specific folders will be dropped.
+    const isDeployedOnStaticServer = env.SERVER_TYPE === "static";
 
     // Analyzing mode options.
     const isAnalyzeMode = env.ENABLE_ANALYZER === "true";
@@ -402,17 +405,26 @@ module.exports = (env) => {
                         context: path.join(__dirname, "src"),
                         force: true,
                         from: "public",
+                        // For deployments on static servers, we don't require the Java EE specific
+                        // folders like `WEB_INF` etc.
+                        globOptions: {
+                            ignore: isDeployedOnStaticServer
+                                ? [ ...JAVA_EE_SERVER_FOLDERS ]
+                                : []
+                        },
                         to: "."
                     },
-                    {
+                    // For deployments on static servers, we don't require `auth.jsp` since we can't use
+                    // `form_post` response mode.
+                    !isDeployedOnStaticServer && {
                         context: path.join(__dirname, "src"),
                         force: true,
                         from: "auth.jsp",
                         to: "."
                     }
-                ]
+                ].filter(Boolean)
             }),
-            isProduction
+            isProduction && !isDeployedOnStaticServer
                 ? new HtmlWebpackPlugin({
                     authorizationCode: "<%=request.getParameter(\"code\")%>",
                     contentType: "<%@ page language=\"java\" contentType=\"text/html; charset=UTF-8\" " +

--- a/apps/myaccount/webpack.config.js
+++ b/apps/myaccount/webpack.config.js
@@ -77,7 +77,8 @@ module.exports = (env) => {
     // will be removed. Since these resources are only available inside IS runtime, when hosted
     // externally, the server (tomcat etc.) will throw errors when trying to resolve them.
     const isDeployedOnExternalServer = env.IS_DEPLOYED_ON_EXTERNAL_SERVER;
-    // Is deployed on a static server. With this option, all the `jsp` files and java specific folders will be dropped.
+    // Flag to determine if the app is deployed on a static server.
+    // With this option, all the `jsp` files and java specific folders will be dropped.
     const isDeployedOnStaticServer = env.SERVER_TYPE === "static";
 
     // Analyzing mode options.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "build:apps": "npx lerna run build --stream --scope '{@wso2is/myaccount,@wso2is/console}'",
         "build:modules": "npx lerna run build --stream --scope '{@wso2is/core,@wso2is/forms,@wso2is/form,@wso2is/i18n,@wso2is/react-components,@wso2is/theme,@wso2is/validation}'",
         "build:external": "npx lerna run build --stream --ignore '{@wso2is/console,@wso2is/myaccount}' && npx lerna run build:external --stream --scope '{@wso2is/console,@wso2is/myaccount}'",
+        "build:external:static": "npx lerna run build --stream --ignore '{@wso2is/console,@wso2is/myaccount}' && npx lerna run build:external:static --stream --scope '{@wso2is/console,@wso2is/myaccount}'",
         "build:theme": "npx lerna run build --stream --scope @wso2is/theme && npx lerna run copy:themes:src --stream --scope '{@wso2is/myaccount,@wso2is/console}'",
         "clean": "npx lerna run clean --stream",
         "clean-all": "npm run remove-package-lock && npm run remove-maven-folders && npm run remove-node-modules",


### PR DESCRIPTION
### Purpose
This PR adds support to generate Console & My Account artifacts without any Java EE server bindings i.e JSP, WEB-INF folder, etc.

*npm commands*

From inside (apps/myaccount | apps/console)

```shell

npm run build:prod -- --env IS_DEPLOYED_ON_EXTERNAL_SERVER=true --env SERVER_TYPE=static
```

or

```shell
npm run build:external:static
```

From Root

```shell
npm run build:external:static
```

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
