### PR TITLE
Fix input add-ons overlapping issue in sign in page

### DIFF
--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -307,7 +307,7 @@
         <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=username%>">
     <% } %>
         <div class="field">
-            <div class="ui fluid left icon input">
+            <div class="ui fluid left icon input addon-wrapper">
                 <input
                     type="password"
                     id="password"


### PR DESCRIPTION
### Purpose
> Addresses the issue of input field add-ons such as password reveal icon get overlapped with the browser added icons/buttons inside the input field in Sign In page.

### Approach
**Before**
<img width="505" alt="image" src="https://user-images.githubusercontent.com/90854808/159233456-e563361b-bc8e-41a3-bf41-b36f66a7d9e1.png">

**After**
<img width="505" alt="image" src="https://user-images.githubusercontent.com/90854808/159233516-3ee0c651-ac3f-49f0-bbc1-f489d0e3ba53.png">

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- #2874 
- #2867 
- #2859 

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
