### PR TITLE
Fix for advance search modal not disappearing on Timeout

### DIFF
--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -88,6 +88,14 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
     const { trySignInSilently, getDecodedIDToken, signOut } = useAuthContext();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
+    const [ sessionTimedOut, setSessionTimedOut ] = useState<boolean>(false);
+
+    /**
+     * set the value of Session Timed Out.
+     */
+    const handleSessionTimeOut = (timedOut: boolean): void => {
+        setSessionTimedOut(timedOut);
+    };
 
     /**
      * Set the deployment configs in redux state.
@@ -312,6 +320,8 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
                                                 onSessionTimeoutAbort={ handleSessionTimeoutAbort }
                                                 onSessionLogout={ handleSessionLogout }
                                                 onLoginAgain={ handleStayLoggedIn }
+                                                setSessionTimedOut={ handleSessionTimeOut }
+                                                sessionTimedOut={ sessionTimedOut }
                                                 modalOptions={ {
                                                     description: (
                                                         <Trans

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -91,7 +91,7 @@ export const App: FunctionComponent<Record<string, never>> = (): ReactElement =>
     const [ sessionTimedOut, setSessionTimedOut ] = useState<boolean>(false);
 
     /**
-     * set the value of Session Timed Out.
+     * Set the value of Session Timed Out.
      */
     const handleSessionTimeOut = (timedOut: boolean): void => {
         setSessionTimedOut(timedOut);

--- a/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
+++ b/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
@@ -19,7 +19,13 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { SearchUtils } from "@wso2is/core/utils";
 import { DropdownChild, Field, Forms } from "@wso2is/forms";
-import { AdvancedSearch, AdvancedSearchPropsInterface, LinkButton, PrimaryButton } from "@wso2is/react-components";
+import { 
+    AdvancedSearch, 
+    AdvancedSearchPropsInterface, 
+    LinkButton, 
+    PrimaryButton, 
+    SessionTimedOutContext 
+} from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Divider, Form, Grid } from "semantic-ui-react";
@@ -149,6 +155,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
     const [ isFormSubmitted, setIsFormSubmitted ] = useState<boolean>(false);
     const [ isFiltersReset, setIsFiltersReset ] = useState<boolean>(false);
     const [ externalSearchQuery, setExternalSearchQuery ] = useState<string>("");
+    const sessionTimedOut = React.useContext(SessionTimedOutContext);
 
     /**
      * Handles the form submit.
@@ -243,6 +250,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
             placeholder={ placeholder }
             resetSubmittedState={ handleResetSubmittedState }
             searchOptionsHeader={ t("console:common.advancedSearch.options.header") }
+            sessionTimedOut={ sessionTimedOut }
             enableQuerySearch={ enableQuerySearch }
             externalSearchQuery={ externalSearchQuery }
             submitted={ isFormSubmitted }

--- a/modules/react-components/src/components/input/advanced-search.tsx
+++ b/modules/react-components/src/components/input/advanced-search.tsx
@@ -109,6 +109,10 @@ export interface AdvancedSearchPropsInterface extends IdentifiableComponentInter
      */
     searchOptionsHeader?: string;
     /**
+     * Session Timed Out status.
+     */
+    sessionTimedOut?: boolean;
+    /**
      * Is form submitted.
      */
     submitted?: boolean;
@@ -159,6 +163,7 @@ export const AdvancedSearch: FunctionComponent<PropsWithChildren<AdvancedSearchP
         placeholder,
         resetSubmittedState,
         searchOptionsHeader,
+        sessionTimedOut,
         submitted,
         [ "data-componentid" ]: componentId,
         [ "data-testid" ]: testId,
@@ -173,6 +178,15 @@ export const AdvancedSearch: FunctionComponent<PropsWithChildren<AdvancedSearchP
     const [ showSearchFieldHint, setShowSearchFieldHint ] = useState<boolean>(false);
     const [ isDropdownVisible, setIsDropdownVisible ] = useState<boolean>(false);
     const [ internalQueryClearTriggerState, setInternalQueryClearTriggerState ] = useState<boolean>(false);
+
+    /**
+     * useEffect hook to handle `sessionTimedOut` change.
+     */
+    useEffect(() => {
+        if (sessionTimedOut) {
+            setIsDropdownVisible(false);
+        }
+    }, [ sessionTimedOut ]);
 
     /**
      * useEffect hook to handle `internalSearchQuery` change.

--- a/modules/react-components/src/providers/session-management/session-management-context.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-context.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -14,8 +14,8 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
-export * from "./session-management-provider";
-export * from "./session-management-context";
+import { createContext } from "react";
+
+export const SessionTimedOutContext = createContext(false);


### PR DESCRIPTION
### Purpose

The advanced search popup modal does not disappear on Session Timeout when the Session Timeout modal pops up. This causes both modals to be displayed on the screen when every other component is grayed out.

This issue is fixed in this PR.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
