### PR TITLE
Send organizations request only if showAppShareModal is enabled.

### DIFF
--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -308,6 +308,10 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
      * Load the list of sub organizations under the current organization for application sharing.
      */
     useEffect(() => {
+        if (!showAppShareModal) {
+            return;
+        }
+
         getOrganizations(
             null,
             null,
@@ -483,7 +487,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                 ) }
                             />
                         </div>
-                    ) 
+                    )
             ) }
             image={
                 applicationConfig.editApplication.getOverriddenImage(inboundProtocolConfigs?.oidc?.clientId,

--- a/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
+++ b/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
@@ -71,6 +71,7 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
     );
     const feature: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const scopes = useSelector((state: AppState) => state.auth.allowedScopes);
+    const tenantDomain: string = useSelector((state: AppState) => state?.auth?.tenantDomain);
 
     const [ associatedOrganizations, setAssociatedOrganizations ] = useState<OrganizationInterface[]>([]);
     const [ listFilter, setListFilter ] = useState("");
@@ -80,11 +81,16 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
     const [ search, setSearch ] = useState<string>("");
 
     const isOrgSwitcherEnabled = useMemo(() => {
-        return isOrganizationManagementEnabled &&
-        hasRequiredScopes(feature?.organizations, feature?.organizations?.scopes?.read, scopes) &&
-        organizationConfigs.showOrganizationDropdown;
+        return (
+            isOrganizationManagementEnabled &&
+            tenantDomain === AppConstants.getSuperTenant() &&
+            hasRequiredScopes(feature?.organizations, feature?.organizations?.scopes?.read, scopes) &&
+            organizationConfigs.showOrganizationDropdown
+        );
     }, [
-        organizationConfigs.showOrganizationDropdown
+        organizationConfigs.showOrganizationDropdown,
+        tenantDomain,
+        feature.organizations
     ]);
 
     const getOrganizationList = useCallback((filter: string, after: string, before: string) => {


### PR DESCRIPTION
### Purpose
> Prevent get-organizations requests from being sent unnecessarily when the application edit screen is loaded.
Resolves https://github.com/wso2/product-is/issues/14395

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
