### PR TITLE
Use authenticator name for totp and backup code authenticators

### DIFF
--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
@@ -70,8 +70,8 @@ interface TOTPProps extends TestableComponentInterface {
 /**
  * TOTP Authenticator.
  *
- * @param {React.PropsWithChildren<TOTPProps>} props - Props injected to the component.
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns React element.
  */
 export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     props: PropsWithChildren<TOTPProps>
@@ -132,7 +132,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Focus to next pin code after enter a value.
-     * @param {string} field The name of the field.
+     * @param field - The name of the field.
      */
     const focusInToNextPinCode = (field: string): void => {
         switch (field) {
@@ -161,7 +161,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Focus to previous pin code after enter Backspace or Delete.
-     * @param {string} field The name of the field.
+     * @param field - The name of the field.
      */
     const focusInToPreviousPinCode = (field: string): void => {
         switch (field) {
@@ -205,7 +205,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Update enabled authenticator list based on the update action.
-     * @param action The update action.
+     * @param action - The update action.
      */
     const handleUpdateEnabledAuthenticators = (action: EnabledAuthenticatorUpdateAction): void => {
         const authenticatorsList: Array<string> = [ ...enabledAuthenticators ];
@@ -306,9 +306,9 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     };
 
     /**
-     * Handle TOTP submit flow
-     * @param event Form submit event
-     * @param isRegenerated Whether the TOTP is regenerated or not
+     * Handle TOTP submit flow.
+     * @param event - Form submit event.
+     * @param isRegenerated - Whether the TOTP is regenerated or not.
      */
     const handleTOTPSubmit = (event: React.FormEvent<HTMLFormElement>, isRegenerated: boolean = false): void => {
         let verificationCode: string =  event.target[0].value;
@@ -338,9 +338,9 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     };
 
     /**
-     * Handle TOTP enable/disable flow
-     * @param {SyntheticEvent} _ Radio button toggle event
-     * @param {CheckboxProps} data Data related to the toggle event
+     * Handle TOTP enable/disable flow.
+     * @param _ - Radio button toggle event.
+     * @param data - Data related to the toggle event.
      */
     const handleTOTPToggle = (_: SyntheticEvent, data: CheckboxProps): void => {
         if (data.checked) {
@@ -351,9 +351,9 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     };
 
     /**
-     * Render TOTP form to shown in TOTP modal
-     * @param {boolean} isRegenerated Whether the TOTP is regenerated or not
-     * @returns {React.ReactElement} Rendered form component
+     * Render TOTP form to shown in TOTP modal.
+     * @param isRegenerated - Whether the TOTP is regenerated or not.
+     * @returns Rendered form component.
      */
     const renderTOTPVerifyForm = (isRegenerated: boolean = false): React.ReactElement => {
         return (
@@ -534,8 +534,8 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     };
 
     /**
-     * Render TOTP configuration modal content
-     * @returns Modal content based on {TOTPModalCurrentStep}
+     * Render TOTP configuration modal content.
+     * @returns Modal content based on TOTPModalCurrentStep.
      */
     const renderTOTPWizardContent = (): React.ReactElement => {
         if (TOTPModalCurrentStep === 0) {
@@ -583,8 +583,8 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     };
 
     /**
-     * Render TOTP configuration modal actions
-     * @returns Modal action based on {TOTPModalCurrentStep}
+     * Render TOTP configuration modal actions.
+     * @returns Modal action based on TOTPModalCurrentStep.
      */
     const renderTOTPWizardActions = (): React.ReactElement => {
         if (TOTPModalCurrentStep === 0) {

--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
@@ -89,8 +89,8 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     const { t } = useTranslation();
 
     const translateKey = "myAccount:components.mfa.authenticatorApp.";
-    const totpAuthenticatorName = "TOTP";
-    const backupCodeAuthenticatorName = "Backup Code Authenticator";
+    const totpAuthenticatorName = "totp";
+    const backupCodeAuthenticatorName = "backup-code-authenticator";
 
     const enableMFAUserWise: boolean = useSelector((state: AppState) => state?.config?.ui?.enableMFAUserWise);
     const shouldContinueToBackupCodes: boolean = isSuperTenantLogin && isBackupCodeForced;

--- a/apps/myaccount/src/components/multi-factor-authentication/multi-factor-authentication.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/multi-factor-authentication.tsx
@@ -115,7 +115,7 @@ export const MultiFactorAuthentication: React.FunctionComponent<MfaProps> = (pro
 
     /**
      * Update state when the authenticator list is updated.
-     * @param updatedAuthenticators Enabled authenticator list after updating
+     * @param updatedAuthenticators - Enabled authenticator list after updating.
      */
     const handleEnabledAuthenticatorsUpdated = (updatedAuthenticators: Array<string>): void => {
         setEnabledAuthenticators(updatedAuthenticators);

--- a/apps/myaccount/src/components/multi-factor-authentication/multi-factor-authentication.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/multi-factor-authentication.tsx
@@ -65,8 +65,8 @@ export const MultiFactorAuthentication: React.FunctionComponent<MfaProps> = (pro
     const [ initBackupCodeFlow, setInitBackupCodeFlow ] = useState<boolean>(false);
 
     const translateKey: string = "myAccount:components.mfa.backupCode.";
-    const totpAuthenticatorName: string = "TOTP";
-    const backupCodeAuthenticatorName = "Backup Code Authenticator";
+    const totpAuthenticatorName: string = "totp";
+    const backupCodeAuthenticatorName = "backup-code-authenticator";
 
     /**
      * Fetch enabled authenticators and set to state.


### PR DESCRIPTION
### Purpose
With the fix for https://github.com/wso2/product-is/issues/14843, we'll be introducing a new parameter to resolve the authenticator identifier in `authenticationOptions`. For backup code feature, ideally we should use authenticator name to resolve the `authenticationOptions` in mfa flow. Hence from the frontend code, authenticator names should be passed.

Details: https://github.com/wso2/product-is/issues/14843#issuecomment-1236530106

### Related Issues
- https://github.com/wso2/product-is/issues/14844

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
