### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ End-user apps in WSO2 Identity Server
 2. Instal the latest version of [pnpm](https://pnpm.io/).
 
     ```shell
-    npm install -g pnpm@latest
+    corepack enable
+    ```
+
+    This will install pnpm on your system. However, it probably would not be the latest version. Hence, to upgrade it, check the [latest pnpm version](https://github.com/pnpm/pnpm/releases/latest) and run:
+
+    ```shell
+    corepack prepare pnpm@<version> --activate
     ```
 
     Or, follow the other [recommended installation options](https://pnpm.io/installation).


### PR DESCRIPTION
### Purpose
> Changed pnpm install section in the README.md file, as the -g tag was deprecated. 
Using corepack is the recommended installation method in the [pnpm doc](https://pnpm.io/installation#using-corepack), hence updated pnpm install section to that method.