### PR TITLE
Improve IFrame component + Add readonly view for Color Picker

### DIFF
--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -70,3 +70,8 @@ export interface CommonConfig {
  * @enum {string}
  */
 export enum AppViewExtensionTypes { }
+
+/**
+ * Interface for the extended feature configs.
+ */
+export type ExtendedFeatureConfigInterface = FeatureConfigInterface;

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -18,6 +18,7 @@
 
 import { HeaderExtension, HeaderLinkCategoryInterface } from "@wso2is/react-components";
 import { HeaderSubPanelItemInterface } from "../../../features/core/components";
+import { FeatureConfigInterface } from "../../../features/core/models";
 
 export interface CommonConfig {
     advancedSearchWithBasicFilters: {

--- a/modules/access-control/src/access-control-constants.ts
+++ b/modules/access-control/src/access-control-constants.ts
@@ -183,6 +183,31 @@ export class AccessControlConstants {
     public static readonly ATTRIBUTE_DELETE: string = "attribute:delete";
 
     /**
+     * Branding feature permission
+     */
+    public static readonly BRANDING: string = "branding";
+
+    /**
+     * Branding read permission
+     */
+    public static readonly BRANDING_READ: string = "branding:read";
+
+    /**
+     * Branding write permission
+     */
+    public static readonly BRANDING_WRITE: string = "branding:write";
+
+    /**
+     * Branding edit permission
+     */
+    public static readonly BRANDING_EDIT: string = "branding:edit";
+
+    /**
+     * Branding delete permission
+     */
+    public static readonly BRANDING_DELETE: string = "branding:delete";
+
+    /**
      * Scope feature permission
      */
     public static readonly SCOPE: string = "scope";

--- a/modules/access-control/src/access-control-context-provider.tsx
+++ b/modules/access-control/src/access-control-context-provider.tsx
@@ -83,6 +83,27 @@ export const AccessControlContext: FunctionComponent<PropsWithChildren<AccessCon
                 [ AccessControlConstants.ATTRIBUTE_DELETE ] : hasRequiredScopes(featureConfig.attributeDialects,
                     featureConfig.attributeDialects.scopes.delete, allowedScopes),
 
+                [ AccessControlConstants.BRANDING ] : hasRequiredScopes(
+                    featureConfig.branding,
+                    featureConfig.branding.scopes.feature,
+                    allowedScopes),
+                [ AccessControlConstants.BRANDING_READ ] : hasRequiredScopes(
+                    featureConfig.attributeDialects,
+                    featureConfig.branding.scopes.read,
+                    allowedScopes),
+                [ AccessControlConstants.BRANDING_WRITE ] : hasRequiredScopes(
+                    featureConfig.attributeDialects,
+                    featureConfig.branding.scopes.create,
+                    allowedScopes),
+                [ AccessControlConstants.BRANDING_EDIT ] : hasRequiredScopes(
+                    featureConfig.attributeDialects,
+                    featureConfig.branding.scopes.update,
+                    allowedScopes),
+                [ AccessControlConstants.BRANDING_DELETE ] : hasRequiredScopes(
+                    featureConfig.attributeDialects,
+                    featureConfig.branding.scopes.delete,
+                    allowedScopes),
+
                 [ AccessControlConstants.GROUP ] : hasRequiredScopes(featureConfig.groups,
                     featureConfig.groups.scopes.feature, allowedScopes),
                 [ AccessControlConstants.GROUP_READ ] : hasRequiredScopes(featureConfig.groups,

--- a/modules/form/src/components/adapters.tsx
+++ b/modules/form/src/components/adapters.tsx
@@ -448,6 +448,7 @@ export const ColorPickerAdapter = (props: ColorPickerAdapterPropsInterface): Rea
         parentFormProps,
         render,
         width,
+        readOnly,
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...filteredRest
     } = rest;
@@ -462,7 +463,7 @@ export const ColorPickerAdapter = (props: ColorPickerAdapterPropsInterface): Rea
                 <Form.Field>
                     <label>{ childFieldProps.label !== "" ? childFieldProps.label : null }</label>
                     <Input
-                        className="color-picker-input"
+                        className={ `color-picker-input ${ readOnly ? "readonly" : "" }` }
                         aria-label={ childFieldProps.ariaLabel }
                         key={ childFieldProps.testId }
                         required={ childFieldProps.required }
@@ -501,6 +502,7 @@ export const ColorPickerAdapter = (props: ColorPickerAdapterPropsInterface): Rea
                     </Input>
                 </Form.Field>
             ) }
+            disabled={ readOnly }
             content={ (
                 <ColorPicker
                     show

--- a/modules/react-components/src/components/containers/iframe.tsx
+++ b/modules/react-components/src/components/containers/iframe.tsx
@@ -48,6 +48,10 @@ export interface IframeProps extends IframeHTMLAttributes<HTMLIFrameElement>, Id
      */
     responsive?: boolean;
     /**
+     * Styles to be injected in to a style tag.
+     */
+    styles?: string;
+    /**
      * External style sheets to be injected in to the iframe.
      */
     stylesheets?: string[];
@@ -74,6 +78,7 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
         cloneParentStyleSheets,
         isReady,
         responsive,
+        styles,
         stylesheets,
         ["data-componentid"]: componentId,
         ...rest
@@ -210,6 +215,29 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
                 isReady(true);
             });
     }, [ stylesheets, isParentStylesheetsCloningCompleted ]);
+
+    /**
+     * 
+     */
+    useEffect(() => {
+
+        // Check if iframe node is loaded before proceeding.
+        if (!iFrameWindow) {
+            return;
+        }
+
+        const styleNodesCollection: HTMLCollectionOf<HTMLStyleElement> = iFrameWindow.document
+            .getElementsByTagName("style");
+        
+        for (const node of styleNodesCollection) {
+            node.remove();
+        }
+
+        const styleNode: HTMLStyleElement = iFrameWindow.document.createElement("style");
+
+        styleNode.innerHTML = styles;
+        iFrameWindow.document.head.prepend(styleNode);
+    }, [ styles, iFrameWindow ]);
 
     /**
      * Injects the passed in stylesheet to the Head element of the document passed in as an argument.

--- a/modules/react-components/src/components/containers/iframe.tsx
+++ b/modules/react-components/src/components/containers/iframe.tsx
@@ -52,6 +52,10 @@ export interface IframeProps extends IframeHTMLAttributes<HTMLIFrameElement>, Id
      */
     styles?: string;
     /**
+     * Whether to add the style node to the begining of the `head` element or to the end of the `head` element.
+     */
+    styleNodeInjectionStrategy?: "append" | "prepend";
+    /**
      * External style sheets to be injected in to the iframe.
      */
     stylesheets?: string[];
@@ -79,6 +83,7 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
         isReady,
         responsive,
         styles,
+        styleNodeInjectionStrategy,
         stylesheets,
         ["data-componentid"]: componentId,
         ...rest
@@ -236,7 +241,12 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
         const styleNode: HTMLStyleElement = iFrameWindow.document.createElement("style");
 
         styleNode.innerHTML = styles;
-        iFrameWindow.document.head.prepend(styleNode);
+        
+        if (styleNodeInjectionStrategy === "append") {
+            iFrameWindow.document.head.appendChild(styleNode);
+        } else {
+            iFrameWindow.document.head.prepend(styleNode);
+        }
     }, [ styles, iFrameWindow ]);
 
     /**
@@ -297,5 +307,6 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
  */
 Iframe.defaultProps = {
     "data-componentid": "iframe",
-    responsive: true
+    responsive: true,
+    styleNodeInjectionStrategy: "append"
 };

--- a/modules/react-components/src/components/containers/iframe.tsx
+++ b/modules/react-components/src/components/containers/iframe.tsx
@@ -63,6 +63,10 @@ export interface IframeProps extends IframeHTMLAttributes<HTMLIFrameElement>, Id
      * Is the iframe ready.
      */
     isReady?: (status: boolean) => void;
+    /**
+     * The zoom percentage. By default will be 100%.
+     */
+    zoom?: number;
 }
 
 /**
@@ -86,6 +90,7 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
         styleNodeInjectionStrategy,
         stylesheets,
         ["data-componentid"]: componentId,
+        zoom,
         ...rest
     } = props;
 
@@ -231,6 +236,8 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
             return;
         }
 
+        // Remove the existing style nodes before adding the new styles to avoid adding the same
+        // styles on `style` prop changes.
         const styleNodesCollection: HTMLCollectionOf<HTMLStyleElement> = iFrameWindow.document
             .getElementsByTagName("style");
         
@@ -248,6 +255,20 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
             iFrameWindow.document.head.prepend(styleNode);
         }
     }, [ styles, iFrameWindow ]);
+
+    /**
+     * Add styling to the iframe body.
+     */
+    useEffect(() => {
+
+        // Check if main body node is loaded before proceeding.
+        if (!iFrameBodyNode || !zoom) {
+            return;
+        }
+
+        // CSSStyleDeclaration doesn't have the `zoom` property.
+        (iFrameBodyNode.style as CSSStyleDeclaration & { zoom: string }).zoom = `${ zoom }%`;
+    }, [ iFrameBodyNode, zoom ]);
 
     /**
      * Injects the passed in stylesheet to the Head element of the document passed in as an argument.

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -2170,6 +2170,13 @@ code {
             border-radius: @defaultBorderRadius;
         }
     }
+
+    &.readonly {
+        .color-swatch {
+            background: @readOnlyFormFieldBgColor;
+            cursor: default;
+        }
+    }
 }
 
 .loadUIOverrides();


### PR DESCRIPTION
### Purpose
1. Avoid duplicate CSS from loading in to iframe
2. Add ability to add style nodes to iframe
3. Add ability to define the style node injection strategy
4. Add ability to configure zoom in iframe
5. Add interface for the extended features
6. Add support to have read only color pickers

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
