### PR TITLE
Secrets CRUD and ESLint fixes

### DIFF
--- a/apps/console/src/features/secrets/components/secrets-list.tsx
+++ b/apps/console/src/features/secrets/components/secrets-list.tsx
@@ -75,7 +75,7 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
     const [ showDeleteConfirmationModal, setShowDeleteConfirmationModal ] = useState<boolean>(false);
     const [ deletingSecret, setDeletingSecret ] = useState<SecretModel>(undefined);
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
-    const allowedScopes: string = useSelector((state: AppState) => state?.auth?.scope);
+    const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
 
     const onSecretEditClick = (event: React.SyntheticEvent, item: SecretModel) => {
         event?.preventDefault();
@@ -89,6 +89,7 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
                 .get(FEATURE_EDIT_PATH)
                 .replace(":type", item?.type)
                 .replace(":name", item?.secretName);
+
             history.push({ pathname });
         }
     };
@@ -125,6 +126,7 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
                         level: AlertLevels.ERROR,
                         message: error.response.data.message
                     }));
+
                     return;
                 }
                 dispatch(addAlert({
@@ -134,6 +136,7 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
                 }));
             } finally {
                 const refreshSecretList = true;
+
                 whenSecretDeleted(deletingSecret, refreshSecretList);
                 setShowDeleteConfirmationModal(false);
                 setDeletingSecret(undefined);


### PR DESCRIPTION
### Purpose
> Fixing the issue where edit and delete options were not showing for secrets

### Related Issues
- https://github.com/wso2/product-is/issues/13319

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
