### PR TITLE
[Port 1.2.x] Improve IDP Extensibility (#3186)

### DIFF
--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -30,6 +30,8 @@
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.AUTHENTICATION_MECHANISM_NOT_CONFIGURED" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.ENABLE_AUTHENTICATION_WITH_REST_API" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.ERROR_WHILE_BUILDING_THE_ACCOUNT_RECOVERY_ENDPOINT_URL" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityProviderDataRetrievalClient" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityProviderDataRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.ArrayList" %>
@@ -314,6 +316,16 @@
                                             isHubIdp = true;
                                             idpName = idpName.substring(0, idpName.length() - 4);
                                         }
+
+                                        // Uses the `IdentityProviderDataRetrievalClient` to get the IDP image.
+                                        String imageURL = "libs/themes/default/assets/images/identity-providers/enterprise-idp-illustration.svg";
+
+                                        try {
+                                            IdentityProviderDataRetrievalClient identityProviderDataRetrievalClient = new IdentityProviderDataRetrievalClient();
+                                            imageURL = identityProviderDataRetrievalClient.getIdPImage(tenantDomain, idpName);
+                                        } catch (IdentityProviderDataRetrievalClientException e) {
+                                            // Exception is ignored and the default `imageURL` value will be used as a fallback.
+                                        }
                             %>
                                 <% if (isHubIdp) { %>
                                     <div class="field">
@@ -336,17 +348,24 @@
                                             </div>
                                         </div>
                                     </div>
+                                    <br>
                                 <% } else { %>
-                                    <div class="field">
-                                        <button class="ui icon button fluid"
-                                            onclick="handleNoDomain(this,
-                                                '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpName))%>',
-                                                '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getValue()))%>')"
-                                            id="icon-<%=iconId%>"
-                                            title="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> <%=Encode.forHtmlAttribute(idpName)%>">
-                                            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> <strong><%=Encode.forHtmlContent(idpName)%></strong>
-                                        </button>
+                                    <div class="external-login blurring external-login-dimmer">
+                                        <div class="field">
+                                            <button
+                                                class="ui icon button fluid"
+                                                onclick="handleNoDomain(this,
+                                                    '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpName))%>',
+                                                    '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getValue()))%>')"
+                                                id="icon-<%=iconId%>"
+                                                title="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> <%=Encode.forHtmlAttribute(idpName)%>"
+                                            >
+                                                <img class="ui image" src="<%=Encode.forHtmlAttribute(imageURL)%>">
+                                                <span><%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> <%=Encode.forHtmlContent(idpName)%></span>
+                                            </button>
+                                        </div>
                                     </div>
+                                    <br>
                                 <% } %>
                             <% } else if (localAuthenticatorNames.size() > 0) {
                                 if (localAuthenticatorNames.contains(IWA_AUTHENTICATOR)) {

--- a/apps/console/src/extensions/configs/identity-provider.tsx
+++ b/apps/console/src/extensions/configs/identity-provider.tsx
@@ -16,17 +16,48 @@
  * under the License.
  */
 
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { FunctionComponent, ReactElement, SVGProps } from "react";
 import { IdentityProviderConfig } from "./models";
-import { AuthenticatorLabels, IdentityProviderManagementConstants } from "../../features/identity-providers";
+import { IdentityProviderManagementConstants } from "../../features/identity-providers/constants";
+import {
+    AuthenticatorLabels,
+    GenericIdentityProviderCreateWizardPropsInterface,
+    IdentityProviderTabTypes
+} from "../../features/identity-providers/models";
 
 export const identityProviderConfig: IdentityProviderConfig = {
     authenticatorResponseExtension: [],
     authenticators: {},
+    createIdentityProvider: {
+        getOverriddenCreateWizard: (
+            _templateId: string,
+            _props: GenericIdentityProviderCreateWizardPropsInterface & IdentifiableComponentInterface
+        ): ReactElement | null => {
+            return null;
+        }
+    },
     editIdentityProvider: {
         attributesSettings: true,
+        getCertificateOptionsForTemplate: (_templateId: string): { JWKS: boolean; PEM: boolean; } | undefined => {
+            return undefined;
+        },
+        getOverriddenAuthenticatorForm: (
+            _type: string,
+            _templateId: string,
+            _props: Record<string, any>
+        ): ReactElement | null => {
+            return null;
+        },
+        isTabEnabledForIdP: (_templateId: string, _tabType: IdentityProviderTabTypes): boolean | undefined => {
+            return true;
+        },
         showAdvancedSettings: true,
         showJitProvisioning: true,
         showOutboundProvisioning: true
+    },
+    getIconExtensions: (): Record<string, string | FunctionComponent<SVGProps<SVGSVGElement>>> => {
+        return {};
     },
     jitProvisioningSettings: {
         menuItemName: "Just-in-Time Provisioning",

--- a/apps/console/src/extensions/configs/models/identity-providers.ts
+++ b/apps/console/src/extensions/configs/models/identity-providers.ts
@@ -16,8 +16,14 @@
  * under the License.
  */
 
-import { ReactNode } from "react";
-import { AuthenticatorInterface, IdentityProviderTemplateInterface } from "../../../features/identity-providers";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { FunctionComponent, ReactElement, ReactNode, SVGProps } from "react";
+import {
+    AuthenticatorInterface,
+    GenericIdentityProviderCreateWizardPropsInterface,
+    IdentityProviderTabTypes,
+    IdentityProviderTemplateInterface
+} from "../../../features/identity-providers/models";
 
 export interface IdentityProviderConfig {
     /**
@@ -30,6 +36,19 @@ export interface IdentityProviderConfig {
     authenticators: {
         [ key: string ]: AuthenticatorExtensionsConfigInterface;
     };
+    createIdentityProvider: {
+        /**
+         * Used to the IDP create wizard of a certain IDP template type.
+         * @param {string} templateId - The IDP Template Type.
+         * @param {
+         *  GenericIdentityProviderCreateWizardPropsInterface & IdentifiableComponentInterface
+        *  } templateId - Props for the component.
+         */
+        getOverriddenCreateWizard: (
+            templateId: string,
+            props: GenericIdentityProviderCreateWizardPropsInterface & IdentifiableComponentInterface
+        ) => ReactElement | null;
+    },
     editIdentityProvider: {
         showAdvancedSettings: boolean;
         showJitProvisioning: boolean;
@@ -40,7 +59,29 @@ export interface IdentityProviderConfig {
          * variable values is pointless.
          */
         attributesSettings: boolean;
+        /**
+         * Used enable/disable certain tabs for certain IDP template type.
+         * @param {string} templateId - The IDP Template Type.
+         * @param {IdentityProviderTabTypes} tabType - Tab Type.
+         */
+        isTabEnabledForIdP: (templateId: string, tabType: IdentityProviderTabTypes) => boolean | undefined;
+        /**
+         * Used to the IDP settings form of a certain IDP template type.
+         * @param {string} type - The IDP Authenticator ID.
+         * @param {string} templateId - The IDP Template Type.
+         * @param {Record<string, any>} templateId - Props for the component.
+         */
+        getOverriddenAuthenticatorForm: (
+            type: string,
+            templateId: string,
+            props: Record<string, any>
+        ) => ReactElement | null;
+        /**
+         * Certain IDP templates can have different settings for Certificate options.
+         */
+        getCertificateOptionsForTemplate: (templateId: string) => { JWKS: boolean; PEM: boolean } | undefined;
     };
+    getIconExtensions: () => Record<string, string | FunctionComponent<SVGProps<SVGSVGElement>>>;
     jitProvisioningSettings: {
         menuItemName: string;
         enableJitProvisioningField: {

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -22,6 +22,11 @@ import { HttpMethods } from "@wso2is/core/models";
 import { AxiosError, AxiosResponse } from "axios";
 import { identityProviderConfig } from "../../../extensions/configs";
 import { store } from "../../core";
+import useRequest, {
+    RequestConfigInterface,
+    RequestErrorInterface,
+    RequestResultInterface
+} from "../../core/hooks/use-request";
 import { IdentityProviderManagementConstants } from "../constants";
 import {
     AuthenticatorInterface,
@@ -83,6 +88,7 @@ export const createIdentityProvider = (identityProvider: object): Promise<any> =
 /**
  * Gets the IdP list with limit and offset.
  *
+ * @deprecated Use `useIdentityProviderList` hook instead.
  * @param {number} limit - Maximum Limit of the IdP List.
  * @param {number} offset - Offset for get to start.
  * @param {string} filter - Search filter.
@@ -122,6 +128,49 @@ export const getIdentityProviderList = (
         }).catch((error) => {
             return Promise.reject(error);
         });
+};
+
+/**
+ * Hook to get the IDP list with limit and offset.
+ *
+ * @param {number} limit - Maximum Limit of the IdP List.
+ * @param {number} offset - Offset for get to start.
+ * @param {string} filter - Search filter.
+ * @param {string} requiredAttributes - Extra attribute to be included in the list response. ex:`isFederationHub`
+ *
+ * @returns {RequestResultInterface<Data, Error>}
+ */
+export const useIdentityProviderList = <Data = IdentityProviderListResponseInterface, Error = RequestErrorInterface>(
+    limit?: number,
+    offset?: number,
+    filter?: string,
+    requiredAttributes?: string
+): RequestResultInterface<Data, Error> => {
+
+    const requestConfig: RequestConfigInterface = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        params: {
+            filter,
+            limit,
+            offset,
+            requiredAttributes
+        },
+        url: store.getState().config.endpoints.identityProviders
+    };
+
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(requestConfig);
+
+    return {
+        data,
+        error: error,
+        isLoading: !error && !data,
+        isValidating,
+        mutate
+    };
 };
 
 /**

--- a/apps/console/src/features/identity-providers/components/forms/factories/authenticator-form-factory.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/factories/authenticator-form-factory.tsx
@@ -18,6 +18,7 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import React, { FunctionComponent, ReactElement } from "react";
+import { identityProviderConfig } from "../../../../../extensions/configs/identity-provider";
 import { IdentityProviderManagementConstants } from "../../../constants";
 import {
     FederatedAuthenticatorListItemInterface,
@@ -56,6 +57,10 @@ interface AuthenticatorFormFactoryInterface extends TestableComponentInterface {
      * Specifies if the form is submitting.
      */
     isSubmitting?: boolean;
+    /**
+     * Created template Id.
+     */
+    templateId?: string;
 }
 
 /**
@@ -79,8 +84,30 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
         showCustomProperties,
         isReadOnly,
         isSubmitting,
+        templateId,
         [ "data-testid" ]: testId
     } = props;
+
+    /**
+     * Override the form if it's defined in the extensions under `getOverriddenAuthenticatorForm` func.
+     */
+    const OverriddenForm: ReactElement | null = identityProviderConfig
+        .editIdentityProvider
+        .getOverriddenAuthenticatorForm(type, templateId, {
+            "data-componentid": testId,
+            enableSubmitButton,
+            initialValues,
+            isSubmitting,
+            metadata,
+            onSubmit,
+            readOnly: isReadOnly,
+            showCustomProperties,
+            triggerSubmit
+        });
+
+    if (OverriddenForm) {
+        return OverriddenForm;
+    }
 
     switch (type) {
         case IdentityProviderManagementConstants.GOOGLE_OIDC_AUTHENTICATOR_ID:

--- a/apps/console/src/features/identity-providers/components/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/components/identity-provider-edit.tsx
@@ -17,14 +17,14 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { ResourceTab } from "@wso2is/react-components";
+import { ContentLoader, EmphasizedSegment, ResourceTab } from "@wso2is/react-components";
 import React, {
     FunctionComponent,
     ReactElement,
     useEffect,
     useState
 } from "react";
-import { Loader, TabProps } from "semantic-ui-react";
+import { TabProps } from "semantic-ui-react";
 import {
     AdvanceSettings,
     AttributeSettings,
@@ -38,6 +38,7 @@ import { IdentityProviderManagementConstants } from "../constants";
 import {
     IdentityProviderAdvanceInterface,
     IdentityProviderInterface,
+    IdentityProviderTabTypes,
     IdentityProviderTemplateInterface
 } from "../models";
 
@@ -127,6 +128,12 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
         isFederationHub: identityProvider.isFederationHub
     };
 
+    const Loader = (): ReactElement => (
+        <EmphasizedSegment padded>
+            <ContentLoader inline="centered" active/>
+        </EmphasizedSegment>
+    );
+
     const GeneralIdentityProviderSettingsTabPane = (): ReactElement => (
         <ResourceTab.Pane controlledSegmentation>
             <GeneralSettings
@@ -149,6 +156,7 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
                 onUpdate={ onUpdate }
                 data-testid={ `${ testId }-general-settings` }
                 isReadOnly = { isReadOnly }
+                loader={ Loader }
             />
         </ResourceTab.Pane>
     );
@@ -179,6 +187,7 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
                     )
                 }
                 isReadOnly={ isReadOnly }
+                loader={ Loader }
             />
         </ResourceTab.Pane>
     );
@@ -191,6 +200,7 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
                 onUpdate={ onUpdate }
                 data-testid={ `${ testId }-authenticator-settings` }
                 isReadOnly={ isReadOnly }
+                loader={ Loader }
             />
         </ResourceTab.Pane>
     );
@@ -204,6 +214,7 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
                 onUpdate={ onUpdate }
                 data-testid={ `${ testId }-outbound-provisioning-settings` }
                 isReadOnly={ isReadOnly }
+                loader={ Loader }
             />
         </ResourceTab.Pane>
     );
@@ -217,6 +228,7 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
                 onUpdate={ onUpdate }
                 data-testid={ `${ testId }-jit-provisioning-settings` }
                 isReadOnly={ isReadOnly }
+                loader={ Loader }
             />
         </ResourceTab.Pane>
     );
@@ -229,6 +241,8 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
                 onUpdate={ onUpdate }
                 data-testid={ `${ testId }-advance-settings` }
                 isReadOnly={ isReadOnly }
+                isLoading={ isLoading }
+                loader={ Loader }
             />
         </ResourceTab.Pane>
     );
@@ -346,22 +360,28 @@ export const EditIdentityProvider: FunctionComponent<EditIdentityProviderPropsIn
             return false;
         }
 
-        return true;
+        const isTabEnabledInExtensions: boolean | undefined = identityProviderConfig
+            .editIdentityProvider
+            .isTabEnabledForIdP(type, IdentityProviderTabTypes.USER_ATTRIBUTES);
+
+        return isTabEnabledInExtensions !== undefined
+            ? isTabEnabledInExtensions
+            : true;
     };
 
+    if (!identityProvider || isLoading) {
+        return <Loader />;
+    }
+
     return (
-        identityProvider && !isLoading
-            ?  (
-                <ResourceTab
-                    data-testid={ `${ testId }-resource-tabs` }
-                    panes={ getPanes() }
-                    defaultActiveIndex={ defaultActiveIndex }
-                    onTabChange={ (e, data: TabProps ) => {
-                        setDefaultActiveIndex(data.activeIndex);
-                    } }
-                />
-            )
-            : <Loader />
+        <ResourceTab
+            data-testid={ `${ testId }-resource-tabs` }
+            panes={ getPanes() }
+            defaultActiveIndex={ defaultActiveIndex }
+            onTabChange={ (e, data: TabProps ) => {
+                setDefaultActiveIndex(data.activeIndex);
+            } }
+        />
     );
 };
 

--- a/apps/console/src/features/identity-providers/components/settings/advance-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/advance-settings.tsx
@@ -44,9 +44,17 @@ interface AdvanceSettingsPropsInterface extends TestableComponentInterface {
      */
     onUpdate: (id: string) => void;
     /**
+     * Is the idp info request loading.
+     */
+    isLoading?: boolean;
+    /**
      * Specifies if the component should only be read-only.
      */
     isReadOnly: boolean;
+    /**
+     * Loading Component.
+     */
+    loader: () => ReactElement;
 }
 
 /**
@@ -64,6 +72,8 @@ export const AdvanceSettings: FunctionComponent<AdvanceSettingsPropsInterface> =
         advancedConfigurations,
         onUpdate,
         isReadOnly,
+        isLoading,
+        loader: Loader,
         [ "data-testid" ]: testId
     } = props;
 
@@ -99,6 +109,10 @@ export const AdvanceSettings: FunctionComponent<AdvanceSettingsPropsInterface> =
                 setIsSubmitting(false);
             });
     };
+
+    if (isLoading) {
+        return <Loader />;
+    }
 
     return (
         <EmphasizedSegment className="advanced-configuration-section">

--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -21,7 +21,6 @@ import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import {
     ConfirmationModal,
-    ContentLoader,
     EmphasizedSegment,
     EmptyPlaceholder,
     PrimaryButton,
@@ -82,6 +81,10 @@ interface IdentityProviderSettingsPropsInterface extends TestableComponentInterf
      * Specifies if the component should only be read-only.
      */
     isReadOnly: boolean;
+    /**
+     * Loading Component.
+     */
+    loader: () => ReactElement;
 }
 
 const GOOGLE_CLIENT_ID_SECRET_MAX_LENGTH = 100;
@@ -104,6 +107,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         isLoading,
         onUpdate,
         isReadOnly,
+        loader: Loader,
         [ "data-testid" ]: testId
     } = props;
 
@@ -685,6 +689,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     data-testid={ `${ testId }-${ authenticator.meta?.name }-content` }
                     isReadOnly={ isReadOnly }
                     isSubmitting={ isSubmitting }
+                    templateId={ identityProvider.templateId }
                 />
             );
         } else {
@@ -803,7 +808,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     }
                 </div>
             )
-            : <ContentLoader />
+            : <Loader />
     );
 };
 

--- a/apps/console/src/features/identity-providers/components/settings/general-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/general-settings.tsx
@@ -21,7 +21,7 @@ import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ConfirmationModal, ContentLoader, DangerZone, DangerZoneGroup } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { CheckboxProps, Divider, List } from "semantic-ui-react";
 import { getApplicationDetails } from "../../../applications/api";
@@ -96,6 +96,10 @@ interface GeneralSettingsInterface extends TestableComponentInterface {
      * IdP is a OIDC provider or not.
      */
     isOidc?: boolean;
+    /**
+     * Loading Component.
+     */
+    loader: () => ReactElement;
 }
 
 /**
@@ -121,6 +125,7 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
         hideIdPLogoEditField,
         isSaml,
         isOidc,
+        loader: Loader,
         [ "data-testid" ]: testId
     } = props;
 
@@ -419,7 +424,7 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
                     }
                 </>
             )
-            : <ContentLoader/>
+            : <Loader />
     );
 };
 

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
@@ -19,9 +19,11 @@
 import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
+import { URLUtils } from "@wso2is/core/utils";
 import { Field, Form } from "@wso2is/form";
 import { CertFileStrategy, Code, EmphasizedSegment, Hint, PrimaryButton, Switcher } from "@wso2is/react-components";
 import { SwitcherOptionProps } from "@wso2is/react-components/";
+import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -29,11 +31,9 @@ import { Divider, Grid, Icon, Segment } from "semantic-ui-react";
 import { AddIdpCertificateModal } from "./add-idp-certificate-modal";
 import { EmptyCertificatesPlaceholder } from "./empty-certificates-placeholder";
 import { IdpCertificatesList } from "./idp-cetificates-list";
+import { commonConfig } from "../../../../../extensions";
 import { updateIDPCertificate } from "../../../api";
 import { IdentityProviderInterface } from "../../../models";
-import { FormValidation } from "@wso2is/validation";
-import { commonConfig } from "../../../../../extensions";
-import { URLUtils } from "@wso2is/core/utils";
 
 /**
  * Props interface of {@link IdpCertificates}
@@ -42,7 +42,14 @@ export interface IdpCertificatesV2Props extends IdentifiableComponentInterface {
     editingIDP: IdentityProviderInterface;
     onUpdate: (id: string) => void;
     isReadOnly: boolean;
-    enableJWKS?: boolean;
+    /**
+     * Is JWKS URL configuring enabled?
+     */
+    isJWKSEnabled?: boolean;
+    /**
+     * Is Cert uploading enabled?
+     */
+    isPEMEnabled?: boolean;
 }
 
 export type CertificateConfigurationMode = "jwks" | "certificates";
@@ -111,7 +118,8 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
         editingIDP,
         onUpdate,
         isReadOnly,
-        enableJWKS
+        isJWKSEnabled,
+        isPEMEnabled
     } = props;
 
     const [ selectedConfigurationMode, setSelectedConfigurationMode ] = useState<CertificateConfigurationMode>();
@@ -132,7 +140,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
     }, [ editingIDP ]);
 
     const setInitialModeOfConfiguration = () => {
-        if (enableJWKS) {
+        if (isJWKSEnabled) {
             if (editingIDP?.certificate?.certificates?.length > 0) {
                 setSelectedConfigurationMode("certificates");
             } else {
@@ -323,10 +331,14 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
         ));
     };
 
+    if (!isJWKSEnabled && !isPEMEnabled) {
+        return null;
+    }
+
     return (
         <EmphasizedSegment padded="very">
             <Grid>
-                { enableJWKS && (
+                { isJWKSEnabled && isPEMEnabled && (
                     <Grid.Row columns={ 1 }>
                         <Grid.Column computer={ 8 } mobile={ 16 } widescreen={ 8 } tablet={ 16 }>
                             <React.Fragment>
@@ -370,11 +382,14 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     </Grid.Column>
                 </Grid.Row>
             </Grid>
-            <AddIdpCertificateModal
-                currentlyEditingIdP={ editingIDP }
-                refreshIdP={ onUpdate }
-                isOpen={ addCertificateModalOpen }
-                onClose={ closeAddCertificateWizard }/>
+            { isPEMEnabled && (
+                <AddIdpCertificateModal
+                    currentlyEditingIdP={ editingIDP }
+                    refreshIdP={ onUpdate }
+                    isOpen={ addCertificateModalOpen }
+                    onClose={ closeAddCertificateWizard }
+                />
+            ) }
         </EmphasizedSegment>
     );
 
@@ -385,7 +400,8 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
  */
 IdpCertificates.defaultProps = {
     "data-componentid": "idp-certificates",
-    enableJWKS: true
+    isJWKSEnabled: true,
+    isPEMEnabled: true
 };
 
 // Component constants.

--- a/apps/console/src/features/identity-providers/components/settings/jit-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/jit-provisioning-settings.tsx
@@ -19,7 +19,7 @@
 import { getUserStoreList } from "@wso2is/core/api";
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ContentLoader, EmphasizedSegment } from "@wso2is/react-components";
+import { EmphasizedSegment } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -52,6 +52,10 @@ interface JITProvisioningSettingsInterface extends TestableComponentInterface {
      * Specifies if the component should only be read-only.
      */
     isReadOnly: boolean;
+    /**
+     * Loading Component.
+     */
+    loader: () => ReactElement;
 }
 
 /**
@@ -69,6 +73,7 @@ export const JITProvisioningSettings: FunctionComponent<JITProvisioningSettingsI
         jitProvisioningConfigurations,
         onUpdate,
         isReadOnly,
+        loader: Loader,
         [ "data-testid" ]: testId
     } = props;
 
@@ -138,7 +143,7 @@ export const JITProvisioningSettings: FunctionComponent<JITProvisioningSettingsI
                     />
                 </EmphasizedSegment>
             )
-            : <ContentLoader/>
+            : <Loader />
     );
 };
 

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning-settings.tsx
@@ -78,6 +78,10 @@ interface ProvisioningSettingsPropsInterface extends TestableComponentInterface 
      * Specifies if the component should only be read-only.
      */
     isReadOnly: boolean;
+    /**
+     * Loading Component.
+     */
+    loader: () => ReactElement;
 }
 
 /**
@@ -96,6 +100,7 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
         isLoading,
         onUpdate,
         isReadOnly,
+        loader: Loader,
         [ "data-testid" ]: testId
     } = props;
 

--- a/apps/console/src/features/identity-providers/components/wizards/steps/shared-steps/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/steps/shared-steps/authenticator-settings.tsx
@@ -86,18 +86,21 @@ export const AuthenticatorSettings: FunctionComponent<AuthenticatorSettingsWizar
     const authenticator = initialValues?.federatedAuthenticators?.authenticators.find(authenticator =>
         authenticator.authenticatorId === initialValues?.federatedAuthenticators?.defaultAuthenticatorId);
 
+    if (!metadata) {
+        return null;
+    }
+
     return (
-        ( metadata ?
-            <AuthenticatorFormFactory
-                metadata={ metadata }
-                initialValues={ (authenticator ? authenticator : {}) }
-                onSubmit={ handleSubmit }
-                type={ authenticator?.name }
-                triggerSubmit={ triggerSubmit }
-                enableSubmitButton={ false }
-                data-testid={ testId }
-                isReadOnly={ false }
-            /> : null
-        )
+        <AuthenticatorFormFactory
+            metadata={ metadata }
+            initialValues={ (authenticator ? authenticator : {}) }
+            onSubmit={ handleSubmit }
+            type={ authenticator?.name }
+            triggerSubmit={ triggerSubmit }
+            enableSubmitButton={ false }
+            data-testid={ testId }
+            isReadOnly={ false }
+            templateId={ initialValues.templateId }
+        />
     );
 };

--- a/apps/console/src/features/identity-providers/configs/ui.ts
+++ b/apps/console/src/features/identity-providers/configs/ui.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { identityProviderConfig } from "../../../extensions/configs/identity-provider";
 import BasicAuthIcon from "../../../themes/default/assets/images/authenticators/basic-auth.png";
 import SMSOTPIcon from "../../../themes/default/assets/images/authenticators/sms-otp.svg";
 import SalesforceLogo from "../../../themes/default/assets/images/connectors/salesforce.png";
@@ -141,7 +142,8 @@ export const getIdPIcons = (): any => {
         smsOTP: SMSOTPIcon,
         twitter: TwitterIdPIllustration,
         wsFed: WSFedLogo,
-        yahoo: YahooIdPIllustration
+        yahoo: YahooIdPIllustration,
+        ...identityProviderConfig.getIconExtensions()
     };
 };
 

--- a/apps/console/src/features/identity-providers/models/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/models/identity-provider.ts
@@ -790,3 +790,13 @@ export enum AuthProtocolTypes {
     WS_TRUST = "ws-trust",
     CUSTOM= "custom"
 }
+
+/**
+ * Enum for IdP Tab types
+ */
+export enum IdentityProviderTabTypes {
+    GENERAL = "General",
+    SETTINGS ="settings",
+    USER_ATTRIBUTES = "user-attributes",
+    ADVANCED = "advanced",
+}

--- a/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
@@ -215,7 +215,7 @@ const IdentityProviderEditPage: FunctionComponent<IDPEditPagePropsInterface> = (
         }
 
         // TODO: Creating internal mapping to resolve the IDP template.
-        // TODO: Should be removed once template id is supported from IDP REST API
+        // TODO: First phase of the issue is fixed, keeping this for backward compatibility.
         // Tracked Here - https://github.com/wso2/product-is/issues/11023
         const resolveTemplateId = (authenticatorId: string) => {
 
@@ -238,8 +238,8 @@ const IdentityProviderEditPage: FunctionComponent<IDPEditPagePropsInterface> = (
 
         const template: IdentityProviderTemplateItemInterface = identityProviderTemplates
             .find((template: IdentityProviderTemplateItemInterface) => {
-                return template.id === resolveTemplateId(
-                    connector.federatedAuthenticators?.defaultAuthenticatorId);
+                return template.id === (connector.templateId
+                    ?? resolveTemplateId(connector.federatedAuthenticators?.defaultAuthenticatorId));
             });
 
         setIdentityProviderTemplate(template);

--- a/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
+++ b/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
@@ -25,8 +25,9 @@ import { I18n } from "@wso2is/i18n";
 import axios from "axios";
 import camelCase from "lodash-es/camelCase";
 import isEmpty from "lodash-es/isEmpty";
-import { identityProviderConfig } from "../../../extensions";
+import { identityProviderConfig } from "../../../extensions/configs/identity-provider";
 import { DocPanelUICardInterface, store } from "../../core";
+import { Config } from "../../core/configs";
 import { getFederatedAuthenticatorsList, getIdentityProviderList, getLocalAuthenticators } from "../api";
 import { IdentityProviderManagementConstants } from "../constants";
 import { AuthenticatorMeta } from "../meta";
@@ -411,5 +412,15 @@ export class IdentityProviderManagementUtils {
             });
 
         return Array.isArray(found.tags) ? found.tags : [];
+    }
+
+    /**
+     * Resolve and get the `commonauth` Endpoint.
+     *
+     * @return {string}
+     */
+    public static getCommonAuthEndpoint(): string {
+
+        return `${ Config.getDeploymentConfig().customServerHost }/commonauth`;
     }
 }

--- a/modules/react-components/src/components/code-editor/code-editor.tsx
+++ b/modules/react-components/src/components/code-editor/code-editor.tsx
@@ -37,6 +37,7 @@ import "codemirror/addon/hint/sql-hint";
 import "codemirror/mode/javascript/javascript";
 import "codemirror/mode/sql/sql";
 import "codemirror/mode/xml/xml";
+import "codemirror/mode/shell/shell";
 import "codemirror/mode/htmlmixed/htmlmixed";
 import "codemirror/addon/edit/closebrackets";
 import "codemirror/addon/edit/matchbrackets";
@@ -88,7 +89,7 @@ export interface CodeEditorProps extends IUnControlledCodeMirror, IdentifiableCo
     /**
      * Language the code is written in.
      */
-    language?: "javascript" | "json" | "typescript" | "htmlmixed";
+    language?: "javascript" | "json" | "typescript" | "htmlmixed" | "shell" | string;
     /**
      * Flat to enable line wrapping.
      */

--- a/modules/theme/src/theme-core/definitions/apps/login-portal.less
+++ b/modules/theme/src/theme-core/definitions/apps/login-portal.less
@@ -110,6 +110,53 @@
                             text-align: right;
                         }
                     }
+
+                    .social-login, .external-login {
+                        &.social-dimmer, .external-login-dimmer {
+                            &.dimmable{
+                                overflow: inherit !important;
+                                z-index: 998 !important;
+                            }
+                            .ui {
+                                &.inverted {
+                                    &.dimmer {
+                                        border-radius: 5px;
+                                    }
+                                }
+                            }
+                            .content {
+                                p {
+                                    font-size: 12px;
+                                    padding: 1.5em;
+                                    color: #474747;
+                                }
+                            }
+                        }
+                        
+                        .ui.button {
+                            width: 100%;
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                            box-shadow: 0 0 1px 0 rgba(0,0,0,0.12), 0 1px 1px 0 rgba(0,0,0,0.24);
+                            background: @loginPortalExternalConnectionButtonBackgroundColor;
+
+                            .ui.image {
+                                height: 22px;
+                                width: 22px;
+                                margin-right: auto;
+                            }
+
+                            span {
+                                margin-right: auto;
+                                margin-left: -1em
+                            }
+
+                            &:hover {
+                                background: @loginPortalExternalConnectionButtonHoverBackgroundColor;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/modules/theme/src/themes/default/apps/login-portal.variables
+++ b/modules/theme/src/themes/default/apps/login-portal.variables
@@ -14,3 +14,5 @@
 @loginPortalLoginCardBorderRadius: @defaultBorderRadius;
 @loginPortalProductTitleMargin: 2em 0 1em;
 @loginPortalProductTitleInHeaderMargin: 5px 0;
+@loginPortalExternalConnectionButtonBackgroundColor: #0000000a;
+@loginPortalExternalConnectionButtonHoverBackgroundColor: @white;

--- a/modules/theme/src/themes/default/modules/modal.overrides
+++ b/modules/theme/src/themes/default/modules/modal.overrides
@@ -584,6 +584,7 @@
                 padding: @sidePanelModalContentPadding;
                 line-height: @sidePanelModalContentPadding;
                 overflow: auto;
+                width: 100%;
                 &:not(.steps-container) {
                     height: @sidePanelModalContentHeight;
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -679,7 +679,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.21.3</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.21.30</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <carbon.identity.oauth.version>6.7.130</carbon.identity.oauth.version>
         <carbon.identity.oauth.imp.pkg.version.range>[6.1.0, 7.0.0)</carbon.identity.oauth.imp.pkg.version.range>


### PR DESCRIPTION
### Purpose

Port the following changes to `1.2.x` branch.

1. Get IDP Image from the API in login page.
2. Add ability to overide a IDP create wizard & settings form.
3. Add ability turn of certificates section in IDP edit.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
