### PR TITLE
Change organization label color and width

### DIFF
--- a/modules/theme/src/themes/default/collections/menu.overrides
+++ b/modules/theme/src/themes/default/collections/menu.overrides
@@ -370,10 +370,11 @@
                 min-height: @userDropdownLinkMinHeight;
             }
             .organization-label {
-                background: #e7f0fe;
+                background: #ffebd2;
                 margin: 5px;
                 min-width: 272px !important;
                 text-align: center;
+                width: calc(100% - 10px);
             }
         }
     }


### PR DESCRIPTION
### Purpose
> The width of the organization label has been set to fill the whole width of the dropdown and the background color has been changed to pale orange.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
