### PR TITLE
Remove description field hint under app general settings

### DIFF
--- a/apps/console/src/features/applications/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/applications/components/forms/general-details-form.tsx
@@ -219,6 +219,8 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                     maxLength={ ApplicationManagementConstants.FORM_FIELD_CONSTRAINTS.APP_NAME_MAX_LENGTH }
                     minLength={ 3 }
                     data-testid={ `${ testId }-application-name-input` }
+                    hint={ t("console:develop.features.applications.forms.generalDetails.fields.name." +
+                    "hint") }
                     width={ 16 }
                 />
             ) }

--- a/apps/console/src/features/applications/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/applications/components/forms/general-details-form.tsx
@@ -219,8 +219,6 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                     maxLength={ ApplicationManagementConstants.FORM_FIELD_CONSTRAINTS.APP_NAME_MAX_LENGTH }
                     minLength={ 3 }
                     data-testid={ `${ testId }-application-name-input` }
-                    hint={ t("console:develop.features.applications.forms.generalDetails.fields.name." +
-                    "hint") }
                     width={ 16 }
                 />
             ) }
@@ -242,8 +240,6 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                 maxLength={ 300 }
                 minLength={ 3 }
                 data-testid={ `${ testId }-application-description-textarea` }
-                hint={ t("console:develop.features.applications.forms.generalDetails.fields.description." +
-                    "description") }
                 width={ 16 }
             />
             {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1344,6 +1344,7 @@ export const console: ConsoleNS = {
                                 }
                             },
                             name: {
+                                hint: "The name of the application",
                                 label: "Name",
                                 placeholder: "My App",
                                 validations: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1325,7 +1325,6 @@ export const console: ConsoleNS = {
                                 }
                             },
                             description: {
-                                description: "A text description of the application.",
                                 label: "Description",
                                 placeholder: "Enter a description for the application"
                             },
@@ -1344,7 +1343,6 @@ export const console: ConsoleNS = {
                                 }
                             },
                             name: {
-                                hint: "The name of the application",
                                 label: "Name",
                                 placeholder: "My App",
                                 validations: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1351,7 +1351,6 @@ export const console: ConsoleNS = {
                                 }
                             },
                             description: {
-                                description: "Une description textuelle de l'application.",
                                 label: "Description",
                                 placeholder: "Saisissez une description pour l'application"
                             },
@@ -1370,7 +1369,6 @@ export const console: ConsoleNS = {
                                 }
                             },
                             name: {
-                                hint: "Le nom de l'application",
                                 label: "Nom",
                                 placeholder: "Mon appli",
                                 validations: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1370,6 +1370,7 @@ export const console: ConsoleNS = {
                                 }
                             },
                             name: {
+                                hint: "Le nom de l'application",
                                 label: "Nom",
                                 placeholder: "Mon appli",
                                 validations: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1332,7 +1332,6 @@ export const console: ConsoleNS = {
                                 }
                             },
                             description: {
-                                description: "මෘදුකාංග යෙදුමේ පෙළ විස්තරයක්.",
                                 label: "විස්තර",
                                 placeholder: "යෙදුම සඳහා විස්තරයක් ඇතුළත් කරන්න"
                             },
@@ -1350,7 +1349,6 @@ export const console: ConsoleNS = {
                                 }
                             },
                             name: {
-                                hint: "යෙදුමේ නම",
                                 label: "නම",
                                 placeholder: "මගේ යෙදුම",
                                 validations: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1350,6 +1350,7 @@ export const console: ConsoleNS = {
                                 }
                             },
                             name: {
+                                hint: "යෙදුමේ නම",
                                 label: "නම",
                                 placeholder: "මගේ යෙදුම",
                                 validations: {


### PR DESCRIPTION
### Purpose
> This removes the app description hint under application general settings form.

### Related Issues

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
