### PR TITLE
Avoid using UMD version of `saveAs`

### DIFF
--- a/apps/console/src/features/applications/components/help-panel/saml-configurations.tsx
+++ b/apps/console/src/features/applications/components/help-panel/saml-configurations.tsx
@@ -19,6 +19,7 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { CertificateManagementUtils } from "@wso2is/core/utils";
 import { CopyInputField, GenericIcon } from "@wso2is/react-components";
+import { saveAs } from "file-saver";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Form, Grid, Icon } from "semantic-ui-react";


### PR DESCRIPTION
### Purpose
The build was failing with the following trace. `saveAs` was used as a UMD.

```
@wso2is/console: TS2686: 'saveAs' refers to a UMD global, but the current file is a module. Consider adding an import instead.
@wso2is/console:     57 |         });
@wso2is/console:     58 |
@wso2is/console:   > 59 |         saveAs(blob, "SAML-Metadata" + ".xml");
@wso2is/console:        |         ^^^^^^
@wso2is/console:     60 |     };
@wso2is/console:     61 |
@wso2is/console:     62 |     return (
@wso2is/console: webpack 5.58.1 compiled with 1 error and 2 warnings in 307186 ms
@wso2is/console: npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
@wso2is/console: npm ERR! A complete log of this run can be found in:
```

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
