### PR TITLE
Fix Resend email with Plus operator

### DIFF
--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -111,10 +111,12 @@
     });
 
     function showResendReCaptcha() {
-        <% if (reCaptchaResendEnabled) { %>
-            window.location.href="resend-confirmation-captcha.jsp?<%=AuthenticationEndpointUtil.cleanErrorMessages(Encode.forJava(request.getQueryString()))%>";
-        <% } else { %>
-            window.location.href="login.do?resend_username=<%=Encode.forHtml(request.getParameter("failedUsername"))%>&<%=AuthenticationEndpointUtil.cleanErrorMessages(Encode.forJava(request.getQueryString()))%>";
+        <% if (StringUtils.isNotBlank(request.getParameter("failedUsername"))){ %>
+            <% if (reCaptchaResendEnabled) { %>
+                window.location.href="resend-confirmation-captcha.jsp?<%=AuthenticationEndpointUtil.cleanErrorMessages(Encode.forJava(request.getQueryString()))%>";
+            <% } else { %>
+                window.location.href="login.do?resend_username=<%=Encode.forHtml(URLEncoder.encode(request.getParameter("failedUsername"), UTF_8))%>&<%=AuthenticationEndpointUtil.cleanErrorMessages(Encode.forJava(request.getQueryString()))%>";
+            <% } %>
         <% } %>
     }
 </script>

--- a/apps/authentication-portal/src/main/webapp/resend-confirmation-captcha.jsp
+++ b/apps/authentication-portal/src/main/webapp/resend-confirmation-captcha.jsp
@@ -30,6 +30,7 @@
 <jsp:directive.include file="includes/init-url.jsp"/>
 
 <%
+    String UTF_8 = "UTF-8";
     boolean reCaptchaResendEnabled = false;
     if (request.getParameter("reCaptchaResend") != null && Boolean.parseBoolean(request.getParameter("reCaptchaResend"))) {
         reCaptchaResendEnabled = true;
@@ -78,7 +79,7 @@
                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "resend.confirmation.page.title")%>
                 </h3>
 
-                <form action="login.do?resend_username=<%=Encode.forHtml(request.getParameter("failedUsername"))%>&<%=AuthenticationEndpointUtil.cleanErrorMessages(Encode.forJava(request.getQueryString()))%>" method="post" id="resendForm">
+                <form action="login.do?resend_username=<%=Encode.forHtml(URLEncoder.encode(request.getParameter("failedUsername"), UTF_8))%>&<%=AuthenticationEndpointUtil.cleanErrorMessages(Encode.forJava(request.getQueryString()))%>" method="post" id="resendForm">
                 
                     <div><%=AuthenticationEndpointUtil.i18n(resourceBundle, "resend.confirmation.page.message")%></div>
                     


### PR DESCRIPTION
### Purpose
When a user with username "+" in the email want to resend the registration email. It fails so far. This PR is will fix it

### Related Issues
[- Issue `#1` or (None)](https://github.com/wso2/product-is/issues/12826)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

**FIX**
When clicking Resend Button following URL generated to login.do endpoint

```
authenticationendpoint/login.do?resend_username=CUSTOMER-DEFAULT/thumimiku95+1@gmail.com&client_id=MY_ACCOUNT&code_challenge=WZY3hIoRa2hrPLVOaKUr4PVtbgngJMh65fZbwkTyEwI&code_challenge_method=S256&commonAuthCallerPath=%2Foauth2%2Fauthorize&forceAuth=false&passiveAuth=false&redirect_uri=https%3A%2F%2Fmyaccount.response_mode=form_post&response_type=code&scope=openid+SYSTEM&t=sample&sessionDataKey=84536322-f33b-4701-950a-dd0bf2d88d48&relyingParty=MY_ACCOUNT&type=oidc&sp=My+Account&isSaaSApp=true&failedUsername=CUSTOMER-DEFAULT%2Fthumimiku95%2B1%40gmail.com&authenticators=BasicAuthenticator%3ALOCAL
```

Note here : resend_username is CUSTOMER-DEFAULT/thumimiku95+1@gmail.com

When interpreting resend_username in jsp file from the request it skips the **+** Charecter.



But when we encode the username as


```
authenticationendpoint/login.do?resend_username=CUSTOMER-DEFAULT/thumimiku95%2B1%40gmail.com&client_id=MY_ACCOUNT&code_challenge=WZY3hIoRa2hrPLVOaKUr4PVtbgngJMh65fZbwkTyEwI&code_challenge_method=S256&commonAuthCallerPath=%2Foauth2%2Fauthorize&forceAuth=false&passiveAuth=false&redirect_uri=https%3A%2F%2Fmyaccount&response_mode=form_post&response_type=code&scope=openid+SYSTEM&t=sample&sessionDataKey=84536322-f33b-4701-950a-dd0bf2d88d48&relyingParty=MY_ACCOUNT&type=oidc&sp=My+Account&isSaaSApp=true&failedUsername=CUSTOMER-DEFAULT%2Fthumimiku95%2B1%40gmail.com&authenticators=BasicAuthenticator%3ALOCAL
```

Note that resend username is : CUSTOMER-DEFAULT/thumimiku95%2B1%40gmail.com


Email resent is successful.



![fix-identity-apps](https://user-images.githubusercontent.com/25488962/143839372-e54a0cc8-6ff8-467e-afa4-9bc772179aa8.gif)


We need to add NPE check in the function otherwise there will be a NPE exception in backend.

Tested both  captcha flow and nrml flow

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
