### PR TITLE
Remove `REDUX_DEVTOOLS` from production

### DIFF
--- a/apps/console/src/features/core/store/index.ts
+++ b/apps/console/src/features/core/store/index.ts
@@ -17,7 +17,7 @@
  */
 
 import { AnyAction, Store, StoreEnhancer, applyMiddleware, createStore } from "redux";
-import { composeWithDevTools } from "redux-devtools-extension";
+import { composeWithDevTools } from "redux-devtools-extension/developmentOnly";
 import thunk from "redux-thunk";
 import { reducers } from "./combine-reducers";
 

--- a/apps/myaccount/src/store/index.ts
+++ b/apps/myaccount/src/store/index.ts
@@ -17,7 +17,7 @@
  */
 
 import { applyMiddleware, createStore } from "redux";
-import { composeWithDevTools } from "redux-devtools-extension";
+import { composeWithDevTools } from "redux-devtools-extension/developmentOnly";
 import thunk from "redux-thunk";
 import { reducers } from "./combine-reducers";
 import { apiMiddleware } from "./middleware";


### PR DESCRIPTION
### Purpose
This PR hides the redux store from being debugged via `Redux Dev Tools` extensions.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
