### PR TITLE
Fix a bug with app switching bar 

### DIFF
--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -225,7 +225,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
         const moderatedItemsToRender: ReactElement[] = [];
         const itemExtensions: HeaderSubPanelItemInterface[] = commonConfig?.header?.getHeaderSubPanelExtensions();
         const defaultItems: HeaderSubPanelItemInterface[] = [
-            {
+            isDevelopAllowed && {
                 component: () => (
                     <Menu.Item
                         name={ config.deployment.developerApp.displayName }
@@ -242,7 +242,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                 floated: "left",
                 order: 1
             },
-            {
+            isManageAllowed && {
                 component: () => (
                     <Menu.Item
                         name={ config.deployment.adminApp.displayName }
@@ -380,7 +380,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             { ...rest }
         >
             {
-                isDevelopAllowed && isManageAllowed && (
+                (isDevelopAllowed || isManageAllowed) && (
                     <div className="secondary-panel" data-testid={ `${ testId }-secondary-panel` }>
                         <Container fluid={ fluid }>
                             { renderSubHeaderPanelItems("left") }


### PR DESCRIPTION
### Purpose
> The app switching bar was shown only when both the develop and manage routes were available. This PR fixes this issue.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
