### PR TITLE
Exclude prop files being duplicated

### DIFF
--- a/apps/authentication-portal/pom.xml
+++ b/apps/authentication-portal/pom.xml
@@ -275,6 +275,9 @@
                         <resource>
                             <!-- this is relative to the pom.xml directory -->
                             <directory>src/main/resources/</directory>
+                            <excludes>
+                                <exclude>EndpointConfig.properties</exclude>
+                            </excludes>
                         </resource>
                     </webResources>
                     <warName>authenticationendpoint</warName>

--- a/apps/recovery-portal/pom.xml
+++ b/apps/recovery-portal/pom.xml
@@ -233,6 +233,9 @@
                         <resource>
                             <!-- this is relative to the pom.xml directory -->
                             <directory>src/main/resources/</directory>
+                            <excludes>
+                                <exclude>RecoveryEndpointConfig.properties</exclude>
+                            </excludes>
                         </resource>
                     </webResources>
                     <warName>accountrecoveryendpoint</warName>


### PR DESCRIPTION
**Purpose:**
> Since, the war plugin packs the resources inside web-inf folder, the property files are also packed inside the webapps and hence need to be excluded. 

### Related Issues
- https://github.com/wso2/product-is/issues/5211