### PR TITLE
Improve displaying attributes without OIDC mappings in application user-attributes section

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
@@ -161,7 +161,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                 <div>
                     { !localDialect ? localClaimDisplayName : displayName }
                 </div>
-                { isOIDCMapping?
+                { isOIDCMapping ?
                     (<Hint warning= { true } popup>
                         {
                             t("console:develop.features.applications.edit.sections.attributes" +

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
@@ -54,9 +54,9 @@ interface AttributeListItemPropInterface extends TestableComponentInterface {
      */
     label?: ReactNode;
     /**
-     * Specify whether hint is displayed.
+     * Specify whether there is an OIDC mapping.
      */
-    hint?: boolean;
+     isOIDCMapping?: boolean;
 }
 
 /**
@@ -88,7 +88,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
         deleteAttribute,
         subject,
         label,
-        hint,
+        isOIDCMapping,
         [ "data-testid" ]: testId
     } = props;
 
@@ -100,6 +100,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
     const [ requested, setRequested ] = useState(true);
     const [ mappedAttribute, setMappedAttribute ] = useState(claimURI);
     const [ defaultMappedAttribute ] = useState(mappedAttribute);
+    const localDialectURI = "http://wso2.org/claims";
 
     const handleMandatoryCheckChange = () => {
         if (mandatory) {
@@ -159,21 +160,29 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
             <Table.Cell>
                 <div>
                     { !localDialect ? localClaimDisplayName : displayName }
-                    { hint? 
-                        (<Hint warning= { true } popup>
-                            {
-                                t("console:develop.features.applications.edit.sections.attributes" +
-                                ".selection.mappingTable.listItem.faultyAttributeMapping")
-                            }
-                        </Hint>)
-                        : "" }
                 </div>
+                { isOIDCMapping?
+                    (<Hint warning= { true } popup>
+                        {
+                            t("console:develop.features.applications.edit.sections.attributes" +
+                                ".selection.mappingTable.listItem.faultyAttributeMappingHint")
+                        }
+                    </Hint>)
+                : "" }
                 {
                     <Popup
-                        content={ claimURI }
+                    content={ claimURI.startsWith(localDialectURI)
+                        ? t("console:develop.features.applications.edit.sections.attributes" +
+                            ".selection.mappingTable.listItem.faultyAttributeMapping")
+                        : claimURI }
                         inverted
                         trigger={ (
-                            <Code compact withBackground={ false }>{ claimURI }</Code>
+                            <Code compact withBackground={ false }>
+                                { claimURI.startsWith(localDialectURI)
+                                    ? t("console:develop.features.applications.edit.sections.attributes" +
+                                        ".selection.mappingTable.listItem.faultyAttributeMapping")
+                                    : claimURI }
+                            </Code>
                         ) }
                         position="bottom left">
                     </Popup>
@@ -213,7 +222,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                                 checked={ initialMandatory || mandatory || subject }
                                 onClick={ !readOnly && handleMandatoryCheckChange }
                                 disabled={ mappingOn ? !requested : false }
-                                readOnly={ subject || readOnly }
+                                readOnly={ subject || readOnly || isOIDCMapping }
                             />
                         )
                     }
@@ -238,7 +247,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
                     flowing = { subject }
                 />
             </Table.Cell>
-            { !readOnly && deleteAttribute ? (
+            { (!readOnly || isOIDCMapping) && deleteAttribute ? (
                 <Table.Cell textAlign="right">
                     <Popup
                         trigger={ (

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection.tsx
@@ -444,7 +444,7 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                     if (claimMapping.localClaim.uri === claim.claimURI){
                         const option: ExtendedExternalClaimInterface = {
                             claimDialectURI: claim.dialectURI,
-                            claimURI: claim.displayName.toLowerCase(),
+                            claimURI: claim.claimURI,
                             id: claim.id,
                             localClaimDisplayName: claim.displayName,
                             mandatory: claim.mandatory,
@@ -1013,7 +1013,8 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                                                                                 readOnly={
                                                                                     (selectedSubjectValue
                                                                                     === claim.mappedLocalClaimURI &&
-                                                                                    !onlyOIDCConfigured)
+                                                                                    !onlyOIDCConfigured
+                                                                                    || !checkMapping(claim))
                                                                                         ? true
                                                                                         : readOnly
                                                                                 }
@@ -1027,7 +1028,7 @@ export const AttributeSelection: FunctionComponent<AttributeSelectionPropsInterf
                                                                                 subject={ selectedSubjectValue
                                                                                 === claim.mappedLocalClaimURI &&
                                                                                 !onlyOIDCConfigured }
-                                                                                hint={
+                                                                                isOIDCMapping={
                                                                                     checkMapping(claim)
                                                                                         ? false
                                                                                         : true

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -493,6 +493,7 @@ export interface ConsoleNS {
                                             subjectDisabledSelection: string;
                                         };
                                         faultyAttributeMapping: string;
+                                        faultyAttributeMappingHint: string;
                                         fields: {
                                             claim: FormAttributes;
                                         };

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -822,7 +822,9 @@ export const console: ConsoleNS = {
                                             subjectDisabledSelection: "This attribute is mandatory because it " +
                                                 "is the subject attribute."
                                         },
-                                        faultyAttributeMapping: "Faulty OIDC Connect Mapping",
+                                        faultyAttributeMapping: "Missing OIDC Connect Mapping",
+                                        faultyAttributeMappingHint: "Attribute value will not be shared to the" +
+                                            " application at the user login.",
                                         fields: {
                                             claim: {
                                                 label: "Please enter a value",

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -822,7 +822,7 @@ export const console: ConsoleNS = {
                                             subjectDisabledSelection: "This attribute is mandatory because it " +
                                                 "is the subject attribute."
                                         },
-                                        faultyAttributeMapping: "Missing OIDC Connect Mapping",
+                                        faultyAttributeMapping: "Missing OpenID Connect Attribute Mapping",
                                         faultyAttributeMappingHint: "Attribute value will not be shared to the" +
                                             " application at the user login.",
                                         fields: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -827,7 +827,9 @@ export const console: ConsoleNS = {
                                             subjectDisabledSelection: "Cet attribut est obligatoire car il " +
                                                 "s'agit de l'attribut sujet."
                                         },
-                                        faultyAttributeMapping: "Mappage de connexion OIDC défectueux",
+                                        faultyAttributeMapping: "Mappage de connexion OIDC manquant",
+                                        faultyAttributeMappingHint: "La valeur d'attribut ne sera pas partagée" +
+                                            " avec l'application lors de la connexion de l'utilisateur.",
                                         fields: {
                                             claim: {
                                                 label: "Veuillez entrer une valeur",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -827,7 +827,7 @@ export const console: ConsoleNS = {
                                             subjectDisabledSelection: "Cet attribut est obligatoire car il " +
                                                 "s'agit de l'attribut sujet."
                                         },
-                                        faultyAttributeMapping: "Mappage de connexion OIDC manquant",
+                                        faultyAttributeMapping: "Mappage d'attribut OpenID Connect manquant",
                                         faultyAttributeMappingHint: "La valeur d'attribut ne sera pas partagée" +
                                             " avec l'application lors de la connexion de l'utilisateur.",
                                         fields: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -825,7 +825,9 @@ export const console: ConsoleNS = {
                                             subjectDisabledSelection: "මෙම ගුණාංගය අනිවාර්ය වන්නේ " +
                                                 "එය විෂය ගුණාංගය වන බැවිනි."
                                         },
-                                        faultyAttributeMapping: "දෝෂ සහිත OIDC සම්බන්ධක සිතියම්කරණය",
+                                        faultyAttributeMapping: "OIDC සම්බන්ධතා සිතියම්ගත කිරීම අස්ථානගත වී ඇත",
+                                        faultyAttributeMappingHint: "පරිශීලක පිවිසුමේදී උපලක්ෂණ අගය යෙදුම වෙත" +
+                                            " බෙදා නොගනු ඇත.",
                                         fields: {
                                             claim: {
                                                 label: "අගය ඇතුලත් කරන්න",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -825,7 +825,8 @@ export const console: ConsoleNS = {
                                             subjectDisabledSelection: "මෙම ගුණාංගය අනිවාර්ය වන්නේ " +
                                                 "එය විෂය ගුණාංගය වන බැවිනි."
                                         },
-                                        faultyAttributeMapping: "OIDC සම්බන්ධතා සිතියම්ගත කිරීම අස්ථානගත වී ඇත",
+                                        faultyAttributeMapping: "OpenID Connect Attribute සිතියම්ගත" +
+                                            " කිරීම අස්ථානගත වී ඇත",
                                         faultyAttributeMappingHint: "පරිශීලක පිවිසුමේදී උපලක්ෂණ අගය යෙදුම වෙත" +
                                             " බෙදා නොගනු ඇත.",
                                         fields: {


### PR DESCRIPTION
### Purpose
> Improve displaying attributes without OIDC mappings in application user-attributes section.
- Disable mandatory checkbox for attributes without OIDC mapping
- Display error warning when there is no OIDC mapping

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/6760

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- https://github.com/wso2/identity-apps/pull/2849

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
