### PR TITLE
fix(sign-on-methods): default script state

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/script-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/script-based-flow.tsx
@@ -346,9 +346,10 @@ export const ScriptBasedFlow: FunctionComponent<AdaptiveScriptsPropsInterface> =
 
         // If there is a script and if the script is not a default script,
         // assume the user has modified the script and show the editor.
-        if (authenticationSequence?.script
-            && !AdaptiveScriptUtils.isDefaultScript(authenticationSequence.script,
-                authenticationSequence?.steps?.length)) {
+        if (authenticationSequence?.script && !AdaptiveScriptUtils.isDefaultScript(
+            authenticationSequence.script,
+            authenticationSequence?.steps?.length
+        )) {
 
             setShowConditionalAuthContent(true);
 
@@ -1205,7 +1206,7 @@ export const ScriptBasedFlow: FunctionComponent<AdaptiveScriptsPropsInterface> =
                                         <Menu.Menu position="right">
                                             { resolveApiDocumentationLink() }
                                             <Menu.Item 
-                                            className={ `action ${isSecretsDropdownOpen ? "selected-secret" : "" }` }>
+                                                className={ `action ${isSecretsDropdownOpen ? "selected-secret" : "" }` }>
                                                 <div>
                                                     { renderSecretListDropdown() }
                                                 </div>

--- a/apps/console/src/features/applications/utils/adaptive-script-utils.ts
+++ b/apps/console/src/features/applications/utils/adaptive-script-utils.ts
@@ -84,16 +84,23 @@ export class AdaptiveScriptUtils {
             + scriptBody
             + ApplicationManagementConstants.DEFAULT_ADAPTIVE_AUTH_SCRIPT_FOOTER;
 
-        return AdaptiveScriptUtils.minifyScript(moderatedScript) === AdaptiveScriptUtils.minifyScript(scriptComposed);
+        const userDefined = AdaptiveScriptUtils.minifyScript(moderatedScript, false);
+        const defaultScript = AdaptiveScriptUtils.minifyScript(scriptComposed, false);
+
+        return userDefined === defaultScript;
     }
 
     /**
      * Strips spaces and new lines in the script.
      *
      * @param {string | string[]} originalScript - Original script.
+     * @param ignoreComments {boolean}
      * @return {string}
      */
-    public static minifyScript(originalScript: string | string[]): string {
+    public static minifyScript(
+        originalScript: string | string[],
+        ignoreComments: boolean = true
+    ): string {
 
         if (!originalScript) return ApplicationManagementConstants.EMPTY_STRING;
 
@@ -122,11 +129,21 @@ export class AdaptiveScriptUtils {
          */
         const comments = /\/\*[\s\S]*?\*\/|\/\/.*/gm;
 
-        return script
-            .replace(comments, ApplicationManagementConstants.EMPTY_STRING)
+        let minimized = script;
+
+        if (ignoreComments)
+            minimized = minimized.replace(
+                comments,
+                ApplicationManagementConstants.EMPTY_STRING
+            );
+
+        minimized = minimized
             .replace(/(?:\r\n|\r|\n)/g, ApplicationManagementConstants.EMPTY_STRING)
             .replace(/\s/g, ApplicationManagementConstants.EMPTY_STRING)
             .trim();
+
+        return minimized;
+
     }
 
     public static isEmptyScript(script: string | string[]): boolean {

--- a/apps/console/src/features/applications/utils/adaptive-script-utils.ts
+++ b/apps/console/src/features/applications/utils/adaptive-script-utils.ts
@@ -84,8 +84,8 @@ export class AdaptiveScriptUtils {
             + scriptBody
             + ApplicationManagementConstants.DEFAULT_ADAPTIVE_AUTH_SCRIPT_FOOTER;
 
-        const userDefined = AdaptiveScriptUtils.minifyScript(moderatedScript, false);
-        const defaultScript = AdaptiveScriptUtils.minifyScript(scriptComposed, false);
+        const userDefined: string = AdaptiveScriptUtils.minifyScript(moderatedScript, false);
+        const defaultScript: string = AdaptiveScriptUtils.minifyScript(scriptComposed, false);
 
         return userDefined === defaultScript;
     }
@@ -94,8 +94,8 @@ export class AdaptiveScriptUtils {
      * Strips spaces and new lines in the script.
      *
      * @param {string | string[]} originalScript - Original script.
-     * @param ignoreComments {boolean}
-     * @return {string}
+     * @param {boolean} ignoreComments Whether to ignore code comments.
+     * @return {string} Minified string.
      */
     public static minifyScript(
         originalScript: string | string[],


### PR DESCRIPTION
### Purpose
> Now in the script minification process we can ignore comments altogether. In the isDefaultScript function, we explicitly ignore all the comments before the comparison.
