### PR TITLE
Modify the doc links pointed by application-info section

### DIFF
--- a/apps/console/src/features/applications/components/settings/info.tsx
+++ b/apps/console/src/features/applications/components/settings/info.tsx
@@ -29,15 +29,17 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider, Grid } from "semantic-ui-react";
 import { AppState } from "../../../core";
+import { ApplicationManagementConstants } from "../../constants";
 import CustomApplicationTemplate
     from "../../data/application-templates/templates/custom-application/custom-application.json";
+import SinglePageApplication
+    from "../../data/application-templates/templates/single-page-application/single-page-application.json";
 import {
     InboundProtocolListItemInterface,
     OIDCApplicationConfigurationInterface,
     SAMLApplicationConfigurationInterface
 } from "../../models";
 import { OIDCConfigurations, SAMLConfigurations } from "../help-panel";
-import { ApplicationManagementConstants } from "../../constants";
 
 /**
  * Proptypes for the server endpoints details component.
@@ -126,8 +128,11 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                                         { t("console:develop.features.applications.edit.sections.info." +
                                             "oidcSubHeading") }
                                         <DocumentationLink
-                                            link={ getLink("develop.applications.editApplication." +
-                                                "oidcApplication.info.learnMore") }
+                                            link={ templateId === SinglePageApplication.id
+                                                ? getLink("develop.applications.editApplication." +
+                                                    "singlePageApplication.info.learnMore")
+                                                : getLink("develop.applications.editApplication." +
+                                                    "oidcApplication.info.learnMore") }
                                         >
                                             { t("common:learnMore") }
                                         </DocumentationLink>


### PR DESCRIPTION
### Purpose
The following doc links are directed from application-info section.
- OIDC - https://stasgrdocsdeeus201.z20.web.core.windows.net/asgardeo/docs/get-started/try-samples/qsg-oidc-webapp-java-ee/#prerequisites
- SAML - https://wso2.com/asgardeo/docs/guides/authentication/saml/
- SPA - https://stasgrdocsdeeus201.z20.web.core.windows.net/asgardeo/docs/guides/authentication/oidc/implement-auth-code-with-pkce/#prerequisites

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
