### PR TITLE
Disable organization switcher altogether if organization management is disabled

### DIFF
--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
+import { hasRequiredScopes, resolveAppLogoFilePath } from "@wso2is/core/helpers";
 import { AnnouncementBannerInterface, ProfileInfoInterface } from "@wso2is/core/models";
 import { LocalStorageUtils, CommonUtils as ReusableCommonUtils } from "@wso2is/core/utils";
 import {
@@ -31,11 +31,11 @@ import {
 import compact from "lodash-es/compact";
 import isEmpty from "lodash-es/isEmpty";
 import sortBy from "lodash-es/sortBy";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Container, Menu } from "semantic-ui-react";
-import { commonConfig } from "../../../extensions";
+import { commonConfig, organizationConfigs } from "../../../extensions";
 import { getApplicationList } from "../../applications/api";
 import { ApplicationListInterface } from "../../applications/models";
 import OrganizationSwitchDropdown
@@ -43,7 +43,7 @@ import OrganizationSwitchDropdown
 import { AppSwitcherIcons, getAppHeaderIcons } from "../configs";
 import { AppConstants } from "../constants";
 import { history } from "../helpers";
-import { AppViewTypes, ConfigReducerStateInterface, StrictAppViewTypes } from "../models";
+import { AppViewTypes, ConfigReducerStateInterface, FeatureConfigInterface, StrictAppViewTypes } from "../models";
 import { AppState, setActiveView } from "../store";
 import { CommonUtils, EventPublisher } from "../utils";
 
@@ -116,10 +116,36 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
         useSelector((state: AppState) => state.accessControl.isDevelopAllowed);
     const isManageAllowed: boolean =
         useSelector((state: AppState) => state.accessControl.isManageAllowed);
+    const feature: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const scopes = useSelector((state: AppState) => state.auth.allowedScopes);
 
     const [ announcement, setAnnouncement ] = useState<AnnouncementBannerInterface>(undefined);
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
+
+    /**
+     * Show the organization switching dropdown only if
+     *  - the extensions config enables this
+     *  - the requires scopes are there
+     *  - the organization management feature is enabled by the backend
+     *  - the user is logged in to a non-super-tenant account
+     */
+    const isOrgSwitcherEnabled = useMemo(() => {
+        return (
+            isOrganizationManagementEnabled &&
+            // The `tenantDomain` takes the organization id when you log in to a sub-organization.
+            // So, we cannot use `tenantDomain` to check
+            // if the user is logged in to a non-super-tenant account reliably.
+            // So, we check if the organization id is there in the URL to see if the user is in a sub-organization.
+            (tenantDomain === AppConstants.getSuperTenant() || window[ "AppUtils" ].getConfig().organizationName) &&
+            hasRequiredScopes(feature?.organizations, feature?.organizations?.scopes?.read, scopes) &&
+            organizationConfigs.showOrganizationDropdown
+        );
+    }, [
+        organizationConfigs.showOrganizationDropdown,
+        tenantDomain,
+        feature.organizations
+    ]);
 
     /**
      * Check if there are applications registered and set the value to local storage.
@@ -389,7 +415,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                         component: renderAppSwitcher(),
                         floated: "right"
                     },
-                    {
+                    isOrgSwitcherEnabled && {
                         component: <OrganizationSwitchDropdown />,
                         floated: "left"
                     }

--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -108,7 +108,7 @@
                 var isSignOutSuccess = userAccessedPath.includes("sign_out_success");
 
                 if (isSignOutSuccess) {
-                    window.location.href = applicationDomain + '/' + "<%= htmlWebpackPlugin.options.basename %>"
+                    window.location.href = userAccessedPath.split("?")[0];
                 }
 
                 if (isSilentSignInDisabled) {


### PR DESCRIPTION
### Purpose
> This PR prevents the organization switcher from rendering if orh=ganization management is disabled.
> Fixes an issue with sign-out redirection.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
