### PR TITLE
Fix redundant endpoint calls in Authenticator Settings of an Identity Provider

### DIFF
--- a/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/authenticator-settings.tsx
@@ -290,9 +290,21 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
      */
     async function fetchAuthenticators() {
         const authenticators: FederatedAuthenticatorWithMetaInterface[] = [];
+
         for (const authenticator of identityProvider.federatedAuthenticators.authenticators) {
-            authenticators.push(await fetchAuthenticator(authenticator.authenticatorId));
+            if(authenticator?.isEnabled){
+                authenticators.push(await fetchAuthenticator(authenticator.authenticatorId));
+            }
         }
+
+        //Push default authenticator if not added.
+        if(!authenticators.length && identityProvider.federatedAuthenticators?.authenticators?.length){
+            authenticators.push(await fetchAuthenticator(
+                identityProvider.federatedAuthenticators?.authenticators[
+                    IdentityProviderManagementConstants.FIRST_AUTHENTICATOR].authenticatorId
+            ));
+        }
+
         return authenticators;
     }
 
@@ -304,7 +316,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         setAvailableAuthenticators([]);
         fetchAuthenticators()
             .then((res) => {
-                const authenticator = res[ 0 ].data;
+                const authenticator = res[ IdentityProviderManagementConstants.FIRST_AUTHENTICATOR ].data;
                 authenticator.isEnabled = true;
                 // Make default authenticator if not added.
                 if (!identityProvider.federatedAuthenticators.defaultAuthenticatorId &&

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -26,6 +26,7 @@ import { IdentityProviderTemplateLoadingStrategies } from "../models";
 export class IdentityProviderManagementConstants {
 
     public static readonly MAXIMUM_NUMBER_OF_LIST_ITEMS_TO_SHOW_INSIDE_CALLOUTS = 3;
+    public static readonly FIRST_AUTHENTICATOR = 0;
 
     /**
      * Identifier for the local IDP.


### PR DESCRIPTION
### Purpose
> - Fix redundant federated authenticator endpoint calls in Authenticator Settings of an IdP.
> - Filtered out the enabled authenticator(s) using 'isEnabled` property
> -  Establish a default authenticator when a federated authenticator is not specified (when creating an IdP using the Management Console)

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/14406

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
