### PR TITLE
Fix inconsistent link button in my account application search

### DIFF
--- a/apps/myaccount/src/components/applications/application-list.tsx
+++ b/apps/myaccount/src/components/applications/application-list.tsx
@@ -17,7 +17,7 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Text } from "@wso2is/react-components";
+import { Text, LinkButton } from "@wso2is/react-components";
 import React, { Fragment, FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Grid, Popup } from "semantic-ui-react";
@@ -71,12 +71,12 @@ export const ApplicationList: FunctionComponent<ApplicationListProps> = (
                 <EmptyPlaceholder
                     data-testid={ `${testId}-empty-search-result-placeholder` }
                     action={ (
-                        <Button
+                        <LinkButton
                             className="link-button"
                             onClick={ onSearchQueryClear }
                         >
                             { t("myAccount:placeholders.emptySearchResult.action") }
-                        </Button>
+                        </LinkButton>
                     ) }
                     image={ getEmptyPlaceholderIllustrations().search }
                     title={ t("myAccount:placeholders.emptySearchResult.title") }
@@ -93,12 +93,12 @@ export const ApplicationList: FunctionComponent<ApplicationListProps> = (
             <EmptyPlaceholder
                 data-testid={ `${testId}-empty-list-placeholder` }
                 action={ (
-                    <Button
+                    <LinkButton
                         className="link-button"
                         onClick={ onListRefresh }
                     >
                         { t("myAccount:components.applications.placeholders.emptyList.action") }
-                    </Button>
+                    </LinkButton>
                 ) }
                 image={ getEmptyPlaceholderIllustrations().emptyList }
                 imageSize="tiny"


### PR DESCRIPTION
### Purpose
This will fix the no application found search link button to be more consistent across platfrom.

<img width="336" alt="Screenshot 2022-04-12 at 13 14 19" src="https://user-images.githubusercontent.com/11191791/162907851-1188e7bc-60f3-488b-bd35-c025e4ae5857.png">


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
