### PR TITLE
Disable Magic Link authenticator for SPAs.

### DIFF
--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -408,7 +408,9 @@
         "gravatarConfig": {
             "fallback": "404"
         },
-        "hiddenAuthenticators": [],
+        "hiddenAuthenticators": [
+            "MagicLinkAuthenticator"
+        ],
         "i18nConfigs": {
             "showLanguageSwitcher": false,
             "langAutoDetectEnabled":false


### PR DESCRIPTION
### Purpose
> Hide magic link authenticator from SPA sign in methods. A configuration is added to disable the feature.

### Related Issues
- https://github.com/wso2/product-is/issues/13991

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
