### PR TITLE
Add capability to exclude attributes from getUsersList api call

### DIFF
--- a/apps/console/src/features/users/api/users.ts
+++ b/apps/console/src/features/users/api/users.ts
@@ -35,7 +35,14 @@ const httpClient = AsgardeoSPAClient.getInstance().httpRequest.bind(AsgardeoSPAC
  *
  * @returns {Promise<UserListInterface>} a promise containing the user list.
  */
-export const getUsersList = (count: number, startIndex: number, filter: string, attributes: string, domain: string):
+export const getUsersList = (
+    count: number, 
+    startIndex: number, 
+    filter: string, 
+    attributes: string, 
+    domain: string,
+    excludedAttributes?: string
+):
     Promise<UserListInterface> => {
     const requestConfig = {
         headers: {
@@ -47,6 +54,7 @@ export const getUsersList = (count: number, startIndex: number, filter: string, 
             attributes,
             count,
             domain,
+            excludedAttributes,
             filter,
             startIndex
         },


### PR DESCRIPTION
### Purpose
`getUsersList()` call provides unused attributes such as `roles` and `groups` of the users in the user list by default. This takes a significant performance hit.  Therefore, this PR will allow the `getUsersList()` call to exclude these properties if needed. They will still be retrieved by default, but now has the option to exclude them if the need arises.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
