### PR TITLE
fix(react-components): disable assertion on confirmation

### DIFF
--- a/modules/react-components/src/components/modal/confirmation-modal/confirmation-modal.tsx
+++ b/modules/react-components/src/components/modal/confirmation-modal/confirmation-modal.tsx
@@ -141,6 +141,7 @@ export const ConfirmationModal: FunctionComponent<ConfirmationModalPropsInterfac
 
         const [ assertionInput, setAssertionInput ] = useState<string>("");
         const [ confirmed, setConfirmed ] = useState<boolean>(false);
+        const [ assertionDisabled, setAssertionDisabled ] = useState<boolean>(false);
 
         /**
      * Called when the assertion input changes.
@@ -171,6 +172,7 @@ export const ConfirmationModal: FunctionComponent<ConfirmationModalPropsInterfac
      */
         const handlePrimaryActionClick = (e: MouseEvent<HTMLButtonElement>) => {
             setAssertionInput("");
+            setAssertionDisabled(true);
             setConfirmed(false);
             onPrimaryActionClick(e);
         };
@@ -311,6 +313,7 @@ export const ConfirmationModal: FunctionComponent<ConfirmationModalPropsInterfac
                                 : assertionHint
                         }
                         <Input
+                            disabled={ assertionDisabled }
                             data-componentid={ `${ componentId }-assertion-input` }
                             data-testid={ `${ testId }-assertion-input` }
                             onChange={ (e: ChangeEvent<HTMLInputElement>): void => setAssertionInput(e.target?.value) }
@@ -327,6 +330,7 @@ export const ConfirmationModal: FunctionComponent<ConfirmationModalPropsInterfac
 
                 return (
                     <Checkbox
+                        disabled={ assertionDisabled }
                         label={ assertionHint }
                         checked={ confirmed }
                         onChange={ (): void => setConfirmed(!confirmed) }

--- a/modules/react-components/src/components/modal/confirmation-modal/confirmation-modal.tsx
+++ b/modules/react-components/src/components/modal/confirmation-modal/confirmation-modal.tsx
@@ -136,12 +136,19 @@ export const ConfirmationModal: FunctionComponent<ConfirmationModalPropsInterfac
             primaryActionLoading,
             [ "data-componentid" ]: componentId,
             [ "data-testid" ]: testId,
+            open,
             ...rest
         } = props;
 
         const [ assertionInput, setAssertionInput ] = useState<string>("");
         const [ confirmed, setConfirmed ] = useState<boolean>(false);
         const [ assertionDisabled, setAssertionDisabled ] = useState<boolean>(false);
+
+        useEffect(() => {
+            if (open) {
+                setAssertionDisabled(false);
+            }
+        }, [ open ]);
 
         /**
      * Called when the assertion input changes.
@@ -347,6 +354,7 @@ export const ConfirmationModal: FunctionComponent<ConfirmationModalPropsInterfac
             <Modal
                 data-componentid={ componentId }
                 data-testid={ testId }
+                open={ open }
                 { ...rest }
                 className={ classes }
             >


### PR DESCRIPTION
### Purpose
> Disables the assertion condition field on modal confirmation.

### Related Issues
- Issue `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Related PRs
- Related PR `#1` or (None)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
