### PR TITLE
Extract the stylesheet name from the themes directory in the portals

### DIFF
--- a/apps/authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-	String themeName = "default";
-	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-		+ "/" + "libs/themes/" + themeName + "/");
-	String[] fileNames = themeDir.list();
-	String themeFileName = "";
+    String themeName = "default";
+    File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
+        + "/" + "libs/themes/" + themeName + "/");
+    String[] fileNames = themeDir.list();
+    String themeFileName = "";
 
-	for(String file: fileNames) {
-		if(file.endsWith("min.css")) {
-			themeFileName = file;
-		}
-	}
+    for(String file: fileNames) {
+        if(file.endsWith("min.css")) {
+            themeFileName = file;
+        }
+    }
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/header.jsp
@@ -18,13 +18,29 @@
 
 <%@ include file="localize.jsp" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
+<%@ page import="java.io.File" %>
+
+<!-- Extract the name of the stylesheet-->
+<%
+  String themeName = "default";
+	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
+    + "/" + "libs/themes/" + themeName + "/");
+	String[] fileNames = themeDir.list();
+  String themeFileName = "";
+
+  for(String file: fileNames) {
+    if(file.endsWith("min.css")) {
+      themeFileName = file;
+    }
+  }
+%>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="icon" href="libs/themes/default/assets/images/branding/favicon.ico" type="image/x-icon"/>
-<link href="libs/themes/default/theme.min.css" rel="stylesheet">
+<link href="libs/themes/default/<%= themeFileName %>" rel="stylesheet">
 
 <title><%=AuthenticationEndpointUtil.i18n(resourceBundle, "wso2.identity.server")%></title>
 

--- a/apps/authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-  String themeName = "default";
+  	String themeName = "default";
 	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-    + "/" + "libs/themes/" + themeName + "/");
+    	+ "/" + "libs/themes/" + themeName + "/");
 	String[] fileNames = themeDir.list();
-  String themeFileName = "";
+  	String themeFileName = "";
 
-  for(String file: fileNames) {
-    if(file.endsWith("min.css")) {
-      themeFileName = file;
-    }
-  }
+  	for(String file: fileNames) {
+    	if(file.endsWith("min.css")) {
+      		themeFileName = file;
+    	}
+  	}
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/authentication-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-  	String themeName = "default";
+	String themeName = "default";
 	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-    	+ "/" + "libs/themes/" + themeName + "/");
+		+ "/" + "libs/themes/" + themeName + "/");
 	String[] fileNames = themeDir.list();
-  	String themeFileName = "";
+	String themeFileName = "";
 
-  	for(String file: fileNames) {
-    	if(file.endsWith("min.css")) {
-      		themeFileName = file;
-    	}
-  	}
+	for(String file: fileNames) {
+		if(file.endsWith("min.css")) {
+			themeFileName = file;
+		}
+	}
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/console/scripts/pre-build.js
+++ b/apps/console/scripts/pre-build.js
@@ -17,6 +17,7 @@
  */
 
 const { execSync } = require("child_process");
+const crypto = require("crypto");
 const path = require("path");
 const fs = require("fs-extra");
 
@@ -57,6 +58,12 @@ log("Completed compiling i18n extensions.");
 
 const i18NTempExtensionsPath = path.join(distDirectory, "resources");
 const i18nExtensions = require(i18NTempExtensionsPath);
+const files = fs.readdirSync(i18nNodeModulesDir);
+const metaJsonFileName = files.filter(file => file.startsWith("meta"))[ 0 ];
+const metaFilePath = path.join(i18nNodeModulesDir, metaJsonFileName);
+const meta = require(metaFilePath);
+
+const namespaces = [];
 
 log("Moving extensions.json files to the build directory");
 for (const value of Object.values(i18nExtensions)) {
@@ -65,10 +72,27 @@ for (const value of Object.values(i18nExtensions)) {
     }
 
     const fileContent = JSON.stringify(value.extensions, undefined, 4);
-    const fileName = "extensions.json";
+    const hash = crypto.createHash("sha1").update(JSON.stringify(fileContent)).digest("hex");
+    const fileName = `extensions.${ hash.substr(0, 8) }.json`;
     const filePath = path.join(i18nNodeModulesDir, value.name, "portals", fileName);
     createFile(filePath, fileContent, null, true);
+
+    // Update the name of the extensions file in the meta.json file.
+    meta[ value.name ].paths.extensions = meta[ value.name ].paths.extensions.replace("{hash}", hash.substr(0, 8));
+
+    // Capture existing namespaces.
+    namespaces.push(value.name);
 }
+
+// Remove non-existent namespaces from the meta.json file.
+Object.keys(meta).forEach((key) => {
+    if (!namespaces.includes(key)) {
+        delete meta[ key ].paths.extensions;
+    }
+});
+
+// Save meta.json file.
+createFile(metaFilePath, JSON.stringify(meta, undefined, 4));
 
 log("Cleaning the tmp directory...");
 execSync("npm run clean:i18n:dist");

--- a/apps/console/src/features/core/constants/i18n-constants.ts
+++ b/apps/console/src/features/core/constants/i18n-constants.ts
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-import { I18nModuleConstants, I18nModuleInitOptions, generateBackendPaths } from "@wso2is/i18n";
-import { Config } from "../configs";
+import { I18nModuleConstants } from "@wso2is/i18n";
 
 /**
  * Class containing portal specific i18n constants.
@@ -68,42 +67,6 @@ export class I18nConstants {
         [ I18nConstants.CONSOLE_PORTAL_NAMESPACE, "portals" ],
         [ I18nConstants.EXTENSIONS_NAMESPACE, "portals" ]
     ]);
-
-    /**
-     * I18n init options.
-     *
-     * @remarks
-     * Since the portals are not deployed per tenant, looking for static resources in tenant qualified URLs will fail.
-     * Using `appBaseNameWithoutTenant` will create a path without the tenant. Therefore, `loadPath()` function will
-     * look for resource files in `https://localhost:9443/<PORTAL>/resources/i18n` rather than looking for the
-     * files in `https://localhost:9443/t/wso2.com/<PORTAL>/resources/i18n`.
-     *
-     * @constant
-     * @type {I18nModuleInitOptions}
-     * @default
-     */
-    public static readonly MODULE_INIT_OPTIONS: I18nModuleInitOptions = {
-        backend: {
-            loadPath: (language, namespace) => generateBackendPaths(
-                language,
-                namespace,
-                window["AppUtils"].getConfig().appBase,
-                Config.getI18nConfig() ?? {
-                    langAutoDetectEnabled: I18nConstants.LANG_AUTO_DETECT_ENABLED,
-                    namespaceDirectories: I18nConstants.BUNDLE_NAMESPACE_DIRECTORIES,
-                    overrideOptions: I18nConstants.INIT_OPTIONS_OVERRIDE,
-                    resourcePath: "/resources/i18n",
-                    xhrBackendPluginEnabled: I18nConstants.XHR_BACKEND_PLUGIN_ENABLED
-                }
-            )
-        },
-        load: "currentOnly", // lookup only current lang key(en-US). Prevents 404 from `en`.
-        ns: [
-            I18nConstants.COMMON_NAMESPACE,
-            I18nConstants.CONSOLE_PORTAL_NAMESPACE,
-            I18nConstants.EXTENSIONS_NAMESPACE
-        ]
-    };
 
     /**
      * I18n init options override flag. The default options in the module will be overridden if set to true.

--- a/apps/console/src/index.html
+++ b/apps/console/src/index.html
@@ -23,7 +23,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
         <meta name="referrer" content="no-referrer" />
 
-        <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.min.css" rel="stylesheet" type="text/css"/>
+        <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.<%= htmlWebpackPlugin.options.themeHash %>.min.css" rel="stylesheet" type="text/css"/>
         <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/assets/images/branding/favicon.ico" />
 
         <script>

--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -33,7 +33,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
         <meta name="referrer" content="no-referrer" />
 
-        <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.min.css" rel="stylesheet" type="text/css"/>
+        <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.<%= htmlWebpackPlugin.options.themeHash %>.min.css" rel="stylesheet" type="text/css"/>
         <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/assets/images/branding/favicon.ico" />
 
         <script>

--- a/apps/console/src/index.tsx
+++ b/apps/console/src/index.tsx
@@ -38,34 +38,34 @@ import "regenerator-runtime/runtime";
 // Set the runtime config in the context.
 ContextUtils.setRuntimeConfig(Config.getDeploymentConfig());
 
-// Set up the i18n module.
-I18n.init({
-    ...Config.getI18nConfig()?.initOptions,
-    debug: window["AppUtils"].getConfig().debug
-    },
-    Config.getI18nConfig()?.overrideOptions,
-    Config.getI18nConfig()?.langAutoDetectEnabled,
-    Config.getI18nConfig()?.xhrBackendPluginEnabled)
-    .then(() => {
+// If `appBaseNameWithoutTenant` is "", avoids adding a forward slash.
+const resolvedAppBaseNameWithoutTenant: string = StringUtils.removeSlashesFromPath(
+    Config.getDeploymentConfig().appBaseNameWithoutTenant)
+    ? `/${ StringUtils.removeSlashesFromPath(Config.getDeploymentConfig().appBaseNameWithoutTenant) }`
+    : "";
 
-        // If `appBaseNameWithoutTenant` is "", avoids adding a forward slash.
-        const resolvedAppBaseNameWithoutTenant: string = StringUtils.removeSlashesFromPath(
-            Config.getDeploymentConfig().appBaseNameWithoutTenant)
-            ? `/${ StringUtils.removeSlashesFromPath(Config.getDeploymentConfig().appBaseNameWithoutTenant) }`
-            : "";
+const metaFileNames = I18nModuleConstants.META_FILENAME.split(".");
+const metaFileName = `${ metaFileNames[ 0 ] }.${ process.env.metaHash }.${ metaFileNames[ 1 ] }`;
 
-        // Since the portals are not deployed per tenant, looking for static resources in tenant qualified URLs
-        // will fail. This constructs the path without the tenant, therefore it'll look for the file in
-        // `https://localhost:9443/<PORTAL>/resources/i18n/meta.json` rather than looking for the file in
-        // `https://localhost:9443/t/wso2.com/<PORTAL>/resources/i18n/meta.json`.
-        const metaPath = `${ resolvedAppBaseNameWithoutTenant }/${
-            StringUtils.removeSlashesFromPath(Config.getI18nConfig().resourcePath) }/${
-            I18nModuleConstants.META_FILENAME
-            }`;
+// Since the portals are not deployed per tenant, looking for static resources in tenant qualified URLs
+// will fail. This constructs the path without the tenant, therefore it'll look for the file in
+// `https://localhost:9443/<PORTAL>/resources/i18n/meta.json` rather than looking for the file in
+// `https://localhost:9443/t/wso2.com/<PORTAL>/resources/i18n/meta.json`.
+const metaPath = `${ resolvedAppBaseNameWithoutTenant }/
+${ StringUtils.removeSlashesFromPath(Config.getI18nConfig().resourcePath) }/${ metaFileName }`;
 
-        // Fetch the meta file to get the supported languages.
-        axios.get(metaPath)
-            .then((response) => {
+// Fetch the meta file to get the supported languages and paths.
+axios.get(metaPath)
+    .then((response) => {
+    // Set up the i18n module.
+    I18n.init({
+        ...Config.getI18nConfig(response?.data)?.initOptions,
+        debug: window["AppUtils"].getConfig().debug
+        },
+        Config.getI18nConfig()?.overrideOptions,
+        Config.getI18nConfig()?.langAutoDetectEnabled,
+        Config.getI18nConfig()?.xhrBackendPluginEnabled)
+        .then(() => {
                 // Set the supported languages in redux store.
                 store.dispatch(setSupportedI18nLanguages(response?.data));
 
@@ -78,10 +78,10 @@ I18n.init({
                         });
                 }
             });
-    })
-    .catch((error) => {
-        throw new I18nInstanceInitException(error);
-    });
+        })
+        .catch((error) => {
+            throw new I18nInstanceInitException(error);
+        });
 
 ReactDOM.render(
     (

--- a/apps/console/webpack.config.js
+++ b/apps/console/webpack.config.js
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+const fs = require("fs");
 const path = require("path");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 const BrotliPlugin = require("brotli-webpack-plugin");
@@ -28,6 +29,7 @@ const TerserPlugin = require("terser-webpack-plugin");
 const webpack = require("webpack");
 const BundleAnalyzerPlugin = require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 const deploymentConfig = require("./src/public/deployment.config.json");
+const { env } = require("process");
 
 // Flag to enable source maps in production.
 const isSourceMapsEnabledInProduction = false;
@@ -50,6 +52,20 @@ const JAVA_EE_SERVER_FOLDERS = [ "**/WEB-INF/**/*" ];  // Java EE server specifi
 // Dev Server Default Configs.
 const DEV_SERVER_PORT = 9001;
 const ROOT_CONTEXT_DEV_SERVER_INITIAL_REDIRECT = "/login";
+
+const THEME_TO_USE = deploymentConfig.ui.theme.name || "default";
+const THEME_DIR = path.resolve(__dirname, "node_modules", "@wso2is", "theme", "dist", "lib", "themes", THEME_TO_USE);
+let themeHash;
+const files = fs.readdirSync(THEME_DIR);
+
+const file = files ? files.filter(file => file.endsWith(".min.css"))[ 0 ] : null;
+themeHash = file ? file.split(".")[ 1 ] : null;
+
+const I18N_DIR = path.resolve(__dirname, "node_modules", "@wso2is", "i18n", "dist", "bundle");
+const metaFiles = fs.readdirSync(I18N_DIR);
+
+const metaFile = metaFiles ? metaFiles.filter(file => file.startsWith("meta"))[ 0 ] : null;
+const metaHash = metaFile ? metaFile.split(".")[ 1 ] : null;
 
 module.exports = (env) => {
 
@@ -77,7 +93,7 @@ module.exports = (env) => {
     const isDevServerHostCheckDisabled = env.DISABLE_DEV_SERVER_HOST_CHECK === "true";
 
     const shouldCopyLessDistribution = env.SHOULD_COPY_LESS_DISTRIBUTION === "true";
-    
+
     const isESLintPluginDisabled = env.DISABLE_ESLINT_PLUGIN === "true";
 
     // Log level.
@@ -473,6 +489,7 @@ module.exports = (env) => {
                     tenantPrefix: !isDeployedOnExternalServer
                         ? "<%=TENANT_AWARE_URL_PREFIX%>"
                         : "",
+                    themeHash: themeHash,
                     vwoScriptVariable: "<%= vwo_ac_id %>",
                     vwoSystemVariable: "<% String vwo_ac_id = System.getenv(\"vwo_account_id\"); %>"
                 })
@@ -484,7 +501,8 @@ module.exports = (env) => {
                     publicPath: !isRootContext
                         ? publicPath
                         : "/",
-                    template: path.join(__dirname, "src", "index.html")
+                    template: path.join(__dirname, "src", "index.html"),
+                    themeHash: themeHash
                 }),
             new HtmlWebpackPlugin({
                 excludeChunks: [ "main", "init" ],
@@ -498,7 +516,8 @@ module.exports = (env) => {
             }),
             new webpack.DefinePlugin({
                 "process.env": {
-                    NODE_ENV: JSON.stringify(env.NODE_ENV)
+                    NODE_ENV: JSON.stringify(env.NODE_ENV),
+                    metaHash: JSON.stringify(metaHash)
                 },
                 "typeof window": JSON.stringify("object")
             }),

--- a/apps/myaccount/src/constants/i18n-constants.ts
+++ b/apps/myaccount/src/constants/i18n-constants.ts
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-import { I18nModuleConstants, I18nModuleInitOptions, generateBackendPaths } from "@wso2is/i18n";
-import { store } from "../store";
+import { I18nModuleConstants } from "@wso2is/i18n";
 
 /**
  * Class containing dev portal specific i18n constants.
@@ -50,38 +49,6 @@ export class I18nConstants {
         [ I18nConstants.COMMON_NAMESPACE, "portals" ],
         [ I18nConstants.PORTAL_NAMESPACE, "portals" ]
     ]);
-
-    /**
-     * I18n init options.
-     *
-     * @remarks
-     * Since the portals are not deployed per tenant, looking for static resources in tenant qualified URLs will fail.
-     * Using `appBaseNameWithoutTenant` will create a path without the tenant. Therefore, `loadPath()` function will
-     * look for resource files in `https://localhost:9443/<PORTAL>/resources/i18n` rather than looking for the
-     * files in `https://localhost:9443/t/wso2.com/<PORTAL>/resources/i18n`.
-     *
-     * @constant
-     * @type {I18nModuleInitOptions}
-     * @default
-     */
-    public static readonly MODULE_INIT_OPTIONS: I18nModuleInitOptions = {
-        backend: {
-            loadPath: (language, namespace) => generateBackendPaths(
-                language,
-                namespace,
-                window["AppUtils"].getConfig().appBase,
-                store.getState().config.i18n ?? {
-                    langAutoDetectEnabled: I18nConstants.LANG_AUTO_DETECT_ENABLED,
-                    namespaceDirectories: I18nConstants.BUNDLE_NAMESPACE_DIRECTORIES,
-                    overrideOptions: I18nConstants.INIT_OPTIONS_OVERRIDE,
-                    resourcePath: "/resources/i18n",
-                    xhrBackendPluginEnabled: I18nConstants.XHR_BACKEND_PLUGIN_ENABLED
-                }
-            )
-        },
-        load: "currentOnly", // lookup only current lang key(en-US). Prevents 404 from `en`.
-        ns: [ I18nConstants.COMMON_NAMESPACE, I18nConstants.PORTAL_NAMESPACE ]
-    };
 
     /**
      * I18n init options override flag. The default options in the module will be overridden if set to true.

--- a/apps/myaccount/src/index.html
+++ b/apps/myaccount/src/index.html
@@ -23,7 +23,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
         <meta name="referrer" content="no-referrer" />
 
-        <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.min.css" rel="stylesheet" type="text/css"/>
+        <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.<%= htmlWebpackPlugin.options.themeHash %>.min.css" rel="stylesheet" type="text/css"/>
         <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/assets/images/branding/favicon.ico" />
 
         <script>

--- a/apps/myaccount/src/index.jsp
+++ b/apps/myaccount/src/index.jsp
@@ -33,7 +33,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
         <meta name="referrer" content="no-referrer" />
 
-        <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.min.css" rel="stylesheet" type="text/css"/>
+        <link href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/theme.<%= htmlWebpackPlugin.options.themeHash %>.min.css" rel="stylesheet" type="text/css"/>
         <link rel="shortcut icon" href="<%= htmlWebpackPlugin.options.publicPath %>/libs/themes/default/assets/images/branding/favicon.ico" />
 
         <script>

--- a/apps/myaccount/webpack.config.js
+++ b/apps/myaccount/webpack.config.js
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+const fs = require("fs");
 const path = require("path");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 const BrotliPlugin = require("brotli-webpack-plugin");
@@ -50,6 +51,20 @@ const JAVA_EE_SERVER_FOLDERS = [ "**/WEB-INF/**/*" ];  // Java EE server specifi
 // Dev Server Default Configs.
 const DEV_SERVER_PORT = 9000;
 const ROOT_CONTEXT_DEV_SERVER_INITIAL_REDIRECT = "/login";
+
+const THEME_TO_USE = deploymentConfig.ui.theme.name || "default";
+const THEME_DIR = path.resolve(__dirname, "node_modules", "@wso2is", "theme", "dist", "lib", "themes", THEME_TO_USE);
+let themeHash;
+const files = fs.readdirSync(THEME_DIR);
+
+const file = files ? files.filter(file => file.endsWith(".min.css"))[ 0 ] : null;
+themeHash = file ? file.split(".")[ 1 ] : null;
+
+const I18N_DIR = path.resolve(__dirname, "node_modules", "@wso2is", "i18n", "dist", "bundle");
+const metaFiles = fs.readdirSync(I18N_DIR);
+
+const metaFile = metaFiles ? metaFiles.filter(file => file.startsWith("meta"))[ 0 ] : null;
+const metaHash = metaFile ? metaFile.split(".")[ 1 ] : null;
 
 module.exports = (env) => {
 
@@ -448,6 +463,7 @@ module.exports = (env) => {
                     tenantPrefix: !isDeployedOnExternalServer
                         ? "<%=TENANT_AWARE_URL_PREFIX%>"
                         : "",
+                    themeHash: themeHash,
                     vwoScriptVariable: "<%= vwo_ac_id %>",
                     vwoSystemVariable: "<% String vwo_ac_id = System.getenv(\"vwo_account_id\"); %>"
                 })
@@ -459,7 +475,8 @@ module.exports = (env) => {
                     publicPath: !isRootContext
                         ? publicPath
                         : "/",
-                    template: path.join(__dirname, "src", "index.html")
+                    template: path.join(__dirname, "src", "index.html"),
+                    themeHash: themeHash
                 }),
             new HtmlWebpackPlugin({
                 excludeChunks: [ "main", "init" ],
@@ -473,7 +490,8 @@ module.exports = (env) => {
             }),
             new webpack.DefinePlugin({
                 "process.env": {
-                    NODE_ENV: JSON.stringify(env.NODE_ENV)
+                    NODE_ENV: JSON.stringify(env.NODE_ENV),
+                    metaHash: JSON.stringify(metaHash)
                 },
                 "typeof window": JSON.stringify("object")
             }),

--- a/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -18,12 +18,28 @@
 
 <jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="java.io.File" %>
+
+<!-- Extract the name of the stylesheet-->
+<%
+  String themeName = "default";
+	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
+    + "/" + "libs/themes/" + themeName + "/");
+	String[] fileNames = themeDir.list();
+  String themeFileName = "";
+
+  for(String file: fileNames) {
+    if(file.endsWith("min.css")) {
+      themeFileName = file;
+    }
+  }
+%>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="icon" href="libs/themes/default/assets/images/branding/favicon.ico" type="image/x-icon"/>
-<link href="libs/themes/default/theme.min.css" rel="stylesheet">
+<link href="libs/themes/default/<%= themeFileName %>" rel="stylesheet">
 
 <title><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Wso2.identity.server")%></title>

--- a/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-  String themeName = "default";
+  	String themeName = "default";
 	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-    + "/" + "libs/themes/" + themeName + "/");
+    	+ "/" + "libs/themes/" + themeName + "/");
 	String[] fileNames = themeDir.list();
-  String themeFileName = "";
+  	String themeFileName = "";
 
-  for(String file: fileNames) {
-    if(file.endsWith("min.css")) {
-      themeFileName = file;
-    }
-  }
+  	for(String file: fileNames) {
+    	if(file.endsWith("min.css")) {
+      		themeFileName = file;
+    	}
+ 	}
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-  	String themeName = "default";
-	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-    	+ "/" + "libs/themes/" + themeName + "/");
-	String[] fileNames = themeDir.list();
-  	String themeFileName = "";
+    String themeName = "default";
+    File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
+        + "/" + "libs/themes/" + themeName + "/");
+    String[] fileNames = themeDir.list();
+    String themeFileName = "";
 
-  	for(String file: fileNames) {
-    	if(file.endsWith("min.css")) {
-      		themeFileName = file;
-    	}
- 	}
+    for(String file: fileNames) {
+        if(file.endsWith("min.css")) {
+            themeFileName = file;
+        }
+    }
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/sms-otp-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/includes/header.jsp
@@ -18,13 +18,29 @@
 
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ include file="localize.jsp" %>
+<%@ page import="java.io.File" %>
+
+<!-- Extract the name of the stylesheet-->
+<%
+  String themeName = "default";
+	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
+    + "/" + "libs/themes/" + themeName + "/");
+	String[] fileNames = themeDir.list();
+  String themeFileName = "";
+
+  for(String file: fileNames) {
+    if(file.endsWith("min.css")) {
+      themeFileName = file;
+    }
+  }
+%>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="icon" href="libs/themes/default/assets/images/branding/favicon.ico" type="image/x-icon"/>
-<link href="libs/themes/default/theme.min.css" rel="stylesheet">
+<link href="libs/themes/default/<%= themeFileName %>" rel="stylesheet">
 
 
 <title><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "wso2.identity.server")%></title>

--- a/apps/sms-otp-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-  	String themeName = "default";
-	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-    	+ "/" + "libs/themes/" + themeName + "/");
-	String[] fileNames = themeDir.list();
-  	String themeFileName = "";
+    String themeName = "default";
+    File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
+        + "/" + "libs/themes/" + themeName + "/");
+    String[] fileNames = themeDir.list();
+    String themeFileName = "";
 
-  	for(String file: fileNames) {
-    	if(file.endsWith("min.css")) {
-      		themeFileName = file;
-    	}
-  	}
+    for(String file: fileNames) {
+        if(file.endsWith("min.css")) {
+            themeFileName = file;
+        }
+    }
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/sms-otp-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/sms-otp-authentication-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-  String themeName = "default";
+  	String themeName = "default";
 	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-    + "/" + "libs/themes/" + themeName + "/");
+    	+ "/" + "libs/themes/" + themeName + "/");
 	String[] fileNames = themeDir.list();
-  String themeFileName = "";
+  	String themeFileName = "";
 
-  for(String file: fileNames) {
-    if(file.endsWith("min.css")) {
-      themeFileName = file;
-    }
-  }
+  	for(String file: fileNames) {
+    	if(file.endsWith("min.css")) {
+      		themeFileName = file;
+    	}
+  	}
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-	String themeName = "default";
-	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-		+ "/" + "libs/themes/" + themeName + "/");
-	String[] fileNames = themeDir.list();
-	String themeFileName = "";
+    String themeName = "default";
+    File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
+        + "/" + "libs/themes/" + themeName + "/");
+    String[] fileNames = themeDir.list();
+    String themeFileName = "";
 
-	for(String file: fileNames) {
-		if(file.endsWith("min.css")) {
-			themeFileName = file;
-		}
-	}
+    for(String file: fileNames) {
+        if(file.endsWith("min.css")) {
+            themeFileName = file;
+        }
+    }
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
@@ -18,12 +18,28 @@
 
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ include file="localize.jsp" %>
+<%@ page import="java.io.File" %>
+
+<!-- Extract the name of the stylesheet-->
+<%
+  String themeName = "default";
+	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
+    + "/" + "libs/themes/" + themeName + "/");
+	String[] fileNames = themeDir.list();
+  String themeFileName = "";
+
+  for(String file: fileNames) {
+    if(file.endsWith("min.css")) {
+      themeFileName = file;
+    }
+  }
+%>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="icon" href="libs/themes/default/assets/images/favicon.ico" type="image/x-icon"/>
-<link href="libs/themes/default/theme.min.css" rel="stylesheet">
+<link href="libs/themes/default/<%= themeFileName %>" rel="stylesheet">
 
 <title><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "wso2.identity.server")%></title>

--- a/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-  String themeName = "default";
+  	String themeName = "default";
 	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-    + "/" + "libs/themes/" + themeName + "/");
+    	+ "/" + "libs/themes/" + themeName + "/");
 	String[] fileNames = themeDir.list();
-  String themeFileName = "";
+  	String themeFileName = "";
 
-  for(String file: fileNames) {
-    if(file.endsWith("min.css")) {
-      themeFileName = file;
-    }
-  }
+  	for(String file: fileNames) {
+    	if(file.endsWith("min.css")) {
+      		themeFileName = file;
+    	}
+  	}
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
+++ b/apps/x509-certificate-authentication-portal/src/main/webapp/includes/header.jsp
@@ -22,17 +22,17 @@
 
 <!-- Extract the name of the stylesheet-->
 <%
-  	String themeName = "default";
+	String themeName = "default";
 	File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
-    	+ "/" + "libs/themes/" + themeName + "/");
+		+ "/" + "libs/themes/" + themeName + "/");
 	String[] fileNames = themeDir.list();
-  	String themeFileName = "";
+	String themeFileName = "";
 
-  	for(String file: fileNames) {
-    	if(file.endsWith("min.css")) {
-      		themeFileName = file;
-    	}
-  	}
+	for(String file: fileNames) {
+		if(file.endsWith("min.css")) {
+			themeFileName = file;
+		}
+	}
 %>
 
 <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/modules/core/src/helpers/user-agent-parser.ts
+++ b/modules/core/src/helpers/user-agent-parser.ts
@@ -23,14 +23,12 @@ import { IBrowser, IDevice, IEngine, IOS } from "../models";
  * Helper class to parse user agent strings.
  */
 export class UserAgentParser {
-
     private static parser: UAParser;
 
     /**
      * Constructor.
      */
     constructor() {
-
         UserAgentParser.parser = new UAParser();
     }
 
@@ -40,7 +38,6 @@ export class UserAgentParser {
      * @param {string} rawString - Raw user agent string.
      */
     public set uaString(rawString: string) {
-
         UserAgentParser.parser.setUA(rawString);
     }
 
@@ -50,7 +47,6 @@ export class UserAgentParser {
      * @return {IBrowser}
      */
     public get browser(): IBrowser {
-
         return UserAgentParser.parser.getBrowser();
     }
 
@@ -63,7 +59,6 @@ export class UserAgentParser {
      * @return {IDevice}
      */
     public get device(): IDevice {
-
         if (UserAgentParser.parser.getDevice() && UserAgentParser.parser.getDevice().type) {
             return UserAgentParser.parser.getDevice();
         }
@@ -71,41 +66,42 @@ export class UserAgentParser {
         const ua = UserAgentParser.parser.getUA();
 
         /* eslint-disable max-len, no-useless-escape */
-        const type =
-            ua.match(/iPad/i) || (ua.match(/tablet/i) && !ua.match(/RX-34/i)) || ua.match(/FOLIO/i)
+        const type = ua
+            ? ua.match(/iPad/i) || (ua.match(/tablet/i) && !ua.match(/RX-34/i)) || ua.match(/FOLIO/i)
                 ? "tablet"
                 : ua.match(/Linux/i) &&
-                ua.match(/Android/i) &&
-                !ua.match(/Fennec|mobi|HTC.Magic|HTCX06HT|Nexus.One|SC-02B|fone.945/i)
-                ? "tablet"
-                : ua.match(/Kindle/i) || (ua.match(/Mac.OS/i) && ua.match(/Silk/i))
+                    ua.match(/Android/i) &&
+                    !ua.match(/Fennec|mobi|HTC.Magic|HTCX06HT|Nexus.One|SC-02B|fone.945/i)
                     ? "tablet"
-                    : ua.match(
-                        /GT-P10|SC-01C|SHW-M180S|SGH-T849|SCH-I800|SHW-M180L|SPH-P100|SGH-I987|zt180|HTC(.Flyer|\_Flyer)|Sprint.ATP51|ViewPad7|pandigital(sprnova|nova)|Ideos.S7|Dell.Streak.7|Advent.Vega|A101IT|A70BHT|MID7015|Next2|nook/i
-                    ) ||
-                    (ua.match(/MB511/i) && ua.match(/RUTEM/i))
+                    : ua.match(/Kindle/i) || (ua.match(/Mac.OS/i) && ua.match(/Silk/i))
                         ? "tablet"
                         : ua.match(
-                            /BOLT|Fennec|Iris|Maemo|Minimo|Mobi|mowser|NetFront|Novarra|Prism|RX-34|Skyfire|Tear|XV6875|XV6975|Google.Wireless.Transcoder/i
-                        )
-                            ? "mobile"
-                            : ua.match(/Opera/i) &&
-                            ua.match(/Windows.NT.5/i) &&
-                            ua.match(/HTC|Xda|Mini|Vario|SAMSUNG\-GT\-i8000|SAMSUNG\-SGH\-i9/i)
+                            /GT-P10|SC-01C|SHW-M180S|SGH-T849|SCH-I800|SHW-M180L|SPH-P100|SGH-I987|zt180|HTC(.Flyer|\_Flyer)|Sprint.ATP51|ViewPad7|pandigital(sprnova|nova)|Ideos.S7|Dell.Streak.7|Advent.Vega|A101IT|A70BHT|MID7015|Next2|nook/i
+                        ) ||
+                            (ua.match(/MB511/i) && ua.match(/RUTEM/i))
+                            ? "tablet"
+                            : ua.match(
+                                /BOLT|Fennec|Iris|Maemo|Minimo|Mobi|mowser|NetFront|Novarra|Prism|RX-34|Skyfire|Tear|XV6875|XV6975|Google.Wireless.Transcoder/i
+                            )
                                 ? "mobile"
-                                : (ua.match(/Windows.(NT|XP|ME|9)/) && !ua.match(/Phone/i)) || ua.match(/Win(9|.9|NT)/i)
-                                    ? "desktop"
-                                    : ua.match(/Macintosh|PowerPC/i) && !ua.match(/Silk/i)
+                                : ua.match(/Opera/i) &&
+                                    ua.match(/Windows.NT.5/i) &&
+                                    ua.match(/HTC|Xda|Mini|Vario|SAMSUNG\-GT\-i8000|SAMSUNG\-SGH\-i9/i)
+                                    ? "mobile"
+                                    : (ua.match(/Windows.(NT|XP|ME|9)/) && !ua.match(/Phone/i)) || ua.match(/Win(9|.9|NT)/i)
                                         ? "desktop"
-                                        : ua.match(/Linux/i) && ua.match(/X11/i)
+                                        : ua.match(/Macintosh|PowerPC/i) && !ua.match(/Silk/i)
                                             ? "desktop"
-                                            : ua.match(/Solaris|SunOS|BSD/i)
+                                            : ua.match(/Linux/i) && ua.match(/X11/i)
                                                 ? "desktop"
-                                                : ua.match(
-                                                    /Bot|Crawler|Spider|Yahoo|ia_archiver|Covario-IDS|findlinks|DataparkSearch|larbin|Mediapartners-Google|NG-Search|Snappy|Teoma|Jeeves|TinEye/i
-                                                ) && !ua.match(/Mobile/i)
+                                                : ua.match(/Solaris|SunOS|BSD/i)
                                                     ? "desktop"
-                                                    : "mobile";
+                                                    : ua.match(
+                                                        /Bot|Crawler|Spider|Yahoo|ia_archiver|Covario-IDS|findlinks|DataparkSearch|larbin|Mediapartners-Google|NG-Search|Snappy|Teoma|Jeeves|TinEye/i
+                                                    ) && !ua.match(/Mobile/i)
+                                                        ? "desktop"
+                                                        : "mobile"
+            : "";
         /* eslint-enable max-len, no-useless-escape */
 
         return {

--- a/modules/i18n/src/helpers.ts
+++ b/modules/i18n/src/helpers.ts
@@ -19,7 +19,7 @@
 import { StringUtils } from "@wso2is/core/utils";
 import { InitOptions, Resource } from "i18next";
 import { I18nModuleConstants } from "./constants";
-import { I18nModuleOptionsInterface, LocaleBundles, SupportedLanguagesMeta } from "./models";
+import { I18nModuleOptionsInterface, LocaleBundles, MetaI18N, SupportedLanguagesMeta } from "./models";
 
 /**
  * Generate the i18n options.
@@ -182,7 +182,8 @@ export const isLanguageSupported = (detectedLanguage: string,
 export const generateBackendPaths = (language: string[],
                                      namespace: string[],
                                      appBaseName: string,
-                                     i18nBundleOptions: I18nModuleOptionsInterface): string => {
+                                     i18nBundleOptions: I18nModuleOptionsInterface,
+                                     metaFile: MetaI18N): string => {
 
     // If `appBaseName` is "", avoids adding a forward slash.
     const resolvedAppBaseName: string = StringUtils.removeSlashesFromPath(appBaseName)
@@ -192,9 +193,12 @@ export const generateBackendPaths = (language: string[],
     const fullResourcePath = `${ resolvedAppBaseName }${
         StringUtils.removeSlashesFromPath(i18nBundleOptions?.resourcePath) }`;
 
+    const fileNames = metaFile[ language[ 0 ] ].paths[ namespace[ 0 ] ].split("/");
+    const fileName = fileNames[ fileNames.length - 1 ];
+
     if (i18nBundleOptions?.namespaceDirectories.has(namespace[0])) {
         return `/${ fullResourcePath }/${ language[0] }/${ i18nBundleOptions.namespaceDirectories.get(namespace[0]) }/${
-            namespace[0] }.json`;
+            fileName}`;
     }
 
     return `/${ fullResourcePath }/${ language[0] }/${ namespace[0] }.json`;

--- a/modules/i18n/src/models/meta.ts
+++ b/modules/i18n/src/models/meta.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,7 +16,19 @@
  * under the License.
  */
 
-export * from "./namespaces";
-export * from "./misc";
-export * from "./common";
-export * from "./meta";
+export interface MetaI18NNamespace {
+    code: string;
+    flag: string;
+    name: string;
+    namespaces: string[];
+    paths: {
+        common: string;
+        console: string;
+        myAccount: string;
+        extensions: string;
+    };
+}
+
+export interface MetaI18N {
+    [ key: string ]: MetaI18NNamespace;
+}


### PR DESCRIPTION
### Purpose
> This PR introduces the logic to extract the name of the stylesheet from the themes directory. This would allow stylesheet name to be dynamic. 
> Restores #2527 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
