### PR TITLE
Turn getUserDropdownLinkExtensions method into an async method

### DIFF
--- a/apps/console/src/extensions/configs/common.tsx
+++ b/apps/console/src/extensions/configs/common.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -30,10 +30,16 @@ export const commonConfig: CommonConfig = {
     header: {
         getHeaderExtensions: (): HeaderExtension[] => [],
         getHeaderSubPanelExtensions: (): HeaderSubPanelItemInterface[] => [],
-        getUserDropdownLinkExtensions: (tenantDomain: string,
-            associatedTenants: any[]): HeaderLinkCategoryInterface[] => [],
+        getUserDropdownLinkExtensions: (
+            _tenantDomain: string,
+            _associatedTenants: any[]): Promise<HeaderLinkCategoryInterface[]> => Promise.resolve([]),
         headerQuickstartMenuItem: "",
         renderAppSwitcherAsDropdown: false
+    },
+    hotjarTracking : {
+        tagAttributes : () : void => {
+            return;
+        }
     },
     leftNavigation: {
         isLeftNavigationCategorized: {
@@ -44,10 +50,5 @@ export const commonConfig: CommonConfig = {
     userEditSection: {
         isGuestUser: false,
         showEmail: true
-    },
-    hotjarTracking : {
-        tagAttributes : () : void => {
-            return;
-        }
-     }
+    }
 };

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -30,24 +30,25 @@ export interface CommonConfig {
     header: {
         /**
          * Get the extensions for the header.
-         * @return {HeaderExtension[]}
+         * @returns
          */
         getHeaderExtensions: () => HeaderExtension[];
         /**
          * Get the extensions for the Header sub panel.
          * These will come along with the `Manage` & `Develop` links.
-         * @return {{aligned: "left" | "right"; component: React.ReactElement; order: number}[]}
+         * @returns
          */
         getHeaderSubPanelExtensions: () => HeaderSubPanelItemInterface[];
         /**
          * Get the user dropdown link extensions.
-         * 
-         * @param {string} tenantDomain - Current tenant.
-         * @param {any[]} associatedTenants - Tenant list.
-         * @return {HeaderLinkCategoryInterface[]}
+         *
+         * @param tenantDomain - Current tenant.
+         * @param associatedTenants - Tenant list.
+         *
+         * @returns
          */
         getUserDropdownLinkExtensions: (tenantDomain: string,
-            associatedTenants: any[]) => HeaderLinkCategoryInterface[];
+            associatedTenants: any[]) => Promise<HeaderLinkCategoryInterface[]>;
         /**
          * Should the app switcher be shown as nine dots dropdown.
          */
@@ -72,7 +73,7 @@ export interface CommonConfig {
     };
     hotjarTracking : {
         /*
-         * Tag hotjar attributes. 
+         * Tag hotjar attributes.
         */
         tagAttributes : () => void;
     }
@@ -82,7 +83,6 @@ export interface CommonConfig {
  * Types of views that are extended.
  * @remarks Any views other than `DEVELOP` and `MANAGE` can go here.
  * @readonly
- * @enum {string}
  */
 export enum AppViewExtensionTypes { }
 

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -23,6 +23,7 @@ import {
     Announcement,
     AppSwitcher,
     GenericIcon,
+    HeaderLinkCategoryInterface,
     Logo,
     ProductBrand,
     Header as ReusableHeader,
@@ -119,6 +120,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
     const scopes = useSelector((state: AppState) => state.auth.allowedScopes);
 
     const [ announcement, setAnnouncement ] = useState<AnnouncementBannerInterface>(undefined);
+    const [ headerLinks, setHeaderLinks ] = useState<HeaderLinkCategoryInterface[]>([]);
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
@@ -147,6 +149,15 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
         tenantDomain,
         feature.organizations
     ]);
+
+    useEffect(() => {
+        commonConfig
+            ?.header
+            ?.getUserDropdownLinkExtensions(tenantDomain, associatedTenants)
+            .then((response: HeaderLinkCategoryInterface[]) => {
+                setHeaderLinks(response);
+            } );
+    }, [ tenantDomain, associatedTenants ]);
 
     /**
      * Check if there are applications registered and set the value to local storage.
@@ -451,7 +462,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                             }
                         ]
                     },
-                    ...commonConfig?.header?.getUserDropdownLinkExtensions(tenantDomain, associatedTenants),
+                    ...headerLinks,
                     {
                         category: "GENERAL",
                         categoryLabel: null,


### PR DESCRIPTION
### Purpose
> This PR makes getUserDropdownLinkExtensions an async function so that async calls can be made within this config method.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
