### PR TITLE
Enable javascript API for Google One Tap

### DIFF
--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -396,10 +396,9 @@
 
                                             <script src="https://accounts.google.com/gsi/client" async defer></script>
 
-                                            <div id="google_parent" class="google-one-tap-container">
-                                            </div>
+                                            <div id="google_parent" class="google-one-tap-container"></div>
 
-                                            <form action="<%=GOOGLE_CALLBACK_URL%>" method="post" id="googleOneTapForm">
+                                            <form action="<%=GOOGLE_CALLBACK_URL%>" method="post" id="googleOneTapForm" style="display: none;">
                                                 <input type="hidden" name="state" value="<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>"/>
                                                 <input type="hidden" name="idp" value="<%=idpName%>"/>
                                                 <input type="hidden" name="authenticator"  value="<%=idpEntry.getValue()%>"/>
@@ -416,10 +415,10 @@
                                                         cancel_on_tap_outside: false,
                                                         nonce: "<%=Encode.forJavaScriptAttribute(request.getParameter("sessionDataKey"))%>",
                                                         callback: handleCredentialResponse
-                                                     });
-                                                     google.accounts.id.prompt((notification) => {
-                                                         onMoment(notification);
-                                                     });
+                                                    });
+                                                    google.accounts.id.prompt((notification) => {
+                                                        onMoment(notification);
+                                                    });
                                                 }
                                             </script>
                                         <% } else { %>
@@ -595,8 +594,8 @@
         }
 
         function handleCredentialResponse(response) {
-            document.getElementById("googleOneTapForm").elements.credential.value = response.credential;
-            document.getElementById("googleOneTapForm").submit();
+           $('#credential').val(response.credential);
+           $('#googleOneTapForm').submit();
         }
 
         function checkSessionKey() {

--- a/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/apps/authentication-portal/src/main/webapp/login.jsp
@@ -397,18 +397,31 @@
                                             <script src="https://accounts.google.com/gsi/client" async defer></script>
 
                                             <div id="google_parent" class="google-one-tap-container">
-                                                <div id="g_id_onload"
-                                                    data-client_id="<%=Encode.forHtmlAttribute(GOOGLE_CLIENT_ID)%>"
-                                                    data-login_uri="<%=Encode.forHtmlAttribute(GOOGLE_CALLBACK_URL)%>"
-                                                    data-prompt_parent_id="google_parent"
-                                                    data-state="<%=request.getParameter("sessionDataKey")%>"
-                                                    data-cancel_on_tap_outside="false"
-                                                    data-authenticator="<%=Encode.forHtmlAttribute(idpEntry.getValue())%>"
-                                                    data-idp="<%=Encode.forHtmlAttribute(idpName)%>"
-                                                    data-one_tap_enabled="true"
-                                                    data-moment_callback="onMoment">
-                                                </div>
                                             </div>
+
+                                            <form action="<%=GOOGLE_CALLBACK_URL%>" method="post" id="googleOneTapForm">
+                                                <input type="hidden" name="state" value="<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>"/>
+                                                <input type="hidden" name="idp" value="<%=idpName%>"/>
+                                                <input type="hidden" name="authenticator"  value="<%=idpEntry.getValue()%>"/>
+                                                <input type="hidden" name="one_tap_enabled"  value="true"/>
+                                                <input type="hidden" name="internal_submission"  value="true"/>
+                                                <input type="hidden" name="credential" id="credential"/>
+                                            </form>
+
+                                            <script>
+                                                window.onload = function callGoogleOneTap() {
+                                                    google.accounts.id.initialize({
+                                                        client_id: "<%=Encode.forJavaScriptAttribute(GOOGLE_CLIENT_ID)%>",
+                                                        prompt_parent_id: "google_parent",
+                                                        cancel_on_tap_outside: false,
+                                                        nonce: "<%=Encode.forJavaScriptAttribute(request.getParameter("sessionDataKey"))%>",
+                                                        callback: handleCredentialResponse
+                                                     });
+                                                     google.accounts.id.prompt((notification) => {
+                                                         onMoment(notification);
+                                                     });
+                                                }
+                                            </script>
                                         <% } else { %>
                                             <script>
                                                 document.getElementById("googleSignIn").style.display = "block";
@@ -579,6 +592,11 @@
                     element.style.display = "none";
                 }
             }
+        }
+
+        function handleCredentialResponse(response) {
+            document.getElementById("googleOneTapForm").elements.credential.value = response.credential;
+            document.getElementById("googleOneTapForm").submit();
         }
 
         function checkSessionKey() {


### PR DESCRIPTION
### Purpose
> Enabling Google One Tap via Javascript API

### Related Issues
- https://github.com/wso2/product-is/issues/14407
- https://github.com/wso2-enterprise/iam-engineering/issues/139

### Related PRs
- https://github.com/wso2-extensions/identity-outbound-auth-google/pull/41

This PR have to be merged once https://github.com/wso2-extensions/identity-outbound-auth-google/pull/41 is done

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
