### PR TITLE
Fix saml attribute page not loading issue

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -271,9 +271,7 @@ export const AttributeSettings: FunctionComponent<AttributeSelectionPropsInterfa
     }, [ isOIDCScopeListLoading ]);
 
     useEffect(() => {
-        if (externalClaims.length !== 0) {
-            getExternalClaimsGroupedByScopes();
-        }
+        getExternalClaimsGroupedByScopes();
     }, [ externalClaims ]);
 
     /**


### PR DESCRIPTION
### Purpose
> This fixes saml attribute page not loading issue, which caused by unnecessary conditional check of externalClaim list length.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.