### PR TITLE
Hide backup code authenticator from console

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
@@ -580,25 +580,30 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
                     <Divider hidden/>
                     <div className="authenticator-grid">
                         {
-                            authenticators.map((authenticator, index) => (
-                                <LabeledCard
-                                    key={ index }
-                                    multilineLabel
-                                    className="authenticator-card"
-                                    size="tiny"
-                                    selected={ selectedSocialAuthenticator?.id === authenticator.id }
-                                    image={ authenticator.image }
-                                    label={
-                                        AuthenticatorMeta.getAuthenticatorDisplayName(authenticator.name)
+                            authenticators
+                                .filter((authenticator) => {
+                                    authenticator.name !== IdentityProviderManagementConstants
+                                        .BACKUP_CODE_AUTHENTICATOR;
+                                })
+                                .map((authenticator, index) => (
+                                    <LabeledCard
+                                        key={ index }
+                                        multilineLabel
+                                        className="authenticator-card"
+                                        size="tiny"
+                                        selected={ selectedSocialAuthenticator?.id === authenticator.id }
+                                        image={ authenticator.image }
+                                        label={
+                                            AuthenticatorMeta.getAuthenticatorDisplayName(authenticator.name)
                                         || authenticator.displayName
-                                    }
-                                    labelEllipsis={ true }
-                                    data-testid={
-                                        `${ testId }-authenticator-${ authenticator.name }`
-                                    }
-                                    onClick={ () => setSelectedSocialAuthenticator(authenticator) }
-                                />
-                            ))
+                                        }
+                                        labelEllipsis={ true }
+                                        data-testid={
+                                            `${ testId }-authenticator-${ authenticator.name }`
+                                        }
+                                        onClick={ () => setSelectedSocialAuthenticator(authenticator) }
+                                    />
+                                ))
                         }
                     </div>
                 </ConfirmationModal.Content>

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -167,7 +167,10 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
         const secondFactorAuth: GenericAuthenticatorInterface[] = [];
 
         localAuthenticators.forEach((authenticator: GenericAuthenticatorInterface) => {
-            if (ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticator.id)) {
+            if (authenticator.name === IdentityProviderManagementConstants.BACKUP_CODE_AUTHENTICATOR) {
+                // Backup code authenticator is not available for customer users at the moment.
+                return;
+            } else if (ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticator.id)) {
                 secondFactorAuth.push(authenticator);
             } else {
                 moderatedLocalAuthenticators.push(authenticator);

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -276,6 +276,7 @@ export class IdentityProviderManagementConstants {
     public static readonly BASIC_AUTHENTICATOR = "BasicAuthenticator";
     public static readonly IDENTIFIER_FIRST_AUTHENTICATOR = "IdentifierExecutor";
     public static readonly SMS_OTP_AUTHENTICATOR = "sms-otp";
+    public static readonly BACKUP_CODE_AUTHENTICATOR = "backup-code-authenticator";
 
     // Known Enterprise authenticator IDs
     public static readonly OIDC_AUTHENTICATOR_ID: string = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I";
@@ -293,6 +294,7 @@ export class IdentityProviderManagementConstants {
     public static readonly BASIC_AUTH_AUTHENTICATOR_ID: string = "QmFzaWNBdXRoUmVxdWVzdFBhdGhBdXRoZW50aWNhdG9y";
     public static readonly OAUTH_BEARER_AUTHENTICATOR_ID: string = "T0F1dGhSZXF1ZXN0UGF0aEF1dGhlbnRpY2F0b3I";
     public static readonly EMAIL_OTP_AUTHENTICATOR_ID: string = "ZW1haWwtb3RwLWF1dGhlbnRpY2F0b3I";
+    public static readonly BACKUP_CODE_AUTHENTICATOR_ID: string = "YmFja3VwLWNvZGUtYXV0aGVudGljYXRvcgo=";
 
     // Known Social authenticator IDs.
     public static readonly GOOGLE_OIDC_AUTHENTICATOR_ID: string = "R29vZ2xlT0lEQ0F1dGhlbnRpY2F0b3I";


### PR DESCRIPTION
### Purpose
> Hide backup code authenticator from console as it is not available for custom users currently.

### Related PRs
- https://github.com/wso2/identity-apps/pull/2963
