### PR TITLE
Add TSDoc lint support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -133,7 +133,7 @@ module.exports = {
         ecmaVersion: 9,
         sourceType: "module"
     },
-    plugins: [ "import" ],
+    plugins: [ "import", "eslint-plugin-tsdoc" ],
     root: true,
     rules: {
         "array-bracket-spacing": [ 1, "always" ],
@@ -256,7 +256,8 @@ module.exports = {
                 minKeys: 2,
                 natural: false
             }
-        ]
+        ],
+        "tsdoc/syntax": "warn"
     },
     settings: {
         react: {

--- a/modules/access-control/.eslintrc.js
+++ b/modules/access-control/.eslintrc.js
@@ -20,5 +20,8 @@
 module.exports = {
     extends: [
         "../../.eslintrc.js"
-    ]
+    ],
+    rules: {
+        "tsdoc/syntax": "off"
+    }
 };

--- a/modules/forms/.eslintrc.js
+++ b/modules/forms/.eslintrc.js
@@ -20,5 +20,8 @@
 module.exports = {
     extends: [
         "../../.eslintrc.js"
-    ]
+    ],
+    rules: {
+        "tsdoc/syntax": "off"
+    }
 };

--- a/modules/i18n/.eslintrc.js
+++ b/modules/i18n/.eslintrc.js
@@ -20,5 +20,8 @@
 module.exports = {
     extends: [
         "../../.eslintrc.js"
-    ]
+    ],
+    rules: {
+        "tsdoc/syntax": "off"
+    }
 };

--- a/modules/theme/.eslintrc.js
+++ b/modules/theme/.eslintrc.js
@@ -20,5 +20,8 @@
 module.exports = {
     extends: [
         "../../.eslintrc.js"
-    ]
+    ],
+    rules: {
+        "tsdoc/syntax": "off"
+    }
 };

--- a/modules/validation/.eslintrc.js
+++ b/modules/validation/.eslintrc.js
@@ -20,5 +20,8 @@
 module.exports = {
     extends: [
         "../../.eslintrc.js"
-    ]
+    ],
+    rules: {
+        "tsdoc/syntax": "off"
+    }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3840,6 +3840,36 @@
                 }
             }
         },
+        "@microsoft/tsdoc": {
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz",
+            "integrity": "sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==",
+            "dev": true
+        },
+        "@microsoft/tsdoc-config": {
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
+            "integrity": "sha512-2RqkwiD4uN6MLnHFljqBlZIXlt/SaUT6cuogU1w2ARw4nKuuppSmR0+s+NC+7kXBQykd9zzu0P4HtBpZT5zBpQ==",
+            "dev": true,
+            "requires": {
+                "@microsoft/tsdoc": "0.14.1",
+                "ajv": "~6.12.6",
+                "jju": "~1.4.0",
+                "resolve": "~1.19.0"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.19.0",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+                    "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+                    "dev": true,
+                    "requires": {
+                        "is-core-module": "^2.1.0",
+                        "path-parse": "^1.0.6"
+                    }
+                }
+            }
+        },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -9052,6 +9082,16 @@
             "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
             "dev": true
         },
+        "eslint-plugin-tsdoc": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.16.tgz",
+            "integrity": "sha512-F/RWMnyDQuGlg82vQEFHQtGyWi7++XJKdYNn0ulIbyMOFqYIjoJOUdE6olORxgwgLkpJxsCJpJbTHgxJ/ggfXw==",
+            "dev": true,
+            "requires": {
+                "@microsoft/tsdoc": "0.14.1",
+                "@microsoft/tsdoc-config": "0.16.1"
+            }
+        },
         "eslint-scope": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -13843,6 +13883,12 @@
                     }
                 }
             }
+        },
+        "jju": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+            "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+            "dev": true
         },
         "jose": {
             "version": "4.8.1",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
         "eslint-plugin-import": "^2.20.2",
         "eslint-plugin-react": "^7.18.3",
         "eslint-plugin-react-hooks": "^4.0.0",
+        "eslint-plugin-tsdoc": "^0.2.16",
         "eslint-webpack-plugin": "^2.5.3",
         "extract-text-webpack-plugin": "^4.0.0-beta.0",
         "fast-xml-parser": "^3.15.0",


### PR DESCRIPTION
### Purpose
> $subject

TSDoc rule is temporally turned off for following modules since these contains `--max-warnings=0`.
* modules/forms
* modules/access-control
* modules/i18n
* modules/theme
* modules/validation

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified. (Not applicable)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation. (Not applicable)
- [ ] Documentation provided. (Add links if there are any) (Not applicable)
- [ ] Unit tests provided. (Add links if there are any) (Not applicable)
- [ ] Integration tests provided. (Add links if there are any) (Not applicable)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report? (Not applicable)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
