### PR TITLE
Update method to form API url in resend confirmation email

### DIFF
--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -187,7 +187,7 @@
         String path = config.getServletContext().getInitParameter(Constants.ACCOUNT_RECOVERY_REST_ENDPOINT_URL);
         String url;
         if (StringUtils.isNotBlank(EndpointConfigManager.getServerOrigin())) {
-            url = EndpointConfigManager.getServerOrigin() + proxyContextPath + path;
+            url = IdentityManagementEndpointUtil.getBasePath(tenantDomain, proxyContextPath + path, false);
         } else {
             url = IdentityUtil.getServerURL(path, true, false);
         }

--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -187,7 +187,7 @@
         String path = config.getServletContext().getInitParameter(Constants.ACCOUNT_RECOVERY_REST_ENDPOINT_URL);
         String url;
         if (StringUtils.isNotBlank(EndpointConfigManager.getServerOrigin())) {
-            url = IdentityManagementEndpointUtil.getBasePath(tenantDomain, proxyContextPath + path, false);
+            url = IdentityManagementEndpointUtil.getBasePath(tenantDomain, path, false);
         } else {
             url = IdentityUtil.getServerURL(path, true, false);
         }


### PR DESCRIPTION
## Purpose
> In resend confirmation email flow, the request sent to from authentication endpoint to APIs needs to honor `internal_hostname` and `identity_server_service_url`.
`identity_server_service_url` is given precedence over `internal_hostname`.

### Related Issues
- Issue https://github.com/wso2/product-is/issues/12741