### PR TITLE
Handle `USER_DEFINED` & `DEFAULT` Sign-In Sequences better in the UI

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -29,6 +29,9 @@ import {
     Text,
     useDocumentation
 } from "@wso2is/react-components";
+import cloneDeep from "lodash-es/cloneDeep";
+import isEmpty from "lodash-es/isEmpty";
+import isEqual from "lodash-es/isEqual";
 import kebabCase from "lodash-es/kebabCase";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -121,7 +124,7 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
 
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
-    const [ sequence, setSequence ] = useState<AuthenticationSequenceInterface>(authenticationSequence);
+    const [ sequence, setSequence ] = useState<AuthenticationSequenceInterface>(cloneDeep(authenticationSequence));
     const [ updateTrigger, setUpdateTrigger ] = useState<boolean>(false);
     const [ adaptiveScript, setAdaptiveScript ] = useState<string | string[]>(undefined);
     const [ requestPathAuthenticators, setRequestPathAuthenticators ] = useState<any>(undefined);
@@ -462,13 +465,25 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
             return null;
         }
 
+        let isDisabled: boolean = isButtonDisabled || isLoading;
+
+        // If the sequence hasn't changed, disable the update button to improve UX.
+        if (isEqual(authenticationSequence.steps, updatedSteps)
+            && (
+                isEmpty(authenticationSequence.script) && AdaptiveScriptUtils.isDefaultScript(adaptiveScript, steps)
+                || isEqual(authenticationSequence.script, adaptiveScript)
+            )
+        ) {
+            isDisabled = true;
+        }
+
         return (
             <>
                 <Divider hidden/>
                 <PrimaryButton
                     onClick={ handleUpdateClick }
                     data-testid={ `${ testId }-update-button` }
-                    disabled={ isButtonDisabled || isLoading }
+                    disabled={ isDisabled }
                     loading={ isLoading }
                 >
                     { t("common:update") }

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -29,9 +29,6 @@ import {
     Text,
     useDocumentation
 } from "@wso2is/react-components";
-import cloneDeep from "lodash-es/cloneDeep";
-import isEmpty from "lodash-es/isEmpty";
-import isEqual from "lodash-es/isEqual";
 import kebabCase from "lodash-es/kebabCase";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -124,7 +121,7 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
 
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
-    const [ sequence, setSequence ] = useState<AuthenticationSequenceInterface>(cloneDeep(authenticationSequence));
+    const [ sequence, setSequence ] = useState<AuthenticationSequenceInterface>(authenticationSequence);
     const [ updateTrigger, setUpdateTrigger ] = useState<boolean>(false);
     const [ adaptiveScript, setAdaptiveScript ] = useState<string | string[]>(undefined);
     const [ requestPathAuthenticators, setRequestPathAuthenticators ] = useState<any>(undefined);
@@ -465,25 +462,13 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
             return null;
         }
 
-        let isDisabled: boolean = isButtonDisabled || isLoading;
-
-        // If the sequence hasn't changed, disable the update button to improve UX.
-        if (isEqual(authenticationSequence.steps, updatedSteps)
-            && (
-                isEmpty(authenticationSequence.script) && AdaptiveScriptUtils.isDefaultScript(adaptiveScript, steps)
-                || isEqual(authenticationSequence.script, adaptiveScript)
-            )
-        ) {
-            isDisabled = true;
-        }
-
         return (
             <>
                 <Divider hidden/>
                 <PrimaryButton
                     onClick={ handleUpdateClick }
                     data-testid={ `${ testId }-update-button` }
-                    disabled={ isDisabled }
+                    disabled={ isButtonDisabled || isLoading }
                     loading={ isLoading }
                 >
                     { t("common:update") }

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
@@ -43,7 +43,12 @@ import {
     IdentityProviderTemplateInterface
 } from "../../../../identity-providers";
 import { ApplicationManagementConstants } from "../../../constants";
-import { ApplicationInterface, AuthenticationSequenceInterface, LoginFlowTypes } from "../../../models";
+import {
+    ApplicationInterface,
+    AuthenticationSequenceInterface,
+    AuthenticationSequenceType,
+    LoginFlowTypes
+} from "../../../models";
 import { AdaptiveScriptUtils } from "../../../utils";
 
 /**
@@ -241,7 +246,7 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
         const isBasicScript: boolean = !authenticationSequence.script
             || AdaptiveScriptUtils.isDefaultScript(authenticationSequence.script, authenticationSequence.steps?.length);
 
-        return isBasicStep && isBasicScript;
+            return isBasicStep && isBasicScript && authenticationSequence.type === AuthenticationSequenceType.DEFAULT;
     };
 
     /**


### PR DESCRIPTION
### Purpose
Only show Application `Sign-In` methods landing view for the first time or if the user reverts the configuration.

### Related Issues
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- None

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
