### PR TITLE
Handle NPEs in Authenticator Search

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
@@ -315,15 +315,15 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
             }
 
             const name: string = (AuthenticatorMeta.getAuthenticatorDisplayName(
-                authenticator.defaultAuthenticator.authenticatorId)
-                || authenticator.displayName).toLocaleLowerCase();
+                authenticator.defaultAuthenticator?.authenticatorId)
+                || authenticator.displayName)?.toLocaleLowerCase();
 
             if (name.includes(query)
                 || IdentityProviderManagementUtils.getAuthenticatorLabels(authenticator)
-                    .some((tag) => tag.toLocaleLowerCase().includes(query)
-                        || startCase(tag).toLocaleLowerCase().includes(query))
-                || authenticator.category.toLocaleLowerCase().includes(query)
-                || authenticator.categoryDisplayName.toLocaleLowerCase().includes(query)) {
+                    .some((tag) => tag?.toLocaleLowerCase()?.includes(query)
+                        || startCase(tag)?.toLocaleLowerCase()?.includes(query))
+                || authenticator.category?.toLocaleLowerCase()?.includes(query)
+                || authenticator.categoryDisplayName?.toLocaleLowerCase()?.includes(query)) {
 
                 return isFiltersMatched(authenticator);
             }

--- a/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
+++ b/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
@@ -306,7 +306,7 @@ export class IdentityProviderManagementUtils {
      */
     public static getAuthenticatorLabels(authenticator: GenericAuthenticatorInterface): string[] {
 
-        return AuthenticatorMeta.getAuthenticatorLabels(authenticator.defaultAuthenticator.authenticatorId)
+        return AuthenticatorMeta.getAuthenticatorLabels(authenticator?.defaultAuthenticator?.authenticatorId)
             ? AuthenticatorMeta.getAuthenticatorLabels(authenticator.defaultAuthenticator.authenticatorId)
             : [];
     }

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -417,9 +417,7 @@
         "gravatarConfig": {
             "fallback": "404"
         },
-        "hiddenAuthenticators": [
-            "MagicLinkAuthenticator"
-        ],
+        "hiddenAuthenticators": [],
         "i18nConfigs": {
             "showLanguageSwitcher": true,
             "langAutoDetectEnabled":false


### PR DESCRIPTION
### Purpose

$subject to fix NPE in Authenticator Search Modal due to Magic Link.

```bash
add-authenticator-modal.tsx?4cc8:325 Uncaught TypeError: Cannot read properties of undefined (reading 'toLocaleLowerCase')
    at eval (add-authenticator-modal.tsx?4cc8:325:1)
    at Array.filter (<anonymous>)
    at getSearchResults (add-authenticator-modal.tsx?4cc8:311:1)
    at Object.handleAuthenticatorSearch [as onChange] (add-authenticator-modal.tsx?4cc8:283:1)
    at apply (_apply.js?85e3:15:25)
    at baseInvoke (_baseInvoke.js?86e1:21:1)
    at apply (_apply.js?85e3:16:25)
    at eval (_overRest.js?2286:32:1)
    at eval (Input.js?ba6c:78:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js?61bb:188:1)
```

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
