### PR TITLE
Setting enableTableHeaders to false

### DIFF
--- a/apps/console/src/extensions/configs/application-list.ts
+++ b/apps/console/src/extensions/configs/application-list.ts
@@ -19,5 +19,5 @@
 import { ApplicationListConfig } from "./models/application-list";
 
 export const applicationListConfig: ApplicationListConfig = {
-    enableTableHeaders: true
+    enableTableHeaders: false
 };


### PR DESCRIPTION
## Purpose
This PR sets the enableTableHeaders config to false. 

## Description
The product-is is not supposed to have the table headers enabled due to inconsistency issues. Therefore the headers are not to be displayed.

## Related Issues
- Issue `#1` or (None)

## Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
