### PR TITLE
Send cookies with My Account change password request

### DIFF
--- a/apps/myaccount/src/api/change-password.ts
+++ b/apps/myaccount/src/api/change-password.ts
@@ -65,7 +65,8 @@ export const updatePassword = (currentPassword: string, newPassword: string): Pr
             "Content-Type": "application/json"
         },
         method: HttpMethods.PATCH,
-        url: store.getState().config.endpoints.me
+        url: store.getState().config.endpoints.me,
+        withCredentials: true
     };
 
     return axios.request(requestConfig)


### PR DESCRIPTION
### Purpose
ATM, we are not using the `withCredentials` in the change password request, resulting in the cookie header not being sent in the request.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
