### PR TITLE
Move to legacy `react-dom` in Console to disable automatic batching in React 18

### DIFF
--- a/apps/console/src/index.tsx
+++ b/apps/console/src/index.tsx
@@ -24,7 +24,7 @@ import { AuthenticateUtils as CommonAuthenticateUtils, ContextUtils, StringUtils
 import axios from "axios";
 import * as React from "react";
 import { ReactElement } from "react";
-import ReactDOM, { Root } from "react-dom/client";
+import * as ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 import { AuthenticateUtils } from "./features/authentication";
@@ -99,8 +99,8 @@ const RootWithConfig = (): ReactElement => {
     );
 };
 
-const root: Root = ReactDOM.createRoot(
-    document.getElementById("root") as HTMLElement
-);
+const rootElement = document.getElementById("root");
 
-root.render(<RootWithConfig />);
+// Moved back to the legacy mode due to Sign On Methods section state update issue.
+// Tracked here: https://github.com/wso2/product-is/issues/14912
+ReactDOM.render(<RootWithConfig />, rootElement);

--- a/apps/console/src/index.tsx
+++ b/apps/console/src/index.tsx
@@ -101,6 +101,6 @@ const RootWithConfig = (): ReactElement => {
 
 const rootElement = document.getElementById("root");
 
-// Moved back to the legacy mode due to Sign On Methods section state update issue.
+// Moved back to the legacy mode due to unpredictable state update issue.
 // Tracked here: https://github.com/wso2/product-is/issues/14912
 ReactDOM.render(<RootWithConfig />, rootElement);

--- a/apps/myaccount/src/layouts/dashboard.tsx
+++ b/apps/myaccount/src/layouts/dashboard.tsx
@@ -21,6 +21,7 @@ import { initializeAlertSystem } from "@wso2is/core/store";
 import { RouteUtils as CommonRouteUtils, CommonUtils, RouteUtils } from "@wso2is/core/utils";
 import {
     Alert,
+    ContentLoader,
     DashboardLayout as DashboardLayoutSkeleton,
     EmptyPlaceholder,
     ErrorBoundary,
@@ -41,7 +42,6 @@ import { fetchApplications } from "../api";
 import {
     Footer,
     Header,
-    PreLoader,
     ProtectedRoute
 } from "../components";
 import { getDashboardLayoutRoutes, getEmptyPlaceholderIllustrations } from "../configs";
@@ -259,7 +259,7 @@ export const DashboardLayout: FunctionComponent<PropsWithChildren<DashboardLayou
                     />
                 ) }
             >
-                <Suspense fallback={ <PreLoader /> }>
+                <Suspense fallback={ <ContentLoader /> }>
                     <Switch>
                         {
                             dashboardLayoutRoutes.map((route, index) => (


### PR DESCRIPTION
### Purpose

React 18's automatic batching seems to be breaking the state handling logic in Console.
As a temp fix, this PR disables the newer batching feature by reverting back to the legacy mode.

### Related Issues
- https://github.com/wso2/product-is/issues/14912

### Related PRs
- https://github.com/wso2/identity-apps/pull/3440

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
