### PR TITLE
Group filtering adhering to userstore domain

### DIFF
--- a/apps/console/src/features/groups/models/groups.ts
+++ b/apps/console/src/features/groups/models/groups.ts
@@ -108,6 +108,7 @@ export interface GroupSCIMOperationsInterface {
  */
 export interface SearchGroupInterface {
     schemas: string[];
+    domain?: string;
     startIndex: number;
     filter: string;
 }

--- a/apps/console/src/features/groups/pages/groups.tsx
+++ b/apps/console/src/features/groups/pages/groups.tsx
@@ -233,13 +233,17 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     };
 
     const searchRoleListHandler = (searchQuery: string) => {
-        const searchData: SearchGroupInterface = {
+        let searchData: SearchGroupInterface = {
             filter: searchQuery,
             schemas: [
                 "urn:ietf:params:scim:api:messages:2.0:SearchRequest"
             ],
             startIndex: 1
         };
+
+        if(userStore) {
+            searchData = { ...searchData, domain: userStore };
+        }
 
         setSearchQuery(searchQuery);
 


### PR DESCRIPTION
### Purpose
> This PR will fix Group filtering in console is not adhering when the userstore is selected.

### Related Issues
https://github.com/wso2/product-is/issues/14093