### PR TITLE
Remove next button in role permission view at create new user

### DIFF
--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -113,8 +113,16 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
     const [ selectedRoleId,  setSelectedRoleId ] = useState<string>();
     const [ isRoleSelected, setRoleSelection ] = useState<boolean>(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ viewNextButton, setViewNextButton ] = useState<boolean>(true);
 
     const [ alert, setAlert, alertComponent ] = useWizardAlert();
+
+    useEffect(() => {
+        if (currentWizardStep != 3) {
+            setViewRolePermissions(false);
+        }
+        setViewNextButton(true);
+    }, [currentWizardStep]);
 
     useEffect(() => {
         if (!selectedRoleId) {
@@ -168,6 +176,10 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
         setViewRolePermissions(!viewRolePermissions);
         setRoleSelection(false);
     };
+
+    const handleViewNextButton = (show: boolean) => {
+        setViewNextButton(show)
+    }
 
     const handleRoleIdSet = (roleId) => {
         setSelectedRoleId(roleId);
@@ -577,6 +589,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                 ? <RolePermissions
                         data-testid={ `${ testId }-role-permission` }
                         handleNavigateBack={ handleViewRolePermission }
+                        handleViewNextButton = { handleViewNextButton }
                         roleId={ selectedRoleId }
                     />
                 : <AddUserRole
@@ -664,7 +677,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                             </LinkButton>
                         </Grid.Column>
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
-                            { currentWizardStep < STEPS.length - 1 && (
+                            { currentWizardStep < STEPS.length - 1 && viewNextButton && (
                                 <PrimaryButton
                                     data-testid={ `${ testId }-next-button` }
                                     floated="right"

--- a/apps/console/src/features/users/components/wizard/user-role-permissions.tsx
+++ b/apps/console/src/features/users/components/wizard/user-role-permissions.tsx
@@ -29,6 +29,7 @@ import { PermissionList, getRoleById } from "../../../roles";
 interface RolePermissionsInterface extends TestableComponentInterface {
     roleId: string;
     handleNavigateBack: () => void;
+    handleViewNextButton?: (show: boolean) => void;
 }
 
 /**
@@ -44,6 +45,7 @@ export const RolePermissions: FunctionComponent<RolePermissionsInterface> = (
     const {
         roleId,
         handleNavigateBack,
+        handleViewNextButton,
         [ "data-testid" ]: testId
     } = props;
 
@@ -68,6 +70,7 @@ export const RolePermissions: FunctionComponent<RolePermissionsInterface> = (
                     setRole(response.data);
                 });
         }
+        handleViewNextButton(false);
     }, [ roleId ]);
 
     /**


### PR DESCRIPTION
### Purpose
> Fixes issues
 - Displaying next button at role permission view  (permissions are not editable). - Next button is removed. 
 - Landing on role permission view of the previously clicked role after clicking previous and coming back to roles view. - Fixed to land on roles list.

### Related Issues
- Issue https://github.com/wso2/product-is/issues/13505

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
