### PR TITLE
[Hotfix] - Fix issue in loading and hiding hidden fields for special claims

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -94,7 +94,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
-    const [ hideSpecialClaims, setHideSpecialClaims] = useState<boolean>(false);
+    const [ hideSpecialClaims, setHideSpecialClaims] = useState<boolean>(true);
 
     const { t } = useTranslation();
 
@@ -105,9 +105,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
         if (claim?.readOnly) {
             setIsClaimReadOnly(true);
         }
-        if (attributeConfig?.systemClaims.length > 0 
-            && attributeConfig?.systemClaims.indexOf(claim?.claimURI) !== -1) {
-            setHideSpecialClaims(true);
+        if (claim && (attributeConfig?.systemClaims.length <= 0
+            || attributeConfig?.systemClaims.indexOf(claim?.claimURI) === -1)) {
+            setHideSpecialClaims(false);
         }
     }, [ claim ]);
 
@@ -149,7 +149,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
             return true;
         } else {
             return !hasRequiredScopes(
-                featureConfig?.attributeDialects, featureConfig?.attributeDialects?.scopes?.update, allowedScopes)
+                featureConfig?.attributeDialects, featureConfig?.attributeDialects?.scopes?.update, allowedScopes);
         }
     }, [ featureConfig, allowedScopes, hideSpecialClaims ]);
 


### PR DESCRIPTION
### Purpose
> Fixes issue in loading and dissapearing the hidden fields including the message box and danger zone in special claims where these fields needs to be hidden. 

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
