### PR TITLE
Fix google sign on selection issue

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
@@ -608,7 +608,7 @@ export const SignOnMethods: FunctionComponent<SignOnMethodsPropsInterface> = (
                         {
                             authenticators
                                 .filter((authenticator) => {
-                                    authenticator.name !== IdentityProviderManagementConstants
+                                    return authenticator.name !== IdentityProviderManagementConstants
                                         .BACKUP_CODE_AUTHENTICATOR;
                                 })
                                 .map((authenticator, index) => (

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-on-methods.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
### Purpose
> This PR fixes the issue happens when there are more than one connection configured from same connection type. Currently, the popup don't show the set of IDPs, so user don't have any option to select which IDP they need to use.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
