### PR TITLE
fix(applications): add a default templateId for application

### DIFF
--- a/apps/console/src/features/applications/components/meta/inbound-protocols.meta.ts
+++ b/apps/console/src/features/applications/components/meta/inbound-protocols.meta.ts
@@ -16,7 +16,15 @@
  * under the License.
  */
 
+import { ApplicationManagementConstants } from "../../constants";
 import { AuthProtocolMetaListItemInterface, SAMLConfigModes, SupportedAuthProtocolTypes } from "../../models";
+
+export const InboundProtocolDefaultFallbackTemplates = new Map<string, string>([
+    [ "passivests", ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS ],
+    [ "openid", ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC ],
+    [ "oauth2", ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC ],
+    [ "samlsso", ApplicationManagementConstants.CUSTOM_APPLICATION_SAML ]
+]);
 
 export const InboundProtocolsMeta: AuthProtocolMetaListItemInterface[] = [
     {
@@ -66,8 +74,8 @@ export const InboundProtocolsMeta: AuthProtocolMetaListItemInterface[] = [
  */
 export const SupportedAuthProtocolTypeDisplayNames = {
     [ SupportedAuthProtocolTypes.SAML ]: "SAML",
-    [ SupportedAuthProtocolTypes.OIDC ] : "OpenID Connect",
-    [ SupportedAuthProtocolTypes.OAUTH2_OIDC ] : "OAuth2.0/OpenID Connect",
+    [ SupportedAuthProtocolTypes.OIDC ]: "OpenID Connect",
+    [ SupportedAuthProtocolTypes.OAUTH2_OIDC ]: "OAuth2.0/OpenID Connect",
     [ SupportedAuthProtocolTypes.WS_FEDERATION ]: "Passive STS",
     [ SupportedAuthProtocolTypes.WS_TRUST ]: "WS-Trust",
     [ SupportedAuthProtocolTypes.CUSTOM ]: "Custom"
@@ -78,10 +86,10 @@ export const SupportedAuthProtocolTypeDisplayNames = {
  */
 export const SupportedAuthProtocolTypeDescriptions = {
     [ SupportedAuthProtocolTypes.SAML ]: "Open-standard for authentication and authorization.",
-    [ SupportedAuthProtocolTypes.OIDC ] : "Authentication layer on top of OAuth 2.0",
+    [ SupportedAuthProtocolTypes.OIDC ]: "Authentication layer on top of OAuth 2.0",
     [ SupportedAuthProtocolTypes.WS_FEDERATION ]: "Enable STS in a web browser.",
     [ SupportedAuthProtocolTypes.WS_TRUST ]: "Standard that provides extensions to WS-Security.",
-    [ SupportedAuthProtocolTypes. CUSTOM ]: "Custom protocol."
+    [ SupportedAuthProtocolTypes.CUSTOM ]: "Custom protocol."
 };
 
 
@@ -89,7 +97,7 @@ export const SupportedAuthProtocolTypeDescriptions = {
  * SAML configuration mode display name mapping.
  */
 export const SAMLConfigurationDisplayNames = {
-    [SAMLConfigModes.MANUAL]: "Manual",
-    [SAMLConfigModes.META_FILE]: "File Based",
-    [SAMLConfigModes.META_URL]: "URL Based"
+    [ SAMLConfigModes.MANUAL ]: "Manual",
+    [ SAMLConfigModes.META_FILE ]: "File Based",
+    [ SAMLConfigModes.META_URL ]: "URL Based"
 };

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -224,6 +224,18 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             return;
         }
 
+        /**
+         * If there's no application templateId in the application model,
+         * then we manually bind a templateId. You may ask why templateId is
+         * null at this point? Well, one reason is that, if you create an
+         * application via the API, the templateId is an optional property
+         * in the model. So, if someone creates one without it, we don't have
+         * a template to bootstrap the model.
+         */
+        if (!application?.templateId) {
+            application.templateId = ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC;
+        }
+
         let template = applicationTemplates.find((template) => template.id === application.templateId);
 
         if (application.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -39,7 +39,7 @@ import {
     toggleHelpPanelVisibility
 } from "../../core";
 import { getApplicationDetails } from "../api";
-import { EditApplication } from "../components";
+import { EditApplication, InboundProtocolDefaultFallbackTemplates } from "../components";
 import { ApplicationManagementConstants } from "../constants";
 import CustomApplicationTemplate
     from "../data/application-templates/templates/custom-application/custom-application.json";
@@ -194,8 +194,8 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
 
         if (!application
             || !(applicationTemplates
-            && applicationTemplates instanceof Array
-            && applicationTemplates.length > 0)) {
+                && applicationTemplates instanceof Array
+                && applicationTemplates.length > 0)) {
 
             /**
              * What's this?
@@ -224,28 +224,40 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             return;
         }
 
+        determineApplicationTemplate();
+
+    }, [ applicationTemplates, application ]);
+
+    useEffect(() => {
+
         /**
-         * If there's no application templateId in the application model,
-         * then we manually bind a templateId. You may ask why templateId is
-         * null at this point? Well, one reason is that, if you create an
-         * application via the API, the templateId is an optional property
-         * in the model. So, if someone creates one without it, we don't have
-         * a template to bootstrap the model.
+         * If there's no application {@link ApplicationInterface.templateId}
+         * in the application instance, then we manually bind a templateId. You
+         * may ask why templateId is null at this point? Well, one reason
+         * is that, if you create an application via the API, the templateId
+         * is an optional property in the model instance.
+         *
+         *      So, if someone creates one without it, we don't have a template
+         * to bootstrap the model. When that happens the edit view will not
+         * work properly.
+         *
+         * We have added a mapping for application's inbound protocol
+         * {@link InboundProtocolDefaultFallbackTemplates} to pick a default
+         * template if none is present. One caveat is that, if we couldn't
+         * find any template from the fallback mapping, we always assign
+         * {@link ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC} to it.
+         * Additionally {@see InboundFormFactory}.
          */
         if (!application?.templateId) {
-            application.templateId = ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC;
+            if (application.inboundProtocols?.length > 0) {
+                application.templateId = InboundProtocolDefaultFallbackTemplates.get(
+                    application.inboundProtocols[ 0 /*We pick the first*/ ].type
+                ) ?? ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC;
+                determineApplicationTemplate();
+            }
         }
 
-        let template = applicationTemplates.find((template) => template.id === application.templateId);
-
-        if (application.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
-            || application.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_SAML
-            || application.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS) {
-            template = applicationTemplates.find((template) => template.id === CustomApplicationTemplate.id );
-        }
-
-        setApplicationTemplate(template);
-    }, [ applicationTemplates, application ]);
+    }, [ isApplicationRequestLoading, application ]);
 
     /**
      * Push to 404 if application edit feature is disabled.
@@ -255,7 +267,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             return;
         }
 
-        if(!isFeatureEnabled(featureConfig.applications,
+        if (!isFeatureEnabled(featureConfig.applications,
             ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT"))) {
 
             history.push(AppConstants.getPaths().get("PAGE_NOT_FOUND"));
@@ -280,9 +292,23 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
         dispatch(
             setHelpPanelDocsContentURL(editApplicationDocs[
                 ApplicationManagementConstants.APPLICATION_TEMPLATE_DOC_MAPPING
-                    .get(applicationTemplate.id) ]?.[ApplicationManagementConstants.APPLICATION_DOCS_OVERVIEW])
+                    .get(applicationTemplate.id) ]?.[ ApplicationManagementConstants.APPLICATION_DOCS_OVERVIEW ])
         );
     }, [ applicationTemplate, helpPanelDocStructure ]);
+
+    const determineApplicationTemplate = () => {
+
+        let template = applicationTemplates.find((template) => template.id === application.templateId);
+
+        if (application.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
+            || application.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_SAML
+            || application.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS) {
+            template = applicationTemplates.find((template) => template.id === CustomApplicationTemplate.id);
+        }
+
+        setApplicationTemplate(template);
+
+    };
 
     /**
      * Retrieves application details from the API.
@@ -366,9 +392,9 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
         }
 
         if (inboundProtocolList.length === 1
-            && inboundProtocolList.includes(SupportedAuthProtocolTypes.OIDC)
-            && inboundProtocolConfigs
-            && inboundProtocolConfigs[ SupportedAuthProtocolTypes.OIDC ]) {
+                && inboundProtocolList.includes(SupportedAuthProtocolTypes.OIDC)
+                && inboundProtocolConfigs
+                && inboundProtocolConfigs[ SupportedAuthProtocolTypes.OIDC ]) {
 
             if (inboundProtocolConfigs[ SupportedAuthProtocolTypes.OIDC ].state === State.REVOKED) {
 


### PR DESCRIPTION
### Purpose
Anyone creating apps directly through the Application API or DCR API will not have `templateIds`. Therefore, we bind a default application `templateId` for the application. We are using a custom application template for it (`custom-application-oidc`).

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
