### PR TITLE
Fix update group name issue

### DIFF
--- a/apps/console/src/features/groups/components/edit-group/edit-group-basic.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-basic.tsx
@@ -319,7 +319,7 @@ export const BasicGroupDetails: FunctionComponent<BasicGroupProps> = (props: Bas
                                                     ? `${ testId }-group-update-button`
                                                     : `${ testId }-role-update-button`
                                             }
-                                            disabled={ !isRegExLoading || isSubmitting }
+                                            disabled={ isRegExLoading || isSubmitting }
                                         >
                                             { t("console:manage.features.roles.edit.basics.buttons.update") }
                                         </Button>


### PR DESCRIPTION
### Purpose
> Fixed the issue that cannot update the group name via console as update button is disabled.

### Related Issues
- https://github.com/wso2/product-is/issues/12981

