### PR TITLE
Remove getTenantId from username-recovery

### DIFF
--- a/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -47,17 +47,6 @@
 
     ReCaptchaApi reCaptchaApi = new ReCaptchaApi();
 
-    if (StringUtils.isNotEmpty(tenantDomain)) {
-        try {
-            IdentityTenantUtil.getTenantId(tenantDomain);
-        } catch (IdentityRuntimeException e) {
-            request.setAttribute("error", true);
-            request.setAttribute("errorMsg", e.getMessage());
-            request.getRequestDispatcher("username-recovery-tenant-request.jsp").forward(request, response);
-            return;
-        }
-    }
-
     try {
         ReCaptchaProperties reCaptchaProperties = reCaptchaApi.getReCaptcha(tenantDomain, true, "ReCaptcha",
                 "username-recovery");


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/12738

When the accountrecoveryendpoint is hosted on an external server, cannot resolve tenant id from the tenant domain since the realmService is null.
This getTenantId is redundant here since the tenantDomain is validated in the username recovery flow even without getting the tenant id from the tenant domain. Hence, it will be removed.