### PR TITLE
Filter the existing groups before update the group list

### DIFF
--- a/apps/console/src/features/users/components/user-groups-edit.tsx
+++ b/apps/console/src/features/users/components/user-groups-edit.tsx
@@ -95,7 +95,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     const [ assignedGroups, setAssignedGroups ] = useState<RolesMemberInterface[]>([]);
     const [ isPrimaryGroupsLoading, setPrimaryGroupsLoading ] = useState<boolean>(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const [ oldGroupList, setOldGroupList ] = useState([]);
+    const [ existingGroupList, setExistingGroupList ] = useState([]);
 
     useEffect(() => {
         if (!(user)) {
@@ -196,7 +196,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
             }
         });
         setSelectedGroupList(addedGroups);
-        setOldGroupList(addedGroups);
+        setExistingGroupList(addedGroups);
         setGroupList(groupListCopy);
         setInitialGroupList(groupListCopy);
         setIsSelectAllGroupsChecked(groupListCopy.length === addedGroups.length);
@@ -306,7 +306,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
 
         if (groupIds && groupIds?.length > 0) {
             groupIds.map((id) => {
-                if (!oldGroupList.find(oldGroup => oldGroup.id === id)) {
+                if (!existingGroupList.find(existingGroup => existingGroup.id === id)) {
                     addOperation = {
                         ...addOperation,
                         ...{ path: "/Groups/" + id }

--- a/apps/console/src/features/users/components/user-groups-edit.tsx
+++ b/apps/console/src/features/users/components/user-groups-edit.tsx
@@ -95,7 +95,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     const [ assignedGroups, setAssignedGroups ] = useState<RolesMemberInterface[]>([]);
     const [ isPrimaryGroupsLoading, setPrimaryGroupsLoading ] = useState<boolean>(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const [ oldGroupLis, setOldGroupList ] = useState([]);
+    const [ oldGroupList, setOldGroupList ] = useState([]);
 
     useEffect(() => {
         if (!(user)) {
@@ -306,7 +306,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
 
         if (groupIds && groupIds?.length > 0) {
             groupIds.map((id) => {
-                if (!oldGroupLis.find(oldGroup => oldGroup.id === id)) {
+                if (!oldGroupList.find(oldGroup => oldGroup.id === id)) {
                     addOperation = {
                         ...addOperation,
                         ...{ path: "/Groups/" + id }

--- a/apps/console/src/features/users/components/user-groups-edit.tsx
+++ b/apps/console/src/features/users/components/user-groups-edit.tsx
@@ -95,6 +95,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     const [ assignedGroups, setAssignedGroups ] = useState<RolesMemberInterface[]>([]);
     const [ isPrimaryGroupsLoading, setPrimaryGroupsLoading ] = useState<boolean>(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ oldGroupLis, setOldGroupList ] = useState([]);
 
     useEffect(() => {
         if (!(user)) {
@@ -195,6 +196,7 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
             }
         });
         setSelectedGroupList(addedGroups);
+        setOldGroupList(addedGroups);
         setGroupList(groupListCopy);
         setInitialGroupList(groupListCopy);
         setIsSelectAllGroupsChecked(groupListCopy.length === addedGroups.length);
@@ -304,11 +306,13 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
 
         if (groupIds && groupIds?.length > 0) {
             groupIds.map((id) => {
-                addOperation = {
-                    ...addOperation,
-                    ...{ path: "/Groups/" + id }
-                };
-                addOperations.push(addOperation);
+                if (!oldGroupLis.find(oldGroup => oldGroup.id === id)) {
+                    addOperation = {
+                        ...addOperation,
+                        ...{ path: "/Groups/" + id }
+                    };
+                    addOperations.push(addOperation);
+                }
             });
 
             addOperations.map((operation) => {


### PR DESCRIPTION
### Purpose

- When update the group list, all the checked groups were sent under the "add" operation and it causes to an error in backend because of trying to `adding an existing group`

- Fixed that issue by filtering the selected groups from already existing groups before add the `groupId` to the  `add` operation,  Now **_only newly selected groups_** are sent under `add` operation with the PATCH request.

### Related Issues
- Issue https://github.com/wso2/product-is/issues/12954
