### PR TITLE
Theme update for add-on field wrapper

### DIFF
--- a/modules/theme/src/themes/default/collections/form.overrides
+++ b/modules/theme/src/themes/default/collections/form.overrides
@@ -143,3 +143,18 @@
         }
     }
 }
+
+/*-------------------------------
+  Addon field wrapper for input fields in My Account
+  & Console to avoid overlapping with browser added icons
+  ex: Password Managers
+--------------------------------*/
+.ui.form {
+    .addon-field-wrapper{
+        .ui.input {
+            > input {
+                border: none;
+            }
+        }
+    }
+}

--- a/modules/theme/src/themes/default/elements/input.overrides
+++ b/modules/theme/src/themes/default/elements/input.overrides
@@ -100,3 +100,28 @@ input[type=password]::-ms-reveal, input[type=password]::-ms-clear {
         }
     }
 }
+
+/*-------------------------------
+  Addon field wrapper for input fields in My Account
+  & Console to avoid overlapping with browser added icons
+  ex: Password Managers
+--------------------------------*/
+.addon-field-wrapper {
+    .ui.input {
+        margin: 0;
+        outline: 0;
+        border: @border;
+        border-radius: @borderRadius;
+        box-shadow: @boxShadow;
+        transition: @transition;
+
+        &:focus-within {
+            border-color: @focusBorderColor;
+        }
+
+        > input {
+            border: none;
+            max-width: calc(100% - 2.67142857em);
+        }
+    }  
+}


### PR DESCRIPTION
### Purpose
> - This theme update fixes the issue of input field add-ons such as password reveal icon getting obstructed by browser added icons such as password managers.
> - `addon-field-wrapper` CSS class was introduced to resolve this issue and it is applicable to `*.tsx` implementations. This CSS class should be added to the `Field` component where the issue occurs.
>     ex: `<Field className="addon-field-wrapper" ...`


### Approach
**Before**
<img width="365" alt="image" src="https://user-images.githubusercontent.com/90854808/157802282-d27a5acf-1d66-44df-8182-b59aae91b4ef.png">

**After**
<img width="365" alt="image" src="https://user-images.githubusercontent.com/90854808/157802231-23f4f335-f64d-4a2a-b1f8-8505cd6133b1.png">

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- #2859

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
