### PR TITLE
Fix role mapping input field in application edit

### DIFF
--- a/modules/theme/src/themes/default/elements/list.overrides
+++ b/modules/theme/src/themes/default/elements/list.overrides
@@ -343,6 +343,7 @@
 
             .field {
                 width: 100%;
+                height: 100%;
 
                 .error.field {
                     position: relative;
@@ -353,6 +354,10 @@
                         left: 0;
                         z-index: 99;
                     }
+                }
+                
+                & * {
+                    height: 100%;
                 }
             }
 


### PR DESCRIPTION
### Purpose
> Fix role mapping input field under the User Attributes tab in the application edit page when the application is in read only mode.

### Related Issues
- https://github.com/wso2/product-is/issues/13445

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

Closes wso2/product-is#13445