### PR TITLE
Remove `init-url.jsp` include from error pages

### DIFF
--- a/apps/recovery-portal/src/main/webapp/errors/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_400.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_400.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_401.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_401.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_403.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_403.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_404.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_404.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_405.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_405.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_408.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_408.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_410.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_410.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_500.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_500.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_502.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_502.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_503.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_503.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>

--- a/apps/recovery-portal/src/main/webapp/errors/error_504.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_504.jsp
@@ -20,7 +20,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 
 <%@ include file="../includes/localize.jsp" %>
-<jsp:directive.include file="../includes/init-url.jsp"/>
 
 <!doctype html>
 <html>


### PR DESCRIPTION
### Purpose
There is no `init-url.jsp` inside `includes` folder in `recovery-portal`. This was causing syntax errors in the JSPs and the error pages appeared broken[1].

And the following stack trace was visible in the terminal.

```shell
[2021-10-25 19:04:06,827] [26637154-223e-4cf6-8cf4-844312ab585f] ERROR {org.apache.catalina.core.ContainerBase.[Catalina].[localhost]} - Exception Processing ErrorPage[errorCode=404, location=/errors/error_404.jsp] org.apache.jasper.JasperException: /errors/error_404.jsp (line: [23], column: [1]) File [../includes/init-url.jsp] not found
```

[1]
![137299996-036dc7af-0708-40ed-9f08-7bd8571cda5a](https://user-images.githubusercontent.com/25959096/138710843-ada7a931-3f08-47a5-b992-8d20aac571b0.png)

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
