### PR TITLE
Validate callback URL against recovery callback URL regex in error.jsp

### DIFF
--- a/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/error.jsp
@@ -19,8 +19,11 @@
 
 <%@ page isErrorPage="true" %>
 <%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.wso2.carbon.identity.event.IdentityEventException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.recovery.IdentityRecoveryConstants" %>
+<%@ page import="org.wso2.carbon.identity.recovery.util.Utils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.net.URISyntaxException" %>
 <jsp:directive.include file="includes/localize.jsp"/>
@@ -28,8 +31,27 @@
 <%
     String errorMsg = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorMsg"));
     String errorCode = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorCode"));
+    String invalidConfirmationErrorCode = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode();
     String callback = request.getParameter("callback");
     boolean isValidCallback = true;
+
+    if (invalidConfirmationErrorCode.equals(errorCode)) {
+        String tenantDomain = StringUtils.EMPTY;
+        if (StringUtils.isNotBlank(request.getParameter("tenantdomain"))){
+            tenantDomain = request.getParameter("tenantdomain").trim();
+        } else if (StringUtils.isNotBlank(request.getParameter("tenantDomain"))){
+            tenantDomain = request.getParameter("tenantDomain").trim();
+        }
+        try {
+            if (StringUtils.isNotBlank(callback) && !Utils.validateCallbackURL
+                (callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig.RECOVERY_CALLBACK_REGEX)) {
+                    isValidCallback = false;
+                }
+        } catch (IdentityEventException e) {
+            isValidCallback = false;
+        }
+    }
+
     try {
         IdentityManagementEndpointUtil.getURLEncodedCallback(callback);
     } catch (URISyntaxException e) {
@@ -82,14 +104,12 @@
                             }
                         %>
                     </div>
-    
-                    <% if (isValidCallback) { %>
+
                     <div id="action-buttons" class="buttons">
-                        <a href="javascript:goBack()" class="ui button primary button">
+                        <a id = "go-back-button" href="javascript:goBack()" class="ui button primary button">
                             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Go back")%>
                         </a>
                     </div>
-                    <% } %>
                 </div>
             </div>
         </div>
@@ -112,18 +132,22 @@
             if ("<%=StringUtils.isEmpty(callback)%>" === "true") {
                 $("#action-buttons").hide();
             }
+            if ("<%=isValidCallback%>" === "false") {
+                $("#go-back-button").addClass("disabled");
+                $("#action-buttons").attr("title", "Request has an invalid callback URL.");
+            }
         });
 
         <% if (isValidCallback) { %>
         function goBack() {
 
             var errorCodeFromParams = "<%=errorCode%>";
-            var invalidConfirmationErrorCode = "<%=IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode()%>";
+            var invalidConfirmationErrorCode = "<%=invalidConfirmationErrorCode%>";
 
             // Check if the error is related to the confirmation code being invalid.
             // If so, navigate the users to the URL defined in `callback` URL param.
             if (errorCodeFromParams === invalidConfirmationErrorCode) {
-                window.location.href = "<%=callback%>";
+                window.location.href = "<%=Encode.forHtmlAttribute(callback)%>";
 
                 return;
             }


### PR DESCRIPTION
## Purpose
> Validate error page callback URL with recovery callback regex when invalid confirmation code is submitted. 

If the callback came from the URL is valid error page has an active `go back` button as follows.

![Screenshot from 2022-06-09 17-42-57](https://user-images.githubusercontent.com/36252628/172844112-231c6bce-4219-4aa7-8078-44bc4316650d.png)

If the callback came from the URL is not valid `go back` button on the error page is disabled and will show the reason for the button being disabled on hovering as follows.

![Screenshot from 2022-06-09 17-42-51](https://user-images.githubusercontent.com/36252628/172844147-d06906fa-f6f3-4d27-84db-131f1e2a632f.png)

