### PR TITLE
Add fallback content for custom userstore manager type

### DIFF
--- a/apps/console/src/features/userstores/constants/user-store-constants.ts
+++ b/apps/console/src/features/userstores/constants/user-store-constants.ts
@@ -60,6 +60,8 @@ export class UserStoreManagementConstants {
  */
 export const JDBC = "JDBC";
 export const CONSUMER_USERSTORE_ID = "Q09OU1VNRVI";
+export const DEFAULT_USERSTORE_TYPE_IMAGE = "default";
+export const DEFAULT_DESCRIPTION_CUSTOM_USERSTORE = "This is a custom userstore manager implementation";
 
 export const USER_STORE_TYPE_DESCRIPTIONS = {
     ActiveDirectoryUserStoreManager: "Active Directory based userstore.",

--- a/apps/console/src/features/userstores/pages/userstores-templates.tsx
+++ b/apps/console/src/features/userstores/pages/userstores-templates.tsx
@@ -28,6 +28,8 @@ import { getAType, getUserstoreTypes } from "../api";
 import { AddUserStore } from "../components";
 import { getUserstoreTemplateIllustrations } from "../configs";
 import {
+    DEFAULT_DESCRIPTION_CUSTOM_USERSTORE,
+    DEFAULT_USERSTORE_TYPE_IMAGE,
     USERSTORE_TYPE_DISPLAY_NAMES,
     USERSTORE_TYPE_IMAGES,
     USER_STORE_TYPE_DESCRIPTIONS
@@ -91,7 +93,6 @@ const UserstoresTemplates: FunctionComponent<UserstoresTemplatesPageInterface> =
             const typeRequests: Promise<any>[] = response.map((type: TypeResponse) => {
                 return getAType(type.typeId, null);
             });
-
             const results: UserstoreType[] = await Promise.all(
                 typeRequests.map(response => response.catch(error => {
                     dispatch(addAlert({
@@ -109,6 +110,7 @@ const UserstoresTemplates: FunctionComponent<UserstoresTemplatesPageInterface> =
             const userstoreTypes: UserstoreTypeListItem[] = [];
             const uniqueUserstoreTypes: UserstoreTypeListItem[] = [];
             const rawUserstoreTypes: UserstoreType[] = [];
+
             results.forEach((type: UserstoreType) => {
                 if (type && !userstoresConfig.shouldShowUserstore(type.typeName)) {
                     rawUserstoreTypes.push(type);
@@ -125,11 +127,11 @@ const UserstoresTemplates: FunctionComponent<UserstoresTemplatesPageInterface> =
                     } else {
                         userstoreTypes.push(
                             {
-                                description: type.description
-                                    ?? USER_STORE_TYPE_DESCRIPTIONS[ type.typeName ],
+                                description: USER_STORE_TYPE_DESCRIPTIONS[ type.typeName ] 
+                                    ?? DEFAULT_DESCRIPTION_CUSTOM_USERSTORE,
                                 id: type.typeId,
-                                image: USERSTORE_TYPE_IMAGES[ type.typeName ],
-                                name: USERSTORE_TYPE_DISPLAY_NAMES[ type.typeName ]
+                                image: USERSTORE_TYPE_IMAGES[ type.typeName ] ?? DEFAULT_USERSTORE_TYPE_IMAGE,
+                                name: USERSTORE_TYPE_DISPLAY_NAMES[ type.typeName ] ?? type.typeName
                             }
                         );
                     }


### PR DESCRIPTION
### Purpose
> Added default label and description for custom userstore manager type.
<img width="1792" alt="Screenshot 2022-07-11 at 18 13 53" src="https://user-images.githubusercontent.com/67315176/178267537-eda8f374-b792-42b5-a143-948097e154fe.png">

### Related Issues
- Closes https://github.com/wso2/product-is/issues/10746

### Related PRs
- None

### Checklist
- [ ] 

e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
