### PR TITLE
Fix UX issues with session termination

### DIFF
--- a/apps/console/src/features/core/utils/http-utils.ts
+++ b/apps/console/src/features/core/utils/http-utils.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { AppConstants as AppConstantsCore } from "@wso2is/core/constants";
+import { AsgardeoSPAClient } from "@asgardeo/auth-react";
 import { hideAJAXTopLoadingBar, showAJAXTopLoadingBar } from "@wso2is/core/store";
 import { AuthenticateUtils } from "@wso2is/core/utils";
 import { AxiosError } from "axios";
@@ -107,12 +107,16 @@ export class HttpUtils {
             return;
         }
 
-        // Dispatch a `network_error_event` Event when the requests returns an un-authorized status code (401)
-        // or are timed out.
+        // Try refreshing the token. If it fails reload the page.
         // NOTE: Axios is unable to handle 401 errors. `!error.response` will usually catch
         // the `401` error. Check the link in the doc comment.
         if (!error.response || error.response.status === 401) {
-            dispatchEvent(new Event(AppConstantsCore.NETWORK_ERROR_EVENT));
+            const auth = AsgardeoSPAClient.getInstance();
+
+            auth.refreshAccessToken()
+                .catch (() => {
+                    location.reload();
+                });
         }
     }
 

--- a/apps/myaccount/src/utils/http-utils.ts
+++ b/apps/myaccount/src/utils/http-utils.ts
@@ -17,8 +17,9 @@
  *
  */
 
-import { AppConstants as AppConstantsCore } from "@wso2is/core/constants";
+import { AsgardeoSPAClient } from "@asgardeo/auth-react";
 import { AuthenticateUtils } from "@wso2is/core/utils";
+import { AxiosError } from "axios";
 import { AppConstants } from "../constants";
 import { history } from "../helpers";
 import { store } from "../store";
@@ -53,7 +54,7 @@ export const onHttpRequestSuccess = (): void => {
  * @param error - Http error.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export const onHttpRequestError = (error: any): null => {
+export const onHttpRequestError = (error: AxiosError): null => {
     // Terminate the session if the token endpoint returns a bad request(400)
     // The token binding feature will return a 400 status code when the session
     // times out.
@@ -65,6 +66,7 @@ export const onHttpRequestError = (error: any): null => {
     ) {
         if (error.response.status === 400) {
             history.push(AppConstants.getAppLogoutPath());
+
             return;
         }
     }
@@ -72,15 +74,19 @@ export const onHttpRequestError = (error: any): null => {
     // If the user doesn't have login permission, redirect to login error page.
     if (store.getState()?.auth?.scope && !AuthenticateUtils.hasLoginPermission(store.getState().auth.scope)) {
         history.push(AppConstants.getPaths().get("LOGIN_ERROR"));
+
         return;
     }
 
-    // Dispatch a `network_error_event` Event when the requests returns an un-authorized status code (401)
-    // or are timed out.
-    // or a forbidden status code (403). NOTE: Axios is unable to handle 401 errors.
-    // `!error.response` will usually catch the `401` error. Check the link in the doc comment.
+    // Try refreshing the token. If it fails reload the page.
+    // NOTE: Axios is unable to handle 401 errors. `!error.response` will usually catch
+    // the `401` error. Check the link in the doc comment.
     if (!error.response || error.response.status === 403 || error.response.status === 401) {
-        dispatchEvent(new Event(AppConstantsCore.NETWORK_ERROR_EVENT));
+        const auth = AsgardeoSPAClient.getInstance();
+
+        auth.refreshAccessToken().catch(() => {
+            location.reload();
+        });
     }
 };
 


### PR DESCRIPTION
### Purpose
> Terminating sessions resulted in subsequent APi calls resulting in a 401 error. This PR handles this issue by trying to refresh the token when a 401 error is thrown. If the token refresh is unsuccessful, the app is reloaded. So, if the user is logged in, then the app is loaded. Otherwise, the user is taken to the SSO page.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
