### PR TITLE
Prevent double submission in buttons in the From module

### DIFF
--- a/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
+++ b/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
@@ -39,6 +39,10 @@ interface AdvancedConfigurationsFormPropsInterface extends TestableComponentInte
      * Application template.
      */
     template?: ApplicationTemplateListItemInterface;
+    /**
+     * Specifies if the form is submitting
+     */
+    isSubmitting?: boolean;
 }
 
 /**
@@ -57,6 +61,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
         onSubmit,
         readOnly,
         template,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -169,7 +174,8 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 ariaLabel="Update button"
                 name="update-button"
                 data-testid={ `${ testId }-submit-button` }
-                disabled={ false }
+                disabled={ isSubmitting }
+                loading={ isSubmitting }
                 hidden={ readOnly }
                 label={ t("common:update") }
             />

--- a/apps/console/src/features/applications/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/applications/components/forms/general-details-form.tsx
@@ -64,6 +64,10 @@ interface GeneralDetailsFormPopsInterface extends TestableComponentInterface {
      * Make the form read only.
      */
     readOnly?: boolean;
+    /**
+     * Specifies if the form is submitting.
+     */
+    isSubmitting?: boolean;
 }
 
 /**
@@ -97,6 +101,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
         accessUrl,
         onSubmit,
         readOnly,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -293,7 +298,8 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                 ariaLabel="Update button"
                 name="update-button"
                 data-testid={ `${ testId }-submit-button` }
-                disabled={ false }
+                disabled={ false || isSubmitting }
+                loading={ isSubmitting }
                 label={ t("common:update") }
                 hidden={ readOnly }
             />

--- a/apps/console/src/features/applications/components/forms/provisioning-configuration-form.tsx
+++ b/apps/console/src/features/applications/components/forms/provisioning-configuration-form.tsx
@@ -30,6 +30,10 @@ interface ProvisioningConfigurationFormPropsInterface extends TestableComponentI
     onSubmit: (values: any) => void;
     useStoreList: SimpleUserStoreListItemInterface[];
     readOnly?: boolean;
+    /**
+     * Specifies if the form is submitting.
+     */
+    isSubmitting?: boolean;
 }
 
 /**
@@ -48,6 +52,7 @@ export const ProvisioningConfigurationsForm: FunctionComponent<ProvisioningConfi
         onSubmit,
         readOnly,
         useStoreList,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -140,7 +145,8 @@ export const ProvisioningConfigurationsForm: FunctionComponent<ProvisioningConfi
                 ariaLabel="Update button"
                 name="update-button"
                 data-testid={ `${ testId }-submit-button` }
-                disabled={ false }
+                disabled={ isSubmitting }
+                loading={ isSubmitting }
                 label={ t("common:update") }
                 hidden={ readOnly }
             />

--- a/apps/console/src/features/applications/components/settings/advanced-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/advanced-settings.tsx
@@ -20,7 +20,7 @@ import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmphasizedSegment } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { AppState, FeatureConfigInterface } from "../../../core";
@@ -81,12 +81,16 @@ export const AdvancedSettings: FunctionComponent<AdvancedSettingsPropsInterface>
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
 
+    const [ isSubmitting, setIsSubmitting ] = useState(false);
+
     /**
      * Handles the advanced config form submit action.
      *
      * @param values - Form values.
      */
     const handleAdvancedConfigFormSubmit = (values: any): void => {
+        setIsSubmitting(true);
+
         updateApplicationConfigurations(appId, values)
             .then(() => {
                 dispatch(addAlert({
@@ -117,6 +121,9 @@ export const AdvancedSettings: FunctionComponent<AdvancedSettingsPropsInterface>
                     message: t("console:develop.features.applications.notifications.updateAdvancedConfig" +
                         ".genericError.message")
                 }));
+            })
+            .finally(() => {
+                setIsSubmitting(false);
             });
     };
 
@@ -133,6 +140,7 @@ export const AdvancedSettings: FunctionComponent<AdvancedSettingsPropsInterface>
                 }
                 template={ template }
                 data-testid={ `${ testId }-form` }
+                isSubmitting={ isSubmitting }
             />
         </EmphasizedSegment>
     );

--- a/apps/console/src/features/applications/components/settings/general-application-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/general-application-settings.tsx
@@ -129,6 +129,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
     const UIConfig: UIConfigInterface = useSelector((state: AppState) => state?.config?.ui);
 
     const [ showDeleteConfirmationModal, setShowDeleteConfirmationModal ] = useState<boolean>(false);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
 
     /**
      * Deletes an application.
@@ -174,6 +175,8 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
      * @param {ApplicationInterface} updatedDetails - Form values.
      */
     const handleFormSubmit = (updatedDetails: ApplicationInterface): void => {
+        setIsSubmitting(true);
+
         updateApplicationDetails(updatedDetails)
             .then(() => {
                 dispatch(addAlert({
@@ -204,6 +207,9 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                     message: t("console:develop.features.applications.notifications.updateApplication.genericError" +
                         ".message")
                 }));
+            })
+            .finally(() => {
+                setIsSubmitting(false);
             });
     };
 
@@ -276,6 +282,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                                 )
                             }
                             data-testid={ `${ testId }-form` }
+                            isSubmitting={ isSubmitting }
                         />
                     </EmphasizedSegment>
                     <Divider hidden />
@@ -316,7 +323,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
             ) :
                 <EmphasizedSegment padded="very">
                     <ContentLoader inline="centered" active/>
-                </EmphasizedSegment>  
+                </EmphasizedSegment>
         );
 };
 

--- a/apps/console/src/features/applications/components/settings/provisioning/inbound-provisioning-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/provisioning/inbound-provisioning-configuration.tsx
@@ -87,6 +87,7 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
 
     const [ accordionActiveIndexes, setAccordionActiveIndexes ] = useState<number[]>(defaultActiveIndexes);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
 
     /**
      * Handles the provisioning config form submit action.
@@ -94,6 +95,8 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
      * @param values - Form values.
      */
     const handleProvisioningConfigFormSubmit = (values: any): void => {
+        setIsSubmitting(true);
+
         updateApplicationConfigurations(appId, values)
             .then(() => {
                 dispatch(addAlert({
@@ -114,6 +117,9 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
                     message: t("console:develop.features.applications.notifications.updateInboundProvisioningConfig" +
                         ".genericError.message")
                 }));
+            })
+            .finally(() => {
+                setIsSubmitting(false);
             });
     };
 
@@ -183,6 +189,7 @@ export const InboundProvisioningConfigurations: FunctionComponent<InboundProvisi
                                                         allowedScopes)
                                                 }
                                                 data-testid={ `${ testId }-form` }
+                                                isSubmitting={ isSubmitting }
                                             />
                                         ),
                                         id: "scim",

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -38,13 +38,13 @@ import {
     Hint
 } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useRef, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Divider, Grid , Form as SemanticForm } from "semantic-ui-react";
 import { attributeConfig } from "../../../../../extensions";
 import { AppConstants, AppState, FeatureConfigInterface, history } from "../../../../core";
-import { ClaimManagementConstants } from "../../../constants";
 import { deleteAClaim, updateAClaim } from "../../../api";
+import { ClaimManagementConstants } from "../../../constants";
 
 /**
  * Prop types for `EditBasicDetailsLocalClaims` component
@@ -82,6 +82,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
     const [ isShowDisplayOrder, setIsShowDisplayOrder ] = useState(false);
     const [ confirmDelete, setConfirmDelete ] = useState(false);
     const [ isClaimReadOnly, setIsClaimReadOnly ] = useState<boolean>(false);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
 
     const nameField = useRef<HTMLElement>(null);
     const regExField = useRef<HTMLElement>(null);
@@ -90,7 +91,6 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
-
 
     const { t } = useTranslation();
 
@@ -216,6 +216,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
             supportedByDefault: values?.supportedByDefault !== undefined
                 ? !!values.supportedByDefault : claim?.supportedByDefault
         };
+
+        setIsSubmitting(true);
+
         updateAClaim(claim.id, data).then(() => {
             dispatch(addAlert(
                 {
@@ -240,6 +243,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             "updateClaim.genericError.description")
                 }
             ));
+        })
+        .finally(() => {
+            setIsSubmitting(false);
         });
     };
 
@@ -384,8 +390,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                 readOnly={ isReadOnly }
                                 hint={ t("console:manage.features.claims.local.forms.requiredHint") }
                                 disabled={ isClaimReadOnly }
-                                { ...( isClaimReadOnly ? 
-                                    { value: false } : 
+                                { ...( isClaimReadOnly ?
+                                    { value: false } :
                                     { defaultValue : claim?.required } ) }
                             />
                     }
@@ -421,6 +427,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                 ariaLabel="submit"
                                 size="small"
                                 buttonType="primary_btn"
+                                loading={ isSubmitting }
+                                disabled={ isSubmitting }
                                 label={ t("common:update") }
                                 name="submit"
                             />

--- a/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
+++ b/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
@@ -97,6 +97,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
     const { t } = useTranslation();
 
     const [ tabPaneExtensions, setTabPaneExtensions ] = useState<any>(undefined);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
 
     /**
      * Check for tab extensions.
@@ -136,6 +137,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
      * @param {MultiFactorAuthenticatorInterface} values - Form values.
      */
     const handleAuthenticatorConfigFormSubmit = (values: MultiFactorAuthenticatorInterface): void => {
+        setIsSubmitting(true);
 
         updateMultiFactorAuthenticatorDetails(authenticator.id, values)
             .then(() => {
@@ -170,6 +172,9 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
                     message: t("console:develop.features.authenticationProvider.notifications" +
                         ".updateEmailOTPAuthenticator.genericError.message")
                 }));
+            })
+            .finally(() => {
+                setIsSubmitting(false);
             });
     };
 
@@ -195,6 +200,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
                                                 type={ type }
                                                 data-testid={ `${ testId }-${ authenticator.name }-content` }
                                                 isReadOnly={ isReadOnly }
+                                                isSubmitting={ isSubmitting }
                                             />
                                         </EmphasizedSegment>
                                     </Grid.Column>
@@ -263,7 +269,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
      * @return {number}
      */
     const resolveDefaultActiveIndex = (activeIndex: number): number => {
-        
+
         if (authenticator.id !== IdentityProviderManagementConstants.TOTP_AUTHENTICATOR_ID) {
             return activeIndex;
         }

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/email-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/email-otp-authenticator-form.tsx
@@ -69,6 +69,10 @@ interface EmailOTPAuthenticatorFormPropsInterface extends TestableComponentInter
      * @remarks Not implemented ATM. Do this when needed.
      */
     showCustomProperties: boolean;
+    /**
+     * Specifies if the form is submitting.
+     */
+    isSubmitting?: boolean;
 }
 
 /**
@@ -141,6 +145,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
         initialValues: originalInitialValues,
         onSubmit,
         readOnly,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -351,7 +356,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                             ".emailOTP.tokenLength.hint"
                         }
                     >
-                        The number of allowed characters in the OTP token. Please pick a value between 
+                        The number of allowed characters in the OTP token. Please pick a value between
                         <Code>4-10</Code>.
                     </Trans>
                 }
@@ -382,7 +387,8 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                             ".emailOTP.useNumericChars.hint"
                         }
                     >
-                       Only numeric characters (<Code>0-9</Code>) are used for the OTP token. Please clear this checkbox to enable alphanumeric characters.
+                        Only numeric characters (<Code>0-9</Code>) are used for the OTP token.
+                        Please clear this checkbox to enable alphanumeric characters.
                     </Trans>
                 }
                 readOnly={ readOnly }
@@ -395,7 +401,8 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                 ariaLabel="Email OTP authenticator update button"
                 name="update-button"
                 data-testid={ `${ testId }-submit-button` }
-                disabled={ false }
+                disabled={ isSubmitting }
+                loading={ isSubmitting }
                 label={ t("common:update") }
                 hidden={ readOnly }
             />

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
@@ -66,6 +66,10 @@ interface FacebookAuthenticatorFormPropsInterface extends TestableComponentInter
      * @remarks Not implemented ATM. Do this when needed.
      */
     showCustomProperties: boolean;
+    /**
+     * Specifies if the form is submitting.
+     */
+    isSubmitting?: boolean;
 }
 
 /**
@@ -131,7 +135,7 @@ interface ScopeMetaInterface {
     /**
      * Scope icon.
      */
-    icon: SemanticICONS
+    icon: SemanticICONS;
 }
 
 /**
@@ -150,6 +154,7 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
         initialValues: originalInitialValues,
         onSubmit,
         readOnly,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -430,7 +435,8 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
                 ariaLabel="Facebook authenticator update button"
                 name="update-button"
                 data-testid={ `${ testId }-submit-button` }
-                disabled={ false }
+                disabled={ isSubmitting }
+                loading={ isSubmitting }
                 label={ t("common:update") }
                 hidden={ readOnly }
             />

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/github-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/github-authenticator-form.tsx
@@ -66,6 +66,10 @@ interface GithubAuthenticatorFormPropsInterface extends TestableComponentInterfa
      * @remarks Not implemented ATM. Do this when needed.
      */
     showCustomProperties: boolean;
+    /**
+     * Specifies if the form is submitting.
+     */
+    isSubmitting?: boolean;
 }
 
 /**
@@ -135,7 +139,7 @@ interface ScopeMetaInterface {
     /**
      * Scope icon.
      */
-    icon: SemanticICONS
+    icon: SemanticICONS;
 }
 
 /**
@@ -154,6 +158,7 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
         initialValues: originalInitialValues,
         onSubmit,
         readOnly,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -441,7 +446,8 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
                 ariaLabel="GitHub authenticator update button"
                 name="update-button"
                 data-testid={ `${ testId }-submit-button` }
-                disabled={ false }
+                disabled={ isSubmitting }
+                loading={ isSubmitting }
                 label={ t("common:update") }
                 hidden={ readOnly }
             />

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/google-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/google-authenticator-form.tsx
@@ -66,6 +66,10 @@ interface GoogleAuthenticatorFormPropsInterface extends TestableComponentInterfa
      * @remarks Not implemented ATM. Do this when needed.
      */
     showCustomProperties: boolean;
+    /**
+     * Specifies if the form is submitting.
+     */
+    isSubmitting?: boolean;
 }
 
 /**
@@ -146,6 +150,7 @@ export const GoogleAuthenticatorForm: FunctionComponent<GoogleAuthenticatorFormP
         initialValues: originalInitialValues,
         onSubmit,
         readOnly,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -471,7 +476,8 @@ export const GoogleAuthenticatorForm: FunctionComponent<GoogleAuthenticatorFormP
                 ariaLabel="Google authenticator update button"
                 name="update-button"
                 data-testid={ `${ testId }-submit-button` }
-                disabled={ false }
+                disabled={ isSubmitting }
+                loading={ isSubmitting }
                 label={ t("common:update") }
                 hidden={ readOnly }
             />

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
@@ -62,6 +62,10 @@ interface SamlSettingsFormPropsInterface extends TestableComponentInterface {
     authenticator: FederatedAuthenticatorWithMetaInterface;
     onSubmit: (values: CommonAuthenticatorFormInitialValuesInterface) => void;
     readOnly?: boolean;
+    /**
+     * Specifies if the form is submitted.
+     */
+    isSubmitting?: boolean;
 }
 
 export interface SamlPropertiesInterface {
@@ -98,6 +102,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
         authenticator,
         onSubmit,
         readOnly,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -579,7 +584,8 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                 ariaLabel="SAML authenticator update button"
                 name="update-button"
                 data-testid={ `${ testId }-submit-button` }
-                disabled={ false }
+                disabled={ isSubmitting }
+                loading={ isSubmitting }
                 label={ t("common:update") }
                 hidden={ readOnly }
             />

--- a/apps/console/src/features/identity-providers/components/forms/factories/authenticator-form-factory.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/factories/authenticator-form-factory.tsx
@@ -52,6 +52,10 @@ interface AuthenticatorFormFactoryInterface extends TestableComponentInterface {
      */
     isReadOnly: boolean;
     authenticator?: FederatedAuthenticatorWithMetaInterface;
+    /**
+     * Specifies if the form is submitting.
+     */
+    isSubmitting?: boolean;
 }
 
 /**
@@ -74,6 +78,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
         enableSubmitButton,
         showCustomProperties,
         isReadOnly,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -89,6 +94,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
                     data-testid={ testId }
                     showCustomProperties={ showCustomProperties }
                     readOnly={ isReadOnly }
+                    isSubmitting={ isSubmitting }
                 />
             );
         case IdentityProviderManagementConstants.FACEBOOK_AUTHENTICATOR_ID:
@@ -102,6 +108,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
                     data-testid={ testId }
                     showCustomProperties={ showCustomProperties }
                     readOnly={ isReadOnly }
+                    isSubmitting={ isSubmitting }
                 />
             );
         case IdentityProviderManagementConstants.GITHUB_AUTHENTICATOR_ID:
@@ -115,6 +122,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
                     data-testid={ testId }
                     showCustomProperties={ showCustomProperties }
                     readOnly={ isReadOnly }
+                    isSubmitting={ isSubmitting }
                 />
             );
         case IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID:
@@ -128,6 +136,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
                     data-testid={ testId }
                     showCustomProperties={ showCustomProperties }
                     readOnly={ isReadOnly }
+                    isSubmitting={ isSubmitting }
                 />
             );
         case IdentityProviderManagementConstants.SAML_AUTHENTICATOR_ID:
@@ -136,6 +145,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
                     onSubmit={ onSubmit }
                     authenticator={ authenticator }
                     readOnly={ isReadOnly }
+                    isSubmitting={ isSubmitting }
                 />
             );
         default:
@@ -149,6 +159,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
                     data-testid={ testId }
                     showCustomProperties={ showCustomProperties }
                     readOnly={ isReadOnly }
+                    isSubmitting={ isSubmitting }
                 />
             );
     }

--- a/apps/console/src/features/identity-providers/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/general-details-form.tsx
@@ -92,6 +92,10 @@ interface GeneralDetailsFormPopsInterface extends TestableComponentInterface {
      * IdP is a OIDC provider or not.
      */
     isOidc?: boolean;
+    /**
+     * Specifies if the form is submitting.
+     */
+    isSubmitting?: boolean;
 }
 
 const IDP_NAME_MAX_LENGTH: number = 50;
@@ -119,6 +123,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
         isReadOnly,
         isSaml,
         isOidc,
+        isSubmitting,
         [ "data-testid" ]: testId
     } = props;
 
@@ -263,7 +268,8 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                             buttonType="primary_btn"
                             label={ t("common:update") }
                             name="submit"
-                            disabled={ false }
+                            disabled={ isSubmitting }
+                            loading={ isSubmitting }
                         />
                     ) }
                 </Form>

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -24,7 +24,6 @@ import {
     ContentLoader,
     EmphasizedSegment,
     EmptyPlaceholder,
-    Heading,
     PrimaryButton,
     SegmentedAccordionTitleActionInterface
 } from "@wso2is/react-components";
@@ -33,7 +32,6 @@ import React, { FormEvent, FunctionComponent, MouseEvent, ReactElement, useEffec
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { CheckboxProps, Grid, Icon } from "semantic-ui-react";
-import { IdpCertificates } from "./idp-certificates";
 import { AppState, ConfigReducerStateInterface, getEmptyPlaceholderIllustrations } from "../../../core";
 import {
     getFederatedAuthenticatorDetails,
@@ -127,6 +125,8 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
     const [ showAddAuthenticatorWizard, setShowAddAuthenticatorWizard ] = useState<boolean>(false);
     const [ isTemplatesLoading, setIsTemplatesLoading ] = useState<boolean>(false);
     const [ isPageLoading, setIsPageLoading ] = useState<boolean>(true);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
     /**
@@ -162,6 +162,8 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
          * `tags` has to be removed.
          */
         values?.tags && delete values.tags;
+
+        setIsSubmitting(true);
 
         updateFederatedAuthenticator(identityProvider.id, values)
             .then(() => {
@@ -200,7 +202,10 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                         "updateFederatedAuthenticator." +
                         "genericError.message")
                 }));
-            });
+            })
+            .finally(() => {
+                setIsSubmitting(false);
+             });
     };
 
     /**
@@ -667,6 +672,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     type={ authenticator.meta?.authenticatorId }
                     data-testid={ `${ testId }-${ authenticator.meta?.name }-content` }
                     isReadOnly={ isReadOnly }
+                    isSubmitting={ isSubmitting }
                 />
             );
         } else {

--- a/apps/console/src/features/identity-providers/components/settings/general-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/general-settings.tsx
@@ -136,6 +136,7 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
 
     const [ idpList, setIdPList ] = useState<IdentityProviderListResponseInterface>({});
     const [ isIdPListRequestLoading, setIdPListRequestLoading ] = useState<boolean>(false);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
 
     /**
      * Loads the identity provider authenticators on initial component load.
@@ -230,6 +231,8 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
      * @param {IdentityProviderInterface} updatedDetails - Form values.
      */
     const handleFormSubmit = (updatedDetails: IdentityProviderInterface): void => {
+        setIsSubmitting(true);
+
         updateIdentityProviderDetails({ id: editingIDP.id, ...updatedDetails })
             .then(() => {
                 dispatch(addAlert({
@@ -243,6 +246,9 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
             })
             .catch((error) => {
                 handleIDPUpdateError(error);
+            })
+            .finally(() => {
+                setIsSubmitting(false);
             });
     };
 
@@ -295,7 +301,7 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
                         idpList={ idpList }
                         data-testid={ `${ testId }-form` }
                         isReadOnly={ isReadOnly }
-
+                        isSubmitting={ isSubmitting }
                     />
                     <Divider hidden />
                     { !(IdentityProviderManagementConstants.DELETING_FORBIDDEN_IDPS.includes(name)) && (

--- a/apps/console/src/features/oidc-scopes/pages/oidc-scopes-edit.tsx
+++ b/apps/console/src/features/oidc-scopes/pages/oidc-scopes-edit.tsx
@@ -110,6 +110,7 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
         const [ sortOrder, setSortOrder ] = useState(true);
         const [ sortByStrategy, setSortByStrategy ] = useState<DropdownItemProps>(SORT_BY[ 0 ]);
         const [ attributeSearchQuery, setAttributeSearchQuery ] = useState<string>("");
+        const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
 
         const initialRender = useRef(true);
 
@@ -350,7 +351,9 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
             setTempSelectedAttributes(selectedAttributes);
         };
 
-        const onSubmit = (values: any): void  => {
+        const onSubmit = (values: any): void => {
+            setIsSubmitting(true);
+
             updateOIDCScopeDetails(scope.name, {
                 claims: scope.claims,
                 description: values?.description !== undefined ?  values?.description?.toString() : scope.description,
@@ -392,6 +395,9 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
                                 )
                         })
                     );
+                })
+                .finally(() => {
+                    setIsSubmitting(false);
                 });
         };
 
@@ -477,6 +483,8 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
                                             <Field.Button
                                                 ariaLabel="submit"
                                                 size="small"
+                                                loading={ isSubmitting }
+                                                disabled={ isSubmitting }
                                                 buttonType="primary_btn"
                                                 label={ t("common:update") }
                                                 name="submit"

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -59,6 +59,7 @@ const UserEditPage = (): ReactElement => {
     const [ showEditAvatarModal, setShowEditAvatarModal ] = useState<boolean>(false);
     const [ connectorProperties, setConnectorProperties ] = useState<ConnectorPropertyInterface[]>(undefined);
     const [ isReadOnlyUserStoresLoading, setReadOnlyUserStoresLoading ] = useState<boolean>(false);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
 
     useEffect(() => {
         const properties: ConnectorPropertyInterface[] = [];
@@ -154,6 +155,8 @@ const UserEditPage = (): ReactElement => {
             schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
         };
 
+        setIsSubmitting(true);
+
         updateUserInfo(user?.id, data)
             .then(() => {
                 dispatch(addAlert<AlertInterface>({
@@ -196,6 +199,7 @@ const UserEditPage = (): ReactElement => {
             })
             .finally(() => {
                 setShowEditAvatarModal(false);
+                setIsSubmitting(false);
             });
     };
 
@@ -260,6 +264,7 @@ const UserEditPage = (): ReactElement => {
                         onCancel={ () => setShowEditAvatarModal(false) }
                         onSubmit={ handleAvatarEditModalSubmit }
                         imageUrl={ profileInfo?.profileUrl }
+                        isSubmitting={ isSubmitting }
                         heading={ t("console:common.modals.editAvatarModal.heading") }
                         submitButtonText={ t("console:common.modals.editAvatarModal.primaryButton") }
                         cancelButtonText={ t("console:common.modals.editAvatarModal.secondaryButton") }

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -86,6 +86,8 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
     const [ showEditAvatarModal, setShowEditAvatarModal ] = useState<boolean>(false);
     const [ showMobileUpdateWizard, setShowMobileUpdateWizard ] = useState<boolean>(false);
     const [ countryList, setCountryList ] = useState<DropdownItemProps[]>([]);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+
     const allowedScopes: string = useSelector((state: AppState) => state?.authenticationInformation?.scope);
 
     // Removed User ID field from profile.
@@ -934,6 +936,8 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
      * @param {string} url - Selected image URL.
      */
     const handleAvatarEditModalSubmit = (e: MouseEvent<HTMLButtonElement>, url: string): void => {
+        setIsSubmitting(true);
+
         updateProfileImageURL(url)
             .then(() => {
                 onAlertFired({
@@ -966,6 +970,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
             })
             .finally(() => {
                 setShowEditAvatarModal(false);
+                setIsSubmitting(false);
             });
     };
 
@@ -1011,6 +1016,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                         imageUrl={ profileDetails?.profileInfo?.profileUrl }
                         heading={ t("myAccount:modals.editAvatarModal.heading") }
                         submitButtonText={ t("myAccount:modals.editAvatarModal.primaryButton") }
+                        isSubmitting={ isSubmitting }
                         cancelButtonText={ t("myAccount:modals.editAvatarModal.secondaryButton") }
                         translations={ {
                             gravatar: {

--- a/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
+++ b/modules/react-components/src/components/modal/edit-avatar-modal/edit-avatar-modal.tsx
@@ -102,6 +102,9 @@ export interface EditAvatarModalPropsInterface extends ModalProps, TestableCompo
      * Flag to decide whether to show the hosted URL option.
      */
     showHostedURLOption?: boolean;
+    /**
+     * Specifies if there is a pending submission.
+     */
 }
 
 const GRAVATAR_IMAGE_MIN_SIZE = 80;
@@ -187,6 +190,7 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
         showHostedURLOption,
         showOptionTitle,
         submitButtonText,
+        isSubmitting,
         [ "data-testid" ]: testId,
         translations,
         ...rest
@@ -246,7 +250,7 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
 
         getGravatarImage(selectedGravatarEmail)
             .then(() => {
-                setIsGravatarQualified(true)
+                setIsGravatarQualified(true);
             })
             .catch(() => {
                 setIsGravatarQualified(false);
@@ -644,7 +648,7 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
                                                                                         key: index,
                                                                                         text: email,
                                                                                         value: email
-                                                                                    }
+                                                                                    };
                                                                                 })
                                                                         }
                                                                         onChange={ handleGravatarEmailDropdownChange }
@@ -742,7 +746,9 @@ export const EditAvatarModal: FunctionComponent<EditAvatarModalPropsInterface> =
                         || !outputURL
                         || (selectedAvatarType === AvatarTypes.URL && !isHostedURLValid)
                         || (selectedAvatarType === AvatarTypes.URL && hostedURL === imageUrl)
+                        || isSubmitting
                     }
+                    loading={ isSubmitting }
                     onClick={ handleModalSubmit }
                 >
                     { submitButtonText }


### PR DESCRIPTION
### Purpose
> A loading indicator is shown while the button is disabled during submission in components that use the Form module.


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
