### PR TITLE
Adding Capability to View the Email OTP Code

### DIFF
--- a/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -116,12 +116,18 @@
                         <label for="password"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "enter.code")%>
                             (<%=Encode.forHtmlContent(request.getParameter("screenValue"))%>)
                         </label>
-                        <input type="password" id='OTPCode' name="OTPCode" c size='30'/>
+                        <div class="ui fluid icon input addon-wrapper">
+                            <input type="password" id='OTPCode' name="OTPCode" c size='30'/>
+                            <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
+                        </div>
                             <% } else { %>
                         <div class="field">
                             <label for="password"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "enter.code")%>
                                 :</label>
-                            <input type="password" id='OTPCode' name="OTPCode" size='30'/>
+                            <div class="ui fluid icon input addon-wrapper">
+                                <input type="password" id='OTPCode' name="OTPCode" size='30'/>
+                                <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
+                            </div>
                             <% } %>
                         </div>
                         <input type="hidden" name="sessionDataKey"
@@ -168,31 +174,40 @@
 <% } %>
 
 <script type="text/javascript">
-            $(document).ready(function () {
-                $('#authenticate').click(function () {
-                    var code = document.getElementById("OTPCode").value;
-                    if (code == "") {
-                        document.getElementById('alertDiv').innerHTML
-                            = '<div id="error-msg" class="ui negative message"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.enter.code")%></div>'
-                              +'<div class="ui divider hidden"></div>';
-                    } else {
-                        if ($('#codeForm').data("submitted") === true) {
-                            console.warn("Prevented a possible double submit event");
-                        } else {
-                            $('#codeForm').data("submitted", true);
-                            $('#codeForm').submit();
-                        }
-                    }
-                });
-            });
-            $(document).ready(function () {
-                $('#resend').click(function () {
-                    document.getElementById("resendCode").value = "true";
+    $(document).ready(function () {
+        $('#authenticate').click(function () {
+            var code = document.getElementById("OTPCode").value;
+            if (code == "") {
+                document.getElementById('alertDiv').innerHTML
+                    = '<div id="error-msg" class="ui negative message"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.enter.code")%></div>'
+                        +'<div class="ui divider hidden"></div>';
+            } else {
+                if ($('#codeForm').data("submitted") === true) {
+                    console.warn("Prevented a possible double submit event");
+                } else {
+                    $('#codeForm').data("submitted", true);
                     $('#codeForm').submit();
-                });
-            });
+                }
+            }
+        });
+    });
+    $(document).ready(function () {
+        $('#resend').click(function () {
+            document.getElementById("resendCode").value = "true";
+            $('#codeForm').submit();
+        });
+    });
 
+    // Show OTP code function.
+    function showOTPCode() {
+        var otpField = $('#OTPCode');
 
+        if (otpField.attr("type") === 'text') {
+            otpField.attr("type", "password");
+        } else {
+            otpField.attr("type", "text");
+        }
+    }
 
 </script>
 </body>

--- a/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -118,7 +118,7 @@
                         </label>
                         <div class="ui fluid icon input addon-wrapper">
                             <input type="password" id='OTPCode' name="OTPCode" c size='30'/>
-                            <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
+                            <i id="password-eye" class="eye icon right-align password-toggle" onclick="showOTPCode()"></i>
                         </div>
                             <% } else { %>
                         <div class="field">
@@ -126,7 +126,7 @@
                                 :</label>
                             <div class="ui fluid icon input addon-wrapper">
                                 <input type="password" id='OTPCode' name="OTPCode" size='30'/>
-                                <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
+                                <i id="password-eye" class="eye icon right-align password-toggle" onclick="showOTPCode()"></i>
                             </div>
                             <% } %>
                         </div>
@@ -204,10 +204,10 @@
 
         if (otpField.attr("type") === 'text') {
             otpField.attr("type", "password");
-            document.getElementById("password-eye").classList.add("slash");
+            document.getElementById("password-eye").classList.remove("slash");
         } else {
             otpField.attr("type", "text");
-            document.getElementById("password-eye").classList.remove("slash");
+            document.getElementById("password-eye").classList.add("slash");
         }
     }
 

--- a/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -204,8 +204,10 @@
 
         if (otpField.attr("type") === 'text') {
             otpField.attr("type", "password");
+            document.getElementById("password-eye").classList.add("slash");
         } else {
             otpField.attr("type", "text");
+            document.getElementById("password-eye").classList.remove("slash");
         }
     }
 


### PR DESCRIPTION
### Purpose
When login for a business app with Email OTP as 2nd step there's no preview option to preview the entered OTP. As a fix an icon will be added to preview the otp.

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
