### PR TITLE
Fix issues when the namespace is "en"

### DIFF
--- a/modules/i18n/src/helpers.ts
+++ b/modules/i18n/src/helpers.ts
@@ -193,8 +193,8 @@ export const generateBackendPaths = (language: string[],
     const fullResourcePath = `${ resolvedAppBaseName }${
         StringUtils.removeSlashesFromPath(i18nBundleOptions?.resourcePath) }`;
 
-    const fileNames = metaFile[ language[ 0 ] ].paths[ namespace[ 0 ] ].split("/");
-    const fileName = fileNames[ fileNames.length - 1 ];
+    const fileNames = metaFile[ language[ 0 ] ]?.paths[ namespace[ 0 ] ]?.split("/");
+    const fileName = fileNames ? fileNames[ fileNames?.length - 1 ] : "";
 
     if (i18nBundleOptions?.namespaceDirectories.has(namespace[0])) {
         return `/${ fullResourcePath }/${ language[0] }/${ i18nBundleOptions.namespaceDirectories.get(namespace[0]) }/${


### PR DESCRIPTION
### Purpose
> The apps throw an error when the namespace of localization logic is set to `en`. This resolves that issue.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
