### PR TITLE
Use the username return from SCIM2/Me for piiPrincipleId

### DIFF
--- a/apps/myaccount/src/api/consents.ts
+++ b/apps/myaccount/src/api/consents.ts
@@ -42,11 +42,6 @@ const httpClientAll = AsgardeoSPAClient.getInstance().httpRequestAll.bind(Asgard
  * @return {Promise<any>} A promise containing the response.
  */
 export const fetchConsentedApps = async (state: ConsentState, username: string): Promise<ConsentInterface[]> => {
-    const userName = username.split("@");
-
-    if (userName.length > 1) {
-        userName.pop();
-    }
 
     const requestConfig = {
         headers: {
@@ -56,7 +51,7 @@ export const fetchConsentedApps = async (state: ConsentState, username: string):
         },
         method: HttpMethods.GET,
         params: {
-            piiPrincipalId: userName.join("@"),
+            piiPrincipalId: username,
             state
         },
         url: store.getState().config.endpoints.consentManagement.consent.listAllConsents

--- a/apps/myaccount/src/components/consents/consents.tsx
+++ b/apps/myaccount/src/components/consents/consents.tsx
@@ -200,6 +200,7 @@ export const Consents: FunctionComponent<ConsentComponentProps> = (props: Consen
         if (!userName) {
             return;
         }
+        
         ( async function _execute() {
             await getConsentedApps();
             await getAllPurposesDetails();

--- a/apps/myaccount/src/components/consents/consents.tsx
+++ b/apps/myaccount/src/components/consents/consents.tsx
@@ -76,7 +76,7 @@ export const Consents: FunctionComponent<ConsentComponentProps> = (props: Consen
     const [ consentListActiveIndexes, setConsentListActiveIndexes ] = useState([]);
     const [ deniedPIIClaimList, setDeniedPIIClaimList ] = useState<Set<PIICategoryClaimToggleItem>>(new Set());
     const [ acceptedPIIClaimList, setAcceptedPIIClaimList ] = useState<Set<PIICategoryClaimToggleItem>>(new Set());
-    const userName: string = useSelector((state: AppState) => state?.authenticationInformation?.username);
+    const userName: string = useSelector((state: AppState) => state?.authenticationInformation?.profileInfo.userName);
     const tenantDomain: string = useSelector((state: AppState) => state?.authenticationInformation?.tenantDomain);
     const { t } = useTranslation();
     const endUserSession = useEndUserSession();
@@ -138,9 +138,8 @@ export const Consents: FunctionComponent<ConsentComponentProps> = (props: Consen
         // thrown it will be handled in @link getConsentedApps function.
         const homeRealmIdentifiers: string[] = await fetchHomeRealmIdentifiers();
 
-        // Recreate the piiPrincipalId from currently authenticated user's username.
-        const fragments = userName.split("@");
-        const piiPrincipalId = fragments.length ? fragments[0] : "";
+        // Use the profile username for the piiPrincipalId.
+        const piiPrincipalId = userName;
 
         const receipt: ConsentInterface = {
             consentReceipt: {
@@ -198,11 +197,14 @@ export const Consents: FunctionComponent<ConsentComponentProps> = (props: Consen
      * Apply any component side-effects here.
      */
     useEffect(() => {
+        if (!userName) {
+            return;
+        }
         ( async function _execute() {
             await getConsentedApps();
             await getAllPurposesDetails();
         }() );
-    }, []);
+    }, [userName]);
 
     /**
      * Populates the PII claim list to state hooks.


### PR DESCRIPTION
### Purpose
Fix https://github.com/wso2/product-is/issues/12583

In the current implementation, we use the "sub" claim returned in the id token (by removing the tenant domain)  for "piiPrincipalId" param.
But with this improvement https://github.com/wso2/product-is/issues/12504, by default user's id is passed as the "sub" claim.

- If the claim config of myaccount SP sets the subject URI as username claim, this issue https://github.com/wso2/product-is/issues/12583 is not reproducible 
- Since the most general solution is to take the username from scim2/Me endpoint, we use that value for "piiPrincipalId" param in this fix.
- 