### PR TITLE
Fix issues in enabling created-time in the user-profile

### DIFF
--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -262,8 +262,9 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                     userInfo[ProfileConstants.SCIM2_ENT_USER_SCHEMA][schemaNames[0]][schemaNames[1]])
                                 );
                         } else {
-                            const subValue = userInfo[schemaNames[0]]
-                                && userInfo[schemaNames[0]]
+                            const subValue = userInfo[schemaNames[0]] &&
+                                Array.isArray(userInfo[schemaNames[0]]) &&
+                                userInfo[schemaNames[0]]
                                     .find((subAttribute) => subAttribute.type === schemaNames[1]);
                             if (schemaNames[0] === "addresses") {
                                 tempProfileInfo.set(


### PR DESCRIPTION
### Purpose
> Fix: The tenant owner's profile page is not rendered if the created-time in enabled in the attribute section.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
