### PR TITLE
Replace `Super` in the organization management breadcrumb with the name of a user's super organization.

### DIFF
--- a/apps/console/src/features/organizations/api/organization.ts
+++ b/apps/console/src/features/organizations/api/organization.ts
@@ -352,9 +352,9 @@ export const getSharedOrganizations = (
 };
 
 /**
- * Gets the super organization id of the current user.
+ * Gets the super organization of the current user.
  *
- * @returns {Promise<string>} The super organization id of teh user.
+ * @returns {RequestResultInterface<OrganizationInterface, Error>} The super organization of the user.
  */
 export const useGetUserSuperOrganization = (): RequestResultInterface<OrganizationInterface, Error> => {
     const requestConfig = {

--- a/apps/console/src/features/organizations/pages/organizations.tsx
+++ b/apps/console/src/features/organizations/pages/organizations.tsx
@@ -46,7 +46,7 @@ import {
     PaginationProps
 } from "semantic-ui-react";
 import { AdvancedSearchWithBasicFilters, EventPublisher, UIConstants } from "../../core";
-import { getOrganization, getOrganizations } from "../api";
+import { getOrganization, getOrganizations, useGetUserSuperOrganization } from "../api";
 import { AddOrganizationModal, OrganizationList } from "../components";
 import { OrganizationManagementConstants } from "../constants";
 import {
@@ -105,6 +105,8 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     const [ paginationReset, triggerResetPagination ] = useTrigger();
+
+    const { data: superOrganization } = useGetUserSuperOrganization();
 
     useEffect(() => {
         let nextFound: boolean = false;
@@ -423,7 +425,8 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
                                     } }
                                 >
                                     <span data-componentid={ `${ testId }-breadcrumb-home` }>
-                                        { OrganizationManagementConstants.ROOT_ORGANIZATION.name }
+                                        { superOrganization?.name
+                                            || OrganizationManagementConstants.ROOT_ORGANIZATION.name }
                                     </span>
                                 </Breadcrumb.Section>
                                 { organizations?.map((organization: OrganizationInterface, index: number) => {


### PR DESCRIPTION
### Purpose
> This PR obtains a user's super organization by sending an API request and uses the super organization name in the breadcrumb instead of the hardcoded `Super` name. 
### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
