### PR TITLE
Restrict adding special characters as input for mapped user attributes

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
@@ -113,7 +113,7 @@ export const AttributeListItem: FunctionComponent<AttributeListItemPropInterface
     };
 
     const handleClaimMapping = (e) => {
-        const mappingValue = e.target.value;
+        const mappingValue = e.target.value.replace(/[^\w+$:/.]/g, '');
 
         setMappedAttribute(mappingValue);
         updateMapping(claimURI, mappingValue);


### PR DESCRIPTION
### Purpose
This PR adds the changes needed to restrict users to add special characters as input for the mapped user attributes field.
Allowed characters are: `a-z`, `A-Z`, `0-9`, `:`, `/`, `.`, `+` and `$`

It was suggested to not allow the users to type the disallowed characters to this field. 

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/9910
