### PR TITLE
Bump framework version to 5.23.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -680,7 +680,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.21.30</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.23.23</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.service.version>1.0.65</identity.organization.management.service.version>
         <identity.org.mgt.version.range>[1.0.65, 2.0.0)</identity.org.mgt.version.range>


### PR DESCRIPTION
### Purpose
> Bump framework version to 5.23.23 from 5.21.30

### Related Issues
- Issue 

### Related PRs
- Related PR https://github.com/wso2/carbon-identity-framework/pull/4233

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
