### PR TITLE
Keyboard tab focus styling changes

### DIFF
--- a/modules/theme/src/themes/default/elements/button.overrides
+++ b/modules/theme/src/themes/default/elements/button.overrides
@@ -223,6 +223,9 @@
             }
         }
     }
+    &:focus-visible{
+        outline: 2px solid blue;
+    }
 }
 
 .ui.labeled.icon.button {
@@ -338,5 +341,17 @@
                 float: left;
                 fontSize: medium;
           }
+    }
+}
+
+.ui.primary.button{
+    &:focus-visible{
+        outline: 2px solid blue;
+    }
+}
+
+.ui.button.secondary{
+    &:focus-visible{
+        outline: 2px solid blue;
     }
 }

--- a/modules/theme/src/themes/default/globals/site.variables
+++ b/modules/theme/src/themes/default/globals/site.variables
@@ -176,10 +176,10 @@
 --------------------*/
 
 /* Used on inputs, textarea etc */
-@focusedFormBorderColor: lighten(@primaryColor, 30);
+@focusedFormBorderColor: @primaryColor;
 
 /* Used on dropdowns, other larger blocks */
-@focusedFormMutedBorderColor: lighten(@primaryColor, 30);
+@focusedFormMutedBorderColor: @primaryColor;
 
 /*-------------------
    Advanced search


### PR DESCRIPTION
### Purpose
> This task is to make sure that there is a visible border around elements that are currently selected by a keyboard tab. This full-fills [2.4.7: Focus Visible](https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=111#focus-visible) WCAG Level AA Standard

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/13083


### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any) - n/a
- [ ] Unit tests provided. (Add links if there are any) - n/a
- [ ] Integration tests provided. (Add links if there are any) - n/a

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
