### PR TITLE
Fix i18n deprecation issue

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -62,7 +62,7 @@
         "history": "^4.9.0",
         "html-react-parser": "^2.0.0",
         "i18next": "^21.9.1",
-        "i18next-browser-languagedetector": "^3.0.3",
+        "i18next-browser-languagedetector": "^6.1.5",
         "i18next-xhr-backend": "^3.2.2",
         "js-beautify": "^1.13.0",
         "lodash-es": "^4.17.21",

--- a/apps/myaccount/package.json
+++ b/apps/myaccount/package.json
@@ -50,7 +50,7 @@
         "axios": "^0.19.2",
         "history": "^4.9.0",
         "i18next": "^21.9.1",
-        "i18next-browser-languagedetector": "^3.0.3",
+        "i18next-browser-languagedetector": "^6.1.5",
         "i18next-xhr-backend": "^3.2.2",
         "lodash-es": "^4.17.21",
         "moment": "2.24.0",

--- a/modules/i18n/package.json
+++ b/modules/i18n/package.json
@@ -45,7 +45,7 @@
         "@wso2is/core": "^1.4.124",
         "babel-jest": "^26.3.0",
         "i18next": "^21.9.1",
-        "i18next-browser-languagedetector": "^3.0.3",
+        "i18next-browser-languagedetector": "^6.1.5",
         "i18next-xhr-backend": "^3.2.2",
         "lodash-es": "^4.17.21",
         "react-i18next": "^11.18.5"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "crypto-js": "^3.1.9-1",
         "final-form": "^4.20.2",
         "history": "^4.9.0",
-        "i18next-browser-languagedetector": "^3.0.3",
+        "i18next-browser-languagedetector": "^6.1.5",
         "i18next-xhr-backend": "^3.2.2",
         "js-beautify": "^1.13.0",
         "jshint": "^2.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
       glob: ^7.1.3
       history: ^4.9.0
       html-webpack-plugin: ^5.2.0
-      i18next-browser-languagedetector: ^3.0.3
+      i18next-browser-languagedetector: ^6.1.5
       i18next-xhr-backend: ^3.2.2
       identity-obj-proxy: ^3.0.0
       jest: ^26.4.2
@@ -164,7 +164,7 @@ importers:
       crypto-js: 3.3.0
       final-form: 4.20.7
       history: 4.10.1
-      i18next-browser-languagedetector: 3.1.1
+      i18next-browser-languagedetector: 6.1.5
       i18next-xhr-backend: 3.2.2
       js-beautify: 1.14.6
       jshint: 2.13.5
@@ -362,7 +362,7 @@ importers:
       history: ^4.9.0
       html-react-parser: ^2.0.0
       i18next: ^21.9.1
-      i18next-browser-languagedetector: ^3.0.3
+      i18next-browser-languagedetector: ^6.1.5
       i18next-xhr-backend: ^3.2.2
       jest: ^26.4.2
       jest-environment-jsdom: ^26.3.0
@@ -424,7 +424,7 @@ importers:
       history: 4.10.1
       html-react-parser: 2.0.0_react@18.2.0
       i18next: 21.9.1
-      i18next-browser-languagedetector: 3.1.1
+      i18next-browser-languagedetector: 6.1.5
       i18next-xhr-backend: 3.2.2
       js-beautify: 1.14.6
       lodash-es: 4.17.21
@@ -543,7 +543,7 @@ importers:
       eslint-webpack-plugin: ^3.1.1
       history: ^4.9.0
       i18next: ^21.9.1
-      i18next-browser-languagedetector: ^3.0.3
+      i18next-browser-languagedetector: ^6.1.5
       i18next-xhr-backend: ^3.2.2
       jest: ^26.4.2
       jest-environment-jsdom: ^26.3.0
@@ -591,7 +591,7 @@ importers:
       axios: 0.19.2
       history: 4.10.1
       i18next: 21.9.1
-      i18next-browser-languagedetector: 3.1.1
+      i18next-browser-languagedetector: 6.1.5
       i18next-xhr-backend: 3.2.2
       lodash-es: 4.17.21
       moment: 2.24.0
@@ -898,7 +898,7 @@ importers:
       eslint-plugin-react: ^7.18.3
       eslint-plugin-react-hooks: ^4.0.0
       i18next: ^21.9.1
-      i18next-browser-languagedetector: ^3.0.3
+      i18next-browser-languagedetector: ^6.1.5
       i18next-xhr-backend: ^3.2.2
       jest: ^26.4.2
       lodash-es: ^4.17.21
@@ -913,7 +913,7 @@ importers:
       '@wso2is/core': link:../core
       babel-jest: 26.6.3
       i18next: 21.9.1
-      i18next-browser-languagedetector: 3.1.1
+      i18next-browser-languagedetector: 6.1.5
       i18next-xhr-backend: 3.2.2
       lodash-es: 4.17.21
       react-i18next: 11.18.5_i18next@21.9.1
@@ -16752,8 +16752,10 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /i18next-browser-languagedetector/3.1.1:
-    resolution: {integrity: sha512-JBgFWijjI1t6as4WgGvDdX4GLJPZwC/SMHzLQQ3ef7XaJsEkomlXFqXifKvOVJg09Hj2BVWe6strDdIF4J/0ng==}
+  /i18next-browser-languagedetector/6.1.5:
+    resolution: {integrity: sha512-11t7b39oKeZe4uyMxLSPnfw28BCPNLZgUk7zyufex0zKXZ+Bv+JnmJgoB+IfQLZwDt1d71PM8vwBX1NCgliY3g==}
+    dependencies:
+      '@babel/runtime': 7.18.9
     dev: false
 
   /i18next-xhr-backend/3.2.2:


### PR DESCRIPTION
### Purpose

Some APIs in `i18next` are deprecated and they throw errors.

### Related Issues
-  Fixes https://github.com/wso2/product-is/issues/14939

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
