### PR TITLE
Removed the exception details from the displayed error message

### DIFF
--- a/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
@@ -43,7 +43,7 @@
         }
     } catch (IdentityRecoveryException e) {
         request.setAttribute("error", true);
-        request.setAttribute("errorMsg", "Callback URL validation failed. " + e);
+        request.setAttribute("errorMsg", "Callback URL validation failed. " + e.getMessage());
         if (!StringUtils.isBlank(username)) {
             request.setAttribute("username", username);
         }


### PR DESCRIPTION
### Purpose

As per the issue https://github.com/wso2/product-is/issues/12469 the callback validation error is displayed as
"Callback URL validation failed. org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityRecoveryException: Error while instantiating IdentityProviderMgtServiceStub"

In this PR "org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityRecoveryException" part has been removed by sending e.getMessage() instead of e.

### Related Issues
https://github.com/wso2/product-is/issues/12469

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
https://github.com/wso2/carbon-identity-framework/pull/4019

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
