### PR TITLE
Fix super admin session termination inconsistency

### DIFF
--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -96,9 +96,9 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     const [ user, setUser ] = useState<ProfileInfoInterface>(selectedUser);
 
     useEffect(() => {
-    //Since the parent component is refreshing twice we are doing a deep equals operation on the user object to 
-    //see if they are the same values. If they are the same values we do not do anything. 
-    //This makes sure the child components or side effects depending on the user object won't re-render or re-trigger.
+        //Since the parent component is refreshing twice we are doing a deep equals operation on the user object to 
+        //see if they are the same values. If they are the same values we do not do anything. 
+        //This makes sure the child components or side effects depending on the user object won't re-render or re-trigger.
         if (!selectedUser || isEqual(user, selectedUser)) {
             return;
         }

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -18,9 +18,11 @@
 
 import { UserstoreConstants } from "@wso2is/core/constants";
 import { hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
-import { AlertInterface, ProfileInfoInterface, SBACInterface } from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, ProfileInfoInterface, SBACInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ResourceTab } from "@wso2is/react-components";
+import { AxiosError } from "axios";
+import isEqual from "lodash-es/isEqual";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -29,8 +31,9 @@ import { UserProfile } from "./user-profile";
 import { UserRolesList } from "./user-roles-edit";
 import { UserSessions } from "./user-sessions";
 import { SCIMConfigs } from "../../../extensions/configs/scim";
+import { getServerConfigs } from "../../../features/server-configurations";
 import { FeatureConfigInterface } from "../../core/models";
-import { AppState } from "../../core/store";
+import { AppState, store } from "../../core/store";
 import { ConnectorPropertyInterface } from "../../server-configurations/models";
 import { UserManagementConstants } from "../constants";
 
@@ -67,7 +70,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
 ): JSX.Element => {
 
     const {
-        user,
+        user: selectedUser,
         handleUserUpdate,
         featureConfig,
         readOnlyUserStores,
@@ -83,12 +86,28 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
         (state: AppState) => state?.config?.ui?.isGroupAndRoleSeparationEnabled);
 
     const [ isReadOnly, setReadOnly ] = useState<boolean>(false);
+    const [ isSuperAdmin, setIsSuperAdmin ] = useState<boolean>(false); 
+    const [ isSelectedSuperAdmin, setIsSelectedSuperAdmin ] = useState<boolean>(false); 
+    const [ 
+        isSuperAdminIdentifierFetchRequestLoading, 
+        setIsSuperAdminIdentifierFetchRequestLoading 
+    ] = useState<boolean>(false);
+    const [ hideTermination, setHideTermination ] = useState<boolean>(false);
+    const [ user, setUser ] = useState<ProfileInfoInterface>(selectedUser);
 
     useEffect(() => {
-        if(!user) {
+    /**
+    Since the parent component is refreshing twice we are doing a deep equals operation on the user object to 
+    see if they are the same values. If they are the same values we do not do anything. 
+    This makes sure the child components or side effects depending on the user object won't re-render or re-trigger.
+    */
+        if(!selectedUser || isEqual(user, selectedUser)) {
             return;
         }
+        setUser(selectedUser);
+    }, [ selectedUser ]);
 
+    useEffect(() => {
         const userStore = user?.userName?.split("/").length > 1
             ? user?.userName?.split("/")[0]
             : UserstoreConstants.PRIMARY_USER_STORE;
@@ -100,10 +119,72 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
         ) {
             setReadOnly(true);
         }
+        
     }, [ user, readOnlyUserStores ]);
+
+    useEffect(() => {
+        checkIsSuperAdmin();
+    }, [ user ]);
 
     const handleAlerts = (alert: AlertInterface) => {
         dispatch(addAlert<AlertInterface>(alert));
+    };
+
+    /**
+    * Util function to check if current user and selected user is a super admin.
+    */
+    const checkIsSuperAdmin = () => {
+        setIsSuperAdminIdentifierFetchRequestLoading(true);
+
+        getServerConfigs()
+
+            .then((response) => {
+                const loggedUserName: string = store.getState().profile.profileInfo.userName;
+                const adminUser: string = response?.realmConfig.adminUser;
+
+                if (loggedUserName === adminUser) {
+                    setIsSuperAdmin(true);
+                }
+                if (user?.userName === adminUser){
+                    setIsSelectedSuperAdmin(true);
+                }
+            
+            })
+            .catch((error: AxiosError) => {
+
+                setHideTermination(true);
+
+                if (error.response
+                && error.response.data
+                && (error.response.data.description || error.response.data.detail)) {
+
+                    dispatch(addAlert<AlertInterface>({
+                        description: error.response.data.description || error.response.data.detail,
+                        level: AlertLevels.ERROR,
+                        message: t(
+                            "console:manage.features.users.userSessions.notifications.getAdminUser." +
+                            "error.message"
+                        )
+                    }));
+
+                    return;
+                }
+
+                dispatch(addAlert<AlertInterface>({
+                    description: t("console:manage.features.users.userSessions.notifications.getAdminUser." +
+                        "genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t(
+                        "console:manage.features.users.userSessions.notifications.getAdminUser." +
+                        "genericError.message"
+                    )
+                }));
+
+
+            })
+            .finally(() => {
+                setIsSuperAdminIdentifierFetchRequestLoading(false);
+            });
     };
 
     const panes = () => ([
@@ -153,7 +234,13 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
             menuItem: t("console:manage.features.users.editUser.tab.menuItems.3"),
             render: () => (
                 <ResourceTab.Pane controlledSegmentation attached={ false }>
-                    <UserSessions user={ user } />
+                    <UserSessions 
+                        user={ user } 
+                        showSessionTerminationButton={ (!isSuperAdminIdentifierFetchRequestLoading && !hideTermination) 
+                        && ((isSelectedSuperAdmin && isSuperAdmin) 
+                            || (!isSelectedSuperAdmin && isSuperAdmin) 
+                            || (!isSelectedSuperAdmin && !isSuperAdmin))
+                        } />
                 </ResourceTab.Pane>
             )
         }

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -175,7 +175,6 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                         "genericError.message"
                     )
                 }));
-
             })
             .finally(() => {
                 setIsSuperAdminIdentifierFetchRequestLoading(false);

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -96,12 +96,10 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     const [ user, setUser ] = useState<ProfileInfoInterface>(selectedUser);
 
     useEffect(() => {
-    /**
-    Since the parent component is refreshing twice we are doing a deep equals operation on the user object to 
-    see if they are the same values. If they are the same values we do not do anything. 
-    This makes sure the child components or side effects depending on the user object won't re-render or re-trigger.
-    */
-        if(!selectedUser || isEqual(user, selectedUser)) {
+    //Since the parent component is refreshing twice we are doing a deep equals operation on the user object to 
+    //see if they are the same values. If they are the same values we do not do anything. 
+    //This makes sure the child components or side effects depending on the user object won't re-render or re-trigger.
+        if (!selectedUser || isEqual(user, selectedUser)) {
             return;
         }
         setUser(selectedUser);
@@ -133,11 +131,10 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     /**
     * Util function to check if current user and selected user is a super admin.
     */
-    const checkIsSuperAdmin = () => {
+    const checkIsSuperAdmin = (): void => {
         setIsSuperAdminIdentifierFetchRequestLoading(true);
 
         getServerConfigs()
-
             .then((response) => {
                 const loggedUserName: string = store.getState().profile.profileInfo.userName;
                 const adminUser: string = response?.realmConfig.adminUser;
@@ -145,10 +142,9 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                 if (loggedUserName === adminUser) {
                     setIsSuperAdmin(true);
                 }
-                if (user?.userName === adminUser){
+                if (user?.userName === adminUser) {
                     setIsSelectedSuperAdmin(true);
                 }
-            
             })
             .catch((error: AxiosError) => {
 
@@ -179,7 +175,6 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                         "genericError.message"
                     )
                 }));
-
 
             })
             .finally(() => {

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -2296,6 +2296,7 @@ export interface ConsoleNS {
                         getUserSessions: Notification;
                         terminateAllUserSessions: Notification;
                         terminateUserSession: Notification;
+                        getAdminUser: Notification;
                     };
                     placeholders: {
                         emptyListPlaceholder: Placeholder;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -8619,6 +8619,16 @@ export const console: ConsoleNS = {
                         }
                     },
                     notifications: {
+                        getAdminUser: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "Retrieval Error"
+                            },
+                            genericError: {
+                                description: "An error occurred while retrieving the current user type.",
+                                message: "Retrieval Error"
+                            }
+                        },
                         getUserSessions: {
                             error: {
                                 description: "{{ description }}",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -7243,6 +7243,17 @@ export const console: ConsoleNS = {
                         }
                     },
                     notifications: {
+                        getAdminUser: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "Erreur de récupération"
+                            },
+                            genericError: {
+                                description: "Une erreur s'est produite lors de la récupération du type" + 
+                                    "d'utilisateur actuel.",
+                                message: "Erreur de récupération"
+                            }
+                        },
                         getUserSessions: {
                             error: {
                                 description: "{{ description }}",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -7071,6 +7071,16 @@ export const console: ConsoleNS = {
                         }
                     },
                     notifications: {
+                        getAdminUser: {
+                            error: {
+                                description: "{{ description }}",
+                                message: "ලබා ගැනීමේ දෝෂය"
+                            },
+                            genericError: {
+                                description: "වත්මන් පරිශීලක වර්ගය ලබා ගැනීමේදී දෝෂයක් ඇති විය.",
+                                message: "ලබා ගැනීමේ දෝෂය"
+                            }
+                        },
                         getUserSessions: {
                             error: {
                                 description: "{{ description }}",


### PR DESCRIPTION
### Purpose
> Fixing the inconsistency between the actions performed by `Terminate` and `Terminate All` used to terminate active sessions of the Super Admin

### Related Issues
- https://github.com/wso2/product-is/issues/13587

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
