### PR TITLE
Display Username as a read only field by removing the edit icon

### DIFF
--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -909,6 +909,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                             <List.Content floated="right">
                                 { !CommonUtils.isProfileReadOnly(isReadOnlyUser)
                                 && schema.mutability !== ProfileConstants.READONLY_SCHEMA
+                                && schema.name !== "userName"
                                 && !isEmpty(profileInfo.get(schema.name))
                                 && hasRequiredScopes(featureConfig?.personalInfo,
                                     featureConfig?.personalInfo?.scopes?.update, allowedScopes)


### PR DESCRIPTION
Fix [wso2/product-is#13528](https://github.com/wso2/product-is/issues/13528)

