### PR TITLE
Add grant types to portal applications only if the grant types are allowed

### DIFF
--- a/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -44,6 +44,7 @@ import org.wso2.identity.apps.common.internal.AppsCommonDataHolder;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.AUTHORIZATION_CODE;
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.GrantTypes.REFRESH_TOKEN;
@@ -272,6 +273,9 @@ public class AppPortalUtils {
                     grantTypes = Arrays.asList(AUTHORIZATION_CODE, REFRESH_TOKEN, GRANT_TYPE_ACCOUNT_SWITCH,
                             GRANT_TYPE_ORGANIZATION_SWITCH);
                 }
+                List<String> allowedGrantTypes = Arrays.asList(AppsCommonDataHolder.getInstance()
+                        .getOAuthAdminService().getAllowedGrantTypes());
+                grantTypes = grantTypes.stream().filter(allowedGrantTypes::contains).collect(Collectors.toList());
                 String consumerKey = appPortal.getConsumerKey();
                 if (!SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
                     consumerKey = consumerKey + "_" + tenantDomain;


### PR DESCRIPTION
### Purpose
The allowed grant types for portal applications are defined in the code level and not validated before assigning. Therefore a validation is added to check whether the corresponding grant type is allowed by the Identity server configurations and proceed.

### Related Issues
https://github.com/wso2/product-is/issues/14360
