### PR TITLE
fix(idp): remove static authn name mappings

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
@@ -613,10 +613,7 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
                                         size="tiny"
                                         selected={ selectedSocialAuthenticator?.id === authenticator.id }
                                         image={ authenticator.image }
-                                        label={
-                                            AuthenticatorMeta.getAuthenticatorDisplayName(authenticator.name)
-                                            || authenticator.displayName
-                                        }
+                                        label={ authenticator.displayName }
                                         labelEllipsis={ true }
                                         data-testid={
                                             `${testId}-authenticator-${authenticator.name}`

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
@@ -314,9 +314,7 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
                 return isFiltersMatched(authenticator);
             }
 
-            const name: string = (AuthenticatorMeta.getAuthenticatorDisplayName(
-                authenticator.defaultAuthenticator?.authenticatorId)
-                || authenticator.displayName)?.toLocaleLowerCase();
+            const name: string = authenticator?.displayName?.toLocaleLowerCase();
 
             if (name.includes(query)
                 || IdentityProviderManagementUtils.getAuthenticatorLabels(authenticator)

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
@@ -229,10 +229,7 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
                                         transparent
                                     />
                                     <span data-testid={ `${ testId }-option-name` }>
-                                        {
-                                            AuthenticatorMeta.getAuthenticatorDisplayName(option.authenticator)
-                                        || authenticator.displayName
-                                        }
+                                        { authenticator.displayName }
                                     </span>
                                 </Card.Content>
                             </Card>

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -320,9 +320,6 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                             imageSize="micro"
                             className={ authenticatorCardClasses }
                             header={
-                                AuthenticatorMeta.getAuthenticatorDisplayName(
-                                    authenticator.defaultAuthenticator.authenticatorId
-                                ) ||
                                 authenticator.displayName ||
                                 defaultName
                             }

--- a/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
+++ b/apps/console/src/features/identity-providers/components/authenticator-grid.tsx
@@ -389,9 +389,7 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                                     resourceName={
                                         isIdP
                                             ? authenticator.name
-                                            : AuthenticatorMeta.getAuthenticatorDisplayName(authenticator.id)
-                                                ? AuthenticatorMeta.getAuthenticatorDisplayName(authenticator.id)
-                                                : (authenticator as AuthenticatorInterface).displayName
+                                            : (authenticator as AuthenticatorInterface).displayName
                                                     || (authenticator as AuthenticatorInterface).name
                                     }
                                     resourceCategory={

--- a/apps/console/src/features/identity-providers/meta/authenticator-meta.ts
+++ b/apps/console/src/features/identity-providers/meta/authenticator-meta.ts
@@ -142,27 +142,6 @@ export class AuthenticatorMeta {
     }
 
     /**
-     * Get Authenticator display name.
-     *
-     * @param {string} authenticatorId - Authenticator ID.
-     *
-     * @return {string}
-     */
-    public static getAuthenticatorDisplayName(authenticatorId: string): string {
-
-        return get({
-            [ IdentityProviderManagementConstants.BASIC_AUTHENTICATOR ]: "Username & Password",
-            [ IdentityProviderManagementConstants.BASIC_AUTHENTICATOR_ID ]: "Username & Password",
-            [ IdentityProviderManagementConstants.FIDO_AUTHENTICATOR_ID ]: "Security Key/Biometrics",
-            [ IdentityProviderManagementConstants.TOTP_AUTHENTICATOR_ID ]: "TOTP",
-            [ IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID ]: "Email OTP",
-            [ IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR_ID ]: "Identifier First",
-            [ IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID ]: "SMS OTP",
-            [ IdentityProviderManagementConstants.MAGIC_LINK_AUTHENTICATOR_ID ]: "Magic Link"
-        }, authenticatorId);
-    }
-
-    /**
      * Get Authenticator Icon.
      *
      * @param {string} authenticatorId - Authenticator ID.

--- a/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
@@ -505,8 +505,7 @@ const IdentityProviderEditPage: FunctionComponent<IDPEditPagePropsInterface> = (
             );
         }
 
-        return AuthenticatorMeta.getAuthenticatorDisplayName(connector.id)
-            ?? (connector.friendlyName || connector.name);
+        return connector.friendlyName || connector.name;
     };
 
     /**

--- a/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
+++ b/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
@@ -128,6 +128,7 @@ export class IdentityProviderManagementUtils {
 
             const getIdPs = ():Promise<IdentityProviderListResponseInterface> => {
                 const attrs = "federatedAuthenticators,provisioning";
+
                 return getIdentityProviderList(limit, offset, "isEnabled eq \"true\"", attrs)
                     .then((response) => {
                         if (!isEmpty(idp)) {
@@ -145,6 +146,7 @@ export class IdentityProviderManagementUtils {
                         // If there is a links section and that has a link to the next set of results, fetch again..
                         if (!isEmpty(response.links) && response.links[0].rel && response.links[0].rel === "next") {
                             offset = offset + limit;
+
                             return getIdPs();
                         } else {
                             return Promise.resolve(idp);
@@ -178,7 +180,7 @@ export class IdentityProviderManagementUtils {
 
         return axios.all(getPromises())
             .then(axios.spread((local: LocalAuthenticatorInterface[],
-                                          federated: IdentityProviderListResponseInterface) => {
+                federated: IdentityProviderListResponseInterface) => {
 
                 const localAuthenticators: GenericAuthenticatorInterface[] = [];
 
@@ -205,8 +207,7 @@ export class IdentityProviderManagementUtils {
                             name: authenticator.name
                         },
                         description: AuthenticatorMeta.getAuthenticatorDescription(authenticator.id),
-                        displayName: AuthenticatorMeta.getAuthenticatorDisplayName(authenticator.id)
-                            ?? authenticator.displayName,
+                        displayName: authenticator.displayName,
                         id: authenticator.id,
                         idp: IdentityProviderManagementConstants.LOCAL_IDP_IDENTIFIER,
                         image: AuthenticatorMeta.getAuthenticatorIcon(authenticator.id),


### PR DESCRIPTION
## Purpose

Remove the static display name mapping logic.
Functionalities such as Advanced Search should
work as expected when the user queries.

## Associated Fixes

- https://github.com/wso2-enterprise/asgardeo-account-lookup/pull/73
- https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/146
- https://github.com/wso2-extensions/identity-local-auth-fido/pull/92
- https://github.com/wso2-extensions/identity-local-auth-magiclink/pull/17
- https://github.com/wso2-enterprise/asgardeo-extensions/pull/35
- https://github.com/wso2-extensions/identity-outbound-auth-backup-code/pull/13
- https://github.com/wso2-extensions/identity-outbound-auth-x509/pull/68
- https://github.com/wso2-extensions/identity-outbound-auth-requestpath-basicauth/pull/42
- https://github.com/wso2-extensions/identity-outbound-auth-requestpath-oauth/pull/30
