### PR TITLE
Issue fix for advance search modal not disappearing on timeout

### DIFF
--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -62,12 +62,6 @@ import {
 import { AppState } from "./features/core/store";
 
 /**
- * Context for state of Session Time Out.
- *
- */
-export const SessionTimedOutContext = React.createContext(false);
-
-/**
  * Main App component.
  *
  * @return {React.ReactElement}
@@ -94,7 +88,7 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
     const [ sessionTimedOut, setSessionTimedOut ] = useState<boolean>(false);
 
     /**
-     * set the value of Session Timed Out.
+     * Set the value of sessionTimedOut.
      */
     const handleSessionTimeOut = (timedOut: boolean): void => {
         setSessionTimedOut(timedOut);
@@ -335,125 +329,123 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
                                                 } }
                                                 type={ SessionTimeoutModalTypes.DEFAULT }
                                             >
-                                                <SessionTimedOutContext.Provider value={ sessionTimedOut }>
-                                                    <>
-                                                        <Helmet>
-                                                            <title>{ appTitle }</title>
-                                                            {
-                                                                (window?.themeHash && window?.publicPath && theme)
-                                                                    ? (
-                                                                        <link
-                                                                            href={
-                                                                                `${
-                                                                                    window?.origin
-                                                                                }${
-                                                                                    window?.publicPath
-                                                                                }/libs/themes/${
-                                                                                    theme
-                                                                                }/theme.${ window?.themeHash }.min.css`
-                                                                            }
-                                                                            rel="stylesheet"
-                                                                            type="text/css"
-                                                                        />
-                                                                    )
-                                                                    : null
-                                                            }
-                                                        </Helmet>
-                                                        <NetworkErrorModal
-                                                            heading={
-                                                                (<Trans
-                                                                    i18nKey={ "common:networkErrorMessage.heading" }
-                                                                >
-                                                                    Your session has expired
-                                                                </Trans>)
-                                                            }
-                                                            description={
-                                                                (<Trans
-                                                                    i18nKey={ "common:networkErrorMessage.description" }
-                                                                >
-                                                                    Please try signing in again.
-                                                                </Trans>)
-                                                            }
-                                                            primaryActionText={
-                                                                (<Trans
-                                                                    i18nKey={
-                                                                        "common:networkErrorMessage.primaryActionText"
-                                                                    }
-                                                                >
-                                                                    Sign In
-                                                                </Trans>)
-                                                            }
-                                                            primaryAction={
-                                                                signOut
-                                                            }
+                                                <>
+                                                    <Helmet>
+                                                        <title>{ appTitle }</title>
+                                                        {
+                                                            (window?.themeHash && window?.publicPath && theme)
+                                                                ? (
+                                                                    <link
+                                                                        href={
+                                                                            `${
+                                                                                window?.origin
+                                                                            }${
+                                                                                window?.publicPath
+                                                                            }/libs/themes/${
+                                                                                theme
+                                                                            }/theme.${ window?.themeHash }.min.css`
+                                                                        }
+                                                                        rel="stylesheet"
+                                                                        type="text/css"
+                                                                    />
+                                                                )
+                                                                : null
+                                                        }
+                                                    </Helmet>
+                                                    <NetworkErrorModal
+                                                        heading={
+                                                            (<Trans
+                                                                i18nKey={ "common:networkErrorMessage.heading" }
+                                                            >
+                                                                Your session has expired
+                                                            </Trans>)
+                                                        }
+                                                        description={
+                                                            (<Trans
+                                                                i18nKey={ "common:networkErrorMessage.description" }
+                                                            >
+                                                                Please try signing in again.
+                                                            </Trans>)
+                                                        }
+                                                        primaryActionText={
+                                                            (<Trans
+                                                                i18nKey={
+                                                                    "common:networkErrorMessage.primaryActionText"
+                                                                }
+                                                            >
+                                                                Sign In
+                                                            </Trans>)
+                                                        }
+                                                        primaryAction={
+                                                            signOut
+                                                        }
+                                                    />
+                                                    <ChunkErrorModal
+                                                        heading={
+                                                            (<Trans
+                                                                i18nKey={
+                                                                    "common:chunkLoadErrorMessage.heading"
+                                                                }
+                                                            >
+                                                                Something went wrong
+                                                            </Trans>)
+                                                        }
+                                                        description={
+                                                            (<Trans
+                                                                i18nKey={
+                                                                    "common:chunkLoadErrorMessage.description"
+                                                                }
+                                                            >
+                                                                An error occurred when serving the requested
+                                                                application. Please try reloading the app.
+                                                            </Trans>)
+                                                        }
+                                                        primaryActionText={
+                                                            (<Trans
+                                                                i18nKey={
+                                                                    "common:chunkLoadErrorMessage.primaryActionText"
+                                                                }
+                                                            >
+                                                                Reload the App
+                                                            </Trans>)
+                                                        }
+                                                    />
+                                                    <Switch>
+                                                        <Redirect
+                                                            exact
+                                                            from="/"
+                                                            to={ AppConstants.getAppHomePath() }
                                                         />
-                                                        <ChunkErrorModal
-                                                            heading={
-                                                                (<Trans
-                                                                    i18nKey={
-                                                                        "common:chunkLoadErrorMessage.heading"
-                                                                    }
-                                                                >
-                                                                    Something went wrong
-                                                                </Trans>)
-                                                            }
-                                                            description={
-                                                                (<Trans
-                                                                    i18nKey={
-                                                                        "common:chunkLoadErrorMessage.description"
-                                                                    }
-                                                                >
-                                                                    An error occurred when serving the requested
-                                                                    application. Please try reloading the app.
-                                                                </Trans>)
-                                                            }
-                                                            primaryActionText={
-                                                                (<Trans
-                                                                    i18nKey={
-                                                                        "common:chunkLoadErrorMessage.primaryActionText"
-                                                                    }
-                                                                >
-                                                                    Reload the App
-                                                                </Trans>)
-                                                            }
-                                                        />
-                                                        <Switch>
-                                                            <Redirect
-                                                                exact
-                                                                from="/"
-                                                                to={ AppConstants.getAppHomePath() }
-                                                            />
-                                                            {
-                                                                baseRoutes.map((route, index) => {
-                                                                    return (
-                                                                        route.protected ?
-                                                                            (
-                                                                                <ProtectedRoute
-                                                                                    component={ route.component }
-                                                                                    path={ route.path }
-                                                                                    key={ index }
-                                                                                    exact={ route.exact }
-                                                                                />
-                                                                            )
-                                                                            :
-                                                                            (
-                                                                                <Route
-                                                                                    path={ route.path }
-                                                                                    render={ (props) =>
-                                                                                        (<route.component
-                                                                                            { ...props }
-                                                                                        />)
-                                                                                    }
-                                                                                    key={ index }
-                                                                                    exact={ route.exact }
-                                                                                />
-                                                                            )
-                                                                    );
-                                                                })
-                                                            }
-                                                        </Switch>
-                                                    </>
-                                                </SessionTimedOutContext.Provider>
+                                                        {
+                                                            baseRoutes.map((route, index) => {
+                                                                return (
+                                                                    route.protected ?
+                                                                        (
+                                                                            <ProtectedRoute
+                                                                                component={ route.component }
+                                                                                path={ route.path }
+                                                                                key={ index }
+                                                                                exact={ route.exact }
+                                                                            />
+                                                                        )
+                                                                        :
+                                                                        (
+                                                                            <Route
+                                                                                path={ route.path }
+                                                                                render={ (props) =>
+                                                                                    (<route.component
+                                                                                        { ...props }
+                                                                                    />)
+                                                                                }
+                                                                                key={ index }
+                                                                                exact={ route.exact }
+                                                                            />
+                                                                        )
+                                                                );
+                                                            })
+                                                        }
+                                                    </Switch>
+                                                </>
                                             </SessionManagementProvider>
                                         </AccessControlProvider>
                                     </Suspense>

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -335,88 +335,6 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
                                                 } }
                                                 type={ SessionTimeoutModalTypes.DEFAULT }
                                             >
-<<<<<<< HEAD
-                                                <>
-                                                    <Helmet>
-                                                        <title>{ appTitle }</title>
-                                                        {
-                                                            (window?.themeHash && window?.publicPath && theme)
-                                                                ? (
-                                                                    <link
-                                                                        href={
-                                                                            `${window?.origin}${window?.publicPath}/libs/themes/${theme}/theme.${window?.themeHash}.min.css`
-                                                                        }
-                                                                        rel="stylesheet"
-                                                                        type="text/css"
-                                                                    />
-                                                                ) 
-                                                                : null
-                                                        }
-                                                    </Helmet>
-                                                    <NetworkErrorModal
-                                                        heading={
-                                                            (<Trans
-                                                                i18nKey={ "common:networkErrorMessage.heading" }
-                                                            >
-                                                                Your session has expired
-                                                            </Trans>)
-                                                        }
-                                                        description={
-                                                            (<Trans
-                                                                i18nKey={ "common:networkErrorMessage.description" }
-                                                            >
-                                                                Please try signing in again.
-                                                            </Trans>)
-                                                        }
-                                                        primaryActionText={
-                                                            (<Trans
-                                                                i18nKey={
-                                                                    "common:networkErrorMessage.primaryActionText"
-                                                                }
-                                                            >
-                                                                Sign In
-                                                            </Trans>)
-                                                        }
-                                                        primaryAction={
-                                                            signOut
-                                                        }
-                                                    />
-                                                    <ChunkErrorModal
-                                                        heading={
-                                                            (<Trans
-                                                                i18nKey={
-                                                                    "common:chunkLoadErrorMessage.heading"
-                                                                }
-                                                            >
-                                                                Something went wrong
-                                                            </Trans>)
-                                                        }
-                                                        description={
-                                                            (<Trans
-                                                                i18nKey={
-                                                                    "common:chunkLoadErrorMessage.description"
-                                                                }
-                                                            >
-                                                                An error occurred when serving the requested
-                                                                application. Please try reloading the app.
-                                                            </Trans>)
-                                                        }
-                                                        primaryActionText={
-                                                            (<Trans
-                                                                i18nKey={
-                                                                    "common:chunkLoadErrorMessage.primaryActionText"
-                                                                }
-                                                            >
-                                                                Reload the App
-                                                            </Trans>)
-                                                        }
-                                                    />
-                                                    <Switch>
-                                                        <Redirect
-                                                            exact
-                                                            from="/"
-                                                            to={ AppConstants.getAppHomePath() }
-=======
                                                 <SessionTimedOutContext.Provider value={ sessionTimedOut }>
                                                     <>
                                                         <Helmet>
@@ -468,7 +386,6 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
                                                             primaryAction={
                                                                 signOut
                                                             }
->>>>>>> 353a72a047... Issue fix for advance search modal not disappearing on timeout
                                                         />
                                                         <ChunkErrorModal
                                                             heading={

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -62,6 +62,12 @@ import {
 import { AppState } from "./features/core/store";
 
 /**
+ * Context for state of Session Time Out.
+ *
+ */
+export const SessionTimedOutContext = React.createContext(false);
+
+/**
  * Main App component.
  *
  * @return {React.ReactElement}
@@ -85,6 +91,14 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
     const { trySignInSilently, getDecodedIDToken, signOut } = useAuthContext();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
+    const [ sessionTimedOut, setSessionTimedOut ] = useState<boolean>(false);
+
+    /**
+     * set the value of Session Timed Out.
+     */
+    const handleSessionTimeOut = (timedOut: boolean): void => {
+        setSessionTimedOut(timedOut);
+    };
 
     /**
      * Set the deployment configs in redux state.
@@ -262,6 +276,8 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
                                                 onSessionTimeoutAbort={ handleSessionTimeoutAbort }
                                                 onSessionLogout={ handleSessionLogout }
                                                 onLoginAgain={ handleStayLoggedIn }
+                                                setSessionTimedOut={ handleSessionTimeOut }
+                                                sessionTimedOut={ sessionTimedOut }
                                                 modalOptions={ {
                                                     description: (
                                                         <Trans
@@ -319,6 +335,7 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
                                                 } }
                                                 type={ SessionTimeoutModalTypes.DEFAULT }
                                             >
+<<<<<<< HEAD
                                                 <>
                                                     <Helmet>
                                                         <title>{ appTitle }</title>
@@ -399,37 +416,127 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
                                                             exact
                                                             from="/"
                                                             to={ AppConstants.getAppHomePath() }
+=======
+                                                <SessionTimedOutContext.Provider value={ sessionTimedOut }>
+                                                    <>
+                                                        <Helmet>
+                                                            <title>{ appTitle }</title>
+                                                            {
+                                                                (window?.themeHash && window?.publicPath && theme)
+                                                                    ? (
+                                                                        <link
+                                                                            href={
+                                                                                `${
+                                                                                    window?.origin
+                                                                                }${
+                                                                                    window?.publicPath
+                                                                                }/libs/themes/${
+                                                                                    theme
+                                                                                }/theme.${ window?.themeHash }.min.css`
+                                                                            }
+                                                                            rel="stylesheet"
+                                                                            type="text/css"
+                                                                        />
+                                                                    )
+                                                                    : null
+                                                            }
+                                                        </Helmet>
+                                                        <NetworkErrorModal
+                                                            heading={
+                                                                (<Trans
+                                                                    i18nKey={ "common:networkErrorMessage.heading" }
+                                                                >
+                                                                    Your session has expired
+                                                                </Trans>)
+                                                            }
+                                                            description={
+                                                                (<Trans
+                                                                    i18nKey={ "common:networkErrorMessage.description" }
+                                                                >
+                                                                    Please try signing in again.
+                                                                </Trans>)
+                                                            }
+                                                            primaryActionText={
+                                                                (<Trans
+                                                                    i18nKey={
+                                                                        "common:networkErrorMessage.primaryActionText"
+                                                                    }
+                                                                >
+                                                                    Sign In
+                                                                </Trans>)
+                                                            }
+                                                            primaryAction={
+                                                                signOut
+                                                            }
+>>>>>>> 353a72a047... Issue fix for advance search modal not disappearing on timeout
                                                         />
-                                                        {
-                                                            baseRoutes.map((route, index) => {
-                                                                return (
-                                                                    route.protected ?
-                                                                        (
-                                                                            <ProtectedRoute
-                                                                                component={ route.component }
-                                                                                path={ route.path }
-                                                                                key={ index }
-                                                                                exact={ route.exact }
-                                                                            />
-                                                                        )
-                                                                        :
-                                                                        (
-                                                                            <Route
-                                                                                path={ route.path }
-                                                                                render={ (props) =>
-                                                                                    (<route.component
-                                                                                        { ...props }
-                                                                                    />)
-                                                                                }
-                                                                                key={ index }
-                                                                                exact={ route.exact }
-                                                                            />
-                                                                        )
-                                                                );
-                                                            })
-                                                        }
-                                                    </Switch>
-                                                </>
+                                                        <ChunkErrorModal
+                                                            heading={
+                                                                (<Trans
+                                                                    i18nKey={
+                                                                        "common:chunkLoadErrorMessage.heading"
+                                                                    }
+                                                                >
+                                                                    Something went wrong
+                                                                </Trans>)
+                                                            }
+                                                            description={
+                                                                (<Trans
+                                                                    i18nKey={
+                                                                        "common:chunkLoadErrorMessage.description"
+                                                                    }
+                                                                >
+                                                                    An error occurred when serving the requested
+                                                                    application. Please try reloading the app.
+                                                                </Trans>)
+                                                            }
+                                                            primaryActionText={
+                                                                (<Trans
+                                                                    i18nKey={
+                                                                        "common:chunkLoadErrorMessage.primaryActionText"
+                                                                    }
+                                                                >
+                                                                    Reload the App
+                                                                </Trans>)
+                                                            }
+                                                        />
+                                                        <Switch>
+                                                            <Redirect
+                                                                exact
+                                                                from="/"
+                                                                to={ AppConstants.getAppHomePath() }
+                                                            />
+                                                            {
+                                                                baseRoutes.map((route, index) => {
+                                                                    return (
+                                                                        route.protected ?
+                                                                            (
+                                                                                <ProtectedRoute
+                                                                                    component={ route.component }
+                                                                                    path={ route.path }
+                                                                                    key={ index }
+                                                                                    exact={ route.exact }
+                                                                                />
+                                                                            )
+                                                                            :
+                                                                            (
+                                                                                <Route
+                                                                                    path={ route.path }
+                                                                                    render={ (props) =>
+                                                                                        (<route.component
+                                                                                            { ...props }
+                                                                                        />)
+                                                                                    }
+                                                                                    key={ index }
+                                                                                    exact={ route.exact }
+                                                                                />
+                                                                            )
+                                                                    );
+                                                                })
+                                                            }
+                                                        </Switch>
+                                                    </>
+                                                </SessionTimedOutContext.Provider>
                                             </SessionManagementProvider>
                                         </AccessControlProvider>
                                     </Suspense>

--- a/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
+++ b/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
@@ -19,11 +19,16 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { SearchUtils } from "@wso2is/core/utils";
 import { DropdownChild, Field, Forms } from "@wso2is/forms";
-import { AdvancedSearch, AdvancedSearchPropsInterface, LinkButton, PrimaryButton } from "@wso2is/react-components";
+import { 
+    AdvancedSearch, 
+    AdvancedSearchPropsInterface, 
+    LinkButton, 
+    PrimaryButton, 
+    SessionTimedOutContext 
+} from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Divider, Form, Grid } from "semantic-ui-react";
-import { SessionTimedOutContext } from "../../../app";
 import { commonConfig } from "../../../extensions";
 import { getAdvancedSearchIcons } from "../configs";
 

--- a/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
+++ b/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
@@ -23,6 +23,7 @@ import { AdvancedSearch, AdvancedSearchPropsInterface, LinkButton, PrimaryButton
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Divider, Form, Grid } from "semantic-ui-react";
+import { SessionTimedOutContext } from "../../../app";
 import { commonConfig } from "../../../extensions";
 import { getAdvancedSearchIcons } from "../configs";
 
@@ -149,6 +150,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
     const [ isFormSubmitted, setIsFormSubmitted ] = useState<boolean>(false);
     const [ isFiltersReset, setIsFiltersReset ] = useState<boolean>(false);
     const [ externalSearchQuery, setExternalSearchQuery ] = useState<string>("");
+    const sessionTimedOut = React.useContext(SessionTimedOutContext);
 
     /**
      * Handles the form submit.
@@ -243,6 +245,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
             placeholder={ placeholder }
             resetSubmittedState={ handleResetSubmittedState }
             searchOptionsHeader={ t("console:common.advancedSearch.options.header") }
+            sessionTimedOut={ sessionTimedOut }
             enableQuerySearch={ enableQuerySearch }
             externalSearchQuery={ externalSearchQuery }
             submitted={ isFormSubmitted }

--- a/modules/react-components/src/components/input/advanced-search.tsx
+++ b/modules/react-components/src/components/input/advanced-search.tsx
@@ -109,6 +109,10 @@ export interface AdvancedSearchPropsInterface extends IdentifiableComponentInter
      */
     searchOptionsHeader?: string;
     /**
+     * Session Timed Out status.
+     */
+    sessionTimedOut?: boolean;
+    /**
      * Is form submitted.
      */
     submitted?: boolean;
@@ -159,6 +163,7 @@ export const AdvancedSearch: FunctionComponent<PropsWithChildren<AdvancedSearchP
         placeholder,
         resetSubmittedState,
         searchOptionsHeader,
+        sessionTimedOut,
         submitted,
         [ "data-componentid" ]: componentId,
         [ "data-testid" ]: testId,
@@ -173,6 +178,15 @@ export const AdvancedSearch: FunctionComponent<PropsWithChildren<AdvancedSearchP
     const [ showSearchFieldHint, setShowSearchFieldHint ] = useState<boolean>(false);
     const [ isDropdownVisible, setIsDropdownVisible ] = useState<boolean>(false);
     const [ internalQueryClearTriggerState, setInternalQueryClearTriggerState ] = useState<boolean>(false);
+
+    /**
+     * useEffect hook to handle `sessionTimedOut` change.
+     */
+    useEffect(() => {
+        if (sessionTimedOut) {
+            setIsDropdownVisible(false);
+        }
+    }, [ sessionTimedOut ]);
 
     /**
      * useEffect hook to handle `internalSearchQuery` change.

--- a/modules/react-components/src/providers/session-management/session-management-context.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-context.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -14,8 +14,8 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
-export * from "./session-management-provider";
-export * from "./session-management-context";
+import { createContext } from "react";
+
+export const SessionTimedOutContext = createContext(false);

--- a/modules/react-components/src/providers/session-management/session-management-provider.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-provider.tsx
@@ -48,6 +48,14 @@ export interface SessionManagementProviderPropsInterface extends TestableCompone
      */
     onLoginAgain?: () => void;
     /**
+     * Session Timed Out callback.
+     */
+    setSessionTimedOut?: (sessionTimedOut : boolean ) => void;
+    /**
+     * Session Timed Out variable.
+     */
+    sessionTimedOut?: boolean;
+    /**
      * Modal options.
      */
     modalOptions?: SessionManagementModalOptionsInterface;
@@ -142,6 +150,8 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
             onSessionLogout,
             onLoginAgain,
             onSessionTimeoutAbort,
+            setSessionTimedOut,
+            sessionTimedOut,
             modalOptions,
             type
         } = props;
@@ -154,8 +164,7 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
         ] = useState<SessionTimeoutEventStateInterface>(undefined);
         const [ showSessionTimeoutModal, setShowSessionTimeoutModal ] = useState<boolean>(false);
         const [ timerDisplay, setTimerDisplay ] = useState<string>(undefined);
-        const [ sessionTimedOut, setSessionTimedOut ] = useState<boolean>(false);
-
+        
         useEffect(() => {
             const sessionTimeoutListener = (e: MessageEventInit) => {
                 const state = e.data;
@@ -181,7 +190,7 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
                 if (JSON.parse(timeout) && type === SessionTimeoutModalTypes.COUNTER) {
                     startTimer(idleTimeout - idleWarningTimeout);
                 }
-
+                setSessionTimedOut(true);
                 setShowSessionTimeoutModal(JSON.parse(timeout));
             };
 
@@ -213,6 +222,7 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
 
             performCleanupTasks();
             setShowSessionTimeoutModal(false);
+            setSessionTimedOut(false);
         };
 
         /**
@@ -221,6 +231,7 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
         const handleSessionLogout = (): void => {
             performCleanupTasks();
             setShowSessionTimeoutModal(false);
+            setSessionTimedOut(false);
             onSessionLogout();
         };
 
@@ -230,6 +241,7 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
         const handleLoginAgain = (): void => {
             performCleanupTasks();
             setShowSessionTimeoutModal(false);
+            setSessionTimedOut(false);
             onLoginAgain();
         };
 
@@ -241,12 +253,14 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
             // If the counter runs out or if the type of the modal is default, try the login again option.
             if (sessionTimedOut || type === SessionTimeoutModalTypes.DEFAULT) {
                 handleLoginAgain();
+                setSessionTimedOut(false);
 
                 return;
             }
 
             // If the counter hasn't run out, and the type of modal is other than `default` abort the termination.
             handleSessionTimeoutAbort();
+            setSessionTimedOut(false);
         };
 
         /**

--- a/modules/react-components/src/providers/session-management/session-management-provider.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-provider.tsx
@@ -28,6 +28,7 @@ import React, {
     useState
 } from "react";
 import { Trans } from "react-i18next";
+import { SessionTimedOutContext } from "./session-management-context";
 import { SessionTimeoutModal } from "../../components";
 
 /**
@@ -301,61 +302,63 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
         };
 
         return (
-            <>
-                { children }
-                <SessionTimeoutModal
-                    closeOnEscape={ false }
-                    closeOnDimmerClick={ false }
-                    open={ showSessionTimeoutModal }
-                    onClose={ handleSessionTimeoutAbort }
-                    onPrimaryActionClick={ handlePrimaryActionClick }
-                    onSecondaryActionClick={ handleSessionLogout }
-                    sessionTimeOut={ sessionTimedOut }
-                    heading={
-                        (type === SessionTimeoutModalTypes.DEFAULT)
-                            ? (
-                                <Trans
-                                    i18nKey={ modalOptions?.headingI18nKey }
-                                >
-                                It looks like you have been inactive for a long time.
-                                </Trans>
-                            )
-                            : (
-                                <Trans
-                                    i18nKey={
-                                        !sessionTimedOut
-                                            ? modalOptions?.headingI18nKey
-                                            : modalOptions?.sessionTimedOutHeadingI18nKey
-                                    }
-                                    tOptions={
-                                        { time: timerDisplay }
-                                    }
-                                >
-                                You will be logged out in <strong>{ timerDisplay }</strong>.
-                                </Trans>
-                            )
-                    }
-                    description={
-                        (type === SessionTimeoutModalTypes.DEFAULT)
-                            ? modalOptions?.description
-                            : sessionTimedOut
-                                ? modalOptions?.sessionTimedOutDescription
-                                : modalOptions?.description
-                    }
-                    primaryButtonText={
-                        (type === SessionTimeoutModalTypes.DEFAULT)
-                            ? modalOptions?.primaryButtonText
-                            : sessionTimedOut
-                                ? modalOptions?.loginAgainButtonText
-                                : modalOptions?.primaryButtonText
-                    }
-                    secondaryButtonText={
-                        (type === SessionTimeoutModalTypes.COUNTER)
-                            ? modalOptions?.secondaryButtonText
-                            : null
-                    }
-                />
-            </>
+            <SessionTimedOutContext.Provider value={ sessionTimedOut } >
+                <>
+                    { children }
+                    <SessionTimeoutModal
+                        closeOnEscape={ false }
+                        closeOnDimmerClick={ false }
+                        open={ showSessionTimeoutModal }
+                        onClose={ handleSessionTimeoutAbort }
+                        onPrimaryActionClick={ handlePrimaryActionClick }
+                        onSecondaryActionClick={ handleSessionLogout }
+                        sessionTimeOut={ sessionTimedOut }
+                        heading={
+                            (type === SessionTimeoutModalTypes.DEFAULT)
+                                ? (
+                                    <Trans
+                                        i18nKey={ modalOptions?.headingI18nKey }
+                                    >
+                                    It looks like you have been inactive for a long time.
+                                    </Trans>
+                                )
+                                : (
+                                    <Trans
+                                        i18nKey={
+                                            !sessionTimedOut
+                                                ? modalOptions?.headingI18nKey
+                                                : modalOptions?.sessionTimedOutHeadingI18nKey
+                                        }
+                                        tOptions={
+                                            { time: timerDisplay }
+                                        }
+                                    >
+                                    You will be logged out in <strong>{ timerDisplay }</strong>.
+                                    </Trans>
+                                )
+                        }
+                        description={
+                            (type === SessionTimeoutModalTypes.DEFAULT)
+                                ? modalOptions?.description
+                                : sessionTimedOut
+                                    ? modalOptions?.sessionTimedOutDescription
+                                    : modalOptions?.description
+                        }
+                        primaryButtonText={
+                            (type === SessionTimeoutModalTypes.DEFAULT)
+                                ? modalOptions?.primaryButtonText
+                                : sessionTimedOut
+                                    ? modalOptions?.loginAgainButtonText
+                                    : modalOptions?.primaryButtonText
+                        }
+                        secondaryButtonText={
+                            (type === SessionTimeoutModalTypes.COUNTER)
+                                ? modalOptions?.secondaryButtonText
+                                : null
+                        }
+                    />
+                </>
+            </SessionTimedOutContext.Provider>
         );
     };
 

--- a/modules/react-components/src/providers/session-management/session-management-provider.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-provider.tsx
@@ -165,7 +165,6 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
         ] = useState<SessionTimeoutEventStateInterface>(undefined);
         const [ showSessionTimeoutModal, setShowSessionTimeoutModal ] = useState<boolean>(false);
         const [ timerDisplay, setTimerDisplay ] = useState<string>(undefined);
-        
         useEffect(() => {
             const sessionTimeoutListener = (e: MessageEventInit) => {
                 const state = e.data;


### PR DESCRIPTION
### Purpose

The advanced search popup modal does not disappear on Session Timeout when the Session Timeout modal pops up. This causes both modals to be displayed on the screen when every other component is grayed out.

This issue is fixed in this PR.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
