### PR TITLE
Fix auto-enabling in conditional auth in SAML apps

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -205,7 +205,7 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
         setAuthenticationSteps(authenticationSequence?.steps);
         setSubjectStepId(authenticationSequence?.subjectStepId);
         setAttributeStepId(authenticationSequence?.attributeStepId);
-    }, [ JSON.stringify(authenticationSequence) ]);
+    }, []);
 
     /**
      * Called when update is triggered.


### PR DESCRIPTION
### Purpose
Removed element `authenticationSequence`  from dependency array as it is a prop passed from the parent and does not require to be included in the `useEffect()` hook. Since it was stringified, it introduced some unexpected behaviour in the UI.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.- N/A
- [ ] Documentation provided. (Add links if there are any)- N/A
- [ ] Unit tests provided. (Add links if there are any)- N/A
- [ ] Integration tests provided. (Add links if there are any)- N/A

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?- N/A
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
