### PR TITLE
Merge useEffects to avoid concurrent getRole calls

### DIFF
--- a/apps/console/src/features/roles/pages/role.tsx
+++ b/apps/console/src/features/roles/pages/role.tsx
@@ -102,21 +102,12 @@ const RolesPage = (): ReactElement => {
     },[ initialRolList?.Resources?.length != 0 ]);
 
     useEffect(() => {
-        getRoles();
-        setListUpdated(false);
-    }, [ isListUpdated ]);
-
-    useEffect(() => {
         getUserStores();
     }, []);
 
     useEffect(() => {
         getRoles();
-    }, [ filterBy ]);
-
-    useEffect(() => {
-        getRoles();
-    }, [ userStore ]);
+    }, [ filterBy, userStore ]);
 
     const getRoles = () => {
         setRoleListFetchRequestLoading(true);
@@ -292,7 +283,7 @@ const RolesPage = (): ReactElement => {
                     "console:manage.features.roles.notifications.deleteRole.success.message"
                 )
             });
-            setListUpdated(true);
+            getRoles();
         });
     };
 

--- a/apps/console/src/features/roles/pages/role.tsx
+++ b/apps/console/src/features/roles/pages/role.tsx
@@ -96,12 +96,6 @@ const RolesPage = (): ReactElement => {
     const [ listSortingStrategy, setListSortingStrategy ] = useState<DropdownItemProps>(ROLES_SORTING_OPTIONS[ 0 ]);
 
     useEffect(() => {
-        if (searchQuery == "") {
-            getRoles();
-        }
-    },[ initialRolList?.Resources?.length != 0 ]);
-
-    useEffect(() => {
         getUserStores();
     }, []);
 

--- a/apps/console/src/features/server-configurations/constants/server-configurations-constants.ts
+++ b/apps/console/src/features/server-configurations/constants/server-configurations-constants.ts
@@ -329,9 +329,7 @@ export class ServerConfigurationsConstants {
 	public static readonly OFFLINE_PASSWORD_RESET: string = "Recovery.AdminPasswordReset.Offline";
 	public static readonly ADMIN_FORCED_PASSWORD_RESET_EXPIRY_TIME: string = "Recovery.AdminPasswordReset.ExpiryTime";
 
-    //multi attribute login set
     public static readonly MULTI_ATTRIBUTE_CLAIM_LIST: string = "account-multiattributelogin-handler-allowedattributes";
-
 
 	/**
 	 * Extensions Constants.


### PR DESCRIPTION
### Purpose
> There were 4 useEffects that calls getRoles function, Merge them to reduce the number of concurrent `getRoles` calls

### Related Issues
- Resolved Issue https://github.com/wso2/product-is/issues/13311

