### PR TITLE
Fix Formatting Issue in Authentication Portal Context Params

### DIFF
--- a/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -137,8 +137,8 @@
     {% if authenticationendpoint.context_params is defined %}
     {% for key, value in authenticationendpoint.context_params.items() %}
     <context-param>
-        <param-name>{{key}}</param-name>
-        <param-value>"{{value}}"</param-value>
+        <param-name>{{ key }}</param-name>
+        <param-value>{{ value }}</param-value>
     </context-param>
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
### Purpose
Removed unnecessary double quotes in `web.xml.j2`