### PR TITLE
Add ability to override baseHref from deployment conf

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "main": "index.js",
     "scripts": {
-        "build": "pnpm prebuild && pnpm build:prod && pnpm postbuild",
+        "build": "pnpm build:prod",
         "build:analyze": "run-script-os",
         "build:analyze:win32": "..\\..\\node_modules\\.bin\\webpack --mode production --env NODE_ENV=production --env ENABLE_ANALYZER=true --env ANALYZER_PORT=8889",
         "build:analyze:default": "../../node_modules/.bin/webpack --mode production --env NODE_ENV=production --env ENABLE_ANALYZER=true --env ANALYZER_PORT=8889",

--- a/apps/console/project.json
+++ b/apps/console/project.json
@@ -40,7 +40,7 @@
                 "compiler": "babel",
                 "outputPath": "apps/console/build/console",
                 "index": "index.html",
-                "baseHref": "/console/",
+                "baseHref": "__IGNORE__",
                 "main": "apps/console/src/index.tsx",
                 "polyfills": "",
                 "tsConfig": "apps/console/tsconfig.json",
@@ -161,7 +161,7 @@
             "options": {
                 "buildTarget": "console:build-base",
                 "port": 9001,
-                "baseHref": "/console/",
+                "baseHref": "__IGNORE__",
                 "open": true,
                 "hmr": true,
                 "ssl": true

--- a/apps/console/project.json
+++ b/apps/console/project.json
@@ -40,7 +40,7 @@
                 "compiler": "babel",
                 "outputPath": "apps/console/build/console",
                 "index": "index.html",
-                "baseHref": "__IGNORE__",
+                "baseHref": "/console/",
                 "main": "apps/console/src/index.tsx",
                 "polyfills": "",
                 "tsConfig": "apps/console/tsconfig.json",
@@ -161,7 +161,7 @@
             "options": {
                 "buildTarget": "console:build-base",
                 "port": 9001,
-                "baseHref": "__IGNORE__",
+                "baseHref": "/console/",
                 "open": true,
                 "hmr": true,
                 "ssl": true

--- a/apps/console/project.json
+++ b/apps/console/project.json
@@ -27,7 +27,7 @@
                     }
                 ],
                 "cwd": "apps/console",
-                "parallel": true
+                "parallel": false
             }
         },
         "build-base": {
@@ -113,7 +113,7 @@
                     }
                 ],
                 "cwd": "apps/console",
-                "parallel": true
+                "parallel": false
             }
         },
         "build": {

--- a/apps/console/scripts/post-build.js
+++ b/apps/console/scripts/post-build.js
@@ -29,9 +29,11 @@ const i18nDir = path.join(__dirname, "..", "build", "console", "resources", "i18
 const i18nFiles = fs.readdirSync(i18nDir);
 
 // Remove tmp directory in the extensions directory
-log("Removing tmp directory in the extensions directory.");
-fs.removeSync(tmpDir);
-log("tmp directory removed.");
+if (fs.existsSync(tmpDir)) {
+    log("Removing tmp directory in the extensions directory.");
+    fs.removeSync(tmpDir);
+    log("tmp directory removed.");
+}
 
 // Remove the redundant meta.json file from the i18n directory in the build directory.
 log("Removing the redundant meta.json file from the i18n directory in the build directory.");

--- a/apps/console/src/extensions/i18n/tsconfig.json
+++ b/apps/console/src/extensions/i18n/tsconfig.json
@@ -1,7 +1,6 @@
 {
     "compilerOptions": {
         "experimentalDecorators": true,
-        "jsx": "react",
         "module": "commonjs",
         "rootDir": ".",
         "outDir": "dist/src"

--- a/apps/console/webpack.config.ts
+++ b/apps/console/webpack.config.ts
@@ -142,7 +142,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%= isOrganizationManagementEnabled() %>"
                     : "false",
                 minify: false,
-                publicPath: context.buildOptions?.baseHref ?? context.options.baseHref,
+                publicPath: getBaseHref(
+                    context.buildOptions?.baseHref ?? context.options.baseHref,
+                    DeploymentConfig.appBaseName
+                ),
                 serverUrl: !isDeployedOnExternalTomcatServer
                     ? "<%=getServerURL(\"\", true, true)%>"
                     : "",
@@ -198,7 +201,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%= isAdaptiveAuthenticationAvailable() %>"
                     : "false",
                 minify: false,
-                publicPath: context.buildOptions?.baseHref ?? context.options.baseHref,
+                publicPath: getBaseHref(
+                    context.buildOptions?.baseHref ?? context.options.baseHref,
+                    DeploymentConfig.appBaseName
+                ),
                 requestForwardSnippet: "if(request.getParameter(\"code\") != null && " +
                     "!request.getParameter(\"code\").trim().isEmpty()) " +
                     "{request.getRequestDispatcher(\"/authenticate?code=\"+request.getParameter(\"code\")+" +
@@ -227,7 +233,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                 filename: ABSOLUTE_PATHS.indexTemplateInDistribution,
                 hash: true,
                 minify: false,
-                publicPath: context.buildOptions?.baseHref ?? context.options.baseHref,
+                publicPath: getBaseHref(
+                    context.buildOptions?.baseHref ?? context.options.baseHref,
+                    DeploymentConfig.appBaseName
+                ),
                 template: ABSOLUTE_PATHS.indexTemplateInSource,
                 themeHash: getThemeConfigs().styleSheetHash
             }) as unknown as WebpackPluginInstance
@@ -462,7 +471,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
             : `${ RELATIVE_PATHS.staticJs }/[name].js`,
         hotUpdateChunkFilename: "hot/[id].[fullhash].hot-update.js",
         hotUpdateMainFilename: "hot/[runtime].[fullhash].hot-update.json",
-        publicPath: context.buildOptions?.baseHref ?? context.options.baseHref
+        publicPath: getBaseHref(
+            context.buildOptions?.baseHref ?? context.options.baseHref,
+            DeploymentConfig.appBaseName
+        )
     };
 
     config.devServer = {
@@ -480,7 +492,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
             writeToDisk: true
         },
         host: "localhost",
-        open: context.buildOptions?.baseHref ?? context.options.baseHref,
+        open: getBaseHref(
+            context.buildOptions?.baseHref ?? context.options.baseHref,
+            DeploymentConfig.appBaseName
+        ),
         port: devServerPort
     };
 
@@ -557,4 +572,16 @@ const getAbsolutePaths = (env: Configuration["mode"], context: NxWebpackContextI
         indexTemplateInDistribution: path.resolve(__dirname, RELATIVE_PATHS.distribution, RELATIVE_PATHS.indexTemplate),
         indexTemplateInSource: path.resolve(__dirname, RELATIVE_PATHS.source, RELATIVE_PATHS.indexTemplate)
     };
+};
+
+const getBaseHref = (baseHrefFromProjectConf: string, baseHrefFromDeploymentConf: string) => {
+
+    // Need a way to override `baseHref` defined in `project.json`.
+    // TODO: Add capability to override the webpack configuration.
+    if (baseHrefFromProjectConf === "__IGNORE__") {
+        // Add leading and trailing slashes if doesn't exist.
+        return baseHrefFromDeploymentConf.replace(/^\/?([^/]+(?:\/[^/]+)*)\/?$/, "/$1/") || "/";
+    }
+
+    return baseHrefFromProjectConf;
 };

--- a/apps/console/webpack.config.ts
+++ b/apps/console/webpack.config.ts
@@ -36,7 +36,7 @@ import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 import DeploymentConfig from "./src/public/deployment.config.json";
 
 interface NxWebpackContextInterface {
-    buildOptions:{
+    buildOptions: {
         index: string;
         baseHref: string;
     };
@@ -53,10 +53,16 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
     // @ts-ignore
     nxReactWebpackConfig(config);
 
+    context = rewriteContext(context);
+
     const ABSOLUTE_PATHS = getAbsolutePaths(config.mode, context);
     const RELATIVE_PATHS = getRelativePaths(config.mode, context);
 
     const isProduction = config.mode === "production";
+    const baseHref = getBaseHref(
+        context.buildOptions?.baseHref ?? context.options.baseHref,
+        DeploymentConfig.appBaseName
+    );
 
     // Flag to determine if the app is intended to be deployed on an external tomcat server
     // outside of the Identity Server runtime. If true, references & usage of internally provided
@@ -142,10 +148,7 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%= isOrganizationManagementEnabled() %>"
                     : "false",
                 minify: false,
-                publicPath: getBaseHref(
-                    context.buildOptions?.baseHref ?? context.options.baseHref,
-                    DeploymentConfig.appBaseName
-                ),
+                publicPath: baseHref,
                 serverUrl: !isDeployedOnExternalTomcatServer
                     ? "<%=getServerURL(\"\", true, true)%>"
                     : "",
@@ -201,10 +204,7 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%= isAdaptiveAuthenticationAvailable() %>"
                     : "false",
                 minify: false,
-                publicPath: getBaseHref(
-                    context.buildOptions?.baseHref ?? context.options.baseHref,
-                    DeploymentConfig.appBaseName
-                ),
+                publicPath: baseHref,
                 requestForwardSnippet: "if(request.getParameter(\"code\") != null && " +
                     "!request.getParameter(\"code\").trim().isEmpty()) " +
                     "{request.getRequestDispatcher(\"/authenticate?code=\"+request.getParameter(\"code\")+" +
@@ -233,10 +233,7 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                 filename: ABSOLUTE_PATHS.indexTemplateInDistribution,
                 hash: true,
                 minify: false,
-                publicPath: getBaseHref(
-                    context.buildOptions?.baseHref ?? context.options.baseHref,
-                    DeploymentConfig.appBaseName
-                ),
+                publicPath: baseHref,
                 template: ABSOLUTE_PATHS.indexTemplateInSource,
                 themeHash: getThemeConfigs().styleSheetHash
             }) as unknown as WebpackPluginInstance
@@ -471,10 +468,7 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
             : `${ RELATIVE_PATHS.staticJs }/[name].js`,
         hotUpdateChunkFilename: "hot/[id].[fullhash].hot-update.js",
         hotUpdateMainFilename: "hot/[runtime].[fullhash].hot-update.json",
-        publicPath: getBaseHref(
-            context.buildOptions?.baseHref ?? context.options.baseHref,
-            DeploymentConfig.appBaseName
-        )
+        publicPath: baseHref
     };
 
     config.devServer = {
@@ -489,13 +483,11 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
         },
         devMiddleware: {
             ...config.devServer?.devMiddleware,
+            publicPath: getStaticFileServePath(baseHref),
             writeToDisk: true
         },
         host: "localhost",
-        open: getBaseHref(
-            context.buildOptions?.baseHref ?? context.options.baseHref,
-            DeploymentConfig.appBaseName
-        ),
+        open: baseHref,
         port: devServerPort
     };
 
@@ -574,14 +566,61 @@ const getAbsolutePaths = (env: Configuration["mode"], context: NxWebpackContextI
     };
 };
 
-const getBaseHref = (baseHrefFromProjectConf: string, baseHrefFromDeploymentConf: string) => {
+/**
+ * Try to figure out if the `baseHref` is trying to be overridden by the `deployment.config.json`.
+ * TODO: Add capability to override the webpack configuration instead.
+ *
+ * @param baseHrefFromProjectConf - `baseHref` defined in `project.json`. ex: `/console/`.
+ * @param baseHrefFromDeploymentConf - `appBaseName` defined in `deployment.config.json`. ex: `console`.
+ * @returns A resolved baseHref.
+ */
+const getBaseHref = (baseHrefFromProjectConf: string, baseHrefFromDeploymentConf: string): string => {
 
-    // Need a way to override `baseHref` defined in `project.json`.
-    // TODO: Add capability to override the webpack configuration.
-    if (baseHrefFromProjectConf === "__IGNORE__") {
-        // Add leading and trailing slashes if doesn't exist.
-        return baseHrefFromDeploymentConf.replace(/^\/?([^/]+(?:\/[^/]+)*)\/?$/, "/$1/") || "/";
+    // Try to check if they are the same value.
+    // CONTEXT: `appBaseName` doesn't have leading or trailing slashes.
+    if (baseHrefFromProjectConf.includes(baseHrefFromDeploymentConf)
+        && baseHrefFromProjectConf.length > 2
+        && baseHrefFromProjectConf.length - 2 === baseHrefFromDeploymentConf.length) {
+
+        return baseHrefFromProjectConf;
     }
 
-    return baseHrefFromProjectConf;
+    return baseHrefFromDeploymentConf.replace(/^\/?([^/]+(?:\/[^/]+)*)\/?$/, "/$1/") || "/";
+};
+
+/**
+ * Get the static file serve path.
+ * ATM, when the context is re-written, dev server static file path is not getting overridden.
+ *
+ * @param baseHref - Resolved BaseHref.
+ * @returns Static file serve path.
+ */
+const getStaticFileServePath = (baseHref: string) => {
+
+    if (baseHref.length === 1) {
+        return path;
+    }
+
+    return baseHref.replace(/\/$/, "");
+};
+
+/**
+ * Re-write the Nx Webpack build context.
+ *
+ * @param context - Nx Webpack build context.
+ * @returns Modified Nx Webpack build context.
+ */
+const rewriteContext = (context: NxWebpackContextInterface): NxWebpackContextInterface => {
+
+    // For DEV environment.
+    if (context.buildOptions?.baseHref) {
+        context.buildOptions.baseHref = getBaseHref(context.buildOptions.baseHref, DeploymentConfig.appBaseName);
+    }
+
+    // For PROD environment.
+    if (context.options?.baseHref) {
+        context.options.baseHref = getBaseHref(context.options.baseHref, DeploymentConfig.appBaseName);
+    }
+
+    return context;
 };

--- a/apps/console/webpack.config.ts
+++ b/apps/console/webpack.config.ts
@@ -507,7 +507,7 @@ const getThemeConfigs = () => {
 };
 
 const getI18nConfigs = () => {
-    const I18N_DIR = path.resolve(__dirname, "node_modules", "@wso2is", "i18n", "dist", "bundle");
+    const I18N_DIR = path.resolve(__dirname, "src", "extensions", "i18n", "tmp");
 
     let metaFiles = null;
 

--- a/apps/myaccount/package.json
+++ b/apps/myaccount/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "main": "index.js",
     "scripts": {
-        "build": "pnpm prebuild && pnpm build:prod",
+        "build": "pnpm build:prod",
         "build:analyze": "run-script-os",
         "build:analyze:win32": "..\\..\\node_modules\\.bin\\webpack --mode production --env NODE_ENV=production --env ENABLE_ANALYZER=true --env ANALYZER_PORT=8888",
         "build:analyze:default": "../../node_modules/.bin/webpack --mode production --env NODE_ENV=production --env ENABLE_ANALYZER=true --env ANALYZER_PORT=8888",

--- a/apps/myaccount/project.json
+++ b/apps/myaccount/project.json
@@ -39,7 +39,7 @@
                 "compiler": "babel",
                 "outputPath": "apps/myaccount/build/myaccount",
                 "index": "index.html",
-                "baseHref": "/myaccount/",
+                "baseHref": "__IGNORE__",
                 "main": "apps/myaccount/src/index.tsx",
                 "polyfills": "",
                 "tsConfig": "apps/myaccount/tsconfig.json",
@@ -141,7 +141,7 @@
             "options": {
                 "buildTarget": "myaccount:build-base",
                 "port": 9000,
-                "baseHref": "/myaccount/",
+                "baseHref": "__IGNORE__",
                 "open": true,
                 "hmr": true,
                 "ssl": true

--- a/apps/myaccount/project.json
+++ b/apps/myaccount/project.json
@@ -39,7 +39,7 @@
                 "compiler": "babel",
                 "outputPath": "apps/myaccount/build/myaccount",
                 "index": "index.html",
-                "baseHref": "__IGNORE__",
+                "baseHref": "/myaccount/",
                 "main": "apps/myaccount/src/index.tsx",
                 "polyfills": "",
                 "tsConfig": "apps/myaccount/tsconfig.json",
@@ -141,7 +141,7 @@
             "options": {
                 "buildTarget": "myaccount:build-base",
                 "port": 9000,
-                "baseHref": "__IGNORE__",
+                "baseHref": "/myaccount/",
                 "open": true,
                 "hmr": true,
                 "ssl": true

--- a/apps/myaccount/project.json
+++ b/apps/myaccount/project.json
@@ -26,7 +26,7 @@
                     }
                 ],
                 "cwd": "apps/myaccount",
-                "parallel": true
+                "parallel": false
             }
         },
         "build-base": {

--- a/apps/myaccount/webpack.config.ts
+++ b/apps/myaccount/webpack.config.ts
@@ -130,7 +130,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%= isOrganizationManagementEnabled() %>"
                     : "false",
                 minify: false,
-                publicPath: context.buildOptions?.baseHref ?? context.options.baseHref,
+                publicPath: getBaseHref(
+                    context.buildOptions?.baseHref ?? context.options.baseHref,
+                    DeploymentConfig.appBaseName
+                ),
                 serverUrl: !isDeployedOnExternalTomcatServer
                     ? "<%=getServerURL(\"\", true, true)%>"
                     : "",
@@ -186,7 +189,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%= isOrganizationManagementEnabled() %>"
                     : "false",
                 minify: false,
-                publicPath: context.buildOptions?.baseHref ?? context.options.baseHref,
+                publicPath: getBaseHref(
+                    context.buildOptions?.baseHref ?? context.options.baseHref,
+                    DeploymentConfig.appBaseName
+                ),
                 requestForwardSnippet : "if(request.getParameter(\"code\") != null && "+
                     "!request.getParameter(\"code\").trim().isEmpty()) "+
                     "{request.getRequestDispatcher(\"/authenticate?code=\"+request.getParameter(\"code\")+"+
@@ -215,7 +221,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                 filename: ABSOLUTE_PATHS.indexTemplateInDistribution,
                 hash: true,
                 minify: false,
-                publicPath: context.buildOptions?.baseHref ?? context.options.baseHref,
+                publicPath: getBaseHref(
+                    context.buildOptions?.baseHref ?? context.options.baseHref,
+                    DeploymentConfig.appBaseName
+                ),
                 template: ABSOLUTE_PATHS.indexTemplateInSource,
                 themeHash: getThemeConfigs().styleSheetHash
             }) as unknown as WebpackPluginInstance
@@ -435,7 +444,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
             : `${ RELATIVE_PATHS.staticJs }/[name].js`,
         hotUpdateChunkFilename: "hot/[id].[fullhash].hot-update.js",
         hotUpdateMainFilename: "hot/[runtime].[fullhash].hot-update.json",
-        publicPath: context.buildOptions?.baseHref ?? context.options.baseHref
+        publicPath: getBaseHref(
+            context.buildOptions?.baseHref ?? context.options.baseHref,
+            DeploymentConfig.appBaseName
+        )
     };
 
     config.devServer = {
@@ -453,7 +465,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
             writeToDisk: true
         },
         host: "localhost",
-        open: context.buildOptions?.baseHref ?? context.options.baseHref,
+        open: getBaseHref(
+            context.buildOptions?.baseHref ?? context.options.baseHref,
+            DeploymentConfig.appBaseName
+        ),
         port: devServerPort
     };
 
@@ -529,4 +544,16 @@ const getAbsolutePaths = (env: Configuration["mode"], context: NxWebpackContextI
         indexTemplateInDistribution: path.resolve(__dirname, RELATIVE_PATHS.distribution, RELATIVE_PATHS.indexTemplate),
         indexTemplateInSource: path.resolve(__dirname, RELATIVE_PATHS.source, RELATIVE_PATHS.indexTemplate)
     };
+};
+
+const getBaseHref = (baseHrefFromProjectConf: string, baseHrefFromDeploymentConf: string) => {
+
+    // Need a way to override `baseHref` defined in `project.json`.
+    // TODO: Add capability to override the webpack configuration.
+    if (baseHrefFromProjectConf === "__IGNORE__") {
+        // Add leading and trailing slashes if doesn't exist.
+        return baseHrefFromDeploymentConf.replace(/^\/?([^/]+(?:\/[^/]+)*)\/?$/, "/$1/") || "/";
+    }
+
+    return baseHrefFromProjectConf;
 };


### PR DESCRIPTION
### Purpose

Application `baseRef` should be overriden from the `deployment.config.json`.
Ideal way would be to give the capability for overriding the `webpack.config` itself.

### Related Issues
- https://github.com/wso2/product-is/issues/13931

### Related PRs
- https://github.com/wso2/identity-apps/pull/3048

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
