### PR TITLE
Add i18n configs for BOD placeholder

### DIFF
--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -3506,6 +3506,12 @@ export interface ConsoleNS {
                         lockUserZone: DangerZone;
                         passwordResetZone: DangerZone;
                     };
+                    dateOfBirth: {
+                        placeholder: {
+                            part1: string;
+                            part2: string;
+                        }
+                    };
                 };
                 forms: {
                     addUserForm: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -7836,6 +7836,12 @@ export const console: ConsoleNS = {
                             subheader: "Once you change the password, the user will no longer be able to log in to " +
                                 "any application using the current password."
                         }
+                    },
+                    dateOfBirth: {
+                        placeholder: {
+                            part1:"Enter the",
+                            part2: "in the format YYYY-MM-DD"
+                        }
                     }
                 },
                 forms: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -6424,6 +6424,12 @@ export const console: ConsoleNS = {
                             subheader: "Une fois le mot de passe modifié, l'utilisateur ne pourra plus se connecter " +
                                 "à aucune application en utilisant le mot de passe actuel."
                         }
+                    },
+                    dateOfBirth: {
+                        placeholder: {
+                            part1:"Entrer le",
+                            part2: "au format AAAA-MM-JJ"
+                        }
                     }
                 },
                 forms: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -6282,6 +6282,12 @@ export const console: ConsoleNS = {
                             subheader: "ඔබ මුරපදය වෙනස් කළ පසු, පරිශීලකයාට දැනට පවතින මුරපදය භාවිතා කර " +
                                 "කිසිඳු යෙදුමකට ප්‍රවේශ විය නොහැක."
                         }
+                    },
+                    dateOfBirth: {
+                        placeholder: {
+                            part1:"ඇතුල් කරන්න",
+                            part2: "YYYY-MM-DD ආකෘතියෙන්"
+                        }
                     }
                 },
                 forms: {


### PR DESCRIPTION
### Purpose
> Add i18n translations for placeholder in birth date input field.

### Related Issues

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
