### PR TITLE
Fix Error Page Not Found Issue

### DIFF
--- a/apps/authentication-portal/src/main/webapp/samlsso_notification.jsp
+++ b/apps/authentication-portal/src/main/webapp/samlsso_notification.jsp
@@ -86,10 +86,12 @@
                 <h2><%=AuthenticationEndpointUtil.i18n(resourceBundle, "saml.sso")%></h2>
                 <h4><%=AuthenticationEndpointUtil.i18n(resourceBundle, errorStat)%></h4>
                 <p><%=AuthenticationEndpointUtil.i18n(resourceBundle, errorMsg)%></p>
-                <div class="ui divider hidden"></div>
-                <jsp:include page="includes/error-tracking-reference.jsp">
-                    <jsp:param name="align" value="centered"/>
-                </jsp:include>
+                <% if (new File(getServletContext().getRealPath("includes/error-tracking-reference.jsp")).exists()) { %>
+                    <div class="ui divider hidden"></div>
+                    <jsp:include page="includes/error-tracking-reference.jsp">
+                        <jsp:param name="align" value="centered"/>
+                    </jsp:include>
+                <% } %>
             </div>
         </div>
     </main>


### PR DESCRIPTION
This PR adds the saml error page in a compatible format to be added to the product-IS. Currently, the product-is cannot find the `error-tracking-reference.jsp` page and throws an exception.

Related PR: https://github.com/wso2/identity-apps/pull/3054