### PR TITLE
Conditional disable edit for attributes

### DIFF
--- a/apps/console/src/extensions/configs/models/scim.ts
+++ b/apps/console/src/extensions/configs/models/scim.ts
@@ -35,4 +35,8 @@ export interface SCIMConfigInterface {
         oneTimePassword: string,
         profileUrl: string
     };
+
+    scimDialectID: {
+        customEnterpriseSchema: string
+    };
 }

--- a/apps/console/src/extensions/configs/scim.ts
+++ b/apps/console/src/extensions/configs/scim.ts
@@ -40,5 +40,9 @@ export const SCIMConfigs: SCIMConfigInterface = {
         isReadOnlyUser: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.isReadOnlyUser",
         oneTimePassword: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.oneTimePassword",
         profileUrl: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.profileUrl"
+    },
+
+    scimDialectID: {
+        customEnterpriseSchema: "dXJuOmlldGY6cGFyYW1zOnNjaW06c2NoZW1hczpleHRlbnNpb246ZW50ZXJwcmlzZToyLjA6VXNlcg"
     }
 };

--- a/apps/console/src/features/claims/api/claims.ts
+++ b/apps/console/src/features/claims/api/claims.ts
@@ -371,6 +371,34 @@ export const getAnExternalClaim = (dialectID: string, claimID: string): Promise<
 };
 
 /**
+ * Gets the external claims with the given ID of the dialect.
+ *
+ * @param {string} dialectID Claim Dialect ID. *
+ * @return {Promise<any>} response.
+ */
+export const getExternalClaims = (dialectID: string): Promise<any> => {
+    const requestConfig = {
+        headers: {
+            Accept: "application/json",
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        url: `${store.getState().config.endpoints.externalClaims.replace("{}", dialectID)}`
+    };
+    return httpClient(requestConfig)
+        .then((response) => {
+            if (response.status !== 200) {
+                return Promise.reject(`An error occurred. The server returned ${response.status}`);
+            }
+            return Promise.resolve(response.data);
+        })
+        .catch((error) => {
+            return Promise.reject(error?.response?.data);
+        });
+};
+
+/**
  * Update an external claim.
  *
  * @param {string} dialectID Dialect ID.


### PR DESCRIPTION
### Purpose
> This PR ensures that **edit section(readOnly,Required,Display on profile)** is conditionally disabled for attributes that have no external mapping(scim mapping)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?