### PR TITLE
Use display name as default in MyAccount if available

### DIFF
--- a/apps/myaccount/src/constants/user-management-constants.ts
+++ b/apps/myaccount/src/constants/user-management-constants.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Class containing app constants which can be used across several applications.
+ */
+export class UserManagementConstants {
+
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     *
+     */
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private constructor() { }
+
+    /**
+     * Set of SCIM2 schema names.apps/myaccount/src/store/actions/authenticate.ts
+     * @typeparam SCIM2_SCHEMA_DICTIONARY - `Map<string, string>`
+     * @defaultValue
+     */
+    public static readonly SCIM2_SCHEMA_DICTIONARY: Map<string, string> = new Map<string, string>()
+        .set("EMAILS", "emails")
+        .set("USERNAME", "userName")
+        .set("NAME", "name")
+        .set("DISPLAY_NAME", "displayName");
+}

--- a/apps/myaccount/src/helpers/user.ts
+++ b/apps/myaccount/src/helpers/user.ts
@@ -134,7 +134,7 @@ export const resolveUserstore= (username: string): string => {
  *
  * @param profileSchema - The schema
  * @param displayName - displayName
- * @returns boolean
+ * @returns if the display name attribute is enabled or not
  */
 const isDisplayNameEnabled = (profileSchema: ProfileSchemaInterface[], displayName?: string): boolean => {
     if (!displayName) {

--- a/apps/myaccount/src/helpers/user.ts
+++ b/apps/myaccount/src/helpers/user.ts
@@ -132,9 +132,9 @@ export const resolveUserstore= (username: string): string => {
 /**
  * Checks if the display name attribute is enabled or not
  *
- * @returns boolean
  * @param profileSchema - The schema
  * @param displayName - displayName
+ * @returns boolean
  */
 const isDisplayNameEnabled = (profileSchema: ProfileSchemaInterface[], displayName?: string): boolean => {
     if (!displayName) {

--- a/apps/myaccount/src/helpers/user.ts
+++ b/apps/myaccount/src/helpers/user.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,15 +17,17 @@
  */
 
 import { getUserNameWithoutDomain } from "@wso2is/core/helpers";
+import { ProfileSchemaInterface } from "@wso2is/core/models";
 import isEmpty from "lodash-es/isEmpty";
 import { AppConstants } from "../constants";
+import { UserManagementConstants } from "../constants/user-management-constants";
 import { AuthStateInterface } from "../models";
 
 /**
  * Resolves the user's display name.
  *
- * @param {AuthStateInterface} state - auth state.
- * @return {string} - Resolved display name.
+ * @param state - auth state.
+ * @returns Resolved display name.
  */
 export const resolveUserDisplayName = (state: AuthStateInterface): string => {
 
@@ -50,13 +52,15 @@ export const resolveUserDisplayName = (state: AuthStateInterface): string => {
 /**
  * Resolves the user's profile name.
  *
- * @param {AuthStateInterface} state - auth state.
+ * @param state - auth state.
  * @param isProfileInfoLoading - SCIM user profile loader status.
- * @return {string} - Resolved profile name.
+ * @returns Resolved profile name.
  */
 export const resolveUserProfileName = (state: AuthStateInterface, isProfileInfoLoading: boolean): string => {
 
-    if (state.profileInfo.name.givenName || state.profileInfo.name.familyName) {
+    if (isDisplayNameEnabled(state.profileSchemas, state.profileInfo.displayName)) {
+        return state.profileInfo.displayName;
+    } else if (state.profileInfo.name.givenName || state.profileInfo.name.familyName) {
         const givenName = isEmpty(state.profileInfo.name.givenName) ? "" : state.profileInfo.name.givenName + " ";
         const familyName = isEmpty(state.profileInfo.name.familyName) ? "" : state.profileInfo.name.familyName;
 
@@ -74,9 +78,9 @@ export const resolveUserProfileName = (state: AuthStateInterface, isProfileInfoL
  * have just the username and the other user store users will have their
  * corresponding user store prefixed to their username.
  *
- * @param {string} username - Username of the user.
- * @param {string} userStoreDomain - User store domain of the user.
- * @return {string}
+ * @param username - Username of the user.
+ * @param userStoreDomain - User store domain of the user.
+ * @returns Resolved username.
  */
 export const resolveUsername = (username: string, userStoreDomain: string): string => {
     // check if the user store is `PRIMARY`.
@@ -93,8 +97,8 @@ export const resolveUsername = (username: string, userStoreDomain: string): stri
  * and the other user store users will have their corresponding
  * user store prefixed to their username.
  *
- * @param {string} username - Username of the user with user store embedded.
- * @return {string}
+ * @param username - Username of the user with user store embedded.
+ * @returns Resolved user store embedded username.
  */
 export const resolveUserStoreEmbeddedUsername = (username: string): string => {
     const parts = username.split("/");
@@ -114,8 +118,8 @@ export const resolveUserStoreEmbeddedUsername = (username: string): string => {
 /**
  * Resolves the user's userstore from the username
  *
- * @param {string} username - Username of the user with user store embedded.
- * @return {string}
+ * @param username - Username of the user with user store embedded.
+ * @returns Resolved user store
  */
 export const resolveUserstore= (username: string): string => {
     // Userstore is index 0 and index 1 is username
@@ -123,4 +127,21 @@ export const resolveUserstore= (username: string): string => {
     const parts = username?.split("/");
 
     return parts[USERSTORE];
+};
+
+/**
+ * Checks if the display name attribute is enabled or not
+ *
+ * @returns boolean
+ * @param profileSchema - The schema
+ * @param displayName - displayName
+ */
+const isDisplayNameEnabled = (profileSchema: ProfileSchemaInterface[], displayName?: string): boolean => {
+    if (!displayName) {
+        return false;
+    }
+
+    return profileSchema
+        .some((schemaItem: ProfileSchemaInterface) =>
+            schemaItem.name === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY.get("DISPLAY_NAME"));
 };


### PR DESCRIPTION
### Purpose
> This PR adds a check to see whether `displayName` is available and resolve the user's shown name from `displayName` rather than firstName and lastName

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
