### PR TITLE
Add search feature to secrets page

### DIFF
--- a/apps/console/src/features/secrets/components/secrets-list.tsx
+++ b/apps/console/src/features/secrets/components/secrets-list.tsx
@@ -19,31 +19,64 @@
 import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
+import { I18n } from "@wso2is/i18n";
 import {
     AppAvatar,
     ConfirmationModal,
     DataTable,
+    EmptyPlaceholder,
     GenericIcon,
     GridLayout,
+    LinkButton,
+    ListLayout,
     TableActionsInterface,
     TableColumnInterface,
     Text
 } from "@wso2is/react-components";
-import React, { FC, Fragment, ReactElement, SyntheticEvent, useState } from "react";
+import find from "lodash-es/find";
+import React, { FC, ReactElement, ReactNode, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Header, Message, SemanticICONS } from "semantic-ui-react";
+import { DropdownItemProps, DropdownProps, Header, Message, SemanticICONS } from "semantic-ui-react";
 import { EmptySecretListPlaceholder } from "./empty-secret-list-placeholder";
-import { AppConstants, AppState, FeatureConfigInterface, getSecretManagementIllustrations, history } from "../../core";
+import { AdvancedSearchWithBasicFilters, AppConstants, AppState, FeatureConfigInterface, 
+    getEmptyPlaceholderIllustrations, getSecretManagementIllustrations, history } from "../../core";
 import { deleteSecret } from "../api/secret";
 import { ADAPTIVE_SCRIPT_SECRETS, FEATURE_EDIT_PATH } from "../constants/secrets.common";
 import { SecretModel } from "../models/secret";
 import { formatDateString, humanizeDateString } from "../utils/secrets.date.utils";
 
+const SECRETS_LIST_SORTING_OPTIONS: DropdownItemProps[] = [
+    {
+        key: 1,
+        text: I18n.instance.t("common:name"),
+        value: "name"
+    },
+    {
+        key: 2,
+        text: I18n.instance.t("common:type"),
+        value: "type"
+    },
+    {
+        key: 3,
+        text: I18n.instance.t("common:createdOn"),
+        value: "createdDate"
+    },
+    {
+        key: 4,
+        text: I18n.instance.t("common:lastUpdatedOn"),
+        value: "lastUpdated"
+    }
+];
+
 /**
  * Props interface of {@link SecretsList}
  */
 export type SecretsListProps = {
+    onEmptyListPlaceholderActionClick?: () => void;
+    isRenderedOnPortal?: boolean;
+    onSearchQueryClear?: () => void;
+    advancedSearch?: ReactNode;
     whenSecretDeleted: (deletedSecret: SecretModel, shouldRefresh: boolean) => void;
     isSecretListLoading: boolean;
     selectedSecretType: string;
@@ -60,6 +93,8 @@ export type SecretsListProps = {
 const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElement => {
 
     const {
+        onSearchQueryClear,
+        advancedSearch,
         whenSecretDeleted,
         isSecretListLoading,
         secretList,
@@ -76,6 +111,11 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
     const [ deletingSecret, setDeletingSecret ] = useState<SecretModel>(undefined);
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
+    const [ filteredSecrets, setFilteredSecrets ] = useState([]);
+    const [ searchQuery, setSearchQuery ] = useState<string>("");
+    const [ listSortingStrategy, setListSortingStrategy ] = useState<DropdownItemProps>(
+        SECRETS_LIST_SORTING_OPTIONS[ 0 ]
+    );
 
     const onSecretEditClick = (event: React.SyntheticEvent, item: SecretModel) => {
         event?.preventDefault();
@@ -93,6 +133,10 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
             history.push({ pathname });
         }
     };
+
+    useEffect(() => {
+        setFilteredSecrets([ ...secretList ].reverse());
+    }, [ secretList ]);
 
     /**
      * This will be only called when user gives their consent.
@@ -266,6 +310,92 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
         ];
     };
 
+    /**
+     * Resolve the relevant placeholder.
+     *
+     * @return {React.ReactElement}
+     */
+    const showPlaceholders = (): ReactElement => {
+        // When the search returns empty.
+        if (searchQuery && filteredSecrets?.length === 0) {
+            return (
+                <EmptyPlaceholder
+                    action={ (
+                        <LinkButton onClick={ onSearchQueryClear }>
+                            { t("console:develop.placeholders.emptySearchResult.action") }
+                        </LinkButton>
+                    ) }
+                    image={ getEmptyPlaceholderIllustrations().emptySearch }
+                    imageSize="tiny"
+                    title={ t("console:develop.placeholders.emptySearchResult.title") }
+                    subtitle={ [
+                        t("console:develop.placeholders.emptySearchResult.subtitles.0", { query: searchQuery }),
+                        t("console:develop.placeholders.emptySearchResult.subtitles.1")
+                    ] }
+                    data-testid={ `${ testId }-empty-search-placeholder` }
+                />
+            );
+        }
+
+        return null;
+    };
+
+    /**
+     * Handles the `onFilter` callback action from the
+     * secrets search component.
+     *
+     * @param {string} query - Search query.
+     */
+    const handleSecretsFilter = (query: string) => {
+
+        setSearchQuery(query);
+
+        if(!query){
+            setFilteredSecrets(secretList.reverse());
+        }
+        
+        const records =  query?.split(" ");
+
+        if(!records){
+            return;
+        }
+        
+        // const attribute  = records[0];
+        const operator = records[1];
+        const keyWords = records.splice(2).join("");
+        const filteredArray = [];
+
+        secretList.forEach((val) => {
+            if (operator === "co" && val?.secretName.includes(keyWords)) {
+                filteredArray.push(val);
+            }
+            if (operator === "sw" && val?.secretName.startsWith(keyWords)) {
+                filteredArray.push(val);
+            }
+            if (operator === "ew" && val?.secretName.endsWith(keyWords)) {
+                filteredArray.push(val);
+            }
+            if (operator === "eq" && val?.secretName == keyWords) {
+                filteredArray.push(val);
+            }
+        });
+        setFilteredSecrets(filteredArray.reverse());
+        
+    };
+
+    /**
+     * Sets the list sorting strategy.
+     *
+     * @param {React.SyntheticEvent<HTMLElement>} event - The event.
+     * @param {DropdownProps} data - Dropdown data.
+     */
+    const handleListSortingStrategyOnChange = (event: SyntheticEvent<HTMLElement>,
+        data: DropdownProps): void => {
+        setListSortingStrategy(find(SECRETS_LIST_SORTING_OPTIONS, (option) => {
+            return data.value === option.value;
+        }));
+    };
+
     const SecretDeleteConfirmationModal: ReactElement = (
         <ConfirmationModal
             onClose={ (): void => {
@@ -318,16 +448,57 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
             }
             { secretList?.length > 0
                 ? (
-                    <Fragment>
+                    <ListLayout
+                        advancedSearch={ (
+                            <AdvancedSearchWithBasicFilters
+                                onFilter={ handleSecretsFilter }
+                                filterAttributeOptions={ [
+                                    {
+                                        key: 0,
+                                        text: t("common:name"),
+                                        value: "name"
+                                    }
+                                ] }
+                                filterAttributePlaceholder={
+                                    t("console:develop.features.secrets.advancedSearch.form" +
+                                        ".inputs.filterAttribute.placeholder")
+                                }
+                                filterConditionsPlaceholder={
+                                    t("console:develop.features.secrets.advancedSearch.form" +
+                                        ".inputs.filterCondition.placeholder")
+                                }
+                                filterValuePlaceholder={
+                                    t("console:develop.features.secrets.advancedSearch.form.inputs.filterValue" +
+                                    ".placeholder")
+                                }
+                                placeholder={ t("console:develop.features.secrets.advancedSearch.placeholder") }
+                                defaultSearchAttribute="name"
+                                defaultSearchOperator="co"
+                                data-testid={ `${ testId }-list-advanced-search` }
+                            />
+                        ) }
+                        currentListSize={ secretList.length }
+                        onPageChange={ () => 
+                            void 0
+                        }
+                        onSortStrategyChange={ handleListSortingStrategyOnChange }
+                        showPagination={ false }
+                        sortOptions={ SECRETS_LIST_SORTING_OPTIONS }
+                        sortStrategy={ listSortingStrategy }
+                        totalPages={ 1 }
+                        data-testid={ `${ testId }-list-layout` }
+                    >
                         <DataTable<SecretModel>
-                            data={ secretList }
+                            externalSearch={ advancedSearch }
+                            data={ filteredSecrets }
                             showHeader={ false }
                             onRowClick={ onSecretEditClick }
                             actions={ createDatatableActions() }
-                            columns={ createDatatableColumns() }>
+                            columns={ createDatatableColumns() }
+                            placeholders={ showPlaceholders() }>
                         </DataTable>
                         { showDeleteConfirmationModal && SecretDeleteConfirmationModal }
-                    </Fragment>
+                    </ListLayout>
                 )
                 : (
                     <EmptySecretListPlaceholder

--- a/apps/console/src/features/secrets/components/secrets-list.tsx
+++ b/apps/console/src/features/secrets/components/secrets-list.tsx
@@ -350,13 +350,13 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
 
         setSearchQuery(query);
 
-        if(!query){
+        if (!query) {
             setFilteredSecrets(secretList.reverse());
         }
         
         const records =  query?.split(" ");
 
-        if(!records){
+        if (!records) {
             return;
         }
         
@@ -389,8 +389,10 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
      * @param {React.SyntheticEvent<HTMLElement>} event - The event.
      * @param {DropdownProps} data - Dropdown data.
      */
-    const handleListSortingStrategyOnChange = (event: SyntheticEvent<HTMLElement>,
-        data: DropdownProps): void => {
+    const handleListSortingStrategyOnChange = (
+        event: SyntheticEvent<HTMLElement>,
+        data: DropdownProps
+    ): void => {
         setListSortingStrategy(find(SECRETS_LIST_SORTING_OPTIONS, (option) => {
             return data.value === option.value;
         }));
@@ -478,9 +480,7 @@ const SecretsList: FC<SecretsListProps> = (props: SecretsListProps): ReactElemen
                             />
                         ) }
                         currentListSize={ secretList.length }
-                        onPageChange={ () => 
-                            void 0
-                        }
+                        onPageChange={ () => void 0 }
                         onSortStrategyChange={ handleListSortingStrategyOnChange }
                         showPagination={ false }
                         sortOptions={ SECRETS_LIST_SORTING_OPTIONS }

--- a/apps/console/src/features/secrets/pages/secrets.tsx
+++ b/apps/console/src/features/secrets/pages/secrets.tsx
@@ -60,6 +60,7 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
     const [ isSecretListLoading, setIsSecretListLoading ] = useState<boolean>(true);
     const [ showAddSecretModal, setShowAddSecretModal ] = useState<boolean>(false);
     const [ selectedSecretType ] = useState<string>(ADAPTIVE_SCRIPT_SECRETS);
+    const [ isLoading, setLoading ] = useState<boolean>(true);
 
     useEffect(() => {
         loadSecretListForSecretType();
@@ -80,6 +81,7 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
                     level: AlertLevels.ERROR,
                     message: error.response.data?.message
                 }));
+                
                 return;
             }
             dispatch(addAlert({
@@ -89,6 +91,7 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
             }));
         }).finally(() => {
             setIsSecretListLoading(false);
+            setLoading(false);
         });
 
     };
@@ -129,11 +132,11 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
     };
 
     return (
+        
         <PageLayout
-            isLoading={ isSecretListLoading }
-            title={ t("console:develop.features.secrets.page.title") }
-            description={ t("console:develop.features.secrets.page.description") }
-            action={ secretList?.length > 0 && (
+            action={
+                (!isLoading && !(secretList?.length <= 0))
+            && (
                 <Show when={ AccessControlConstants.SECRET_WRITE }>
                     <PrimaryButton
                         onClick={ onAddNewSecretButtonClick }
@@ -142,7 +145,14 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
                         { t("console:develop.features.secrets.page.primaryActionButtonText") }
                     </PrimaryButton>
                 </Show>
-            ) }>
+            )
+            }
+            
+            isLoading={ isSecretListLoading }
+            title={ t("console:develop.features.secrets.page.title") }
+            description={ t("console:develop.features.secrets.page.description") }
+        >
+               
             <Show when={ AccessControlConstants.SECRET_READ }>
                 <SecretsList
                     whenSecretDeleted={ whenSecretDeleted }
@@ -150,6 +160,7 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
                     secretList={ secretList }
                     selectedSecretType={ selectedSecretType }
                     onAddNewSecretButtonClick={ onAddNewSecretButtonClick }
+                    onSearchQueryClear={ loadSecretListForSecretType }
                 />
             </Show>
             { showAddSecretModal && (

--- a/apps/console/src/features/secrets/pages/secrets.tsx
+++ b/apps/console/src/features/secrets/pages/secrets.tsx
@@ -81,7 +81,7 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
                     level: AlertLevels.ERROR,
                     message: error.response.data?.message
                 }));
-                
+
                 return;
             }
             dispatch(addAlert({
@@ -145,8 +145,7 @@ const SecretsPage: FC<SecretsPageProps> = (props: SecretsPageProps): ReactElemen
                         { t("console:develop.features.secrets.page.primaryActionButtonText") }
                     </PrimaryButton>
                 </Show>
-            )
-            }
+            ) }
             
             isLoading={ isSecretListLoading }
             title={ t("console:develop.features.secrets.page.title") }

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -2038,6 +2038,22 @@ export interface ConsoleNS {
                 emptyPlaceholder: Placeholder;
             };
             secrets?: {
+                advancedSearch: {
+                    form: {
+                        inputs: {
+                            filterAttribute: {
+                                placeholder: string;
+                            };
+                            filterCondition: {
+                                placeholder: string;
+                            };
+                            filterValue: {
+                                placeholder: string;
+                            };
+                        };
+                    };
+                    placeholder: string;
+                };
                 page?: {
                     title: string;
                     description: string;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -5094,6 +5094,22 @@ export const console: ConsoleNS = {
                 }
             },
             secrets: {
+                advancedSearch: {
+                    form: {
+                        inputs: {
+                            filterAttribute: {
+                                placeholder: "E.g. Name, Description etc."
+                            },
+                            filterCondition: {
+                                placeholder: "E.g. Starts with etc."
+                            },
+                            filterValue: {
+                                placeholder: "Enter value to search"
+                            }
+                        }
+                    },
+                    placeholder: "Search by secret name"
+                },
                 alerts: {
                     createdSecret: {
                         description: "Successfully created the secret.",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -3820,6 +3820,22 @@ export const console: ConsoleNS = {
                 }
             },
             secrets: {
+                advancedSearch: {
+                    form: {
+                        inputs: {
+                            filterAttribute: {
+                                placeholder: "Par exemple, nom, description, etc."
+                            },
+                            filterCondition: {
+                                placeholder: "Par exemple, commence par etc."
+                            },
+                            filterValue: {
+                                placeholder: "Saisir une valeur à rechercher"
+                            }
+                        }
+                    },
+                    placeholder: "Chercher par nom d'secret"
+                },
                 alerts: {
                     createdSecret: {
                         description: "Le secret a été créé avec succès.",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -3717,6 +3717,22 @@ export const console: ConsoleNS = {
                 }
             },
             secrets: {
+                advancedSearch: {
+                    form: {
+                        inputs: {
+                            filterAttribute: {
+                                placeholder: "උදා. නම, විස්තරය ආදිය."
+                            },
+                            filterCondition: {
+                                placeholder: "උදා. ආදිය සමඟ ආරම්භ වේ."
+                            },
+                            filterValue: {
+                                placeholder: "සෙවීමට අගයක් ඇතුළත් කරන්න"
+                            }
+                        }
+                    },
+                    placeholder: "රහස් නාමයෙන් සොයන්න"
+                },
                 alerts: {
                     createdSecret: {
                         description: "නිර්මාණය සාර්ථකයි.",


### PR DESCRIPTION
### Purpose
> Add advanced searching feature to the secrets page in the console.
![secret search](https://user-images.githubusercontent.com/67315176/162682867-0fc2ebda-d239-4881-a682-10bd0cc96628.png)

### Related Issues
- https://github.com/wso2/product-is/issues/13319

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
