### PR TITLE
Append default config for custom SAML application in manual creation flow

### DIFF
--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -292,15 +292,18 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                 
                 application.templateId = ApplicationManagementConstants.CUSTOM_APPLICATION_SAML;
 
-                application.inboundProtocolConfiguration.saml.manualConfiguration = Object.assign(
-                    application.inboundProtocolConfiguration.saml.manualConfiguration,
-                    {
-                        attributeProfile: {
-                            "alwaysIncludeAttributesInResponse": true,
-                            "enabled": true
+                if (samlConfigureMode === SAMLConfigModes.MANUAL) {
+                    application.inboundProtocolConfiguration.saml.manualConfiguration = Object.assign(
+                        application.inboundProtocolConfiguration.saml.manualConfiguration,
+                        {
+                            attributeProfile: {
+                                "alwaysIncludeAttributesInResponse": true,
+                                "enabled": true
+                            }
                         }
-                    }
-                );
+                    );
+                }
+
             } else if (customApplicationProtocol === SupportedAuthProtocolTypes.WS_FEDERATION) {
                 application.templateId = ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS;
             }


### PR DESCRIPTION
### Purpose
> Append enabling default config `Enable attribute profile` for custom SAML application creation only in the Manual flow.

### Related Issues
- None

### Related PRs
- https://github.com/wso2/identity-apps/pull/3382

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
