### PR TITLE
Improve auto login flow to handle hosting recovery endpoint in different domain

### DIFF
--- a/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -50,6 +50,7 @@
     String PASSWORD_RESET_PAGE = "password-reset.jsp";
     String AUTO_LOGIN_COOKIE_NAME = "ALOR";
     String AUTO_LOGIN_FLOW_TYPE = "RECOVERY";
+    String AUTO_LOGIN_COOKIE_DOMAIN = "AutoLoginCookieDomain";
     String passwordHistoryErrorCode = "22001";
     String passwordPatternErrorCode = "20035";
     String confirmationKey =
@@ -97,10 +98,14 @@
                     username = userStoreDomain + "/" + username + "@" + tenantDomain;
                 }
                 
+                String cookieDomain = application.getInitParameter(AUTO_LOGIN_COOKIE_DOMAIN);
                 JSONObject contentValueInJson = new JSONObject();
                 contentValueInJson.put("username", username);
                 contentValueInJson.put("createdTime", System.currentTimeMillis());
                 contentValueInJson.put("flowType", AUTO_LOGIN_FLOW_TYPE);
+                if (StringUtils.isNotBlank(cookieDomain)) {
+                    contentValueInJson.put("domain", cookieDomain);
+                }
                 String content = contentValueInJson.toString();
         
                 JSONObject cookieValueInJson = new JSONObject();
@@ -114,6 +119,9 @@
                 cookie.setPath("/");
                 cookie.setSecure(true);
                 cookie.setMaxAge(300);
+                if (StringUtils.isNotBlank(cookieDomain)) {
+                    cookie.setDomain(cookieDomain);
+                }
                 response.addCookie(cookie);
             }
         } catch (ApiException e) {

--- a/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -40,6 +40,7 @@
 <%@ page import="org.apache.http.client.utils.URIBuilder" %>
 <%@ page import="java.net.URI" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.User" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
 
 <jsp:directive.include file="includes/localize.jsp"/>
 <jsp:directive.include file="tenant-resolve.jsp"/>
@@ -59,8 +60,8 @@
     String callback = request.getParameter("callback");
     String userStoreDomain = request.getParameter("userstoredomain");
     String username = null;
-    boolean isAutoLoginEnable = Boolean.parseBoolean(Utils.getConnectorConfig("Recovery.AutoLogin.Enable",
-            tenantDomain));
+    PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
+    Boolean isAutoLoginEnable = preferenceRetrievalClient.checkAutoLoginAfterPasswordRecoveryEnabled(tenantDomain);
 
     if (StringUtils.isBlank(callback)) {
         callback = IdentityManagementEndpointUtil.getUserPortalUrl(

--- a/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -19,20 +19,26 @@
 
 <%@ page import="org.apache.commons.collections.map.HashedMap" %>
 <%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.wso2.carbon.core.util.SignatureUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementServiceUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApiException" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.SelfRegisterApi" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.UsernameRecoveryApi" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.*" %>
+<%@ page import="org.wso2.carbon.identity.recovery.util.Utils" %>
+<%@ page import="org.json.simple.JSONObject" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="java.util.Base64" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
+<%@ page import="javax.servlet.http.Cookie" %>
 <jsp:directive.include file="includes/localize.jsp"/>
 <jsp:directive.include file="tenant-resolve.jsp"/>
 
@@ -81,6 +87,13 @@
             String SELF_REGISTRATION_WITH_VERIFICATION_PAGE = "self-registration-with-verification.jsp";
             String SELF_REGISTRATION_WITHOUT_VERIFICATION_PAGE = "* self-registration-without-verification.jsp";
             String passwordPatternErrorCode = "20035";
+            String AUTO_LOGIN_COOKIE_NAME = "ALOR";
+            String AUTO_LOGIN_COOKIE_DOMAIN = "AutoLoginCookieDomain";
+            String AUTO_LOGIN_FLOW_TYPE = "SIGNUP";
+            PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
+            Boolean isAutoLoginEnable = preferenceRetrievalClient.checkAutoLoginAfterSelfRegistrationEnabled(tenantDomain);
+            Boolean isSelfRegistrationWithVerificationEnabled = preferenceRetrievalClient.checkSelfRegistrationLockOnCreation(tenantDomain);
+    
             boolean isSelfRegistrationWithVerification =
                     Boolean.parseBoolean(request.getParameter("isSelfRegistrationWithVerification"));
 
@@ -199,6 +212,37 @@
 
                 SelfRegisterApi selfRegisterApi = new SelfRegisterApi();
                 selfRegisterApi.mePostCall(selfUserRegistrationRequest, requestHeaders);
+                // Add auto login cookie.
+                if (isAutoLoginEnable && !isSelfRegistrationWithVerificationEnabled) {
+                    if (StringUtils.isNotEmpty(user.getRealm())) {
+                        username = user.getRealm() + "/" + user.getUsername() + "@" + user.getTenantDomain();
+                    } else {
+                        username = user.getUsername() + "@" + user.getTenantDomain();
+                    }
+                    String cookieDomain = application.getInitParameter(AUTO_LOGIN_COOKIE_DOMAIN);
+                    JSONObject contentValueInJson = new JSONObject();
+                    contentValueInJson.put("username", username);
+                    contentValueInJson.put("createdTime", System.currentTimeMillis());
+                    contentValueInJson.put("flowType", AUTO_LOGIN_FLOW_TYPE);
+                    if (StringUtils.isNotBlank(cookieDomain)) {
+                        contentValueInJson.put("domain", cookieDomain);
+                    }
+                    String content = contentValueInJson.toString();
+        
+                    JSONObject cookieValueInJson = new JSONObject();
+                    cookieValueInJson.put("content", content);
+                    String signature = Base64.getEncoder().encodeToString(SignatureUtil.doSignature(content));
+                    cookieValueInJson.put("signature", signature);
+                    Cookie cookie = new Cookie(AUTO_LOGIN_COOKIE_NAME,
+                            Base64.getEncoder().encodeToString(cookieValueInJson.toString().getBytes()));
+                    cookie.setPath("/");
+                    cookie.setSecure(true);
+                    cookie.setMaxAge(300);
+                    if (StringUtils.isNotBlank(cookieDomain)) {
+                        cookie.setDomain(cookieDomain);
+                    }
+                    response.addCookie(cookie);
+                }
                 request.setAttribute("callback", callback);
                 request.getRequestDispatcher("self-registration-complete.jsp").forward(request, response);
 

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
@@ -21,6 +21,7 @@
 <%@ page import="org.wso2.carbon.base.MultitenantConstants" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.SelfRegisterApi" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.CodeValidationRequest" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.Property" %>
@@ -48,8 +49,8 @@
     String confirmationKey = request.getParameter("confirmation");
     String callback = request.getParameter("callback");
     String httpMethod = request.getMethod();
-    Boolean isAutoLoginEnable = Boolean.parseBoolean(Utils.getConnectorConfig("SelfRegistration.AutoLogin.Enable",
-                tenantDomain));
+    PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
+    Boolean isAutoLoginEnable = preferenceRetrievalClient.checkAutoLoginAfterSelfRegistrationEnabled(tenantDomain);
 
     // Some mail providers initially sends a HEAD request to
     // check the validity of the link before redirecting users.

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
@@ -41,6 +41,7 @@
     boolean error = IdentityManagementEndpointUtil.getBooleanValue(request.getAttribute("error"));
     String errorMsg = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorMsg"));
     String AUTO_LOGIN_COOKIE_NAME = "ALOR";
+    String AUTO_LOGIN_COOKIE_DOMAIN = "AutoLoginCookieDomain";
     String AUTO_LOGIN_FLOW_TYPE = "SIGNUP";
     String username = null;
 
@@ -87,10 +88,14 @@
         if (isAutoLoginEnable) {
             username = userStoreDomain + "/" + username + "@" + tenantDomain;
 
+            String cookieDomain = application.getInitParameter(AUTO_LOGIN_COOKIE_DOMAIN);
             JSONObject contentValueInJson = new JSONObject();
             contentValueInJson.put("username", username);
             contentValueInJson.put("createdTime", System.currentTimeMillis());
             contentValueInJson.put("flowType", AUTO_LOGIN_FLOW_TYPE);
+            if (StringUtils.isNotBlank(cookieDomain)) {
+                contentValueInJson.put("domain", cookieDomain);
+            }
             String content = contentValueInJson.toString();
 
             JSONObject cookieValueInJson = new JSONObject();
@@ -102,6 +107,9 @@
             cookie.setPath("/");
             cookie.setSecure(true);
             cookie.setMaxAge(300);
+            if (StringUtils.isNotBlank(cookieDomain)) {
+                cookie.setDomain(cookieDomain);
+            }
             response.addCookie(cookie);
         }
 

--- a/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -42,6 +42,12 @@
                <param-value>{{ accountrecoveryendpoint.use_username_with_domain_for_self_signup_name_check }}</param-value>
            </context-param>
     {% endif %}
+    {% if accountrecoveryendpoint.auto_login_cookie_domain is defined %}
+        <context-param>
+                <param-name>AutoLoginCookieDomain</param-name>
+                <param-value>{{ accountrecoveryendpoint.auto_login_cookie_domain }}</param-value>
+        </context-param>
+    {% endif %}
     <!-- *************** End of Global configurations ********************** -->
     <!--  End of Custom Page configurations -->
     <context-param>

--- a/pom.xml
+++ b/pom.xml
@@ -662,7 +662,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.20.280</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.306</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.oauth.version>6.7.35</carbon.identity.oauth.version>
         <carbon.identity.oauth.imp.pkg.version.range>[6.1.0, 7.0.0)</carbon.identity.oauth.imp.pkg.version.range>


### PR DESCRIPTION
### Purpose
- Configure ALOR Cookie Domain
- Use PreferenceRetrievalClient to get auto login config
- Add auto login after self sign up without verification

if you are exposing accountrecoveryendpoint in accounts.ipd.com and server APIs in api.idp.com, then add the following to to deployment.toml,
```
[accountrecoveryendpoint]
auto_login_cookie_domain = "idp.com"
```

If you are hosting account recovery endpoint externally, then add this to the web.xml of the accountrecoveryendpoint
```
         <context-param>
                <param-name>AutoLoginCookieDomain</param-name>
                <param-value>idp.com</param-value>
        </context-param>
```
So with this configurations, the ALOR cookie will be set to idp.com and available to api.idp.com when browser initializing an authentication flow. So auto login will work.

Merge after https://github.com/wso2/carbon-identity-framework/pull/3901

### Related Issues
- fix https://github.com/wso2/product-is/issues/13053

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
