### PR TITLE
[HotFix][v1.2.649] Fix `Link` component breaking for `hrefs`

### DIFF
--- a/modules/react-components/src/components/links/link.tsx
+++ b/modules/react-components/src/components/links/link.tsx
@@ -96,6 +96,11 @@ export const Link: FunctionComponent<PropsWithChildren<LinkPropsInterface>> = (
             rel="noopener noreferrer"
             className={ classes }
             onClick={ (e: SyntheticEvent) => {
+                // If `onClick` is not defined, going further will break the behaviour of anchor.
+                if (!onClick) {
+                    return;
+                }
+
                 e.preventDefault();
                 onClick(e);
             } }


### PR DESCRIPTION
### Purpose
When an `onClick` is not passed in, the component breaks.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Public https://github.com/wso2/identity-apps/pull/2671

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
