### PR TITLE
Set the organziation type to the Redux store add a config to show/hide organization creation

### DIFF
--- a/apps/console/src/extensions/configs/models/organization.ts
+++ b/apps/console/src/extensions/configs/models/organization.ts
@@ -26,4 +26,5 @@ export interface OrganizationConfigs {
         onClick: (breadcrumbItem: BreadcrumbItem) => void
     ) => ReactElement;
     showSwitcherInTenants: boolean;
+    canCreateOrganization: () => boolean;
 }

--- a/apps/console/src/extensions/configs/organization.tsx
+++ b/apps/console/src/extensions/configs/organization.tsx
@@ -21,6 +21,9 @@ import { OrganizationConfigs } from "./models";
 import { BreadcrumbItem } from "../../features/organizations/models";
 
 export const organizationConfigs: OrganizationConfigs = {
+    canCreateOrganization: (): boolean => {
+        return true;
+    },
     showOrganizationDropdown: true,
     showSwitcherInTenants: false,
     superOrganizationBreadcrumb: (

--- a/apps/console/src/features/core/models/reducer-state.ts
+++ b/apps/console/src/features/core/models/reducer-state.ts
@@ -34,8 +34,8 @@ import {
 } from "./config";
 import { PortalDocumentationStructureInterface } from "./help-panel";
 import { AppViewTypes } from "./ui";
-import { OrganizationResponseInterface } from "../../organizations/models";
 import { OrganizationType } from "../../organizations/constants";
+import { OrganizationResponseInterface } from "../../organizations/models";
 
 /**
  * Portal config reducer state interface.

--- a/apps/console/src/features/core/models/reducer-state.ts
+++ b/apps/console/src/features/core/models/reducer-state.ts
@@ -35,6 +35,7 @@ import {
 import { PortalDocumentationStructureInterface } from "./help-panel";
 import { AppViewTypes } from "./ui";
 import { OrganizationResponseInterface } from "../../organizations/models";
+import { OrganizationType } from "../../organizations/constants";
 
 /**
  * Portal config reducer state interface.
@@ -79,6 +80,7 @@ export interface OrganizationReducerStateInterface {
     organization?: OrganizationResponseInterface;
     getOrganizationLoading: boolean;
     isFirstLevelOrganization: boolean;
+    organizationType: OrganizationType;
 }
 
 export interface RoutesReducerStateInterface {

--- a/apps/console/src/features/core/store/actions/organization.ts
+++ b/apps/console/src/features/core/store/actions/organization.ts
@@ -20,9 +20,11 @@ import {
     OrganizationActionTypes,
     SetGetOrganizationLoadingActionInterface,
     SetIsFirstLevelOrganizationInterface,
-    SetOrganizationActionInterface
+    SetOrganizationActionInterface,
+    SetOrganizationTypeInterface
 } from "./types";
 import { OrganizationResponseInterface } from "../../../organizations/models";
+import { OrganizationType } from "../../../organizations/constants";
 
 /**
  * This action sets an organization in the redux store.
@@ -62,5 +64,18 @@ export const setIsFirstLevelOrganization = (isFirstLevel: boolean): SetIsFirstLe
     return {
         payload: isFirstLevel,
         type: OrganizationActionTypes.SET_IS_FIRST_LEVEL_ORGANIZATION
+    };
+};
+
+/**
+ * Sets the organization type.
+ *
+ * @param orgType - The organization type.
+ * @returns Redux action
+ */
+export const setOrganizationType = (orgType: OrganizationType): SetOrganizationTypeInterface => {
+    return {
+        payload: orgType,
+        type: OrganizationActionTypes.SET_ORGANIZATION_TYPE
     };
 };

--- a/apps/console/src/features/core/store/actions/organization.ts
+++ b/apps/console/src/features/core/store/actions/organization.ts
@@ -23,8 +23,8 @@ import {
     SetOrganizationActionInterface,
     SetOrganizationTypeInterface
 } from "./types";
-import { OrganizationResponseInterface } from "../../../organizations/models";
 import { OrganizationType } from "../../../organizations/constants";
+import { OrganizationResponseInterface } from "../../../organizations/models";
 
 /**
  * This action sets an organization in the redux store.

--- a/apps/console/src/features/core/store/actions/types/organization.ts
+++ b/apps/console/src/features/core/store/actions/types/organization.ts
@@ -16,12 +16,14 @@
  * under the License.
  */
 
+import { OrganizationType } from "../../../../organizations/constants";
 import { OrganizationResponseInterface } from "../../../../organizations/models";
 
 export enum OrganizationActionTypes {
     SET_ORGANIZATION = "SET_ORGANIZATION",
     SET_GET_ORGANIZATION_LOADING = "SET_GET_ORGANIZATION_LOADING",
-    SET_IS_FIRST_LEVEL_ORGANIZATION = "SET_IS_FIRST_LEVEL_ORGANIZATION"
+    SET_IS_FIRST_LEVEL_ORGANIZATION = "SET_IS_FIRST_LEVEL_ORGANIZATION",
+    SET_ORGANIZATION_TYPE = "SET_ORGANIZATION_TYPE"
 }
 
 export interface SetOrganizationActionInterface {
@@ -39,7 +41,13 @@ export interface SetIsFirstLevelOrganizationInterface {
     type: OrganizationActionTypes.SET_IS_FIRST_LEVEL_ORGANIZATION;
 }
 
+export interface SetOrganizationTypeInterface {
+    payload: OrganizationType;
+    type: OrganizationActionTypes.SET_ORGANIZATION_TYPE;
+}
+
 export type OrganizationAction =
     | SetOrganizationActionInterface
     | SetGetOrganizationLoadingActionInterface
-    | SetIsFirstLevelOrganizationInterface;
+    | SetIsFirstLevelOrganizationInterface
+    | SetOrganizationTypeInterface;

--- a/apps/console/src/features/core/store/reducers/organization.ts
+++ b/apps/console/src/features/core/store/reducers/organization.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { OrganizationManagementConstants } from "../../../organizations/constants";
+import { OrganizationManagementConstants, OrganizationType } from "../../../organizations/constants";
 import { OrganizationReducerStateInterface } from "../../models";
 import { OrganizationAction, OrganizationActionTypes } from "../actions/types";
 
@@ -37,7 +37,8 @@ const initialState: OrganizationReducerStateInterface = {
         },
         status: "",
         type: ""
-    }
+    },
+    organizationType: OrganizationType.SUPER_ORGANIZATION
 };
 
 export const organizationReducer = (
@@ -59,6 +60,11 @@ export const organizationReducer = (
             return {
                 ...state,
                 isFirstLevelOrganization: action.payload
+            };
+        case OrganizationActionTypes.SET_ORGANIZATION_TYPE:
+            return {
+                ...state,
+                organizationType: action.payload
             };
         default:
             return {

--- a/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
+++ b/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
@@ -45,6 +45,7 @@ import {
 } from "semantic-ui-react";
 import OrganizationListItem from "./organization-list-item";
 import OrganizationSwitcherList from "./organization-switch-list";
+import { organizationConfigs } from "../../../../extensions";
 import { ReactComponent as CrossIcon } from "../../../../themes/default/assets/images/icons/cross-icon.svg";
 import { AppState, getMiscellaneousIcons } from "../../../core";
 import { getOrganizations } from "../../api";
@@ -370,21 +371,23 @@ const OrganizationSwitchDropdown: FunctionComponent<OrganizationSwitchDropdownIn
                                             </h5>
                                         </Grid.Column>
                                         <Grid.Column width={ 4 }>
-                                            <Show
-                                                when={
-                                                    AccessControlConstants.ORGANIZATION_WRITE
-                                                }
-                                            >
-                                                <Button
-                                                    basic
-                                                    floated="right"
-                                                    onClick={ handleNewClick }
-                                                    data-componentid={ `${ componentId }-new-button` }
+                                            { organizationConfigs.canCreateOrganization() && (
+                                                <Show
+                                                    when={
+                                                        AccessControlConstants.ORGANIZATION_WRITE
+                                                    }
                                                 >
-                                                    <Icon name="add" />
-                                                    { t("common:new") }
-                                                </Button>
-                                            </Show>
+                                                    <Button
+                                                        basic
+                                                        floated="right"
+                                                        onClick={ handleNewClick }
+                                                        data-componentid={ `${ componentId }-new-button` }
+                                                    >
+                                                        <Icon name="add" />
+                                                        { t("common:new") }
+                                                    </Button>
+                                                </Show>
+                                            ) }
                                         </Grid.Column>
                                     </Grid.Row>
                                 </Grid>

--- a/apps/console/src/features/organizations/constants/organization-constants.ts
+++ b/apps/console/src/features/organizations/constants/organization-constants.ts
@@ -21,9 +21,6 @@ import { OrganizationInterface } from "../models";
 export class OrganizationManagementConstants {
     /**
      * Set of keys used to enable/disable features.
-     * @constant
-     * @type {Map<string, string>}
-     * @default
      */
     public static readonly FEATURE_DICTIONARY: Map<string, string> = new Map<string, string>()
         .set("ORGANIZATION_CREATE", "organizations.create")
@@ -39,9 +36,6 @@ export class OrganizationManagementConstants {
     /**
      * Super organization object.
      *
-     * @@constant
-     * @type {OrganizationInterface}
-     * @default
      */
     public static readonly ROOT_ORGANIZATION: OrganizationInterface = {
         id: this.ROOT_ORGANIZATION_ID,
@@ -61,9 +55,6 @@ export enum ORGANIZATION_TYPE {
 export class OrganizationRoleManagementConstants {
     /**
      * Set of keys used to enable/disable features.
-     * @constant
-     * @type {Map<string, string>}
-     * @default
      */
     public static readonly FEATURE_DICTIONARY: Map<string, string> = new Map<string, string>()
         .set("ORGANIZATION_ROLE_CREATE", "organization-roles.create")
@@ -89,8 +80,8 @@ export const ORGANIZATION_DESCRIPTION_MAX_LENGTH = 300;
  * Contains all the possible types of organizations.
  */
 export enum OrganizationType {
-    SUBORGANIZATION,
-    TENANT,
-    FIRST_LEVEL_ORGANIZATION,
-    SUPER_ORGANIZATION
+    SUBORGANIZATION = "SUBORGANIZATION",
+    TENANT = "TENANT",
+    FIRST_LEVEL_ORGANIZATION = "FIRST_LEVEL_ORGANIZATION",
+    SUPER_ORGANIZATION= "SUPER_ORGANIZATION"
 }

--- a/apps/console/src/features/organizations/constants/organization-constants.ts
+++ b/apps/console/src/features/organizations/constants/organization-constants.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -84,3 +84,13 @@ export const ORGANIZATION_NAME_MIN_LENGTH = 3;
 export const ORGANIZATION_NAME_MAX_LENGTH = 32;
 export const ORGANIZATION_DESCRIPTION_MIN_LENGTH = 3;
 export const ORGANIZATION_DESCRIPTION_MAX_LENGTH = 300;
+
+/**
+ * Contains all the possible types of organizations.
+ */
+export enum OrganizationType {
+    SUBORGANIZATION,
+    TENANT,
+    FIRST_LEVEL_ORGANIZATION,
+    SUPER_ORGANIZATION
+}

--- a/apps/console/src/features/organizations/hooks/use-get-organization-type.tsx
+++ b/apps/console/src/features/organizations/hooks/use-get-organization-type.tsx
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useSelector } from "react-redux";
+import { AppState } from "../../core";
+import { OrganizationType } from "../constants";
+
+/**
+ * This is a React hook that returns the type of the organization.
+ *
+ * @returns The type of the organization.
+ */
+export const useGetOrganizationType = (): OrganizationType => {
+    return useSelector(
+        (state: AppState) => state.organization.organizationType
+    );
+};

--- a/apps/console/src/features/organizations/pages/organizations.tsx
+++ b/apps/console/src/features/organizations/pages/organizations.tsx
@@ -46,6 +46,7 @@ import {
     Icon,
     PaginationProps
 } from "semantic-ui-react";
+import { organizationConfigs } from "../../../extensions";
 import { AdvancedSearchWithBasicFilters, AppState, EventPublisher, UIConstants } from "../../core";
 import { getOrganization, getOrganizations } from "../api";
 import { AddOrganizationModal, OrganizationList } from "../components";
@@ -372,7 +373,8 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
             <PageLayout
                 action={
                     !isOrganizationListRequestLoading &&
-                    !(!searchQuery && (isEmpty(organizationList) || organizationList?.organizations?.length <= 0)) && (
+                    !(!searchQuery && (isEmpty(organizationList) || organizationList?.organizations?.length <= 0)) &&
+                        organizationConfigs.canCreateOrganization() && (
                         <Show when={ AccessControlConstants.ORGANIZATION_WRITE }>
                             <PrimaryButton
                                 disabled={ isOrganizationListRequestLoading }
@@ -388,6 +390,7 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
                             </PrimaryButton>
                         </Show>
                     )
+
                 }
                 pageTitle="Organizations"
                 title={

--- a/apps/console/src/features/organizations/utils/organization.ts
+++ b/apps/console/src/features/organizations/utils/organization.ts
@@ -17,7 +17,7 @@
  */
 
 import { store } from "../../core/store";
-import { OrganizationManagementConstants } from "../constants";
+import { OrganizationManagementConstants, OrganizationType } from "../constants";
 import { GenericOrganization } from "../models";
 
 export class OrganizationUtils {
@@ -45,5 +45,14 @@ export class OrganizationUtils {
     public static isCurrentOrganizationRoot(): boolean {
         return store.getState().organization?.organization?.id
             === OrganizationManagementConstants.ROOT_ORGANIZATION_ID;
+    }
+
+    /**
+     * Get the type of the current organization.
+     *
+     * @returns The type of the current organization.
+     */
+    public static getOrganizationType(): OrganizationType{
+        return store.getState().organization?.organizationType;
     }
 }

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -375,7 +375,11 @@ export const AppUtils = (function() {
          * @param skipSuperTenant - Flag to skip super tenant.
          * @returns Tenant path.
          */
-        getTenantPath: function(skipSuperTenant = false) {
+        getTenantPath: function (skipSuperTenant = false) {
+            if (this.getOrganizationName()) {
+                return "";
+            }
+
             if (skipSuperTenant && (this.getTenantName() === this.getSuperTenant() || this.getTenantName() === "")) {
                 return urlPathForSuperTenantOriginsFallback;
             }


### PR DESCRIPTION
### Purpose

> This PR 
> - sets the organization type to the REdux store
> - adds a config to show/hide organization creation buttons
> - adds hooks and util methods to get the organization type.
> 

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
