### PR TITLE
Send the initial get organization call to the organization's endpoint

### DIFF
--- a/apps/console/src/features/core/models/reducer-state.ts
+++ b/apps/console/src/features/core/models/reducer-state.ts
@@ -33,7 +33,7 @@ import {
 } from "./config";
 import { PortalDocumentationStructureInterface } from "./help-panel";
 import { AppViewTypes } from "./ui";
-import { OrganizationInterface } from "../../organizations/models";
+import { OrganizationResponseInterface } from "../../organizations/models";
 
 /**
  * Portal config reducer state interface.
@@ -75,7 +75,7 @@ export interface AccessControlReducerStateInterface {
  * Organization Reducer State Interface.
  */
 export interface OrganizationReducerStateInterface {
-    organization?: OrganizationInterface;
+    organization?: OrganizationResponseInterface;
     getOrganizationLoading: boolean;
 }
 

--- a/apps/console/src/features/core/store/actions/organization.ts
+++ b/apps/console/src/features/core/store/actions/organization.ts
@@ -16,8 +16,12 @@
 * under the License.
 */
 
-import { OrganizationActionTypes, SetGetOrganizationLoadingActionInterface, SetOrganizationActionInterface } from "./types";
-import { OrganizationInterface, OrganizationResponseInterface } from "../../../organizations/models";
+import {
+    OrganizationActionTypes,
+    SetGetOrganizationLoadingActionInterface,
+    SetOrganizationActionInterface
+} from "./types";
+import { OrganizationResponseInterface } from "../../../organizations/models";
 
 /**
  * This action sets an organization in the redux store.

--- a/apps/console/src/features/core/store/actions/organization.ts
+++ b/apps/console/src/features/core/store/actions/organization.ts
@@ -17,7 +17,7 @@
 */
 
 import { OrganizationActionTypes, SetGetOrganizationLoadingActionInterface, SetOrganizationActionInterface } from "./types";
-import { OrganizationInterface } from "../../../organizations/models";
+import { OrganizationInterface, OrganizationResponseInterface } from "../../../organizations/models";
 
 /**
  * This action sets an organization in the redux store.
@@ -26,7 +26,7 @@ import { OrganizationInterface } from "../../../organizations/models";
  *
  * @returns {SetOrganizationActionInterface} - A set organization action
  */
-export const setOrganization = (organization: OrganizationInterface): SetOrganizationActionInterface => {
+export const setOrganization = (organization: OrganizationResponseInterface): SetOrganizationActionInterface => {
     return {
         payload: organization,
         type: OrganizationActionTypes.SET_ORGANIZATION

--- a/apps/console/src/features/core/store/actions/types/organization.ts
+++ b/apps/console/src/features/core/store/actions/types/organization.ts
@@ -16,7 +16,7 @@
 * under the License.
 */
 
-import { OrganizationInterface } from "../../../../organizations/models";
+import { OrganizationResponseInterface } from "../../../../organizations/models";
 
 export enum OrganizationActionTypes {
     SET_ORGANIZATION,
@@ -24,7 +24,7 @@ export enum OrganizationActionTypes {
 }
 
 export interface SetOrganizationActionInterface {
-    payload: OrganizationInterface;
+    payload: OrganizationResponseInterface;
     type: OrganizationActionTypes.SET_ORGANIZATION;
 }
 

--- a/apps/console/src/features/core/store/reducers/organization.ts
+++ b/apps/console/src/features/core/store/reducers/organization.ts
@@ -22,7 +22,22 @@ import { OrganizationAction, OrganizationActionTypes } from "../actions/types";
 
 const initialState: OrganizationReducerStateInterface = {
     getOrganizationLoading: true,
-    organization: OrganizationManagementConstants.ROOT_ORGANIZATION
+    organization: {
+        attributes: [],
+        created: new Date().toString(),
+        description: "",
+        domain: "",
+        id: OrganizationManagementConstants.ROOT_ORGANIZATION.id,
+        lastModified: new Date().toString(),
+        name: OrganizationManagementConstants.ROOT_ORGANIZATION.name,
+        parent: {
+            id: "",
+            ref: ""
+        },
+        status: "",
+        type: ""
+
+    }
 };
 
 export const organizationReducer = (

--- a/apps/console/src/features/organizations/components/add-organization-role/organization-role-sumary.tsx
+++ b/apps/console/src/features/organizations/components/add-organization-role/organization-role-sumary.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-groups.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-groups.tsx
@@ -18,7 +18,6 @@
 
 import {
     AlertLevels,
-    RolesInterface,
     RolesMemberInterface,
     TestableComponentInterface
 } from "@wso2is/core/models";
@@ -57,7 +56,11 @@ import { AppState, getEmptyPlaceholderIllustrations } from "../../../core";
 import { getGroupList } from "../../../groups/api";
 import { patchOrganizationRoleDetails } from "../../api";
 import { APPLICATION_DOMAIN, INTERNAL_DOMAIN, PRIMARY_DOMAIN } from "../../constants";
-import { OrganizationInterface, OrganizationRoleInterface, PatchOrganizationRoleDataInterface } from "../../models";
+import {
+    OrganizationResponseInterface,
+    OrganizationRoleInterface,
+    PatchOrganizationRoleDataInterface
+} from "../../models";
 
 interface RoleGroupsPropsInterface extends TestableComponentInterface {
     /**
@@ -103,7 +106,7 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
     const [ isLoadingAssignedGroups, setIsLoadingAssignedGroups ] = useState<boolean>(true);
 
     const [ alert, setAlert, alertComponent ] = useWizardAlert();
-    const currentOrganization: OrganizationInterface = useSelector(
+    const currentOrganization: OrganizationResponseInterface = useSelector(
         (state: AppState) => state.organization.organization
     );
 

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-permission.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-permission.tsx
@@ -24,7 +24,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { OrganizationPermissionList } from "./organization-role-permission";
 import { AppState } from "../../../core";
 import { patchOrganizationRoleDetails } from "../../api";
-import { OrganizationInterface, OrganizationRoleInterface, TreeNode } from "../../models";
+import { OrganizationResponseInterface, OrganizationRoleInterface, TreeNode } from "../../models";
 
 /**
  * Interface to capture permission edit props.
@@ -58,7 +58,7 @@ export const RolePermissionDetails: FunctionComponent<RolePermissionDetailProps>
     const { t } = useTranslation();
     const dispatch = useDispatch();
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const currentOrganization: OrganizationInterface = useSelector(
+    const currentOrganization: OrganizationResponseInterface = useSelector(
         (state: AppState) => state.organization.organization
     );
 

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
@@ -28,7 +28,11 @@ import { AppConstants, AppState, SharedUserStoreConstants, SharedUserStoreUtils,
 import { PRIMARY_USERSTORE_PROPERTY_VALUES } from "../../../userstores";
 import { deleteOrganizationRole, getOrganizationRoles, patchOrganizationRoleDetails } from "../../api";
 import { OrganizationRoleManagementConstants } from "../../constants";
-import { OrganizationInterface, OrganizationRoleInterface, PatchOrganizationRoleDataInterface } from "../../models";
+import {
+    OrganizationResponseInterface,
+    OrganizationRoleInterface,
+    PatchOrganizationRoleDataInterface
+} from "../../models";
 
 /**
  * Interface to contain props needed for component
@@ -82,7 +86,7 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
     const [ isRegExLoading, setRegExLoading ] = useState<boolean>(false);
     const [ userStore ] = useState<string>(SharedUserStoreConstants.PRIMARY_USER_STORE);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const currentOrganization: OrganizationInterface = useSelector(
+    const currentOrganization: OrganizationResponseInterface = useSelector(
         (state: AppState) => state.organization.organization
     );
 

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-users.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-users.tsx
@@ -27,7 +27,7 @@ import { patchOrganizationRoleDetails } from "../../api";
 import { PRIMARY_DOMAIN } from "../../constants";
 import {
     CreateOrganizationRoleMemberInterface,
-    OrganizationInterface,
+    OrganizationResponseInterface,
     PatchOrganizationRoleDataInterface
 } from "../../models";
 
@@ -52,7 +52,7 @@ export const RoleUserDetails: FunctionComponent<RoleUserDetailsProps> = (
 
     const [ currentUserStore, setCurrentUserStore ] = useState<string>(undefined);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const currentOrganization: OrganizationInterface = useSelector(
+    const currentOrganization: OrganizationResponseInterface = useSelector(
         (state: AppState) => state.organization.organization
     );
 

--- a/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
+++ b/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
@@ -37,7 +37,12 @@ import { ReactComponent as CrossIcon } from "../../../../themes/default/assets/i
 import { AppConstants, AppState, getMiscellaneousIcons, getSidePanelIcons, history } from "../../../core";
 import { getOrganizations } from "../../api";
 import { OrganizationManagementConstants } from "../../constants";
-import { OrganizationInterface, OrganizationLinkInterface, OrganizationListInterface } from "../../models";
+import {
+    OrganizationInterface,
+    OrganizationLinkInterface,
+    OrganizationListInterface,
+    OrganizationResponseInterface
+} from "../../models";
 import { OrganizationUtils } from "../../utils";
 
 /**
@@ -53,7 +58,7 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
     const { t } = useTranslation();
     const dispatch = useDispatch();
 
-    const currentOrganization: OrganizationInterface = useSelector(
+    const currentOrganization: OrganizationResponseInterface = useSelector(
         (state: AppState) => state.organization.organization
     );
 
@@ -170,7 +175,7 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
         </span>
     );
 
-    const handleOrganizationSwitch = (organization: OrganizationInterface): void => {
+    const handleOrganizationSwitch = (organization: OrganizationInterface | OrganizationResponseInterface): void => {
         let newOrgPath: string = "";
 
         if (OrganizationUtils.isRootOrganization(organization)) {
@@ -205,7 +210,8 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
         e.stopPropagation();
     };
 
-    const getOrganizationItemGroup = (organization: OrganizationInterface, isClickable: boolean) => (
+    const getOrganizationItemGroup = (organization: OrganizationInterface | OrganizationResponseInterface,
+        isClickable: boolean) => (
         <Item.Group className="tenant-item-wrapper" unstackable>
             <Item
                 className="header"

--- a/apps/console/src/features/organizations/pages/organization-roles-edit.tsx
+++ b/apps/console/src/features/organizations/pages/organization-roles-edit.tsx
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import { AppConstants, AppState, FeatureConfigInterface, history } from "../../core";
 import { getOrganizationRoleById } from "../api";
 import { EditOrganizationRole } from "../components/edit-organization-role";
-import { OrganizationInterface, OrganizationRoleInterface } from "../models";
+import { OrganizationResponseInterface, OrganizationRoleInterface } from "../models";
 
 const OrganizationRolesEdit: FunctionComponent = (
 ): ReactElement => {
@@ -17,7 +17,7 @@ const OrganizationRolesEdit: FunctionComponent = (
     const [ roleId, setRoleId ] = useState<string>(undefined);
     const [ roleObject, setRoleObject ] = useState<OrganizationRoleInterface>();
     const [ isRoleDetailsRequestLoading, setIsRoleDetailsRequestLoading ] = useState<boolean>(false);
-    const currentOrganization: OrganizationInterface = useSelector(
+    const currentOrganization: OrganizationResponseInterface = useSelector(
         (state: AppState) => state.organization.organization
     );
 

--- a/apps/console/src/features/organizations/pages/organization-roles.tsx
+++ b/apps/console/src/features/organizations/pages/organization-roles.tsx
@@ -49,7 +49,7 @@ import { createOrganizationRole, getOrganizationRoles } from "../api/organizatio
 import { OrganizationRoleList } from "../components";
 import { AddOrganizationRoleWizard } from "../components/add-organization-role-wizard";
 import {
-    OrganizationInterface,
+    OrganizationResponseInterface,
     OrganizationRoleListItemInterface,
     OrganizationRoleListResponseInterface
 } from "../models";
@@ -98,7 +98,7 @@ const OrganizationRoles: FunctionComponent<OrganizationRolesPageInterface> = (
     const [ activePage, setActivePage ] = useState<number>(1);
 
     const [ paginationReset, triggerResetPagination ] = useTrigger();
-    const currentOrganization: OrganizationInterface = useSelector(
+    const currentOrganization: OrganizationResponseInterface = useSelector(
         (state: AppState) => state.organization.organization
     );
 

--- a/apps/console/src/features/organizations/utils/organization.ts
+++ b/apps/console/src/features/organizations/utils/organization.ts
@@ -17,7 +17,7 @@
 */
 
 import { OrganizationManagementConstants } from "../constants";
-import { OrganizationInterface } from "../models";
+import { OrganizationResponseInterface } from "../models";
 
 export class OrganizationUtils {
     /**
@@ -34,7 +34,7 @@ export class OrganizationUtils {
      *
      * @returns {boolean}
      */
-    public static isRootOrganization(organization: OrganizationInterface): boolean {
+    public static isRootOrganization(organization: OrganizationResponseInterface): boolean {
         return !organization || organization.id === OrganizationManagementConstants.ROOT_ORGANIZATION_ID;
     }
 }

--- a/apps/console/src/features/organizations/utils/organization.ts
+++ b/apps/console/src/features/organizations/utils/organization.ts
@@ -17,7 +17,7 @@
 */
 
 import { OrganizationManagementConstants } from "../constants";
-import { OrganizationResponseInterface } from "../models";
+import { OrganizationInterface, OrganizationResponseInterface } from "../models";
 
 export class OrganizationUtils {
     /**
@@ -34,7 +34,7 @@ export class OrganizationUtils {
      *
      * @returns {boolean}
      */
-    public static isRootOrganization(organization: OrganizationResponseInterface): boolean {
+    public static isRootOrganization(organization: OrganizationResponseInterface | OrganizationInterface): boolean {
         return !organization || organization.id === OrganizationManagementConstants.ROOT_ORGANIZATION_ID;
     }
 }

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -48,7 +48,7 @@ import {
 } from "@wso2is/i18n";
 import axios, { AxiosResponse } from "axios";
 import has from "lodash-es/has";
-import React, {FunctionComponent, lazy, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, ReactElement, lazy, useEffect, useState } from "react";
 import { I18nextProvider, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { commonConfig } from "./extensions";
@@ -116,9 +116,6 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
 
             let tenantDomain: string = "";
 
-            // This is to make sure the call to the organization endpoint is generated.
-            await dispatch(setServiceResourceEndpoints(Config.getServiceResourceEndpoints()));
-
             if (window[ "AppUtils" ].getConfig().organizationName) {
                 // We are actually getting the orgId here rather than orgName
                 const orgId = window["AppUtils"].getConfig().organizationName;
@@ -139,6 +136,8 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                     status: "",
                     type: ""
                 }));
+
+                // This is to make sure the endpoints are generated with the organization path.
                 await dispatch(setServiceResourceEndpoints(Config.getServiceResourceEndpoints()));
 
                 dispatch(setGetOrganizationLoading(true));


### PR DESCRIPTION
### Purpose
> Before, the initial get organization call was sent to the root organization. This resulted in a non-super admin user being unable to log in. This PR resolves this issue by sending the initial organization call to the organization's endpoint.
### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
