### PR TITLE
Strip out comments in recovery portal for signup flows

### DIFF
--- a/apps/recovery-portal/src/main/webapp/challenge-question-add.jsp
+++ b/apps/recovery-portal/src/main/webapp/challenge-question-add.jsp
@@ -66,7 +66,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <!-- title -->
+        <%-- title --%>
         <%
             File titleFile = new File(getServletContext().getRealPath("extensions/title.jsp"));
             if (titleFile.exists()) {
@@ -89,7 +89,7 @@
 
     <body>
 
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -99,11 +99,11 @@
             <jsp:include page="includes/header.jsp"/>
     <% } %>
 
-    <!-- page content -->
+    <%-- page content --%>
     <div class="container-fluid body-wrapper">
 
         <div class="row">
-            <!-- content -->
+            <%-- content --%>
             <div class="col-xs-12 col-sm-10 col-md-8 col-lg-5 col-centered wr-login">
                 <h2 class="wr-title uppercase blue-bg padding-double white boarder-bottom-blue margin-none">
                     <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Update.security.question")%>
@@ -176,12 +176,12 @@
                 </div>
                 <div class="clearfix"></div>
             </div>
-            <!-- /content/body -->
+            <%-- /content/body --%>
 
         </div>
     </div>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/challenge-question-view.jsp
+++ b/apps/recovery-portal/src/main/webapp/challenge-question-view.jsp
@@ -67,7 +67,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -79,7 +79,7 @@
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
-                <!-- page content -->
+                <%-- page content --%>
                 <%
                     if (errorResponse != null) {
                 %>
@@ -137,7 +137,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -149,7 +149,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/challenge-questions-view-all.jsp
+++ b/apps/recovery-portal/src/main/webapp/challenge-questions-view-all.jsp
@@ -44,7 +44,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- title -->
+    <%-- title --%>
     <%
         File titleFile = new File(getServletContext().getRealPath("extensions/title.jsp"));
         if (titleFile.exists()) {
@@ -73,7 +73,7 @@
     %>
 </head>
 <body>
-<!-- header -->
+<%-- header --%>
 <%
     File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
     if (headerFile.exists()) {
@@ -83,11 +83,11 @@
         <jsp:include page="includes/header.jsp"/>
 <% } %>
 
-<!-- page content -->
+<%-- page content --%>
 <div class="container-fluid body-wrapper">
 
     <div class="row">
-        <!-- content -->
+        <%-- content --%>
         <div class="col-xs-12 col-sm-10 col-md-8 col-lg-5 col-centered wr-login">
             <%
                 if (errorResponse != null) {
@@ -149,16 +149,16 @@
                 </div>
             </div>
         </div>
-        <!-- /content/body -->
+        <%-- /content/body --%>
 
     </div>
 </div>
-<!-- /content/body -->
+<%-- /content/body --%>
 
 </div>
 </div>
 
-<!-- footer -->
+<%-- footer --%>
 <%
     File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
     if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/error.jsp
@@ -72,7 +72,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -85,7 +85,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -123,7 +123,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -135,7 +135,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {
@@ -170,7 +170,7 @@
 
                 return;
             }
-    
+
             window.history.back();
         }
         <% } %>

--- a/apps/recovery-portal/src/main/webapp/errors/error.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_400.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_400.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_401.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_401.jsp
@@ -44,6 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
+        <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_401.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_401.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,6 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +61,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +73,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_403.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_403.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_404.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_404.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_405.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_405.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_408.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_408.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_410.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_410.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_500.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_500.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_502.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_502.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_503.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_503.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/errors/error_504.jsp
+++ b/apps/recovery-portal/src/main/webapp/errors/error_504.jsp
@@ -31,7 +31,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -44,7 +44,7 @@
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -74,7 +74,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -22,7 +22,7 @@
 
 <jsp:directive.include file="layout-resolver.jsp"/>
 
-<!-- Extract the name of the stylesheet-->
+<%-- Extract the name of the stylesheet--%>
 <%
     String themeName = "default";
     File themeDir = new File(request.getSession().getServletContext().getRealPath("/")
@@ -44,7 +44,7 @@
 <link rel="icon" href="libs/themes/default/assets/images/branding/favicon.ico" type="image/x-icon"/>
 <link href="libs/themes/default/<%= themeFileName %>" rel="stylesheet">
 
-<!-- Layout specific style sheet -->
+<%-- Layout specific style sheet --%>
 <%
     String styleFilePath = "extensions/layouts/" + layout + "/styles.css";
     if (config.getServletContext().getResource(styleFilePath) != null) {

--- a/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
@@ -19,7 +19,7 @@
 <jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
-<!-- footer -->
+<%-- footer --%>
 <footer class="footer" style="text-align: center">
     <div class="container-fluid">
         <p><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Wso2.identity.server")%> | &copy;

--- a/apps/recovery-portal/src/main/webapp/includes/title.jsp
+++ b/apps/recovery-portal/src/main/webapp/includes/title.jsp
@@ -19,5 +19,5 @@
 <jsp:directive.include file="localize.jsp" />
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 
-<!-- title -->
+<%-- title --%>
 <title><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Wso2.identity.server")%></title>

--- a/apps/recovery-portal/src/main/webapp/lite-user-confirm.jsp
+++ b/apps/recovery-portal/src/main/webapp/lite-user-confirm.jsp
@@ -60,7 +60,7 @@
         request.getRequestDispatcher("error.jsp").forward(request, response);
         return;
     }
-    
+
     if (StringUtils.isBlank(callback)) {
         callback = IdentityManagementEndpointUtil.getUserPortalUrl(
                 application.getInitParameter(IdentityManagementEndpointConstants.ConfigConstants.USER_PORTAL_URL), tenantDomain);
@@ -113,7 +113,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <!-- title -->
+        <%-- title --%>
         <%
             File titleFile = new File(getServletContext().getRealPath("extensions/title.jsp"));
             if (titleFile.exists()) {
@@ -136,7 +136,7 @@
 
     <body>
 
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -146,11 +146,11 @@
             <jsp:include page="includes/header.jsp"/>
     <% } %>
 
-    <!-- page content -->
+    <%-- page content --%>
     <div class="container-fluid body-wrapper">
 
         <div class="row">
-            <!-- content -->
+            <%-- content --%>
             <div class="col-xs-12 col-sm-10 col-md-8 col-lg-5 col-centered wr-login">
 
                 <div class="boarder-all ">
@@ -172,7 +172,7 @@
         </div>
     </div>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
@@ -130,7 +130,7 @@
         </div>
     </div>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-recovery-tenant-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-tenant-request.jsp
@@ -38,7 +38,7 @@
 
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -51,7 +51,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -62,7 +62,7 @@
             <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
-            <!-- content -->
+            <%-- content --%>
             <div class="ui segment">
                 <h2 class="wr-title uppercase blue-bg padding-double white boarder-bottom-blue margin-none">
                     <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Start.password.recovery")%>
@@ -118,7 +118,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -130,7 +130,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-recovery-username-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-username-request.jsp
@@ -68,7 +68,7 @@
 
 <html>
     <head>
-        <!-- header -->
+        <%-- header --%>
         <%
             File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
             if (headerFile.exists()) {
@@ -86,7 +86,7 @@
     <body class="login-portal layout recovery-layout">
         <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
             <layout:component componentName="ProductHeader" >
-                <!-- product-title -->
+                <%-- product-title --%>
                 <%
                     File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                     if (productTitleFile.exists()) {
@@ -98,7 +98,7 @@
             </layout:component>
             <layout:component componentName="MainSection" >
                 <div class="ui segment">
-                    <!-- page content -->
+                    <%-- page content --%>
                     <div class="segment-form">
                         <form class="ui large form" action="recoverpassword.do" method="post" id="tenantBasedRecovery">
                             <h2>
@@ -161,7 +161,7 @@
                 </div>
             </layout:component>
             <layout:component componentName="ProductFooter" >
-                <!-- product-footer -->
+                <%-- product-footer --%>
                 <%
                     File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                     if (productFooterFile.exists()) {
@@ -173,7 +173,7 @@
             </layout:component>
         </layout:main>
 
-        <!-- footer -->
+        <%-- footer --%>
         <%
             File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
             if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-notify.jsp
@@ -87,7 +87,7 @@
         </div>
     </div>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
@@ -191,7 +191,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -203,7 +203,7 @@
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
-                <!-- page content -->
+                <%-- page content --%>
                 <h3 class="ui header">
                     <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Recover.password")%>
                 </h3>
@@ -273,7 +273,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -285,7 +285,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-recovery-with-claims.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-with-claims.jsp
@@ -136,7 +136,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -158,7 +158,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -308,7 +308,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -321,7 +321,7 @@
     </layout:main>
 
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -141,7 +141,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -153,7 +153,7 @@
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
-                <!-- page content -->
+                <%-- page content --%>
                 <h3 class="ui header">
                     <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Recover.password")%>
                 </h3>
@@ -306,7 +306,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -318,7 +318,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -102,7 +102,7 @@
                 if (userStoreDomain != null) {
                     username = userStoreDomain + "/" + username + "@" + tenantDomain;
                 }
-                
+
                 String cookieDomain = application.getInitParameter(AUTO_LOGIN_COOKIE_DOMAIN);
                 JSONObject contentValueInJson = new JSONObject();
                 contentValueInJson.put("username", username);
@@ -112,7 +112,7 @@
                     contentValueInJson.put("domain", cookieDomain);
                 }
                 String content = contentValueInJson.toString();
-        
+
                 JSONObject cookieValueInJson = new JSONObject();
                 cookieValueInJson.put("content", content);
                 String signature = Base64.getEncoder().encodeToString(SignatureUtil.doSignature(content));
@@ -214,7 +214,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/password-reset.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-reset.jsp
@@ -66,7 +66,7 @@
     <body class="login-portal layout recovery-layout">
         <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
             <layout:component componentName="ProductHeader" >
-                <!-- product-title -->
+                <%-- product-title --%>
                 <%
                     File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                     if (productTitleFile.exists()) {
@@ -78,7 +78,7 @@
             </layout:component>
             <layout:component componentName="MainSection" >
                 <div class="ui segment">
-                    <!-- content -->
+                    <%-- content --%>
                     <h2>
                         <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Reset.Password")%>
                     </h2>
@@ -180,7 +180,7 @@
                 </div>
             </layout:component>
             <layout:component componentName="ProductFooter" >
-                <!-- product-footer -->
+                <%-- product-footer --%>
                 <%
                     File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                     if (productFooterFile.exists()) {
@@ -192,7 +192,7 @@
             </layout:component>
         </layout:main>
 
-        <!-- footer -->
+        <%-- footer --%>
         <%
             File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
             if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/self-registration-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-complete.jsp
@@ -146,7 +146,7 @@
         </div>
     <% }%>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -51,7 +51,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- title -->
+    <%-- title --%>
     <%
         File titleFile = new File(getServletContext().getRealPath("extensions/title.jsp"));
         if (titleFile.exists()) {
@@ -72,7 +72,7 @@
     <![endif]-->
 </head>
 <body>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -82,7 +82,7 @@
     <jsp:include page="includes/header.jsp"/>
     <% } %>
 
-    <!-- page content -->
+    <%-- page content --%>
     <div class="container-fluid body-wrapper">
 
         <%
@@ -97,7 +97,7 @@
             PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
             Boolean isAutoLoginEnable = preferenceRetrievalClient.checkAutoLoginAfterSelfRegistrationEnabled(tenantDomain);
             Boolean isSelfRegistrationWithVerificationEnabled = preferenceRetrievalClient.checkSelfRegistrationLockOnCreation(tenantDomain);
-    
+
             boolean isSelfRegistrationWithVerification =
                     Boolean.parseBoolean(request.getParameter("isSelfRegistrationWithVerification"));
 
@@ -249,7 +249,7 @@
                         contentValueInJson.put("domain", cookieDomain);
                     }
                     String content = contentValueInJson.toString();
-        
+
                     JSONObject cookieValueInJson = new JSONObject();
                     cookieValueInJson.put("content", content);
                     String signature = Base64.getEncoder().encodeToString(SignatureUtil.doSignature(content));
@@ -288,7 +288,7 @@
     </div>
 
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -78,7 +78,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -91,7 +91,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -113,7 +113,7 @@
                     <%= IdentityManagementEndpointUtil.i18nBase64(recoveryResourceBundle, errorMsg) %>
                 </div>
                 <% } %>
-                <!-- validation -->
+                <%-- validation --%>
 
                 <div class="ui divider hidden"></div>
                 <div class="segment-form">
@@ -168,7 +168,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -180,7 +180,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {
@@ -216,7 +216,7 @@
             $.fn.preventDoubleSubmission = function() {
                 $(this).on("submit", function(e){
                     var $form = $(this);
-                    $("#error-msg").hide(); 
+                    $("#error-msg").hide();
                     $("#server-error-msg").hide();
                     $("#error-msg").text("");
 
@@ -230,7 +230,7 @@
                         var userName = document.getElementById("username");
                         var normalizedUsername = userName.value.trim();
                         userName.value = normalizedUsername;
-                        
+
                         if (normalizedUsername) {
                             if (!/^[^/].*[^@]$/g.test(normalizedUsername)) {
                                 $("#error-msg").text("Username pattern policy violated");

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
@@ -146,7 +146,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <!-- title -->
+        <%-- title --%>
         <%
             File titleFile = new File(getServletContext().getRealPath("extensions/title.jsp"));
             if (titleFile.exists()) {
@@ -169,7 +169,7 @@
 
     <body>
 
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -179,11 +179,11 @@
             <jsp:include page="includes/header.jsp"/>
     <% } %>
 
-    <!-- page content -->
+    <%-- page content --%>
     <div class="container-fluid body-wrapper">
 
         <div class="row">
-            <!-- content -->
+            <%-- content --%>
             <div class="col-xs-12 col-sm-10 col-md-8 col-lg-5 col-centered wr-login">
 
                 <div class="boarder-all ">
@@ -205,7 +205,7 @@
         </div>
     </div>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification-notify.jsp
@@ -74,7 +74,7 @@
         </div>
     </div>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -242,7 +242,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -265,7 +265,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -282,7 +282,7 @@
                     <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Create.account")%>
                 </h2>
                 <div class="ui divider hidden"></div>
-                <!-- content -->
+                <%-- content --%>
                 <div class="segment-form">
                     <% if (skipSignUpEnableCheck) { %>
                     <form class="ui large form" action="../commonauth" method="post" id="register">
@@ -307,7 +307,7 @@
                                 </p>
                             </div>
                             <div class="ui divider hidden"></div>
-                            <!-- validation -->
+                            <%-- validation --%>
                             <div>
                                 <div id="regFormError" class="ui negative message" style="display:none"></div>
                                 <div id="regFormSuc" class="ui positive message" style="display:none"></div>
@@ -562,19 +562,19 @@
                                     <%
                                         if (consentDisplayType == "template") {
                                     %>
-                                    <!--User Consents from Template-->
+                                    <%--User Consents from Template--%>
                                         <div class="consent-statement"></div>
-                                    <!--End User Consents from Template-->
+                                    <%--End User Consents from Template--%>
                                     <% } else if (consentDisplayType == "tree") { %>
-                                    <!--User Consents Tree-->
+                                    <%--User Consents Tree--%>
                                         <div id="tree-table"></div>
-                                    <!--End User Consents Tree-->
+                                    <%--End User Consents Tree--%>
                                     <%
                                     } else if (consentDisplayType == "row") {
                                     %>
-                                    <!--User Consents Row-->
+                                    <%--User Consents Row--%>
                                         <div id="row-container"></div>
-                                    <!--End User Consents Row-->
+                                    <%--End User Consents Row--%>
                                     <%
                                         }
                                     %>
@@ -602,7 +602,7 @@
                                 %>
                                 <div class="ui divider hidden"></div>
                                 <div>
-                                    <!--Cookie Policy-->
+                                    <%--Cookie Policy--%>
                                     <div class="ui message info compact" role="alert">
                                         <div>
                                             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
@@ -614,11 +614,11 @@
                                             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "For.more.details")%>
                                         </div>
                                     </div>
-                                    <!--End Cookie Policy-->
+                                    <%--End Cookie Policy--%>
                                 </div>
                                 <div class="ui divider hidden"></div>
                                 <div>
-                                    <!--Terms/Privacy Policy-->
+                                    <%--Terms/Privacy Policy--%>
                                     <div class="required field">
                                         <div class="ui checkbox">
                                             <input id="termsCheckbox" type="checkbox"/>
@@ -629,7 +629,7 @@
                                                 </a></label>
                                         </div>
                                     </div>
-                                    <!--End Terms/Privacy Policy-->
+                                    <%--End Terms/Privacy Policy--%>
                                 </div>
                                 <div class="ui divider hidden"></div>
                                 <div class="align-right buttons">
@@ -672,7 +672,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -684,7 +684,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/self-registration-without-verification.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-without-verification.jsp
@@ -71,7 +71,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <!-- title -->
+        <%-- title --%>
         <%
             File titleFile = new File(getServletContext().getRealPath("extensions/title.jsp"));
             if (titleFile.exists()) {
@@ -104,7 +104,7 @@
 
     <body>
 
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -114,11 +114,11 @@
             <jsp:include page="includes/header.jsp"/>
     <% } %>
 
-    <!-- page content -->
+    <%-- page content --%>
     <div class="container-fluid body-wrapper">
 
         <div class="row">
-            <!-- content -->
+            <%-- content --%>
             <div class="col-xs-12 col-sm-10 col-md-8 col-lg-5 col-centered wr-login">
                 <form action="processregistration.do" method="post" id="register">
                     <h2 class="wr-title uppercase blue-bg padding-double white boarder-bottom-blue margin-none">
@@ -140,7 +140,7 @@
                         <div class="padding-double font-large"><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                                 "Enter.required.fields.to.complete.registration")%>
                         </div>
-                        <!-- validation -->
+                        <%-- validation --%>
                         <div class="padding-double">
                             <div id="regFormError" class="alert alert-danger" style="display:none"></div>
                             <div id="regFormSuc" class="alert alert-success" style="display:none"></div>
@@ -268,11 +268,11 @@
                 </form>
             </div>
         </div>
-        <!-- /content/body -->
+        <%-- /content/body --%>
 
     </div>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
@@ -102,7 +102,7 @@
         </div>
     </div>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/username-recovery-tenant-request.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery-tenant-request.jsp
@@ -39,7 +39,7 @@
 
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -52,7 +52,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -63,7 +63,7 @@
             <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
-            <!-- content -->
+            <%-- content --%>
             <div class="ui segment">
                 <h2 class="wr-title uppercase blue-bg padding-double white boarder-bottom-blue margin-none">
                     <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Start.username.recovery")%>
@@ -118,7 +118,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -130,7 +130,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {

--- a/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -132,7 +132,7 @@
 <!doctype html>
 <html>
 <head>
-    <!-- header -->
+    <%-- header --%>
     <%
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
@@ -154,7 +154,7 @@
 <body class="login-portal layout recovery-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
         <layout:component componentName="ProductHeader" >
-            <!-- product-title -->
+            <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
@@ -298,7 +298,7 @@
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter" >
-            <!-- product-footer -->
+            <%-- product-footer --%>
             <%
                 File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
                 if (productFooterFile.exists()) {
@@ -310,7 +310,7 @@
         </layout:component>
     </layout:main>
 
-    <!-- footer -->
+    <%-- footer --%>
     <%
         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
         if (footerFile.exists()) {


### PR DESCRIPTION
### Purpose
> We need to remove comments in our source files in recovery portal when shipped to the browser, which are unnecessary and increase the size of the content loaded to the browser in the runtime when in signup flows. This PR refactors display comments to hidden comments in all JSP files in recovery portal.

### Related PRs
- https://github.com/wso2/identity-apps/pull/3426

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
