### PR TITLE
Add React Hook to get window dimensions

### DIFF
--- a/modules/react-components/README.md
+++ b/modules/react-components/README.md
@@ -45,6 +45,18 @@ Use the component along with your other react components.
 />
 ```
 
+## What's Available
+
+### Hooks
+
+#### useWindowDimensions
+
+`useWindowDimensions` hook automatically updates width and height values when screen size changes.
+
+```tsx
+    const { width, height } = useWindowDimensions();
+```
+
 ## License
 
 Licenses this source under the Apache License, Version 2.0 ([LICENSE](../../LICENSE)), You may not use this file except in compliance with the License.

--- a/modules/react-components/src/hooks/index.ts
+++ b/modules/react-components/src/hooks/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -14,10 +14,6 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
-export * from "./components";
-export * from "./hooks";
-export * from "./layouts";
-export * from "./providers";
+export * from "./use-window-dimensions";

--- a/modules/react-components/src/hooks/use-window-dimensions.ts
+++ b/modules/react-components/src/hooks/use-window-dimensions.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useEffect, useState } from "react";
+
+export interface useWindowDimensionsHookValuesInterface {
+    /**
+     * Window Height.
+     */
+    height: Window[ "innerHeight" ];
+    /**
+     * Window Width.
+     */
+    width: Window[ "innerWidth" ];
+}
+
+/**
+ * Hook to retrieve the window dimensions.
+ *
+ * @param {useWindowDimensionsHookValuesInterface} initialValues - Initial Values.
+ * @return {useWindowDimensionsHookValuesInterface} - Window Dimensions.
+ */
+export const useWindowDimensions = (initialValues: useWindowDimensionsHookValuesInterface = {
+    height: undefined,
+    width: undefined
+}): useWindowDimensionsHookValuesInterface => {
+
+    const [ windowDimensions, setWindowDimensions ] = useState<useWindowDimensionsHookValuesInterface>(initialValues);
+
+    /**
+     * Onmount calculate the window dimensions.
+     */
+    useEffect(() => {
+        // Handler to call on window resize.
+        const handleResize = (): void => {
+            // Set window width/height to state
+            setWindowDimensions({
+                height: window.innerHeight,
+                width: window.innerWidth
+            });
+        };
+
+        // Add event listener.
+        window.addEventListener("resize", handleResize);
+
+        // Call handler right away so state gets updated with initial window size.
+        handleResize();
+
+        // Housekeeping, Remove event listener on unmount.
+        return () => {
+            window.removeEventListener("resize", handleResize);
+        };
+    }, []);
+
+    return windowDimensions;
+};


### PR DESCRIPTION
### Purpose
Add a React hook to get the window resolutions.

##### Usage

```jsx
    const { width, height } = useWindowDimensions();
```

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [x] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
