### PR TITLE
Add file watchers error and resolution to troubleshooting

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -5,9 +5,9 @@ Look through here if you come across any issue.
 ✨ If your issues isn't here and you were able to figure a solution, please consider contribute to the guide.
 
 * [Node](#node)
-  * [Dev Server Failures](#dev-server-failures)
+    * [Dev Server Failures](#dev-server-failures)
 * [Maven](#maven)
-  * [Build Failures](#build-failures)
+    * [Build Failures](#build-failures)
 
 ## Node
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,10 +4,10 @@ Look through here if you come across any issue.
 
 ✨ If your issues isn't here and you were able to figure a solution, please consider contribute to the guide.
 
-- [Node](#node)
-  - [Dev Server Failures](#dev-server-failures)
-- [Maven](#maven)
-  - [Build Failures](#build-failures)
+* [Node](#node)
+  * [Dev Server Failures](#dev-server-failures)
+* [Maven](#maven)
+  * [Build Failures](#build-failures)
 
 ## Node
 
@@ -15,11 +15,13 @@ Look through here if you come across any issue.
 
 #### File watchers exceed error
 
-- If you are getting 'Error: ENOSPC: System limit for number of file watchers reached' error in ubuntu, you need to increase the amount of max_user_watches in system file.
-- Use 'sudo nano /etc/sysctl.conf' to access the file.
-- Then add 'fs.inotify.max_user_watches = 5242881' at the end of the file.
-- Next save the file and exit.
-- Finally use 'sudo sysctl -p' to apply changes.
+- Error: ENOSPC: System limit for number of file watchers reached
+- Steps to resolve:
+    - Need to increase the amount of max_user_watches in system file.
+    - Use 'sudo nano /etc/sysctl.conf' to access the file.
+    - Then add 'fs.inotify.max_user_watches = 5242881' at the end of the file.
+    - Next save the file and exit.
+    - Finally use 'sudo sysctl -p' to apply changes.
 
 ## Maven
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,16 +4,22 @@ Look through here if you come across any issue.
 
 ✨ If your issues isn't here and you were able to figure a solution, please consider contribute to the guide.
 
-* [Node](#node)
-    * [Dev Server Failures](#dev-server-failures)
-* [Maven](#maven)
-    * [Build Failures](#build-failures)
+- [Node](#node)
+  - [Dev Server Failures](#dev-server-failures)
+- [Maven](#maven)
+  - [Build Failures](#build-failures)
 
 ## Node
 
 ### Dev Server Failures
 
 #### File watchers exceed error
+
+- If you are getting 'Error: ENOSPC: System limit for number of file watchers reached' error in ubuntu, you need to increase the amount of max_user_watches in system file.
+- Use 'sudo nano /etc/sysctl.conf' to access the file.
+- Then add 'fs.inotify.max_user_watches = 5242881' at the end of the file.
+- Next save the file and exit.
+- Finally use 'sudo sysctl -p' to apply changes.
 
 ## Maven
 


### PR DESCRIPTION
### Purpose
> This pull request explains the 'Error: ENOSPC: System limit for number of file watchers reached' error in ubuntu and how to solve it by increasing max_user_watches

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on final implementation.
- [ ] Documentation provided. (Add links if there's any)
- [ ] Unit tests provided. (Add links if there's any)
- [ ] Integration tests provided. (Add links if there's any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
