### PR TITLE
Fix displaying subject identifier checkboxes

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
@@ -139,11 +139,15 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
 
     let isContainsOTPAuthenticator = false;
 
-    step.options.map(option => [
-        IdentityProviderManagementConstants.TOTP_AUTHENTICATOR, 
-        IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR, 
-        IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR ]
-        .includes(option.authenticator) && (isContainsOTPAuthenticator = true));
+    step.options.map(option => {
+        if([ IdentityProviderManagementConstants.TOTP_AUTHENTICATOR, 
+            IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR, 
+            IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR ]
+            .includes(option.authenticator)) {
+            isContainsOTPAuthenticator = true;
+        }
+    }
+    );
 
     /**
      * Resolves the authenticator step option.

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
@@ -137,6 +137,14 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
 
     const classes = classNames("authentication-step-container timeline-body", className);
 
+    let isContainsOTPAuthenticator = false;
+
+    step.options.map(option => [
+        IdentityProviderManagementConstants.TOTP_AUTHENTICATOR, 
+        IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR, 
+        IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR ]
+        .includes(option.authenticator) && (isContainsOTPAuthenticator = true));
+
     /**
      * Resolves the authenticator step option.
      *
@@ -258,7 +266,7 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
             );
         }
     };
-
+    
     return (
         <div className="timeline-item">
             <div className="timeline-badge">
@@ -355,7 +363,8 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
                 {
                     (!readOnly
                         && showStepMeta
-                        && (step.options && step.options instanceof Array && step.options.length > 0)) && (
+                        && (step.options && step.options instanceof Array && step.options.length > 0))
+                        && !isContainsOTPAuthenticator && (
                         <div className="checkboxes-extension">
                             <Checkbox
                                 label={ t(

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -273,6 +273,7 @@ export class IdentityProviderManagementConstants {
     public static readonly FIDO_AUTHENTICATOR: string = "FIDOAuthenticator";
     public static readonly BASIC_AUTHENTICATOR = "BasicAuthenticator";
     public static readonly IDENTIFIER_FIRST_AUTHENTICATOR = "IdentifierExecutor";
+    public static readonly SMS_OTP_AUTHENTICATOR = "sms-otp";
 
     // Known Enterprise authenticator IDs
     public static readonly OIDC_AUTHENTICATOR_ID: string = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I";


### PR DESCRIPTION
### Purpose
> This fixes the issue of displaying pick subject identifier checkboxes with TOTP, Email-OTP and SMS-OTP based authenticators

### Related Issues

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
