### PR TITLE
Redirect username recovery not enabled error to error.jsp

### DIFF
--- a/apps/recovery-portal/src/main/webapp/recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/recovery.jsp
@@ -126,12 +126,12 @@
                 request.setAttribute("error", true);
                 request.setAttribute("errorMsg", IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                         "No.valid.user.found"));
-                request.getRequestDispatcher("recoveraccountrouter.do").forward(request, response);
+                request.getRequestDispatcher("error.jsp").forward(request, response);
                 return;
             }
 
             IdentityManagementEndpointUtil.addErrorInformation(request, e);
-            request.getRequestDispatcher("recoveraccountrouter.do").forward(request, response);
+            request.getRequestDispatcher("error.jsp").forward(request, response);
             return;
         }
 


### PR DESCRIPTION
### Purpose
> Redirect username recovery not enabled error to error.jsp, as all the other errors of username recovery flow and password recovery flow are redirected to the error.jsp as well

### Related Issues
- fixes https://github.com/wso2/product-is/issues/14618

![recording 2](https://user-images.githubusercontent.com/46132469/183350223-31cd5e07-cf59-49d5-829e-fbd4b472e985.gif)

