### PR TITLE
Unifying user role management in both org view and root org view

### DIFF
--- a/apps/console/src/features/core/configs/routes.ts
+++ b/apps/console/src/features/core/configs/routes.ts
@@ -539,13 +539,13 @@ export const getAdminViewRoutes = (): RouteInterface[] => {
                         showOnSidePanel: true
                     },
                     {
-                        category: "console:manage.features.sidePanel.categories.organizations",
+                        category: "console:manage.features.sidePanel.categories.users",
                         children: [
                             {
                                 component: lazy(() => import("../../organizations/pages/organization-roles-edit")),
                                 exact: true,
                                 icon: {
-                                    icon: getSidePanelIcons().organization
+                                    icon: getSidePanelIcons().roles
                                 },
                                 id: "organization-roles-edit",
                                 name: "organization Roles Edit",
@@ -557,7 +557,7 @@ export const getAdminViewRoutes = (): RouteInterface[] => {
                         component: lazy(() => import("../../organizations/pages/organization-roles")),
                         exact: true,
                         icon: {
-                            icon: getSidePanelIcons().organization
+                            icon: getSidePanelIcons().roles
                         },
                         id: "organization-roles",
                         name: "Organization Roles",

--- a/apps/console/src/features/core/constants/app-constants.ts
+++ b/apps/console/src/features/core/constants/app-constants.ts
@@ -359,4 +359,14 @@ export class AppConstants {
         "organization-roles",
         "applications"
     ]
+
+    /**
+     * Route ids that are enabled in only for an organizations (Not allowed in root organization).
+     * @constant
+     * @type {string[]}
+     * @default
+     */
+    public static readonly ORGANIZATION_ONLY_ROUTES: string[] = [
+        "organization-roles"
+    ]
 }

--- a/apps/console/src/features/core/utils/route-utils.ts
+++ b/apps/console/src/features/core/utils/route-utils.ts
@@ -302,4 +302,8 @@ export class RouteUtils {
     public static filterOrganizationEnabledRoutes(routes: RouteInterface[]): RouteInterface[] {
         return routes.filter((route: RouteInterface) => AppConstants.ORGANIZATION_ENABLED_ROUTES.includes(route.id));
     }
+
+    public static filterOutOrganizationOnlyRoutes(routes: RouteInterface[]): RouteInterface[] {
+        return routes.filter((route: RouteInterface) => !AppConstants.ORGANIZATION_ONLY_ROUTES.includes(route.id));
+    }
 }

--- a/apps/console/src/views/admin.tsx
+++ b/apps/console/src/views/admin.tsx
@@ -143,10 +143,22 @@ export const AdminView: FunctionComponent<AdminViewPropsInterface> = (
 
     const getOrganizationEnabledRoutes = useCallback((): RouteInterface[] => {
         if (!OrganizationUtils.isRootOrganization(organization.organization)) {
-            return RouteUtils.filterOrganizationEnabledRoutes(getAdminViewRoutes());
+            const orgRoutes = RouteUtils.filterOrganizationEnabledRoutes(getAdminViewRoutes());
+
+            // Mapping the name of org roles to "Roles" to unify role management sub menu item in both organization view
+            // and root organization view.
+            return orgRoutes
+                .map((route: RouteInterface) => {
+                    if (route.id === "organization-roles") {
+                        route.name = "Roles";
+                    }
+
+                    return route;
+                });
         }
 
-        return getAdminViewRoutes();
+        // Remove the organization only routes from the admin view routes for root organizations.
+        return RouteUtils.filterOutOrganizationOnlyRoutes(getAdminViewRoutes());
     }, [ organization.organization ]);
 
     useEffect(() => {


### PR DESCRIPTION
### Purpose
> This PR implements the route and sub menu merging / unifying to organization roles view and native roles management view in organization & root organization context

Sub Organization View (Organization Roles shown in sub menu as Roles) - 
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/19621533/179122342-1e226bb3-88b7-4dcb-8342-da4da7b11891.png">


Root Organization View (Organization Roles sub menu item is hidden here) - 
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/19621533/179122308-906cd7b2-0ba7-4834-9f71-4749cec597ab.png">


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
