### PR TITLE
Fix custom error scenarios in retry.do page

### DIFF
--- a/apps/authentication-portal/src/main/webapp/retry.jsp
+++ b/apps/authentication-portal/src/main/webapp/retry.jsp
@@ -69,8 +69,9 @@
     } else if (StringUtils.isNotEmpty(stat) || StringUtils.isNotEmpty(statusMessage)) {
         String i18nErrorMapping = AuthenticationEndpointUtil.getErrorCodeToi18nMapping(stat, statusMessage);
         if (Constants.ErrorToi18nMappingConstants.INCORRECT_ERROR_MAPPING_KEY.equals(i18nErrorMapping)) {
-            stat = null;
-            statusMessage = null;
+            stat = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.error");
+            statusMessage = AuthenticationEndpointUtil.i18n(resourceBundle, 
+                    "something.went.wrong.during.authentication");
         } else {
             if (StringUtils.isNotEmpty(stat)) {
                 stat = AuthenticationEndpointUtil.customi18n(resourceBundle, stat);

--- a/apps/authentication-portal/src/main/webapp/retry.jsp
+++ b/apps/authentication-portal/src/main/webapp/retry.jsp
@@ -1,7 +1,7 @@
 <%--
-  ~ Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2014, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
   ~
-  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
@@ -19,6 +19,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.client.model.AuthenticationRequestWrapper" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApplicationDataRetrievalClient" %>
@@ -39,43 +40,53 @@
     private static final String REQUEST_PARAM_ERROR_KEY = "errorKey";
 %>
 <%
-    String stat = request.getParameter("status");
-    String statusMessage = request.getParameter("statusMsg");
+    String stat = request.getParameter(Constants.STATUS);
+    String statusMessage = request.getParameter(Constants.STATUS_MSG);
     String sp = request.getParameter("sp");
     String applicationAccessURLWithoutEncoding = null;
-    // Check the error is null or whether there is no corresponding value in the resource bundle.
-    if (stat == null || statusMessage == null) {
-        String errorKey = request.getParameter(REQUEST_PARAM_ERROR_KEY);
-        if (errorKey != null) {
-            if (request.getParameter(Constants.STATUS) != null) {
-                String statusParam = request.getParameter(Constants.STATUS);
-                String statusMessageParam = request.getParameter(Constants.STATUS_MSG);
-                if (StringUtils.isNotEmpty(statusParam)) {
-                    stat = AuthenticationEndpointUtil.customi18n(resourceBundle, statusParam);
-                }
-                if (StringUtils.isNotEmpty(statusMessageParam)) {
-                    statusMessage = AuthenticationEndpointUtil.customi18n(resourceBundle, statusMessageParam);
-                }
+
+    String errorKey = request.getParameter(REQUEST_PARAM_ERROR_KEY);
+    String statAuthParam = null;
+    String statusMsgAuthParam = null;
+
+    if (StringUtils.isNotEmpty(errorKey)) {
+        AuthenticationRequestWrapper authRequest = (AuthenticationRequestWrapper) request;
+        statAuthParam = authRequest.getAuthParameter(Constants.STATUS);
+        statusMsgAuthParam = authRequest.getAuthParameter(Constants.STATUS_MSG);
+    }
+
+    // If auth params are available, can skip i18n mapping validations. This is to allow displaying
+    // custom error messages.
+    if (StringUtils.isNotEmpty(statAuthParam) || StringUtils.isNotEmpty(statusMsgAuthParam)) {
+        stat = statAuthParam;
+        statusMessage = statusMsgAuthParam;
+        if (StringUtils.isNotEmpty(stat)) {
+            stat = AuthenticationEndpointUtil.customi18n(resourceBundle, stat);
+        }
+        if (StringUtils.isNotEmpty(statusMessage)) {
+            statusMessage = AuthenticationEndpointUtil.customi18n(resourceBundle, statusMessage);
+        }
+    } else if (StringUtils.isNotEmpty(stat) || StringUtils.isNotEmpty(statusMessage)) {
+        String i18nErrorMapping = AuthenticationEndpointUtil.getErrorCodeToi18nMapping(stat, statusMessage);
+        if (Constants.ErrorToi18nMappingConstants.INCORRECT_ERROR_MAPPING_KEY.equals(i18nErrorMapping)) {
+            stat = null;
+            statusMessage = null;
+        } else {
+            if (StringUtils.isNotEmpty(stat)) {
+                stat = AuthenticationEndpointUtil.customi18n(resourceBundle, stat);
+            }
+            if (StringUtils.isNotEmpty(statusMessage)) {
+                statusMessage = AuthenticationEndpointUtil.customi18n(resourceBundle, statusMessage);
             }
         }
-        if (StringUtils.isEmpty(stat)) {
-            stat = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.error");
-        }
-        if (StringUtils.isEmpty(statusMessage)) {
-            statusMessage =  AuthenticationEndpointUtil.i18n(resourceBundle,
-                    "something.went.wrong.during.authentication");
-        }
-    } else {
-        String i18nErrorMapping = AuthenticationEndpointUtil.getErrorCodeToi18nMapping(
-            stat, statusMessage);
-        if (!(Constants.ErrorToi18nMappingConstants.INCORRECT_ERROR_MAPPING_KEY).equals(i18nErrorMapping)) {
-            stat = AuthenticationEndpointUtil.customi18n(resourceBundle, stat);
-            statusMessage = AuthenticationEndpointUtil.customi18n(resourceBundle, statusMessage);
-        } else {
-            stat = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.error");
-            statusMessage =  AuthenticationEndpointUtil.i18n(resourceBundle,
+    }
+
+    if (StringUtils.isEmpty(stat)) {
+        stat = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.error");
+    }
+    if (StringUtils.isEmpty(statusMessage)) {
+        statusMessage = AuthenticationEndpointUtil.i18n(resourceBundle,
                 "something.went.wrong.during.authentication");
-        }
     }
     session.invalidate();
 

--- a/pom.xml
+++ b/pom.xml
@@ -671,7 +671,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.25.14</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.22</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.core.service.version>1.0.0
         </identity.organization.management.core.service.version>


### PR DESCRIPTION
### Purpose
There's a requirement to show custom error scenarios in retry.do page. With functions like `sendError` in adaptive scripts, it is possible to display customized error messages to the end user in their error flows. In these cases it is not possible to perform i18 mapping checks with a set of predefined values. However allowing this should not expose our frontend code for content spoofing scenarios.

#### Changes proposed in this PR
- Fix issue of showing customized error scenarios in retry.do page (Fix e2e test in age based access control).
- Prevent content spoofing scenarios when only one query parameter is defined with invalid errorKey.

#### Approach
With recent improvements, now we are not sending `status` and `statusMessage` as query parameters and those will be resolved in a tomcat filter using a backend generated error key. This is a random UUID and will be added to the cache with the error details while authenticating the user. So only a small subset of keys will be visible as query parameters in the UI.

Therefore the fix will be done as follows.
- A new method is added to backend  to obtain only the auth parameters. Auth parameters will be obtained by calling `request.getAuthParameter()`.
- If auth parameters are available, priority will be given to them and will skip i18n validations.
- If auth parameters are not available but query parameters found for `stat` and `statusMsg`, perform i18n mappings validations. If the mapping is incorrect, set those params to default.
- If one of stat or statusMsg is not defined, set the default value.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
