### PR TITLE
Fix `next` Jenkins Iteration Build Failure

### DIFF
--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -69,7 +69,11 @@ processArgs.map((arg) => {
 	args[argSplit[0]] = argSplit[1];
 });
 
-const packageFiles = ["package.json", "package-lock.json", "lerna.json"];
+const packageFiles = [
+    "package.json",
+    "lerna.json",
+    "pnpm-workspace.yaml"
+];
 
 /**
  * Stage changed files


### PR DESCRIPTION
### Purpose

`pnpm-workspace.yaml` was not being watched in the set of files to be committed for the next iteration.

```bash
Lockfile is up to date, resolution step is skipped
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with apps/authentication-portal/package.json
```

### Related Issues
- None

### Related PRs
- https://github.com/wso2/identity-apps/pull/3048

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
