### PR TITLE
Remove `brotli-webpack-plugin` and use  default plugin for Brotli compression

### DIFF
--- a/apps/console/webpack.config.js
+++ b/apps/console/webpack.config.js
@@ -18,8 +18,8 @@
 
 const fs = require("fs");
 const path = require("path");
+const zlib = require("zlib");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
-const BrotliPlugin = require("brotli-webpack-plugin");
 const CompressionPlugin = require("compression-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ESLintPlugin = require("eslint-webpack-plugin");
@@ -592,13 +592,19 @@ module.exports = (env) => {
                 algorithm: "gzip",
                 filename: "[path][base].gz",
                 minRatio: 0.8,
-                test: /\.(js|css|html|svg)$/,
+                test: /\.js$|\.css$|\.html$|\.png$|\.svg$|\.jpeg$|\.jpg$/,
                 threshold: 10240
             }),
-            isProduction && new BrotliPlugin({
-                asset: "[path].br[query]",
+            isProduction && new CompressionPlugin({
+                algorithm: "brotliCompress",
+                compressionOptions: {
+                    params: {
+                        [ zlib.constants.BROTLI_PARAM_QUALITY ]: 11
+                    }
+                },
+                filename: "[path][base].br",
                 minRatio: 0.8,
-                test: /\.(js|css|html|svg)$/,
+                test: /\.(js|css|html|png|svg|jpeg|jpg)$/,
                 threshold: 10240
             }),
             !isESLintPluginDisabled && new ESLintPlugin({

--- a/apps/myaccount/webpack.config.js
+++ b/apps/myaccount/webpack.config.js
@@ -18,8 +18,8 @@
 
 const fs = require("fs");
 const path = require("path");
+const zlib = require("zlib");
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
-const BrotliPlugin = require("brotli-webpack-plugin");
 const CompressionPlugin = require("compression-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ESLintPlugin = require("eslint-webpack-plugin");
@@ -551,13 +551,19 @@ module.exports = (env) => {
                 algorithm: "gzip",
                 filename: "[path][base].gz",
                 minRatio: 0.8,
-                test: /\.(js|css|html|svg)$/,
+                test: /\.js$|\.css$|\.html$|\.png$|\.svg$|\.jpeg$|\.jpg$/,
                 threshold: 10240
             }),
-            isProduction && new BrotliPlugin({
-                asset: "[path].br[query]",
+            isProduction && new CompressionPlugin({
+                algorithm: "brotliCompress",
+                compressionOptions: {
+                    params: {
+                        [ zlib.constants.BROTLI_PARAM_QUALITY ]: 11
+                    }
+                },
+                filename: "[path][base].br",
                 minRatio: 0.8,
-                test: /\.(js|css|html|svg)$/,
+                test: /\.(js|css|html|png|svg|jpeg|jpg)$/,
                 threshold: 10240
             }),
             !isESLintPluginDisabled && new ESLintPlugin({

--- a/package-lock.json
+++ b/package-lock.json
@@ -5920,13 +5920,6 @@
                 }
             }
         },
-        "base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true,
-            "optional": true
-        },
         "base64url": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
@@ -5972,42 +5965,6 @@
             "optional": true,
             "requires": {
                 "file-uri-to-path": "1.0.0"
-            }
-        },
-        "bl": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-            "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "buffer": "^5.5.0",
-                "inherits": "^2.0.4",
-                "readable-stream": "^3.4.0"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    }
-                }
             }
         },
         "bluebird": {
@@ -6099,28 +6056,6 @@
                 "fill-range": "^7.0.1"
             }
         },
-        "brotli": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
-            "integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "base64-js": "^1.1.2"
-            }
-        },
-        "brotli-webpack-plugin": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/brotli-webpack-plugin/-/brotli-webpack-plugin-1.1.0.tgz",
-            "integrity": "sha512-byxKhV7L/OsN9urBgcD8Gkgq0OW61KYdSBwN249vT77VRl+9iz6TlWDXhg45rwYynZYetr+WRVuUvQ5WzwcYDQ==",
-            "dev": true,
-            "requires": {
-                "async": "~2.6.0",
-                "brotli": "^1.3.1",
-                "iltorb": "^2.0.1",
-                "webpack-sources": "^1.0.2"
-            }
-        },
         "browser-process-hrtime": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -6161,17 +6096,6 @@
             "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
             "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
             "dev": true
-        },
-        "buffer": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-            "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.1.13"
-            }
         },
         "buffer-from": {
             "version": "1.1.2",
@@ -7848,16 +7772,6 @@
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
-        "decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "mimic-response": "^2.0.0"
-            }
-        },
         "dedent": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -7876,13 +7790,6 @@
                 "object-keys": "^1.1.1",
                 "regexp.prototype.flags": "^1.2.0"
             }
-        },
-        "deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "dev": true,
-            "optional": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -8073,13 +7980,6 @@
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
             "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
             "dev": true
-        },
-        "detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "dev": true,
-            "optional": true
         },
         "detect-newline": {
             "version": "3.1.0",
@@ -9304,13 +9204,6 @@
                 }
             }
         },
-        "expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "dev": true,
-            "optional": true
-        },
         "expect": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/expect/-/expect-26.6.2.tgz",
@@ -10148,13 +10041,6 @@
             "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
             "dev": true
         },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "dev": true,
-            "optional": true
-        },
         "fs-extra": {
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -10951,13 +10837,6 @@
             "requires": {
                 "ini": "^1.3.2"
             }
-        },
-        "github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-            "dev": true,
-            "optional": true
         },
         "glob": {
             "version": "7.2.0",
@@ -11785,13 +11664,6 @@
                 "harmony-reflect": "^1.4.6"
             }
         },
-        "ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "dev": true,
-            "optional": true
-        },
         "iferr": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
@@ -11811,20 +11683,6 @@
             "dev": true,
             "requires": {
                 "minimatch": "^3.0.4"
-            }
-        },
-        "iltorb": {
-            "version": "2.4.5",
-            "resolved": "https://registry.npmjs.org/iltorb/-/iltorb-2.4.5.tgz",
-            "integrity": "sha512-EMCMl3LnnNSZJS5QrxyZmMTaAC4+TJkM5woD+xbpm9RB+mFYCr7C05GFE3TEGCsVQSVHmjX+3sf5AiwsylNInQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "detect-libc": "^1.0.3",
-                "nan": "^2.14.0",
-                "npmlog": "^4.1.2",
-                "prebuild-install": "^5.3.3",
-                "which-pm-runs": "^1.0.0"
             }
         },
         "import-cwd": {
@@ -14924,13 +14782,6 @@
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
             "dev": true
         },
-        "mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-            "dev": true,
-            "optional": true
-        },
         "min-document": {
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
@@ -15102,13 +14953,6 @@
                 "minimist": "^1.2.5"
             }
         },
-        "mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "dev": true,
-            "optional": true
-        },
         "mkdirp-promise": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
@@ -15259,13 +15103,6 @@
                 }
             }
         },
-        "napi-build-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "dev": true,
-            "optional": true
-        },
         "native-url": {
             "version": "0.2.6",
             "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
@@ -15313,25 +15150,6 @@
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
                     "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
                     "dev": true
-                }
-            }
-        },
-        "node-abi": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-            "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "semver": "^5.4.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true,
-                    "optional": true
                 }
             }
         },
@@ -15502,13 +15320,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
             "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
-        },
-        "noop-logger": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-            "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-            "dev": true,
-            "optional": true
         },
         "nopt": {
             "version": "5.0.0",
@@ -16611,30 +16422,6 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
-        "prebuild-install": {
-            "version": "5.3.6",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-            "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "detect-libc": "^1.0.3",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.7.0",
-                "noop-logger": "^0.1.1",
-                "npmlog": "^4.0.1",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^3.0.3",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0",
-                "which-pm-runs": "^1.0.0"
-            }
-        },
         "prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -16991,28 +16778,6 @@
                         "ajv": "^6.12.5",
                         "ajv-keywords": "^3.5.2"
                     }
-                }
-            }
-        },
-        "rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "dependencies": {
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-                    "dev": true,
-                    "optional": true
                 }
             }
         },
@@ -18411,25 +18176,6 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
             "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
         },
-        "simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "dev": true,
-            "optional": true
-        },
-        "simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "decompress-response": "^4.2.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
-        },
         "simple-git": {
             "version": "1.132.0",
             "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.132.0.tgz",
@@ -19343,57 +19089,6 @@
                     "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
                     "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
                     "dev": true
-                }
-            }
-        },
-        "tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    }
                 }
             }
         },
@@ -21451,13 +21146,6 @@
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
             "dev": true
-        },
-        "which-pm-runs": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-            "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-            "dev": true,
-            "optional": true
         },
         "wide-align": {
             "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
         "autoprefixer": "^9.8.6",
         "babel-loader": "^8.1.0",
         "babel-plugin-rename-jsx-attribute": "^0.2.4",
-        "brotli-webpack-plugin": "1.1.0",
         "child_process": "^1.0.2",
         "compression-webpack-plugin": "^7.1.2",
         "copy-webpack-plugin": "^7.0.0",


### PR DESCRIPTION
### Purpose

`brotli-webpack-plugin` is not maintained now.  (https://github.com/mynameiswhm/brotli-webpack-plugin/issues/42)

The default `CompressionWebpackPlugin` has support for `Brotli` now. (https://webpack.js.org/plugins/compression-webpack-plugin/#using-brotli)

### Related Issues
- https://github.com/mynameiswhm/brotli-webpack-plugin/issues/42

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- https://github.com/wso2/identity-apps/pull/2821

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
