### PR TITLE
Duplicated GET requests on Protocol tab update of an Application

### DIFF
--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -493,11 +493,10 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
 
                 const protocolName = mapProtocolTypeToName(protocol.type);
 
-                if(!protocolNames.includes(protocolName)){
+                if(!protocolNames.includes(protocolName)) {
                     protocolNames.push(protocolName);
+                    inboundProtocolRequests.push(getInboundProtocolConfig(appId, protocolName));
                 }
-
-                inboundProtocolRequests.push(getInboundProtocolConfig(appId, protocolName));
             });
 
             setIsInboundProtocolConfigRequestLoading(true);

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -493,7 +493,9 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
 
                 const protocolName = mapProtocolTypeToName(protocol.type);
 
-                protocolNames.push(protocolName);
+                if(!protocolNames.includes(protocolName)){
+                    protocolNames.push(protocolName);
+                }
 
                 inboundProtocolRequests.push(getInboundProtocolConfig(appId, protocolName));
             });


### PR DESCRIPTION
### Purpose
- The GET request sent upon updating information in the Protocol tab of an Application was duplicated.
- With this fix, there should be only one request per configured protocol.

### Related Issues
- Resolves: wso2-enterprise/asgardeo-product#11884
