### PR TITLE
Update getting started page for second time users

### DIFF
--- a/apps/console/src/extensions/configs/common.tsx
+++ b/apps/console/src/extensions/configs/common.tsx
@@ -31,6 +31,7 @@ export const commonConfig: CommonConfig = {
         getHeaderExtensions: (): HeaderExtension[] => [],
         getHeaderSubPanelExtensions: (): HeaderSubPanelItemInterface[] => [],
         getUserDropdownLinkExtensions: (): HeaderLinkCategoryInterface[] => [],
+        headerQuickstartMenuItem: "",
         renderAppSwitcherAsDropdown: false
     },
     leftNavigation: {

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -48,6 +48,10 @@ export interface CommonConfig {
          * Should the app switcher be shown as nine dots dropdown.
          */
         renderAppSwitcherAsDropdown: boolean;
+        /**
+         * Header menu item config.
+         */
+        headerQuickstartMenuItem: string;
     };
     leftNavigation: {
         /**
@@ -76,9 +80,7 @@ export interface CommonConfig {
  * @readonly
  * @enum {string}
  */
-export enum AppViewExtensionTypes {
-    QUICKSTART = "QUICKSTART"
-}
+export enum AppViewExtensionTypes { }
 
 /**
  * Interface for the extended feature configs.

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -72,11 +72,13 @@ export interface CommonConfig {
 
 /**
  * Types of views that are extended.
- * @remarks Any views other thant `DEVELOP` and `MANAGE` can go here.
+ * @remarks Any views other than `DEVELOP` and `MANAGE` can go here.
  * @readonly
  * @enum {string}
  */
-export enum AppViewExtensionTypes { }
+export enum AppViewExtensionTypes {
+    QUICKSTART = "QUICKSTART"
+}
 
 /**
  * Interface for the extended feature configs.

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -18,13 +18,13 @@
 
 import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
 import { AnnouncementBannerInterface, ProfileInfoInterface } from "@wso2is/core/models";
-import { CommonUtils as ReusableCommonUtils, LocalStorageUtils } from "@wso2is/core/utils";
+import { LocalStorageUtils, CommonUtils as ReusableCommonUtils } from "@wso2is/core/utils";
 import {
     Announcement,
     AppSwitcher,
+    GenericIcon,
     Logo,
     ProductBrand,
-    GenericIcon,
     Header as ReusableHeader,
     HeaderPropsInterface as ReusableHeaderPropsInterface
 } from "@wso2is/react-components";
@@ -35,14 +35,14 @@ import React, { FunctionComponent, ReactElement, useEffect, useState } from "rea
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Container, Menu } from "semantic-ui-react";
-import { commonConfig } from "../../../extensions/configs";
+import { AppViewExtensionTypes, commonConfig } from "../../../extensions";
+import { ApplicationListInterface, getApplicationList } from "../../applications";
+import { AppSwitcherIcons, getAppHeaderIcons } from "../configs";
+import { AppConstants } from "../constants";
 import { history } from "../helpers";
 import { AppViewTypes, ConfigReducerStateInterface, StrictAppViewTypes } from "../models";
 import { AppState, setActiveView } from "../store";
 import { CommonUtils, EventPublisher } from "../utils";
-import { ApplicationListInterface, getApplicationList } from "../../applications";
-import { AppSwitcherIcons, getAppHeaderIcons } from "../configs";
-import { AppConstants } from "../constants";
 
 /**
  * Dashboard layout Prop types.
@@ -292,11 +292,11 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             itemExtensions[0].component = (
                 currentActiveView?: AppViewTypes, onClickCb?: (newActiveView: AppViewTypes) => void) => (
                 <Menu.Item
-                    active={ currentActiveView === "QUICKSTART" as AppViewTypes }
+                    active={ currentActiveView === AppViewExtensionTypes?.QUICKSTART }
                     className="secondary-panel-item quickstart-page-switch"
                     onClick={ () => {
                         history.push(`${ AppConstants.getMainViewBasePath() }/getting-started`);
-                        onClickCb && onClickCb("QUICKSTART" as AppViewTypes);
+                        onClickCb && onClickCb(AppViewExtensionTypes?.QUICKSTART);
                     } }
                     data-testid="app-header-quick-start-switch"
                 >

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -292,11 +292,12 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             itemExtensions[0].component = (
                 currentActiveView?: AppViewTypes, onClickCb?: (newActiveView: AppViewTypes) => void) => (
                 <Menu.Item
-                    active={ currentActiveView === AppViewExtensionTypes?.QUICKSTART }
+                    active={ currentActiveView === commonConfig.header.headerQuickstartMenuItem }
                     className="secondary-panel-item quickstart-page-switch"
                     onClick={ () => {
                         history.push(`${ AppConstants.getMainViewBasePath() }/getting-started`);
-                        onClickCb && onClickCb(AppViewExtensionTypes?.QUICKSTART);
+                        onClickCb &&
+                        onClickCb(commonConfig.header.headerQuickstartMenuItem as AppViewTypes);
                     } }
                     data-testid="app-header-quick-start-switch"
                 >

--- a/apps/console/src/features/core/configs/ui.ts
+++ b/apps/console/src/features/core/configs/ui.ts
@@ -132,6 +132,7 @@ import { ReactComponent as ReactLogo } from "../../../themes/default/assets/imag
 import { ReactComponent as VueLogo } from "../../../themes/default/assets/images/technologies/vue-logo.svg";
 import { ReactComponent as WindowsLogo } from "../../../themes/default/assets/images/technologies/windows-logo.svg";
 import { ServerConfigurationsConstants } from "../../server-configurations/constants";
+import { ReactComponent as HomeIcon } from "../../../themes/default/assets/images/icons/outline-icons/home-outline.svg";
 
 /**
  * Typed interface of {@link getTechnologyLogos}
@@ -490,5 +491,24 @@ export const getGeneralIcons = (): GetGeneralIconsInterface => {
     return {
         crossIcon: CrossIcon,
         myAccountSolidIcon: MyAccountSolidIcon
+    };
+};
+
+/**
+ * Typed interface of {@link getAppHeaderIcons}
+ */
+export type GetAppHeaderIconsInterface = {
+    homeIcon: FunctionComponent,
+};
+
+/**
+ * App Header Icons. Please add the types to
+ * {@link GetAppHeaderIconsInterface} if introducing
+ * new icons/images.
+ */
+export const getAppHeaderIcons = (): GetAppHeaderIconsInterface => {
+
+    return {
+        homeIcon: HomeIcon
     };
 };

--- a/modules/theme/src/themes/default/assets/images/icons/outline-icons/home-outline.svg
+++ b/modules/theme/src/themes/default/assets/images/icons/outline-icons/home-outline.svg
@@ -1,0 +1,24 @@
+<!--
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="14" height="14.002" viewBox="0 0 14 14.002">
+  <g id="home-outline" transform="translate(-12841 1863)">
+    <rect id="Rectangle_766" data-name="Rectangle 766" width="14" height="14" transform="translate(12841 -1863)" fill="#fff" opacity="0"/>
+    <path id="Path_2512" data-name="Path 2512" d="M7.958,14.165a.41.41,0,0,1-.41-.41v-.023a.431.431,0,0,1-.02-.128V9.634H5.216V13.6a.39.39,0,0,1-.023.135c0,.006,0,.012,0,.017a.41.41,0,0,1-.406.41H.5a.4.4,0,0,1-.4-.485A.433.433,0,0,1,.095,13.6V5.223a.408.408,0,0,1,.144-.311.408.408,0,0,1,.084-.088L6.106.263A.408.408,0,0,1,6.319.169h0l.015,0h.086l.012,0h0l.014,0h0l.012,0h0l.015,0h0a.408.408,0,0,1,.143.076L12.42,4.823a.408.408,0,0,1,.085.09.409.409,0,0,1,.143.311V13.6a.412.412,0,0,1-.007.075.41.41,0,0,1-.4.486Zm-.02-5.351a.41.41,0,0,1,.409.41v4.121h3.48V5.4L6.371,1.1.914,5.4v7.945H4.394V9.224a.41.41,0,0,1,.412-.41H7.938Z" transform="translate(12841.605 -1863.164)"/>
+  </g>
+</svg>

--- a/modules/theme/src/themes/default/assets/images/icons/solid-icons/home-solid.svg
+++ b/modules/theme/src/themes/default/assets/images/icons/solid-icons/home-solid.svg
@@ -1,0 +1,24 @@
+<!--
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+-->
+
+<svg xmlns="http://www.w3.org/2000/svg" class="icon" width="14" height="14.002" viewBox="0 0 14 14.002">
+  <g id="home-filled" transform="translate(-12841 1863)">
+    <rect id="Rectangle_766" data-name="Rectangle 766" width="14" height="14" transform="translate(12841 -1863)" fill="#fff" opacity="0"/>
+    <path id="Path_2512" data-name="Path 2512" d="M7.958,14.165a.41.41,0,0,1-.41-.41v-.023a.431.431,0,0,1-.02-.128V9.634H5.216V13.6a.39.39,0,0,1-.023.135c0,.006,0,.012,0,.017a.41.41,0,0,1-.406.41H.5a.4.4,0,0,1-.4-.485A.433.433,0,0,1,.095,13.6V5.223a.408.408,0,0,1,.144-.311.408.408,0,0,1,.084-.088L6.106.263A.408.408,0,0,1,6.319.169h0l.015,0h.086l.012,0h0l.014,0h0l.012,0h0l.015,0h0a.408.408,0,0,1,.143.076L12.42,4.823a.408.408,0,0,1,.085.09.409.409,0,0,1,.143.311V13.6a.412.412,0,0,1-.007.075.41.41,0,0,1-.4.486Z" transform="translate(12841.605 -1863.164)"/>
+  </g>
+</svg>

--- a/modules/theme/src/themes/default/collections/menu.overrides
+++ b/modules/theme/src/themes/default/collections/menu.overrides
@@ -110,14 +110,14 @@
                     &:last-child {
                         margin-bottom: 0 !important;
                     }
-                    
+
                     .header-dropdown-item-inner {
                         padding: 0;
-                        
+
                         &.flex {
                             display: flex !important;
                         }
-                        
+
                         .header {
                             font-weight: 400;
                         }


### PR DESCRIPTION
### Purpose
> This PR introduces support to switch the quick start icon to the home icon depending on whether there're any applications registered in the system.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
