### PR TITLE
Improve Safari FIDO flow handling logic

### DIFF
--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/fido-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/fido-authenticator.tsx
@@ -89,11 +89,15 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
             return;
         }
 
+        // Exception is not handled here since this request is dispatched on page load.
+        // TODO: Add a logger to print the exception
         startFidoUsernamelessFlow()
             .then((response) => {
                 setFidoFlowStartResponse(response);
             });
 
+        // Exception is not handled here since this request is dispatched on page load.
+        // TODO: Add a logger to print the exception
         commonConfig.accountSecurityPage.mfa.fido2.allowLegacyKeyRegistration &&
             startFidoFlow()
                 .then((response) => {

--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/fido-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/fido-authenticator.tsx
@@ -417,7 +417,11 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
             >
                 <ModalContent>
                     { commonConfig.accountSecurityPage.mfa.fido2.allowLegacyKeyRegistration && (
-                        <Button className="negative-modal-link-button" onClick={ addDevice }>
+                        <Button
+                            className="negative-modal-link-button"
+                            onClick={ addDevice }
+                            data-testid={ `${ testId }-error-retry` }
+                        >
                             { t("myAccount:components.mfa.fido.tryButton") }
                         </Button>
                     ) }
@@ -463,6 +467,7 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
                                         : false
                                 }
                                 maxLength={ 30 }
+                                data-testid={ `${ testId }-fido-device-name` }
                             />
                         </Form.Field>
                     </Form>
@@ -506,6 +511,7 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
                                         size="small"
                                         color="grey"
                                         name="add"
+                                        data-testid={ `${ testId }-add-device-button` }
                                         onClick={ addUsernamelessDevice }
                                     />
                                 </span>
@@ -561,6 +567,7 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
                                                                     ) }
                                                                     type="text"
                                                                     maxLength={ 30 }
+                                                                    data-testid={ `${ testId }-fido-device-name` }
                                                                 />
                                                                 <Field hidden={ true } type="divider" />
                                                                 <Form.Group inline={ true }>
@@ -568,6 +575,9 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
                                                                         size="small"
                                                                         type="submit"
                                                                         value={ t("common:update").toString() }
+                                                                        data-testid={
+                                                                            `${ testId }-fido-device-name-submit`
+                                                                        }
                                                                     />
                                                                     <Field
                                                                         className="link-button"
@@ -577,6 +587,9 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
                                                                         size="small"
                                                                         type="button"
                                                                         value={ t("common:cancel").toString() }
+                                                                        data-testid={
+                                                                            `${ testId }-fido-device-name-cancel`
+                                                                        }
                                                                     />
                                                                 </Form.Group>
                                                             </Forms>
@@ -611,6 +624,7 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
                                                                 size="large"
                                                                 color="grey"
                                                                 name="pencil alternate"
+                                                                data-testid={ `${ testId }-edit-device` }
                                                                 onClick={ () => {
                                                                     showEdit(device.credential.credentialId);
                                                                 } }
@@ -627,6 +641,7 @@ export const FIDOAuthenticator: React.FunctionComponent<FIDOAuthenticatorProps> 
                                                                         color="red"
                                                                         size="small"
                                                                         className="list-icon"
+                                                                        data-testid={ `${ testId }-remove-device` }
                                                                         onClick={ () => {
                                                                             setDeleteKey(
                                                                                 device.credential.credentialId);


### PR DESCRIPTION
### Purpose
> The backend requests are dispatched on page load in Safari so that the FIDO flow trigger button can trigger the flow directly.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
