### PR TITLE
Remove Username recovery and Manage notifications sending internally connectors for the orgnization context

### DIFF
--- a/apps/console/src/features/server-configurations/utils/governance-connector-utils.ts
+++ b/apps/console/src/features/server-configurations/utils/governance-connector-utils.ts
@@ -102,9 +102,7 @@ export class GovernanceConnectorUtils {
                     id: "YWNjb3VudC1yZWNvdmVyeQ",
                     name: "account-recovery",
                     properties: [
-                        "Recovery.Notification.Password.Enable", // Notification based password recovery
-                        "Recovery.Notification.Username.Enable", // Username recovery
-                        "Recovery.Notification.InternallyManage" // Manage notifications sending internally
+                        "Recovery.Notification.Password.Enable" // Notification based password recovery
                     ]
                 }
             ],


### PR DESCRIPTION
### Purpose
> Remove Username recovery and Manage notifications sending internally connectors for the orgnization context

### After the change
The account management section will look like this in an orgniaztion context
<img width="1791" alt="Screenshot 2022-09-27 at 13 03 13" src="https://user-images.githubusercontent.com/46097917/192472053-cadd8889-6be7-4097-b2f1-28f060a5c520.png">
