### PR TITLE
Fix update Photo URL issue due to max length

### DIFF
--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -1191,7 +1191,9 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                 }));
                         }
                     } }
-                    maxLength={ 30 }
+                    maxLength={ 
+                        fieldName.toLowerCase().includes("uri") || fieldName.toLowerCase().includes("url") ? -1 : 30 
+                    }
                 />
             );
         }

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -786,7 +786,10 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                                                         }
                                                     } }
                                                     value={ resolveProfileInfoSchemaValue(schema) }
-                                                    maxLength={ schema.name === "emails" ? 50 : 30 }
+                                                    maxLength={ schema.name === "emails" ? 50 
+                                                        : fieldName.toLowerCase().includes("uri") 
+                                                        || fieldName.toLowerCase().includes("url") ? -1 : 30 
+                                                    }
                                                 />
                                             )
                                             }


### PR DESCRIPTION
### Purpose
This PR fixes following issues.

From Console, admins cannot update the Photo URL claims as 
1. The input has a max char limitation of 30  

From MyAccount, the user cannot update the Photo URL claims as 
1. The input has a max char limitation of 30  

### Related Issues
- https://github.com/wso2/product-is/issues/14825

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
