### PR TITLE
fix(claims): disallow displaying meta `location` on user profile

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -339,6 +339,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         //Hides on user_id, username and groups claims
                         claim && claim.claimURI !== ClaimManagementConstants.USER_ID_CLAIM_URI
                             && claim.claimURI !== ClaimManagementConstants.USER_NAME_CLAIM_URI
+                            && claim.claimURI !== ClaimManagementConstants.LOCATION_CLAIM_URI
                             && claim.claimURI !== ClaimManagementConstants.GROUPS_CLAIM_URI &&
                         (
                             <Field.Checkbox

--- a/apps/console/src/features/claims/constants/claim-management-constants.ts
+++ b/apps/console/src/features/claims/constants/claim-management-constants.ts
@@ -141,6 +141,7 @@ export class ClaimManagementConstants {
     public static readonly USER_ID_CLAIM_URI: string = "http://wso2.org/claims/userid";
     public static readonly USER_NAME_CLAIM_URI: string = "http://wso2.org/claims/username";
     public static readonly GROUPS_CLAIM_URI: string = "http://wso2.org/claims/groups";
+    public static readonly LOCATION_CLAIM_URI: string = "http://wso2.org/claims/location";
 
     public static readonly EMPTY_STRING = "";
 


### PR DESCRIPTION
### Purpose
> Please note $subject. Now `location` meta sub-attribute is hidden and disallowed from displaying from the user's profile.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
