### PR TITLE
Add a config to show/hide organization switch dropdown

### DIFF
--- a/apps/console/src/extensions/configs/index.ts
+++ b/apps/console/src/extensions/configs/index.ts
@@ -26,3 +26,4 @@ export * from "./scim";
 export * from "./server-configuration";
 export * from "./userstores";
 export * from "./user";
+export * from "./organization";

--- a/apps/console/src/extensions/configs/models/organization.ts
+++ b/apps/console/src/extensions/configs/models/organization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/extensions/configs/models/organization.ts
+++ b/apps/console/src/extensions/configs/models/organization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,13 +16,6 @@
  * under the License.
  */
 
-export * from "./attribute";
-export * from "./documentation";
-export * from "./endpoints";
-export * from "./identity-providers";
-export * from "./application";
-export * from "./group";
-export * from "./common";
-export * from "./userstores";
-export * from "./user";
-export * from "./organization";
+export interface OrganizationConfigs {
+    showOrganizationDropdown: boolean
+}

--- a/apps/console/src/extensions/configs/organization.ts
+++ b/apps/console/src/extensions/configs/organization.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,14 +15,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { OrganizationConfigs } from "./models";
 
-export * from "./attribute";
-export * from "./documentation";
-export * from "./endpoints";
-export * from "./identity-providers";
-export * from "./application";
-export * from "./group";
-export * from "./common";
-export * from "./userstores";
-export * from "./user";
-export * from "./organization";
+export const organizationConfigs: OrganizationConfigs = {
+    showOrganizationDropdown: true
+};

--- a/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
+++ b/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
@@ -16,24 +16,16 @@
  * under the License.
  */
 
-import { SessionStorageUtils } from "@wso2is/core/utils";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
-import { setServiceResourceEndpoints } from "@wso2is/core/src/store";
+import { SessionStorageUtils } from "@wso2is/core/utils";
 import { GenericIcon } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement, SyntheticEvent, useCallback, useEffect, useState } from "react";
+import React, { FunctionComponent, ReactElement, SyntheticEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Button, Divider, Dropdown, Input, Item, Menu, Placeholder, Popup } from "semantic-ui-react";
+import { organizationConfigs } from "../../../../extensions";
 import { ReactComponent as CrossIcon } from "../../../../themes/default/assets/images/icons/cross-icon.svg";
-import {
-    AppConstants,
-    AppState,
-    Config,
-    getMiscellaneousIcons,
-    getSidePanelIcons,
-    history,
-    setOrganization
-} from "../../../core";
+import { AppConstants, AppState, getMiscellaneousIcons, getSidePanelIcons, history } from "../../../core";
 import { getOrganizations } from "../../api";
 import { OrganizationManagementConstants } from "../../constants";
 import { OrganizationInterface, OrganizationLinkInterface, OrganizationListInterface } from "../../models";
@@ -63,6 +55,9 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
     const [ beforeCursor, setBeforeCursor ] = useState<string>();
     const [ isDropDownOpen, setIsDropDownOpen ] = useState<boolean>(false);
     const [ search, setSearch ] = useState<string>("");
+
+    const isOrgSwitcherEnabled = useMemo(() => organizationConfigs.showOrganizationDropdown,
+        [ organizationConfigs.showOrganizationDropdown ]);
 
     const getOrganizationList = useCallback((filter: string, after: string, before: string) => {
         getOrganizations(filter, 5, after, before, true, true)
@@ -373,7 +368,7 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
 
                     { associatedOrganizations ? resolveAssociatedOrganizations() : null }
 
-                    <Divider />
+                    <Divider/>
 
                     { tenantPagination }
                 </Dropdown.Menu>
@@ -381,7 +376,11 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
         </Menu.Item>
     );
 
-    return <>{ tenantDropdownMenu }</>;
+    return (<>{
+        isOrgSwitcherEnabled
+            ? tenantDropdownMenu
+            : null
+    }</>);
 };
 
 export default OrganizationSwitchDropdown;


### PR DESCRIPTION
### Purpose
> This PR added a config to removeunwanted organization features appeared in asgadeo. This includes

1. Organization switch dropdown
2. Organization roles submenu item

### Related PRs
- https://github.com/wso2-enterprise/asgardeo-app-extensions/pull/1874

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
