### PR TITLE
Update request to replace JWKS url with certificate

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/add-idp-certificate-modal.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/add-idp-certificate-modal.tsx
@@ -126,34 +126,7 @@ export const AddIdpCertificateModal: FC<AddIdPCertificateModalV2Props> = (props)
                 "operation": "ADD",
                 "path": "/certificate/certificates/" + certificateIndex,
                 "value": pemBase64String
-            },
-            /**
-             * What is the goal of below array spread operation?
-             *
-             * If we have a JWKS URL in place; then, send a REPLACE operation
-             * along with the ADD operation to persist above certificate
-             * correctly. But why though right? good question!.
-             *
-             * TLDR; Use one option at a time. If JWKS already configured, then
-             * remove it first.
-             *
-             * Answer: consider this; a user configured an OIDC IdP with a JWKS url from the
-             * create wizard itself. Now for some reason user wants to use a certificate
-             * instead of the JWKS url. In this case API allows only one option to be
-             * configured. So that, we can't send an individual ADD operation when we have a
-             * JWKS configured. We have to explicitly say, "Remove this jwksUri and add this"
-             * otherwise the API won't do anything because the logic in the backend assumes
-             * you want to keep the jwksUrl. It is the expected behaviour of this function.
-             * For more info you can have a look at [1,2]
-             *
-             * [1] {@link https://github.com/wso2/identity-api-server/pull/264#discussion_r568688778}
-             * [2] {@link https://github.com/wso2/product-is/issues/12361}
-             */
-            ...[ !isEmpty(currentlyEditingIdP?.certificate?.jwksUri) ? {
-                "operation": "REPLACE",
-                "path": "/certificate/jwksUri",
-                "value": null
-            } : null ].filter(Boolean)
+            }
         ];
 
         const doOnSuccess = () => {


### PR DESCRIPTION
### Purpose
> Removes the REPLACE operation from the patch request to replace JWKS url current value with null when adding a certificate to the identity provider. 
> The ADD operation in the patch request which adds the certificate removes the JWKS url as well and therefore the REPLACE operation gives an error mentioning that there is no JWKS url to be replaced. 

### Related Issues
https://github.com/wso2/product-is/issues/13314

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)


### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
