### PR TITLE
Catch MalformedURLException when encoding access URL

### DIFF
--- a/apps/authentication-portal/src/main/webapp/util/timeout.jsp
+++ b/apps/authentication-portal/src/main/webapp/util/timeout.jsp
@@ -24,6 +24,8 @@
 <%@ page import="static org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil.*" %>
 <%@ page import="static org.apache.commons.lang.StringUtils.isNotBlank" %>
 
+<%@ page import="java.net.MalformedURLException" %>
+
 <%--Include timeout JS functions--%>
 <jsp:include page="countdown.jsp"/>
 
@@ -125,7 +127,7 @@
             appAccessUrlEncoded = encodeURL(url);
         }
 
-    } catch (ApplicationDataRetrievalClientException e) {
+    } catch (ApplicationDataRetrievalClientException | MalformedURLException e) {
         // Ignored and fallback to login page url.
     }
 


### PR DESCRIPTION
### Purpose
When a URL without a protocol is entered as access URL for an application, the authentication portal breaks when trying to login, since the attempt to encode the access URL results in an uncaught `MalformedURLException`.
This PR handles that exception.


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
