### PR TITLE
Update oidc-configurations.tsx too revert the height of the text fields

### DIFF
--- a/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
+++ b/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
@@ -16,289 +16,289 @@
  * under the License.
  */
 
- import { IdentityClient } from "@wso2/identity-oidc-js";
- import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
- import { addAlert } from "@wso2is/core/store";
- import { CopyInputField, GenericIcon } from "@wso2is/react-components";
- import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
- import { useTranslation } from "react-i18next";
- import { useDispatch, useSelector } from "react-redux";
- import { Form, Grid, Icon } from "semantic-ui-react";
- import { AppState } from "../../../core/store";
- import { getHelpPanelIcons } from "../../configs";
- import {
-     OIDCApplicationConfigurationInterface,
-     OIDCEndpointsInterface
- } from "../../models";
- 
- /**
-  * Get an identity client instance.
-  *
-  */
- const identityClient = IdentityClient.getInstance();
- 
- /**
-  * Proptypes for the OIDC application configurations component.
-  */
- interface OIDCConfigurationsPropsInterface extends TestableComponentInterface {
-     oidcConfigurations: OIDCApplicationConfigurationInterface;
- }
- 
- /**
-  * OIDC application configurations Component.
-  *
-  * @param {OIDCConfigurationsPropsInterface} props - Props injected to the component.
-  *
-  * @return {React.ReactElement}
-  */
- export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterface> = (
-     props: OIDCConfigurationsPropsInterface
- ): ReactElement => {
- 
-     const { t } = useTranslation();
-     const dispatch = useDispatch();
- 
-     const {
-         oidcConfigurations,
-         [ "data-testid" ]: testId
-     } = props;
- 
-     const serverOrigin: string = useSelector((state: AppState) => state?.config?.deployment?.serverOrigin);
- 
-     const [ endpoints, setEndpoints ] = useState<OIDCEndpointsInterface>(undefined);
- 
-     useEffect(() => {
-         if (endpoints !== undefined) {
-             return;
-         }
- 
-         // Fetch the server endpoints for OIDC applications.
-         identityClient.getServiceEndpoints()
-             .then((response) => {
-                 setEndpoints(response);
-             })
-             .catch(() => {
-                 dispatch(addAlert({
-                     description: t("console:develop.features.applications.notifications.fetchOIDCServiceEndpoints" +
-                         ".genericError.description"),
-                     level: AlertLevels.ERROR,
-                     message: t("console:develop.features.applications.notifications.fetchOIDCServiceEndpoints." +
-                         "genericError.message")
-                 }));
-             });
-     });
- 
-     return (
-         <>
-         <Form>
-         <Grid verticalAlign="middle">
-                 <Grid.Row columns={ 2 }>
-                     <Grid.Column readonly mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                         <GenericIcon
-                             icon={ getHelpPanelIcons().endpoints.wellKnown }
-                             size="micro"
-                             square
-                             transparent
-                             inline
-                             className="left-icon"
-                             verticalAlign="middle"
-                             spaced="right"
-                         />
-                         <label data-testid={ `${ testId }-introspection-label` }>
-                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                 "oidcConfigurations.labels.wellKnown") }
-                         </label>
-                     </Grid.Column>
-                
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                         <CopyInputField
-                             value={ oidcConfigurations?.wellKnownEndpoint  }
-                             data-testid={ `${ testId }-introspection-readonly-input` }
-                         />
-                     </Grid.Column>
-                 </Grid.Row>
-                 <Grid.Row columns={ 2 }>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                         <GenericIcon
-                             icon={ getHelpPanelIcons().endpoints.authorize }
-                             size="micro"
-                             square
-                             transparent
-                             inline
-                             className="left-icon"
-                             verticalAlign="middle"
-                             spaced="right"
-                         />
-                         <label data-testid={ `${ testId }-authorize-label` }>
-                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                 "oidcConfigurations.labels.authorize") }
-                         </label>
-                     </Grid.Column>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                         <CopyInputField
-                             value={ oidcConfigurations?.authorizeEndpoint }
-                             data-testid={ `${ testId }-authorize-readonly-input` }
-                         />
-                     </Grid.Column>
-                 </Grid.Row>
-                 <Grid.Row columns={ 2 }>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                         <GenericIcon
-                             icon={ getHelpPanelIcons().endpoints.token }
-                             size="micro"
-                             square
-                             transparent
-                             inline
-                             className="left-icon"
-                             verticalAlign="middle"
-                             spaced="right"
-                         />
-                         <label data-testid={ `${ testId }-token-label` }>
-                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                 "oidcConfigurations.labels.token") }
-                         </label>
-                     </Grid.Column>
-                     <Grid.Column  mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                         <CopyInputField
-                              
-                             value={ oidcConfigurations?.tokenEndpoint }
-                             data-testid={ `${ testId }-token-readonly-input` }
-                         />
-                     </Grid.Column>
-                 </Grid.Row>
-                 <Grid.Row columns={ 2 }>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                         <GenericIcon
-                             icon={ getHelpPanelIcons().endpoints.userInfo }
-                             size="micro"
-                             square
-                             transparent
-                             inline
-                             className="left-icon"
-                             verticalAlign="middle"
-                             spaced="right"
-                         />
-                         <label data-testid={ `${ testId }-userInfo-label` }>
-                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                 "oidcConfigurations.labels.userInfo") }
-                         </label>
-                     </Grid.Column>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        
-                         <CopyInputField
-                             value={ oidcConfigurations?.userEndpoint }
-                             data-testid={ `${ testId }-userInfo-readonly-input` }
-                         />
-                     </Grid.Column>
-                 </Grid.Row>
-                 <Grid.Row columns={ 2 }>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                         <GenericIcon
-                             icon={ getHelpPanelIcons().endpoints.introspect }
-                             size="micro"
-                             square
-                             transparent
-                             inline
-                             className="left-icon"
-                             verticalAlign="middle"
-                             spaced="right"
-                         />
-                         <label data-testid={ `${ testId }-introspection-label` }>
-                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                 "oidcConfigurations.labels.introspection") }
-                         </label>
-                     </Grid.Column>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                         <CopyInputField
-                             value={ oidcConfigurations?.introspectionEndpoint }
-                             data-testid={ `${ testId }-introspection-readonly-input` }
-                         />
-                     </Grid.Column>
-                 </Grid.Row>
-                 <Grid.Row columns={ 2 }>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                         <GenericIcon
-                             icon={ getHelpPanelIcons().endpoints.jwks }
-                             size="micro"
-                             square
-                             transparent
-                             inline
-                             className="left-icon"
-                             verticalAlign="middle"
-                             spaced="right"
-                         />
-                         <label data-testid={ `${ testId }-jwks-label` }>
-                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                 "oidcConfigurations.labels.jwks") }
-                         </label>
-                     </Grid.Column>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                         <CopyInputField
-                             value={ oidcConfigurations?.jwksEndpoint }
-                             data-testid={ `${ testId }-jwks-readonly-input` }
-                         />
-                     </Grid.Column>
-                 </Grid.Row>
-                 <Grid.Row columns={ 2 }>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                         <GenericIcon
-                             icon={ getHelpPanelIcons().endpoints.revoke }
-                             size="micro"
-                             square
-                             transparent
-                             inline
-                             className="left-icon"
-                             verticalAlign="middle"
-                             spaced="right"
-                         />
-                         <label data-testid={ `${ testId }-token-revoke-label` }>
-                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                 "oidcConfigurations.labels.revoke") }
-                         </label>
-                     </Grid.Column>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                         <CopyInputField
-                             value={ oidcConfigurations?.tokenRevocationEndpoint }
-                             className="panel-url-input"
-                             data-testid={ `${ testId }-token-revoke-readonly-input` }
-                         />
-                     </Grid.Column>
-                 </Grid.Row>
-                 <Grid.Row columns={ 2 }>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                         <GenericIcon
-                             icon={ <Icon className={ "mr-0" } name="power off" /> }
-                             size="micro"
-                             square
-                             transparent
-                             inline
-                             className="left-icon"
-                             verticalAlign="middle"
-                             spaced="right"
-                         />
-                         <label data-testid={ `${ testId }-logout-label` }>
-                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                 "oidcConfigurations.labels.endSession") }
-                         </label>
-                     </Grid.Column>
-                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                         <CopyInputField 
-                             value={ oidcConfigurations?.endSessionEndpoint  }
-                             className="panel-url-input"
-                             data-testid={ `${ testId }-logout-readonly-input` }
-                         />
-                     </Grid.Column>
-                 </Grid.Row>
-             </Grid>
-         </Form>
-             
-         </>
-     );
- };
- 
- /**
-  * Default props for the OIDC application Configurations component.
-  */
- OIDCConfigurations.defaultProps = {
-     "data-testid": "applications-help-panel-oidc-configs"
+import { IdentityClient } from "@wso2/identity-oidc-js";
+import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { CopyInputField, GenericIcon } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import { Grid, Icon } from "semantic-ui-react";
+import { AppState } from "../../../core/store";
+import { getHelpPanelIcons } from "../../configs";
+import {
+    OIDCApplicationConfigurationInterface,
+    OIDCEndpointsInterface
+} from "../../models";
+
+/**
+ * Get an identity client instance.
+ *
+ */
+const identityClient = IdentityClient.getInstance();
+
+/**
+ * Proptypes for the OIDC application configurations component.
+ */
+interface OIDCConfigurationsPropsInterface extends TestableComponentInterface {
+    oidcConfigurations: OIDCApplicationConfigurationInterface;
+}
+
+/**
+ * OIDC application configurations Component.
+ *
+ * @param {OIDCConfigurationsPropsInterface} props - Props injected to the component.
+ *
+ * @return {React.ReactElement}
+ */
+export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterface> = (
+    props: OIDCConfigurationsPropsInterface
+): ReactElement => {
+
+    const { t } = useTranslation();
+    const dispatch = useDispatch();
+
+    const {
+        oidcConfigurations,
+        [ "data-testid" ]: testId
+    } = props;
+
+    const serverOrigin: string = useSelector((state: AppState) => state?.config?.deployment?.serverOrigin);
+
+    const [ endpoints, setEndpoints ] = useState<OIDCEndpointsInterface>(undefined);
+
+    useEffect(() => {
+        if (endpoints !== undefined) {
+            return;
+        }
+
+        // Fetch the server endpoints for OIDC applications.
+        identityClient.getServiceEndpoints()
+            .then((response) => {
+                setEndpoints(response);
+            })
+            .catch(() => {
+                dispatch(addAlert({
+                    description: t("console:develop.features.applications.notifications.fetchOIDCServiceEndpoints" +
+                        ".genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("console:develop.features.applications.notifications.fetchOIDCServiceEndpoints." +
+                        "genericError.message")
+                }));
+            });
+    });
+
+    return (
+        <>
+            <Grid verticalAlign="middle">
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.wellKnown }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-introspection-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.wellKnown") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.wellKnownEndpoint  }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-introspection-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.authorize }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-authorize-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.authorize") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.authorizeEndpoint }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-authorize-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.token }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-token-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.token") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.tokenEndpoint }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-token-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.userInfo }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-userInfo-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.userInfo") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.userEndpoint }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-userInfo-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.introspect }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-introspection-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.introspection") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.introspectionEndpoint }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-introspection-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.jwks }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-jwks-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.jwks") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.jwksEndpoint }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-jwks-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.revoke }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-token-revoke-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.revoke") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.tokenRevocationEndpoint }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-token-revoke-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                        <GenericIcon
+                            icon={ <Icon className={ "mr-0" } name="power off" /> }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-logout-label` }>
+                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.endSession") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.endSessionEndpoint  }
+                            className="panel-url-input"
+                            data-testid={ `${ testId }-logout-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+            </Grid>
+        </>
+    );
+};
+
+/**
+ * Default props for the OIDC application Configurations component.
+ */
+OIDCConfigurations.defaultProps = {
+    "data-testid": "applications-help-panel-oidc-configs"
 };

--- a/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
+++ b/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
@@ -16,289 +16,289 @@
  * under the License.
  */
 
-import { IdentityClient } from "@wso2/identity-oidc-js";
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
-import { addAlert } from "@wso2is/core/store";
-import { CopyInputField, GenericIcon } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
-import { Grid, Icon } from "semantic-ui-react";
-import { AppState } from "../../../core/store";
-import { getHelpPanelIcons } from "../../configs";
-import {
-    OIDCApplicationConfigurationInterface,
-    OIDCEndpointsInterface
-} from "../../models";
-
-/**
- * Get an identity client instance.
- *
- */
-const identityClient = IdentityClient.getInstance();
-
-/**
- * Proptypes for the OIDC application configurations component.
- */
-interface OIDCConfigurationsPropsInterface extends TestableComponentInterface {
-    oidcConfigurations: OIDCApplicationConfigurationInterface;
-}
-
-/**
- * OIDC application configurations Component.
- *
- * @param {OIDCConfigurationsPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
- */
-export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterface> = (
-    props: OIDCConfigurationsPropsInterface
-): ReactElement => {
-
-    const { t } = useTranslation();
-    const dispatch = useDispatch();
-
-    const {
-        oidcConfigurations,
-        [ "data-testid" ]: testId
-    } = props;
-
-    const serverOrigin: string = useSelector((state: AppState) => state?.config?.deployment?.serverOrigin);
-
-    const [ endpoints, setEndpoints ] = useState<OIDCEndpointsInterface>(undefined);
-
-    useEffect(() => {
-        if (endpoints !== undefined) {
-            return;
-        }
-
-        // Fetch the server endpoints for OIDC applications.
-        identityClient.getServiceEndpoints()
-            .then((response) => {
-                setEndpoints(response);
-            })
-            .catch(() => {
-                dispatch(addAlert({
-                    description: t("console:develop.features.applications.notifications.fetchOIDCServiceEndpoints" +
-                        ".genericError.description"),
-                    level: AlertLevels.ERROR,
-                    message: t("console:develop.features.applications.notifications.fetchOIDCServiceEndpoints." +
-                        "genericError.message")
-                }));
-            });
-    });
-
-    return (
-        <>
-            <Grid verticalAlign="middle">
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.wellKnown }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-introspection-label` }>
-                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.wellKnown") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.wellKnownEndpoint  }
-                            className="panel-url-input"
-                            data-testid={ `${ testId }-introspection-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.authorize }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-authorize-label` }>
-                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.authorize") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.authorizeEndpoint }
-                            className="panel-url-input"
-                            data-testid={ `${ testId }-authorize-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.token }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-token-label` }>
-                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.token") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.tokenEndpoint }
-                            className="panel-url-input"
-                            data-testid={ `${ testId }-token-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.userInfo }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-userInfo-label` }>
-                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.userInfo") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.userEndpoint }
-                            className="panel-url-input"
-                            data-testid={ `${ testId }-userInfo-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.introspect }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-introspection-label` }>
-                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.introspection") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.introspectionEndpoint }
-                            className="panel-url-input"
-                            data-testid={ `${ testId }-introspection-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.jwks }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-jwks-label` }>
-                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.jwks") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.jwksEndpoint }
-                            className="panel-url-input"
-                            data-testid={ `${ testId }-jwks-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.revoke }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-token-revoke-label` }>
-                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.revoke") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.tokenRevocationEndpoint }
-                            className="panel-url-input"
-                            data-testid={ `${ testId }-token-revoke-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
-                        <GenericIcon
-                            icon={ <Icon className={ "mr-0" } name="power off" /> }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-logout-label` }>
-                            { t("console:develop.features.applications.helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.endSession") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.endSessionEndpoint  }
-                            className="panel-url-input"
-                            data-testid={ `${ testId }-logout-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-            </Grid>
-        </>
-    );
-};
-
-/**
- * Default props for the OIDC application Configurations component.
- */
-OIDCConfigurations.defaultProps = {
-    "data-testid": "applications-help-panel-oidc-configs"
+ import { IdentityClient } from "@wso2/identity-oidc-js";
+ import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+ import { addAlert } from "@wso2is/core/store";
+ import { CopyInputField, GenericIcon } from "@wso2is/react-components";
+ import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+ import { useTranslation } from "react-i18next";
+ import { useDispatch, useSelector } from "react-redux";
+ import { Form, Grid, Icon } from "semantic-ui-react";
+ import { AppState } from "../../../core/store";
+ import { getHelpPanelIcons } from "../../configs";
+ import {
+     OIDCApplicationConfigurationInterface,
+     OIDCEndpointsInterface
+ } from "../../models";
+ 
+ /**
+  * Get an identity client instance.
+  *
+  */
+ const identityClient = IdentityClient.getInstance();
+ 
+ /**
+  * Proptypes for the OIDC application configurations component.
+  */
+ interface OIDCConfigurationsPropsInterface extends TestableComponentInterface {
+     oidcConfigurations: OIDCApplicationConfigurationInterface;
+ }
+ 
+ /**
+  * OIDC application configurations Component.
+  *
+  * @param {OIDCConfigurationsPropsInterface} props - Props injected to the component.
+  *
+  * @return {React.ReactElement}
+  */
+ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterface> = (
+     props: OIDCConfigurationsPropsInterface
+ ): ReactElement => {
+ 
+     const { t } = useTranslation();
+     const dispatch = useDispatch();
+ 
+     const {
+         oidcConfigurations,
+         [ "data-testid" ]: testId
+     } = props;
+ 
+     const serverOrigin: string = useSelector((state: AppState) => state?.config?.deployment?.serverOrigin);
+ 
+     const [ endpoints, setEndpoints ] = useState<OIDCEndpointsInterface>(undefined);
+ 
+     useEffect(() => {
+         if (endpoints !== undefined) {
+             return;
+         }
+ 
+         // Fetch the server endpoints for OIDC applications.
+         identityClient.getServiceEndpoints()
+             .then((response) => {
+                 setEndpoints(response);
+             })
+             .catch(() => {
+                 dispatch(addAlert({
+                     description: t("console:develop.features.applications.notifications.fetchOIDCServiceEndpoints" +
+                         ".genericError.description"),
+                     level: AlertLevels.ERROR,
+                     message: t("console:develop.features.applications.notifications.fetchOIDCServiceEndpoints." +
+                         "genericError.message")
+                 }));
+             });
+     });
+ 
+     return (
+         <>
+         <Form>
+         <Grid verticalAlign="middle">
+                 <Grid.Row columns={ 2 }>
+                     <Grid.Column readonly mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                         <GenericIcon
+                             icon={ getHelpPanelIcons().endpoints.wellKnown }
+                             size="micro"
+                             square
+                             transparent
+                             inline
+                             className="left-icon"
+                             verticalAlign="middle"
+                             spaced="right"
+                         />
+                         <label data-testid={ `${ testId }-introspection-label` }>
+                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                 "oidcConfigurations.labels.wellKnown") }
+                         </label>
+                     </Grid.Column>
+                
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                         <CopyInputField
+                             value={ oidcConfigurations?.wellKnownEndpoint  }
+                             data-testid={ `${ testId }-introspection-readonly-input` }
+                         />
+                     </Grid.Column>
+                 </Grid.Row>
+                 <Grid.Row columns={ 2 }>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                         <GenericIcon
+                             icon={ getHelpPanelIcons().endpoints.authorize }
+                             size="micro"
+                             square
+                             transparent
+                             inline
+                             className="left-icon"
+                             verticalAlign="middle"
+                             spaced="right"
+                         />
+                         <label data-testid={ `${ testId }-authorize-label` }>
+                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                 "oidcConfigurations.labels.authorize") }
+                         </label>
+                     </Grid.Column>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                         <CopyInputField
+                             value={ oidcConfigurations?.authorizeEndpoint }
+                             data-testid={ `${ testId }-authorize-readonly-input` }
+                         />
+                     </Grid.Column>
+                 </Grid.Row>
+                 <Grid.Row columns={ 2 }>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                         <GenericIcon
+                             icon={ getHelpPanelIcons().endpoints.token }
+                             size="micro"
+                             square
+                             transparent
+                             inline
+                             className="left-icon"
+                             verticalAlign="middle"
+                             spaced="right"
+                         />
+                         <label data-testid={ `${ testId }-token-label` }>
+                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                 "oidcConfigurations.labels.token") }
+                         </label>
+                     </Grid.Column>
+                     <Grid.Column  mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                         <CopyInputField
+                              
+                             value={ oidcConfigurations?.tokenEndpoint }
+                             data-testid={ `${ testId }-token-readonly-input` }
+                         />
+                     </Grid.Column>
+                 </Grid.Row>
+                 <Grid.Row columns={ 2 }>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                         <GenericIcon
+                             icon={ getHelpPanelIcons().endpoints.userInfo }
+                             size="micro"
+                             square
+                             transparent
+                             inline
+                             className="left-icon"
+                             verticalAlign="middle"
+                             spaced="right"
+                         />
+                         <label data-testid={ `${ testId }-userInfo-label` }>
+                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                 "oidcConfigurations.labels.userInfo") }
+                         </label>
+                     </Grid.Column>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                        
+                         <CopyInputField
+                             value={ oidcConfigurations?.userEndpoint }
+                             data-testid={ `${ testId }-userInfo-readonly-input` }
+                         />
+                     </Grid.Column>
+                 </Grid.Row>
+                 <Grid.Row columns={ 2 }>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                         <GenericIcon
+                             icon={ getHelpPanelIcons().endpoints.introspect }
+                             size="micro"
+                             square
+                             transparent
+                             inline
+                             className="left-icon"
+                             verticalAlign="middle"
+                             spaced="right"
+                         />
+                         <label data-testid={ `${ testId }-introspection-label` }>
+                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                 "oidcConfigurations.labels.introspection") }
+                         </label>
+                     </Grid.Column>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                         <CopyInputField
+                             value={ oidcConfigurations?.introspectionEndpoint }
+                             data-testid={ `${ testId }-introspection-readonly-input` }
+                         />
+                     </Grid.Column>
+                 </Grid.Row>
+                 <Grid.Row columns={ 2 }>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                         <GenericIcon
+                             icon={ getHelpPanelIcons().endpoints.jwks }
+                             size="micro"
+                             square
+                             transparent
+                             inline
+                             className="left-icon"
+                             verticalAlign="middle"
+                             spaced="right"
+                         />
+                         <label data-testid={ `${ testId }-jwks-label` }>
+                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                 "oidcConfigurations.labels.jwks") }
+                         </label>
+                     </Grid.Column>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                         <CopyInputField
+                             value={ oidcConfigurations?.jwksEndpoint }
+                             data-testid={ `${ testId }-jwks-readonly-input` }
+                         />
+                     </Grid.Column>
+                 </Grid.Row>
+                 <Grid.Row columns={ 2 }>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                         <GenericIcon
+                             icon={ getHelpPanelIcons().endpoints.revoke }
+                             size="micro"
+                             square
+                             transparent
+                             inline
+                             className="left-icon"
+                             verticalAlign="middle"
+                             spaced="right"
+                         />
+                         <label data-testid={ `${ testId }-token-revoke-label` }>
+                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                 "oidcConfigurations.labels.revoke") }
+                         </label>
+                     </Grid.Column>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                         <CopyInputField
+                             value={ oidcConfigurations?.tokenRevocationEndpoint }
+                             className="panel-url-input"
+                             data-testid={ `${ testId }-token-revoke-readonly-input` }
+                         />
+                     </Grid.Column>
+                 </Grid.Row>
+                 <Grid.Row columns={ 2 }>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
+                         <GenericIcon
+                             icon={ <Icon className={ "mr-0" } name="power off" /> }
+                             size="micro"
+                             square
+                             transparent
+                             inline
+                             className="left-icon"
+                             verticalAlign="middle"
+                             spaced="right"
+                         />
+                         <label data-testid={ `${ testId }-logout-label` }>
+                             { t("console:develop.features.applications.helpPanel.tabs.start.content." +
+                                 "oidcConfigurations.labels.endSession") }
+                         </label>
+                     </Grid.Column>
+                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
+                         <CopyInputField 
+                             value={ oidcConfigurations?.endSessionEndpoint  }
+                             className="panel-url-input"
+                             data-testid={ `${ testId }-logout-readonly-input` }
+                         />
+                     </Grid.Column>
+                 </Grid.Row>
+             </Grid>
+         </Form>
+             
+         </>
+     );
+ };
+ 
+ /**
+  * Default props for the OIDC application Configurations component.
+  */
+ OIDCConfigurations.defaultProps = {
+     "data-testid": "applications-help-panel-oidc-configs"
 };

--- a/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
+++ b/apps/console/src/features/applications/components/help-panel/oidc-configurations.tsx
@@ -90,7 +90,8 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
 
     return (
         <>
-            <Grid verticalAlign="middle">
+        <form>
+        <Grid verticalAlign="middle">
                 <Grid.Row columns={ 2 }>
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 5 }>
                         <GenericIcon
@@ -111,7 +112,6 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
                         <CopyInputField
                             value={ oidcConfigurations?.wellKnownEndpoint  }
-                            className="panel-url-input"
                             data-testid={ `${ testId }-introspection-readonly-input` }
                         />
                     </Grid.Column>
@@ -136,7 +136,6 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
                         <CopyInputField
                             value={ oidcConfigurations?.authorizeEndpoint }
-                            className="panel-url-input"
                             data-testid={ `${ testId }-authorize-readonly-input` }
                         />
                     </Grid.Column>
@@ -161,7 +160,6 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
                         <CopyInputField
                             value={ oidcConfigurations?.tokenEndpoint }
-                            className="panel-url-input"
                             data-testid={ `${ testId }-token-readonly-input` }
                         />
                     </Grid.Column>
@@ -186,7 +184,6 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
                         <CopyInputField
                             value={ oidcConfigurations?.userEndpoint }
-                            className="panel-url-input"
                             data-testid={ `${ testId }-userInfo-readonly-input` }
                         />
                     </Grid.Column>
@@ -211,7 +208,6 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
                         <CopyInputField
                             value={ oidcConfigurations?.introspectionEndpoint }
-                            className="panel-url-input"
                             data-testid={ `${ testId }-introspection-readonly-input` }
                         />
                     </Grid.Column>
@@ -236,7 +232,6 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
                         <CopyInputField
                             value={ oidcConfigurations?.jwksEndpoint }
-                            className="panel-url-input"
                             data-testid={ `${ testId }-jwks-readonly-input` }
                         />
                     </Grid.Column>
@@ -261,7 +256,6 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
                         <CopyInputField
                             value={ oidcConfigurations?.tokenRevocationEndpoint }
-                            className="panel-url-input"
                             data-testid={ `${ testId }-token-revoke-readonly-input` }
                         />
                     </Grid.Column>
@@ -286,12 +280,13 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 11 }>
                         <CopyInputField
                             value={ oidcConfigurations?.endSessionEndpoint  }
-                            className="panel-url-input"
                             data-testid={ `${ testId }-logout-readonly-input` }
                         />
                     </Grid.Column>
                 </Grid.Row>
             </Grid>
+        </form>
+           
         </>
     );
 };


### PR DESCRIPTION
### Purpose
Reverted the height of the text fields and make them read-only text fields.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
