### PR TITLE
Fix the subheading hiding issue when it exceeds the screen width

### DIFF
--- a/modules/theme/src/themes/default/elements/header.overrides
+++ b/modules/theme/src/themes/default/elements/header.overrides
@@ -67,7 +67,7 @@ h6.ui.header .sub.header {
             margin-top: 2px;
             color: @dustyGray;
             text-overflow: ellipsis;
-            white-space: nowrap;
+            white-space: normal;
             overflow: hidden;
         }
 


### PR DESCRIPTION
### Purpose
> This PR fix the hiding of the subheading when it exceeds the screen width and allow the heading to go to next line.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
