### PR TITLE
Use preference retrieval client to get the status self-registration and user recovery configs in identifier first login

### DIFF
--- a/apps/authentication-portal/src/main/webapp/identifierauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/identifierauth.jsp
@@ -26,12 +26,12 @@
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.bean.UserDTO" %>
 <%@ page import="java.net.URLEncoder" %>
 <%@ page import="javax.ws.rs.core.Response" %>
-<%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.isSelfSignUpEPAvailable" %>
-<%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.isRecoveryEPAvailable" %>
 <%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.isEmailUsernameEnabled" %>
 <%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.getServerURL" %>
 <%@ page import="org.wso2.carbon.identity.core.URLBuilderException" %>
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClientException" %>
 
 <jsp:directive.include file="includes/init-loginform-action-url.jsp"/>
 
@@ -131,28 +131,27 @@
         (request.getParameter("sessionDataKey"))%>'/>
 
     <%
-        String recoveryEPAvailable = application.getInitParameter("EnableRecoveryEndpoint");
-        String enableSelfSignUpEndpoint = application.getInitParameter("EnableSelfSignUpEndpoint");
-        Boolean isRecoveryEPAvailable = false;
-        Boolean isSelfSignUpEPAvailable = false;
+        Boolean isUsernameRecoveryEnabledInTenant = false;
+        Boolean isSelfSignUpEnabledInTenant = false;
+
         String identityMgtEndpointContext = "";
         String accountRegistrationEndpointURL = "";
         String urlEncodedURL = "";
         String urlParameters = "";
 
-        if (StringUtils.isNotBlank(recoveryEPAvailable)) {
-            isRecoveryEPAvailable = Boolean.valueOf(recoveryEPAvailable);
-        } else {
-            isRecoveryEPAvailable = isRecoveryEPAvailable();
+        try {
+            PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
+            isSelfSignUpEnabledInTenant = preferenceRetrievalClient.checkSelfRegistration(tenantDomain);
+            isUsernameRecoveryEnabledInTenant = preferenceRetrievalClient.checkUsernameRecovery(tenantDomain);
+        } catch (PreferenceRetrievalClientException e) {
+            request.setAttribute("error", true);
+            request.setAttribute("errorMsg", AuthenticationEndpointUtil.i18n(resourceBundle, "something.went.wrong.contact.admin"));
+            IdentityManagementEndpointUtil.addErrorInformation(request, e);
+            request.getRequestDispatcher("error.jsp").forward(request, response);
+            return;
         }
 
-        if (StringUtils.isNotBlank(enableSelfSignUpEndpoint)) {
-            isSelfSignUpEPAvailable = Boolean.valueOf(enableSelfSignUpEndpoint);
-        } else {
-            isSelfSignUpEPAvailable = isSelfSignUpEPAvailable();
-        }
-
-        if (isRecoveryEPAvailable || isSelfSignUpEPAvailable) {
+        if (isUsernameRecoveryEnabledInTenant || isSelfSignUpEnabledInTenant) {
             String scheme = request.getScheme();
             String serverName = request.getServerName();
             int serverPort = request.getServerPort();
@@ -184,7 +183,7 @@
         }
     %>
 
-    <% if (isSelfSignUpEPAvailable) { %>
+    <% if (isUsernameRecoveryEnabledInTenant) { %>
         <div class="field">
             <a id="usernameRecoverLink" href="<%=getRecoverAccountUrl(identityMgtEndpointContext, urlEncodedURL, true, urlParameters)%>">
                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "forgot.username.password")%>
@@ -195,7 +194,7 @@
 
     <div class="ui two column stackable grid">
         <div class="column align-left buttons">
-            <% if (isRecoveryEPAvailable) { %>
+            <% if (isSelfSignUpEnabledInTenant) { %>
             <input
                 type="button"
                 onclick="window.location.href='<%=getRegistrationUrl(accountRegistrationEndpointURL, urlEncodedURL, urlParameters)%>';"


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/13615

The identifier first login is showing username recovery config and self-registration config even if it is not enabled. This is because, the identifier first JSP page is using some older api. So we need to use  preference retrieval client to get the status of the self-registration and user recovery configs using the tenant.

When self-registration or user-recovery is not enabled, the UI will look like below
<img width="580" alt="Screenshot 2022-05-13 at 16 03 40" src="https://user-images.githubusercontent.com/17597293/168266637-5694c020-5082-48af-9ea4-352a05d8d614.png">

When username recovery is enabled


<img width="738" alt="Screenshot 2022-05-13 at 16 01 35" src="https://user-images.githubusercontent.com/17597293/168266651-0ea16c7d-13c4-43d7-8443-1725de523581.png">

### Purpose
> Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. Remove this placeholder when you're editing.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
