### PR TITLE
Change i18n translation and i18n tags for not authorized to use this authorization grant type error

### DIFF
--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -194,7 +194,7 @@ error.retry=Authentication Failed! Please Retry
 error.retry.code.invalid=Authentication failed. The code you entered is invalid or expired. Please retry.
 authenticate=Continue
 no.valid.client.in.tenant=A valid client with the given client_id cannot be found in the tenant domain.
-not.authorized.for.requested.grant.type=The authenticated client is not authorized to use the requested grant type.
+not.authorized.to.use.requested.grant.type=The authenticated client is not authorized to use the requested grant type.
 
 # TOTP authentication
 error.fail=Authentication Failed!

--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -191,7 +191,7 @@ error.retry=Authentification Ã©chouÃ©e ! Veuillez rÃ©essayer
 error.retry.code.invalid=Authentification Ã©chouÃ©e. Le code que vous avez entrÃ© est invalide ou a expirÃ©. Veuillez rÃ©essayer
 authenticate=Continuer
 no.valid.client.in.tenant=Un client valide avec le client_id donné est introuvable dans le domaine du locataire.
-not.authorized.for.requested.grant.type=Le client authentifié n'est pas autorisé à utiliser le type d'octroi demandé.
+not.authorized.to.use.requested.grant.type=Le client authentifié n'est pas autorisé à utiliser le type d'octroi demandé.
 
 # TOTP authentication
 error.fail=Echec de l'authentification !


### PR DESCRIPTION
### Purpose
 - Changed the i18n tags for `The authenticated client is not authorized to use this authorization grant type.` error

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
