### PR TITLE
Displaying Application template name in the applications list of console

### DIFF
--- a/apps/console/src/features/applications/api/application.ts
+++ b/apps/console/src/features/applications/api/application.ts
@@ -191,10 +191,11 @@ export const getApplicationList = (limit: number, offset: number,
  *
  * @param {number} limit - Maximum Limit of the application List.
  * @param {number} offset - Offset for get to start.
- * @param {string} filter - Search filter. 
+ * @param {string} filter - Search filter.
  * @returns {RequestResultInterface<Data, Error>}
  */
 export const useApplicationList = <Data = ApplicationListInterface, Error = RequestErrorInterface>(
+    attributes?: string,
     limit?: number,
     offset?: number,
     filter?: string
@@ -207,6 +208,7 @@ export const useApplicationList = <Data = ApplicationListInterface, Error = Requ
         },
         method: HttpMethods.GET,
         params: {
+            attributes,
             filter,
             limit,
             offset

--- a/apps/console/src/features/applications/components/application-list.tsx
+++ b/apps/console/src/features/applications/components/application-list.tsx
@@ -256,12 +256,8 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
      * @return {TableColumnInterface[]}
      */
 
-    const templateIDArray = ["single_page", "standard_web", "other"];
-
     const resolveTableColumns = (): TableColumnInterface[] => {
-        // const randTempIdNo = 2;
-        const randTempIdNo = Math.floor(Math.random() * 3);
-        // console.log("hi there");
+        console.log("resolveTableColumns called")
         return [
             {
                 allowToggleVisibility: false,
@@ -314,17 +310,6 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                                     data-testid={ `${ testId }-item-sub-heading` }
                                 >
                                     {
-                                        template && (
-                                            <Label
-                                                size="mini"
-                                                className="compact spaced-right"
-                                                data-testid={ `${ testId }-template-type` }
-                                            >
-                                                { template.name }
-                                            </Label>
-                                        )
-                                    }
-                                    {
                                         app.description?.length > 80
                                             ? (
                                                 <Popup
@@ -355,82 +340,12 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                         && applicationTemplates instanceof Array
                         && applicationTemplates.length > 0
                         && applicationTemplates.find((template) => template.id === app.templateId);
-
-                    const randTempIdNo = Math.floor(Math.random() * 3);
-
+                    console.log({ app, template })
+                    // Displays the template name of the application
                     return (
                         <div>
-                            <p>{ templateIDArray[randTempIdNo] }</p>
-                            {/*<p>{app.templateId}</p>*/}
+                            <p>{ template?.name }</p>
                         </div>
-
-                        // <p>hi</p>
-                        // <Header
-                        //     image
-                        //     as="h6"
-                        //     className="header-with-icon"
-                        //     data-testid={ `${ testId }-item-heading` }
-                        // >
-                        //     {
-                        //         app.image
-                        //             ? (
-                        //                 <AppAvatar
-                        //                     size="mini"
-                        //                     name={ app.name }
-                        //                     image={ app.image }
-                        //                     spaced="right"
-                        //                     data-testid={ `${ testId }-item-image` }
-                        //                 />
-                        //             )
-                        //             : (
-                        //                 <AppAvatar
-                        //                     image={ (
-                        //                         <AnimatedAvatar
-                        //                             name={ app.name }
-                        //                             size="mini"
-                        //                             data-testid={ `${ testId }-item-image-inner` }
-                        //                         />
-                        //                     ) }
-                        //                     size="mini"
-                        //                     spaced="right"
-                        //                     data-testid={ `${ testId }-item-image` }
-                        //                 />
-                        //             )
-                        //     }
-                        //     <Header.Content>
-                        //         { app.name }
-                        //         <Header.Subheader
-                        //             className="truncate ellipsis"
-                        //             data-testid={ `${ testId }-item-sub-heading` }
-                        //         >
-                        //             {
-                        //                 template && (
-                        //                     <Label
-                        //                         size="mini"
-                        //                         className="compact spaced-right"
-                        //                         data-testid={ `${ testId }-template-type` }
-                        //                     >
-                        //                         { template.name }
-                        //                     </Label>
-                        //                 )
-                        //             }
-                        //             {
-                        //                 app.description?.length > 80
-                        //                     ? (
-                        //                         <Popup
-                        //                             content={ app.description }
-                        //                             trigger={ (
-                        //                                 <span>{
-                        //                                     app.description
-                        //                                 }</span>
-                        //                             ) }
-                        //                         />
-                        //                     )
-                        //                     : app.description
-                        //             }
-                        //         </Header.Subheader>
-                        //     </Header.Content>
-                        // </Header>
                     );
                 },
                 title: t("console:develop.features.applications.list.columns.name")

--- a/apps/console/src/features/applications/components/application-list.tsx
+++ b/apps/console/src/features/applications/components/application-list.tsx
@@ -38,8 +38,7 @@ import {
     TableColumnInterface,
     useConfirmationModalAlert
 } from "@wso2is/react-components";
-// eslint-disable-next-line no-restricted-imports
-import _ from "lodash";
+import cloneDeep from "lodash-es/cloneDeep";
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -64,7 +63,7 @@ import {
     ApplicationTemplateListItemInterface
 } from "../models";
 import { ApplicationTemplateManagementUtils } from "../utils";
-import {OAuthProtocolTemplateItem, PassiveStsProtocolTemplateItem, SAMLProtocolTemplateItem} from "./meta";
+import { OAuthProtocolTemplateItem, PassiveStsProtocolTemplateItem, SAMLProtocolTemplateItem } from "./meta";
 
 /**
  *
@@ -258,9 +257,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
      *
      * @return {TableColumnInterface[]}
      */
-
     const resolveTableColumns = (): TableColumnInterface[] => {
-        console.log("resolveTableColumns called")
         return [
             {
                 allowToggleVisibility: false,
@@ -346,7 +343,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                     // And change the name according to the templateId passed from the backend
 
                     // Create a set with custom-application Ids
-                    const customApplicationIds = new Set( [
+                    const customApplicationIds = new Set([
                         ApplicationManagementConstants.CUSTOM_APPLICATION_SAML,
                         ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC,
                         ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS
@@ -359,24 +356,25 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                             && applicationTemplates instanceof Array
                             && applicationTemplates.length > 0
                             && applicationTemplates.find((template) => {
-                                return template.templateId === "custom-application";
+                                return template.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION;
                             });
 
                         // Cloning the template and replacing the name with specific template name
-                        const template_clone = _.cloneDeep(template);
-                        if (template_clone) {
+                        const templateClone = cloneDeep(template);
+
+                        if (templateClone) {
                             if (app.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_SAML) {
-                                template_clone.name = SAMLProtocolTemplateItem.name;
+                                templateClone.name = SAMLProtocolTemplateItem.name;
                             } else if (app.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC) {
-                                template_clone.name = OAuthProtocolTemplateItem.name;
+                                templateClone.name = OAuthProtocolTemplateItem.name;
                             } else if (app.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS) {
-                                template_clone.name = PassiveStsProtocolTemplateItem.name;
+                                templateClone.name = PassiveStsProtocolTemplateItem.name;
                             }
                         }
 
                         return (
                             <div>
-                                <p>{ template_clone?.name }</p>
+                                { templateClone?.name }
                             </div>
                         );
                     } else {
@@ -385,10 +383,10 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                             && applicationTemplates instanceof Array
                             && applicationTemplates.length > 0
                             && applicationTemplates.find((template) => template.id === app.templateId);
-
+                        console.log(app.isManagementApp);
                         return (
                             <div>
-                                <p>{template?.name}</p>
+                                { template?.name }
                             </div>
                         );
                     }

--- a/apps/console/src/features/applications/components/application-list.tsx
+++ b/apps/console/src/features/applications/components/application-list.tsx
@@ -255,7 +255,13 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
      *
      * @return {TableColumnInterface[]}
      */
+
+    const templateIDArray = ["single_page", "standard_web", "other"];
+
     const resolveTableColumns = (): TableColumnInterface[] => {
+        // const randTempIdNo = 2;
+        const randTempIdNo = Math.floor(Math.random() * 3);
+        // console.log("hi there");
         return [
             {
                 allowToggleVisibility: false,
@@ -335,6 +341,96 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                                 </Header.Subheader>
                             </Header.Content>
                         </Header>
+                    );
+                },
+                title: t("console:develop.features.applications.list.columns.name")
+            },
+            {
+                allowToggleVisibility: false,
+                dataIndex: "templateID",
+                id: "templateID",
+                key: "templateID",
+                render: (app: ApplicationListItemInterface): ReactNode => {
+                    const template = applicationTemplates
+                        && applicationTemplates instanceof Array
+                        && applicationTemplates.length > 0
+                        && applicationTemplates.find((template) => template.id === app.templateId);
+
+                    const randTempIdNo = Math.floor(Math.random() * 3);
+
+                    return (
+                        <div>
+                            <p>{ templateIDArray[randTempIdNo] }</p>
+                            {/*<p>{app.templateId}</p>*/}
+                        </div>
+
+                        // <p>hi</p>
+                        // <Header
+                        //     image
+                        //     as="h6"
+                        //     className="header-with-icon"
+                        //     data-testid={ `${ testId }-item-heading` }
+                        // >
+                        //     {
+                        //         app.image
+                        //             ? (
+                        //                 <AppAvatar
+                        //                     size="mini"
+                        //                     name={ app.name }
+                        //                     image={ app.image }
+                        //                     spaced="right"
+                        //                     data-testid={ `${ testId }-item-image` }
+                        //                 />
+                        //             )
+                        //             : (
+                        //                 <AppAvatar
+                        //                     image={ (
+                        //                         <AnimatedAvatar
+                        //                             name={ app.name }
+                        //                             size="mini"
+                        //                             data-testid={ `${ testId }-item-image-inner` }
+                        //                         />
+                        //                     ) }
+                        //                     size="mini"
+                        //                     spaced="right"
+                        //                     data-testid={ `${ testId }-item-image` }
+                        //                 />
+                        //             )
+                        //     }
+                        //     <Header.Content>
+                        //         { app.name }
+                        //         <Header.Subheader
+                        //             className="truncate ellipsis"
+                        //             data-testid={ `${ testId }-item-sub-heading` }
+                        //         >
+                        //             {
+                        //                 template && (
+                        //                     <Label
+                        //                         size="mini"
+                        //                         className="compact spaced-right"
+                        //                         data-testid={ `${ testId }-template-type` }
+                        //                     >
+                        //                         { template.name }
+                        //                     </Label>
+                        //                 )
+                        //             }
+                        //             {
+                        //                 app.description?.length > 80
+                        //                     ? (
+                        //                         <Popup
+                        //                             content={ app.description }
+                        //                             trigger={ (
+                        //                                 <span>{
+                        //                                     app.description
+                        //                                 }</span>
+                        //                             ) }
+                        //                         />
+                        //                     )
+                        //                     : app.description
+                        //             }
+                        //         </Header.Subheader>
+                        //     </Header.Content>
+                        // </Header>
                     );
                 },
                 title: t("console:develop.features.applications.list.columns.name")

--- a/apps/console/src/features/applications/components/application-list.tsx
+++ b/apps/console/src/features/applications/components/application-list.tsx
@@ -38,6 +38,8 @@ import {
     TableColumnInterface,
     useConfirmationModalAlert
 } from "@wso2is/react-components";
+// eslint-disable-next-line no-restricted-imports
+import _ from "lodash";
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -62,6 +64,7 @@ import {
     ApplicationTemplateListItemInterface
 } from "../models";
 import { ApplicationTemplateManagementUtils } from "../utils";
+import {OAuthProtocolTemplateItem, PassiveStsProtocolTemplateItem, SAMLProtocolTemplateItem} from "./meta";
 
 /**
  *
@@ -336,17 +339,59 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                 id: "templateID",
                 key: "templateID",
                 render: (app: ApplicationListItemInterface): ReactNode => {
-                    const template = applicationTemplates
-                        && applicationTemplates instanceof Array
-                        && applicationTemplates.length > 0
-                        && applicationTemplates.find((template) => template.id === app.templateId);
-                    console.log({ app, template })
-                    // Displays the template name of the application
-                    return (
-                        <div>
-                            <p>{ template?.name }</p>
-                        </div>
-                    );
+
+                    // Note: the templateId for Standard-Based Applications in applicationTemplates is 'custom-application' (only 1 template is available)
+                    // But backend passes 3 distinct ids for Standard Based Applications
+                    // So, a deep clone of a template with templateId === 'custom-application' should be made
+                    // And change the name according to the templateId passed from the backend
+
+                    // Create a set with custom-application Ids
+                    const customApplicationIds = new Set( [
+                        ApplicationManagementConstants.CUSTOM_APPLICATION_SAML,
+                        ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC,
+                        ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS
+                    ]);
+
+                    // Checking whether the templateId from backend, is for a custom application
+                    // If so, find the single template from applicationTemplates
+                    if (customApplicationIds.has(app.templateId)) {
+                        const template = applicationTemplates
+                            && applicationTemplates instanceof Array
+                            && applicationTemplates.length > 0
+                            && applicationTemplates.find((template) => {
+                                return template.templateId === "custom-application";
+                            });
+
+                        // Cloning the template and replacing the name with specific template name
+                        const template_clone = _.cloneDeep(template);
+                        if (template_clone) {
+                            if (app.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_SAML) {
+                                template_clone.name = SAMLProtocolTemplateItem.name;
+                            } else if (app.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC) {
+                                template_clone.name = OAuthProtocolTemplateItem.name;
+                            } else if (app.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS) {
+                                template_clone.name = PassiveStsProtocolTemplateItem.name;
+                            }
+                        }
+
+                        return (
+                            <div>
+                                <p>{ template_clone?.name }</p>
+                            </div>
+                        );
+                    } else {
+                        // Displaying template name if it's not a Standard-Based Application
+                        const template = applicationTemplates
+                            && applicationTemplates instanceof Array
+                            && applicationTemplates.length > 0
+                            && applicationTemplates.find((template) => template.id === app.templateId);
+
+                        return (
+                            <div>
+                                <p>{template?.name}</p>
+                            </div>
+                        );
+                    }
                 },
                 title: t("console:develop.features.applications.list.columns.name")
             },

--- a/apps/console/src/features/applications/components/meta/oauth-protocol-template.meta.ts
+++ b/apps/console/src/features/applications/components/meta/oauth-protocol-template.meta.ts
@@ -22,12 +22,14 @@ import {
     DefaultProtocolTemplate,
     State
 } from "../../models";
+import {ApplicationManagementConstants} from "../../constants";
 
 export const OAuthProtocolTemplateItem: ApplicationTemplateListItemInterface = {
     authenticationProtocol: "oidc",
     id: DefaultProtocolTemplate.OIDC,
     image: "oidc",
-    name: "OIDC"
+    name: "OIDC",
+    templateId: ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
 };
 
 export const OAuthProtocolTemplate: ApplicationTemplateInterface = {

--- a/apps/console/src/features/applications/components/meta/passive-sts-protocol-template.meta.ts
+++ b/apps/console/src/features/applications/components/meta/passive-sts-protocol-template.meta.ts
@@ -21,12 +21,14 @@ import {
     ApplicationTemplateListItemInterface,
     DefaultProtocolTemplate
 } from "../../models";
+import {ApplicationManagementConstants} from "../../constants";
 
 export const PassiveStsProtocolTemplateItem: ApplicationTemplateListItemInterface = {
     authenticationProtocol: "passive-sts",
     id: DefaultProtocolTemplate.WS_FEDERATION,
     image: "wsFed",
-    name: "Passive STS"
+    name: "Passive STS",
+    templateId: ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS
 };
 
 export const PassiveStsProtocolTemplate: ApplicationTemplateInterface = {

--- a/apps/console/src/features/applications/components/meta/saml-protocol-template.meta.ts
+++ b/apps/console/src/features/applications/components/meta/saml-protocol-template.meta.ts
@@ -21,12 +21,14 @@ import {
     ApplicationTemplateListItemInterface,
     DefaultProtocolTemplate
 } from "../../models";
+import {ApplicationManagementConstants} from "../../constants";
 
 export const SAMLProtocolTemplateItem: ApplicationTemplateListItemInterface = {
     authenticationProtocol: "saml",
     id: DefaultProtocolTemplate.SAML,
     image: "saml",
-    name: "SAML"
+    name: "SAML",
+    templateId: ApplicationManagementConstants.CUSTOM_APPLICATION_SAML
 };
 
 export const SAMLProtocolTemplate: ApplicationTemplateInterface = {

--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -420,6 +420,8 @@ export class ApplicationManagementConstants {
 
     public static readonly CUSTOM_APPLICATION_PASSIVE_STS = "custom-application-passive-sts";
 
+    public static readonly CUSTOM_APPLICATION = "custom-application";
+
     public static readonly CUSTOM_APPLICATION_PROTOCOL_ORDER: Map<string, number> =
         new Map<string, number>([
             [ "oidc", 0 ],

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -144,7 +144,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
         isLoading: isApplicationListFetchRequestLoading,
         error: applicationListFetchRequestError,
         mutate: mutateApplicationListFetchRequest
-    } = useApplicationList("advancedConfigurations,templateId",listItemLimit, listOffset, searchQuery);
+    } = useApplicationList("advancedConfigurations,templateId", listItemLimit, listOffset, searchQuery);
 
     /**
      * Sets the initial spinner.

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -144,7 +144,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
         isLoading: isApplicationListFetchRequestLoading,
         error: applicationListFetchRequestError,
         mutate: mutateApplicationListFetchRequest
-    } = useApplicationList(listItemLimit, listOffset, searchQuery);
+    } = useApplicationList("advancedConfigurations,templateId",listItemLimit, listOffset, searchQuery);
 
     /**
      * Sets the initial spinner.


### PR DESCRIPTION
### Purpose
> This improvement displays the name of the template from which an application is created from, in the console, in a separate column.

### Related Issues
- Issue `#1` https://github.com/wso2/product-is/issues/10681#issue-757081311
- Issue `#2` https://github.com/wso2/product-is/issues/13944
- Issue `#3` https://github.com/wso2/product-is/issues/14114

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
