### PR TITLE
Fix `react-final` form event propagation issues

### DIFF
--- a/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
+++ b/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -45,12 +45,13 @@ interface AdvancedConfigurationsFormPropsInterface extends TestableComponentInte
     isSubmitting?: boolean;
 }
 
+const FORM_ID: string = "application-advanced-configuration-form";
+
 /**
  * Advanced configurations form component.
  *
- * @param {AdvancedConfigurationsFormPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfigurationsFormPropsInterface> = (
     props: AdvancedConfigurationsFormPropsInterface
@@ -68,10 +69,9 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
     const { t } = useTranslation();
 
     /**
-     * Prepare form values for submitting.
+     * Update configuration.
      *
      * @param values - Form values.
-     * @return {any} Sanitized form values.
      */
     const updateConfiguration = (values: any): void => {
         const data = {
@@ -95,6 +95,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
 
     return (
         <Form
+            id={ FORM_ID }
             uncontrolledForm={ false }
             onSubmit={ (values) => {
                 updateConfiguration(values);
@@ -171,6 +172,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 hint={ t("console:develop.features.applications.forms.advancedConfig.fields.enableAuthorization.hint") }
             />
             <Field.Button
+                form={ FORM_ID }
                 size="small"
                 buttonType="primary_btn"
                 ariaLabel="Update button"

--- a/apps/console/src/features/applications/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/applications/components/forms/general-details-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -23,10 +23,10 @@ import React, { FunctionComponent, ReactElement, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider } from "semantic-ui-react";
+import { applicationConfig } from "../../../../extensions";
 import { AppState, UIConfigInterface } from "../../../core";
 import { ApplicationManagementConstants } from "../../constants";
-import { applicationConfig } from "../../../../extensions";
-import {ApplicationInterface} from "../../models";
+import { ApplicationInterface } from "../../models";
 
 /**
  * Proptypes for the applications general details form component.
@@ -96,12 +96,13 @@ export interface GeneralDetailsFormErrorValidationsInterface {
     accessUrl?: string;
 }
 
+const FORM_ID: string = "application-general-details";
+
 /**
  * Form to edit general details of the application.
  *
- * @param {GeneralDetailsFormPopsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterface> = (
     props: GeneralDetailsFormPopsInterface
@@ -136,7 +137,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
      * Prepare form values for submitting.
      *
      * @param values - Form values.
-     * @return {any} Sanitized form values.
+     * @returns Sanitized form values.
      */
     const updateConfigurations = (values) => {
         onSubmit({
@@ -155,8 +156,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
      * Validates the Form.
      *
      * @param values - Form Values.
-     *
-     * @return {GeneralDetailsFormErrorValidationsInterface}
+     * @returns Form validation.
      */
     const validateForm = (values):
         GeneralDetailsFormErrorValidationsInterface => {
@@ -176,8 +176,8 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
     /**
      * Application Name validation.
      *
-     * @param {string} name - Application Name.
-     * @return {string | void}
+     * @param name - Application Name.
+     * @returns Name validation.
      */
     const validateName = (name: string): string | void => {
 
@@ -193,8 +193,8 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
     /**
      * Application Description validation.
      *
-     * @param {string} description - Application Description.
-     * @return {string | void}
+     * @param description - Application Description.
+     * @returns Description validation.
      */
     const validateDescription = (description: string): string | void => {
 
@@ -209,6 +209,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
 
     return (
         <Form
+            id={ FORM_ID }
             uncontrolledForm={ false }
             onSubmit={ (values) => {
                 updateConfigurations(values);
@@ -227,7 +228,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
             { isManagementApp && (
                 <Message
                     type="info"
-                    content={
+                    content={ (
                         <>
                             { t("console:develop.features.applications.forms.generalDetails.managementAppBanner") }
                             <DocumentationLink
@@ -237,7 +238,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                                 }
                             </DocumentationLink>
                         </>
-                    }
+                    ) }
                 />
             ) }
             { !UIConfig.systemAppsIdentifiers.includes(name) && (
@@ -336,13 +337,14 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                                 </strong>
                             )
                             : (
-                                <strong 
+                                <strong
                                     className="link pointing"
-                                    data-testid="application-name-assertion" 
-                                    onClick={ 
+                                    data-testid="application-name-assertion"
+                                    onClick={
                                         () => window.open(getLink("develop.applications.managementApplication"+
-                                                        ".selfServicePortal"), "_blank") 
-                                    }>
+                                                        ".selfServicePortal"), "_blank")
+                                    }
+                                >
                                     My Account
                                 </strong>
                             )
@@ -364,8 +366,14 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                         ".placeholder")
                 }
                 value={ accessUrl }
-                readOnly={ !hasRequiredScope || ( readOnly && applicationConfig.generalSettings.getFieldReadOnlyStatus(
-                     application, "ACCESS_URL"))}
+                readOnly={
+                    !hasRequiredScope || (
+                        readOnly
+                        && applicationConfig.generalSettings.getFieldReadOnlyStatus(
+                            application, "ACCESS_URL"
+                        )
+                    )
+                }
                 maxLength={ 200 }
                 minLength={ 3 }
                 data-testid={ `${ testId }-application-access-url-input` }
@@ -373,6 +381,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                 width={ 16 }
             />
             <Field.Button
+                form={ FORM_ID }
                 size="small"
                 buttonType="primary_btn"
                 ariaLabel="Update button"
@@ -381,8 +390,14 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                 disabled={ isSubmitting }
                 loading={ isSubmitting }
                 label={ t("common:update") }
-                hidden={ !hasRequiredScope || ( readOnly && applicationConfig.generalSettings.getFieldReadOnlyStatus(
-                    application, "ACCESS_URL"))}
+                hidden={
+                    !hasRequiredScope || (
+                        readOnly
+                        && applicationConfig.generalSettings.getFieldReadOnlyStatus(
+                            application, "ACCESS_URL"
+                        )
+                    )
+                }
             />
         </Form>
     );

--- a/apps/console/src/features/applications/components/forms/provisioning-configuration-form.tsx
+++ b/apps/console/src/features/applications/components/forms/provisioning-configuration-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -36,12 +36,13 @@ interface ProvisioningConfigurationFormPropsInterface extends TestableComponentI
     isSubmitting?: boolean;
 }
 
+const FORM_ID: string = "application-provisioning-configuration-form";
+
 /**
  * Provisioning configurations form component.
  *
- * @param {ProvisioningConfigurationFormPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const ProvisioningConfigurationsForm: FunctionComponent<ProvisioningConfigurationFormPropsInterface> = (
     props: ProvisioningConfigurationFormPropsInterface
@@ -64,7 +65,7 @@ export const ProvisioningConfigurationsForm: FunctionComponent<ProvisioningConfi
      * Prepare form values for submitting.
      *
      * @param values - Form values.
-     * @return {any} Sanitized form values.
+     * @returns Sanitized form values.
      */
     const updateConfiguration = (values: any): void => {
         const formData = {
@@ -107,6 +108,7 @@ export const ProvisioningConfigurationsForm: FunctionComponent<ProvisioningConfi
 
     return (
         <Form
+            id={ FORM_ID }
             uncontrolledForm={ false }
             onSubmit={ (values) => {
                 updateConfiguration(values);
@@ -141,6 +143,7 @@ export const ProvisioningConfigurationsForm: FunctionComponent<ProvisioningConfi
                     "userstoreDomain.hint") }
             />
             <Field.Button
+                form={ FORM_ID }
                 size="small"
                 buttonType="primary_btn"
                 ariaLabel="Update button"

--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -53,12 +53,13 @@ interface AdvanceAttributeSettingsPropsInterface extends TestableComponentInterf
 
 export const SubjectAttributeFieldName = "subjectAttribute";
 
+const FORM_ID: string = "application-attributes-advance-settings-form";
+
 /**
  * Advanced attribute settings component.
  *
- * @param {AdvanceAttributeSettingsPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSettingsPropsInterface> = (
     props: AdvanceAttributeSettingsPropsInterface
@@ -258,6 +259,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
         (initialRole && initialSubject)
             ? (
                 <Form
+                    id={ FORM_ID }
                     uncontrolledForm={ false }
                     initialValues={
                         !onlyOIDCConfigured &&

--- a/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -1,20 +1,20 @@
 /**
-* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* WSO2 Inc. licenses this file to you under the Apache License,
-* Version 2.0 (the 'License'); you may not use this file except
-* in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
@@ -64,12 +64,13 @@ interface EditBasicDetailsLocalClaimsPropsInterface extends TestableComponentInt
     update: () => void;
 }
 
+const FORM_ID: string = "local-claim-basic-details-form";
+
 /**
  * This component renders the Basic Details pane of the edit local claim screen
  *
- * @param {EditBasicDetailsLocalClaimsPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLocalClaimsPropsInterface> = (
     props: EditBasicDetailsLocalClaimsPropsInterface
@@ -192,9 +193,10 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     /**
      * This deletes a local claim
-     * @param {string} id
+     *
+     * @param id - Claim id.
      */
-    const deleteLocalClaim = (id: string) => {
+    const deleteLocalClaim = (id: string): void => {
         deleteAClaim(id).then(() => {
             history.push(AppConstants.getPaths().get("LOCAL_CLAIMS"));
             dispatch(addAlert(
@@ -325,6 +327,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                     </Grid.Row>
                 </Grid>
                 <Form
+                    id={ FORM_ID }
                     uncontrolledForm={ false }
                     onSubmit={ (values): void => {
                         onSubmit(values as any);
@@ -541,6 +544,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         ) && !hideSpecialClaims &&
                         (
                             <Field.Button
+                                form={ FORM_ID }
                                 ariaLabel="submit"
                                 size="small"
                                 buttonType="primary_btn"

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/email-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/email-otp-authenticator-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -56,7 +56,7 @@ interface EmailOTPAuthenticatorFormPropsInterface extends TestableComponentInter
     initialValues: CommonAuthenticatorFormInitialValuesInterface;
     /**
      * Callback for form submit.
-     * @param {CommonAuthenticatorFormInitialValuesInterface} values - Resolved Form Values.
+     * @param values - Resolved Form Values.
      */
     onSubmit: (values: CommonAuthenticatorFormInitialValuesInterface) => void;
     /**
@@ -136,12 +136,13 @@ export interface EmailOTPAuthenticatorFormErrorValidationsInterface {
     EmailOTP_OtpRegex_UseNumericChars: string;
 }
 
+const FORM_ID: string = "email-otp-authenticator-form";
+
 /**
  * Email OTP Authenticator Form.
  *
- * @param {EmailOTPAuthenticatorFormPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorFormPropsInterface> = (
     props: EmailOTPAuthenticatorFormPropsInterface
@@ -184,7 +185,8 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
             const moderatedName: string = value.name.replace(/\./g, "_");
 
             // Converting expiry time from seconds to minutes
-            if (moderatedName === IdentityProviderManagementConstants.AUTHENTICATOR_INIT_VALUES_EMAIL_OTP_EXPIRY_TIME_KEY) {
+            if (moderatedName === IdentityProviderManagementConstants
+                .AUTHENTICATOR_INIT_VALUES_EMAIL_OTP_EXPIRY_TIME_KEY) {
                 const expiryTimeInMinutes = Math.round(parseInt(value.value, 10) / 60);
 
                 resolvedInitialValues = {
@@ -227,8 +229,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
      * Prepare form values for submitting.
      *
      * @param values - Form values.
-     *
-     * @return {CommonAuthenticatorFormInitialValuesInterface} Sanitized form values.
+     * @returns Sanitized form values.
      */
     const getUpdatedConfigurations = (values: EmailOTPAuthenticatorFormInitialValuesInterface)
         : CommonAuthenticatorFormInitialValuesInterface => {
@@ -267,9 +268,8 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
     /**
      * Validates the Form.
      *
-     * @param {EmailOTPAuthenticatorFormInitialValuesInterface} values - Form Values.
-     *
-     * @return {EmailOTPAuthenticatorFormErrorValidationsInterface}
+     * @param values - Form Values.
+     * @returns Form validation.
      */
     const validateForm = (values: EmailOTPAuthenticatorFormInitialValuesInterface):
         EmailOTPAuthenticatorFormErrorValidationsInterface => {
@@ -310,8 +310,11 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
             || (parseInt(values.EmailOTP_OTPLength, 10) > IdentityProviderManagementConstants
                 .EMAIL_OTP_AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS.OTP_LENGTH_MAX_VALUE)) {
             // Check for invalid range.
-            errors.EmailOTP_OTPLength = t("console:develop.features.authenticationProvider.forms" +
-                `.authenticatorSettings.emailOTP.tokenLength.validations.range.${isOTPNumeric ? "digits" : "characters"}`);
+            errors.EmailOTP_OTPLength = t(
+                "console:develop.features.authenticationProvider.forms" +
+                `.authenticatorSettings.emailOTP.tokenLength.validations.range.${
+                    isOTPNumeric ? "digits" : "characters"
+                }`);
         }
 
         return errors;
@@ -319,6 +322,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
 
     return (
         <Form
+            id={ FORM_ID }
             uncontrolledForm={ false }
             onSubmit={ (values) => {
                 onSubmit(getUpdatedConfigurations(values as EmailOTPAuthenticatorFormInitialValuesInterface));
@@ -442,6 +446,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                 </Label>
             </Field.Input>
             <Field.Button
+                form={ FORM_ID }
                 size="small"
                 buttonType="primary_btn"
                 ariaLabel="Email OTP authenticator update button"

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/facebook-authenticator-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -53,7 +53,7 @@ interface FacebookAuthenticatorFormPropsInterface extends TestableComponentInter
     initialValues: CommonAuthenticatorFormInitialValuesInterface;
     /**
      * Callback for form submit.
-     * @param {CommonAuthenticatorFormInitialValuesInterface} values - Resolved Form Values.
+     * @param values - Resolved Form Values.
      */
     onSubmit: (values: CommonAuthenticatorFormInitialValuesInterface) => void;
     /**
@@ -145,12 +145,13 @@ interface ScopeMetaInterface {
     icon: SemanticICONS;
 }
 
+const FORM_ID: string = "facebook-authenticator-form";
+
 /**
  * Facebook Authenticator Form.
  *
- * @param {FacebookAuthenticatorFormPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorFormPropsInterface> = (
     props: FacebookAuthenticatorFormPropsInterface
@@ -209,8 +210,7 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
      * Prepare form values for submitting.
      *
      * @param values - Form values.
-     *
-     * @return {CommonAuthenticatorFormInitialValuesInterface} Sanitized form values.
+     * @returns Sanitized form values.
      */
     const getUpdatedConfigurations = (values: FacebookAuthenticatorFormInitialValuesInterface)
         : CommonAuthenticatorFormInitialValuesInterface => {
@@ -235,9 +235,8 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
     /**
      * Resolve metadata for UI rendering of scopes.
      *
-     * @param {string} scope - Input scope.
-     *
-     * @return {ScopeMetaInterface}
+     * @param scope - Input scope.
+     * @returns Scope metadata.
      */
     const resolveScopeMetadata = (scope: string): ScopeMetaInterface => {
 
@@ -276,6 +275,7 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
 
     return (
         <Form
+            id={ FORM_ID }
             uncontrolledForm={ false }
             onSubmit={ (values) => onSubmit(getUpdatedConfigurations(values as any)) }
             initialValues={ initialValues }
@@ -327,7 +327,7 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
                     t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
                         ".facebook.clientSecret.placeholder")
                 }
-                hint={
+                hint={ (
                     <Trans
                         i18nKey={
                             "console:develop.features.authenticationProvider.forms.authenticatorSettings" +
@@ -336,7 +336,7 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
                     >
                         The <Code>App secret</Code> value of the Facebook application.
                     </Trans>
-                }
+                ) }
                 required={ formFields?.ClientSecret?.meta?.isMandatory }
                 readOnly={
                     readOnly || (
@@ -447,16 +447,17 @@ export const FacebookAuthenticatorForm: FunctionComponent<FacebookAuthenticatorF
                             >
                                 Permissions provide a way for connected apps to access data from Facebook.
                                 Click <a
-                                href="https://developers.facebook.com/docs/permissions/reference"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >here</a> to learn more.
+                                    href="https://developers.facebook.com/docs/permissions/reference"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >here</a> to learn more.
                             </Trans>
                         </Hint>
                     </FormSection>
                 )
             }
             <Field.Button
+                form={ FORM_ID }
                 size="small"
                 buttonType="primary_btn"
                 ariaLabel="Facebook authenticator update button"

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/github-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/github-authenticator-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -53,7 +53,7 @@ interface GithubAuthenticatorFormPropsInterface extends TestableComponentInterfa
     initialValues: CommonAuthenticatorFormInitialValuesInterface;
     /**
      * Callback for form submit.
-     * @param {CommonAuthenticatorFormInitialValuesInterface} values - Resolved Form Values.
+     * @param values - Resolved Form Values.
      */
     onSubmit: (values: CommonAuthenticatorFormInitialValuesInterface) => void;
     /**
@@ -149,12 +149,13 @@ interface ScopeMetaInterface {
     icon: SemanticICONS;
 }
 
+const FORM_ID: string = "github-authenticator-form";
+
 /**
  * GitHub Authenticator Form.
  *
- * @param {GithubAuthenticatorFormPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormPropsInterface> = (
     props: GithubAuthenticatorFormPropsInterface
@@ -213,8 +214,7 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
      * Prepare form values for submitting.
      *
      * @param values - Form values.
-     *
-     * @return {CommonAuthenticatorFormInitialValuesInterface} Sanitized form values.
+     * @returns Sanitized form values.
      */
     const getUpdatedConfigurations = (values: GithubAuthenticatorFormInitialValuesInterface)
         : CommonAuthenticatorFormInitialValuesInterface => {
@@ -239,9 +239,8 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
     /**
      * Resolve metadata for UI rendering of scopes.
      *
-     * @param {string} scope - Input scope.
-     *
-     * @return {ScopeMetaInterface}
+     * @param scope - Input scope.
+     * @returns Scope metadata.
      */
     const resolveScopeMetadata = (scope: string): ScopeMetaInterface => {
 
@@ -278,6 +277,7 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
 
     return (
         <Form
+            id={ FORM_ID }
             uncontrolledForm={ false }
             onSubmit={ (values) => onSubmit(getUpdatedConfigurations(values as any)) }
             initialValues={ initialValues }
@@ -294,7 +294,7 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
                     t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
                         ".github.clientId.placeholder")
                 }
-                hint={
+                hint={ (
                     <Trans
                         i18nKey={
                             "console:develop.features.authenticationProvider.forms.authenticatorSettings" +
@@ -303,7 +303,7 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
                     >
                         The <Code>Client ID</Code> you received from GitHub for your OAuth app.
                     </Trans>
-                }
+                ) }
                 required={ formFields?.ClientId?.meta?.isMandatory }
                 readOnly={
                     readOnly || (
@@ -335,7 +335,7 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
                     t("console:develop.features.authenticationProvider.forms" +
                         ".authenticatorSettings.github.clientSecret.placeholder")
                 }
-                hint={
+                hint={ (
                     <Trans
                         i18nKey={
                             "console:develop.features.authenticationProvider.forms.authenticatorSettings" +
@@ -344,7 +344,7 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
                     >
                         The <Code>Client secret</Code> you received from GitHub for your OAuth app.
                     </Trans>
-                }
+                ) }
                 required={ formFields?.ClientSecret?.meta?.isMandatory }
                 readOnly={
                     readOnly || (
@@ -455,19 +455,20 @@ export const GithubAuthenticatorForm: FunctionComponent<GithubAuthenticatorFormP
                             >
                                 The scopes specifies the type of access provided for connected apps
                                 to access data from GitHub. Click <a
-                                href={
-                                    "https://docs.github.com/en/developers/apps/building-oauth" +
-                                    "-apps/scopes-for-oauth-apps"
-                                }
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >here</a> to learn more.
+                                    href={
+                                        "https://docs.github.com/en/developers/apps/building-oauth" +
+                                        "-apps/scopes-for-oauth-apps"
+                                    }
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >here</a> to learn more.
                             </Trans>
                         </Hint>
                     </FormSection>
                 )
             }
             <Field.Button
+                form={ FORM_ID }
                 size="small"
                 buttonType="primary_btn"
                 ariaLabel="GitHub authenticator update button"

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/google-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/google-authenticator-form.tsx
@@ -141,12 +141,13 @@ interface ScopeMetaInterface {
     icon: SemanticICONS
 }
 
+const FORM_ID: string = "google-authenticator-form";
+
 /**
  * Google Authenticator Form.
  *
  * @param props - Props injected to the component.
- *
- * @returns GoogleAuthenticatorForm component
+ * @returns Functional component.
  */
 export const GoogleAuthenticatorForm: FunctionComponent<GoogleAuthenticatorFormPropsInterface> = (
     props: GoogleAuthenticatorFormPropsInterface
@@ -310,6 +311,7 @@ export const GoogleAuthenticatorForm: FunctionComponent<GoogleAuthenticatorFormP
 
     return (
         <Form
+            id={ FORM_ID }
             uncontrolledForm={ false }
             onSubmit={ (values) => onSubmit(getUpdatedConfigurations(values as any)) }
             initialValues={ initialValues }
@@ -537,6 +539,7 @@ export const GoogleAuthenticatorForm: FunctionComponent<GoogleAuthenticatorFormP
                 )
             }
             <Field.Button
+                form={ FORM_ID }
                 size="small"
                 buttonType="primary_btn"
                 ariaLabel="Google authenticator update button"

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/saml-authenticator-form.tsx
@@ -95,11 +95,13 @@ export interface SamlPropertiesInterface {
     IsUserIdInClaims?: boolean;
 }
 
+const FORM_ID: string = "saml-authenticator-form";
+
 /**
  * SAML Authenticator settings form.
  *
  * @param props - Props injected to the component.
- * @returns SAML authenticator settings form component.
+ * @returns Functional component.
  */
 export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPropsInterface> = (
     props: SamlSettingsFormPropsInterface
@@ -226,10 +228,11 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
 
     return (
         <Form
+            id={ FORM_ID }
             onSubmit={ onFormSubmit }
             uncontrolledForm={ true }
-            initialValues={ formValues }>
-
+            initialValues={ formValues }
+        >
             <Field.Input
                 required={ true }
                 name="SPEntityId"
@@ -590,6 +593,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
             </FormSection>
 
             <Field.Button
+                form={ FORM_ID }
                 size="small"
                 buttonType="primary_btn"
                 ariaLabel="SAML authenticator update button"

--- a/apps/console/src/features/identity-providers/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/general-details-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -102,11 +102,13 @@ interface GeneralDetailsFormPopsInterface extends TestableComponentInterface {
 const IDP_NAME_MAX_LENGTH: number = 50;
 const IDP_DESCRIPTION_MAX_LENGTH: number = 300;
 
+const FORM_ID: string = "idp-general-details-form";
+
 /**
  * Form to edit general details of the identity provider.
  *
- * @param props GeneralDetailsFormPopsInterface.
- * @return {React.ReactElement}.
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterface> = (
     props: GeneralDetailsFormPopsInterface): ReactElement => {
@@ -122,7 +124,6 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
         hideIdPLogoEditField,
         isReadOnly,
         isSaml,
-        isOidc,
         isSubmitting,
         [ "data-testid" ]: testId
     } = props;
@@ -140,7 +141,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
 
     /**
      * Check whether IDP name is already exist or not.
-     * @param value IDP name
+     * @param value - IDP name
      * @returns error msg if name is already taken.
      */
     const idpNameValidation = (value: string): string => {
@@ -193,7 +194,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
      * Prepare form values for submitting.
      *
      * @param values - Form values.
-     * @return {any} Sanitized form values.
+     * @returns Sanitized form values.
      */
     const updateConfigurations = (values): void => {
         onSubmit({
@@ -206,7 +207,8 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
 
     /**
      * Checks if the certificates section should be shown.
-     * @returns {boolean}
+     *
+     * @returns Should show/hide certificates.
      */
     const shouldShowCertificates = (): boolean => {
 
@@ -225,6 +227,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
         <React.Fragment>
             <EmphasizedSegment padded="very">
                 <Form
+                    id={ FORM_ID }
                     uncontrolledForm={ false }
                     onSubmit={ (values): void => {
                         updateConfigurations(values);
@@ -279,11 +282,11 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                                 "placeholder") }
                             value={ imageUrl }
                             data-testid={ `${ testId }-idp-image` }
-                            maxLength={ 
+                            maxLength={
                                 IdentityProviderManagementConstants
                                     .GENERAL_FORM_CONSTRAINTS.IMAGE_URL_MAX_LENGTH as number
                             }
-                            minLength={ 
+                            minLength={
                                 IdentityProviderManagementConstants
                                     .GENERAL_FORM_CONSTRAINTS.IMAGE_URL_MIN_LENGTH as number
                             }
@@ -294,6 +297,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                     ) }
                     { !isReadOnly && (
                         <Field.Button
+                            form={ FORM_ID }
                             ariaLabel="Update General Details"
                             size="small"
                             buttonType="primary_btn"

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/attribute-mapping-list-item.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/attribute-mapping-list-item.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -45,6 +45,8 @@ export interface AttributeMappingListItemProps {
 
 const toBits = (bool: boolean): number => bool ? 1 : 0;
 
+const FORM_ID: string = "idp-attributes-mapping-list-item-form";
+
 /**
  * This is a common interface that allows the user to map one attribute
  * to another local attribute. The interface looks like this: -
@@ -59,12 +61,12 @@ const toBits = (bool: boolean): number => bool ? 1 : 0;
  *
  * This component is a <Form> internally. And the fields value submissions
  * are handled by onSubmit so, it is mandatory to have a submission
- * button. If you pass editingMode={true} it will render plus icon button
+ * button. If you pass editingMode=`true` it will render plus icon button
  * inline and hide button with text "Add Mapping Button" below it
  * and input labels.
  *
- * @param props {AttributeMappingListItemProps}
- * @constructor
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const AttributeMappingListItem: FunctionComponent<AttributeMappingListItemProps> = (
     props: AttributeMappingListItemProps
@@ -93,6 +95,7 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
     useEffect(() => {
         if (availableAttributeList) {
             const copy = [ ...availableAttributeList ];
+
             // When you enter into editing mode the available attribute list
             // will not contain the mapping itself. We need to manually append
             // it to the attrs to make it work.
@@ -125,8 +128,8 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
 
     /**
      * Form submission handler.
-     * @param values {Record<string, any>}
-     * @param form {FormApi<Record<string, any>>}
+     * @param values - Form values.
+     * @param form - Form.
      */
     const onFormSub = (values: Record<string, any>, form: FormApi<Record<string, any>>) => {
         // Find the claim by id and create a instance of
@@ -138,7 +141,9 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
             ),
             mappedValue: values.mappedValue
         } as IdentityProviderCommonClaimMappingInterface;
+
         onSubmit(newMapping);
+
         if (!editingMode) {
             // Resets the form field values and its fields states.
             form.change("mappedValue", "");
@@ -152,6 +157,7 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
 
     return (
         <Form
+            id={ FORM_ID }
             onSubmit={ onFormSub }
             uncontrolledForm={ true }
             initialValues={ mapping && {
@@ -174,6 +180,7 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
                             validation={ (value) => {
                                 if (!value || !value.trim()) {
                                     setMappingHasError(true);
+
                                     return FieldConstants.FIELD_REQUIRED_ERROR;
                                 }
                                 /**
@@ -184,17 +191,19 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
                                  * In the following if condition we do a bitwise AND SC operation
                                  * to either allow one of them.
                                  *
-                                 * {@see https://datatracker.ietf.org/doc/html/rfc8409#section-4.1}
+                                 * @see {@link https://datatracker.ietf.org/doc/html/rfc8409#section-4.1}
                                  */
                                 if (toBits(!FormValidation.url(value)) &
                                     toBits(!FormValidation.isValidResourceName(value))) {
                                     setMappingHasError(true);
+
                                     return FieldConstants.INVALID_RESOURCE_ERROR;
                                 }
                                 // Check whether this attribute external name is already mapped.
                                 const mappedValues = new Set(
                                     alreadyMappedAttributesList.map((a) => a.mappedValue)
                                 );
+
                                 if (mappedValues.has(value)) {
                                     // This means we have a mapping value like this...
                                     // But we need to make sure that if the current value
@@ -202,13 +211,16 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
                                     // editing mode...
                                     if (editingMode && mapping?.mappedValue === value) {
                                         setMappingHasError(false);
+
                                         return undefined;
                                     }
                                     setMappingHasError(true);
+
                                     return "There's already a attribute mapped with this name.";
                                 }
                                 // If there's no errors.
                                 setMappingHasError(false);
+
                                 return undefined;
                             } }
                             listen={ (value: string) => setMappedInputValue(value) }
@@ -235,6 +247,7 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
                         <React.Fragment>
                             <Grid.Column width={ 1 }>
                                 <Field.Button
+                                    form={ FORM_ID }
                                     disabled={
                                         mappingHasError ||
                                         !mappedInputValue ||
@@ -254,6 +267,7 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
                     <Grid.Row columns={ 1 }>
                         <Grid.Column width={ 16 } textAlign="right">
                             <Field.Button
+                                form={ FORM_ID }
                                 disabled={
                                     mappingHasError ||
                                     !mappedInputValue ||
@@ -270,5 +284,4 @@ export const AttributeMappingListItem: FunctionComponent<AttributeMappingListIte
             </Grid>
         </Form>
     );
-
 };

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/attribute-selection-v2.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/attribute-selection-v2.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -37,12 +37,17 @@ export interface AttributesSelectionV2Props extends TestableComponentInterface {
     isReadOnly: boolean;
 }
 
+const FORM_ID: string = "idp=attribute-selection-v2-form";
+
 /**
  * New implementation of attributes selection for IdPs. It has a similar
  * look and feel of Claims components.
  *
- * @param props {AttributesSelectionV2Props}
- * @constructor
+ * TODO: Validate the necessity of this component. If this is the way forward, remove the
+ * v1 component and remove the v2 suffix from this component.
+ *
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const AttributesSelectionV2: FunctionComponent<AttributesSelectionV2Props> = (
     props: AttributesSelectionV2Props
@@ -63,15 +68,19 @@ export const AttributesSelectionV2: FunctionComponent<AttributesSelectionV2Props
     const { t } = useTranslation();
 
     useEffect(() => {
-        const ids = [];
+        const ids: string[] = [];
+
         for (const mapping of mappedAttributesList) {
             ids.push(mapping.claim.id);
         }
+
         setMappedAttrIds(ids);
     }, [ attributeList ]);
 
     /**
-     * @predicate
+     * Check if there are mapped attibutes.
+     *
+     * @returns Has mapped attributes or not.
      */
     const hasMappedAttributes = (): boolean => {
         return mappedAttributesList &&
@@ -80,7 +89,8 @@ export const AttributesSelectionV2: FunctionComponent<AttributesSelectionV2Props
 
     /**
      * The placeholder component to show when there's no attributes selected.
-     * @return {ReactElement} JSX
+     *
+     * @returns Selection modal placeholder.
      */
     const _noAttributesSelectedModalPlaceholder = (): ReactElement => {
         return (
@@ -109,7 +119,8 @@ export const AttributesSelectionV2: FunctionComponent<AttributesSelectionV2Props
     /**
      * The placeholder component to show when there's no results for
      * the search query {@link searchQuery}.
-     * @return {ReactElement} JSX
+     *
+     * @returns Empty results placeholder.
      */
     const _attributesListSearchResultsEmptyPlaceholder = (): ReactElement => {
         return (
@@ -143,7 +154,7 @@ export const AttributesSelectionV2: FunctionComponent<AttributesSelectionV2Props
      * is, we simply close the modal and call {@link onAttributesSelected}
      * with the newly added mappings + existing mappings.
      *
-     * @param mappingsToBeAdded {IdentityProviderCommonClaimMappingInterface}
+     * @param mappingsToBeAdded - Set of mappings.
      */
     const onSave = (mappingsToBeAdded: IdentityProviderCommonClaimMappingInterface[]) => {
         onAttributesSelected([ ...mappedAttributesList, ...mappingsToBeAdded ]);
@@ -166,8 +177,11 @@ export const AttributesSelectionV2: FunctionComponent<AttributesSelectionV2Props
                             <Grid>
                                 <Grid.Row columns={ 2 }>
                                     <Grid.Column width={ 7 }>
-                                        <Form onSubmit={ () => ({ /*Noop*/ }) }
-                                              uncontrolledForm={ false }>
+                                        <Form
+                                            id={ FORM_ID }
+                                            onSubmit={ () => ({ /*Noop*/ }) }
+                                            uncontrolledForm={ false }
+                                        >
                                             <Field.Input
                                                 icon="search"
                                                 iconPosition="left"
@@ -202,6 +216,7 @@ export const AttributesSelectionV2: FunctionComponent<AttributesSelectionV2Props
                                                         return m.mappedValue.startsWith(searchQuery) ||
                                                             m.claim.id.startsWith(searchQuery);
                                                     }
+
                                                     return true;
                                                 })
                                             }

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/attribute-selection-v2.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/attribute-selection-v2.tsx
@@ -37,7 +37,7 @@ export interface AttributesSelectionV2Props extends TestableComponentInterface {
     isReadOnly: boolean;
 }
 
-const FORM_ID: string = "idp=attribute-selection-v2-form";
+const FORM_ID: string = "idp-attribute-selection-v2-form";
 
 /**
  * New implementation of attributes selection for IdPs. It has a similar

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/add-idp-certificate-modal.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/add-idp-certificate-modal.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -29,7 +29,6 @@ import {
     PrimaryButton,
     useWizardAlert
 } from "@wso2is/react-components";
-import isEmpty from "lodash-es/isEmpty";
 import React, { FC, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -48,13 +47,15 @@ export interface AddIdPCertificateModalV2Props extends IdentifiableComponentInte
     onClose: () => void;
 }
 
+const FORM_ID: string = "idp-certificate-add-modal-form";
+
 /**
  * This component is responsible for adding certificates to a given
  * IdP {@link IdentityProviderInterface}. It can take user input in PEM
  * and Certificate file formats.
  *
- * @param props {AddIdPCertificateModalV2Props}
- * @constructor
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const AddIdpCertificateModal: FC<AddIdPCertificateModalV2Props> = (props): ReactElement => {
 
@@ -75,7 +76,9 @@ export const AddIdpCertificateModal: FC<AddIdPCertificateModalV2Props> = (props)
     const [ requestInProgress, setRequestInProgress ] = useState<boolean>(false);
 
     /**
-     * @param result {@link PickerResult<string | File>}
+     * Callback for on certificate change.
+     *
+     * @param result - Picker results.
      */
     const onCertificateChange = (result: PickerResult<string | File>): void => {
         try {
@@ -112,6 +115,7 @@ export const AddIdpCertificateModal: FC<AddIdPCertificateModalV2Props> = (props)
             }));
             setRequestInProgress(false);
             onClose();
+
             return;
         }
 
@@ -151,6 +155,7 @@ export const AddIdpCertificateModal: FC<AddIdPCertificateModalV2Props> = (props)
                         ".updateIDPCertificate.error.message")
                 });
                 setRequestInProgress(false);
+
                 return;
             }
             setAlert({
@@ -189,7 +194,11 @@ export const AddIdpCertificateModal: FC<AddIdPCertificateModalV2Props> = (props)
 
             <Modal.Content className="content-container">
                 { alert && alertComponent }
-                <Form onSubmit={ () => ({ /*No Operations*/ }) } uncontrolledForm={ true }>
+                <Form
+                    id={ FORM_ID }
+                    onSubmit={ () => ({ /*No Operations*/ }) }
+                    uncontrolledForm={ true }
+                >
                     <FilePicker
                         key={ 1 }
                         fileStrategy={ new CertFileStrategy() }

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -21,8 +21,15 @@ import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models
 import { addAlert } from "@wso2is/core/store";
 import { URLUtils } from "@wso2is/core/utils";
 import { Field, Form } from "@wso2is/form";
-import { CertFileStrategy, Code, EmphasizedSegment, Hint, PrimaryButton, Switcher } from "@wso2is/react-components";
-import { SwitcherOptionProps } from "@wso2is/react-components";
+import {
+    CertFileStrategy,
+    Code,
+    EmphasizedSegment,
+    Hint,
+    PrimaryButton,
+    Switcher,
+    SwitcherOptionProps
+} from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -31,9 +38,9 @@ import { Divider, Grid, Icon, Segment } from "semantic-ui-react";
 import { AddIdpCertificateModal } from "./add-idp-certificate-modal";
 import { EmptyCertificatesPlaceholder } from "./empty-certificates-placeholder";
 import { IdpCertificatesList } from "./idp-cetificates-list";
+import { commonConfig } from "../../../../../extensions/configs";
 import { updateIDPCertificate } from "../../../api";
 import { IdentityProviderInterface } from "../../../models";
-import { commonConfig } from "../../../../../extensions/configs";
 
 /**
  * Props interface of {@link IdpCertificates}
@@ -53,6 +60,8 @@ export interface IdpCertificatesV2Props extends IdentifiableComponentInterface {
 }
 
 export type CertificateConfigurationMode = "jwks" | "certificates";
+
+const FORM_ID: string = "idp-certificate-jwks-input-form";
 
 /**
  * This is the certificates component for IdPs.
@@ -95,7 +104,7 @@ export type CertificateConfigurationMode = "jwks" | "certificates";
  *  |   | Upload | Paste |                                                 |
  *  |   +==============================================================+   |
  *  |   |                                                              |   |
- *  |   |                         <Some Icon>                          |   |
+ *  |   |                         Some Icon                          |   |
  *  |   |                                                              |   |
  *  |   |             Drag and drop a certificate file here.           |   |
  *  |   |                                                              |   |
@@ -109,7 +118,8 @@ export type CertificateConfigurationMode = "jwks" | "certificates";
  *  |                                                                      |
  *  +======================================================================+
  *
- * @constructor
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props): ReactElement => {
 
@@ -170,7 +180,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
 
     /**
      * The following function update the IDP JWKS endpoint.
-     * @param values {Record<string, any>}
+     * @param values - Form values.
      */
     const onJWKSFormSubmit = (values: Record<string, any>) => {
 
@@ -227,19 +237,20 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
 
     const jwksInputForm: ReactNode = (
         <Form
+            id={ FORM_ID }
             uncontrolledForm={ true }
             initialValues={ { jwks_endpoint: editingIDP?.certificate?.jwksUri } }
             onSubmit={ onJWKSFormSubmit }>
 
             <Field.Input
                 required
-                hint={
+                hint={ (
                     <React.Fragment>
                         A JSON Web Key (JWK) Set is a JSON object that represents a set of JWKs. The JSON
                         object MUST have a <Code>keys</Code> member, with its value being an array of
                         JWKs.
                     </React.Fragment>
-                }
+                ) }
                 label="JWKS Endpoint URL"
                 ariaLabel="JWKS Endpoint URL"
                 inputType="url"
@@ -247,21 +258,25 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                 validation={ (value: string) => {
                     if (!value || !FormValidation.url(value)) {
                         setIsJwksValueValid(false);
+
                         return t("console:develop.features.applications.forms.inboundSAML" +
                             ".fields.metaURL.validations.invalid");
                     }
                     if (commonConfig?.blockLoopBackCalls && URLUtils.isLoopBackCall(value)) {
                         setIsJwksValueValid(false);
+
                         return t("console:develop.features.idp.forms.common.internetResolvableErrorMessage");
                     }
                     setIsJwksValueValid(true);
+
                     return undefined;
                 } }
                 listen={ (value: string) => setJwksValue(value) }
                 placeholder="https://{ oauth-provider-url }/oauth/jwks"
                 maxLength={ JWKS_MAX_LENGTH }
                 minLength={ JWKS_MIN_LENGTH }
-                name="jwks_endpoint"/>
+                name="jwks_endpoint"
+            />
 
             <Show when={ AccessControlConstants.IDP_EDIT }>
                 <PrimaryButton

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-cetificates-list.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-cetificates-list.tsx
@@ -239,7 +239,9 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
     /**
      * Creates a dummy label telling that we're unable to visualize
      * this certificate.
-     * @param certificate {DisplayCertificate}
+     *
+     * @param certificate - Certificate.
+     * @returns Dummy validity label.
      */
     const createDummyValidityLabel = (certificate: DisplayCertificate): ReactNode => {
         return (
@@ -282,9 +284,9 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
     const createCertificateActions = (certificate: DisplayCertificate, index: number) => {
         return [
             {
-                hidden: certificate?.infoUnavailable,
-                disabled: certificate?.infoUnavailable,
                 "data-componentid": `${ testId }-edit-cert-${ index }-button`,
+                disabled: certificate?.infoUnavailable,
+                hidden: certificate?.infoUnavailable,
                 icon: "eye",
                 onClick: () => handleViewCertificate(certificate),
                 popupText: "Preview",

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-cetificates-list.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-cetificates-list.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -33,7 +33,6 @@ import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Grid, Icon, Popup, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
 import { ShowCertificateModal } from "./show-certificate-modal";
-import { UIConstants } from "../../../../core";
 import { updateIDPCertificate } from "../../../api";
 import { IdentityProviderInterface } from "../../../models";
 
@@ -46,11 +45,13 @@ export interface IdpCertificatesListProps extends IdentifiableComponentInterface
     isReadOnly: boolean;
 }
 
+const FORM_ID: string = "idp-certificates-list-form";
+
 /**
  * List of added certificates.
  *
- * @param props {IdpCertificatesListProps}
- * @constructor
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
     props: PropsWithChildren<IdpCertificatesListProps>
@@ -67,7 +68,7 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
     const dispatch = useDispatch();
 
     /**
-     * {@see deleteCertificate} function's doc comment. Enforcing this in components
+     * @see {@link deleteCertificate} function's doc comment. Enforcing this in components
      * state to ensure developers to not to make mistakes.
      *
      * {@link https://www.typescriptlang.org/docs/handbook/2/objects.html#the-readonlyarray-type}
@@ -97,7 +98,7 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
      * Why call this in two places?
      *
      * 1) First, this func checks whether this IdP has certificates and
-     *    re-binds the new state to the component as {@link DisplayCertificate[]}.
+     *    re-binds the new state to the component as @see DisplayCertificate[].
      *
      * 2) Initially, when the component renders and when user adds a new certificate
      *    we need to refresh the state.
@@ -121,10 +122,10 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
      * Remove the certificate from the certificated list.
      * The path attribute of the patch request requires the certificate index.
      * At the moment, the index of the certificate to be deleted is obtained from the indexes of
-     * {@see certificates} array. This may cause unexpected behaviours if the certificates array is manipulated
+     * @see certificates array. This may cause unexpected behaviours if the certificates array is manipulated
      * for some reason.
      *
-     * @param certificateIndex {number}
+     * @param certificateIndex - Cert index.
      */
     const deleteCertificate = async (certificateIndex: number) => {
 
@@ -184,9 +185,9 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
     /**
      * Creates the resource item header.
      *
-     * @param validFrom {Date}
-     * @param validTill {Date}
-     * @param issuer {string}
+     * @param validFrom - Validate from date.
+     * @param validTill - Validate till date.
+     * @param issuer - Issuer.
      */
     const createValidityLabel = (validFrom: Date, validTill: Date, issuer: string): ReactElement => {
 
@@ -262,8 +263,8 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
     /**
      * Creates the resource item description.
      *
-     * @param validFrom {Date}
-     * @param validTill {Date}
+     * @param validFrom - Validate from date.
+     * @param validTill - Validate till date.
      */
     const createDescription = (validFrom: Date, validTill: Date): string => {
         return CertificateManagementUtils.getValidityPeriodInHumanReadableFormat(
@@ -275,8 +276,8 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
     /**
      * Creates the certificate actions.
      *
-     * @param certificate {DisplayCertificate}
-     * @param index {number}
+     * @param certificate - Certificate.
+     * @param index - Cert index.
      */
     const createCertificateActions = (certificate: DisplayCertificate, index: number) => {
         return [
@@ -301,7 +302,8 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
 
     /**
      * Creates what to show as the resource list item avatar.
-     * @param certificate {DisplayCertificate}
+     *
+     * @param certificate - Certificate.
      */
     const createCertificateResourceAvatar = (certificate: DisplayCertificate): ReactElement => {
         return (
@@ -319,8 +321,10 @@ export const IdpCertificatesList: FC<IdpCertificatesListProps> = (
 
     return (
         <Form
+            id={ FORM_ID }
             onSubmit={ CertificateManagementConstants.NO_OPERATIONS }
-            uncontrolledForm={ true }>
+            uncontrolledForm={ true }
+        >
             <Grid>
                 <Grid.Row>
                     <Grid.Column>

--- a/apps/console/src/features/identity-providers/components/wizards/expert-mode/expert-mode-authentication-provider-create-wizard-content.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/expert-mode/expert-mode-authentication-provider-create-wizard-content.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -36,17 +36,17 @@ import { handleGetIDPListCallError } from "../../utils";
 interface ExpertModeAuthenticationProviderCreateWizardContentPropsInterface extends IdentifiableComponentInterface {
     /**
      * Trigger form submit.
-     * @param {() => void} submitFunctionCb - Callback.
+     * @param submitFunctionCb - Callback.
      */
     triggerSubmission: (submitFunctionCb: () => void) => void;
     /**
      * Trigger previous page.
-     * @param {() => void} previousFunctionCb - Callback.
+     * @param previousFunctionCb - Callback.
      */
     triggerPrevious: (previousFunctionCb: () => void) => void;
     /**
      * Callback to change the wizard page,
-     * @param {number} pageNo - Page Number.
+     * @param pageNo - Page Number.
      */
     changePageNumber: (pageNo: number) => void;
     /**
@@ -55,22 +55,23 @@ interface ExpertModeAuthenticationProviderCreateWizardContentPropsInterface exte
     template: IdentityProviderTemplateInterface;
     /**
      * Total wizard page count.
-     * @param {number} pageCount - Page number.
+     * @param pageCount - Page number.
      */
     setTotalPage: (pageCount: number) => void;
     /**
      * Callback to be triggered for form submit.
-     * @param values
+     * @param values - Form values.
      */
     onSubmit: (values: ExpertModeAuthenticationProviderCreateWizardFormValuesInterface) => void;
 }
 
+const FORM_ID: string = "expert-mode-authenticator-wizard-form";
+
 /**
  * Expert Mode Authentication Provider Create Wizard content component.
  *
- * @param {ExpertModeAuthenticationProviderCreateWizardContentPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const ExpertModeAuthenticationProviderCreateWizardContent: FunctionComponent<
     ExpertModeAuthenticationProviderCreateWizardContentPropsInterface
@@ -110,8 +111,7 @@ export const ExpertModeAuthenticationProviderCreateWizardContent: FunctionCompon
         /**
          * Check whether IDP name is already exist or not.
          *
-         * @param value IDP name - IDP Name.
-         *
+         * @param value - IDP name.
          * @returns error msg if name is already taken.
          */
         const idpNameValidation = (value): string => {
@@ -141,9 +141,8 @@ export const ExpertModeAuthenticationProviderCreateWizardContent: FunctionCompon
         /**
          * Validates the Form.
          *
-         * @param {ExpertModeAuthenticationProviderCreateWizardFormValuesInterface} values - Form Values.
-         *
-         * @return {ExpertModeAuthenticationProviderCreateWizardFormErrorValidationsInterface}
+         * @param values - Form Values.
+         * @returns Form validation.
          */
         const validateForm = (values: ExpertModeAuthenticationProviderCreateWizardFormValuesInterface):
         ExpertModeAuthenticationProviderCreateWizardFormErrorValidationsInterface => {
@@ -166,6 +165,7 @@ export const ExpertModeAuthenticationProviderCreateWizardContent: FunctionCompon
 
         return (
             <Wizard
+                id={ FORM_ID }
                 initialValues={ {
                     name: template?.idp?.name
                 } }

--- a/apps/console/src/features/identity-providers/components/wizards/facebook/facebook-authentication-provider-create-wizard-content.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/facebook/facebook-authentication-provider-create-wizard-content.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -35,17 +35,17 @@ import { handleGetIDPListCallError } from "../../utils";
 interface GithubAuthenticationProviderCreateWizardContentPropsInterface extends TestableComponentInterface {
     /**
      * Trigger form submit.
-     * @param {() => void} submitFunctionCb - Callback.
+     * @param submitFunctionCb - Callback.
      */
     triggerSubmission: (submitFunctionCb: () => void) => void;
     /**
      * Trigger previous page.
-     * @param {() => void} previousFunctionCb - Callback.
+     * @param previousFunctionCb - Callback.
      */
     triggerPrevious: (previousFunctionCb: () => void) => void;
     /**
      * Callback to change the wizard page,
-     * @param {number} pageNo - Page Number.
+     * @param pageNo - Page Number.
      */
     changePageNumber: (pageNo: number) => void;
     /**
@@ -54,26 +54,28 @@ interface GithubAuthenticationProviderCreateWizardContentPropsInterface extends 
     template: IdentityProviderTemplateInterface;
     /**
      * Total wizard page count.
-     * @param {number} pageCount - Page number.
+     * @param pageCount - Page number.
      */
     setTotalPage: (pageCount: number) => void;
     /**
      * Callback to be triggered for form submit.
-     * @param values
+     * @param values - Form values.
      */
     onSubmit: (values: FacebookAuthenticationProviderCreateWizardFormValuesInterface) => void;
 }
 
+const FORM_ID: string = "facebook-authenticator-wizard-form";
+
 /**
  * Facebook Authentication Provider Create Wizard content component.
  *
- * @param {GithubAuthenticationProviderCreateWizardContentPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const FacebookAuthenticationProviderCreateWizardContent: FunctionComponent<
-    GithubAuthenticationProviderCreateWizardContentPropsInterface> = (
-        props: GithubAuthenticationProviderCreateWizardContentPropsInterface
+    GithubAuthenticationProviderCreateWizardContentPropsInterface
+> = (
+    props: GithubAuthenticationProviderCreateWizardContentPropsInterface
 ): ReactElement => {
 
     const {
@@ -121,8 +123,7 @@ export const FacebookAuthenticationProviderCreateWizardContent: FunctionComponen
     /**
      * Check whether IDP name is already exist or not.
      *
-     * @param value IDP name - IDP Name.
-     *
+     * @param value - IDP name - IDP Name.
      * @returns error msg if name is already taken.
      */
     const idpNameValidation = (value): string => {
@@ -147,9 +148,8 @@ export const FacebookAuthenticationProviderCreateWizardContent: FunctionComponen
     /**
      * Validates the Form.
      *
-     * @param {FacebookAuthenticationProviderCreateWizardFormValuesInterface} values - Form Values.
-     *
-     * @return {GithubAuthenticationProviderCreateWizardFormErrorValidationsInterface}
+     * @param values - Form Values.
+     * @returns Form validation.
      */
     const validateForm = (values: FacebookAuthenticationProviderCreateWizardFormValuesInterface):
         FacebookAuthenticationProviderCreateWizardFormErrorValidationsInterface => {
@@ -180,6 +180,7 @@ export const FacebookAuthenticationProviderCreateWizardContent: FunctionComponen
         (isIdPListRequestLoading !== undefined && isIdPListRequestLoading === false)
             ? (
                 <Wizard
+                    id={ FORM_ID }
                     initialValues={ { name: template?.idp?.name } }
                     onSubmit={
                         (values: FacebookAuthenticationProviderCreateWizardFormValuesInterface) => onSubmit(values)

--- a/apps/console/src/features/identity-providers/components/wizards/github/github-authentication-provider-create-wizard-content.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/github/github-authentication-provider-create-wizard-content.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -35,17 +35,17 @@ import { handleGetIDPListCallError } from "../../utils";
 interface GitHubAuthenticationProviderCreateWizardContentPropsInterface extends TestableComponentInterface {
     /**
      * Trigger form submit.
-     * @param {() => void} submitFunctionCb - Callback.
+     * @param submitFunctionCb - Callback.
      */
     triggerSubmission: (submitFunctionCb: () => void) => void;
     /**
      * Trigger previous page.
-     * @param {() => void} previousFunctionCb - Callback.
+     * @param previousFunctionCb - Callback.
      */
     triggerPrevious: (previousFunctionCb: () => void) => void;
     /**
      * Callback to change the wizard page,
-     * @param {number} pageNo - Page Number.
+     * @param pageNo - Page Number.
      */
     changePageNumber: (pageNo: number) => void;
     /**
@@ -54,26 +54,28 @@ interface GitHubAuthenticationProviderCreateWizardContentPropsInterface extends 
     template: IdentityProviderTemplateInterface;
     /**
      * Total wizard page count.
-     * @param {number} pageCount - Page number.
+     * @param pageCount - Page number.
      */
     setTotalPage: (pageCount: number) => void;
     /**
      * Callback to be triggered for form submit.
-     * @param values
+     * @param values - Form values.
      */
     onSubmit: (values: GitHubAuthenticationProviderCreateWizardFormValuesInterface) => void;
 }
 
+const FORM_ID: string = "github-authenticator-wizard-form";
+
 /**
  * GitHub Authentication Provider Create Wizard content component.
  *
- * @param {GitHubAuthenticationProviderCreateWizardContentPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const GitHubAuthenticationProviderCreateWizardContent: FunctionComponent<
-    GitHubAuthenticationProviderCreateWizardContentPropsInterface> = (
-        props: GitHubAuthenticationProviderCreateWizardContentPropsInterface
+    GitHubAuthenticationProviderCreateWizardContentPropsInterface
+> = (
+    props: GitHubAuthenticationProviderCreateWizardContentPropsInterface
 ): ReactElement => {
 
     const {
@@ -121,8 +123,7 @@ export const GitHubAuthenticationProviderCreateWizardContent: FunctionComponent<
     /**
      * Check whether IDP name is already exist or not.
      *
-     * @param value IDP name - IDP Name.
-     *
+     * @param value - IDP name.
      * @returns error msg if name is already taken.
      */
     const idpNameValidation = (value): string => {
@@ -147,9 +148,8 @@ export const GitHubAuthenticationProviderCreateWizardContent: FunctionComponent<
     /**
      * Validates the Form.
      *
-     * @param {GitHubAuthenticationProviderCreateWizardFormValuesInterface} values - Form Values.
-     *
-     * @return {GithubAuthenticationProviderCreateWizardFormErrorValidationsInterface}
+     * @param values - Form Values.
+     * @returns Form validation.
      */
     const validateForm = (values: GitHubAuthenticationProviderCreateWizardFormValuesInterface):
         GithubAuthenticationProviderCreateWizardFormErrorValidationsInterface => {
@@ -180,6 +180,7 @@ export const GitHubAuthenticationProviderCreateWizardContent: FunctionComponent<
         (isIdPListRequestLoading !== undefined && isIdPListRequestLoading === false)
             ? (
                 <Wizard
+                    id={ FORM_ID }
                     initialValues={ { name: template?.idp?.name } }
                     onSubmit={
                         (values: GitHubAuthenticationProviderCreateWizardFormValuesInterface) => onSubmit(values)

--- a/apps/console/src/features/identity-providers/components/wizards/google/google-authentication-provider-create-wizard-content.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/google/google-authentication-provider-create-wizard-content.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,7 +18,6 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Wizard, WizardPage } from "@wso2is/form";
-import { ContentLoader } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getIdentityProviderList } from "../../../api";
@@ -32,17 +31,17 @@ import { handleGetIDPListCallError } from "../../utils";
 interface GitHubAuthenticationProviderCreateWizardContentPropsInterface extends TestableComponentInterface {
     /**
      * Trigger form submit.
-     * @param {() => void} submitFunctionCb - Callback.
+     * @param submitFunctionCb - Callback.
      */
     triggerSubmission: (submitFunctionCb: () => void) => void;
     /**
      * Trigger previous page.
-     * @param {() => void} previousFunctionCb - Callback.
+     * @param previousFunctionCb - Callback.
      */
     triggerPrevious: (previousFunctionCb: () => void) => void;
     /**
      * Callback to change the wizard page,
-     * @param {number} pageNo - Page Number.
+     * @param pageNo - Page Number.
      */
     changePageNumber: (pageNo: number) => void;
     /**
@@ -51,12 +50,12 @@ interface GitHubAuthenticationProviderCreateWizardContentPropsInterface extends 
     template: IdentityProviderTemplateInterface;
     /**
      * Total wizard page count.
-     * @param {number} pageCount - Page number.
+     * @param pageCount - Page number.
      */
     setTotalPage: (pageCount: number) => void;
     /**
      * Callback to be triggered for form submit.
-     * @param values
+     * @param values - Form values.
      */
     onSubmit: (values: GoogleAuthenticationProviderCreateWizardFormValuesInterface) => void;
 }
@@ -83,15 +82,17 @@ export interface GoogleAuthenticationProviderCreateWizardFormValuesInterface {
     name: string;
 }
 
+const FORM_ID: string = "google-authenticator-wizard-form";
+
 /**
  * GitHub Authentication Provider Create Wizard content component.
  *
- * @param {GitHubAuthenticationProviderCreateWizardContentPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const GoogleAuthenticationProviderCreateWizardContent: FunctionComponent<
-    GitHubAuthenticationProviderCreateWizardContentPropsInterface> = (
+    GitHubAuthenticationProviderCreateWizardContentPropsInterface
+> = (
     props: GitHubAuthenticationProviderCreateWizardContentPropsInterface
 ): ReactElement => {
 
@@ -140,8 +141,7 @@ export const GoogleAuthenticationProviderCreateWizardContent: FunctionComponent<
     /**
      * Check whether IDP name is already exist or not.
      *
-     * @param value IDP name - IDP Name.
-     *
+     * @param value - IDP name - IDP Name.
      * @returns error msg if name is already taken.
      */
     const idpNameValidation = (value: string): string => {
@@ -166,6 +166,7 @@ export const GoogleAuthenticationProviderCreateWizardContent: FunctionComponent<
         (isIdPListRequestLoading !== undefined && isIdPListRequestLoading === false)
             ? (
                 <Wizard
+                    id={ FORM_ID }
                     initialValues={ { name: template?.idp?.name } }
                     onSubmit={
                         (values: GoogleAuthenticationProviderCreateWizardFormValuesInterface) => onSubmit(values)

--- a/apps/console/src/features/identity-providers/components/wizards/oidc-authentication-wizard-page.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/oidc-authentication-wizard-page.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +16,7 @@
  * under the License.
  */
 
- import { TestableComponentInterface } from "@wso2is/core/models";
+import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Wizard, WizardPage } from "@wso2is/form";
 import React, { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
@@ -37,6 +37,15 @@ const URL_MAX_LENGTH: number = 2048;
     setTotalPage: (number) => void;
     onSubmit: (values)=> void;
 }
+
+const FORM_ID: string = "oidc-authenticator-wizard-form";
+
+/**
+ * OIDC Authenticator wizard form.
+ *
+ * @param props - Props injected to the component.
+ * @returns Functional component.
+ */
 export const OidcAuthenticationWizardFrom = (props: OidcAuthenticationWizardFromPropsInterface): ReactElement => {
 
     const {
@@ -56,6 +65,7 @@ export const OidcAuthenticationWizardFrom = (props: OidcAuthenticationWizardFrom
      */
     const clientIdRegexValidation= (value) => {
         const regex = new RegExp(".*");
+
         if (!regex.test(value)) {
             return "Please enter a valid input.";
         }
@@ -63,40 +73,42 @@ export const OidcAuthenticationWizardFrom = (props: OidcAuthenticationWizardFrom
 
     return (
         <>
-        <Wizard
-            initialValues={ { name: template?.idp?.name } }
-            onSubmit={ (values)=>onSubmit(values) }
-            triggerSubmit={ (submitFunction) => triggerSubmission(submitFunction) }
-            triggerPrevious= { (previousFunction) => triggerPrevious(previousFunction) }
-            changePage= { (step:number)=> changePageNumber(step) }
-            setTotalPage= { (step:number)=> setTotalPage(step) }
-            data-testid={ testId }
-        >
-            <WizardPage
-                // TODO: Need to refactor once wizard can handle validation properly.
-                validate={ (values): any => {
-
-                    const errors: any = {};
-
-                    if (!values.name) {
-                        errors.name = "This is a required field.";
-                    }
-                    if (!values.clientId) {
-                        errors.clientId = "This is a required field.";
-                    }
-                    if (!values.clientSecret) {
-                        errors.clientSecret = "This is a required field.";
-                    }
-                    if (!values.authorizationEndpointUrl) {
-                        errors.authorizationEndpointUrl = "This is a required field.";
-                    }
-                    if (!values.tokenEndpointUrl) {
-                        errors.tokenEndpointUrl = "This is a required field.";
-                    }
-                    return errors;
-                } }
+            <Wizard
+                id={ FORM_ID }
+                initialValues={ { name: template?.idp?.name } }
+                onSubmit={ (values)=>onSubmit(values) }
+                triggerSubmit={ (submitFunction) => triggerSubmission(submitFunction) }
+                triggerPrevious= { (previousFunction) => triggerPrevious(previousFunction) }
+                changePage= { (step:number)=> changePageNumber(step) }
+                setTotalPage= { (step:number)=> setTotalPage(step) }
+                data-testid={ testId }
             >
-            <Field.Input
+                <WizardPage
+                    // TODO: Need to refactor once wizard can handle validation properly.
+                    validate={ (values): any => {
+
+                        const errors: any = {};
+
+                        if (!values.name) {
+                            errors.name = "This is a required field.";
+                        }
+                        if (!values.clientId) {
+                            errors.clientId = "This is a required field.";
+                        }
+                        if (!values.clientSecret) {
+                            errors.clientSecret = "This is a required field.";
+                        }
+                        if (!values.authorizationEndpointUrl) {
+                            errors.authorizationEndpointUrl = "This is a required field.";
+                        }
+                        if (!values.tokenEndpointUrl) {
+                            errors.tokenEndpointUrl = "This is a required field.";
+                        }
+
+                        return errors;
+                    } }
+                >
+                    <Field.Input
                         ariaLabel= "name"
                         inputType= "name"
                         name="name"
@@ -175,13 +187,13 @@ export const OidcAuthenticationWizardFrom = (props: OidcAuthenticationWizardFrom
                     />
                 </WizardPage>
             </Wizard>
-            </>
+        </>
     );
 };
 
 /**
  * Default props for the oidc creation wizard.
  */
- OidcAuthenticationWizardFrom.defaultProps = {
+OidcAuthenticationWizardFrom.defaultProps = {
     "data-testid": "idp-edit-idp-create-wizard"
 };

--- a/apps/console/src/features/identity-providers/components/wizards/oidc-authentication-wizard-page.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/oidc-authentication-wizard-page.tsx
@@ -72,122 +72,120 @@ export const OidcAuthenticationWizardFrom = (props: OidcAuthenticationWizardFrom
     };
 
     return (
-        <>
-            <Wizard
-                id={ FORM_ID }
-                initialValues={ { name: template?.idp?.name } }
-                onSubmit={ (values)=>onSubmit(values) }
-                triggerSubmit={ (submitFunction) => triggerSubmission(submitFunction) }
-                triggerPrevious= { (previousFunction) => triggerPrevious(previousFunction) }
-                changePage= { (step:number)=> changePageNumber(step) }
-                setTotalPage= { (step:number)=> setTotalPage(step) }
-                data-testid={ testId }
+        <Wizard
+            id={ FORM_ID }
+            initialValues={ { name: template?.idp?.name } }
+            onSubmit={ (values)=>onSubmit(values) }
+            triggerSubmit={ (submitFunction) => triggerSubmission(submitFunction) }
+            triggerPrevious= { (previousFunction) => triggerPrevious(previousFunction) }
+            changePage= { (step:number)=> changePageNumber(step) }
+            setTotalPage= { (step:number)=> setTotalPage(step) }
+            data-testid={ testId }
+        >
+            <WizardPage
+                // TODO: Need to refactor once wizard can handle validation properly.
+                validate={ (values): any => {
+
+                    const errors: any = {};
+
+                    if (!values.name) {
+                        errors.name = "This is a required field.";
+                    }
+                    if (!values.clientId) {
+                        errors.clientId = "This is a required field.";
+                    }
+                    if (!values.clientSecret) {
+                        errors.clientSecret = "This is a required field.";
+                    }
+                    if (!values.authorizationEndpointUrl) {
+                        errors.authorizationEndpointUrl = "This is a required field.";
+                    }
+                    if (!values.tokenEndpointUrl) {
+                        errors.tokenEndpointUrl = "This is a required field.";
+                    }
+
+                    return errors;
+                } }
             >
-                <WizardPage
-                    // TODO: Need to refactor once wizard can handle validation properly.
-                    validate={ (values): any => {
-
-                        const errors: any = {};
-
-                        if (!values.name) {
-                            errors.name = "This is a required field.";
-                        }
-                        if (!values.clientId) {
-                            errors.clientId = "This is a required field.";
-                        }
-                        if (!values.clientSecret) {
-                            errors.clientSecret = "This is a required field.";
-                        }
-                        if (!values.authorizationEndpointUrl) {
-                            errors.authorizationEndpointUrl = "This is a required field.";
-                        }
-                        if (!values.tokenEndpointUrl) {
-                            errors.tokenEndpointUrl = "This is a required field.";
-                        }
-
-                        return errors;
-                    } }
-                >
-                    <Field.Input
-                        ariaLabel= "name"
-                        inputType= "name"
-                        name="name"
-                        label={ t("console:develop.features.authenticationProvider.forms." +
-                            "generalDetails.name.label") }
-                        required={ true }
-                        maxLength={ 50 }
-                        minLength={ 3 }
-                        // TODO: checkon key press usecase
-                        // onKeyDown={ keyPressed }
-                        data-testid={ `${ testId }-idp-name` }
-                        width={ 13 }
-                    />
-                    <Field.Input
-                        ariaLabel= "clientId"
-                        inputType= "identifier"
-                        name="clientId"
-                        label={ "Client ID" }
-                        required={ true }
-                        autoComplete={ "" + Math.random() }
-                        maxLength={ CLIENT_ID_MAX_LENGTH }
-                        minLength={ 3 }
-                        validation ={ (value)=>clientIdRegexValidation(value) }
-                        // TODO: checkon key press usecase
-                        // onKeyDown={ keyPressed }
-                        data-testid={ `${ testId }-idp-client-id` }
-                        width={ 13 }
-                    />
-                    <Field.Input
-                        ariaLabel= "clientSecret"
-                        inputType="password"
-                        className="addon-field-wrapper"
-                        name="clientSecret"
-                        label={ "Client secret" }
-                        required={ true }
-                        hidePassword={ t("common:hide") }
-                        showPassword={ t("common:show") }
-                        autoComplete={ "" + Math.random() }
-                        maxLength={ CLIENT_SECRET_MAX_LENGTH }
-                        minLength={ 3 }
-                        type="password"
-                        // TODO: checkon key press usecase
-                        // onKeyDown={ keyPressed }
-                        data-testid={ `${ testId }-idp-client-secret` }
-                        width={ 13 }
-                    />
-                    <Field.Input
-                        ariaLabel= "authorizationEndpointUrl"
-                        inputType="url"
-                        name="authorizationEndpointUrl"
-                        label={ "Authorization endpoint URL" }
-                        required={ true }
-                        placeholder={ "https://ENTERPRISE_DOMAIN/authorize" }
-                        autoComplete={ "" + Math.random() }
-                        maxLength={ URL_MAX_LENGTH }
-                        minLength={ 3 }
-                        // TODO: checkon key press usecase
-                        // onKeyDown={ keyPressed }
-                        data-testid={ `${ testId }-idp-authorization-endpoint-url` }
-                        width={ 13 }
-                    />
-                    <Field.Input
-                        ariaLabel= "tokenEndpointUrl"
-                        inputType="url"
-                        name="tokenEndpointUrl"
-                        label={ "Token endpoint URL" }
-                        required={ true }
-                        placeholder={ "https://ENTERPRISE_DOMAIN/token" }
-                        autoComplete={ "" + Math.random() }
-                        maxLength={ URL_MAX_LENGTH }
-                        minLength={ 3 }
-                        // TODO: checkon key press usecase
-                        // onKeyDown={ keyPressed }
-                        data-testid={ `${ testId }-idp-token-endpoint-url` }
-                        width={ 13 }
-                    />
-                </WizardPage>
-            </Wizard>
-        </>
+                <Field.Input
+                    ariaLabel= "name"
+                    inputType= "name"
+                    name="name"
+                    label={ t("console:develop.features.authenticationProvider.forms." +
+                        "generalDetails.name.label") }
+                    required={ true }
+                    maxLength={ 50 }
+                    minLength={ 3 }
+                    // TODO: checkon key press usecase
+                    // onKeyDown={ keyPressed }
+                    data-testid={ `${ testId }-idp-name` }
+                    width={ 13 }
+                />
+                <Field.Input
+                    ariaLabel= "clientId"
+                    inputType= "identifier"
+                    name="clientId"
+                    label={ "Client ID" }
+                    required={ true }
+                    autoComplete={ "" + Math.random() }
+                    maxLength={ CLIENT_ID_MAX_LENGTH }
+                    minLength={ 3 }
+                    validation ={ (value)=>clientIdRegexValidation(value) }
+                    // TODO: checkon key press usecase
+                    // onKeyDown={ keyPressed }
+                    data-testid={ `${ testId }-idp-client-id` }
+                    width={ 13 }
+                />
+                <Field.Input
+                    ariaLabel= "clientSecret"
+                    inputType="password"
+                    className="addon-field-wrapper"
+                    name="clientSecret"
+                    label={ "Client secret" }
+                    required={ true }
+                    hidePassword={ t("common:hide") }
+                    showPassword={ t("common:show") }
+                    autoComplete={ "" + Math.random() }
+                    maxLength={ CLIENT_SECRET_MAX_LENGTH }
+                    minLength={ 3 }
+                    type="password"
+                    // TODO: checkon key press usecase
+                    // onKeyDown={ keyPressed }
+                    data-testid={ `${ testId }-idp-client-secret` }
+                    width={ 13 }
+                />
+                <Field.Input
+                    ariaLabel= "authorizationEndpointUrl"
+                    inputType="url"
+                    name="authorizationEndpointUrl"
+                    label={ "Authorization endpoint URL" }
+                    required={ true }
+                    placeholder={ "https://ENTERPRISE_DOMAIN/authorize" }
+                    autoComplete={ "" + Math.random() }
+                    maxLength={ URL_MAX_LENGTH }
+                    minLength={ 3 }
+                    // TODO: checkon key press usecase
+                    // onKeyDown={ keyPressed }
+                    data-testid={ `${ testId }-idp-authorization-endpoint-url` }
+                    width={ 13 }
+                />
+                <Field.Input
+                    ariaLabel= "tokenEndpointUrl"
+                    inputType="url"
+                    name="tokenEndpointUrl"
+                    label={ "Token endpoint URL" }
+                    required={ true }
+                    placeholder={ "https://ENTERPRISE_DOMAIN/token" }
+                    autoComplete={ "" + Math.random() }
+                    maxLength={ URL_MAX_LENGTH }
+                    minLength={ 3 }
+                    // TODO: checkon key press usecase
+                    // onKeyDown={ keyPressed }
+                    data-testid={ `${ testId }-idp-token-endpoint-url` }
+                    width={ 13 }
+                />
+            </WizardPage>
+        </Wizard>
     );
 };
 

--- a/apps/console/src/features/identity-providers/components/wizards/organization-enterprise/organization-enterprise-authentication-provider-create-wizard-content.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/organization-enterprise/organization-enterprise-authentication-provider-create-wizard-content.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,17 +36,17 @@ interface OrganizationEnterpriseAuthenticationProviderCreateWizardContentPropsIn
     extends IdentifiableComponentInterface {
     /**
      * Trigger form submit.
-     * @param {() => void} submitFunctionCb - Callback.
+     * @param submitFunctionCb - Callback.
      */
     triggerSubmission: (submitFunctionCb: () => void) => void;
     /**
      * Trigger previous page.
-     * @param {() => void} previousFunctionCb - Callback.
+     * @param previousFunctionCb - Callback.
      */
     triggerPrevious: (previousFunctionCb: () => void) => void;
     /**
      * Callback to change the wizard page,
-     * @param {number} pageNo - Page Number.
+     * @param pageNo - Page Number.
      */
     changePageNumber: (pageNo: number) => void;
     /**
@@ -55,22 +55,23 @@ interface OrganizationEnterpriseAuthenticationProviderCreateWizardContentPropsIn
     template: IdentityProviderTemplateInterface;
     /**
      * Total wizard page count.
-     * @param {number} pageCount - Page number.
+     * @param pageCount - Page number.
      */
     setTotalPage: (pageCount: number) => void;
     /**
      * Callback to be triggered for form submit.
-     * @param values
+     * @param values - Form values.
      */
     onSubmit: (values: OrganizationEnterpriseAuthenticationProviderCreateWizardFormErrorValidationsInterface) => void;
 }
 
+const FORM_ID: string = "organization-enterprise-authenticator-wizard-form";
+
 /**
  * Authentication Provider Create Wizard content component.
  *
- * @param {OrganizationEnterpriseAuthenticationProviderCreateWizardContentPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const OrganizationEnterpriseAuthenticationProviderCreateWizardContent:
     FunctionComponent<OrganizationEnterpriseAuthenticationProviderCreateWizardContentPropsInterface> = (
@@ -122,8 +123,7 @@ export const OrganizationEnterpriseAuthenticationProviderCreateWizardContent:
         /**
      * Check whether IDP name is already exist or not.
      *
-     * @param value IDP name - IDP Name.
-     *
+     * @param value - IDP name.
      * @returns error msg if name is already taken.
      */
         const idpNameValidation = (value): string => {
@@ -148,9 +148,8 @@ export const OrganizationEnterpriseAuthenticationProviderCreateWizardContent:
         /**
      * Validates the Form.
      *
-     * @param {FacebookAuthenticationProviderCreateWizardFormValuesInterface} values - Form Values.
-     *
-     * @return {GithubAuthenticationProviderCreateWizardFormErrorValidationsInterface}
+     * @param values - Form Values.
+     * @returns Form validation.
      */
         const validateForm = (values: OrganizationEnterpriseAuthenticationProviderCreateWizardFormValuesInterface):
         OrganizationEnterpriseAuthenticationProviderCreateWizardFormErrorValidationsInterface => {
@@ -172,6 +171,7 @@ export const OrganizationEnterpriseAuthenticationProviderCreateWizardContent:
             (isIdPListRequestLoading !== undefined && isIdPListRequestLoading === false)
                 ? (
                     <Wizard
+                        id={ FORM_ID }
                         initialValues={ { name: template?.idp?.name } }
                         onSubmit={
                             (values: OrganizationEnterpriseAuthenticationProviderCreateWizardFormValuesInterface) =>

--- a/apps/console/src/features/oidc-scopes/components/wizards/add-oidc-scope-form.tsx
+++ b/apps/console/src/features/oidc-scopes/components/wizards/add-oidc-scope-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,7 +18,7 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Wizard, WizardPage } from "@wso2is/form";
-import React, { FunctionComponent, ReactElement, useEffect } from "react";
+import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 
 const SCOPE_NAME_MAX_LENGTH: number = 40;
@@ -36,12 +36,13 @@ interface AddOIDCScopeFormPropsInterface extends TestableComponentInterface {
     onSubmit: (values: any) => void;
 }
 
+const FORM_ID: string = "oidc-scope-add-form";
+
 /**
  * Add OIDC scope form component.
  *
- * @param {AddOIDCScopeFormPropsInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const AddOIDCScopeForm: FunctionComponent<AddOIDCScopeFormPropsInterface> = (
     props: AddOIDCScopeFormPropsInterface
@@ -49,7 +50,6 @@ export const AddOIDCScopeForm: FunctionComponent<AddOIDCScopeFormPropsInterface>
 
     const {
         initialValues,
-        triggerSubmit,
         triggerSubmission,
         onSubmit,
         [ "data-testid" ]: testId
@@ -65,88 +65,93 @@ export const AddOIDCScopeForm: FunctionComponent<AddOIDCScopeFormPropsInterface>
         };
     };
 
-let triggerPreviousForm: () => void;
+    let triggerPreviousForm: () => void;
 
     return (
-    <Wizard
-        initialValues={ {
-            scopeName: initialValues?.scopeName,
-            displayName: initialValues?.displayName,
-            description: initialValues?.description
-        } }
-        onSubmit={ (values) => {
-            onSubmit(getFormValues(values));
-        } }
-        triggerSubmit={ (submitFunction) => triggerSubmission(submitFunction) }
-        triggerPrevious={ (previousFunction: () => void) => {
-            triggerPreviousForm = previousFunction; } }
-    >
-        <WizardPage
-            validate={ (values): any => {
-                const errors:any = {};
-                if (!values.scopeName && !initialValues?.scopeName) {
-                    errors.scopeName = t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
-                    "scopeName.validations.empty");
-                }
-                if (!values.displayName && !initialValues?.displayName) {
-                    errors.displayName = t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
-                    "displayName.validations.empty");
-                }
-                return errors;
+        <Wizard
+            id={ FORM_ID }
+            initialValues={ {
+                description: initialValues?.description,
+                displayName: initialValues?.displayName,
+                scopeName: initialValues?.scopeName
+            } }
+            onSubmit={ (values) => {
+                onSubmit(getFormValues(values));
+            } }
+            triggerSubmit={ (submitFunction) => triggerSubmission(submitFunction) }
+            triggerPrevious={ (previousFunction: () => void) => {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                triggerPreviousForm = previousFunction;
             } }
         >
-            <Field.Input
-                data-testid={ `${ testId }-oidc-scope-form-name-input` }
-                ariaLabel="scopeName"
-                inputType="name"
-                name="scopeName"
-                label={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs.scopeName.label") }
-                required={ true }
-                requiredErrorMessage={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
-                    "scopeName.validations.empty") }
-                placeholder={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
-                    "scopeName.placeholder") }
-                validation={ (value: string) => {
-                    if (!value.toString().match(/^[\w.-]+$/)) {
-                        return t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
-                            "scopeName.validations.invalid");
+            <WizardPage
+                validate={ (values): any => {
+                    const errors:any = {};
+
+                    if (!values.scopeName && !initialValues?.scopeName) {
+                        errors.scopeName = t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
+                        "scopeName.validations.empty");
                     }
+                    if (!values.displayName && !initialValues?.displayName) {
+                        errors.displayName = t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
+                        "displayName.validations.empty");
+                    }
+
+                    return errors;
                 } }
-                maxLength={ SCOPE_NAME_MAX_LENGTH }
-                minLength={ 3 }
-                width={ FIELD_WIDTH }
-            />
-            <Field.Input
-                ariaLabel="displayName"
-                inputType="resource_name"
-                data-testid={ `${ testId }-oidc-scope-form-name-input` }
-                name="displayName"
-                label={ t("console:manage.features.oidcScopes.forms.addScopeForm." +
-                    "inputs.displayName.label") }
-                required={ true }
-                message={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
-                    "displayName.validations.empty") }
-                placeholder={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
-                    "displayName.placeholder") }
-                maxLength={ SCOPE_DISPLAY_NAME_MAX_LENGTH }
-                minLength={ 3 }
-                width={ FIELD_WIDTH }
-            />
-            <Field.Input
-                data-testid={ `${ testId }-oidc-scope-form-name-input` }
-                ariaLabel="description"
-                inputType="description"
-                name="description"
-                label={ t("console:manage.features.oidcScopes.forms.addScopeForm." +
-                    "inputs.description.label") }
-                required={ false }
-                placeholder={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
-                    "description.placeholder") }
-                maxLength={ SCOPE_DESCRIPTION_MAX_LENGTH }
-                minLength={ 3 }
-                width={ FIELD_WIDTH }
-            />
-        </WizardPage>
-    </Wizard>
+            >
+                <Field.Input
+                    data-testid={ `${ testId }-oidc-scope-form-name-input` }
+                    ariaLabel="scopeName"
+                    inputType="name"
+                    name="scopeName"
+                    label={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs.scopeName.label") }
+                    required={ true }
+                    requiredErrorMessage={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
+                        "scopeName.validations.empty") }
+                    placeholder={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
+                        "scopeName.placeholder") }
+                    validation={ (value: string) => {
+                        if (!value.toString().match(/^[\w.-]+$/)) {
+                            return t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
+                                "scopeName.validations.invalid");
+                        }
+                    } }
+                    maxLength={ SCOPE_NAME_MAX_LENGTH }
+                    minLength={ 3 }
+                    width={ FIELD_WIDTH }
+                />
+                <Field.Input
+                    ariaLabel="displayName"
+                    inputType="resource_name"
+                    data-testid={ `${ testId }-oidc-scope-form-name-input` }
+                    name="displayName"
+                    label={ t("console:manage.features.oidcScopes.forms.addScopeForm." +
+                        "inputs.displayName.label") }
+                    required={ true }
+                    message={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
+                        "displayName.validations.empty") }
+                    placeholder={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
+                        "displayName.placeholder") }
+                    maxLength={ SCOPE_DISPLAY_NAME_MAX_LENGTH }
+                    minLength={ 3 }
+                    width={ FIELD_WIDTH }
+                />
+                <Field.Input
+                    data-testid={ `${ testId }-oidc-scope-form-name-input` }
+                    ariaLabel="description"
+                    inputType="description"
+                    name="description"
+                    label={ t("console:manage.features.oidcScopes.forms.addScopeForm." +
+                        "inputs.description.label") }
+                    required={ false }
+                    placeholder={ t("console:manage.features.oidcScopes.forms.addScopeForm.inputs." +
+                        "description.placeholder") }
+                    maxLength={ SCOPE_DESCRIPTION_MAX_LENGTH }
+                    minLength={ 3 }
+                    width={ FIELD_WIDTH }
+                />
+            </WizardPage>
+        </Wizard>
     );
 };

--- a/apps/console/src/features/oidc-scopes/pages/oidc-scopes-edit.tsx
+++ b/apps/console/src/features/oidc-scopes/pages/oidc-scopes-edit.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -59,12 +59,13 @@ interface OIDCScopesEditPagePathParams {
  */
 type OIDCScopesEditPageInterface = TestableComponentInterface;
 
+const FORM_ID: string = "oidc-scope-form";
+
 /**
  * OIDC Scopes Edit page component.
  *
- * @param {OIDCScopesEditPageInterface} props - Props injected to the component.
- *
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPagePathParams> &
     OIDCScopesEditPageInterface> = (
@@ -101,7 +102,7 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
         const [ claims, setClaims ] = useState<Claim[]>([]);
         const [ isScopeRequestLoading, setScopeRequestLoading ] = useState<boolean>(true);
         const [ isAttributeRequestLoading, setIsAttributeRequestLoading ] = useState<boolean>(true);
-        const [ listItemLimit, setListItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);
+        const [ listItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);
         const [ OIDCAttributes, setOIDCAttributes ] = useState<ExternalClaim[]>(undefined);
         const [ selectedAttributes, setSelectedAttributes ] = useState<ExternalClaim[]>([]);
         const [ tempSelectedAttributes, setTempSelectedAttributes ] = useState<ExternalClaim[]>([]);
@@ -330,7 +331,7 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
         /**
         * Handles sort order change.
         *
-        * @param {boolean} isAscending.
+        * @param isAscending - Is ascending or not.
         */
         const handleSortOrderChange = (isAscending: boolean) => {
             setSortOrder(isAscending);
@@ -339,8 +340,8 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
         /**
         * Handle sort strategy change.
         *
-        * @param {React.SyntheticEvent<HTMLElement>} event.
-        * @param {DropdownProps} data.
+        * @param event - Sort event..
+        * @param data - Dropdown data.
         */
         const handleSortStrategyChange = (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => {
             setSortByStrategy(SORT_BY.filter(option => option.value === data.value)[ 0 ]);
@@ -435,6 +436,7 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
                             <Grid.Column width={ 6 }>
                                 { !isScopeRequestLoading && !isAttributeRequestLoading ? (
                                     <Form
+                                        id={ FORM_ID }
                                         uncontrolledForm={ false }
                                         onSubmit={ (values): void => {
                                             onSubmit(values);
@@ -483,8 +485,9 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
                                             minLength={ 3 }
                                             readOnly={ isReadOnly }
                                         />
-                                        { !isReadOnly &&
-                                            (<Field.Button
+                                        { !isReadOnly && (
+                                            <Field.Button
+                                                form={ FORM_ID }
                                                 ariaLabel="submit"
                                                 size="small"
                                                 loading={ isSubmitting }
@@ -492,8 +495,8 @@ const OIDCScopesEditPage: FunctionComponent<RouteComponentProps<OIDCScopesEditPa
                                                 buttonType="primary_btn"
                                                 label={ t("common:update") }
                                                 name="submit"
-                                            />)
-                                        }
+                                            />
+                                        ) }
                                     </Form>
                                 ) : (
                                     <Placeholder>

--- a/apps/console/src/features/organizations/components/add-organization-modal.tsx
+++ b/apps/console/src/features/organizations/components/add-organization-modal.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -53,10 +53,13 @@ export interface AddOrganizationModalPropsInterface extends IdentifiableComponen
     onUpdate?: () => void;
 }
 
+const FORM_ID: string = "organization-add-modal-form";
+
 /**
  * An app creation wizard with only the minimal features.
  *
- * @param {AddOrganizationModalPropsInterface} props Props to be injected into the component.
+ * @param props - Props to be injected into the component.
+ * @returns Functional component.
  */
 export const AddOrganizationModal: FunctionComponent<AddOrganizationModalPropsInterface> = (
     props: AddOrganizationModalPropsInterface
@@ -68,7 +71,7 @@ export const AddOrganizationModal: FunctionComponent<AddOrganizationModalPropsIn
     const dispatch = useDispatch();
 
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const [ type, setType ] = useState<ORGANIZATION_TYPE>(ORGANIZATION_TYPE.STRUCTURAL);
+    const [ type ] = useState<ORGANIZATION_TYPE>(ORGANIZATION_TYPE.STRUCTURAL);
 
     const submitForm = useRef<() => void>();
 
@@ -193,6 +196,7 @@ export const AddOrganizationModal: FunctionComponent<AddOrganizationModalPropsIn
                         <Grid.Row columns={ 1 }>
                             <Grid.Column width={ 16 }>
                                 <Form
+                                    id={ FORM_ID }
                                     uncontrolledForm={ false }
                                     onSubmit={ submitOrganization }
                                     validate={ validate }

--- a/apps/console/src/features/organizations/components/edit-organization/organization-overview.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization/organization-overview.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -32,7 +32,6 @@ import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Button, CheckboxProps, Divider, Grid } from "semantic-ui-react";
 import { FeatureConfigInterface } from "../../../core";
-import { DISABLED } from "../../../userstores";
 import { deleteOrganization, patchOrganization } from "../../api";
 import {
     ORGANIZATION_DESCRIPTION_MAX_LENGTH,
@@ -68,6 +67,14 @@ interface OrganizationOverviewPropsInterface extends SBACInterface<FeatureConfig
     onOrganizationDelete: (organizationId: string) => void;
 }
 
+const FORM_ID: string = "organization-overview-form";
+
+/**
+ * Organization overview component.
+ *
+ * @param props - Props injected to the component.
+ * @returns Functional component.
+ */
 export const OrganizationOverview: FunctionComponent<OrganizationOverviewPropsInterface> = (
     props: OrganizationOverviewPropsInterface
 ): ReactElement => {
@@ -320,7 +327,7 @@ export const OrganizationOverview: FunctionComponent<OrganizationOverviewPropsIn
 
         if (values?.description && (values?.description.length > ORGANIZATION_DESCRIPTION_MAX_LENGTH
             || values?.description.length < ORGANIZATION_DESCRIPTION_MIN_LENGTH)) {
-            error.description = `Organization description length should be at least 
+            error.description = `Organization description length should be at least
             ${ ORGANIZATION_DESCRIPTION_MIN_LENGTH } and at most ${ ORGANIZATION_DESCRIPTION_MAX_LENGTH } characters`;
         }
 
@@ -334,6 +341,7 @@ export const OrganizationOverview: FunctionComponent<OrganizationOverviewPropsIn
                     <Grid.Row columns={ 1 }>
                         <Grid.Column width={ 8 }>
                             <Form
+                                id={ FORM_ID }
                                 data-testid={ `${testId}-form` }
                                 onSubmit={ handleSubmit }
                                 uncontrolledForm={ false }

--- a/apps/console/src/features/secrets/components/add-secret-wizard.tsx
+++ b/apps/console/src/features/secrets/components/add-secret-wizard.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -59,13 +59,14 @@ type FieldDropDownOption = {
     value: string;
 }
 
+const FORM_ID: string = "secrets-add-wizard-form";
+
 /**
  * This wizard is sorely responsible for adding a new `secret` for a
  * given `secret-type`.
  *
- * @param props {AddSecretWizardProps}
- * @constructor
- * @return {ReactElement}
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps): ReactElement => {
 
@@ -89,13 +90,13 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
     const [ secretNameInvalid, setSecretNameInvalid ] = useState<boolean>(false);
     const [ secretValueInvalid, setSecretValueInvalid ] = useState<boolean>(false);
     const [ initialFormValues, setInitialFormValues ] = useState<Record<string, any>>({});
-    const [ showInfoMessage, setShowInfoMessage ] = useState<boolean>(true);
+    const [ showInfoMessage ] = useState<boolean>(true);
 
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
     /**
      * Initial state hook. Fetches the available secret types and
-     * sets it to {@code secretTypes} state. Also, it fetches the
+     * sets it to `secretTypes` state. Also, it fetches the
      * available secrets for the initial secret-type :)
      */
     useEffect(() => {
@@ -151,8 +152,8 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
     }, []);
 
     /**
-     * Triggered whenever {@code secretNameInvalid} or
-     * {@code secretValueInvalid} changes.
+     * Triggered whenever `secretNameInvalid` or
+     * `secretValueInvalid` changes.
      */
     useEffect(() => {
         setSubmitShouldBeDisabled(secretNameInvalid || secretValueInvalid);
@@ -209,9 +210,9 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
 
     /**
      * Called when wizard Cancel button click and when after a
-     * successful submission of the wizard. {@see onWizardSubmission}
+     * successful submission of the wizard. @see onWizardSubmission.
      *
-     * @param shouldRefreshTheSecretListOnClose {boolean}
+     * @param shouldRefreshTheSecretListOnClose - should refresh the secret list on close or not.
      */
     const onWizardClose = (shouldRefreshTheSecretListOnClose?: boolean): void => {
         if (onClose)
@@ -225,7 +226,7 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
      * is a static secret-type supported by the API.
      *
      * @remarks Note that this function is WIP and may change in the future.
-     * @return {Promise<FieldDropDownOption[]>}
+     * @returns Promise of type FieldDropDownOption[].
      */
     const fetchSecretTypes = async (): Promise<FieldDropDownOption[]> => {
         // FIXME: Practically, this should be a API call that fetches all the available
@@ -241,8 +242,10 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
     };
 
     /**
-     * Fetches all the secrets for the {@param secretType}.
-     * @param secretType {string}
+     * Fetches all the secrets for the given secret type.
+     *
+     * @param secretType - Type of the secret.
+     * @returns Promise fo type SecretModel[].
      */
     const fetchAllSecretsForSecretType = async (secretType: string): Promise<SecretModel[]> => {
         try {
@@ -281,6 +284,7 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
             <Modal.Content className="content-container">
                 { alert && alertComponent }
                 <Form
+                    id={ FORM_ID }
                     ref={ formRef }
                     onSubmit={ onWizardSubmission }
                     uncontrolledForm={ false }
@@ -351,8 +355,8 @@ const AddSecretWizard: FC<AddSecretWizardProps> = (props: AddSecretWizardProps):
                                 type="info"
                                 content={
                                     t("console:develop.features.secrets.banners.secretIsHidden.content",
-                                    { productName: config.ui?.productName }
-                                ) }
+                                        { productName: config.ui?.productName })
+                                }
                             />
                         )
                     }

--- a/apps/console/src/features/secrets/components/secret-description-form.tsx
+++ b/apps/console/src/features/secrets/components/secret-description-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -32,6 +32,14 @@ export type SecretDescriptionFormProps = {
     editingSecret: SecretModel;
 } & IdentifiableComponentInterface;
 
+const FORM_ID: string = "secrets-description-form";
+
+/**
+ * Secret description form.
+ *
+ * @param props - Props injected to the component.
+ * @returns Functional component.
+ */
 const SecretDescriptionForm: FC<SecretDescriptionFormProps> = (
     props: SecretDescriptionFormProps
 ): ReactElement => {
@@ -54,8 +62,8 @@ const SecretDescriptionForm: FC<SecretDescriptionFormProps> = (
     }, []);
 
     /**
-     * This is used only for validation. Even though {@code secretDescription}
-     * and form submission value is equal, we use the submission's {@code values}.
+     * This is used only for validation. Even though `secretDescription`
+     * and form submission value is equal, we use the submission's `values`.
      */
     useEffect(() => {
         if (!secretDescription ||
@@ -70,7 +78,7 @@ const SecretDescriptionForm: FC<SecretDescriptionFormProps> = (
     /**
      * Updates a secret. To update both `value` and `description` must
      * be in the form values otherwise the API will complain with 400.
-     * @param values {Record<string, any>}
+     * @param values - Form values.
      */
     const updateSecretDescription = (values: Record<string, any>): void => {
 
@@ -109,6 +117,7 @@ const SecretDescriptionForm: FC<SecretDescriptionFormProps> = (
                     level: AlertLevels.ERROR,
                     message: error.response.data?.message
                 }));
+
                 return;
             }
             dispatch(addAlert({
@@ -124,7 +133,11 @@ const SecretDescriptionForm: FC<SecretDescriptionFormProps> = (
 
     return (
         <Fragment>
-            <Form uncontrolledForm={ true } onSubmit={ updateSecretDescription }>
+            <Form
+                id={ FORM_ID }
+                uncontrolledForm={ true }
+                onSubmit={ updateSecretDescription }
+            >
                 <Field.Textarea
                     data-componentid={ `${ testId }-description-field` }
                     ariaLabel={
@@ -145,6 +158,7 @@ const SecretDescriptionForm: FC<SecretDescriptionFormProps> = (
                 />
                 <Show when={ AccessControlConstants.SECRET_EDIT }>
                     <Field.Button
+                        form={ FORM_ID }
                         data-componentid={ `${ testId }-update-button` }
                         loading={ loading }
                         disabled={ !canUpdateDescription || loading }

--- a/modules/form/src/components/field-button.tsx
+++ b/modules/form/src/components/field-button.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,6 +24,12 @@ import { FieldButtonTypes } from "../models";
 
 export interface FieldButtonPropsInterface extends FormFieldPropsInterface {
     /**
+     * Unique id of the form that needs to be submitted.
+     * Required for event propagation.
+     * @see {@link https://github.com/final-form/react-final-form/issues/878}
+     */
+    form: string;
+    /**
      * Type of the button field.
      */
     buttonType: "primary_btn" | "cancel_btn" | "danger_btn" | "secondary_btn";
@@ -31,14 +37,20 @@ export interface FieldButtonPropsInterface extends FormFieldPropsInterface {
 
 /**
  * Implementation of the Button Field component.
- * @param props
+ *
+ * @param props - Props injected to the component.
+ * @returns Functional component.
  */
 export const FieldButton = (props: FieldButtonPropsInterface): ReactElement => {
 
-    const { [ "data-testid" ]: testId } = props;
+    const {
+        form,
+        [ "data-testid" ]: testId
+    } = props;
 
     return (
         <FinalFormField
+            form={ form }
             key={ testId }
             name={ props.name }
             component={ ButtonAdapter }

--- a/modules/form/src/components/form.tsx
+++ b/modules/form/src/components/form.tsx
@@ -31,6 +31,12 @@ import { Grid, Form as SemanticForm } from "semantic-ui-react";
 export interface FormPropsInterface extends FormProps {
 
     /**
+     * Unique id for the form.
+     * Required for event propagation.
+     * @see {@link https://github.com/final-form/react-final-form/issues/878}
+     */
+    id: string;
+    /**
      * Turn on/off native form validations.
      */
     noValidate?: boolean;
@@ -51,7 +57,7 @@ export interface FormPropsInterface extends FormProps {
 export const Form: ForwardRefExoticComponent<PropsWithChildren<FormPropsInterface>> =
     forwardRef((props: PropsWithChildren<FormProps>, ref): ReactElement => {
 
-        const { noValidate, triggerSubmit, ...other } = props;
+        const { id, noValidate, triggerSubmit, ...other } = props;
         const { children, onSubmit, uncontrolledForm, ...rest } = other;
 
         const formRef = useRef(null);
@@ -180,6 +186,7 @@ export const Form: ForwardRefExoticComponent<PropsWithChildren<FormPropsInterfac
 
                     return (
                         <form
+                            id={ id }
                             noValidate={ noValidate }
                             onSubmit={ handleSubmit }
                             ref={ formRef }

--- a/modules/form/src/components/wizard.tsx
+++ b/modules/form/src/components/wizard.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { ReactElement, cloneElement, useState, useEffect } from "react";
+import React, { ReactElement, useState } from "react";
 import { FormProps } from "react-final-form";
 import { Form } from ".";
 import { WizardPage } from "./wizardPage";
@@ -25,7 +25,13 @@ import { WizardPage } from "./wizardPage";
 /**
  * Interface for the wizard steps.
  */
- interface WizardFormInterface extends FormProps { 
+ interface WizardFormInterface extends FormProps {
+    /**
+     * Unique id for the form.
+     * Required for event propagation.
+     * @see {@link https://github.com/final-form/react-final-form/issues/878}
+     */
+    id: string;
     /**
      * Function to change to previous step.
      */
@@ -46,23 +52,25 @@ import { WizardPage } from "./wizardPage";
 
 /**
  * Implementation of wizard component.
- * @param props Wizard form based on react froms
- * @returns 
+ *
+ * @param props - Wizard form based on react froms
+ * @returns Functional component.
  */
 export const Wizard= (props: WizardFormInterface ): ReactElement => {
 
-    const { 
-        children, 
-        onSubmit, 
-        triggerPrevious, 
+    const {
+        id,
+        children,
+        onSubmit,
+        triggerPrevious,
         changePage,
-        setTotalPage, 
-        ...rest 
+        setTotalPage,
+        ...rest
     } = props;
 
 
-    const [page, setPage] = useState<number>(0);
-    const [values, setValues] = useState<any>({});
+    const [ page, setPage ] = useState<number>(0);
+    const [ values, setValues ] = useState<any>({});
 
 
     /**
@@ -73,7 +81,7 @@ export const Wizard= (props: WizardFormInterface ): ReactElement => {
             setTotalPage(React.Children.count(children));
         }
     }, []);
- 
+
     const handlNext = (values): void => {
         setPage(Math.min(page + 1,children.length-1));
         setValues(values);
@@ -81,23 +89,19 @@ export const Wizard= (props: WizardFormInterface ): ReactElement => {
     };
 
     const handlPrevious = () => {
-      setPage(Math.max(page - 1,0));
-      changePage(Math.max(page - 1,0));
-
-    }
-
-    const passPageNumber =():number =>{
-        return page;
-    }
+        setPage(Math.max(page - 1,0));
+        changePage(Math.max(page - 1,0));
+    };
 
     const handleSubmit = (values,form )=> {
-        const isLastPage = page === React.Children.count(children) - 1
+        const isLastPage = page === React.Children.count(children) - 1;
+
         if (isLastPage) {
-          return onSubmit(values,form)
+            return onSubmit(values,form);
         } else {
-            handlNext(values)
+            handlNext(values);
         }
-    }
+    };
 
     if (triggerPrevious && typeof triggerPrevious === "function") {
         triggerPrevious(handlPrevious);
@@ -105,25 +109,26 @@ export const Wizard= (props: WizardFormInterface ): ReactElement => {
 
     const  validate = values => {
         const activePage:any = React.Children.toArray(children)[page];
-        return activePage.props.validate ? activePage.props.validate(values) : {}
-    }
+
+        return activePage.props.validate ? activePage.props.validate(values) : {};
+    };
 
     const activePage = React.Children.toArray(children)[page];
-    const isLastPage = page === React.Children.count(children) - 1;
 
     return (
         <Form
-            initialValues={values}
-            validate={validate}
-            onSubmit={handleSubmit}
+            id={ id }
+            initialValues={ values }
+            validate={ validate }
+            onSubmit={ handleSubmit }
             keepDirtyOnReinitialize={ true }
-            uncontrolledForm={true}
+            uncontrolledForm={ true }
             { ...rest }
         >
-            {activePage}
+            { activePage }
         </Form>
-    )
-   
-}
+    );
+
+};
 
 Wizard.Page= WizardPage;

--- a/modules/form/src/components/wizard.tsx
+++ b/modules/form/src/components/wizard.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import React, { ReactElement, useState } from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 import { FormProps } from "react-final-form";
 import { Form } from ".";
 import { WizardPage } from "./wizardPage";

--- a/modules/form/src/components/wizard2.tsx
+++ b/modules/form/src/components/wizard2.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,26 +16,40 @@
  * under the License.
  */
 
+import React, { ReactElement, forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { FormProps } from "react-final-form";
-import React, { forwardRef, ReactElement, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { Form } from "./form";
 import { WizardPage } from "./wizardPage";
 
 interface ImperativeWizardProps extends FormProps {
+    /**
+     * Unique id for the form.
+     * Required for event propagation.
+     * @see {@link https://github.com/final-form/react-final-form/issues/878}
+     */
+    id: string;
     children: any;
     pageChanged?: (currentPageIndex: number) => void;
     setTotalPages?: (pageCount: number) => void;
     uncontrolledForm?: boolean;
 }
 
+/**
+ * Wizard Component.
+ * TODO: If working on a refactor, consider exporting one wizard type.
+ *
+ * @param props - Props injected to the component.
+ * @param ref - Component ref.
+ * @returns Functional component.
+ */
 const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
 
     const {
+        id,
         children,
         onSubmit,
         setTotalPages,
         pageChanged,
-        getController,
         initialValues,
         uncontrolledForm,
         ...rest
@@ -52,10 +66,10 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
     const [ values, setValues ] = useState<any>();
 
     useImperativeHandle(ref, () => ({
-        gotoNextPage: gotoNextPage,
-        gotoPreviousPage: gotoPreviousPage,
         getCurrentPageNumber: getCurrentPageNumber,
-        getValues: getValues
+        getValues: getValues,
+        gotoNextPage: gotoNextPage,
+        gotoPreviousPage: gotoPreviousPage
     }));
 
     useEffect(() => {
@@ -75,6 +89,7 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
 
     const gotoNextPage = (): void => {
         const nextIndex = Math.min(currentPageIndex + 1, lastPageIndex);
+
         setCurrentPageIndex(nextIndex);
         if (formRef) {
             formRef.current.triggerSubmit();
@@ -89,7 +104,7 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
 
     const handleSubmit = (values, form) => {
         if (currentPageIndex === lastPageIndex) {
-            return onSubmit(values, form)
+            return onSubmit(values, form);
         } else {
             setValues(values);
         }
@@ -97,14 +112,17 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
 
     const validate = (values: { [ key: string ]: any }) => {
         const activePage: any = React.Children.toArray(children)[ currentPageIndex ];
+
         if (activePage?.props?.validate) {
             return activePage.props.validate(values);
         }
+
         return {};
     };
 
     return (
         <Form
+            id={ id }
             ref={ formRef }
             initialValues={ initialValues }
             validate={ validate }
@@ -121,4 +139,3 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
 ImperativeWizard.Page = WizardPage;
 
 export const Wizard2 = forwardRef(ImperativeWizard);
-


### PR DESCRIPTION
### Purpose

In React 18, `react-final` form has event propagation issues that affect the form submit.

#### Fix

Add mandatory id to the `Form` from `@wso2is/form` and make `form` attribute mandatory for `Field.Button`, as suggested in https://github.com/final-form/react-final-form/issues/878.

```diff
import { Form } from "@wso2is/form";

<Form
+     id="unique-form-id"
      onSubmit={ ... }
      ...
>
     ...
      <Field.Button
+          form="unique-form-id"
            ...
      />
</Form>
```

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
