### PR TITLE
Fix only searched attributes getting saved as added attributes

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection-oidc.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection-oidc.tsx
@@ -62,6 +62,8 @@ interface AttributeSelectionOIDCPropsInterface extends TestableComponentInterfac
     externalClaims: ExtendedExternalClaimInterface[];
     externalClaimsGroupedByScopes: OIDCScopesClaimsListInterface[];
     setExternalClaimsGroupedByScopes: any;
+    unfilteredExternalClaimsGroupedByScopes: OIDCScopesClaimsListInterface[];
+    setUnfilteredExternalClaimsGroupedByScopes: any;
     setExternalClaims: any;
     selectedExternalClaims: ExtendedExternalClaimInterface[];
     setSelectedExternalClaims: any;
@@ -98,6 +100,8 @@ export const AttributeSelectionOIDC: FunctionComponent<AttributeSelectionOIDCPro
         externalClaimsGroupedByScopes,
         setExternalClaimsGroupedByScopes,
         setExternalClaims,
+        unfilteredExternalClaimsGroupedByScopes,
+        setUnfilteredExternalClaimsGroupedByScopes,
         selectedExternalClaims,
         selectedDialect,
         setSelectedExternalClaims,
@@ -121,11 +125,6 @@ export const AttributeSelectionOIDC: FunctionComponent<AttributeSelectionOIDCPro
         filterSelectedExternalClaims,
         setFilterSelectedExternalClaims
     ] = useState<ExtendedExternalClaimInterface[]>([]);
-
-    const [
-        unfilteredExternalClaimsGroupedByScopes,
-        setUnfilteredExternalClaimsGroupedByScopes
-    ] = useState<OIDCScopesClaimsListInterface[]>(externalClaimsGroupedByScopes);
 
     const [ expandedScopes, setExpandedScopes ] = useState<string[]>([]);
 

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -194,6 +194,8 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
     const [ scopes, setScopes ] = useState<OIDCScopesListInterface[]>(null);
     const [ externalClaimsGroupedByScopes, setExternalClaimsGroupedByScopes ]
         = useState<OIDCScopesClaimsListInterface[]>(null);
+    const [ unfilteredExternalClaimsGroupedByScopes, setUnfilteredExternalClaimsGroupedByScopes ] 
+        = useState<OIDCScopesClaimsListInterface[]>([]);
 
     // Manage available claims in local and external dialects.
     const [ isClaimRequestLoading, setIsClaimRequestLoading ] = useState(true);
@@ -422,6 +424,7 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                 selected: isScopelessClaimRequested
             });
         }
+        setUnfilteredExternalClaimsGroupedByScopes(sortBy(updatedScopes, "name"));
         setExternalClaimsGroupedByScopes(sortBy(updatedScopes, "name"));
         setIsScopeExternalClaimMappingLoading(false);
     };
@@ -953,7 +956,7 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                 }
             });
         } else {
-            externalClaimsGroupedByScopes.map((scope) => {
+            unfilteredExternalClaimsGroupedByScopes.map((scope) => {
                 scope?.claims.map((claim: ExtendedExternalClaimInterface) => {
                     if (claim.requested) {
                         const requestedClaim = {
@@ -1080,6 +1083,12 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
                                                 externalClaims={ externalClaims }
                                                 externalClaimsGroupedByScopes = { externalClaimsGroupedByScopes }
                                                 setExternalClaimsGroupedByScopes = { setExternalClaimsGroupedByScopes }
+                                                unfilteredExternalClaimsGroupedByScopes = { 
+                                                    unfilteredExternalClaimsGroupedByScopes 
+                                                }
+                                                setUnfilteredExternalClaimsGroupedByScopes = { 
+                                                    setUnfilteredExternalClaimsGroupedByScopes
+                                                }
                                                 setExternalClaims={ setExternalClaims }
                                                 selectedExternalClaims={ selectedExternalClaims }
                                                 setSelectedExternalClaims={ setSelectedExternalClaims }


### PR DESCRIPTION
### Purpose
> When a user attribute is searched and marked rewuested and saved, only that attribute is getting saved at the backend. 

### Related Issues
- None

### Related PRs
- None

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
