### PR TITLE
Hide tenanted My Account URL

### DIFF
--- a/apps/console/src/extensions/configs/application.tsx
+++ b/apps/console/src/extensions/configs/application.tsx
@@ -27,6 +27,7 @@ import {
 export const applicationConfig: ApplicationConfig = {
     advancedConfigurations: {
         showEnableAuthorization: true,
+        showMyAccount: false,
         showReturnAuthenticatedIdPs: true,
         showSaaS: true
     },

--- a/apps/console/src/extensions/configs/models/application.ts
+++ b/apps/console/src/extensions/configs/models/application.ts
@@ -27,6 +27,7 @@ import {
 export interface ApplicationConfig {
     advancedConfigurations: {
         showEnableAuthorization: boolean;
+        showMyAccount: boolean;
         showSaaS: boolean;
         showReturnAuthenticatedIdPs: boolean;
     };

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -53,6 +53,7 @@ import {
     PaginationProps,
     Popup
 } from "semantic-ui-react";
+import { applicationConfig } from "../../../extensions";
 import {
     AdvancedSearchWithBasicFilters,
     AppConstants,
@@ -292,7 +293,8 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
      * @return {React.ReactElement}
      */
     const renderTenantedMyAccountLink = (): ReactElement => {
-        if (AppConstants.getTenant() === AppConstants.getSuperTenant()) {
+        if (AppConstants.getTenant() === AppConstants.getSuperTenant() ||
+            !applicationConfig.advancedConfigurations.showMyAccount) {
             return null;
         }
 


### PR DESCRIPTION
### Purpose
> Hide the My Account URL from the Applications list page for tenanted users. 

### Related Issues
- https://github.com/wso2/product-is/issues/13395

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
