### PR TITLE
Fix issue in OIDC attribute mapping dropdown

### DIFF
--- a/apps/console/src/features/claims/components/add/add-external-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-external-claim.tsx
@@ -462,6 +462,9 @@ export const AddExternalClaims: FunctionComponent<AddExternalClaimsPropsInterfac
 
                                         setLocalClaimsSearchResults(itemList);
                                     } }
+                                    onClose={ () => {
+                                        setLocalClaimsSearchResults(filteredLocalClaims);
+                                    } }
                                     children={
                                         localClaimsSearchResults?.map((claim: Claim, index) => {
                                             return {


### PR DESCRIPTION
### Purpose
After a user enters a search-text in the `User Attribute to map to` field and selects a results, if the user clicks on the drop-down list again to select a different attribute, only the results from the previous search are displayed, unless the user enters a new search-text. This PR addresses this issue.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
