### PR TITLE
Adding page to capture org name at the enterprise login

### DIFF
--- a/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
+++ b/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
@@ -347,6 +347,11 @@
         <url-pattern>/magic_link_notification.do</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <servlet-name>org_name.do</servlet-name>
+        <jsp-file>/org_name.jsp</jsp-file>
+    </servlet>
+
     <servlet-mapping>
         <servlet-name>totp_enroll.do</servlet-name>
         <url-pattern>/totp_enroll.do</url-pattern>
@@ -385,6 +390,11 @@
     <servlet-mapping>
         <servlet-name>email_otp_error.do</servlet-name>
         <url-pattern>/email_otp_error.do</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org_name.do</servlet-name>
+        <url-pattern>/org_name.do</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -102,24 +102,24 @@
 
                     <div id="alertDiv"></div>
 
-                    <div class="segment-form">
-                        <form class="ui large form" id="pin_form" name="pin_form" action="<%=commonauthURL%>" method="GET">
-                            <div class="ui segment">
-                                <p>Name of the Organization:</p>
-                                <input type="text" id='ORG_NAME' name="org" size='30'/>
-                                <input id="idp" name="idp" type="hidden" value="<%=Encode.forHtmlAttribute(idp)%>"/>
-                                <input id="authenticator" name="authenticator" type="hidden" value="<%=Encode.forHtmlAttribute(authenticator)%>"/>
-				                <input id="sessionDataKey" name="sessionDataKey" type="hidden" value="<%=Encode.forHtmlAttribute(sessionDataKey)%>"/>
-                                <div class="ui divider hidden"></div>
-                                <div class="align-right buttons">
-                                    <button type="submit" class="ui primary large button">
-                                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "Submit")%>
-                                    </button>
-                                </div>
 
+                    <form class="ui large form" id="pin_form" name="pin_form" action="<%=commonauthURL%>" method="GET">
+                        <div class="ui segment">
+                            <p>Name of the Organization:</p>
+                            <input type="text" id='ORG_NAME' name="org" size='30'/>
+                            <input id="idp" name="idp" type="hidden" value="<%=Encode.forHtmlAttribute(idp)%>"/>
+                            <input id="authenticator" name="authenticator" type="hidden" value="<%=Encode.forHtmlAttribute(authenticator)%>"/>
+                            <input id="sessionDataKey" name="sessionDataKey" type="hidden" value="<%=Encode.forHtmlAttribute(sessionDataKey)%>"/>
+                            <div class="ui divider hidden"></div>
+                            <div class="align-right buttons">
+                                <button type="submit" class="ui primary large button">
+                                    <%=AuthenticationEndpointUtil.i18n(resourceBundle, "Submit")%>
+                                </button>
                             </div>
-                        </form>
-                    </div>
+
+                        </div>
+                    </form>
+
                 </div>
             </div>
         </main>

--- a/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -151,22 +151,5 @@
         <%
             }
         %>
-
-        <!-- <script type="text/javascript">
-            $(document).ready(function() {
-                $('#update').click(function() {
-                    var orgName = document
-                            .getElementById("ORG_NAME").value;
-                    if (orgName == "") {
-                        document.getElementById('alertDiv').innerHTML
-                            = '<div id="error-msg" class="ui negative message"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.enter.email")%></div>'
-                              +'<div class="ui divider hidden"></div>';
-                    } else {
-                        $('#pin_form').submit();
-                    }
-                });
-            });
-
-        </script> -->
     </body>
 </html>

--- a/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -27,7 +27,8 @@
 
 <%
 
-    String fidp = request.getParameter("fidp");
+    String idp = request.getParameter("idp");
+    String authenticator = request.getParameter("authenticator");
     String sessionDataKey = request.getParameter(Constants.SESSION_DATA_KEY);
     
     String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
@@ -106,7 +107,8 @@
                             <div class="ui segment">
                                 <p>Name of the Organization:</p>
                                 <input type="text" id='ORG_NAME' name="org" size='30'/>
-                                <input id="fidp" name="fidp" type="hidden" value="<%=Encode.forHtmlAttribute(fidp)%>"/>
+                                <input id="idp" name="idp" type="hidden" value="<%=Encode.forHtmlAttribute(idp)%>"/>
+                                <input id="authenticator" name="authenticator" type="hidden" value="<%=Encode.forHtmlAttribute(authenticator)%>"/>
 				                <input id="sessionDataKey" name="sessionDataKey" type="hidden" value="<%=Encode.forHtmlAttribute(sessionDataKey)%>"/>
                                 <div class="ui divider hidden"></div>
                                 <div class="align-right buttons">

--- a/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
   ~
   ~ WSO2 Inc. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -1,0 +1,170 @@
+<%--
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  --%>
+
+<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="java.io.File" %>
+<%@ page import="java.util.Map" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ include file="includes/localize.jsp" %>
+<%@ include file="includes/init-url.jsp" %>
+
+<%
+
+    String fidp = request.getParameter("fidp");
+    String sessionDataKey = request.getParameter(Constants.SESSION_DATA_KEY);
+    
+    String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
+    String authenticationFailed = "false";
+    
+    if (Boolean.parseBoolean(request.getParameter(Constants.AUTH_FAILURE))) {
+        authenticationFailed = "true";
+        
+        if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
+            errorMessage = request.getParameter(Constants.AUTH_FAILURE_MSG);
+            
+            if (errorMessage.equalsIgnoreCase("authentication.fail.message")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
+            }
+        }
+    }
+%>
+
+<html>
+    <head>
+        <!-- header -->
+        <%
+            File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
+            if (headerFile.exists()) {
+        %>
+                <jsp:include page="extensions/header.jsp"/>
+        <%
+            } else {
+        %>
+                <jsp:include page="includes/header.jsp"/>
+        <%
+            }
+        %>
+
+        <!--[if lt IE 9]>
+        <script src="js/html5shiv.min.js"></script>
+        <script src="js/respond.min.js"></script>
+        <![endif]-->
+    </head>
+
+    <body class="login-portal layout authentication-portal-layout">
+        <main class="center-segment">
+            <div class="ui container medium center aligned middle aligned">
+                <!-- product-title -->
+                <%
+                    File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                    if (productTitleFile.exists()) {
+                %>
+                        <jsp:include page="extensions/product-title.jsp"/>
+                <%
+                    } else {
+                %>
+                        <jsp:include page="includes/product-title.jsp"/>
+                <%
+                    }
+                %>
+
+                <div class="ui segment">
+                    <!-- page content -->
+                    <h2>Sign In with Enterprise Login</h2>
+                    <div class="ui divider hidden"></div>
+
+                    <%
+                        if ("true".equals(authenticationFailed)) {
+                    %>
+                            <div class="ui negative message" id="failed-msg"><%=Encode.forHtmlContent(errorMessage)%></div>
+                            <div class="ui divider hidden"></div>
+                    <%
+                        }
+                    %>
+
+                    <div id="alertDiv"></div>
+
+                    <div class="segment-form">
+                        <form class="ui large form" id="pin_form" name="pin_form" action="<%=commonauthURL%>" method="GET">
+                            <div class="ui segment">
+                                <p>Name of the Organization:</p>
+                                <input type="text" id='ORG_NAME' name="org" size='30'/>
+                                <input id="fidp" name="fidp" type="hidden" value="<%=Encode.forHtmlAttribute(fidp)%>"/>
+				                <input id="sessionDataKey" name="sessionDataKey" type="hidden" value="<%=Encode.forHtmlAttribute(sessionDataKey)%>"/>
+                                <div class="ui divider hidden"></div>
+                                <div class="align-right buttons">
+                                    <button type="submit" class="ui primary large button">
+                                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "Submit")%>
+                                    </button>
+                                </div>
+
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </main>
+
+        <!-- product-footer -->
+        <%
+            File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+            if (productFooterFile.exists()) {
+        %>
+                <jsp:include page="extensions/product-footer.jsp"/>
+        <%
+            } else {
+        %>
+                <jsp:include page="includes/product-footer.jsp"/>
+        <%
+            }
+        %>
+
+        <!-- footer -->
+        <%
+            File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
+            if (footerFile.exists()) {
+        %>
+                <jsp:include page="extensions/footer.jsp"/>
+        <%
+            } else {
+        %>
+                <jsp:include page="includes/footer.jsp"/>
+        <%
+            }
+        %>
+
+        <!-- <script type="text/javascript">
+            $(document).ready(function() {
+                $('#update').click(function() {
+                    var orgName = document
+                            .getElementById("ORG_NAME").value;
+                    if (orgName == "") {
+                        document.getElementById('alertDiv').innerHTML
+                            = '<div id="error-msg" class="ui negative message"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.enter.email")%></div>'
+                              +'<div class="ui divider hidden"></div>';
+                    } else {
+                        $('#pin_form').submit();
+                    }
+                });
+            });
+
+        </script> -->
+    </body>
+</html>


### PR DESCRIPTION
### Purpose
Adding page / servlet endpoint to capture the organization name when using enterprise login. Implemented as part of the Organization login https://github.com/wso2/product-is/issues/13731. 

The business application can be shared to an organization in the hierarchy. When user from that child organization wants to login to the application, user will have to provide the organization name to proceed to the correct login flow. This implementation provides the interface to request the organization name from the user.

Sample screen:
![image](https://user-images.githubusercontent.com/6595027/174715642-fa9eb12f-d430-4310-9890-d0ff6c2e3d2f.png)
