### PR TITLE
Auto enable checkbox in attribute section

### DIFF
--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -81,7 +81,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
     } = props;
 
     const dispatch = useDispatch();
-    const [ isDisplayCheck, setDisplayCheck] = useState<boolean>(false);
+    const [ shouldShowOnProfile, isSupportedByDefault ] = useState<boolean>(false);
     const [ isShowDisplayOrder, setIsShowDisplayOrder ] = useState(false);
     const [ confirmDelete, setConfirmDelete ] = useState(false);
     const [ isClaimReadOnly, setIsClaimReadOnly ] = useState<boolean>(false);
@@ -429,7 +429,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                 listen={ (values) => {
                                     setIsShowDisplayOrder(!!values?.supportedByDefault);
                                 } }
-                                checked = {isDisplayCheck}
+                                checked={ shouldShowOnProfile }
                                 data-testid={ `${testId}-form-supported-by-default-input` }
                                 readOnly={ isReadOnly }
                                 disabled={ !hasMapping }
@@ -474,9 +474,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                 data-testid={ `${ testId }-form-required-checkbox` }
                                 readOnly={ isReadOnly }
                                 hint={ t("console:manage.features.claims.local.forms.requiredHint") }
-                                listen = {(value) =>{
-                                    setDisplayCheck(value);
-                                }}
+                                listen ={ (value) => {
+                                    isSupportedByDefault(value);
+                                } }
                                 disabled={ isClaimReadOnly || !hasMapping }
                                 { ...( isClaimReadOnly ?
                                     { value: false } :


### PR DESCRIPTION
### Purpose
No usage of enabling "**Make this attribute required on the user profile"** checkbox without **"Display this attribute on user profile"** checkbox. So here it Auto enable **"Display this attribute on user profile"** , upon checking **Make this attribute required on the user profile"** 

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
