### PR TITLE
Build multiOptionURI using parameter map

### DIFF
--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -39,10 +39,6 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.apache.commons.lang.StringUtils" %>
-<%@ page import="org.apache.http.client.utils.URLEncodedUtils" %>
-<%@ page import="org.apache.http.NameValuePair" %>
-<%@ page import="org.apache.http.message.BasicNameValuePair" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 
 <%@ include file="includes/localize.jsp" %>

--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -39,6 +39,10 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.Map" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.apache.http.client.utils.URLEncodedUtils" %>
+<%@ page import="org.apache.http.NameValuePair" %>
+<%@ page import="org.apache.http.message.BasicNameValuePair" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 
 <%@ include file="includes/localize.jsp" %>
@@ -109,7 +113,9 @@
             return;
         }
 
-        String queryParamString = request.getQueryString() != null ? ("?" + request.getQueryString()) : "";
+        // Build the query string using the parameter map since the query string can contain fewer parameters
+        // due to parameter filtering.
+        String queryParamString = AuthenticationEndpointUtil.resolveQueryString(request.getParameterMap());
         multiOptionURIParam = "&multiOptionURI=" + Encode.forUriComponent(baseURL + queryParamString);
     }
 %>

--- a/pom.xml
+++ b/pom.xml
@@ -671,7 +671,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.25.4</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.14</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.core.service.version>1.0.0
         </identity.organization.management.core.service.version>


### PR DESCRIPTION
### Purpose

- Build `multiOptionURI` using the parameter map instead of query string.
- This fixes backup code options not being displayed in the TOTP page when `enable_shortened_urls` in `authenticationendpoint` is set to `true`.

### Related Issues
https://github.com/wso2/product-is/issues/14878

### Checklist
- [x] Manual test round performed and verified.
