### PR TITLE
Error code fix for user account lock

### DIFF
--- a/apps/authentication-portal/src/main/webapp/smsOtpError.jsp
+++ b/apps/authentication-portal/src/main/webapp/smsOtpError.jsp
@@ -66,7 +66,7 @@
                 errorMessage = IdentityManagementEndpointUtil.i18n(resourceBundle,"error.user.account.locked");
                 String unlockTime = request.getParameter("unlockTime");
                 if (unlockTime != null) {
-                  errorMessage = String.format(IdentityManagementEndpointUtil.i18n(resourceBundle,"error.user.locked.temporarly"), unlockTime);
+                  errorMessage = String.format(IdentityManagementEndpointUtil.i18n(resourceBundle,"error.user.account.temporarly.locked"), unlockTime);
                 }
             } else if (SMSOTPUtils.useInternalErrorCodes()) {
                 String httpCode = URLDecoder.decode(errorMessage, SMSOTPConstants.CHAR_SET_UTF_8);


### PR DESCRIPTION
## Description
Fix the error code to be displayed with the account lock on SMS OTP.

## Related Issue
- https://github.com/wso2/product-is/issues/14868

## Related PR
- https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/151