### PR TITLE
fix element clickable issues in tablet devices

### DIFF
--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -406,7 +406,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                     ".placeholder")
                                 }
                                 placeholder={ t("console:develop.features.applications.advancedSearch.placeholder") }
-                                style={ { minWidth: "450px" } }
+                                style={ { minWidth: "430px" } }
                                 defaultSearchAttribute="name"
                                 defaultSearchOperator="co"
                                 predefinedDefaultSearchStrategy={
@@ -470,7 +470,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                     placeholder={
                                         t("console:develop.features.applications.advancedSearch.placeholder")
                                     }
-                                    style={ { minWidth: "450px" } }
+                                    style={ { minWidth: "430px" } }
                                     defaultSearchAttribute="name"
                                     defaultSearchOperator="co"
                                     predefinedDefaultSearchStrategy={

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -406,7 +406,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                     ".placeholder")
                                 }
                                 placeholder={ t("console:develop.features.applications.advancedSearch.placeholder") }
-                                style={ { minWidth: "500px" } }
+                                style={ { minWidth: "450px" } }
                                 defaultSearchAttribute="name"
                                 defaultSearchOperator="co"
                                 predefinedDefaultSearchStrategy={
@@ -470,7 +470,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                     placeholder={
                                         t("console:develop.features.applications.advancedSearch.placeholder")
                                     }
-                                    style={ { minWidth: "500px" } }
+                                    style={ { minWidth: "450px" } }
                                     defaultSearchAttribute="name"
                                     defaultSearchOperator="co"
                                     predefinedDefaultSearchStrategy={

--- a/modules/react-components/src/layouts/list.tsx
+++ b/modules/react-components/src/layouts/list.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -62,19 +62,19 @@ export interface ListLayoutPropsInterface extends PaginationProps, IdentifiableC
     minimalPagination?: boolean;
     /**
      * Callback to be fired on page number change.
-     * @param {React.MouseEvent<HTMLAnchorElement, MouseEvent>} event - Event.
-     * @param {PaginationProps} data - Pagination data.
+     * @param event - Mouse event.
+     * @param data - Pagination data.
      */
     onPageChange: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>, data: PaginationProps) => void;
     /**
      * Callback to be fired when the sort strategy is changed.
-     * @param {React.SyntheticEvent<HTMLElement>} event - Event.
-     * @param {DropdownProps} data - Metadata.
+     * @param event - Synthetic event.
+     * @param data - Metadata.
      */
     onSortStrategyChange?: (event: SyntheticEvent<HTMLElement>, data: DropdownProps) => void;
     /**
      * Callback to be fired when the sort order is changed.
-     * @param {boolean} isAscending - Is the order ascending.
+     * @param isAscending - Is the order ascending.
      */
     onSortOrderChange?: (isAscending: boolean) => void;
     /**
@@ -115,8 +115,8 @@ export interface ListLayoutPropsInterface extends PaginationProps, IdentifiableC
     totalListSize?: number;
     /**
      * Callback for items per page change.
-     * @param {React.SyntheticEvent<HTMLElement>} event - Click event.
-     * @param {DropdownProps} data - Data.
+     * @param event - Click event.
+     * @param data - Data.
      */
     onItemsPerPageDropdownChange?: (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => void;
     /**
@@ -128,9 +128,9 @@ export interface ListLayoutPropsInterface extends PaginationProps, IdentifiableC
 /**
  * List layout.
  *
- * @param {React.PropsWithChildren<ListLayoutPropsInterface>} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @return React element.
  */
 export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInterface>> = (
     props: PropsWithChildren<ListLayoutPropsInterface>
@@ -186,13 +186,13 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
                         >
                             <Grid>
                                 <Grid.Row>
-                                    <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 8 }>
+                                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
                                         <div className="left-aligned actions">
                                             { advancedSearchPosition === "left" && advancedSearch }
                                             { leftActionPanel }
                                         </div>
                                     </Grid.Column>
-                                    <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 8 }>
+                                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
                                         <div className="actions right-aligned">
                                             { advancedSearchPosition === "right" && advancedSearch }
                                             { rightActionPanel }
@@ -217,10 +217,10 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
                                                             data-testid={ `${ testId }-sort` }
                                                         />
                                                         <Button
-                                                            data-tooltip={ 
-                                                                isAscending 
-                                                                    ? "Sort in the descending order" 
-                                                                    : "Sort in the ascending order" 
+                                                            data-tooltip={
+                                                                isAscending
+                                                                    ? "Sort in the descending order"
+                                                                    : "Sort in the ascending order"
                                                             }
                                                             data-position="top right"
                                                             data-inverted=""

--- a/modules/react-components/src/layouts/list.tsx
+++ b/modules/react-components/src/layouts/list.tsx
@@ -130,7 +130,7 @@ export interface ListLayoutPropsInterface extends PaginationProps, IdentifiableC
  *
  * @param props - Props injected to the component.
  *
- * @return React element.
+ * @returns React element.
  */
 export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInterface>> = (
     props: PropsWithChildren<ListLayoutPropsInterface>


### PR DESCRIPTION
### Purpose
> Fix the unclickable issue happens in tablet devices when the left-action-panel of lists are wider than 50% of the window.

### Related Issues
- [#12133](https://github.com/wso2-enterprise/asgardeo-product/issues/12133)