### PR TITLE
Fixes in settings tab of IdPs created using the Management Console

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -135,7 +135,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
      * @param values - Form values.
      */
     const handleAuthenticatorConfigFormSubmit = (values: FederatedAuthenticatorListItemInterface, 
-        isDefaultAuthSet = true): void => {
+        isDefaultAuthSet: boolean = true): void => {
 
         addCallbackUrl(values);
         setIsPageLoading(true);

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -134,7 +134,8 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
      *
      * @param values - Form values.
      */
-    const handleAuthenticatorConfigFormSubmit = (values: FederatedAuthenticatorListItemInterface): void => {
+    const handleAuthenticatorConfigFormSubmit = (values: FederatedAuthenticatorListItemInterface, 
+        isDefaultAuthSet = true): void => {
 
         addCallbackUrl(values);
         setIsPageLoading(true);
@@ -167,15 +168,17 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
 
         updateFederatedAuthenticator(identityProvider.id, values)
             .then(() => {
-                dispatch(addAlert({
-                    description: t("console:develop.features.authenticationProvider" +
-                        ".notifications.updateFederatedAuthenticator." +
-                        "success.description"),
-                    level: AlertLevels.SUCCESS,
-                    message: t("console:develop.features.authenticationProvider.notifications." +
-                        "updateFederatedAuthenticator." +
-                        "success.message")
-                }));
+                if (isDefaultAuthSet) {
+                    dispatch(addAlert({
+                        description: t("console:develop.features.authenticationProvider" +
+                            ".notifications.updateFederatedAuthenticator." +
+                            "success.description"),
+                        level: AlertLevels.SUCCESS,
+                        message: t("console:develop.features.authenticationProvider.notifications." +
+                            "updateFederatedAuthenticator." +
+                            "success.message")
+                    }));
+                }
                 onUpdate(identityProvider.id);
             })
             .catch((error) => {
@@ -205,7 +208,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
             })
             .finally(() => {
                 setIsSubmitting(false);
-             });
+            });
     };
 
     /**
@@ -303,7 +306,12 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                 if (!identityProvider.federatedAuthenticators.defaultAuthenticatorId &&
                     identityProvider.federatedAuthenticators.authenticators.length > 0) {
                     authenticator.isDefault = true;
-                    handleAuthenticatorConfigFormSubmit(authenticator);
+
+                    const isDefaultAuthIdSet = Boolean(
+                        identityProvider?.federatedAuthenticators?.defaultAuthenticatorId
+                    );
+
+                    handleAuthenticatorConfigFormSubmit(authenticator, isDefaultAuthIdSet);
                 }
                 setAvailableAuthenticators(res);
                 setIsPageLoading(false);
@@ -593,6 +601,10 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     identityProvider.federatedAuthenticators.defaultAuthenticatorId === authenticator.id
                 ));
 
+            if (!authenticator) {
+                return;
+            }
+                
             // TODO: Need to update below values in the OIDC authenticator metadata API
             // Set additional meta data if the authenticator is OIDC
             if (authenticator.id === IdentityProviderManagementConstants.OIDC_AUTHENTICATOR_ID) {


### PR DESCRIPTION
### Purpose
> - Fix to the page crashing issue when navigating to the `Settings` tab of an IdP created using the Management Console when accessed for the first time. 
> - Hiding the success message upon retrieval of a default authenticator ID in the instance it is not set when creating the IdP using the Management Console.

### Related Issues
- Closes https://github.com/wso2/product-is/issues/13871

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
