### PR TITLE
Adjust tab order of sign-in pages

### DIFF
--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -311,7 +311,6 @@
                     id="username"
                     value=""
                     name="username"
-                    tabindex="1"
                     placeholder="<%=AuthenticationEndpointUtil.i18n(resourceBundle, usernameLabel)%>"
                     data-testid="login-page-username-input"
                     required>
@@ -329,7 +328,6 @@
                     name="password"
                     value=""
                     autocomplete="off"
-                    tabindex="2"
                     placeholder="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "password")%>"
                     data-testid="login-page-password-input"
                     style="padding-right: 2.3em !important;"
@@ -429,7 +427,6 @@
             <% if (!isIdentifierFirstLogin(inputType) && isUsernameRecoveryEnabledInTenant) { %>
             <a
                 id="usernameRecoverLink"
-                tabindex="5"
                 href="<%=StringEscapeUtils.escapeHtml4(getRecoverAccountUrl(identityMgtEndpointContext, urlEncodedURL, true, urlParameters))%>"
                 data-testid="login-page-username-recovery-button"
             >
@@ -442,7 +439,6 @@
               if (isPasswordRecoveryEnabledInTenant) { %>
             <a
                 id="passwordRecoverLink"
-                tabindex="6"
                 href="<%=StringEscapeUtils.escapeHtml4(getRecoverAccountUrlWithUsername(identityMgtEndpointContext, urlEncodedURL, false, urlParameters, usernameIdentifier))%>"
                 data-testid="login-page-password-recovery-button"
             >
@@ -455,7 +451,13 @@
 
         <% if (isIdentifierFirstLogin(inputType)) { %>
         <div class="field">
-            <a id="backLink" tabindex="7" onclick="goBack()" data-testid="login-page-back-button">
+            <a 
+                id="backLink" 
+                class="clickable-link" 
+                tabindex="0" 
+                onclick="goBack()" 
+                onkeypress="javascript: if (window.event.keyCode === 13) goBack()"
+                data-testid="login-page-back-button">
                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.different.account")%>
             </a>
         </div>
@@ -467,7 +469,6 @@
     <div class="field">
         <div class="ui checkbox">
             <input
-                tabindex="3"
                 type="checkbox"
                 id="chkRemember"
                 name="chkRemember"
@@ -499,7 +500,6 @@
         <div class="column buttons">
             <button
                 class="ui primary fluid large button"
-                tabindex="4"
                 type="submit"
             >
                 <%=StringEscapeUtils.escapeHtml4(AuthenticationEndpointUtil.i18n(resourceBundle, "continue"))%>
@@ -512,7 +512,6 @@
                 onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(getRegistrationUrl(accountRegistrationEndpointURL, urlEncodedURL, urlParameters))%>';"
                 class="ui secondary fluid large button"
                 id="registerLink"
-                tabindex="8"
                 role="button"
                 data-testid="login-page-create-account-button"
             >
@@ -575,6 +574,20 @@
         function onSubmitResend(token) {
            $("#resendForm").submit();
         }
+
+        // Removing the recaptcha UI from the keyboard tab order
+        Array.prototype.forEach.call(document.getElementsByClassName('g-recaptcha'), function (element) {
+            //Add a load event listener to each wrapper, using capture.
+            element.addEventListener('load', function (e) {
+                //Get the data-tabindex attribute value from the wrapper.
+                var tabindex = e.currentTarget.getAttribute('data-tabindex');
+                //Check if the attribute is set.
+                if (tabindex) {
+                    //Set the tabIndex on the iframe.
+                    e.target.tabIndex = "-1";
+                }
+            }, true);
+        });
 
     </script>
 

--- a/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -283,8 +283,9 @@
                                     data-size="invisible"
                                     data-callback="onCompleted"
                                     data-action="passwordRecovery"
-                                    data-sitekey=
-                                            "<%=Encode.forHtmlContent(reCaptchaKey)%>">
+                                    data-sitekey="<%=Encode.forHtmlContent(reCaptchaKey)%>"
+                                    data-tabindex="-1"
+                                    >
                             </div>
                         </div>
                         <%
@@ -378,6 +379,20 @@
 
                 return true;
             });
+        });
+
+        // Removing the recaptcha UI from the keyboard tab order
+        Array.prototype.forEach.call(document.getElementsByClassName('g-recaptcha'), function (element) {
+            //Add a load event listener to each wrapper, using capture.
+            element.addEventListener('load', function (e) {
+                //Get the data-tabindex attribute value from the wrapper.
+                var tabindex = e.currentTarget.getAttribute('data-tabindex');
+                //Check if the attribute is set.
+                if (tabindex) {
+                    //Set the tabIndex on the iframe.
+                    e.target.tabIndex = "-1";
+                }
+            }, true);
         });
 
     </script>


### PR DESCRIPTION
### Purpose
> This task is to make sure the the order of content within the pages for keyboard users in selected in the correct flow. This full-fills [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=111#focus-order) WCAG Level A Standard

### Related Issues
> https://github.com/wso2/product-is/issues/15086

### Related PRs
- https://github.com/wso2/identity-apps/pull/3568

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
