### PR TITLE
Add content loader to Groups and Users tabs of a Role

### DIFF
--- a/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
@@ -98,7 +98,7 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
     const [ isSelectAssignedAllRolesChecked, setIsSelectAssignedAllRolesChecked ] = useState(false);
     const [ assignedGroups, setAssignedGroups ] = useState<RolesMemberInterface[]>([]);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const [isLoadingAssignedGroups, setIsLoadingAssignedGroups] = useState<boolean>(true);
+    const [ isLoadingAssignedGroups, setIsLoadingAssignedGroups ] = useState<boolean>(true);
 
     const [ alert, setAlert, alertComponent ] = useWizardAlert();
 
@@ -728,7 +728,8 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
                                     </Grid.Row>
                                 </EmphasizedSegment>
                             ) : (
-                                !isLoadingAssignedGroups ? (
+                                !isLoadingAssignedGroups
+                                ? (
                                     <EmphasizedSegment>
                                         <EmptyPlaceholder
                                             data-testid="role-mgt-empty-groups-list"

--- a/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
@@ -729,35 +729,35 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
                                 </EmphasizedSegment>
                             ) : (
                                 !isLoadingAssignedGroups
-                                ? (
-                                    <EmphasizedSegment>
-                                        <EmptyPlaceholder
-                                            data-testid="role-mgt-empty-groups-list"
-                                            title={ t("console:manage.features.roles.edit.groups." +
-                                                    "emptyPlaceholder.title") }
-                                            subtitle={ [
-                                                t("console:manage.features.roles.edit.groups." +
-                                                        "emptyPlaceholder.subtitles")
-                                            ] }
-                                            action={
-                                                !isReadOnly && (
-                                                    <PrimaryButton
-                                                        data-testid="role-mgt-empty-groups-list-assign-group-button"
-                                                        icon="plus"
-                                                        onClick={ handleOpenAddNewGroupModal }
-                                                    >
-                                                        { t("console:manage.features.roles.edit.groups." +
-                                                                "emptyPlaceholder.action") }
-                                                    </PrimaryButton>
-                                                )
-                                            }
-                                            image={ getEmptyPlaceholderIllustrations().emptyList }
-                                            imageSize="tiny"
-                                        />
-                                    </EmphasizedSegment>
+                                    ? (
+                                        <EmphasizedSegment>
+                                            <EmptyPlaceholder
+                                                data-testid="role-mgt-empty-groups-list"
+                                                title={ t("console:manage.features.roles.edit.groups." +
+                                                        "emptyPlaceholder.title") }
+                                                subtitle={ [
+                                                    t("console:manage.features.roles.edit.groups." +
+                                                            "emptyPlaceholder.subtitles")
+                                                ] }
+                                                action={
+                                                    !isReadOnly && (
+                                                        <PrimaryButton
+                                                            data-testid="role-mgt-empty-groups-list-assign-group-button"
+                                                            icon="plus"
+                                                            onClick={ handleOpenAddNewGroupModal }
+                                                        >
+                                                            { t("console:manage.features.roles.edit.groups." +
+                                                                    "emptyPlaceholder.action") }
+                                                        </PrimaryButton>
+                                                    )
+                                                }
+                                                image={ getEmptyPlaceholderIllustrations().emptyList }
+                                                imageSize="tiny"
+                                            />
+                                        </EmphasizedSegment>
+                                    )
+                                    : <ContentLoader className="p-3" active />
                                 )
-                                : <ContentLoader className="p-3" active />
-                            )
                         }
                     </Grid.Column>
                 </Grid.Row>

--- a/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
@@ -24,6 +24,7 @@ import {
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import {
+    ContentLoader,
     EmphasizedSegment,
     EmptyPlaceholder,
     Heading,
@@ -97,6 +98,7 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
     const [ isSelectAssignedAllRolesChecked, setIsSelectAssignedAllRolesChecked ] = useState(false);
     const [ assignedGroups, setAssignedGroups ] = useState<RolesMemberInterface[]>([]);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [isLoadingAssignedGroups, setIsLoadingAssignedGroups] = useState<boolean>(true);
 
     const [ alert, setAlert, alertComponent ] = useWizardAlert();
 
@@ -141,6 +143,7 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
             .then((response) => {
                 setPrimaryGroups(response.data.Resources);
             });
+        setIsLoadingAssignedGroups(false);
     }, []);
 
     const mapUserRoles = () => {
@@ -725,31 +728,34 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
                                     </Grid.Row>
                                 </EmphasizedSegment>
                             ) : (
-                                <EmphasizedSegment>
-                                    <EmptyPlaceholder
-                                        data-testid="role-mgt-empty-groups-list"
-                                        title={ t("console:manage.features.roles.edit.groups." +
-                                                "emptyPlaceholder.title") }
-                                        subtitle={ [
-                                            t("console:manage.features.roles.edit.groups." +
-                                                    "emptyPlaceholder.subtitles")
-                                        ] }
-                                        action={
-                                            !isReadOnly && (
-                                                <PrimaryButton
-                                                    data-testid="role-mgt-empty-groups-list-assign-group-button"
-                                                    icon="plus"
-                                                    onClick={ handleOpenAddNewGroupModal }
-                                                >
-                                                    { t("console:manage.features.roles.edit.groups." +
-                                                            "emptyPlaceholder.action") }
-                                                </PrimaryButton>
-                                            )
-                                        }
-                                        image={ getEmptyPlaceholderIllustrations().emptyList }
-                                        imageSize="tiny"
-                                    />
-                                </EmphasizedSegment>
+                                !isLoadingAssignedGroups ? (
+                                    <EmphasizedSegment>
+                                        <EmptyPlaceholder
+                                            data-testid="role-mgt-empty-groups-list"
+                                            title={ t("console:manage.features.roles.edit.groups." +
+                                                    "emptyPlaceholder.title") }
+                                            subtitle={ [
+                                                t("console:manage.features.roles.edit.groups." +
+                                                        "emptyPlaceholder.subtitles")
+                                            ] }
+                                            action={
+                                                !isReadOnly && (
+                                                    <PrimaryButton
+                                                        data-testid="role-mgt-empty-groups-list-assign-group-button"
+                                                        icon="plus"
+                                                        onClick={ handleOpenAddNewGroupModal }
+                                                    >
+                                                        { t("console:manage.features.roles.edit.groups." +
+                                                                "emptyPlaceholder.action") }
+                                                    </PrimaryButton>
+                                                )
+                                            }
+                                            image={ getEmptyPlaceholderIllustrations().emptyList }
+                                            imageSize="tiny"
+                                        />
+                                    </EmphasizedSegment>
+                                )
+                                : <ContentLoader className="p-3" active />
                             )
                         }
                     </Grid.Column>

--- a/apps/console/src/features/roles/components/wizard/role-user-assign.tsx
+++ b/apps/console/src/features/roles/components/wizard/role-user-assign.tsx
@@ -20,6 +20,7 @@ import { RolesMemberInterface, TestableComponentInterface } from "@wso2is/core/m
 import { Forms } from "@wso2is/forms";
 import {
     Button,
+    ContentLoader,
     EmphasizedSegment,
     EmptyPlaceholder,
     Heading,
@@ -166,11 +167,12 @@ export const AddRoleUsers: FunctionComponent<AddRoleUserProps> = (props: AddRole
                             userObject.name?.givenName?.localeCompare(comparedUserObject.name?.givenName)
                         );
                         setSelectedUsers(selectedUserList);
-                        setIsSelectedUsersLoading(false);
                         setInitialSelectedUsers(selectedUserList);
                         setTempUserList(selectedUserList);
                     }
                 }
+
+                setIsSelectedUsersLoading(false);
 
                 if (initialValues && initialValues instanceof Array) {
                     const selectedUserList: UserBasicInterface[] = [];
@@ -579,7 +581,8 @@ export const AddRoleUsers: FunctionComponent<AddRoleUserProps> = (props: AddRole
                                                 imageSize="tiny"
                                             />
                                         </EmphasizedSegment>
-                                    ) : null
+                                    )
+                                    : <ContentLoader className="p-3" active />
                                 )
                             }
                         </Grid.Column>

--- a/apps/console/src/features/roles/components/wizard/role-user-assign.tsx
+++ b/apps/console/src/features/roles/components/wizard/role-user-assign.tsx
@@ -95,6 +95,8 @@ export const AddRoleUsers: FunctionComponent<AddRoleUserProps> = (props: AddRole
 
     const [ showAddNewUserModal, setAddNewUserModalView ] = useState<boolean>(false);
 
+    const [isSelectedUsersLoading, setIsSelectedUsersLoading] = useState<boolean>(true);
+
     const initialRenderTempUsers = useRef(true);
 
     useEffect(() => {
@@ -164,6 +166,7 @@ export const AddRoleUsers: FunctionComponent<AddRoleUserProps> = (props: AddRole
                             userObject.name?.givenName?.localeCompare(comparedUserObject.name?.givenName)
                         );
                         setSelectedUsers(selectedUserList);
+                        setIsSelectedUsersLoading(false);
                         setInitialSelectedUsers(selectedUserList);
                         setTempUserList(selectedUserList);
                     }
@@ -550,31 +553,33 @@ export const AddRoleUsers: FunctionComponent<AddRoleUserProps> = (props: AddRole
                                         </Grid.Row>
                                     </EmphasizedSegment>
                                 ) : (
-                                    <EmphasizedSegment>
-                                        <EmptyPlaceholder
-                                            title={ t("console:manage.features.roles.edit.users.list." +
-                                                "emptyPlaceholder.title") }
-                                            subtitle={ [
-                                                t("console:manage.features.roles.edit.users.list." +
-                                                    "emptyPlaceholder.subtitles", { type: "role" })
-                                            ] }
-                                            action={
-                                                !isReadOnly && (
-                                                    <PrimaryButton
-                                                        data-testid={ `${ testId }-users-list-empty-assign-users-
-                                                        button` }
-                                                        onClick={ handleOpenAddNewGroupModal }
-                                                        icon="plus"
-                                                    >
-                                                        { t("console:manage.features.roles.edit.users.list." +
-                                                            "emptyPlaceholder.action") }
-                                                    </PrimaryButton>
-                                                )
-                                            }
-                                            image={ getEmptyPlaceholderIllustrations().emptyList }
-                                            imageSize="tiny"
-                                        />
-                                    </EmphasizedSegment>
+                                    !isSelectedUsersLoading ? (
+                                        <EmphasizedSegment>
+                                            <EmptyPlaceholder
+                                                title={ t("console:manage.features.roles.edit.users.list." +
+                                                    "emptyPlaceholder.title") }
+                                                subtitle={ [
+                                                    t("console:manage.features.roles.edit.users.list." +
+                                                        "emptyPlaceholder.subtitles", { type: "role" })
+                                                ] }
+                                                action={
+                                                    !isReadOnly && (
+                                                        <PrimaryButton
+                                                            data-testid={ `${ testId }-users-list-empty-assign-users-
+                                                            button` }
+                                                            onClick={ handleOpenAddNewGroupModal }
+                                                            icon="plus"
+                                                        >
+                                                            { t("console:manage.features.roles.edit.users.list." +
+                                                                "emptyPlaceholder.action") }
+                                                        </PrimaryButton>
+                                                    )
+                                                }
+                                                image={ getEmptyPlaceholderIllustrations().emptyList }
+                                                imageSize="tiny"
+                                            />
+                                        </EmphasizedSegment>
+                                    ) : null
                                 )
                             }
                         </Grid.Column>

--- a/apps/console/src/features/roles/components/wizard/role-user-assign.tsx
+++ b/apps/console/src/features/roles/components/wizard/role-user-assign.tsx
@@ -96,7 +96,7 @@ export const AddRoleUsers: FunctionComponent<AddRoleUserProps> = (props: AddRole
 
     const [ showAddNewUserModal, setAddNewUserModalView ] = useState<boolean>(false);
 
-    const [isSelectedUsersLoading, setIsSelectedUsersLoading] = useState<boolean>(true);
+    const [ isSelectedUsersLoading, setIsSelectedUsersLoading ] = useState<boolean>(true);
 
     const initialRenderTempUsers = useRef(true);
 
@@ -555,7 +555,8 @@ export const AddRoleUsers: FunctionComponent<AddRoleUserProps> = (props: AddRole
                                         </Grid.Row>
                                     </EmphasizedSegment>
                                 ) : (
-                                    !isSelectedUsersLoading ? (
+                                    !isSelectedUsersLoading
+                                    ? (
                                         <EmphasizedSegment>
                                             <EmptyPlaceholder
                                                 title={ t("console:manage.features.roles.edit.users.list." +

--- a/apps/console/src/features/roles/components/wizard/role-user-assign.tsx
+++ b/apps/console/src/features/roles/components/wizard/role-user-assign.tsx
@@ -556,35 +556,35 @@ export const AddRoleUsers: FunctionComponent<AddRoleUserProps> = (props: AddRole
                                     </EmphasizedSegment>
                                 ) : (
                                     !isSelectedUsersLoading
-                                    ? (
-                                        <EmphasizedSegment>
-                                            <EmptyPlaceholder
-                                                title={ t("console:manage.features.roles.edit.users.list." +
-                                                    "emptyPlaceholder.title") }
-                                                subtitle={ [
-                                                    t("console:manage.features.roles.edit.users.list." +
-                                                        "emptyPlaceholder.subtitles", { type: "role" })
-                                                ] }
-                                                action={
-                                                    !isReadOnly && (
-                                                        <PrimaryButton
-                                                            data-testid={ `${ testId }-users-list-empty-assign-users-
-                                                            button` }
-                                                            onClick={ handleOpenAddNewGroupModal }
-                                                            icon="plus"
-                                                        >
-                                                            { t("console:manage.features.roles.edit.users.list." +
-                                                                "emptyPlaceholder.action") }
-                                                        </PrimaryButton>
-                                                    )
-                                                }
-                                                image={ getEmptyPlaceholderIllustrations().emptyList }
-                                                imageSize="tiny"
-                                            />
-                                        </EmphasizedSegment>
+                                        ? (
+                                            <EmphasizedSegment>
+                                                <EmptyPlaceholder
+                                                    title={ t("console:manage.features.roles.edit.users.list." +
+                                                        "emptyPlaceholder.title") }
+                                                    subtitle={ [
+                                                        t("console:manage.features.roles.edit.users.list." +
+                                                            "emptyPlaceholder.subtitles", { type: "role" })
+                                                    ] }
+                                                    action={
+                                                        !isReadOnly && (
+                                                            <PrimaryButton
+                                                                data-testid={ `${ testId }-users-list-empty-assign-
+                                                                users-button` }
+                                                                onClick={ handleOpenAddNewGroupModal }
+                                                                icon="plus"
+                                                            >
+                                                                { t("console:manage.features.roles.edit.users.list." +
+                                                                    "emptyPlaceholder.action") }
+                                                            </PrimaryButton>
+                                                        )
+                                                    }
+                                                    image={ getEmptyPlaceholderIllustrations().emptyList }
+                                                    imageSize="tiny"
+                                                />
+                                            </EmphasizedSegment>
+                                        )
+                                        : <ContentLoader className="p-3" active />
                                     )
-                                    : <ContentLoader className="p-3" active />
-                                )
                             }
                         </Grid.Column>
                     </Grid.Row>


### PR DESCRIPTION
### Purpose
>Add a Content loader to resolve showing intermediate UI when switching between Groups and Users tabs of a Role in console

### Related Issues
- Resolved  Issue https://github.com/wso2/product-is/issues/13384