### PR TITLE
Block deleting org-creator role from the FE

### DIFF
--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
@@ -16,12 +16,7 @@
  * under the License
  */
 
-import {
-    AlertInterface,
-    AlertLevels,
-    RolesInterface,
-    TestableComponentInterface
-} from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms, Validation } from "@wso2is/forms";
 import { ConfirmationModal, DangerZone, DangerZoneGroup, EmphasizedSegment } from "@wso2is/react-components";
@@ -32,6 +27,7 @@ import { Button, Divider, Form, Grid, InputOnChangeData } from "semantic-ui-reac
 import { AppConstants, AppState, SharedUserStoreConstants, SharedUserStoreUtils, history } from "../../../core";
 import { PRIMARY_USERSTORE_PROPERTY_VALUES } from "../../../userstores";
 import { deleteOrganizationRole, getOrganizationRoles, patchOrganizationRoleDetails } from "../../api";
+import { OrganizationRoleManagementConstants } from "../../constants";
 import { OrganizationInterface, OrganizationRoleInterface, PatchOrganizationRoleDataInterface } from "../../models";
 
 /**
@@ -362,7 +358,10 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
             </EmphasizedSegment>
             <Divider hidden />
             {
-                !isReadOnly && (
+                (
+                    !isReadOnly &&
+                    roleObject?.displayName !== OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME
+                ) && (
                     <DangerZoneGroup sectionHeader="Danger Zone">
                         <DangerZone
                             actionTitle={
@@ -389,8 +388,8 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
                             onActionClick={ () => setShowDeleteConfirmationModal(!showRoleDeleteConfirmation) }
                             data-testid={
                                 isGroup
-                                    ? `${ testId }-group-danger-zone`
-                                    : `${ testId }-role-danger-zone`
+                                    ? `${testId}-group-danger-zone`
+                                    : `${testId}-role-danger-zone`
                             }
                         />
                     </DangerZoneGroup>

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
@@ -388,8 +388,8 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
                             onActionClick={ () => setShowDeleteConfirmationModal(!showRoleDeleteConfirmation) }
                             data-testid={
                                 isGroup
-                                    ? `${testId}-group-danger-zone`
-                                    : `${testId}-role-danger-zone`
+                                    ? `${ testId }-group-danger-zone`
+                                    : `${ testId }-role-danger-zone`
                             }
                         />
                     </DangerZoneGroup>

--- a/apps/console/src/features/organizations/components/organization-role-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-role-list.tsx
@@ -313,12 +313,12 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
             },
             {
                 "data-testid": `${testId}-item-delete-button`,
-                hidden: () => {
+                hidden: (role: OrganizationRoleListItemInterface) => {
                     return !hasRequiredScopes(
                         featureConfig?.organizationsRoles,
                         featureConfig?.organizationsRoles?.scopes?.delete,
                         allowedScopes
-                    );
+                    ) || role.displayName === OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME;
                 },
                 icon: (): SemanticICONS => "trash alternate",
                 onClick: (e: SyntheticEvent, role: OrganizationRoleListItemInterface): void => {

--- a/apps/console/src/features/organizations/constants/organization-constants.ts
+++ b/apps/console/src/features/organizations/constants/organization-constants.ts
@@ -70,6 +70,8 @@ export class OrganizationRoleManagementConstants {
         .set("ORGANIZATION_ROLE_DELETE", "organization-roles.delete")
         .set("ORGANIZATION_ROLE_READ", "organization-roles.read");
 
+    public static readonly ORG_CREATOR_ROLE_NAME = "org-creator";
+
 }
 
 export const APPLICATION_DOMAIN = "Application/";


### PR DESCRIPTION
### Purpose
> This PR implements hiding the delete role actions from the UI for default organization creator role (org-creator)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
