### PR TITLE
Prevent sign-in request from being sent while sign-out query params are getting removed

### DIFF
--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -109,10 +109,8 @@
 
                 if (isSignOutSuccess) {
                     window.location.href = userAccessedPath.split("?")[0];
-                }
-
-                if (isSilentSignInDisabled) {
-                    window.location.href = applicationDomain + '/' + "<%= htmlWebpackPlugin.options.basename %>" + '/authenticate?disable_silent_sign_in=true&invite_user=true';
+                } else if (isSilentSignInDisabled) {
+                        window.location.href = applicationDomain + '/' + "<%= htmlWebpackPlugin.options.basename %>" + '/authenticate?disable_silent_sign_in=true&invite_user=true';
                 } else {
                     sessionStorage.setItem("auth_callback_url_console",
                         userAccessedPath.split(window.origin)[1]


### PR DESCRIPTION
### Purpose
> This prevents sign-in requests from being sent while the sign-out query params are getting removed. This prevents users from getting redirected to the 404 page after signing in.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
