### PR TITLE
Derive Tenant Domain from Subject

### DIFF
--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -87,8 +87,10 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
 
             dispatchEvent(event);
 
+            const tenantDomain = CommonAuthenticateUtils.deriveTenantDomainFromSubject(response.sub);
+
             // Update the app base name with the newly resolved tenant.
-            window[ "AppUtils" ].updateTenantQualifiedBaseName(response.tenantDomain);
+            window[ "AppUtils" ].updateTenantQualifiedBaseName(tenantDomain);
 
             // When the tenant domain changes, we have to reset the auth callback in session storage.
             // If not, it will hang and the app will be unresponsive with in the tab.

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -87,7 +87,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
 
             dispatchEvent(event);
 
-            const tenantDomain = CommonAuthenticateUtils.deriveTenantDomainFromSubject(response.sub);
+            const tenantDomain: string = CommonAuthenticateUtils.deriveTenantDomainFromSubject(response.sub);
 
             // Update the app base name with the newly resolved tenant.
             window[ "AppUtils" ].updateTenantQualifiedBaseName(tenantDomain);

--- a/apps/myaccount/src/protected-app.tsx
+++ b/apps/myaccount/src/protected-app.tsx
@@ -96,7 +96,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
 
             dispatchEvent(event);
 
-            const tenantDomain = AuthenticateUtils.deriveTenantDomainFromSubject(response.sub);
+            const tenantDomain: string = AuthenticateUtils.deriveTenantDomainFromSubject(response.sub);
 
             // Update the app base name with the newly resolved tenant.
             window[ "AppUtils" ].updateTenantQualifiedBaseName(tenantDomain);

--- a/apps/myaccount/src/protected-app.tsx
+++ b/apps/myaccount/src/protected-app.tsx
@@ -96,8 +96,10 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
 
             dispatchEvent(event);
 
+            const tenantDomain = AuthenticateUtils.deriveTenantDomainFromSubject(response.sub);
+
             // Update the app base name with the newly resolved tenant.
-            window[ "AppUtils" ].updateTenantQualifiedBaseName(response.tenantDomain);
+            window[ "AppUtils" ].updateTenantQualifiedBaseName(tenantDomain);
 
             dispatch(setDeploymentConfigs<DeploymentConfigInterface>(Config.getDeploymentConfig()));
             dispatch(

--- a/modules/core/src/utils/authenticate-utils.ts
+++ b/modules/core/src/utils/authenticate-utils.ts
@@ -112,17 +112,16 @@ export class AuthenticateUtils {
         window.sessionStorage.removeItem(`auth_callback_url_${app}`);
     }
 
+   /**
     * Tenant domain decoded from the subject claim of the ID Token.
-    * @param {string} sub - Subject claim of the ID Token
+    *
+    * @param {string} sub - Subject claim of the ID Token.
     * @return {string} Tenant domain.
-    */
-    * @param {string} sub - Subject claim of the ID Token
-    * @return {string} Tenant domain.
-    * Tenant domain decoded from the subject claim of the ID Token.
     */
     public static deriveTenantDomainFromSubject(sub: string): string {
         const subParts: string[] = sub.split("@");
         const tenantDomain: string = subParts[ subParts.length - 1 ];
+
         return tenantDomain;
     }
 }

--- a/modules/core/src/utils/authenticate-utils.ts
+++ b/modules/core/src/utils/authenticate-utils.ts
@@ -112,14 +112,17 @@ export class AuthenticateUtils {
         window.sessionStorage.removeItem(`auth_callback_url_${app}`);
     }
 
-    /**
+    * Tenant domain decoded from the subject claim of the ID Token.
+    * @param {string} sub - Subject claim of the ID Token
+    * @return {string} Tenant domain.
+    */
     * @param {string} sub - Subject claim of the ID Token
     * @return {string} Tenant domain.
     * Tenant domain decoded from the subject claim of the ID Token.
     */
     public static deriveTenantDomainFromSubject(sub: string): string {
-        const subParts = sub.split("@");
-        const tenantDomain = subParts[ subParts.length - 1 ];
+        const subParts: string[] = sub.split("@");
+        const tenantDomain: string = subParts[ subParts.length - 1 ];
         return tenantDomain;
     }
 }

--- a/modules/core/src/utils/authenticate-utils.ts
+++ b/modules/core/src/utils/authenticate-utils.ts
@@ -111,4 +111,15 @@ export class AuthenticateUtils {
     public static removeAuthenticationCallbackUrl(app: string): void {
         window.sessionStorage.removeItem(`auth_callback_url_${app}`);
     }
+
+    /**
+    * @param {string} sub - Subject claim of the ID Token
+    * @return {string} Tenant domain.
+    * Tenant domain decoded from the subject claim of the ID Token.
+    */
+    public static deriveTenantDomainFromSubject(sub: string): string {
+        const subParts = sub.split("@");
+        const tenantDomain = subParts[ subParts.length - 1 ];
+        return tenantDomain;
+    }
 }


### PR DESCRIPTION
Fix [wso2/product-is#13003](https://github.com/wso2/product-is/issues/13003)

Previously tenant domain was derived only when the email was used as the username [1]. This is correct for asgardeo, but not for IS. In IS, the tenant domain was set as empty. 
To fix that issue, I changed the logic in my account and console to get the right hand side of the last `@` in the subject claim of the ID token as the tenant domain.

[1] [https://github.com/asgardeo/asgardeo-auth-js-sdk/blob/07190e82904c44b19ee7b30441e9b411d0c1266a/lib/src/utils/authentication-utils.ts#L73](https://github.com/asgardeo/asgardeo-auth-js-sdk/blob/07190e82904c44b19ee7b30441e9b411d0c1266a/lib/src/utils/authentication-utils.ts#L73)