### PR TITLE
Add option to allow accessing management APIs

### DIFF
--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -593,6 +593,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 template={ template }
                 readOnly={ readOnly }
                 data-testid={ `${ testId }-general-settings` }
+                isManagementApp={ application.isManagementApp }
             />
         </ResourceTab.Pane>
     );

--- a/apps/console/src/features/applications/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/applications/components/forms/general-details-form.tsx
@@ -18,9 +18,11 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Form } from "@wso2is/form";
+import { Message } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
+import { Icon } from "semantic-ui-react";
 import { AppState, UIConfigInterface } from "../../../core";
 import { ApplicationManagementConstants } from "../../constants";
 
@@ -68,6 +70,10 @@ interface GeneralDetailsFormPopsInterface extends TestableComponentInterface {
      * Specifies if the form is submitting.
      */
     isSubmitting?: boolean;
+    /**
+     * Specifies a Management Application
+     */
+    isManagementApp?: boolean;
 }
 
 /**
@@ -102,6 +108,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
         onSubmit,
         readOnly,
         isSubmitting,
+        isManagementApp,
         [ "data-testid" ]: testId
     } = props;
 
@@ -199,6 +206,13 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
             } }
             validate={ validateForm }
         >
+            { isManagementApp && 
+                (<Message className="with-inline-icon" icon visible info small>
+                    <Icon name="info" size="small" />
+                    { t("console:develop.features.applications.forms.generalDetails.managementAppBanner") } 
+                </Message>)
+            }
+
             { !UIConfig.systemAppsIdentifiers.includes(name) && (
                 <Field.Input
                     ariaLabel="Application name"

--- a/apps/console/src/features/applications/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/applications/components/forms/general-details-form.tsx
@@ -18,11 +18,11 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Form } from "@wso2is/form";
-import { Message } from "@wso2is/react-components";
+import { DocumentationLink, Message, useDocumentation } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Icon } from "semantic-ui-react";
+import { Divider, Icon } from "semantic-ui-react";
 import { AppState, UIConfigInterface } from "../../../core";
 import { ApplicationManagementConstants } from "../../constants";
 
@@ -113,6 +113,8 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
     } = props;
 
     const { t } = useTranslation();
+
+    const { getLink } = useDocumentation();
 
     const UIConfig: UIConfigInterface = useSelector((state: AppState) => state?.config?.ui);
 
@@ -206,13 +208,28 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
             } }
             validate={ validateForm }
         >
-            { isManagementApp && 
-                (<Message className="with-inline-icon" icon visible info small>
-                    <Icon name="info" size="small" />
-                    { t("console:develop.features.applications.forms.generalDetails.managementAppBanner") } 
-                </Message>)
+            { getLink("develop.connections.newConnection.enterprise.samlLearnMore") === undefined
+                ? null
+                : <Divider hidden/>
             }
-
+            { isManagementApp && (
+                <Message className="with-inline-icon" icon visible info small >
+                    <div className="ui grid">
+                        <div className="one wide column pt-0 pb-0 mt-1">
+                            <Icon name="info" size="large"/>
+                        </div>
+                        <div className="fifteen wide column pt-0 pb-0">
+                            { t("console:develop.features.applications.forms.generalDetails.managementAppBanner") } 
+                            <DocumentationLink 
+                                link={ getLink("develop.applications.managementApplication.learnMore") } >
+                                {
+                                    t("common:learnMore")
+                                }
+                            </DocumentationLink>
+                        </div>
+                    </div>
+                </Message>
+            ) }
             { !UIConfig.systemAppsIdentifiers.includes(name) && (
                 <Field.Input
                     ariaLabel="Application name"

--- a/apps/console/src/features/applications/components/settings/general-application-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/general-application-settings.tsx
@@ -92,6 +92,10 @@ interface GeneralApplicationSettingsInterface extends SBACInterface<FeatureConfi
      * Application template.
      */
     template?: ApplicationTemplateListItemInterface;
+    /**
+     * Specifies a Management Application
+     */
+    isManagementApp?: boolean;
 }
 
 /**
@@ -118,6 +122,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
         onDelete,
         onUpdate,
         readOnly,
+        isManagementApp,
         [ "data-testid" ]: testId
     } = props;
 
@@ -287,6 +292,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                             }
                             data-testid={ `${ testId }-form` }
                             isSubmitting={ isSubmitting }
+                            isManagementApp={ isManagementApp }
                         />
                     </EmphasizedSegment>
                     <Divider hidden />

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -23,6 +23,7 @@ import {
     ContentLoader,
     DocumentationLink,
     Heading,
+    Hint,
     LinkButton,
     PrimaryButton,
     SelectionCard,
@@ -262,6 +263,13 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
 
         application.name = generalFormValues.get("name").toString();
         application.templateId = selectedTemplate.id;
+        // If the application is a OIDC standard-based application
+        if (customApplicationProtocol === SupportedAuthProtocolTypes.OAUTH2_OIDC
+            && selectedTemplate?.templateId === "custom-application") {
+            application.isManagementApp = generalFormValues.get("isManagementApp").length >= 2
+                ? true
+                : false;
+        }
 
         // If the selected template is Custom, assign the proper `template ids`.
         if (selectedTemplate.id === CustomApplicationTemplate.id) {
@@ -682,7 +690,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
             : subTemplates;
 
         return (
-            <Grid.Row className="pt-0">
+            <Grid.Row className="pt-0 mt-0">
                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 14 }>
                     <div className="sub-template-selection">
                         <label className="sub-templates-label">{ subTemplatesSectionTitle }</label>
@@ -882,11 +890,38 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                         </Grid.Column>
                     </Grid.Row>
                     { renderSubTemplateSelection() }
-                    <Grid.Row className="pt-0">
+                    <Grid.Row className="pt-0 mt-0">
                         <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 14 }>
                             { resolveMinimalProtocolFormFields() }
                         </Grid.Column>
                     </Grid.Row>
+                    { 
+                        // The Management App checkbox is only present in OIDC Standard-Based apps
+                        (customApplicationProtocol === SupportedAuthProtocolTypes.OAUTH2_OIDC
+                            && selectedTemplate?.templateId === "custom-application") && (
+                            <div className="pt-0 mt-0">
+                                <Field
+                                    data-testid={ `${ testId }-management-app-checkbox` }
+                                    name={ "isManagementApp" }
+                                    required={ false }
+                                    requiredErrorMessage={ "is required" }
+                                    type="checkbox"
+                                    value={ [ "isManagementApp" ] }
+                                    children={ [
+                                        {
+                                            label: t("console:develop.features.applications.forms.generalDetails" +
+                                                ".fields.isManagementApp.label" ),
+                                            value: "manageApp"
+                                        }
+                                    ] }
+                                />
+                                <Hint compact>
+                                    { t("console:develop.features.applications.forms.generalDetails.fields" +
+                                            ".isManagementApp.hint" ) }
+                                </Hint>
+                            </div>
+                        )
+                    }
                 </Grid>
             </Forms>
         );

--- a/apps/console/src/features/applications/models/application.ts
+++ b/apps/console/src/features/applications/models/application.ts
@@ -35,6 +35,7 @@ export interface ApplicationBasicInterface {
     description?: string;
     accessUrl?: string;
     templateId?: string;
+    isManagementApp?: boolean;
 }
 
 export enum ApplicationAccessTypes {
@@ -243,6 +244,10 @@ export interface ApplicationTemplateListItemInterface {
     description?: string;
     image?: string;
     authenticationProtocol?: string;
+    /**
+     * Specifies a Management Application
+     */
+    isManagementApp?: boolean;
     /**
      * Template group.
      * ex: "web-application"

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -752,7 +752,10 @@ export interface ConsoleNS {
                             imageUrl: FormAttributes;
                             discoverable: FormAttributes;
                             accessUrl: FormAttributes;
+                            isManagementApp: FormAttributes;
                         };
+                        managementAppBanner: string;
+                        
                     };
                     inboundCustom: {
                         fields: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1355,6 +1355,10 @@ export const console: ConsoleNS = {
                                     invalid: "This is not a valid image URL"
                                 }
                             },
+                            isManagementApp: {
+                                hint: "Enable to allow the application to access management API of this organization.",
+                                label: "Management Application"
+                            },
                             name: {
                                 label: "Name",
                                 placeholder: "My App",
@@ -1364,7 +1368,9 @@ export const console: ConsoleNS = {
                                     empty: "Application name is required."
                                 }
                             }
-                        }
+                        },
+                        managementAppBanner: "The application is allowed to access the management APIs of this " +
+                            "organization."
                     },
                     inboundCustom: {
                         fields: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1388,6 +1388,11 @@ export const console: ConsoleNS = {
                                     invalid: "Ceci n'est pas une URL d'image valide"
                                 }
                             },
+                            isManagementApp: {
+                                hint: "Activez pour autoriser l'application à accéder à l'API de gestion de cette " +
+                                "organisation.",
+                                label: "Application de gestion"
+                            },
                             name: {
                                 label: "Nom",
                                 placeholder: "Mon appli",
@@ -1395,7 +1400,9 @@ export const console: ConsoleNS = {
                                     empty: "Ceci est un champ obligatoire."
                                 }
                             }
-                        }
+                        },
+                        managementAppBanner: "L'application est autorisée à accéder aux API de gestion de cette " +
+                            "organisation."
                     },
                     inboundCustom: {
                         fields: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1361,6 +1361,10 @@ export const console: ConsoleNS = {
                                     invalid: "මෙය වලංගු රූප URL එකක් නොවේ"
                                 }
                             },
+                            isManagementApp: {
+                                hint: "මෙම සංවිධානයේ කළමනාකරණ API වෙත ප්‍රවේශ වීමට යෙදුමට ඉඩ දීමට සබල කරන්න.",
+                                label: "කළමනාකරණ යෙදුම"
+                            },
                             name: {
                                 label: "නම",
                                 placeholder: "මගේ යෙදුම",
@@ -1370,7 +1374,8 @@ export const console: ConsoleNS = {
                                     empty: "මෙය අත්‍යවශ්‍ය ක්ෂේත්‍රයකි."
                                 }
                             }
-                        }
+                        },
+                        managementAppBanner: "මෙම සංවිධානයේ කළමනාකරණ API වෙත ප්‍රවේශ වීමට යෙදුමට අවසර ඇත."
                     },
                     inboundCustom: {
                         fields: {


### PR DESCRIPTION
### Purpose
> Add option to allow accessing management APIs and display a banner for applications that has access to management APIs.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
