### PR TITLE
Add Enterprise IDP to Org management feature

### DIFF
--- a/apps/console/src/extensions/configs/identity-provider.tsx
+++ b/apps/console/src/extensions/configs/identity-provider.tsx
@@ -52,6 +52,7 @@ export const identityProviderConfig: IdentityProviderConfig = {
         github: true,
         google: true,
         oidc: true,
+        organizationEnterprise: true,
         saml: true
     },
     fidoTags: [

--- a/apps/console/src/extensions/configs/models/identity-providers.ts
+++ b/apps/console/src/extensions/configs/models/identity-providers.ts
@@ -96,6 +96,7 @@ export interface IdentityProviderConfig {
          */
         saml: boolean;
         oidc: boolean;
+        organizationEnterprise: boolean;
     }
     fidoTags: string[];
     filterFidoTags: (tags: string[]) => string[];

--- a/apps/console/src/features/identity-providers/components/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/components/identity-provider-edit.tsx
@@ -118,6 +118,9 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
     const [ tabPaneExtensions, setTabPaneExtensions ] = useState<any>(undefined);
     const [ defaultActiveIndex, setDefaultActiveIndex ] = useState<any>(0);
 
+    const isOrganizationEnterpriseAuthenticator = identityProvider.federatedAuthenticators
+        .defaultAuthenticatorId === IdentityProviderManagementConstants.ORGANIZATION_ENTERPRISE_AUTHENTICATOR_ID;
+
     const urlSearchParams: URLSearchParams = new URLSearchParams(location.search);
 
     const idpAdvanceConfig: IdentityProviderAdvanceInterface = {
@@ -279,7 +282,7 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
             render: GeneralIdentityProviderSettingsTabPane
         });
 
-        panes.push({
+        !isOrganizationEnterpriseAuthenticator && panes.push({
             menuItem: "Settings",
             render: AuthenticatorSettingsTabPane
         });

--- a/apps/console/src/features/identity-providers/components/identity-provider-list.tsx
+++ b/apps/console/src/features/identity-providers/components/identity-provider-list.tsx
@@ -184,6 +184,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                     );
 
                     const appNames: string[] = [];
+
                     results.forEach((app) => {
                         appNames.push(app.name);
                     });
@@ -363,8 +364,8 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                 icon: (): SemanticICONS =>
                     hasRequiredScopes(featureConfig?.identityProviders,
                         featureConfig?.identityProviders?.scopes?.update, allowedScopes)
-                            ? "pencil alternate"
-                            : "eye",
+                        ? "pencil alternate"
+                        : "eye",
                 onClick: (e: SyntheticEvent, idp: IdentityProviderInterface): void =>
                     handleIdentityProviderEdit(idp.id),
                 popupText: (): string =>
@@ -416,7 +417,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                 deletingIDP && (
                     <ConfirmationModal
                         onClose={ (): void => setShowDeleteConfirmationModal(false) }
-                        type="warning"
+                        type="negative"
                         open={ showDeleteConfirmationModal }
                         assertion={ deletingIDP?.name }
                         assertionHint={ t("console:develop.features.authenticationProvider."+
@@ -436,7 +437,7 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                         </ConfirmationModal.Header>
                         <ConfirmationModal.Message
                             attached
-                            warning
+                            negative
                             data-testid={ `${ testId }-delete-confirmation-modal-message` }
                         >
                             { t("console:develop.features.idp.confirmations.deleteIDP.message") }
@@ -474,8 +475,8 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                             <List ordered className="ml-6">
                                 {
                                     isAppsLoading ? (
-                                            <ContentLoader/>
-                                        ) :
+                                        <ContentLoader/>
+                                    ) :
                                         connectedApps?.map((app, index) => {
                                             return (
                                                 <List.Item key={ index }>{ app }</List.Item>

--- a/apps/console/src/features/identity-providers/components/identity-provider-list.tsx
+++ b/apps/console/src/features/identity-providers/components/identity-provider-list.tsx
@@ -33,12 +33,11 @@ import {
     TableColumnInterface
 } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Divider, Header, Icon, List, SemanticICONS } from "semantic-ui-react";
+import { Divider, Header, Icon, Label, List, SemanticICONS } from "semantic-ui-react";
 import { handleIDPDeleteError } from "./utils";
-import { getApplicationDetails } from "../../applications/api";
-import { ApplicationBasicInterface } from "../../applications/models";
+import { ApplicationBasicInterface, getApplicationDetails } from "../../applications";
 import {
     AppConstants,
     AppState,
@@ -293,47 +292,61 @@ export const IdentityProviderList: FunctionComponent<IdentityProviderListPropsIn
                 dataIndex: "name",
                 id: "name",
                 key: "name",
-                render: (idp: IdentityProviderInterface): ReactNode => (
-                    <Header
-                        image
-                        as="h6"
-                        className="header-with-icon"
-                        data-testid={ `${ testId }-item-heading` }
-                    >
-                        {
-                            idp.image
-                                ? (
-                                    <AppAvatar
-                                        size="mini"
-                                        name={ idp.name }
-                                        image={ idp.image }
-                                        spaced="right"
-                                        data-testid={ `${ testId }-item-image` }
-                                    />
-                                )
-                                : (
-                                    <AppAvatar
-                                        image={ (
-                                            <AnimatedAvatar
-                                                name={ idp.name }
-                                                size="mini"
-                                                data-testid={ `${ testId }-item-image-inner` }
-                                            />
-                                        ) }
-                                        size="mini"
-                                        spaced="right"
-                                        data-testid={ `${ testId }-item-image` }
-                                    />
-                                )
-                        }
-                        <Header.Content>
-                            { idp.name }
-                            <Header.Subheader data-testid={ `${ testId }-item-sub-heading` }>
-                                { idp.description }
-                            </Header.Subheader>
-                        </Header.Content>
-                    </Header>
-                ),
+                render: (idp: IdentityProviderInterface): ReactNode => {
+                    const isOrgIdp = (idp.federatedAuthenticators.defaultAuthenticatorId ===
+                        IdentityProviderManagementConstants.ORGANIZATION_ENTERPRISE_AUTHENTICATOR_ID);
+
+                    return (
+                        <Header
+                            image
+                            as="h6"
+                            className="header-with-icon"
+                            data-testid={ `${testId}-item-heading` }
+                        >
+                            {
+                                idp.image
+                                    ? (
+                                        <AppAvatar
+                                            size="mini"
+                                            name={ idp.name }
+                                            image={ idp.image }
+                                            spaced="right"
+                                            data-testid={ `${testId}-item-image` }
+                                        />
+                                    )
+                                    : (
+                                        <AppAvatar
+                                            image={ (
+                                                <AnimatedAvatar
+                                                    name={ idp.name }
+                                                    size="mini"
+                                                    data-testid={ `${testId}-item-image-inner` }
+                                                />
+                                            ) }
+                                            size="mini"
+                                            spaced="right"
+                                            data-testid={ `${testId}-item-image` }
+                                        />
+                                    )
+                            }
+                            <Header.Content>
+                                { idp.name }
+                                {
+                                    isOrgIdp && (
+                                        <Label
+                                            size="mini"
+                                            color="teal">
+                                            Organization IDP
+                                        </Label>
+                                    )
+                                }
+                                <Header.Subheader data-testid={ `${testId}-item-sub-heading` }>
+                                    { idp.description }
+                                </Header.Subheader>
+                            </Header.Content>
+                        </Header>
+                    );
+                },
                 title: t("console:develop.features.idp.list.name")
             },
             {

--- a/apps/console/src/features/identity-providers/components/wizards/authenticator-create-wizard-factory.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/authenticator-create-wizard-factory.tsx
@@ -26,6 +26,9 @@ import { FacebookAuthenticationProviderCreateWizard } from "./facebook";
 import { GitHubAuthenticationProviderCreateWizard } from "./github";
 import { GoogleAuthenticationProviderCreateWizard } from "./google";
 import { OidcAuthenticationProviderCreateWizard } from "./oidc-authentication-provider-create-wizard";
+import {
+    OrganizationEnterpriseAuthenticationProviderCreateWizard
+} from "./organization-enterprise/organization-enterprise-authentication-provider-create-wizard";
 import { ConfigReducerStateInterface } from "../../../core/models";
 import { AppState } from "../../../core/store";
 import { getIdentityProviderList, getIdentityProviderTemplate } from "../../api";
@@ -328,6 +331,24 @@ export const AuthenticatorCreateWizardFactory: FunctionComponent<AuthenticatorCr
             return (showWizard && !isEmpty(selectedTemplateWithUniqueName))
                 ? (
                     <OidcAuthenticationProviderCreateWizard
+                        title={ selectedTemplateWithUniqueName?.name }
+                        subTitle={ selectedTemplateWithUniqueName?.description }
+                        onWizardClose={ () => {
+                            setSelectedTemplateWithUniqueName(undefined);
+                            setSelectedTemplate(undefined);
+                            setShowWizard(false);
+                            onWizardClose();
+                        } }
+                        template={ selectedTemplateWithUniqueName }
+                        data-componentid={ selectedTemplate?.templateId }
+                        { ...rest }
+                    />
+                )
+                : null;
+        case IdentityProviderManagementConstants.IDP_TEMPLATE_IDS.ORGANIZATION_ENTERPRISE_IDP:
+            return (showWizard && !isEmpty(selectedTemplateWithUniqueName))
+                ? (
+                    <OrganizationEnterpriseAuthenticationProviderCreateWizard
                         title={ selectedTemplateWithUniqueName?.name }
                         subTitle={ selectedTemplateWithUniqueName?.description }
                         onWizardClose={ () => {

--- a/apps/console/src/features/identity-providers/components/wizards/organization-enterprise/organization-enterprise-authentication-provider-create-wizard-content.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/organization-enterprise/organization-enterprise-authentication-provider-create-wizard-content.tsx
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { Field, Wizard, WizardPage } from "@wso2is/form";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+    OrganizationEnterpriseAuthenticationProviderCreateWizardFormErrorValidationsInterface,
+    OrganizationEnterpriseAuthenticationProviderCreateWizardFormValuesInterface
+} from "./organization-enterprise-authentication-provider-create-wizard";
+import { getIdentityProviderList } from "../../../api";
+import { IdentityProviderManagementConstants } from "../../../constants";
+import { IdentityProviderListResponseInterface, IdentityProviderTemplateInterface } from "../../../models";
+import { handleGetIDPListCallError } from "../../utils";
+
+/**
+ * Proptypes for the GitHub Authentication Provider create wizard content.
+ */
+interface OrganizationEnterpriseAuthenticationProviderCreateWizardContentPropsInterface
+    extends IdentifiableComponentInterface {
+    /**
+     * Trigger form submit.
+     * @param {() => void} submitFunctionCb - Callback.
+     */
+    triggerSubmission: (submitFunctionCb: () => void) => void;
+    /**
+     * Trigger previous page.
+     * @param {() => void} previousFunctionCb - Callback.
+     */
+    triggerPrevious: (previousFunctionCb: () => void) => void;
+    /**
+     * Callback to change the wizard page,
+     * @param {number} pageNo - Page Number.
+     */
+    changePageNumber: (pageNo: number) => void;
+    /**
+     * IDP template.
+     */
+    template: IdentityProviderTemplateInterface;
+    /**
+     * Total wizard page count.
+     * @param {number} pageCount - Page number.
+     */
+    setTotalPage: (pageCount: number) => void;
+    /**
+     * Callback to be triggered for form submit.
+     * @param values
+     */
+    onSubmit: (values: OrganizationEnterpriseAuthenticationProviderCreateWizardFormErrorValidationsInterface) => void;
+}
+
+/**
+ * Authentication Provider Create Wizard content component.
+ *
+ * @param {OrganizationEnterpriseAuthenticationProviderCreateWizardContentPropsInterface} props - Props injected to the component.
+ *
+ * @return {React.ReactElement}
+ */
+export const OrganizationEnterpriseAuthenticationProviderCreateWizardContent:
+    FunctionComponent<OrganizationEnterpriseAuthenticationProviderCreateWizardContentPropsInterface> = (
+        props: OrganizationEnterpriseAuthenticationProviderCreateWizardContentPropsInterface
+    ): ReactElement => {
+
+        const {
+            triggerSubmission,
+            triggerPrevious,
+            changePageNumber,
+            template,
+            setTotalPage,
+            onSubmit,
+            ["data-componentid"]: componentId
+        } = props;
+
+        const { t } = useTranslation();
+
+        const [ idpList, setIdPList ] = useState<IdentityProviderListResponseInterface>({});
+        const [ isIdPListRequestLoading, setIdPListRequestLoading ] = useState<boolean>(undefined);
+
+        /**
+     * Loads the identity provider authenticators on initial component load.
+     */
+        useEffect(() => {
+
+            getIDPlist();
+        }, []);
+
+        /**
+     * Get Idp List.
+     */
+        const getIDPlist = (): void => {
+
+            setIdPListRequestLoading(true);
+
+            getIdentityProviderList(null, null, null)
+                .then((response) => {
+                    setIdPList(response);
+                })
+                .catch((error) => {
+                    handleGetIDPListCallError(error);
+                })
+                .finally(() => {
+                    setIdPListRequestLoading(false);
+                });
+        };
+
+        /**
+     * Check whether IDP name is already exist or not.
+     *
+     * @param value IDP name - IDP Name.
+     *
+     * @returns error msg if name is already taken.
+     */
+        const idpNameValidation = (value): string => {
+
+            let nameExist = false;
+
+            if (idpList?.count > 0) {
+                idpList?.identityProviders.map((idp) => {
+                    if (idp?.name === value) {
+                        nameExist = true;
+
+                    }
+                });
+            }
+            if (nameExist) {
+                return t("console:develop.features." +
+                "authenticationProvider.forms.generalDetails.name." +
+                "validations.duplicate");
+            }
+        };
+
+        /**
+     * Validates the Form.
+     *
+     * @param {FacebookAuthenticationProviderCreateWizardFormValuesInterface} values - Form Values.
+     *
+     * @return {GithubAuthenticationProviderCreateWizardFormErrorValidationsInterface}
+     */
+        const validateForm = (values: OrganizationEnterpriseAuthenticationProviderCreateWizardFormValuesInterface):
+        OrganizationEnterpriseAuthenticationProviderCreateWizardFormErrorValidationsInterface => {
+
+            const errors: OrganizationEnterpriseAuthenticationProviderCreateWizardFormErrorValidationsInterface = {
+                description: undefined,
+                name: undefined
+            };
+
+            if (!values.name) {
+                errors.name = t("console:develop.features.authenticationProvider.forms.common" +
+                ".requiredErrorMessage");
+            }
+            if (!values.description) {
+                errors.description = t("console:develop.features.authenticationProvider.forms.common" +
+                ".requiredErrorMessage");
+            }
+
+            return errors;
+        };
+
+        return (
+            (isIdPListRequestLoading !== undefined && isIdPListRequestLoading === false)
+                ? (
+                    <Wizard
+                        initialValues={ { name: template?.idp?.name } }
+                        onSubmit={
+                            (values: OrganizationEnterpriseAuthenticationProviderCreateWizardFormValuesInterface) =>
+                                onSubmit(values)
+                        }
+                        triggerSubmit={ (submitFunction) => triggerSubmission(submitFunction) }
+                        triggerPrevious={ (previousFunction) => triggerPrevious(previousFunction) }
+                        changePage={ (step: number) => changePageNumber(step) }
+                        setTotalPage={ (step: number) => setTotalPage(step) }
+                        data-componenentid={ componentId }
+                    >
+                        <WizardPage validate={ validateForm }>
+                            <Field.Input
+                                ariaLabel="Organization IDP Name"
+                                inputType="name"
+                                name="name"
+                                label={ t("console:develop.features.authenticationProvider.forms." +
+                                "generalDetails.name.label") }
+                                placeholder={ t("console:develop.features.authenticationProvider.forms." +
+                                "generalDetails.name.placeholder") }
+                                required={ true }
+                                validation={ (value) => idpNameValidation(value) }
+                                maxLength={
+                                IdentityProviderManagementConstants
+                                    .AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS.IDP_NAME_MAX_LENGTH as number
+                                }
+                                minLength={
+                                IdentityProviderManagementConstants
+                                    .AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS.IDP_NAME_MIN_LENGTH as number
+                                }
+                                data-componentid={ `${componentId}-idp-name` }
+                                width={ 13 }
+                            />
+                            <Field.Input
+                                ariaLabel="Organization IDP Description"
+                                inputType="description"
+                                name="description"
+                                label={
+                                    t("console:develop.features.authenticationProvider.forms." +
+                                    "generalDetails.description.placeholder")
+                                }
+                                placeholder={
+                                    t("console:develop.features.authenticationProvider.forms." +
+                                    "generalDetails.description.placeholder")
+                                }
+                                required={ true }
+                                message={
+                                    t("console:develop.features.authenticationProvider.forms." +
+                                    "generalDetails.description.placeholder")
+                                }
+                                type="text"
+                                maxLength={
+                                IdentityProviderManagementConstants
+                                    .AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS
+                                    .IDP_DESCRIPTION_MAX_LENGTH as number
+                                }
+                                minLength={
+                                IdentityProviderManagementConstants
+                                    .AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS
+                                    .IDP_DESCRIPTION_MIN_LENGTH as number
+                                }
+                                data-componentid={ `${componentId}-idp-description` }
+                                width={ 30 }
+                            />
+                        </WizardPage>
+                    </Wizard>
+                )
+                : null
+        );
+    };
+
+/**
+ * Default props for the Facebook Authentication Provider Create Wizard Page Component.
+ */
+OrganizationEnterpriseAuthenticationProviderCreateWizardContent.defaultProps = {
+    "data-componentid": "organization-enterprise-idp-create-wizard-content"
+};

--- a/apps/console/src/features/identity-providers/components/wizards/organization-enterprise/organization-enterprise-authentication-provider-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/organization-enterprise/organization-enterprise-authentication-provider-create-wizard.tsx
@@ -1,0 +1,484 @@
+/**
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentityAppsError } from "@wso2is/core/errors";
+import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { GenericIcon, LinkButton, PrimaryButton, useWizardAlert } from "@wso2is/react-components";
+import { ContentLoader } from "@wso2is/react-components/src/components/loader/content-loader";
+import get from "lodash-es/get";
+import isEmpty from "lodash-es/isEmpty";
+import React, { FunctionComponent, ReactElement, Suspense, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import { Grid } from "semantic-ui-react";
+import {
+    OrganizationEnterpriseAuthenticationProviderCreateWizardContent
+} from "./organization-enterprise-authentication-provider-create-wizard-content";
+import { identityProviderConfig } from "../../../../../extensions/configs";
+import {
+    AppState,
+    ConfigReducerStateInterface,
+    EventPublisher,
+    ModalWithSidePanel,
+    TierLimitReachErrorModal
+} from "../../../../core";
+import { createIdentityProvider } from "../../../api";
+import { getIdPIcons } from "../../../configs";
+import { IdentityProviderManagementConstants } from "../../../constants";
+import {
+    GenericIdentityProviderCreateWizardPropsInterface,
+    IdentityProviderInterface,
+    OutboundProvisioningConnectorInterface
+} from "../../../models";
+
+/**
+ * Proptypes for the Organization Enterprise Authentication Provider Create Wizard.
+ */
+interface OrganizationEnterpriseAuthenticationProviderCreateWizardPropsInterface extends IdentifiableComponentInterface,
+    GenericIdentityProviderCreateWizardPropsInterface {
+}
+
+/**
+ * Proptypes for the Authentication Wizard Form values.
+ */
+export interface OrganizationEnterpriseAuthenticationProviderCreateWizardFormValuesInterface {
+    /**
+     * Name for the Idp
+     */
+    name: string;
+    /**
+     * Description of the Idp
+     */
+    description: string;
+}
+
+/**
+ * Proptypes for the Authentication Wizard Form error messages.
+ */
+export interface OrganizationEnterpriseAuthenticationProviderCreateWizardFormErrorValidationsInterface {
+    /**
+     * Error message for the Authenticator name.
+     */
+    name: string;
+    /**
+     * Error message for the description.
+     */
+    description: string;
+}
+
+/**
+ * Facebook Authentication Provider Create Wizard Component.
+ *
+ * @param { OrganizationEnterpriseAuthenticationProviderCreateWizardPropsInterface } props - Props injected to
+ * the component.
+ *
+ * @return { React.ReactElement }
+ */
+export const OrganizationEnterpriseAuthenticationProviderCreateWizard: FunctionComponent<OrganizationEnterpriseAuthenticationProviderCreateWizardPropsInterface> = (
+    props: OrganizationEnterpriseAuthenticationProviderCreateWizardPropsInterface
+): ReactElement => {
+
+    const {
+        onWizardClose,
+        onIDPCreate,
+        currentStep,
+        title,
+        template,
+        ["data-componentid"]: componentId
+    } = props;
+
+    const dispatch = useDispatch();
+
+    const { t } = useTranslation();
+
+    const [ alert, setAlert, alertComponent ] = useWizardAlert();
+
+    const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
+
+    const [ currentWizardStep, setCurrentWizardStep ] = useState<number>(currentStep);
+    const [ wizStep, setWizStep ] = useState<number>(0);
+    const [ totalStep, setTotalStep ] = useState<number>(0);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ openLimitReachedModal, setOpenLimitReachedModal ] = useState<boolean>(false);
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
+
+    /**
+     * Track wizard steps from wizard component.
+     */
+    useEffect(() => {
+        setCurrentWizardStep(wizStep + 1);
+    }, [ wizStep ]);
+
+    /**
+     * Creates a new identity provider.
+     *
+     * @param identityProvider Identity provider object.
+     */
+    const createNewIdentityProvider = (identityProvider: IdentityProviderInterface): void => {
+
+        // TODO Uncomment below once template id is supported from IDP REST API
+        // Tracked Here - https://github.com/wso2/product-is/issues/11023
+        // identityProvider.templateId = template.id;
+
+        setIsSubmitting(true);
+
+        createIdentityProvider(identityProvider)
+            .then((response) => {
+                eventPublisher.publish("connections-finish-adding-connection", {
+                    type: componentId
+                });
+
+                dispatch(addAlert({
+                    description: t("console:develop.features.authenticationProvider.notifications.addIDP." +
+                        "success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("console:develop.features.authenticationProvider.notifications.addIDP." +
+                        "success.message")
+                }));
+
+                // The created resource's id is sent as a location header.
+                // If that's available, navigate to the edit page.
+                if (!isEmpty(response.headers.location)) {
+                    const location = response.headers.location;
+                    const createdIdpID = location.substring(location.lastIndexOf("/") + 1);
+
+                    onIDPCreate(createdIdpID);
+
+                    return;
+                }
+
+                // Since the location header is not present, trigger callback without the id.
+                onIDPCreate();
+            })
+            .catch((error) => {
+                const identityAppsError: IdentityAppsError = identityProviderConfig.useNewConnectionsView
+                    ? IdentityProviderManagementConstants.ERROR_CREATE_LIMIT_REACHED
+                    : IdentityProviderManagementConstants.ERROR_CREATE_LIMIT_REACHED_IDP;
+
+                if (error.response.status === 403 &&
+                    error?.response?.data?.code ===
+                    identityAppsError.getErrorCode()) {
+                    setOpenLimitReachedModal(true);
+
+                    return;
+                }
+
+                if (error.response && error.response.data && error.response.data.description) {
+                    setAlert({
+                        description: t("console:develop.features.authenticationProvider.notifications." +
+                            "addIDP.error.description",
+                        { description: error.response.data.description }),
+                        level: AlertLevels.ERROR,
+                        message: t("console:develop.features.authenticationProvider.notifications." +
+                            "addIDP.error.message")
+                    });
+
+                    return;
+                }
+
+                setAlert({
+                    description: t("console:develop.features.authenticationProvider.notifications.addIDP." +
+                        "genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("console:develop.features.authenticationProvider.notifications.addIDP." +
+                        "genericError.message")
+                });
+            })
+            .finally(() => {
+                setIsSubmitting(false);
+            })
+        ;
+    };
+
+    /**
+     * Handles the final wizard submission.
+     *
+     * @param identityProvider - Identity provider data.
+     */
+    const handleWizardFormFinish = (identityProvider: IdentityProviderInterface): void => {
+
+        const connector: OutboundProvisioningConnectorInterface =
+            identityProvider?.provisioning?.outboundConnectors?.connectors[0];
+
+        const isGoogleConnector: boolean = get(connector,
+            IdentityProviderManagementConstants.PROVISIONING_CONNECTOR_DISPLAY_NAME) ===
+            IdentityProviderManagementConstants.PROVISIONING_CONNECTOR_GOOGLE;
+
+        // If the outbound connector is Google, remove the displayName from the connector.
+        if (connector && isGoogleConnector) {
+            delete connector[
+                IdentityProviderManagementConstants.PROVISIONING_CONNECTOR_DISPLAY_NAME
+            ];
+        }
+
+        delete (identityProvider.image);
+        delete (identityProvider.certificate);
+        delete (identityProvider.claims);
+        delete (identityProvider.provisioning);
+
+        // Use description from template.
+        identityProvider.description = template.description;
+
+        createNewIdentityProvider(identityProvider);
+    };
+
+    /**
+     * Called when modal close event is triggered.
+     */
+    const handleWizardClose = (): void => {
+
+        // Trigger the close method from props.
+        onWizardClose();
+    };
+
+    /**
+     * Close the limit reached modal.
+     */
+    const handleLimitReachedModalClose = (): void => {
+        setOpenLimitReachedModal(false);
+        handleWizardClose();
+    };
+
+    /**
+     * Callback triggered when the form is submitted.
+     *
+     * @param {OrganizationEnterpriseAuthenticationProviderCreateWizardFormValuesInterface} values - Form values.
+     */
+    const onSubmitWizard = async (
+        values: OrganizationEnterpriseAuthenticationProviderCreateWizardFormValuesInterface
+    ): Promise<void> => {
+
+        await identityProviderConfig.overrideTemplate(template);
+
+        const identityProvider: IdentityProviderInterface = { ...template.idp };
+
+        identityProvider.name = values.name.toString();
+        identityProvider.description = values.name.toString();
+
+        // // TODO: Refactor the usage of absolute image paths once Media Service is available.
+        // // Tracked here - https://github.com/wso2/product-is/issues/12396
+        // if (AppConstants.getClientOrigin()) {
+        //     if (AppConstants.getAppBasename()) {
+        //         identityProvider.image = AppConstants.getClientOrigin() +
+        //         "/" + AppConstants.getAppBasename() +
+        //         "/libs/themes/default/assets/images/identity-providers/enterprise-idp-illustration.svg";
+        //     } else {
+        //         identityProvider.image = AppConstants.getClientOrigin() +
+        //         "/libs/themes/default/assets/images/identity-providers/enterprise-idp-illustration.svg";
+        //     }
+        // }
+
+        handleWizardFormFinish(identityProvider);
+    };
+
+    /**
+     * Resolve the step wizard actions.
+     *
+     * @return {React.ReactElement}
+     */
+    const resolveStepActions = (): ReactElement => {
+
+        return (
+            <Grid>
+                <Grid.Row column={ 1 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
+                        <LinkButton
+                            floated="left"
+                            onClick={ handleWizardClose }
+                            data-testid={ `${componentId}-modal-cancel-button` }
+                        >
+                            { t("common:cancel") }
+                        </LinkButton>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>
+                        { currentWizardStep !== totalStep ? (
+                            <PrimaryButton
+                                floated="right"
+                                onClick={ () => {
+                                    submitForm();
+                                } }
+                                data-testid={ `${componentId}-modal-finish-button` }
+                                loading={ isSubmitting }
+                                disabled={ isSubmitting }
+                            >
+                                { t("console:develop.features.authenticationProvider.wizards.buttons.next") }
+                            </PrimaryButton>
+                        ) : (
+                            <>
+                                <PrimaryButton
+                                    floated="right"
+                                    onClick={ () => {
+                                        submitForm();
+                                    } }
+                                    data-testid={ `${componentId}-modal-finish-button` }
+                                    loading={ isSubmitting }
+                                    disabled={ isSubmitting }
+                                >
+                                    { t("console:develop.features.authenticationProvider.wizards.buttons.finish") }
+                                </PrimaryButton>
+                            </>
+                        ) }
+                        {
+                            currentWizardStep > 1 &&
+                            (<LinkButton
+                                floated="right"
+                                onClick={ () => {
+                                    triggerPreviousForm();
+                                } }
+                                data-testid={ `${componentId}-modal-previous-button` }
+                            >
+                                { t("console:develop.features.authenticationProvider.wizards.buttons.previous") }
+                            </LinkButton>)
+                        }
+                    </Grid.Column>
+                </Grid.Row>
+            </Grid>
+        );
+    };
+
+    /**
+     * Renders the help panel containing wizard help.
+     *
+     * @return {React.ReactElement}
+     */
+    const renderHelpPanel = (): ReactElement => {
+
+        // Return null when `showHelpPanel` is false or `wizardHelp` is not defined in `selectedTemplate` object.
+        if (!template?.content?.wizardHelp || currentWizardStep === 0) {
+            return null;
+        }
+
+        const {
+            wizardHelp: WizardHelp
+        } = template?.content;
+
+        return (
+            <ModalWithSidePanel.SidePanel>
+                <ModalWithSidePanel.Header className="wizard-header help-panel-header muted">
+                    <div className="help-panel-header-text">
+                        {
+                            t("console:develop.features.authenticationProvider.templates" +
+                                ".facebook.wizardHelp.heading")
+                        }
+                    </div>
+                </ModalWithSidePanel.Header>
+                <ModalWithSidePanel.Content>
+                    <Suspense fallback={ <ContentLoader/> }>
+                        <WizardHelp/>
+                    </Suspense>
+                </ModalWithSidePanel.Content>
+            </ModalWithSidePanel.SidePanel>
+        );
+    };
+
+    /**
+     * Closure to submit form.
+     */
+    let submitForm: () => void;
+
+    /**
+     * Closure to trigger previous form.
+     */
+    let triggerPreviousForm: () => void;
+
+    return (
+        <>
+            { openLimitReachedModal &&
+                (<TierLimitReachErrorModal
+                    actionLabel={ t(
+                        "console:develop.features.idp.notifications." +
+                        "tierLimitReachedError.emptyPlaceholder.action"
+                    ) }
+                    handleModalClose={ handleLimitReachedModalClose }
+                    header={ t(
+                        "console:develop.features.idp.notifications.tierLimitReachedError.heading"
+                    ) }
+                    description={ t(
+                        "console:develop.features.idp.notifications." +
+                        "tierLimitReachedError.emptyPlaceholder.subtitles"
+                    ) }
+                    message={ t(
+                        "console:develop.features.idp.notifications." +
+                        "tierLimitReachedError.emptyPlaceholder.title"
+                    ) }
+                    openModal={ openLimitReachedModal }
+                />) }
+            <ModalWithSidePanel
+                open={ !openLimitReachedModal }
+                className="wizard identity-provider-create-wizard"
+                dimmer="blurring"
+                onClose={ handleWizardClose }
+                closeOnDimmerClick={ false }
+                closeOnEscape
+                data-testid={ `${componentId}-modal` }
+            >
+                <ModalWithSidePanel.MainPanel>
+                    <ModalWithSidePanel.Header
+                        className="wizard-header"
+                        data-testid={ `${componentId}-modal-header` }
+                    >
+                        <div className="display-flex">
+                            <GenericIcon
+                                icon={ getIdPIcons().default }
+                                size="mini"
+                                transparent
+                                spaced="right"
+                                data-testid={ `${componentId}-image` }
+                            />
+                            <div className="ml-1">
+                                { title }
+                            </div>
+                        </div>
+                    </ModalWithSidePanel.Header>
+                    <ModalWithSidePanel.Content
+                        className="content-container"
+                        data-testid={ `${componentId}-modal-content` }
+                    >
+                        { alert && alertComponent }
+                        <OrganizationEnterpriseAuthenticationProviderCreateWizardContent
+                            onSubmit={ onSubmitWizard }
+                            triggerSubmission={ (submitFunctionCb: () => void) => {
+                                submitForm = submitFunctionCb;
+                            } }
+                            triggerPrevious={ (previousFunctionCb: () => void) => {
+                                triggerPreviousForm = previousFunctionCb;
+                            } }
+                            changePageNumber={ (step: number) => setWizStep(step) }
+                            setTotalPage={ (pageNumber: number) => setTotalStep(pageNumber) }
+                            template={ template }
+                        />
+                    </ModalWithSidePanel.Content>
+                    <ModalWithSidePanel.Actions data-testid={ `${componentId}-modal-actions` }>
+                        { resolveStepActions() }
+                    </ModalWithSidePanel.Actions>
+                </ModalWithSidePanel.MainPanel>
+                { renderHelpPanel() }
+            </ModalWithSidePanel>
+        </>
+    );
+};
+
+/**
+ * Default props for the Facebook Authentication Provider Create Wizard.
+ */
+OrganizationEnterpriseAuthenticationProviderCreateWizard.defaultProps = {
+    currentStep: 1,
+    "data-componentid": "organization-enterprise-idp"
+};

--- a/apps/console/src/features/identity-providers/components/wizards/steps/shared-steps/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/steps/shared-steps/authenticator-settings.tsx
@@ -59,11 +59,11 @@ export const AuthenticatorSettings: FunctionComponent<AuthenticatorSettingsWizar
             onSubmit({
                 ...initialValues,
                 federatedAuthenticators: {
-                    authenticators: [{
+                    authenticators: [ {
                         ...authenticator,
                         isDefault: true,
                         isEnabled: true
-                    }],
+                    } ],
                     defaultAuthenticatorId: initialValues?.federatedAuthenticators?.defaultAuthenticatorId
                 }
             });
@@ -71,12 +71,12 @@ export const AuthenticatorSettings: FunctionComponent<AuthenticatorSettingsWizar
             // Add new authenticator instance
             onSubmit({
                 federatedAuthenticators: {
-                    authenticators: [{
+                    authenticators: [ {
                         authenticatorId: authenticator.authenticatorId,
                         isDefault: false,
                         isEnabled: true,
                         properties: authenticator.properties
-                    }],
+                    } ],
                     defaultAuthenticatorId: authenticator.authenticatorId
                 }
             });
@@ -88,7 +88,7 @@ export const AuthenticatorSettings: FunctionComponent<AuthenticatorSettingsWizar
 
     return (
         ( metadata ?
-            <AuthenticatorFormFactory
+            (<AuthenticatorFormFactory
                 metadata={ metadata }
                 initialValues={ (authenticator ? authenticator : {}) }
                 onSubmit={ handleSubmit }
@@ -97,7 +97,7 @@ export const AuthenticatorSettings: FunctionComponent<AuthenticatorSettingsWizar
                 enableSubmitButton={ false }
                 data-testid={ testId }
                 isReadOnly={ false }
-            /> : null
+            />) : null
         )
     );
 };

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -90,6 +90,7 @@ export class IdentityProviderManagementConstants {
         GITHUB: "github-idp",
         GOOGLE: "8ea23303-49c0-4253-b81f-82c0fe6fb4a0",
         OIDC: "oidc-idp",
+        ORGANIZATION_ENTERPRISE_IDP: "organization-enterprise-idp",
         SAML: "saml-idp"
     };
 
@@ -103,6 +104,8 @@ export class IdentityProviderManagementConstants {
         CLIENT_ID_MIN_LENGTH: 3,
         CLIENT_SECRET_MAX_LENGTH: 100,
         CLIENT_SECRET_MIN_LENGTH: 3,
+        IDP_DESCRIPTION_MAX_LENGTH: 50,
+        IDP_DESCRIPTION_MIN_LENGTH: 3,
         IDP_NAME_MAX_LENGTH: 50,
         IDP_NAME_MIN_LENGTH: 3
     };
@@ -320,6 +323,7 @@ export class IdentityProviderManagementConstants {
     // Known Enterprise authenticator IDs
     public static readonly OIDC_AUTHENTICATOR_ID: string = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I";
     public static readonly SAML_AUTHENTICATOR_ID: string = "U0FNTFNTT0F1dGhlbnRpY2F0b3I";
+    public static readonly ORGANIZATION_ENTERPRISE_AUTHENTICATOR_ID: string = "T3JnYW5pemF0aW9uQXV0aGVudGljYXRvcg";
 
     // Known Local Authenticator IDS.
     public static readonly BASIC_AUTHENTICATOR_ID: string = "QmFzaWNBdXRoZW50aWNhdG9y";

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/identity-provider-templates-config.ts
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/identity-provider-templates-config.ts
@@ -141,7 +141,9 @@ export const getIdentityProviderTemplatesConfig = (): IdentityProviderTemplatesC
                                 wizardHelp: lazy(() => import("./templates/" +
                                 "organization-enterprise-identity-provider/create-wizard-help"))
                             },
-                            enabled: true,
+                            enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates
+                                ?.organizationEnterprise?.enabled
+                                ?? identityProviderConfig.templates.organizationEnterprise,
                             id: OrganizationEnterpriseIDPTemplate.id,
                             resource: OrganizationEnterpriseIDPTemplate
                         },

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/identity-provider-templates-config.ts
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/identity-provider-templates-config.ts
@@ -29,12 +29,11 @@ import GitHubIDPTemplate from "./templates/github/github.json";
 import GoogleIDPTemplate from "./templates/google/google.json";
 import EnterpriseOIDCIdentityProviderTemplate
     from "./templates/oidc-identity-provider/enterprise-oidc-identity-provider.json";
+import OrganizationEnterpriseIDPTemplate from "./templates/organization-enterprise-identity-provider/organization-enterprise-identity-provider.json";
 import EnterpriseSAMLIdentityProviderTemplate
     from "./templates/saml-identity-provider/enterprise-saml-identity-provider.json";
 import { ExtensionsManager, identityProviderConfig } from "../../../../extensions";
-import {
-    EnterpriseIdentityProviderTemplateExtension
-} from "../../../../extensions/configs/identity-providers-templates";
+import { EnterpriseIdentityProviderTemplateExtension } from "../../../../extensions/configs/identity-providers-templates";
 import { IdentityProviderTemplateCategoryInterface, IdentityProviderTemplateGroupInterface } from "../../models";
 
 /**
@@ -139,13 +138,22 @@ export const getIdentityProviderTemplatesConfig = (): IdentityProviderTemplatesC
                         },
                         {
                             content: {
+                                wizardHelp: lazy(() => import("./templates/" +
+                                "organization-enterprise-identity-provider/create-wizard-help"))
+                            },
+                            enabled: true,
+                            id: OrganizationEnterpriseIDPTemplate.id,
+                            resource: OrganizationEnterpriseIDPTemplate
+                        },
+                        {
+                            content: {
                                 wizardHelp: lazy(() =>
                                     import("./templates/oidc-identity-provider/create-wizard-help")
                                 )
                             },
                             enabled: window["AppUtils"].getConfig()
                                 .ui.identityProviderTemplates?.enterpriseOIDC?.enabled
-                                    ?? identityProviderConfig.templates.oidc,
+                                ?? identityProviderConfig.templates.oidc,
                             id: EnterpriseOIDCIdentityProviderTemplate.id,
                             resource: EnterpriseOIDCIdentityProviderTemplate
                         },

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/organization-enterprise-identity-provider/create-wizard-help.tsx
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/organization-enterprise-identity-provider/create-wizard-help.tsx
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestableComponentInterface } from "@wso2is/core/models";
+import { Heading } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement } from "react";
+import { Divider } from "semantic-ui-react";
+
+/**
+ * Prop types of the component.
+ */
+type OrganizationEnterpriseIdentityProviderCreateWizardHelpPropsInterface = TestableComponentInterface
+
+/**
+ * Help content for the custom IDP template creation wizard.
+ *
+ * @param {OrganizationEnterpriseIdentityProviderCreateWizardHelpPropsInterface} props - Props injected into the component.
+ * @return {React.ReactElement}
+ */
+const OrganizationEnterpriseIdentityProviderCreateWizardHelp:
+    FunctionComponent<OrganizationEnterpriseIdentityProviderCreateWizardHelpPropsInterface> = (
+        props: OrganizationEnterpriseIdentityProviderCreateWizardHelpPropsInterface
+    ): ReactElement => {
+
+        const {
+            ["data-testid"]: testId
+        } = props;
+
+        return (
+            <>
+                <div data-testid={ testId }>
+                    <Heading as="h5">Name</Heading>
+                    <p>Provide a unique name for the enterprise authentication provider so that it can be
+                    easily identified.</p>
+                    <p>E.g., MyOrgEnterpriseAuthProvider.</p>
+                </div>
+
+                <Divider/>
+
+                <div data-testid={ testId }>
+                    <Heading as="h5">Description</Heading>
+                    <p>Provide a description for the enterprise authentication provider to explain more about it.</p>
+                    <p>E.g., This is the authenticator for MyOrg, which acts as the IDP for MyApp.</p>
+                </div>
+            </>
+        );
+    };
+
+/**
+ * Default props for the component
+ */
+OrganizationEnterpriseIdentityProviderCreateWizardHelp.defaultProps = {
+    "data-testid": "organization-enterprise-app-create-wizard-help"
+};
+
+/**
+ * A default export was added to support React.lazy.
+ * TODO: Change this to a named export once react starts supporting named exports for code splitting.
+ * @see {@link https://reactjs.org/docs/code-splitting.html#reactlazy}
+ */
+export default OrganizationEnterpriseIdentityProviderCreateWizardHelp;

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/organization-enterprise-identity-provider/organization-enterprise-identity-provider.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/organization-enterprise-identity-provider/organization-enterprise-identity-provider.json
@@ -9,7 +9,7 @@
         "Organization-Login"
     ],
     "idp": {
-        "name": "SSO",
+        "name": "Organization IDP",
         "description": "IdP for Organization SSO",
         "image": "",
         "isPrimary": false,

--- a/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/organization-enterprise-identity-provider/organization-enterprise-identity-provider.json
+++ b/apps/console/src/features/identity-providers/data/identity-provider-templates/templates/organization-enterprise-identity-provider/organization-enterprise-identity-provider.json
@@ -1,0 +1,35 @@
+{
+    "id": "organization-enterprise-idp",
+    "name": "Organization Enterprise Login",
+    "templateId": "organization-enterprise-idp",
+    "category": "DEFAULT",
+    "description": "Organization Managed Enterprise login",
+    "displayOrder": 4,
+    "tags": [
+        "Organization-Login"
+    ],
+    "idp": {
+        "name": "SSO",
+        "description": "IdP for Organization SSO",
+        "image": "",
+        "isPrimary": false,
+        "isFederationHub": false,
+        "homeRealmIdentifier": "EnterpriseIDP",
+        "alias": "https://localhost:9443/oauth2/token",
+        "federatedAuthenticators": {
+            "defaultAuthenticatorId": "T3JnYW5pemF0aW9uQXV0aGVudGljYXRvcg",
+            "authenticators": [
+                {
+                    "authenticatorId": "T3JnYW5pemF0aW9uQXV0aGVudGljYXRvcg",
+                    "isEnabled": true,
+                    "isDefault": true,
+                    "properties": []
+                }
+            ]
+        }
+    },
+    "image": "organization",
+    "services": [],
+    "disabled": false,
+    "type": "ENTERPRISE"
+}


### PR DESCRIPTION
### Purpose
> This PR implements a new IDP template **Organization Enterprise IDP** to support the organization management feature. This implementation includes
- New template for the IDP
- Create modal for IDP creation
- Connect with the backend API
- Label to identify Organization IDPs in IDP list view
- Hide settings tab for Organization IDPs

### Related Issues
- https://github.com/wso2/product-is/issues/14304

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
