### PR TITLE
Fix relative auth spa lib path

### DIFF
--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -33,7 +33,7 @@
 <!DOCTYPE HTML>
 <html>
     <head>
-        <script src="<%= htmlWebpackPlugin.options.basename %>/auth-spa-0.3.3.min.js"></script>
+        <script src="/<%= htmlWebpackPlugin.options.basename %>/auth-spa-0.3.3.min.js"></script>
     </head>
     <body>
         <script>

--- a/apps/myaccount/src/index.jsp
+++ b/apps/myaccount/src/index.jsp
@@ -38,7 +38,7 @@
                 window.location.href = applicationDomain+'/'+"<%= htmlWebpackPlugin.options.basename %>"
             }
         </script>
-        <script src="<%= htmlWebpackPlugin.options.basename %>/auth-spa-0.3.3.min.js"></script>
+        <script src="/<%= htmlWebpackPlugin.options.basename %>/auth-spa-0.3.3.min.js"></script>
     </head>
     <body>
         <script>


### PR DESCRIPTION
### Purpose
> Fix relative auth spa lib path when using slash for accessing the app. Ex: `console/` over `console`

### Related Issues

### Related PRs
https://github.com/wso2/identity-apps/pull/3269

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
