### PR TITLE
Tab order adjustment of consent pages

### DIFF
--- a/apps/authentication-portal/src/main/webapp/consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/consent.jsp
@@ -118,7 +118,7 @@
                                         %>
                                         <div class="field required">
                                             <div class="ui checkbox checked read-only disabled claim-cb">
-                                                <input type="checkbox" class="mandatory-claim hidden" name="consent_<%=Encode.forHtmlAttribute(claimId)%>" id="consent_<%=Encode.forHtmlAttribute(claimId)%>" required checked readonly />
+                                                <input tabindex="-1" type="checkbox" class="mandatory-claim hidden" name="consent_<%=Encode.forHtmlAttribute(claimId)%>" id="consent_<%=Encode.forHtmlAttribute(claimId)%>" required checked readonly />
                                                 <label for="consent_<%=Encode.forHtmlAttribute(claimId)%>"><%=Encode.forHtml(displayName)%></label>
                                             </div>
                                         </div>
@@ -206,7 +206,7 @@
         <jsp:include page="includes/footer.jsp"/>
     <% } %>
 
-    <div class="ui modal mini" id="modal_claim_validation" tabindex="-1" role="dialog" aria-labelledby="mySmallModalLabel">
+    <div class="ui modal mini" id="modal_claim_validation" role="dialog" aria-labelledby="mySmallModalLabel">
         <div class="header">
             <h4 class="modal-title"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "mandatory.claims")%></h4>
         </div>

--- a/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
@@ -186,7 +186,7 @@
                                             %>
                                             <div class="field required">
                                                 <div class="ui checkbox checked read-only disabled claim-cb">
-                                                    <input type="checkbox" class="mandatory-claim hidden" name="consent_<%=Encode.forHtmlAttribute(claimId)%>" id="consent_<%=Encode.forHtmlAttribute(claimId)%>" required checked readonly />
+                                                    <input tabindex="-1" type="checkbox" class="mandatory-claim hidden" name="consent_<%=Encode.forHtmlAttribute(claimId)%>" id="consent_<%=Encode.forHtmlAttribute(claimId)%>" required checked readonly />
                                                     <label for="consent_<%=Encode.forHtmlAttribute(claimId)%>"><%=Encode.forHtml(displayName)%></label>
                                                 </div>
                                             </div>
@@ -313,7 +313,6 @@
                                 <div class="field">
                                     <div class="ui checkbox">
                                         <input
-                                            tabindex="3"
                                             type="checkbox"
                                             id="rememberApproval"
                                             name="rememberApproval"


### PR DESCRIPTION
### Purpose
> This task is to make sure the the order of content within the pages for keyboard users in selected in the correct flow. This full-fills [2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=111#focus-order) WCAG Level A Standard

### Related Issues
> https://github.com/wso2/product-is/issues/15086

### Related PRs
- https://github.com/wso2/identity-apps/pull/3558

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

