### PR TITLE
feat: extend card ribbon

### DIFF
--- a/modules/theme/src/themes/default/views/card.overrides
+++ b/modules/theme/src/themes/default/views/card.overrides
@@ -22,6 +22,7 @@
 ------------------------------*/
 
 .ui.card {
+    overflow: clip;
     .content {
         &.extra {
             &.selection {
@@ -1129,3 +1130,28 @@
     }
 }
 
+/*-----------------------------------------
+         Reusable Card Directives
+-------------------------------------------*/
+
+.ui.card {
+    .coming-soon-ribbon {
+        top: 0;
+        width: fit-content;
+        min-width: 100px;
+        font-size: 0.8em;
+        height: 24px;
+        position: absolute;
+        right: 0;
+        display: flex;
+        flex-direction: row;
+        align-content: center;
+        align-items: center;
+        justify-content: space-around;
+        font-weight: 500;
+        color: @white;
+        background: linear-gradient(270deg, lighten(@primaryColor, 15) 0%, @primaryColor 100%);
+        clip-path: polygon(4% 0, 0 100%, 100% 100%, 100% 0, 100% 0);
+        -webkit-clip-path: polygon(4% 0, 0 100%, 100% 100%, 100% 0, 100% 0);
+    }
+}


### PR DESCRIPTION
### Purpose

- Card clips overflown elements.
- Cards can have a ribbon positioned on absolute top and right.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
