### PR TITLE
Fix invalid docs url construction

### DIFF
--- a/apps/console/src/extensions/configs/documentation.ts
+++ b/apps/console/src/extensions/configs/documentation.ts
@@ -18,21 +18,23 @@
 
 import { DocumentationLinksExtensionInterface } from "./models";
 
-export const DocumentationLinksExtension: DocumentationLinksExtensionInterface = {
-    develop: {
-        applications: {
-            editApplication: {
-                signInMethod: {
-                    fido: "#"
+export const getDocumentationLinksExtension = () : DocumentationLinksExtensionInterface => {
+    return {
+        develop: {
+            applications: {
+                editApplication: {
+                    signInMethod: {
+                        fido: "#"
+                    }
                 }
-            }
-        },
-        connections: {
-            edit: {
-                advancedSettings: {
-                    jit: "#"
+            },
+            connections: {
+                edit: {
+                    advancedSettings: {
+                        jit: "#"
+                    }
                 }
             }
         }
-    }
+    };
 };

--- a/apps/console/src/features/core/configs/documentation.ts
+++ b/apps/console/src/features/core/configs/documentation.ts
@@ -17,7 +17,7 @@
  */
 
 // DO NOT SHORTEN THE IMPORT PATH as it could lead to circular dependencies.
-import { DocumentationLinksExtension } from "../../../extensions/configs/documentation";
+import { getDocumentationLinksExtension } from "../../../extensions/configs/documentation";
 import { DocumentationLinksInterface } from "../models";
 
 /**
@@ -26,5 +26,5 @@ import { DocumentationLinksInterface } from "../models";
  * @return {DocumentationLinksInterface}
  */
 export const DocumentationLinks: DocumentationLinksInterface = {
-    ...DocumentationLinksExtension
+    ...getDocumentationLinksExtension()
 };


### PR DESCRIPTION
### Purpose
This fixes the issue of documentation URLs are invalid due to hoisting issue. 

### Related Issues

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
