### PR TITLE
fix(applications): Switch out correct `protocol` for custom `OIDC`

### DIFF
--- a/apps/console/src/features/applications/api/application.ts
+++ b/apps/console/src/features/applications/api/application.ts
@@ -30,8 +30,10 @@ import {
     ApplicationTemplateInterface,
     ApplicationTemplateListInterface,
     AuthProtocolMetaListItemInterface,
-    OIDCDataInterface, OIDCDiscoveryEndpointsInterface,
-    SAMLApplicationConfigurationInterface
+    OIDCDataInterface,
+    OIDCDiscoveryEndpointsInterface,
+    SAMLApplicationConfigurationInterface,
+    SupportedAuthProtocolTypes
 } from "../models";
 import { ApplicationManagementUtils } from "../utils";
 
@@ -343,6 +345,17 @@ export const updateOIDCData = (id: string, OIDC: object): Promise<any> => {
  */
 export const updateAuthProtocolConfig = <T>(id: string, config: any,
                                             protocol: string): Promise<T> => {
+
+    /**
+     * On template level we use {@link SupportedAuthProtocolTypes.OAUTH2_OIDC}
+     * to determine custom oidc applications. But for the API "oauth2-oidc" is
+     * an unknown protocol. We manually switch out the protocol or re-correct
+     * in this API call to avoid unattended PUT errors.
+     */
+    if (SupportedAuthProtocolTypes.OAUTH2_OIDC === protocol) {
+        protocol = SupportedAuthProtocolTypes.OIDC;
+    }
+
     const requestConfig = {
         data: config,
         headers: {


### PR DESCRIPTION
### Purpose
> With a recent template change we have introduced `oauth2-oidc` protocol type which basically implies custom oidc application.
But the API doesn't know this protocol type. We have to use the base protocol `oidc` to make a valid `PUT` call.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
