### PR TITLE
Add tour-id prop to generic icon component

### DIFF
--- a/modules/react-components/src/components/icon/generic-icon.tsx
+++ b/modules/react-components/src/components/icon/generic-icon.tsx
@@ -137,6 +137,7 @@ export interface GenericIconProps extends TestableComponentInterface {
      * Vertical alignment.
      */
     verticalAlign?: SemanticVERTICALALIGNMENTS;
+    "data-tourid"?: string;
 }
 
 /**
@@ -199,7 +200,8 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
         transparent,
         twoTone,
         verticalAlign,
-        [ "data-testid" ]: testId
+        [ "data-testid" ]: testId,
+        [ "data-tourid"]: tourId
     } = props;
     
     const [ renderedIcon, setRenderedIcon ] = useState<HTMLElement | SVGElement | ReactElement | JSX.Element>(null);
@@ -384,6 +386,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
             style={ style }
             onClick={ onIconClickHandler }
             data-testid={ testId }
+            data-tourid={ tourId }
         >
             { renderedIcon }
         </div>
@@ -399,6 +402,7 @@ GenericIcon.defaultProps = {
     bordered: false,
     className: "",
     "data-testid": "generic-icon",
+    "data-tourid": null,
     defaultIcon: false,
     disabled: false,
     floated: null,

--- a/modules/react-components/src/components/icon/generic-icon.tsx
+++ b/modules/react-components/src/components/icon/generic-icon.tsx
@@ -204,7 +204,7 @@ export const GenericIcon: React.FunctionComponent<PropsWithChildren<GenericIconP
         twoTone,
         verticalAlign,
         [ "data-testid" ]: testId,
-        [ "data-tourid"]: tourId
+        [ "data-tourid" ]: tourId
     } = props;
     
     const [ renderedIcon, setRenderedIcon ] = useState<HTMLElement | SVGElement | ReactElement | JSX.Element>(null);

--- a/modules/react-components/src/components/icon/generic-icon.tsx
+++ b/modules/react-components/src/components/icon/generic-icon.tsx
@@ -137,6 +137,9 @@ export interface GenericIconProps extends TestableComponentInterface {
      * Vertical alignment.
      */
     verticalAlign?: SemanticVERTICALALIGNMENTS;
+    /**
+     * ID used to recognize components in guided tour wizards.
+     */
     "data-tourid"?: string;
 }
 


### PR DESCRIPTION
### Purpose
This PR adds a new prop `data-tourid` which is used to point pop-ups of guided wizards. This will fix an issue where the 3rd and final step disappears in the guided tour of conditional authentication section.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
