### PR TITLE
Improve privileged business user login

### DIFF
--- a/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -86,6 +86,14 @@
         </context-param>
     {% endif %}
 
+    {% if authenticationendpoint.console_url is defined %}
+     <!-- *************** Console URL ********************** -->
+        <context-param>
+            <param-name>ConsoleURL</param-name>
+            <param-value>{{ authenticationendpoint.console_url }}</param-value>
+        </context-param>
+    {% endif %}
+
     <!-- *************** End of Account Recovery Endpoint Context URL Configuration ********************** -->
     <!-- *************** Identity Server Endpoint URL Configuration ********************** -->
     {% if authenticationendpoint.identity_server_endpoint_url is defined %}


### PR DESCRIPTION
### Purpose
- Passs console url as a config 

Add the console login url as config in the `deployment.toml`. 
Eg

```
[authenticationendpoint]
console_url = "https://localhost:9443/console"
```

### Related Issues
- Issue 

### Related PRs
- Related PR 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
