### PR TITLE
Hide my account link

### DIFF
--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -179,6 +179,8 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
     const appList = useMemo(() => {
         const links = [];
 
+        // Show MyAccount link only if the user is in the Root Organization (This is a temporary hide since as of now
+        // Org management APIs are not available for MyAccount)
         if (OrganizationUtils.isCurrentOrganizationRoot()) {
             links.push({
                 "data-testid": "app-switch-myaccount",
@@ -250,6 +252,8 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                                 window.open(consoleAppURL, "_self");
                             }
                         },
+                        // Show MyAccount link only if the user is in the Root Organization (This is a temporary hide
+                        // since as of now Org management APIs are not available for MyAccount)
                         OrganizationUtils.isCurrentOrganizationRoot() && {
                             "data-testid": "app-switch-myaccount",
                             description: t("console:common.header.appSwitch.myAccount.description"),


### PR DESCRIPTION
### Purpose
> Since we don't have API support for MyAccount in Sub-Organization context, this PR hides the link to the MyAccount when the user is in Sub-Organization context

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/19621533/184607267-47d04a8d-6b07-4dc9-9422-3a8a881388fb.png">

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
