### PR TITLE
Update theme for input add-ons

### DIFF
--- a/modules/theme/src/themes/default/collections/form.overrides
+++ b/modules/theme/src/themes/default/collections/form.overrides
@@ -130,3 +130,16 @@
         }
     }
 }
+
+/*-------------------------------
+  Addon wrapper for input fields to avoid
+  overlapping with browser added icons
+  ex: Password Managers
+--------------------------------*/
+.ui.form {
+    .ui.input.addon-wrapper {
+        > input {
+            border: none;
+        }
+    }
+}

--- a/modules/theme/src/themes/default/elements/input.overrides
+++ b/modules/theme/src/themes/default/elements/input.overrides
@@ -76,3 +76,27 @@ input[type=password]::-ms-reveal, input[type=password]::-ms-clear {
     display: none;
 }
 
+/*-------------------------------
+  Addon wrapper for input fields to avoid
+  overlapping with browser added icons
+  ex: Password Managers
+--------------------------------*/
+.ui.input {
+    &.addon-wrapper {
+        margin: 0;
+        outline: 0;
+        border: @border;
+        border-radius: @borderRadius;
+        box-shadow: @boxShadow;
+        transition: @transition;
+
+        &:focus-within {
+            border-color: @focusBorderColor;
+        }
+
+        > input {
+            border: none;
+            max-width: calc(100% - 2.67142857em);
+        }
+    }
+}


### PR DESCRIPTION
### Purpose
> - This theme update fixes the issue of password reveal icon and organization name validity icon in user input fields getting obstructed by password managers' icon.
> - `addon-wrapper` CSS class was introduced to resolve issue of overlapping input add-ons with browser added icons such as password managers. This CSS class should be added to the wrapping element (`div`) of the `input` field where the issue occurs.

### Approach
**Before**
<img width="355" alt="image" src="https://user-images.githubusercontent.com/90854808/157210606-e71d5423-e3e6-41db-9fee-95eb4e40f5c5.png">

 **After**
<img width="355" alt="image" src="https://user-images.githubusercontent.com/90854808/157210833-9f248b4b-2915-46ef-9e72-77a4dd79aae1.png">



### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
