### PR TITLE
Org management/role assignment and share organization fix

### DIFF
--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -322,7 +322,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
         ).then((response) => {
             setSubOrganizationList(response.organizations);
         });
-    }, [ getOrganizations ]);
+    }, [ getOrganizations, showAppShareModal ]);
 
     const determineApplicationTemplate = () => {
 

--- a/apps/console/src/features/groups/components/wizard/create-group-wizard.tsx
+++ b/apps/console/src/features/groups/components/wizard/create-group-wizard.tsx
@@ -28,6 +28,7 @@ import { GroupBasics } from "./group-basics";
 import { CreateGroupSummary } from "./group-summary";
 import { AppConstants, AppState, AssignRoles, RolePermissions, history } from "../../../core";
 import { getOrganizationRoles } from "../../../organizations/api";
+import { OrganizationRoleManagementConstants } from "../../../organizations/constants";
 import { OrganizationRoleListItemInterface } from "../../../organizations/models";
 import { OrganizationUtils } from "../../../organizations/utils";
 import { getRolesList, updateRole } from "../../../roles/api";
@@ -140,7 +141,14 @@ export const CreateGroupWizard: FunctionComponent<CreateGroupProps> = (props: Cr
             } else {
                 getOrganizationRoles(currentOrganization.id, null, 100, null)
                     .then((response) => {
-                        setRoleList(response.Resources);
+                        if (!response.Resources) {
+                            return;
+                        }
+
+                        const roles = response.Resources.filter((role) =>
+                            role.displayName !== OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME);
+                        
+                        setRoleList(roles);
                     });
             }
         }

--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -35,6 +35,7 @@ import { AppConstants } from "../../../core/constants";
 import { history } from "../../../core/helpers";
 import { getGroupList, updateGroupDetails } from "../../../groups/api";
 import { getOrganizationRoles } from "../../../organizations/api";
+import { OrganizationRoleManagementConstants } from "../../../organizations/constants";
 import { OrganizationRoleListItemInterface } from "../../../organizations/models";
 import { OrganizationUtils } from "../../../organizations/utils";
 import { getRolesList, updateRoleDetails } from "../../../roles/api";
@@ -157,8 +158,15 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                 // Get Roles from the Organization API
                 getOrganizationRoles(currentOrganization.id, null, 100, null)
                     .then((response) => {
-                        setRoleList(response.Resources);
-                        setInitialRoleList(response.Resources);
+                        if (!response.Resources) {
+                            return;
+                        }
+
+                        const roles = response.Resources.filter((role) =>
+                            role.displayName !== OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME);
+
+                        setRoleList(roles);
+                        setInitialRoleList(roles);
                     });
             }
         }


### PR DESCRIPTION
### Purpose
> This PR implements the following
* Fixed **getOrganizations** API call not calling in Application Share Modal
* Made **org-creator** role non-assignable in users and groups creation views

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
