### PR TITLE
Stop Safari from using `webWorker` as storage for SDK

### DIFF
--- a/apps/console/src/features/authentication/utils/authenticate-utils.ts
+++ b/apps/console/src/features/authentication/utils/authenticate-utils.ts
@@ -17,7 +17,7 @@
  */
 
 import { AuthReactConfig, ResponseMode, Storage } from "@asgardeo/auth-react";
-import { TokenConstants } from "@wso2is/core/constants";
+import { AppConstants, TokenConstants } from "@wso2is/core/constants";
 import UAParser from "ua-parser-js";
 
 /**
@@ -74,20 +74,24 @@ export class AuthenticateUtils {
      * @returns {Storage}
      */
     public static resolveStorage(): Storage {
-        const storageFallback: Storage =
-            new UAParser().getBrowser().name === "IE" ? Storage.SessionStorage : Storage.WebWorker;
+
+        const activeBrowser: string = new UAParser()?.getBrowser()?.name;
+
+        const storageFallback: Storage = AppConstants.WEB_WORKER_UNSUPPORTED_AGENTS.includes(activeBrowser)
+            ? Storage.SessionStorage
+            : Storage.WebWorker;
 
         if (window["AppUtils"].getConfig().idpConfigs?.storage) {
             if (
                 window["AppUtils"].getConfig().idpConfigs?.storage === Storage.WebWorker &&
-                new UAParser().getBrowser().name === "IE"
+                storageFallback !== Storage.WebWorker
             ) {
                 return Storage.SessionStorage;
             }
-
+    
             return window["AppUtils"].getConfig().idpConfigs?.storage;
         }
-
+    
         return storageFallback;
     }
 

--- a/apps/console/src/features/authentication/utils/authenticate-utils.ts
+++ b/apps/console/src/features/authentication/utils/authenticate-utils.ts
@@ -88,10 +88,10 @@ export class AuthenticateUtils {
             ) {
                 return Storage.SessionStorage;
             }
-    
+
             return window["AppUtils"].getConfig().idpConfigs?.storage;
         }
-    
+
         return storageFallback;
     }
 

--- a/apps/myaccount/src/utils/authenticate-util.ts
+++ b/apps/myaccount/src/utils/authenticate-util.ts
@@ -18,7 +18,7 @@
  */
 
 import { AuthReactConfig, Hooks, ResponseMode, Storage, useAuthContext } from "@asgardeo/auth-react";
-import { TokenConstants } from "@wso2is/core/constants";
+import { AppConstants, TokenConstants } from "@wso2is/core/constants";
 import UAParser from "ua-parser-js";
 import { store } from "../store";
 
@@ -85,13 +85,17 @@ const resolveBaseUrls = (): string[] => {
 };
 
 const resolveStorage = (): Storage => {
-    const storageFallback: Storage =
-        new UAParser().getBrowser().name === "IE" ? Storage.SessionStorage : Storage.WebWorker;
+
+    const activeBrowser: string = new UAParser()?.getBrowser()?.name;
+
+    const storageFallback: Storage = AppConstants.WEB_WORKER_UNSUPPORTED_AGENTS.includes(activeBrowser)
+        ? Storage.SessionStorage
+        : Storage.WebWorker;
 
     if (window["AppUtils"].getConfig().idpConfigs?.storage) {
         if (
             window["AppUtils"].getConfig().idpConfigs?.storage === Storage.WebWorker &&
-            new UAParser().getBrowser().name === "IE"
+            storageFallback !== Storage.WebWorker
         ) {
             return Storage.SessionStorage;
         }

--- a/modules/core/src/constants/app-constants.ts
+++ b/modules/core/src/constants/app-constants.ts
@@ -86,4 +86,18 @@ export class AppConstants {
      * @default
      */
     public static readonly FULL_UI_SCOPE: string = "console:full";
+
+    /**
+     * Set of Browsers that do not properly support Web Worker APIs.
+     * TODO: Remove `Safari` from here when https://github.com/wso2/product-is/issues/14652 is fixed.
+     * @constant
+     * @type {string[]}
+     * @default
+     */
+    public static readonly WEB_WORKER_UNSUPPORTED_AGENTS: string[] = [
+        "IE",
+        "Safari",
+        "[Mobile] Safari",
+        "Mobile Safari"
+    ];
 }

--- a/modules/react-components/src/components/containers/iframe.tsx
+++ b/modules/react-components/src/components/containers/iframe.tsx
@@ -333,7 +333,7 @@ export const Iframe: FunctionComponent<PropsWithChildren<IframeProps>> = (
                 className={ !isWrapped && classes }
                 ref={ contentRef }
                 data-componentid={ componentId }
-                { ...rest }
+                { ...rest as any }
             >
                 { iFrameBodyNode && createPortal(children, iFrameBodyNode) }
             </iframe>


### PR DESCRIPTION
### Purpose

$subject

### Related Issues
- Temp fix for https://github.com/wso2/product-is/issues/14652
- Fixes https://github.com/wso2/product-is/issues/14574

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
