### PR TITLE
Fix intermittent claim loading issue

### DIFF
--- a/apps/console/src/features/claims/components/edit/external-dialect/edit-external-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/external-dialect/edit-external-claims.tsx
@@ -348,15 +348,27 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
                     featureConfig?.attributeDialects,
                     featureConfig?.attributeDialects?.scopes?.create, allowedScopes
                 ) && (
-                    <PrimaryButton
-                        onClick={ (): void => setShowAddExternalClaim(true) }
-                        disabled={ showAddExternalClaim }
-                        data-testid={ `${ testId }-list-layout-add-button` }
-                    >
-                        <Icon name="add"/>
-                        { t("console:manage.features.claims.external.pageLayout.edit.primaryAction",
-                            { type: resolveType(attributeType, true) }) }
-                    </PrimaryButton>
+                    /**
+                     * `loading` property is used to check whether the current selected
+                     * dialect is same as the dialect which the claims are loaded. 
+                     * If it's different, this condition will wait until the correct
+                     * dialects are loaded onto the view.
+                     */
+                     <PrimaryButton
+                     loading={ claims && attributeUri !== claims[0]?.claimDialectURI  }
+                     onClick={ (): void => {
+                         if (attributeUri !== claims[0]?.claimDialectURI ) {
+                             return;
+                         }
+                         setShowAddExternalClaim(true) 
+                     } }
+                     disabled={ showAddExternalClaim || (claims && attributeUri !== claims[0]?.claimDialectURI) }
+                     data-testid={ `${ testId }-list-layout-add-button` }
+                 >
+                     <Icon name="add"/>
+                     { t("console:manage.features.claims.external.pageLayout.edit.primaryAction",
+                         { type: resolveType(attributeType, true) }) }
+                 </PrimaryButton>
                 ) }
             data-testid={ `${ testId }-list-layout` }
         >


### PR DESCRIPTION
### Purpose
This will fix the intermittent issue where the entire claim list is loaded on to the add claim mapping wizard window claim list.

**Approach**
As per the current implementation we load the dialect id per tab pane and request the relevant claims depending on the 
tab pane dialect id. In some occurrences even though the tab pane is successfully loaded, the relavent claims are yet to be loaded. This results in wrong claims getting loaded to the modal. 

For this we have checked the tab pane dialect id with the claims list dialect id and if it's different, we keep the button disabled until the proper claims are finished loading.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
