### PR TITLE
Get profile info from the id token instead of the Me endpoint

### DIFF
--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -126,7 +126,6 @@ export const getProfileInformation = (
                     return;
                 }
                 dispatch(setProfileInfo<ProfileInfoInterface>(infoResponse));
-
                 commonConfig.hotjarTracking.tagAttributes();
 
                 getProfileSchema();

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { AsgardeoSPAClient, DecodedIDTokenPayload } from "@asgardeo/auth-react";
 import { getProfileInfo, getProfileSchemas } from "@wso2is/core/api";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import {
@@ -34,9 +35,9 @@ import {
 import { I18n } from "@wso2is/i18n";
 import isEmpty from "lodash-es/isEmpty";
 import { Dispatch } from "redux";
+import { commonConfig } from "../../../../extensions";
 import { Config } from "../../../core/configs";
 import { store } from "../../../core/store";
-import { commonConfig } from "../../../../extensions";
 
 /**
  *  Gets profile information by making an API call
@@ -48,92 +49,117 @@ export const getProfileInformation = (
 
     dispatch(setProfileInfoRequestLoadingStatus(true));
 
-    // Get the profile info.
-    // TODO: Add the function to handle SCIM disabled error.
-    getProfileInfo(meEndpoint, clientOrigin, null)
-        .then((infoResponse: ProfileInfoInterface) => {
-            if (infoResponse.responseStatus !== 200) {
+    const getProfileInfoFromToken = true;
+
+    const getProfileSchema = (): void => {
+        // If the schemas in the redux store is empty, fetch the SCIM schemas from the API.
+        if (isEmpty(store.getState().profile.profileSchemas)) {
+            dispatch(setProfileSchemaRequestLoadingStatus(true));
+
+            getProfileSchemas(store.getState().config.endpoints?.schemas)
+                .then((response: ProfileSchemaInterface[]) => {
+                    dispatch(setSCIMSchemas<ProfileSchemaInterface[]>(response));
+                })
+                .catch((error: IdentityAppsApiException) => {
+                    if (error?.response?.data?.description) {
+                        dispatch(
+                            addAlert<AlertInterface>({
+                                description: error.response.data.description,
+                                level: AlertLevels.ERROR,
+                                message: I18n.instance.t("console:manage.notifications.getProfileSchema." +
+                                    "error.message")
+                            })
+                        );
+                    }
+
+                    dispatch(
+                        addAlert<AlertInterface>({
+                            description: I18n.instance.t(
+                                "console:manage.notifications.getProfileSchema.genericError.description"
+                            ),
+                            level: AlertLevels.ERROR,
+                            message: I18n.instance.t(
+                                "console:manage.notifications.getProfileSchema.genericError.message"
+                            )
+                        })
+                    );
+                })
+                .finally(() => {
+                    dispatch(setProfileSchemaRequestLoadingStatus(false));
+                });
+        }
+    };
+
+    if (getProfileInfoFromToken && meEndpoint.includes("scim2/Me")) {
+        AsgardeoSPAClient.getInstance().getDecodedIDToken().then((decodedToken: DecodedIDTokenPayload) => {
+            const profileInfo: ProfileInfoInterface = {
+                emails: [ decodedToken.email ] ?? [],
+                id: decodedToken.sub,
+                name: {
+                    familyName: decodedToken.family_name ?? "",
+                    givenName: decodedToken.given_name ?? ""
+                },
+                profileUrl: "",
+                userName: decodedToken.username
+            };
+
+            dispatch(setProfileInfo(profileInfo));
+            dispatch(setProfileInfoRequestLoadingStatus(false));
+            getProfileSchema();
+        });
+    } else {
+        // Get the profile info.
+        // TODO: Add the function to handle SCIM disabled error.
+        getProfileInfo(meEndpoint, clientOrigin, null)
+            .then((infoResponse: ProfileInfoInterface) => {
+                if (infoResponse.responseStatus !== 200) {
+                    dispatch(
+                        addAlert({
+                            description: I18n.instance.t(
+                                "console:manage.notifications.getProfileInfo.genericError.description"
+                            ),
+                            level: AlertLevels.ERROR,
+                            message: I18n.instance.t("console:manage.notifications.getProfileInfo.genericError.message")
+                        })
+                    );
+
+                    return;
+                }
+                dispatch(setProfileInfo<ProfileInfoInterface>(infoResponse));
+
+                commonConfig.hotjarTracking.tagAttributes();
+
+                getProfileSchema();
+
+                return;
+            })
+            .catch((error: IdentityAppsApiException) => {
+                if (error.response && error.response.data && error.response.data.detail) {
+                    dispatch(
+                        addAlert({
+                            description: I18n.instance.t(
+                                "console:manage.notifications.getProfileInfo.error.description", {
+                                    description: error.response.data.detail
+                                } ),
+                            level: AlertLevels.ERROR,
+                            message: I18n.instance.t("console:manage.notifications.getProfileInfo.error.message")
+                        })
+                    );
+
+                    return;
+                }
+
                 dispatch(
                     addAlert({
-                        description: I18n.instance.t(
-                            "console:manage.notifications.getProfileInfo.genericError.description"
-                        ),
+                        description: I18n.instance.t("console:manage.notifications.getProfileInfo.genericError." +
+                            "description"),
                         level: AlertLevels.ERROR,
                         message: I18n.instance.t("console:manage.notifications.getProfileInfo.genericError.message")
                     })
                 );
-
-                return;
-            }
-
-            dispatch(setProfileInfo<ProfileInfoInterface>(infoResponse));
-
-            commonConfig.hotjarTracking.tagAttributes();
-
-            // If the schemas in the redux store is empty, fetch the SCIM schemas from the API.
-            if (isEmpty(store.getState().profile.profileSchemas)) {
-                dispatch(setProfileSchemaRequestLoadingStatus(true));
-
-                getProfileSchemas()
-                    .then((response: ProfileSchemaInterface[]) => {
-                        dispatch(setSCIMSchemas<ProfileSchemaInterface[]>(response));
-                    })
-                    .catch((error: IdentityAppsApiException) => {
-                        if (error?.response?.data?.description) {
-                            dispatch(
-                                addAlert<AlertInterface>({
-                                    description: error.response.data.description,
-                                    level: AlertLevels.ERROR,
-                                    message: I18n.instance.t("console:manage.notifications.getProfileSchema." +
-                                        "error.message")
-                                })
-                            );
-                        }
-
-                        dispatch(
-                            addAlert<AlertInterface>({
-                                description: I18n.instance.t(
-                                    "console:manage.notifications.getProfileSchema.genericError.description"
-                                ),
-                                level: AlertLevels.ERROR,
-                                message: I18n.instance.t(
-                                    "console:manage.notifications.getProfileSchema.genericError.message"
-                                )
-                            })
-                        );
-                    })
-                    .finally(() => {
-                        dispatch(setProfileSchemaRequestLoadingStatus(false));
-                    });
-            }
-
-            return;
-        })
-        .catch((error: IdentityAppsApiException) => {
-            if (error.response && error.response.data && error.response.data.detail) {
-                dispatch(
-                    addAlert({
-                        description: I18n.instance.t("console:manage.notifications.getProfileInfo.error.description", {
-                            description: error.response.data.detail
-                        }),
-                        level: AlertLevels.ERROR,
-                        message: I18n.instance.t("console:manage.notifications.getProfileInfo.error.message")
-                    })
-                );
-
-                return;
-            }
-
-            dispatch(
-                addAlert({
-                    description: I18n.instance.t("console:manage.notifications.getProfileInfo.genericError." +
-                        "description"),
-                    level: AlertLevels.ERROR,
-                    message: I18n.instance.t("console:manage.notifications.getProfileInfo.genericError.message")
-                })
-            );
-        })
-        .finally(() => {
-            dispatch(setProfileInfoRequestLoadingStatus(false));
-        });
+            })
+            .finally(() => {
+                dispatch(setProfileInfoRequestLoadingStatus(false));
+            });
+    }
 };

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -49,7 +49,7 @@ export const getProfileInformation = (
 
     dispatch(setProfileInfoRequestLoadingStatus(true));
 
-    const getProfileInfoFromToken = true;
+    const getProfileInfoFromToken = window[ "AppUtils" ].getConfig().getProfileInfoFromIDToken ?? false;
 
     const getProfileSchema = (): void => {
         // If the schemas in the redux store is empty, fetch the SCIM schemas from the API.

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -127,7 +127,6 @@ export const getProfileInformation = (
                 }
                 dispatch(setProfileInfo<ProfileInfoInterface>(infoResponse));
                 commonConfig.hotjarTracking.tagAttributes();
-
                 getProfileSchema();
 
                 return;

--- a/apps/console/src/features/claims/components/add/add-local-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-local-claim.tsx
@@ -29,7 +29,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Grid, Icon, Modal } from "semantic-ui-react";
 import { UserStoreListItem } from "../../../../features/userstores";
 import { attributeConfig } from "../../../../extensions";
-import { AppState, EventPublisher } from "../../../core";
+import { AppState, EventPublisher, store } from "../../../core";
 import { AppConstants } from "../../../core/constants";
 import { history } from "../../../core/helpers";
 import { addDialect, addExternalClaim, addLocalClaim } from "../../api";
@@ -105,7 +105,7 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
 
     /**
      * Conditionally disable map attribute step
-     * if there are no secondary user stores and 
+     * if there are no secondary user stores and
      * if the user stores are disabled
      */
     useEffect(() => {
@@ -114,7 +114,7 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
 
         if ( hiddenUserStores && hiddenUserStores.length > 0) {
             attributeConfig.localAttributes.isUserStoresHidden(hiddenUserStores).then(state => {
-                state.map((store: UserStoreListItem) => {   
+                state.map((store: UserStoreListItem) => {
                     if(store.enabled){
                         userStoresEnabled = true;
                     }
@@ -243,7 +243,7 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
     const fetchUpdatedSchemaList = (): void => {
         dispatch(setProfileSchemaRequestLoadingStatus(true));
 
-        getProfileSchemas()
+        getProfileSchemas(store.getState().config.endpoint?.schemas)
             .then((response: ProfileSchemaInterface[]) => {
                 dispatch(setSCIMSchemas<ProfileSchemaInterface[]>(response));
             })

--- a/apps/console/src/features/claims/components/claims-list.tsx
+++ b/apps/console/src/features/claims/components/claims-list.tsx
@@ -46,15 +46,15 @@ import {
 } from "@wso2is/react-components";
 import isEqual from "lodash-es/isEqual";
 import React,{
-    Dispatch, 
-    FunctionComponent, 
-    ReactElement, 
-    ReactNode, 
-    SetStateAction, 
-    SyntheticEvent, 
-    useEffect, 
-    useRef, 
-    useState 
+    Dispatch,
+    FunctionComponent,
+    ReactElement,
+    ReactNode,
+    SetStateAction,
+    SyntheticEvent,
+    useEffect,
+    useRef,
+    useState
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -67,7 +67,8 @@ import {
     FeatureConfigInterface,
     UIConstants,
     getEmptyPlaceholderIllustrations,
-    history
+    history,
+    store
 } from "../../core";
 import { UserStoreListItem, getUserStores } from "../../userstores";
 import { deleteAClaim, deleteADialect, deleteAnExternalClaim } from "../api";
@@ -404,7 +405,7 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
     const fetchUpdatedSchemaList = (): void => {
         dispatch(setProfileSchemaRequestLoadingStatus(true));
 
-        getProfileSchemas()
+        getProfileSchemas(store.getState().config.endpoint?.schemas)
             .then((response: ProfileSchemaInterface[]) => {
                 dispatch(setSCIMSchemas<ProfileSchemaInterface[]>(response));
             })
@@ -1045,13 +1046,13 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
                 },
                 attributeConfig.externalAttributes.showDeleteIcon(dialectID, list) && {
                     hidden: (claim: ExternalClaim): boolean => {
-                        if (!hasRequiredScopes(featureConfig?.attributeDialects, 
-                            featureConfig?.attributeDialects?.scopes?.delete, allowedScopes) 
+                        if (!hasRequiredScopes(featureConfig?.attributeDialects,
+                            featureConfig?.attributeDialects?.scopes?.delete, allowedScopes)
                             || attributeConfig.externalAttributes.hideDeleteIcon(claim)) {
                             return true;
                         }
-                        
-                        if (attributeConfig.defaultScimMapping 
+
+                        if (attributeConfig.defaultScimMapping
                             && Object.keys(attributeConfig.defaultScimMapping).length > 0) {
                             const defaultSCIMClaims: Map<string, string> = attributeConfig
                                 .defaultScimMapping[claim.claimDialectURI];

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -46,7 +46,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Divider, Grid, Form as SemanticForm } from "semantic-ui-react";
 import { attributeConfig } from "../../../../../extensions";
 import { SCIMConfigs } from "../../../../../extensions/configs/scim";
-import { AppConstants, AppState, FeatureConfigInterface, history } from "../../../../core";
+import { AppConstants, AppState, FeatureConfigInterface, history, store } from "../../../../core";
 import { deleteAClaim, getExternalClaims, updateAClaim } from "../../../api";
 import { ClaimManagementConstants } from "../../../constants";
 
@@ -226,7 +226,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
     const fetchUpdatedSchemaList = (): void => {
         dispatch(setProfileSchemaRequestLoadingStatus(true));
 
-        getProfileSchemas()
+        getProfileSchemas(store.getState().config.endpoint?.schemas)
             .then((response: ProfileSchemaInterface[]) => {
                 dispatch(setSCIMSchemas<ProfileSchemaInterface[]>(response));
             })

--- a/apps/console/src/features/core/store/reducers/config.ts
+++ b/apps/console/src/features/core/store/reducers/config.ts
@@ -118,6 +118,7 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
             rolesWithoutOrgPath: "",
             rootOrganization: "",
             saml2Meta: "",
+            schemas: "",
             selfSignUp: "",
             serverConfigurations: "",
             serverSupportedSchemas: "",

--- a/apps/console/src/features/users/configs/endpoints.ts
+++ b/apps/console/src/features/users/configs/endpoints.ts
@@ -26,8 +26,9 @@ import { UsersResourceEndpointsInterface } from "../models";
  */
 export const getUsersResourceEndpoints = (serverHost: string): UsersResourceEndpointsInterface => {
     return {
-        bulk: `${ serverHost }/scim2/Bulk`,
-        groups: `${ serverHost }/scim2/Groups`,
+        bulk: `${serverHost}/scim2/Bulk`,
+        groups: `${serverHost}/scim2/Groups`,
+        schemas: `${ serverHost }/scim2/Schemas`,
         userSessions: `${ serverHost }/api/users/v1/{0}/sessions`,
         userStores: `${ serverHost }/api/server/v1/userstores`,
         users: `${ serverHost }/scim2/Users`

--- a/apps/console/src/features/users/models/endpoints.ts
+++ b/apps/console/src/features/users/models/endpoints.ts
@@ -25,4 +25,5 @@ export interface UsersResourceEndpointsInterface {
     userSessions: string;
     userStores: string;
     users: string;
+    schemas: string;
 }

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -242,6 +242,7 @@ export const AppUtils = (function() {
                 docSiteUrl: _config.docSiteUrl,
                 documentation: _config.documentation,
                 extensions: _config.extensions,
+                getProfileInfoFromIDToken: _config.getProfileInfoFromIDToken,
                 idpConfigs: this.resolveIdpConfigs(),
                 isSaas: this.isSaas(),
                 loginCallbackURL: this.constructRedirectURLs(_config.loginCallbackPath),

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -166,9 +166,8 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                 });
             } else {
                 dispatch(setGetOrganizationLoading(false));
+                tenantDomain = CommonAuthenticateUtils.deriveTenantDomainFromSubject(response.sub);
             }
-
-            tenantDomain = CommonAuthenticateUtils.deriveTenantDomainFromSubject(response.sub);
 
             // Update the app base name with the newly resolved tenant.
             window[ "AppUtils" ].updateTenantQualifiedBaseName(tenantDomain);

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -43,6 +43,7 @@
         "logoutEndpointURL": "${serverOrigin}/${tenantPrefix}/${superTenantDomain}/oidc/logout",
         "oidcSessionIFrameEndpointURL": "${serverOrigin}/${tenantPrefix}/${superTenantDomain}/oidc/checksession"
     },
+    "getProfileInfoFromIDToken": true,
     "i18nResourcePath": "",
     "isSaas": true,
     "loginCallbackPath": "",

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -36,7 +36,7 @@
         "enablePKCE": true,
         "clockTolerance": 300,
         "responseMode": "query",
-        "scope": [ "SYSTEM" ],
+        "scope": [ "SYSTEM", "profile" ],
         "serverOrigin": "https://localhost:9443",
         "storage": "webWorker",
         "authorizeEndpointURL": "${serverOrigin}/${tenantPrefix}/${superTenantDomain}/oauth2/authorize?ut=${userTenantDomain}",

--- a/apps/myaccount/src/store/actions/authenticate.ts
+++ b/apps/myaccount/src/store/actions/authenticate.ts
@@ -100,7 +100,7 @@ export const getScimSchemas = (
 
     dispatch(setProfileSchemaLoader(true));
 
-    getProfileSchemas()
+    getProfileSchemas(store.getState().config.endpoint?.schemas)
         .then((response: ProfileSchema[]) => {
             dispatch(setProfileSchemaLoader(false));
             dispatch(setScimSchemas(response));
@@ -131,7 +131,7 @@ export const getProfileInformation = (updateProfileCompletion = false) => (dispa
                         dispatch(
                             setProfileInfo({
                                 ...infoResponse,
-                                isReadOnly: 
+                                isReadOnly:
                                     response[SCIMConfigs.scim.customEnterpriseSchema]
                                         ?.isReadOnlyUser
                             })

--- a/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/features/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -107,6 +107,9 @@
         {% endfor %}
         {% endif %}
     },
+    {% if console.get_profile_info_from_id_token is defined %}
+        "getProfileInfoFromIDToken": {{ console.get_profile_info_from_id_token }},
+    {% endif %}
     "ui": {
         "announcements": [
             {% if console.ui.announcements is defined %}

--- a/modules/core/src/api/profile.ts
+++ b/modules/core/src/api/profile.ts
@@ -218,12 +218,12 @@ export const updateProfileImageURL = (url: string): Promise<ProfileInfoInterface
  * @return {Promise<ProfileSchemaInterface[]>} Array of profile schemas as a Promise.
  * @throws {IdentityAppsApiException}
  */
-export const getProfileSchemas = (): Promise<ProfileSchemaInterface[]> => {
+export const getProfileSchemas = (url?: string): Promise<ProfileSchemaInterface[]> => {
 
     const requestConfig = {
         headers: HTTPRequestHeaders(ContextUtils.getRuntimeConfig().clientHost, null, ContentTypeHeaderValues.APP_JSON),
         method: HttpMethods.GET,
-        url: CommonServiceResourcesEndpoints(ContextUtils.getRuntimeConfig().serverHost).profileSchemas
+        url: url ?? CommonServiceResourcesEndpoints(ContextUtils.getRuntimeConfig().serverHost).profileSchemas
     };
     const schemaAttributes: ProfileSchemaInterface[] = [];
 


### PR DESCRIPTION
### Purpose
> To avoid requests being sent to the `Me` endpoint of the root organization, get the profile info from the ID token.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
