### PR TITLE
Remove the last / in All Permissions resourcePath

### DIFF
--- a/apps/console/src/features/organizations/api/organization-role.ts
+++ b/apps/console/src/features/organizations/api/organization-role.ts
@@ -219,7 +219,7 @@ export const getOrganizationPermissions = (): Promise<any> => {
             data: [
                 {
                     "displayName": "All Permissions",
-                    "resourcePath": "/permission/"
+                    "resourcePath": "/permission"
                 },
                 {
                     "displayName": "Admin",


### PR DESCRIPTION
### Purpose
> Since the permission list is hardcoded in the FE for now, there was a mistake when defining the "All Permission" resource path. This PR tallies it with the BE

### Related Issues
- https://github.com/wso2/product-is/issues/14331 (Partially related)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
