### PR TITLE
Filter apps by clientId on application listing view

### DIFF
--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -484,8 +484,9 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                     }
                                     defaultSearchAttribute="name"
                                     defaultSearchOperator="co"
-                                    predefinedDefaultSearchStrategy={"name co %search-value% " +
-                                    "or clientId co %search-value%"}
+                                    predefinedDefaultSearchStrategy={
+                                        "name co %search-value% or clientId co %search-value%"
+                                    }
                                     triggerClearQuery={ triggerClearQuery }
                                     data-testid={ `${ testId }-list-advanced-search` }
                                 />

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -406,6 +406,11 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                         key: 0,
                                         text: t("common:name"),
                                         value: "name"
+                                    },
+                                    {
+                                        key: 1,
+                                        text: "ClientId",
+                                        value: "clientId"
                                     }
                                 ] }
                                 filterAttributePlaceholder={
@@ -423,6 +428,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                 placeholder={ t("console:develop.features.applications.advancedSearch.placeholder") }
                                 defaultSearchAttribute="name"
                                 defaultSearchOperator="co"
+                                predefinedDefaultSearchStrategy="name co %search-value% or clientId co %search-value%"
                                 triggerClearQuery={ triggerClearQuery }
                                 data-testid={ `${ testId }-list-advanced-search` }
                             />
@@ -454,6 +460,11 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                             key: 0,
                                             text: t("common:name"),
                                             value: "name"
+                                        },
+                                        {
+                                            key: 1,
+                                            text: "ClientId",
+                                            value: "clientId"
                                         }
                                     ] }
                                     filterAttributePlaceholder={
@@ -473,6 +484,8 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                     }
                                     defaultSearchAttribute="name"
                                     defaultSearchOperator="co"
+                                    predefinedDefaultSearchStrategy={"name co %search-value% " +
+                                    "or clientId co %search-value%"}
                                     triggerClearQuery={ triggerClearQuery }
                                     data-testid={ `${ testId }-list-advanced-search` }
                                 />

--- a/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
+++ b/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
@@ -99,7 +99,7 @@ export interface AdvancedSearchWithBasicFiltersPropsInterface extends TestableCo
      */
     placeholder: string;
     /**
-     * Predefined Default Search strategy. ex: "name co %search-value% or clientId co %search-value%"
+     * Predefined Default Search strategy. ex: "name co %search-value% or clientId co %search-value%".
      */
     predefinedDefaultSearchStrategy?: string;
     /**

--- a/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
+++ b/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
@@ -99,6 +99,10 @@ export interface AdvancedSearchWithBasicFiltersPropsInterface extends TestableCo
      */
     placeholder: string;
     /**
+     * Predefined Default Search strategy. ex: "name co %search-value% or clientId co %search-value%"
+     */
+    predefinedDefaultSearchStrategy?: string;
+    /**
      * Submit button text.
      */
     submitButtonLabel?: string;
@@ -143,6 +147,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
         filterValuePlaceholder,
         onFilter,
         placeholder,
+        predefinedDefaultSearchStrategy,
         resetButtonLabel,
         showResetButton,
         submitButtonLabel,
@@ -212,6 +217,17 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
     };
 
     /**
+     * Handles defaultSearchStrategy value.
+     */
+    const handleDefaultSearchStrategy = (): string => {
+        if (predefinedDefaultSearchStrategy) {
+            return predefinedDefaultSearchStrategy;
+        } else {
+            return `${defaultSearchAttribute} ${defaultSearchOperator} %search-value%`;
+        }
+    }
+
+    /**
      * Default filter condition options.
      *
      * @type {({text: string; value: string})[]}
@@ -240,7 +256,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
             aligned="left"
             clearButtonPopupLabel={ t("console:common.advancedSearch.popups.clear") }
             clearIcon={ getAdvancedSearchIcons().clear }
-            defaultSearchStrategy={ defaultSearchAttribute + " " + defaultSearchOperator }
+            defaultSearchStrategy={ handleDefaultSearchStrategy() }
             dropdownTriggerPopupLabel={ t("console:common.advancedSearch.popups.dropdown") }
             fill={ fill }
             hintActionKeys={ t("console:common.advancedSearch.hints.querySearch.actionKeys") }

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -573,7 +573,7 @@ export const console: ConsoleNS = {
                             }
                         }
                     },
-                    placeholder: "Search by application name"
+                    placeholder: "Search by application name or clientId"
                 },
                 confirmations: {
                     addSocialLogin: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -571,7 +571,7 @@ export const console: ConsoleNS = {
                             }
                         }
                     },
-                    placeholder: "Chercher par nom d'application"
+                    placeholder: "Chercher par nom d'application ou clientId"
                 },
                 confirmations: {
                     addSocialLogin: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -579,7 +579,7 @@ export const console: ConsoleNS = {
                             }
                         }
                     },
-                    placeholder: "යෙදුම් නාමයෙන් සොයන්න"
+                    placeholder: "යෙදුම් නාමයෙන් හෝ සේවාලාභී හැඳුනුම්පතෙන් සොයන්න"
                 },
                 confirmations: {
                     addSocialLogin: {

--- a/modules/react-components/src/components/input/advanced-search.tsx
+++ b/modules/react-components/src/components/input/advanced-search.tsx
@@ -304,7 +304,7 @@ export const AdvancedSearch: FunctionComponent<PropsWithChildren<AdvancedSearchP
                 if (advancedSearch) {
                     query = internalSearchQuery;
                 } else {
-                    query = defaultSearchStrategy.replace(/%search-value%/g,internalSearchQuery);
+                    query = defaultSearchStrategy.replace(/%search-value%/g, internalSearchQuery);
                 }
             }
             onSearchQuerySubmit(false, query);

--- a/modules/react-components/src/components/input/advanced-search.tsx
+++ b/modules/react-components/src/components/input/advanced-search.tsx
@@ -55,7 +55,7 @@ export interface AdvancedSearchPropsInterface extends IdentifiableComponentInter
      */
     clearIcon?: any;
     /**
-     * Search strategy ex: name sw.
+     * Search strategy ex: name co %search-value%.
      */
     defaultSearchStrategy: string;
     /**
@@ -304,7 +304,7 @@ export const AdvancedSearch: FunctionComponent<PropsWithChildren<AdvancedSearchP
                 if (advancedSearch) {
                     query = internalSearchQuery;
                 } else {
-                    query = `${ defaultSearchStrategy } ${ internalSearchQuery }`;
+                    query = defaultSearchStrategy.replace(/%search-value%/g,internalSearchQuery);
                 }
             }
             onSearchQuerySubmit(false, query);


### PR DESCRIPTION
### Purpose
Allow users to filter applications by clientId and change the default search query format to "name co %search-value% or clientId co %search-value%"

### Related Issues
- [#11545](https://github.com/wso2-enterprise/asgardeo-product/issues/11545)
- [#13933](https://github.com/wso2/product-is/issues/13933)

### Related PRs
- Merge after merging [#386](https://github.com/wso2/identity-api-server/pull/386)