### PR TITLE
Fix password change issue via myaccount

### DIFF
--- a/apps/myaccount/src/api/change-password.ts
+++ b/apps/myaccount/src/api/change-password.ts
@@ -48,7 +48,7 @@ export const updatePassword = (currentPassword: string, newPassword: string): Pr
     const requestConfig: AxiosRequestConfig = {
         auth: {
             password: currentPassword,
-            username: store.getState().authenticationInformation.username
+            username: [store.getState().authenticationInformation?.profileInfo.userName, '@', store.getState().authenticationInformation.tenantDomain].join('')
         },
         data: {
             Operations: [


### PR DESCRIPTION
### Purpose
Resolved https://github.com/wso2/product-is/issues/12979

### Approach
The sub of the id_token is the user_id of user by default.
but it was passed as the username in /scim2/Me password PATCH request's basic authorizatuon. 
The issue is resolved by passing the join of username from the profileInfo +  tenantDomain as the username.
