### PR TITLE
fix(claims): [extensible] prevent ss-claims api call for oidc dialect

### DIFF
--- a/apps/console/src/extensions/configs/attribute.ts
+++ b/apps/console/src/extensions/configs/attribute.ts
@@ -127,6 +127,7 @@ export const attributeConfig: AttributeConfig = {
             showSummary: true
         },
         customDialectURI: "",
+        oidcDialectURI: "",
         getDialect: (dialectURI: string) => { return Promise.resolve(dialectURI); },
         isSCIMCustomDialectAvailable: () =>  { return Promise.resolve(""); },
         isUserStoresHidden: () =>  { return Promise.resolve([]); },

--- a/apps/console/src/extensions/configs/models/attribute.ts
+++ b/apps/console/src/extensions/configs/models/attribute.ts
@@ -73,6 +73,7 @@ export interface AttributeConfig {
             identifyAsCustomAttrib: boolean;
         }
         customDialectURI: string;
+        oidcDialectURI: string;
         createCustomDialect: boolean;
         mapClaimToCustomDialect: boolean;
         checkAttributeNameAvailability: (attributeName: string, protocol: string) => Promise<Map<string, boolean>>;

--- a/apps/console/src/features/claims/components/add/add-external-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-external-claim.tsx
@@ -146,7 +146,10 @@ export const AddExternalClaims: FunctionComponent<AddExternalClaimsPropsInterfac
     }, [serverSupportedClaims, filteredLocalClaims])
 
     useEffect(() => {
-        if (claimDialectUri === attributeConfig.localAttributes.customDialectURI) {
+        if (
+            claimDialectUri === attributeConfig.localAttributes.customDialectURI ||
+            claimDialectUri === attributeConfig.localAttributes.oidcDialectURI
+        ) {
             setServerSideClaimsLoading(false);
             return;
         }


### PR DESCRIPTION
### Purpose
> Now with `oidcDialectURI` you can prevent fetching server-side claims via extensions.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
