### PR TITLE
Fix Popups being blurred issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -276,6 +276,11 @@ module.exports = {
                     {
                         message: "Please use import foo from 'lodash-es/foo' instead.",
                         name: "lodash-es"
+                    },
+                    {
+                        importNames: [ "Popup" ],
+                        message: "Avoid using Popup from Semantic. Instead import it from @wso2is/react-components.",
+                        name: "semantic-ui-react"
                     }
                 ],
                 patterns: [ "@wso2is/**/dist/**", "lodash/**", "lodash/fp/**" ]

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -30,10 +30,10 @@ import {
     Popup,
     useDocumentation
 } from "@wso2is/react-components";
-import { AxiosResponse } from "axios";
+import { AxiosError, AxiosResponse } from "axios";
 import get from "lodash-es/get";
 import sortBy from "lodash-es/sortBy";
-import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { Dispatch, Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Divider, Grid, Header, Button as SemButton } from "semantic-ui-react";
@@ -55,7 +55,9 @@ import CustomApplicationTemplate
 import {
     ApplicationInterface,
     ApplicationTemplateListItemInterface,
+    AuthProtocolMetaInterface,
     CertificateInterface, OIDCDataInterface,
+    OIDCMetadataInterface,
     SAML2ConfigurationInterface,
     SAMLConfigModes,
     SupportedAuthProtocolMetaTypes,
@@ -179,11 +181,12 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
     const { t } = useTranslation();
     const { getLink } = useDocumentation();
 
-    const dispatch = useDispatch();
+    const dispatch: Dispatch<any> = useDispatch();
 
-    const authProtocolMeta = useSelector((state: AppState) => state.application.meta.protocolMeta);
+    const authProtocolMeta: AuthProtocolMetaInterface = useSelector(
+        (state: AppState) => state.application.meta.protocolMeta);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
-    const tenantName = store.getState().config.deployment.tenant;
+    const tenantName: string = store.getState().config.deployment.tenant;
     const allowMultipleProtocol: boolean = useSelector(
         (state: AppState) => state.config.deployment.allowMultipleAppProtocols);
 
@@ -216,7 +219,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
 
                 onUpdate(appId);
             })
-            .catch((error) => {
+            .catch((error: AxiosError) => {
                 if (error?.response?.data?.description) {
                     dispatch(addAlert({
                         description: error?.response?.data?.description,
@@ -249,7 +252,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
             .then(() => {
                 onUpdate(appId);
             })
-            .catch((error) => {
+            .catch((error: AxiosError) => {
                 if (error?.response?.data?.description) {
                     dispatch(addAlert({
                         description: error?.response?.data?.description,
@@ -294,7 +297,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                 }));
                 onAllowedOriginsUpdate();
             })
-            .catch((error) => {
+            .catch((error: AxiosError) => {
                 updateError= true;
                 if (error?.response?.data?.description) {
                     dispatch(addAlert({
@@ -341,7 +344,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
             .then(async () => {
                 await handleInboundConfigFormSubmit(values.inbound, selectedProtocol);
             })
-            .catch((error) => {
+            .catch((error: AxiosError) => {
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(addAlert({
                         description: error.response.data.description,
@@ -381,7 +384,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                 onApplicationSecretRegenerate(response.data);
                 onUpdate(appId);
             })
-            .catch((error) => {
+            .catch((error: AxiosError) => {
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(addAlert({
                         description: error.response.data.description,
@@ -416,7 +419,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                 }));
                 onUpdate(appId);
             })
-            .catch((error) => {
+            .catch((error: AxiosError) => {
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(addAlert({
                         description: error.response.data.description,
@@ -456,7 +459,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         }
 
         // Filter out legacy and unsupported auth protocols.
-        supportedProtocols = supportedProtocols.filter((protocol) => {
+        supportedProtocols = supportedProtocols.filter((protocol: string) => {
 
             if (template && template.id === CustomApplicationTemplate.id
                 && applicationConfig.customApplication.allowedProtocolTypes
@@ -499,7 +502,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         let supportedProtocols: string[] = getSupportedProtocols();
 
         // Sort the list of protocols.
-        supportedProtocols = sortBy(supportedProtocols, (element) => {
+        supportedProtocols = sortBy(supportedProtocols, (element: string) => {
 
             let customOrder: Record<string, unknown> = {
                 [ SupportedAuthProtocolTypes.OIDC ] : 0,
@@ -507,7 +510,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
             };
 
             if (inboundProtocols.length > 0) {
-                inboundProtocols.forEach((protocol, index) => {
+                inboundProtocols.forEach((protocol: string, index: number) => {
                     if (Object.values(SupportedAuthProtocolTypes).includes(protocol as SupportedAuthProtocolTypes)) {
                         customOrder = {
                             ...customOrder,
@@ -880,7 +883,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
 
         const protocols: string[] = Object.values(SupportedAuthProtocolMetaTypes);
 
-        protocols.map((selected) => {
+        protocols.map((selected: string) => {
 
             if (selected === SupportedAuthProtocolTypes.WS_FEDERATION
                 || selected === SupportedAuthProtocolTypes.WS_TRUST) {
@@ -888,16 +891,16 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                 return;
             }
 
-            const selectedProtocol = selected as SupportedAuthProtocolMetaTypes;
+            const selectedProtocol: SupportedAuthProtocolMetaTypes = selected as SupportedAuthProtocolMetaTypes;
 
             // Check if the metadata for the selected auth protocol is available in redux store.
             // If not, fetch the metadata related to the selected auth protocol.
             if (!Object.prototype.hasOwnProperty.call(authProtocolMeta, selectedProtocol)) {
                 getAuthProtocolMetadata(selectedProtocol)
-                    .then((response) => {
+                    .then((response: OIDCMetadataInterface) => {
                         dispatch(setAuthProtocolMeta(selectedProtocol, response));
                     })
-                    .catch((error) => {
+                    .catch((error: AxiosError) => {
                         if (error.response && error.response.data && error.response.data.description) {
                             dispatch(addAlert({
                                 description: error.response.data.description,

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -33,7 +33,7 @@ import {
 import { AxiosError, AxiosResponse } from "axios";
 import get from "lodash-es/get";
 import sortBy from "lodash-es/sortBy";
-import React, { Dispatch, Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Divider, Grid, Header, Button as SemButton } from "semantic-ui-react";
@@ -67,6 +67,7 @@ import { setAuthProtocolMeta } from "../../store";
 import { ApplicationManagementUtils } from "../../utils";
 import { InboundFormFactory } from "../forms";
 import { ApplicationCreateWizard } from "../wizard";
+import { Dispatch } from "redux";
 
 /**
  * Prop-types for the applications settings component.
@@ -181,7 +182,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
     const { t } = useTranslation();
     const { getLink } = useDocumentation();
 
-    const dispatch: Dispatch<any> = useDispatch();
+    const dispatch: Dispatch = useDispatch();
 
     const authProtocolMeta: AuthProtocolMetaInterface = useSelector(
         (state: AppState) => state.application.meta.protocolMeta);

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -27,6 +27,7 @@ import {
     EmphasizedSegment,
     GenericIcon,
     Message,
+    Popup,
     useDocumentation
 } from "@wso2is/react-components";
 import { AxiosResponse } from "axios";
@@ -35,7 +36,7 @@ import sortBy from "lodash-es/sortBy";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Divider, Grid, Header, Popup, Button as SemButton } from "semantic-ui-react";
+import { Divider, Grid, Header, Button as SemButton } from "semantic-ui-react";
 import { SAMLSelectionLanding } from "./protocols";
 import { applicationConfig } from "../../../../extensions";
 import { AppState, FeatureConfigInterface, store } from "../../../core";

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-list-item.tsx
@@ -17,11 +17,11 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Code, Hint } from "@wso2is/react-components";
+import { Code, Hint, Popup } from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Checkbox, Icon, Input, Popup, Table } from "semantic-ui-react";
+import { Checkbox, Icon, Input, Table } from "semantic-ui-react";
 import { ExtendedClaimMappingInterface } from "./attribute-settings";
 
 interface AttributeListItemPropInterface extends TestableComponentInterface {

--- a/apps/console/src/features/applications/components/settings/certificate/application-certificate-list.tsx
+++ b/apps/console/src/features/applications/components/settings/certificate/application-certificate-list.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import { Forms } from "@wso2is/forms";
 import {
     ConfirmationModal,
     EmptyPlaceholder,
+    Popup,
     PrimaryButton,
     ResourceList,
     ResourceListItem,
@@ -33,7 +34,7 @@ import moment from "moment";
 import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Divider, Grid, Icon, Popup, Segment, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
+import { Divider, Grid, Icon, Segment, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
 import { AddApplicationCertificateWizard } from "./add-certificate-wizard";
 import { UIConstants, getEmptyPlaceholderIllustrations } from "../../../../core";
 import { updateApplicationDetails } from "../../../api";
@@ -64,9 +65,9 @@ interface ApplicationCertificatesPropsListInterface extends TestableComponentInt
 /**
  * Application certificates list component.
  *
- * @param {ApplicationCertificatesPropsListInterface} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @returns
  */
 export const ApplicationCertificatesListComponent: FunctionComponent<ApplicationCertificatesPropsListInterface> = (
     props: ApplicationCertificatesPropsListInterface
@@ -120,7 +121,7 @@ export const ApplicationCertificatesListComponent: FunctionComponent<Application
 
     /**
      * Show the certificate details.
-     * @param certificate
+     * @param certificate - Certificate to be displayed.
      */
     const handleViewCertificate = (certificate: DisplayCertificate) => {
         setCertificateDisplay(certificate);
@@ -211,9 +212,9 @@ export const ApplicationCertificatesListComponent: FunctionComponent<Application
     /**
      * Creates the resource item header.
      *
-     * @param validFrom {Date}
-     * @param validTill {Date}
-     * @param issuer {string}
+     * @param validFrom - Valid from date.
+     * @param validTill - Valid till date.
+     * @param issuer - Issuer.
      */
     const createValidityLabel = (validFrom: Date, validTill: Date, issuer: string): ReactElement => {
 
@@ -264,7 +265,8 @@ export const ApplicationCertificatesListComponent: FunctionComponent<Application
 
     /**
      * Creates what to show as the resource list item avatar.
-     * @param certificate {DisplayCertificate}
+     *
+     * @param certificate - Certificate.
      */
     const createCertificateResourceAvatar = (certificate: DisplayCertificate): ReactElement => {
         return (
@@ -283,7 +285,7 @@ export const ApplicationCertificatesListComponent: FunctionComponent<Application
     /**
      * Creates a dummy label telling that we're unable to visualize
      * this certificate.
-     * @param certificate {DisplayCertificate}
+     * @param certificate - Certificate.
      */
     const createDummyValidityLabel = (certificate: DisplayCertificate): ReactNode => {
         return (

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/script-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/script-based-flow.tsx
@@ -28,6 +28,7 @@ import {
     DocumentationLink,
     GenericIcon,
     Heading,
+    Popup,
     SegmentedAccordion,
     Text,
     Tooltip,
@@ -45,7 +46,7 @@ import React, { ChangeEvent, FunctionComponent, ReactElement, useEffect, useRef,
 import { Trans, useTranslation } from "react-i18next";
 import Joyride, { CallBackProps, STATUS, Step } from "react-joyride";
 import { useDispatch } from "react-redux";
-import { Checkbox, Dropdown, Header, Icon, Input, Menu, Popup, Sidebar } from "semantic-ui-react";
+import { Checkbox, Dropdown, Header, Icon, Input, Menu, Sidebar } from "semantic-ui-react";
 import { stripSlashes } from "slashes";
 import { ScriptTemplatesSidePanel } from "./script-templates-side-panel";
 import { organizationConfigs } from "../../../../../../extensions";

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/script-templates-side-panel.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/script-templates-side-panel.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,7 +17,7 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Heading, Tooltip } from "@wso2is/react-components";
+import { Heading, Popup, Tooltip } from "@wso2is/react-components";
 import sortBy from "lodash-es/sortBy";
 import React, {
     FunctionComponent,
@@ -30,7 +30,7 @@ import React, {
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
-import { Accordion, Icon, Menu, Popup, Segment, Sidebar } from "semantic-ui-react";
+import { Accordion, Icon, Menu, Segment, Sidebar } from "semantic-ui-react";
 import { TemplateDescription } from "./template-description";
 import { AdaptiveAuthTemplateInterface } from "../../../../models";
 
@@ -45,7 +45,8 @@ export type ScriptTemplatesSidePanelRefType = HTMLDivElement;
 interface ScriptTemplatesSidePanelInterface extends TestableComponentInterface {
     /**
      * Fired on template selection.
-     * @param {AdaptiveAuthTemplateInterface} template -Auth template.
+     *
+     * @param template - Auth template.
      */
     onTemplateSelect: (template: AdaptiveAuthTemplateInterface) => void;
     /**
@@ -77,8 +78,9 @@ interface ScriptTemplatesSidePanelInterface extends TestableComponentInterface {
 /**
  * Adaptive script templates side panel.
  *
- * @param {ScriptTemplatesSidePanelInterface} props - Props injected to the component.
- * @return {ReactElement}
+ * @param props - Props injected to the component.
+ *
+ * @returns
  */
 export const ScriptTemplatesSidePanel: FunctionComponent<ScriptTemplatesSidePanelInterface> =
     forwardRef<ScriptTemplatesSidePanelRefType, ScriptTemplatesSidePanelInterface>((
@@ -107,8 +109,8 @@ export const ScriptTemplatesSidePanel: FunctionComponent<ScriptTemplatesSidePane
         /**
          * Handles accordion title click.
          *
-         * @param {React.SyntheticEvent} e - Click event.
-         * @param {number} index - Clicked on index.
+         * @param e - Click event.
+         * @param index - Clicked on index.
          */
         const handleAccordionOnClick = (e: SyntheticEvent, { index }: { index: number }): void => {
             const newIndexes = [ ...accordionActiveIndexes ];

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
@@ -17,11 +17,11 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { EmptyPlaceholder, GenericIcon, Heading, LinkButton } from "@wso2is/react-components";
+import { EmptyPlaceholder, GenericIcon, Heading, LinkButton, Popup } from "@wso2is/react-components";
 import classNames from "classnames";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Card, Checkbox, Form, Icon, Label, Popup, Radio } from "semantic-ui-react";
+import { Card, Checkbox, Form, Icon, Label, Radio } from "semantic-ui-react";
 import { getGeneralIcons } from "../../../../../core";
 import {
     FederatedAuthenticatorInterface,
@@ -153,15 +153,15 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
     }, [ JSON.stringify(step.options) ]);
 
     const isSubjectIdentifierChecked = useMemo(
-        () => (subjectStepId === (stepIndex + 1)), 
+        () => (subjectStepId === (stepIndex + 1)),
         [ subjectStepId, stepIndex ]
     );
 
     const isAttributeIdentifierChecked = useMemo(
-        () => (attributeStepId === (stepIndex + 1)), 
+        () => (attributeStepId === (stepIndex + 1)),
         [ attributeStepId, stepIndex ]
     );
-    
+
     /**
      * Resolves the authenticator step option.
      *

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -17,11 +17,11 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Code, Heading, InfoCard, Text } from "@wso2is/react-components";
+import { Code, Heading, InfoCard, Popup, Text } from "@wso2is/react-components";
 import classNames from "classnames";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { Icon, Label, Popup } from "semantic-ui-react";
+import { Icon, Label } from "semantic-ui-react";
 import { applicationConfig } from "../../../../../../extensions";
 import {
     AuthenticatorCategories,

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -18,14 +18,13 @@
 
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ConfirmationModal, GenericIcon } from "@wso2is/react-components";
+import { ConfirmationModal, GenericIcon, Popup } from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
 import orderBy from "lodash-es/orderBy";
 import union from "lodash-es/union";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Popup } from "semantic-ui-react";
 import { AddAuthenticatorModal } from "./add-authenticator-modal";
 import { AuthenticationStep } from "./authentication-step";
 import { applicationConfig } from "../../../../../../extensions";

--- a/apps/console/src/features/applications/models/reducer-state.ts
+++ b/apps/console/src/features/applications/models/reducer-state.ts
@@ -48,6 +48,6 @@ interface ApplicationMetaInterface {
  * Interface for the auth protocol metadata.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-interface AuthProtocolMetaInterface {
+export interface AuthProtocolMetaInterface {
     [ key: string ]: OIDCMetadataInterface | any;
 }

--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -19,7 +19,14 @@
 import { hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertLevels, StorageIdentityAppsSettingsInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { AnimatedAvatar, AppAvatar, LabelWithPopup, PrimaryButton, TabPageLayout } from "@wso2is/react-components";
+import {
+    AnimatedAvatar,
+    AppAvatar,
+    LabelWithPopup,
+    Popup,
+    PrimaryButton,
+    TabPageLayout
+} from "@wso2is/react-components";
 import cloneDeep from "lodash-es/cloneDeep";
 import get from "lodash-es/get";
 import isEmpty from "lodash-es/isEmpty";
@@ -27,7 +34,7 @@ import React, { FunctionComponent, ReactElement, useCallback, useEffect, useRef,
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router";
-import { Label, Popup } from "semantic-ui-react";
+import { Label } from "semantic-ui-react";
 import { applicationConfig } from "../../../extensions/configs/application";
 import {
     AppConstants,

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -27,6 +27,7 @@ import {
     GenericIcon,
     ListLayout,
     PageLayout,
+    Popup,
     PrimaryButton,
     useDocumentation
 } from "@wso2is/react-components";
@@ -50,8 +51,7 @@ import {
     Icon,
     Label,
     List,
-    PaginationProps,
-    Popup
+    PaginationProps
 } from "semantic-ui-react";
 import { applicationConfig } from "../../../extensions";
 import {
@@ -400,8 +400,8 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                     hideOnScroll
                                     inverted
                                 />
-                            ) : null 
-                            } 
+                            ) : null
+                            }
                             <Grid.Column
                                 mobile={ 16 }
                                 computer={ 1 }
@@ -409,7 +409,7 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                 { !isSubOrg && (
                                     <Popup
                                         trigger={ (
-                                            <Button 
+                                            <Button
                                                 icon="setting"
                                                 onClick={ (): void => navigateToMyAccountSettings() }
                                             />

--- a/apps/console/src/features/claims/components/claims-list.tsx
+++ b/apps/console/src/features/claims/components/claims-list.tsx
@@ -38,6 +38,7 @@ import {
     DataTable,
     EmptyPlaceholder,
     LinkButton,
+    Popup,
     PrimaryButton,
     TableActionsInterface,
     TableColumnInterface,
@@ -57,7 +58,7 @@ import React,{
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Header, Icon, ItemHeader, Popup, SemanticICONS } from "semantic-ui-react";
+import { Header, Icon, ItemHeader, SemanticICONS } from "semantic-ui-react";
 import { EditExternalClaim } from "./edit";
 import { attributeConfig } from "../../../extensions";
 import {

--- a/apps/console/src/features/claims/components/wizard/local-claim/basic-details-local-claims.tsx
+++ b/apps/console/src/features/claims/components/wizard/local-claim/basic-details-local-claims.tsx
@@ -18,10 +18,10 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms, Validation } from "@wso2is/forms";
-import { GenericIcon, Hint, InlineEditInput, Message } from "@wso2is/react-components";
+import { GenericIcon, Hint, InlineEditInput, Message, Popup } from "@wso2is/react-components";
 import React, { ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Card, Grid, Icon, Label, Popup } from "semantic-ui-react";
+import { Card, Grid, Icon, Label } from "semantic-ui-react";
 import { attributeConfig } from "../../../../../extensions";
 import { getTechnologyLogos } from "../../../../core";
 
@@ -284,7 +284,6 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                         } }
                                         position="bottom left"
                                         context={ claimField }
-                                        popper={ <div style={ { filter: "none" } }></div> }
                                     />
                                     <Label className="mb-3 ml-0">
                                         <em>Attribute URI</em>:&nbsp;
@@ -444,9 +443,6 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                                                                 size="mini"
                                                                                 hideOnScroll
                                                                                 inverted
-                                                                                popper={ 
-                                                                                    <div style={ { filter: "none" } }/>
-                                                                                }
                                                                             />
                                                                         ): null
                                                                     }
@@ -494,7 +490,6 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                             } }
                             position="bottom left"
                             context={ nameField }
-                            popper={ <div style={ { filter: "none" } }></div> }
                         />
                         {
                             attributeConfig.localAttributes.createWizard.customWIzard && (
@@ -540,7 +535,6 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                     } }
                                     position="bottom left"
                                     context={ claimField }
-                                    popper={ <div style={ { filter: "none" } }></div> }
                                 />
                                 {
                                     claimID
@@ -604,7 +598,6 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                     } }
                                     position="bottom left"
                                     context={ regExField }
-                                    popper={ <div style={ { filter: "none" } }></div> }
                                 />
                             </Grid.Column>
                         )
@@ -670,7 +663,6 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                     } }
                                     position="bottom left"
                                     context={ displayOrderField }
-                                    popper={ <div style={ { filter: "none" } }></div> }
                                 />
                             </Grid.Column>
                         </Grid.Row>

--- a/apps/console/src/features/claims/pages/claim-dialects.tsx
+++ b/apps/console/src/features/claims/pages/claim-dialects.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -26,12 +26,13 @@ import {
     GenericIcon,
     GridLayout,
     PageLayout,
+    Popup,
     PrimaryButton
 } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Divider, Grid, Header, Icon, Image, List, Popup } from "semantic-ui-react";
+import { Divider, Grid, Header, Icon, Image, List } from "semantic-ui-react";
 import { attributeConfig } from "../../../extensions";
 import { getDialects } from "../../claims/api";
 import {
@@ -53,9 +54,9 @@ type ClaimDialectsPageInterface = TestableComponentInterface;
 /**
  * This displays a list fo claim dialects.
  *
- * @param {ClaimDialectsPageInterface} props - Props injected to the component.
+ * @param  props - Props injected to the component.
  *
- * @return {ReactElement}
+ * @returns
  */
 const ClaimDialectsPage: FunctionComponent<ClaimDialectsPageInterface> = (
     props: ClaimDialectsPageInterface
@@ -82,10 +83,10 @@ const ClaimDialectsPage: FunctionComponent<ClaimDialectsPageInterface> = (
     /**
      * Fetches all the dialects.
      *
-     * @param {number} limit.
-     * @param {number} offset.
-     * @param {string} sort.
-     * @param {string} filter.
+     * @param limit - Limit per page.
+     * @param offset - Offset value.
+     * @param sort - Sort order.
+     * @param filter - Filter criteria.
      */
     const getDialect = (limit?: number, offset?: number, sort?: string, filter?: string): void => {
         setIsLoading(true);
@@ -434,8 +435,8 @@ const ClaimDialectsPage: FunctionComponent<ClaimDialectsPageInterface> = (
                         )
                     }
                     {
-                        !attributeConfig.showCustomDialectInSCIM && 
-                            otherAttributeMappings?.length > 0 && 
+                        !attributeConfig.showCustomDialectInSCIM &&
+                            otherAttributeMappings?.length > 0 &&
                             (
                                 <EmphasizedSegment
                                     onClick={ () => {

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
@@ -27,6 +27,7 @@ import {
     EmptyPlaceholder,
     Heading,
     LinkButton,
+    Popup,
     PrimaryButton,
     TransferComponent,
     TransferList,
@@ -48,7 +49,6 @@ import {
     Input,
     Label,
     Modal,
-    Popup,
     Table
 } from "semantic-ui-react";
 import { AppState, getEmptyPlaceholderIllustrations, updateResources } from "../../../core";

--- a/apps/console/src/features/groups/components/edit-group/edit-group-users.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-users.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -25,6 +25,7 @@ import {
     EmptyPlaceholder,
     Heading,
     LinkButton,
+    Popup,
     PrimaryButton,
     TransferComponent,
     TransferList,
@@ -45,7 +46,7 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Grid, Header, Icon, Input, Modal, Popup, Table } from "semantic-ui-react";
+import { Grid, Header, Icon, Input, Modal, Table } from "semantic-ui-react";
 import { getEmptyPlaceholderIllustrations } from "../../../core";
 import { UserBasicInterface } from "../../../users";
 import { updateGroupDetails } from "../../api";
@@ -110,7 +111,7 @@ export const GroupUsersList: FunctionComponent<GroupUsersListProps> = (props: Gr
     };
 
     const handleSearchFieldChange = (e: FormEvent<HTMLInputElement>, query: string, list: UserBasicInterface[],
-                                     stateAction: Dispatch<SetStateAction<any>>) => {
+        stateAction: Dispatch<SetStateAction<any>>) => {
 
         let isMatch: boolean = false;
         const filteredRoleList: UserBasicInterface[] = [];
@@ -185,6 +186,7 @@ export const GroupUsersList: FunctionComponent<GroupUsersListProps> = (props: Gr
 
     const updateGroupUsersList = (selectedUsers: UserBasicInterface[]) => {
         const newUsers: CreateGroupMemberInterface[] = [];
+
         for (const selectedUser of selectedUsers) {
             newUsers.push({
                 display: selectedUser.userName,
@@ -382,20 +384,20 @@ export const GroupUsersList: FunctionComponent<GroupUsersListProps> = (props: Gr
                         <Popup
                             trigger={ (
                                 <Icon
-                                link={ true }
-                                data-testid={ `${ testId }-user-delete-button` }
-                                className="list-icon pr-4"
-                                size="large"
-                                color="grey"
-                                name="trash alternate"
-                                onClick={ () => {
-                                    deleteGroupUser(user);
-                                } }
+                                    link={ true }
+                                    data-testid={ `${ testId }-user-delete-button` }
+                                    className="list-icon pr-4"
+                                    size="large"
+                                    color="grey"
+                                    name="trash alternate"
+                                    onClick={ () => {
+                                        deleteGroupUser(user);
+                                    } }
                                 />
                             ) }
                             position="top right"
                             content={ t("common:remove") }
-                        inverted
+                            inverted
                         />
                     </Show>
                 </Table.Cell>
@@ -415,7 +417,7 @@ export const GroupUsersList: FunctionComponent<GroupUsersListProps> = (props: Gr
                                         data-testid={ `${ testId }-users-list-search-input` }
                                         icon={ <Icon name="search"/> }
                                         onChange={ (e: FormEvent<HTMLInputElement>,
-                                                    { value }: { value: string }) => {
+                                            { value }: { value: string }) => {
                                             handleSearchFieldChange(e, value, selectedUsers,
                                                 setSelectedUserList);
                                         } }

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/subject-attribute-list-item.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/subject-attribute-list-item.tsx
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the 'License'); you may not use this file except
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -10,16 +10,16 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Code } from "@wso2is/react-components";
+import { Code, Popup } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
-import { Popup, Table } from "semantic-ui-react";
+import { Table } from "semantic-ui-react";
 
 export interface SubjectAttributeListItemPropInterface extends TestableComponentInterface {
     key: string;
@@ -32,9 +32,9 @@ export interface SubjectAttributeListItemPropInterface extends TestableComponent
 /**
  * Selected Attribute list item component.
  *
- * @param {SubjectAttributeListItemPropInterface} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @returns
  */
 export const SubjectAttributeListItem: FunctionComponent<SubjectAttributeListItemPropInterface> = (
     props: SubjectAttributeListItemPropInterface

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-cetificates-list.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-cetificates-list.tsx
@@ -26,12 +26,18 @@ import {
 import { addAlert } from "@wso2is/core/store";
 import { CertificateManagementUtils } from "@wso2is/core/utils";
 import { Form } from "@wso2is/form";
-import { ResourceList, ResourceListActionInterface, ResourceListItem, UserAvatar } from "@wso2is/react-components";
+import {
+    Popup,
+    ResourceList,
+    ResourceListActionInterface,
+    ResourceListItem,
+    UserAvatar
+} from "@wso2is/react-components";
 import moment from "moment";
 import React, { FC, PropsWithChildren, ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Grid, Icon, Popup, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
+import { Grid, Icon, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
 import { ShowCertificateModal } from "./show-certificate-modal";
 import { updateIDPCertificate } from "../../../api";
 import { IdentityProviderInterface } from "../../../models";

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning/outbound-provisioning-roles.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning/outbound-provisioning-roles.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,17 +19,14 @@
 import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { AlertLevels, RoleListInterface, RolesInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { Heading, Hint } from "@wso2is/react-components";
+import { Heading, Hint, Popup } from "@wso2is/react-components";
 import filter from "lodash-es/filter";
 import isEmpty from "lodash-es/isEmpty";
 import isEqual from "lodash-es/isEqual";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
-import { Button, DropdownItemProps, Form, Grid, Icon, Label, Popup } from "semantic-ui-react";
-import { AppState } from "../../../../core";
-import { getOrganizationRoles } from "../../../../organizations/api";
-import { OrganizationResponseInterface } from "../../../../organizations/models";
+import { useDispatch } from "react-redux";
+import { Button, DropdownItemProps, Form, Grid, Icon, Label } from "semantic-ui-react";
 import { OrganizationUtils } from "../../../../organizations/utils";
 import { getRolesList } from "../../../../roles/api";
 import { updateIDPRoleMappings } from "../../../api";

--- a/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-edit.tsx
@@ -24,6 +24,7 @@ import {
     AnimatedAvatar,
     AppAvatar,
     LabelWithPopup,
+    Popup,
     TabPageLayout
 } from "@wso2is/react-components";
 import get from "lodash-es/get";
@@ -40,7 +41,7 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router";
-import { Label, Popup } from "semantic-ui-react";
+import { Label } from "semantic-ui-react";
 import { AuthenticatorExtensionsConfigInterface, identityProviderConfig } from "../../../extensions/configs";
 import {
     AppConstants,
@@ -134,7 +135,7 @@ const IdentityProviderEditPage: FunctionComponent<IDPEditPagePropsInterface> = (
             }
         }
     }, [ idpDescElement, isConnectorDetailsFetchRequestLoading ]);
-    
+
     /**
      * Use effect for the initial component load.
      */
@@ -289,7 +290,7 @@ const IdentityProviderEditPage: FunctionComponent<IDPEditPagePropsInterface> = (
      * Retrieves the local authenticator details from the API.
      *
      * @param id - Authenticator id.
-     * @param useAuthenticatorsAPI - Use the 
+     * @param useAuthenticatorsAPI - Use the
      */
     const getMultiFactorAuthenticator = (id: string, useAuthenticatorsAPI: boolean = true): void => {
 

--- a/apps/console/src/features/organizations/components/organization-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-list.tsx
@@ -30,6 +30,7 @@ import {
     EmptyPlaceholder,
     GenericIcon,
     LinkButton,
+    Popup,
     PrimaryButton,
     TableActionsInterface,
     TableColumnInterface
@@ -38,7 +39,7 @@ import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Header, Icon, Label, Popup, SemanticICONS } from "semantic-ui-react";
+import { Header, Icon, Label, SemanticICONS } from "semantic-ui-react";
 import { organizationConfigs } from "../../../extensions";
 import {
     AppConstants,

--- a/apps/console/src/features/organizations/components/organization-switch/organization-list-item.tsx
+++ b/apps/console/src/features/organizations/components/organization-switch/organization-list-item.tsx
@@ -18,10 +18,10 @@
 
 import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { IdentifiableComponentInterface } from "@wso2is/core/src/models";
-import { GenericIcon } from "@wso2is/react-components";
+import { GenericIcon, Popup } from "@wso2is/react-components";
 import React, { ReactElement, SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { Grid, Icon, Placeholder, Popup } from "semantic-ui-react";
+import { Grid, Icon, Placeholder } from "semantic-ui-react";
 import { organizationConfigs } from "../../../../extensions";
 import { AppConstants, getMiscellaneousIcons, history } from "../../../core";
 import { GenericOrganization } from "../../models";

--- a/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
+++ b/apps/console/src/features/organizations/components/organization-switch/organization-switch-dropdown.tsx
@@ -21,7 +21,7 @@ import {
     IdentifiableComponentInterface
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { GenericIcon } from "@wso2is/react-components";
+import { GenericIcon, Popup } from "@wso2is/react-components";
 import React, {
     FunctionComponent,
     ReactElement,
@@ -39,7 +39,6 @@ import {
     Input,
     Item,
     Loader,
-    Popup,
     Segment
 } from "semantic-ui-react";
 import OrganizationListItem from "./organization-list-item";

--- a/apps/console/src/features/remote-repository-configuration/components/remote-fetch-status.tsx
+++ b/apps/console/src/features/remote-repository-configuration/components/remote-fetch-status.tsx
@@ -18,13 +18,13 @@
 
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { Hint, LinkButton } from "@wso2is/react-components/src";
+import { Hint, LinkButton, Popup } from "@wso2is/react-components/src";
 import { AxiosResponse } from "axios";
 import moment from "moment";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Button, Icon, Menu, Popup } from "semantic-ui-react";
+import { Button, Icon, Menu } from "semantic-ui-react";
 import { RemoteFetchDetails } from "./remote-fetch-details";
 import {
     InterfaceRemoteConfigDetails,

--- a/apps/console/src/features/secrets/components/secret-value-form.tsx
+++ b/apps/console/src/features/secrets/components/secret-value-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,11 +19,11 @@
 import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { Hint } from "@wso2is/react-components";
+import { Hint, Popup } from "@wso2is/react-components";
 import React, { FC, Fragment, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Button, Divider, Form, Grid, Icon, Popup, TextArea, TextAreaProps, Transition } from "semantic-ui-react";
+import { Button, Divider, Form, Grid, Icon, TextArea, TextAreaProps, Transition } from "semantic-ui-react";
 import { patchSecret } from "../api/secret";
 import { EMPTY_STRING } from "../constants/secrets.common";
 import { SecretModel } from "../models/secret";
@@ -84,6 +84,7 @@ const SecretValueForm: FC<SecretValueFormProps> = (props: SecretValueFormProps):
                     level: AlertLevels.ERROR,
                     message: error.response.data?.message
                 }));
+
                 return;
             }
             dispatch(addAlert({
@@ -101,13 +102,14 @@ const SecretValueForm: FC<SecretValueFormProps> = (props: SecretValueFormProps):
      * This is the secret field value validator. When the field
      * is in readonly mode it will always return undefined.
      *
-     * @param value {string} User input.
-     * @return error {string | undefined} if valid undefined
+     * @param value - User input.
+     * @returns error - if valid undefined
      */
     const fieldValidator = (value: string): string | undefined => {
         if (isEditingSecretValue) {
             return secretValueValidator(value);
         }
+
         return undefined;
     };
 
@@ -116,9 +118,8 @@ const SecretValueForm: FC<SecretValueFormProps> = (props: SecretValueFormProps):
      * readonly mode it will act as a enabler. Otherwise a submission
      * event handler.
      *
-     * @event-handler
-     * - @param event {React.FormEvent<HTMLFormElement>}
-     * - @param data {FormProps}
+     * - @param event - Form submission event.
+     * - @param data - Form data.
      */
     const onSubmission = async () => {
         if (isEditingSecretValue) {
@@ -133,8 +134,7 @@ const SecretValueForm: FC<SecretValueFormProps> = (props: SecretValueFormProps):
      * This resets the state back to initial. This should be called
      * if the user decides to cancel the update operation.
      *
-     * @event-handler
-     * @return {Promise<void>}
+     * @returns
      */
     const resetFieldState = async () => {
         setIsEditingSecretValue(false);
@@ -148,9 +148,8 @@ const SecretValueForm: FC<SecretValueFormProps> = (props: SecretValueFormProps):
     /**
      * Calls everytime when textarea value changes.
      *
-     * @event-handler
-     * @param event {React.ChangeEvent<HTMLInputElement>}
-     * @param props {TextAreaProps}
+     * @param event - React.ChangeEvent<HTMLTextAreaElement>
+     * @param props - TextAreaProps
      */
     const onSecretFieldValueChange = (
         event: React.ChangeEvent<HTMLTextAreaElement>,

--- a/apps/console/src/features/users/components/user-roles-edit.tsx
+++ b/apps/console/src/features/users/components/user-roles-edit.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -28,6 +28,7 @@ import {
     EmptyPlaceholder,
     Heading,
     LinkButton,
+    Popup,
     PrimaryButton,
     TransferComponent,
     TransferList,
@@ -39,7 +40,7 @@ import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Button, Divider, Grid, Icon, Input, Label, Modal, Popup, Table } from "semantic-ui-react";
+import { Button, Divider, Grid, Icon, Input, Label, Modal, Table } from "semantic-ui-react";
 import { UserRolePermissions } from "./user-role-permissions";
 import { RolePermissions } from "./wizard";
 import { AppState, getEmptyPlaceholderIllustrations, updateResources } from "../../core";
@@ -528,7 +529,7 @@ export const UserRolesList: FunctionComponent<UserRolesPropsInterface> = (
     /**
      * The following method handles creating a label for the list item.
      *
-     * @param roleName: string
+     * @param roleName - Name of the role.
      */
     const createItemLabel = (roleName: string) => {
         const role = roleName?.split("/");
@@ -901,6 +902,6 @@ export const UserRolesList: FunctionComponent<UserRolesPropsInterface> = (
  * Default props for the component.
  */
 UserRolesList.defaultProps = {
-    showDomain: true,
-    hideApplicationRoles: false
+    hideApplicationRoles: false,
+    showDomain: true
 };

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -25,7 +25,7 @@ import {
     emptyProfileInfo
 }from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { EditAvatarModal, TabPageLayout, UserAvatar } from "@wso2is/react-components";
+import { EditAvatarModal, Popup, TabPageLayout, UserAvatar } from "@wso2is/react-components";
 import React, { MouseEvent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -276,10 +276,10 @@ const UserEditPage = (): ReactElement => {
                                                     content={ t("common:disabled") }
                                                     inverted
                                                 />
-                                            ) 
+                                            )
                                     }
                                     { resolveUserDisplayName(user, null, "Administrator") }
-                                    
+
                                 </>
                             ) : (
                                 <>
@@ -287,7 +287,7 @@ const UserEditPage = (): ReactElement => {
                                 </>
                             )
                     }
-                </> 
+                </>
             ) }
             pageTitle="Edit User"
             description={ t("" + user.emails && user.emails !== undefined ? resolvePrimaryEmail(user?.emails) :

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -30,7 +30,7 @@ import React, { MouseEvent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
-import { Icon, Popup } from "semantic-ui-react";
+import { Icon } from "semantic-ui-react";
 import { getProfileInformation } from "../../authentication/store";
 import { AppConstants, AppState, FeatureConfigInterface, SharedUserStoreUtils, history } from "../../core";
 import { OrganizationUtils } from "../../organizations/utils";

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -26,12 +26,13 @@ import {
     EmptyPlaceholder,
     ListLayout,
     PageLayout,
+    Popup,
     PrimaryButton
 } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Dropdown, DropdownProps, Icon, PaginationProps, Popup } from "semantic-ui-react";
+import { Dropdown, DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
 import {
     AdvancedSearchWithBasicFilters,
     AppState,

--- a/apps/console/src/features/userstores/components/sql-editor.tsx
+++ b/apps/console/src/features/userstores/components/sql-editor.tsx
@@ -1,26 +1,26 @@
 /**
-* Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-* WSO2 Inc. licenses this file to you under the Apache License,
-* Version 2.0 (the 'License'); you may not use this file except
-* in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { CodeEditor, GenericIcon, Heading, LinkButton, PrimaryButton, Tooltip } from "@wso2is/react-components";
+import { CodeEditor, GenericIcon, Heading, LinkButton, Popup, PrimaryButton, Tooltip } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Accordion, Icon, Menu, Popup, Segment, Sidebar } from "semantic-ui-react";
+import { Accordion, Icon, Menu, Segment, Sidebar } from "semantic-ui-react";
 import { getOperationIcons } from "../../core/configs";
 import { RequiredBinary } from "../models";
 
@@ -33,9 +33,9 @@ interface SqlEditorPropsInterface extends TestableComponentInterface {
 /**
  * SQL Editor component.
  *
- * @param {SqlEditorPropsInterface} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @returns
  */
 export const SqlEditor: FunctionComponent<SqlEditorPropsInterface> = (
     props: SqlEditorPropsInterface
@@ -360,6 +360,7 @@ export const SqlEditor: FunctionComponent<SqlEditorPropsInterface> = (
                                     onClick={ () => {
                                         setPropertyValue(propertyDefaultValue);
                                         const defaultValue = propertyDefaultValue;
+
                                         setPropertyDefaultValue("");
                                         setTimeout(() => {
                                             setPropertyDefaultValue(defaultValue);

--- a/apps/console/src/features/userstores/components/user-stores-list.tsx
+++ b/apps/console/src/features/userstores/components/user-stores-list.tsx
@@ -1,20 +1,20 @@
 /**
-* Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
-*
-* WSO2 LLC. licenses this file to you under the Apache License,
-* Version 2.0 (the 'License'); you may not use this file except
-* in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 import { UserstoreConstants } from "@wso2is/core/constants";
 import { hasRequiredScopes } from "@wso2is/core/helpers";
@@ -31,6 +31,7 @@ import {
     EmptyPlaceholder,
     GenericIcon,
     LinkButton,
+    Popup,
     PrimaryButton,
     TableActionsInterface,
     TableColumnInterface
@@ -38,7 +39,7 @@ import {
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Header, Icon, Popup, SemanticICONS } from "semantic-ui-react";
+import { Header, Icon, SemanticICONS } from "semantic-ui-react";
 import { userstoresConfig } from "../../../extensions";
 import {
     AppConstants,
@@ -350,7 +351,7 @@ export const UserStoresList: FunctionComponent<UserStoresListPropsInterface> = (
                                             content={ t("common:disabled") }
                                             inverted
                                         />
-                                    ) 
+                                    )
                             }
                         </Header.Content>
                         <Header.Content>

--- a/apps/myaccount/src/components/account-recovery/options/email-recovery.tsx
+++ b/apps/myaccount/src/components/account-recovery/options/email-recovery.tsx
@@ -19,13 +19,13 @@
 import { ProfileConstants } from "@wso2is/core/constants";
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Forms, Validation } from "@wso2is/forms";
-import { GenericIcon } from "@wso2is/react-components";
+import { GenericIcon, Popup } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import isEmpty from "lodash-es/isEmpty";
 import React, { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Form, Grid, Icon, List, Popup } from "semantic-ui-react";
+import { Form, Grid, Icon, List } from "semantic-ui-react";
 import { updateProfileInfo } from "../../../api";
 import { getAccountRecoveryIcons } from "../../../configs";
 import { CommonConstants } from "../../../constants";

--- a/apps/myaccount/src/components/applications/application-list.tsx
+++ b/apps/myaccount/src/components/applications/application-list.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,10 +17,10 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { ContentLoader, LinkButton, Text } from "@wso2is/react-components";
+import { ContentLoader, LinkButton, Popup, Text } from "@wso2is/react-components";
 import React, { Fragment, FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
-import { Grid, Popup } from "semantic-ui-react";
+import { Grid } from "semantic-ui-react";
 import { ApplicationListItem } from "./application-list-item";
 import { getEmptyPlaceholderIllustrations } from "../../configs";
 import { Application } from "../../models";
@@ -43,7 +43,7 @@ interface ApplicationListProps extends TestableComponentInterface {
 /**
  * Application list component.
  *
- * @return {JSX.Element}
+ * @returns
  */
 export const ApplicationList: FunctionComponent<ApplicationListProps> = (
     props: ApplicationListProps
@@ -62,7 +62,8 @@ export const ApplicationList: FunctionComponent<ApplicationListProps> = (
 
     /**
      * Shows list placeholders.
-     * @return {JSX.Element}
+     *
+     * @returns
      */
     const showPlaceholders = (): JSX.Element => {
         // When the search returns empty.

--- a/apps/myaccount/src/components/applications/recent-applications.tsx
+++ b/apps/myaccount/src/components/applications/recent-applications.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,9 +17,9 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { Text } from "@wso2is/react-components";
+import { Popup, Text } from "@wso2is/react-components";
 import React, { FunctionComponent } from "react";
-import { Grid, Popup } from "semantic-ui-react";
+import { Grid } from "semantic-ui-react";
 import { RecentApplicationCard } from "./recent-application-card";
 import { Application } from "../../models";
 
@@ -36,7 +36,7 @@ interface RecentApplicationsProps extends TestableComponentInterface {
 /**
  * Recent applications component.
  *
- * @return {JSX.Element}
+ * @returns
  */
 export const RecentApplications: FunctionComponent<RecentApplicationsProps> = (
     props: RecentApplicationsProps
@@ -74,23 +74,23 @@ export const RecentApplications: FunctionComponent<RecentApplicationsProps> = (
                                         <Grid.Row>
                                             <Grid.Column>
                                                 <Text>
-                                                    { 
-                                                        app.name?.length > 55 
-                                                        ? app.name?.substring(0, 56) + " ..." 
-                                                        : app.name 
+                                                    {
+                                                        app.name?.length > 55
+                                                            ? app.name?.substring(0, 56) + " ..."
+                                                            : app.name
                                                     }
                                                 </Text>
                                             </Grid.Column>
                                             <Grid.Column>
                                                 <Text className="hint-description">
-                                                    { 
+                                                    {
                                                         app.description
                                                     }
                                                 </Text>
                                             </Grid.Column>
                                         </Grid.Row>
                                     ) }
-                                /> 
+                                />
                             </Grid.Column>
                         ))
                         : null

--- a/apps/myaccount/src/components/federated-associations/federated-associations.tsx
+++ b/apps/myaccount/src/components/federated-associations/federated-associations.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,10 +20,10 @@ import {
     AsgardeoSPAClient
 } from "@asgardeo/auth-react";
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { AppAvatar } from "@wso2is/react-components";
+import { AppAvatar, Popup } from "@wso2is/react-components";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Grid, Icon, List, Modal, Popup } from "semantic-ui-react";
+import { Button, Grid, Icon, List, Modal } from "semantic-ui-react";
 import { deleteFederatedAssociation, getFederatedAssociations } from "../../api/federated-associations";
 import { getSettingsSectionIcons } from "../../configs";
 import { commonConfig } from "../../extensions";
@@ -46,7 +46,7 @@ interface FederatedAssociationsPropsInterface extends TestableComponentInterface
 
 /**
  * This renders the federated associations component
- * @param props
+ * @param props - Props injected to the component
  */
 export const FederatedAssociations: FunctionComponent<FederatedAssociationsPropsInterface> = (
     props: FederatedAssociationsPropsInterface
@@ -59,13 +59,13 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
         ["data-testid"]: testId
     } = props;
 
-    const [confirmDelete, setConfirmDelete] = useState(false);
-    const [id, setId] = useState(null);
+    const [ confirmDelete, setConfirmDelete ] = useState(false);
+    const [ id, setId ] = useState(null);
     const { t } = useTranslation();
-    const [federatedAssociations, setFederatedAssociations] = useState<FederatedAssociation[]>([]);
-    const [showExternalLogins, setShowExternalLogins] = useState<boolean>(true);
-    const [currentIDP, setCurrentIDP] = useState<string>();
-    const [linkedAttribute, setLinkedAttribute] = useState<string>();
+    const [ federatedAssociations, setFederatedAssociations ] = useState<FederatedAssociation[]>([]);
+    const [ showExternalLogins, setShowExternalLogins ] = useState<boolean>(true);
+    const [ currentIDP, setCurrentIDP ] = useState<string>();
+    const [ linkedAttribute, setLinkedAttribute ] = useState<string>();
     const auth = AsgardeoSPAClient.getInstance();
 
     /**
@@ -81,9 +81,9 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
                     description:
                         t("myAccount:components.federatedAssociations.notifications.getFederatedAssociations."
                             + "error.description",
-                            {
-                                description: error
-                            }
+                        {
+                            description: error
+                        }
                         ),
                     level: AlertLevels.ERROR,
                     message:
@@ -145,11 +145,11 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
                 setShowExternalLogins(true);
             }
         }
-    }, [federatedAssociations]);
+    }, [ federatedAssociations ]);
 
     /**
      * This function calls the `deleteFederatedAssociation` api call
-     * @param id
+     * @param id - ID of the association to be deleted
      */
     const removeFederatedAssociation = (id: string) => {
         deleteFederatedAssociation(id)
@@ -167,9 +167,9 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
                 onAlertFired({
                     description: t("myAccount:components.federatedAssociations.notifications"
                         + ".removeFederatedAssociation.error.description",
-                        {
-                            description: error
-                        }),
+                    {
+                        description: error
+                    }),
                     level: AlertLevels.ERROR,
                     message: t("myAccount:components.federatedAssociations.notifications"
                         + ".removeFederatedAssociation.error.message")
@@ -224,9 +224,11 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
      */
     const federatedAssociationsList = (): React.ReactElement => {
         return (
-            <List divided verticalAlign="middle"
-                  className="main-content-inner"
-                  data-testid={ `${testId}-list` }
+            <List
+                divided
+                verticalAlign="middle"
+                className="main-content-inner"
+                data-testid={ `${testId}-list` }
             >
                 {
                     federatedAssociations && federatedAssociations.map(
@@ -238,16 +240,16 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
                                             <Grid.Column width={ 11 } className="first-column">
                                                 <div className="associations-list-avatar-wrapper">
                                                     <AppAvatar
-                                                            size="mini"
-                                                            image={ federatedAssociation.idp.imageUrl }
-                                                            name={ federatedAssociation.federatedUserId }
-                                                        />
+                                                        size="mini"
+                                                        image={ federatedAssociation.idp.imageUrl }
+                                                        name={ federatedAssociation.federatedUserId }
+                                                    />
                                                     <List.Content>
                                                         <List.Header>
-                                                        {
-                                                            federatedAssociation.idp.displayName
+                                                            {
+                                                                federatedAssociation.idp.displayName
                                                             || federatedAssociation.idp.name
-                                                        }
+                                                            }
                                                         </List.Header>
                                                         <List.Description>
                                                             { linkedAttribute }
@@ -258,28 +260,28 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
                                             { !isNonLocalCredentialUser &&
                                                 !(currentIDP==federatedAssociation.idp.name ||
                                                 currentIDP==federatedAssociation.idp.displayName) ?
-                                            <Grid.Column width={ 5 } className="last-column">
-                                                <List.Content floated="right">
-                                                    <Popup
-                                                        trigger={ (
-                                                            <Icon
-                                                                link
-                                                                className="list-icon padded-icon"
-                                                                size="small"
-                                                                color="grey"
-                                                                name="trash alternate"
-                                                                onClick={ () => {
-                                                                    setId(federatedAssociation.id);
-                                                                    setConfirmDelete(true);
-                                                                } }
-                                                            />
-                                                        ) }
-                                                        inverted
-                                                        position="top center"
-                                                        content={ t("common:remove") }
-                                                    />
-                                                </List.Content>
-                                            </Grid.Column>:null
+                                                (<Grid.Column width={ 5 } className="last-column">
+                                                    <List.Content floated="right">
+                                                        <Popup
+                                                            trigger={ (
+                                                                <Icon
+                                                                    link
+                                                                    className="list-icon padded-icon"
+                                                                    size="small"
+                                                                    color="grey"
+                                                                    name="trash alternate"
+                                                                    onClick={ () => {
+                                                                        setId(federatedAssociation.id);
+                                                                        setConfirmDelete(true);
+                                                                    } }
+                                                                />
+                                                            ) }
+                                                            inverted
+                                                            position="top center"
+                                                            content={ t("common:remove") }
+                                                        />
+                                                    </List.Content>
+                                                </Grid.Column>):null
                                             }
                                         </Grid.Row>
                                     </Grid>
@@ -294,7 +296,7 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
 
     return (
         showExternalLogins &&
-            <SettingsSection
+            (<SettingsSection
                 data-testid={ `${testId}-settings-section` }
                 description={ t("myAccount:sections.federatedAssociations.description") }
                 header={ t("myAccount:sections.federatedAssociations.heading") }
@@ -307,7 +309,7 @@ export const FederatedAssociations: FunctionComponent<FederatedAssociationsProps
             >
                 { deleteConfirmation() }
                 { federatedAssociationsList() }
-            </SettingsSection>
+            </SettingsSection>)
     );
 };
 

--- a/apps/myaccount/src/components/linked-accounts/linked-accounts-list.tsx
+++ b/apps/myaccount/src/components/linked-accounts/linked-accounts-list.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2019, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,9 +17,10 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
+import { Popup } from "@wso2is/react-components";
 import React, { FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button, Grid, Icon, List, Modal, Popup } from "semantic-ui-react";
+import { Button, Grid, Icon, List, Modal } from "semantic-ui-react";
 import { getGravatarImage } from "../../api";
 import { resolveUsername } from "../../helpers";
 import { LinkedAccountInterface } from "../../models";
@@ -38,21 +39,22 @@ interface LinkedAccountsListProps extends TestableComponentInterface {
 /**
  * Linked accounts list component.
  *
- * @param {LinkedAccountsListProps} props - Props injected to the component.
- * @return {React.ReactElement}
+ * @param props - Props injected to the component.
+ *
+ * @returns
  */
 export const LinkedAccountsList: FunctionComponent<LinkedAccountsListProps> = (
     props: LinkedAccountsListProps
 ): React.ReactElement => {
-    
+
     const {
         linkedAccounts,
         onLinkedAccountRemove,
         onLinkedAccountSwitch,
         ["data-testid"]: testId
     } = props;
-    const [confirmDelete, setConfirmDelete] = useState(false);
-    const [userID, setUserID] = useState(null);
+    const [ confirmDelete, setConfirmDelete ] = useState(false);
+    const [ userID, setUserID ] = useState(null);
 
     const { t } = useTranslation();
 

--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/fido-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/fido-authenticator.tsx
@@ -18,12 +18,12 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Forms } from "@wso2is/forms";
-import { ConfirmationModal, GenericIcon } from "@wso2is/react-components";
+import { ConfirmationModal, GenericIcon, Popup } from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
 import React, { ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Button, Divider, Form, Grid, Icon, List, ModalContent, Popup } from "semantic-ui-react";
+import { Button, Divider, Form, Grid, Icon, List, ModalContent } from "semantic-ui-react";
 import UAParser from "ua-parser-js";
 import {
     connectToDevice,

--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
@@ -17,7 +17,7 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { GenericIcon } from "@wso2is/react-components";
+import { GenericIcon, Popup } from "@wso2is/react-components";
 import QRCode from "qrcode.react";
 import React, { FormEvent, PropsWithChildren, SyntheticEvent, useEffect, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
@@ -33,7 +33,6 @@ import {
     List,
     Message,
     Modal,
-    Popup,
     Segment
 } from "semantic-ui-react";
 import {
@@ -112,7 +111,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     const [ isViewTOTPModalOpen, setIsViewTOTPModalOpen ] = useState<boolean>(false);
     const [ viewTOTPModalCurrentStep, setViewTOTPModalCurrentStep ] = useState<number>(0);
     const [ isConfirmRegenerate, setIsConfirmRegenerate ] = useState<boolean>(false);
-    
+
     const pinCode1 = useRef<HTMLInputElement>();
     const pinCode2 = useRef<HTMLInputElement>();
     const pinCode3 = useRef<HTMLInputElement>();
@@ -123,7 +122,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     /**
      * Check whether the TOTP is configured.
      */
-    useEffect(() => {        
+    useEffect(() => {
         checkIfTOTPEnabled().then((response) => {
             setIsTOTPConfigured(response);
         });
@@ -132,13 +131,13 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     /**
      * Check whether the TOTP is enabled.
      */
-    useEffect(() => {         
+    useEffect(() => {
         setIsTOTPEnabled(enabledAuthenticators?.includes(totpAuthenticatorName) ?? false);
     }, [ enabledAuthenticators ]);
 
     /**
      * Focus to next pin code after enter a value.
-     * 
+     *
      * @param field - The name of the field.
      */
     const focusInToNextPinCode = (field: string): void => {
@@ -161,14 +160,14 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                 break;
             case "pincode-5":
                 pinCode6.current.focus();
-                
+
                 break;
         }
     };
 
     /**
      * Focus to previous pin code after enter Backspace or Delete.
-     * 
+     *
      * @param field - The name of the field.
      */
     const focusInToPreviousPinCode = (field: string): void => {
@@ -191,7 +190,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                 break;
             case "pincode-6":
                 pinCode5.current.focus();
-                
+
                 break;
         }
     };
@@ -213,7 +212,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Update enabled authenticator list based on the update action.
-     * 
+     *
      * @param action - The update action.
      */
     const handleUpdateEnabledAuthenticators = (action: EnabledAuthenticatorUpdateAction): void => {
@@ -224,8 +223,8 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                 if (!authenticatorsList.includes(totpAuthenticatorName)) {
                     authenticatorsList.push(totpAuthenticatorName);
                 }
-                if (isSuperTenantLogin 
-                        && isBackupCodeForced 
+                if (isSuperTenantLogin
+                        && isBackupCodeForced
                         && !authenticatorsList.includes(backupCodeAuthenticatorName)) {
                     authenticatorsList.push(backupCodeAuthenticatorName);
                 }
@@ -236,8 +235,8 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                 if (authenticatorsList.includes(totpAuthenticatorName)) {
                     authenticatorsList.splice(authenticatorsList.indexOf(totpAuthenticatorName), 1);
                 }
-                if (isSuperTenantLogin 
-                        && isBackupCodeForced 
+                if (isSuperTenantLogin
+                        && isBackupCodeForced
                         && authenticatorsList.includes(backupCodeAuthenticatorName)) {
                     authenticatorsList.splice(authenticatorsList.indexOf(backupCodeAuthenticatorName), 1);
                 }
@@ -253,7 +252,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
             })
             .catch((errorMessage => {
                 onAlertFired({
-                    description: t(translateKey + 
+                    description: t(translateKey +
                             "notifications.updateAuthenticatorError.error.description", {
                         error: errorMessage
                     }),
@@ -316,7 +315,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Handle TOTP submit flow.
-     * 
+     *
      * @param event - Form submit event.
      * @param isRegenerated - Whether the TOTP is regenerated or not.
      */
@@ -349,7 +348,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Handle TOTP enable/disable flow.
-     * 
+     *
      * @param _ - Radio button toggle event.
      * @param data - Data related to the toggle event.
      */
@@ -363,7 +362,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Render TOTP form to shown in TOTP modal.
-     * 
+     *
      * @param isRegenerated - Whether the TOTP is regenerated or not.
      * @returns Rendered form component.
      */
@@ -375,133 +374,133 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                     {
                         isTOTPError
                             ? (
-                                <Message 
-                                    className="totp-error-message" 
+                                <Message
+                                    className="totp-error-message"
                                     data-testid={ `${ testId }-code-verification-form-field-error` }>
                                     { t(translateKey + "modals.verify.error") }
                                 </Message>
                             ) : null
                     }
                     <Form
-                        onSubmit={ 
-                            (event: React.FormEvent<HTMLFormElement>) => handleTOTPSubmit(event, isRegenerated) 
+                        onSubmit={
+                            (event: React.FormEvent<HTMLFormElement>) => handleTOTPSubmit(event, isRegenerated)
                         }>
                         <Container>
                             <Grid className="ml-3 mr-3">
                                 <Grid.Row textAlign="center" centered columns={ 6 } >
                                     <Grid.Column >
                                         <Form.Field >
-                                            <input 
-                                                autoFocus 
-                                                ref = { pinCode1 } 
-                                                name = "pincode-1" 
-                                                placeholder = "." 
-                                                className = "text-center totp-input" 
-                                                type = "text" 
-                                                maxLength = { 1 } 
+                                            <input
+                                                autoFocus
+                                                ref = { pinCode1 }
+                                                name = "pincode-1"
+                                                placeholder = "."
+                                                className = "text-center totp-input"
+                                                type = "text"
+                                                maxLength = { 1 }
                                                 onKeyUp = { (event) => {
                                                     if (event.currentTarget.value.length !== 0) {
                                                         focusInToNextPinCode("pincode-1");
                                                     }
                                                     if ((event.key === "Backspace") || (event.key === "Delete")) {
                                                         focusInToPreviousPinCode("pincode-1");
-                                                    } 
+                                                    }
                                                 } }
                                             />
                                         </Form.Field>
                                     </Grid.Column>
                                     <Grid.Column >
                                         <Form.Field>
-                                            <input 
-                                                ref = { pinCode2 } 
-                                                name = "pincode-2" 
-                                                placeholder = "." 
-                                                className = "text-center totp-input" 
-                                                type = "text" 
-                                                maxLength = { 1 } 
+                                            <input
+                                                ref = { pinCode2 }
+                                                name = "pincode-2"
+                                                placeholder = "."
+                                                className = "text-center totp-input"
+                                                type = "text"
+                                                maxLength = { 1 }
                                                 onKeyUp = { (event) => {
                                                     if (event.currentTarget.value.length !== 0) {
                                                         focusInToNextPinCode("pincode-2");
                                                     }
                                                     if ((event.key === "Backspace") || (event.key === "Delete")) {
                                                         focusInToPreviousPinCode("pincode-2");
-                                                    } 
+                                                    }
                                                 } }/>
                                         </Form.Field>
                                     </Grid.Column>
                                     <Grid.Column >
                                         <Form.Field >
-                                            <input 
-                                                ref = { pinCode3 } 
-                                                name ="pincode-3" 
-                                                placeholder ="." 
-                                                className ="text-center totp-input" 
-                                                type ="text" 
-                                                maxLength = { 1 } 
+                                            <input
+                                                ref = { pinCode3 }
+                                                name ="pincode-3"
+                                                placeholder ="."
+                                                className ="text-center totp-input"
+                                                type ="text"
+                                                maxLength = { 1 }
                                                 onKeyUp = { (event) => {
                                                     if (event.currentTarget.value.length !== 0) {
                                                         focusInToNextPinCode("pincode-3");
                                                     }
                                                     if ((event.key === "Backspace") || (event.key === "Delete")) {
                                                         focusInToPreviousPinCode("pincode-3");
-                                                    } 
+                                                    }
                                                 } }/>
                                         </Form.Field>
                                     </Grid.Column>
                                     <Grid.Column>
                                         <Form.Field>
-                                            <input 
-                                                ref = { pinCode4 } 
-                                                name ="pincode-4" 
-                                                placeholder = "." 
-                                                className = "text-center totp-input" 
-                                                type = "text" 
-                                                maxLength = { 1 } 
+                                            <input
+                                                ref = { pinCode4 }
+                                                name ="pincode-4"
+                                                placeholder = "."
+                                                className = "text-center totp-input"
+                                                type = "text"
+                                                maxLength = { 1 }
                                                 onKeyUp = { (event) => {
                                                     if (event.currentTarget.value.length !== 0) {
                                                         focusInToNextPinCode("pincode-4");
                                                     }
                                                     if ((event.key === "Backspace") || (event.key === "Delete")) {
                                                         focusInToPreviousPinCode("pincode-4");
-                                                    } 
+                                                    }
                                                 } }/>
                                         </Form.Field>
                                     </Grid.Column>
                                     <Grid.Column >
                                         <Form.Field>
-                                            <input 
-                                                ref = { pinCode5 } 
-                                                name = "pincode-5" 
-                                                placeholder = "." 
-                                                className = "text-center totp-input" 
-                                                type = "text" 
-                                                maxLength = { 1 }                        
+                                            <input
+                                                ref = { pinCode5 }
+                                                name = "pincode-5"
+                                                placeholder = "."
+                                                className = "text-center totp-input"
+                                                type = "text"
+                                                maxLength = { 1 }
                                                 onKeyUp = { (event) => {
                                                     if (event.currentTarget.value.length !== 0) {
                                                         focusInToNextPinCode("pincode-5");
                                                     }
                                                     if ((event.key === "Backspace") || (event.key === "Delete")) {
                                                         focusInToPreviousPinCode("pincode-5");
-                                                    } 
+                                                    }
                                                 } }/>
                                         </Form.Field>
                                     </Grid.Column>
                                     <Grid.Column >
                                         <Form.Field>
-                                            <input 
-                                                ref = { pinCode6 } 
-                                                name = "pincode-6" 
-                                                placeholder = "." 
-                                                className = "text-center totp-input" 
-                                                type = "text" 
-                                                maxLength = { 1 } 
+                                            <input
+                                                ref = { pinCode6 }
+                                                name = "pincode-6"
+                                                placeholder = "."
+                                                className = "text-center totp-input"
+                                                type = "text"
+                                                maxLength = { 1 }
                                                 onKeyUp = { (event) => {
                                                     if (event.currentTarget.value.length !== 0) {
                                                         focusInToNextPinCode("pincode-6");
                                                     }
                                                     if ((event.key === "Backspace") || (event.key === "Delete")) {
                                                         focusInToPreviousPinCode("pincode-6");
-                                                    } 
+                                                    }
                                                 } }/>
                                         </Form.Field>
                                     </Grid.Column>
@@ -547,7 +546,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Render TOTP configuration modal content.
-     * 
+     *
      * @returns Modal content based on TOTPModalCurrentStep.
      */
     const renderTOTPWizardContent = (): React.ReactElement => {
@@ -556,8 +555,8 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                 <Segment basic >
                     <h5 className=" text-center"> { t(translateKey + "modals.scan.heading") }</h5>
                     <Segment textAlign="center" basic className="qr-code">
-                        { qrCode 
-                            ? <QRCode value={ qrCode } data-testid={ `${ testId }-modals-scan-qrcode` }/> 
+                        { qrCode
+                            ? <QRCode value={ qrCode } data-testid={ `${ testId }-modals-scan-qrcode` }/>
                             : null
                         }
                     </Segment>
@@ -592,34 +591,34 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                 </div>
                 <p className= "success-content">{ t(translateKey + "modals.done") }</p>
             </Segment>
-        );  
+        );
     };
 
     /**
      * Render TOTP configuration modal actions.
-     * 
+     *
      * @returns Modal action based on TOTPModalCurrentStep.
      */
     const renderTOTPWizardActions = (): React.ReactElement => {
         if (TOTPModalCurrentStep === 0) {
             return (
-                <Message className="totp-tooltip display-flex">      
+                <Message className="totp-tooltip display-flex">
                     <Icon name="info circle" />
-                    <Message.Content> 
+                    <Message.Content>
                         <Trans
                             i18nKey={ (translateKey + "modals.toolTip") }
                         >
-                            Don&apos;t have an app? Download an authenticator 
-                            application like Google Authenticator from 
+                            Don&apos;t have an app? Download an authenticator
+                            application like Google Authenticator from
                             <a
                                 target="_blank"
-                                href="https://www.apple.com/us/search/totp?src=globalnav" 
+                                href="https://www.apple.com/us/search/totp?src=globalnav"
                                 rel="noopener noreferrer"> App Store </a>
-                            or 
+                            or
                             <a
                                 target="_blank"
-                                href="https://play.google.com/store/search?q=totp" 
-                                rel="noopener noreferrer"> Google Play </a> 
+                                href="https://play.google.com/store/search?q=totp"
+                                rel="noopener noreferrer"> Google Play </a>
                         </Trans>
                     </Message.Content>
                 </Message>
@@ -650,7 +649,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Renders the TOTP configuration Modal.
-     * 
+     *
      * @returns Rendered modal component
      */
     const renderTOTPWizard = (): React.ReactElement => {
@@ -737,7 +736,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
 
     /**
      * Renders modal content.
-     * 
+     *
      * @returns Modal content based on viewTOTPModalCurrentStep.
      */
     const renderViewTOTPWizardContent = (): React.ReactElement => {
@@ -747,7 +746,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                     <Segment basic >
                         <h5 className=" text-center"> { t(translateKey + "modals.scan.heading") }</h5>
                         <Segment textAlign="center" basic className="qr-code">
-                            { qrCode 
+                            { qrCode
                                 ? <QRCode value={ qrCode } data-testid={ `${ testId }-view-modals-scan-qrcode` }/>
                                 : null
                             }
@@ -779,10 +778,10 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                                             type="button"
                                             className=" totp-verify-action-button"
                                             onClick={ handleRegenerateQRCode }
-                                            disabled= { 
-                                                isLoading 
+                                            disabled= {
+                                                isLoading
                                                 || (commonConfig.accountSecurityPage
-                                                    .mfa.totp.showRegenerateConfirmation && !isConfirmRegenerate) 
+                                                    .mfa.totp.showRegenerateConfirmation && !isConfirmRegenerate)
                                             }
                                             data-testid={ `${ testId }-view-modal-actions-primary-button` }
                                         >
@@ -821,7 +820,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                         { renderTOTPVerifyForm(true) }
                     </Segment>
                 );
-        
+
             default:
                 return (
                     <Segment className="totp">
@@ -856,23 +855,23 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
     const renderViewTOTPWizardActions = (): React.ReactElement => {
         if (viewTOTPModalCurrentStep === 0 || viewTOTPModalCurrentStep === 1) {
             return (
-                <Message className="totp-tooltip display-flex">      
+                <Message className="totp-tooltip display-flex">
                     <Icon name="info circle" />
-                    <Message.Content> 
+                    <Message.Content>
                         <Trans
                             i18nKey={ (translateKey + "modals.toolTip") }
                         >
-                    Don&apos;t have an app? Download an authenticator 
-                    application like Google Authenticator from 
+                    Don&apos;t have an app? Download an authenticator
+                    application like Google Authenticator from
                             <a
                                 target="_blank"
-                                href="https://www.apple.com/us/search/totp?src=globalnav" 
+                                href="https://www.apple.com/us/search/totp?src=globalnav"
                                 rel="noopener noreferrer"> App Store </a>
-                    or 
+                    or
                             <a
                                 target="_blank"
-                                href="https://play.google.com/store/search?q=totp" 
-                                rel="noopener noreferrer"> Google Play </a> 
+                                href="https://play.google.com/store/search?q=totp"
+                                rel="noopener noreferrer"> Google Play </a>
                         </Trans>
                     </Message.Content>
                 </Message>
@@ -1019,10 +1018,10 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
         );
     };
 
-    return ( 
+    return (
         <>
             { renderTOTPWizard() }
-            { !isTOTPConfigured 
+            { !isTOTPConfigured
                 ? (
                     <Grid padded={ true } data-testid={ testId }>
                         <Grid.Row columns={ 2 }>
@@ -1098,8 +1097,8 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                                         </List.Description>
                                     </List.Content>
                                 </Grid.Column>
-                                { 
-                                    (isSuperTenantLogin && enableMFAUserWise) 
+                                {
+                                    (isSuperTenantLogin && enableMFAUserWise)
                                         ? (
                                             <Grid.Column width={ 1 } floated="right">
                                                 <List.Content floated="right">
@@ -1121,11 +1120,11 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                                                     />
                                                 </List.Content>
                                             </Grid.Column>
-                                        ) : null 
+                                        ) : null
                                 }
-                                <Grid.Column 
-                                    width={ (isSuperTenantLogin && enableMFAUserWise) ? 2 : 3 } 
-                                    className="last-column" 
+                                <Grid.Column
+                                    width={ (isSuperTenantLogin && enableMFAUserWise) ? 2 : 3 }
+                                    className="last-column"
                                     floated="right"
                                 >
                                     <List.Content floated="right">
@@ -1170,7 +1169,7 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
                             </Grid.Row>
                         </Grid>
                     </>
-                ) 
+                )
             }
         </>
     );

--- a/apps/myaccount/src/components/overview/widgets/account-status-widget.tsx
+++ b/apps/myaccount/src/components/overview/widgets/account-status-widget.tsx
@@ -17,11 +17,11 @@
  */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
-import { GenericIcon } from "@wso2is/react-components";
+import { GenericIcon, Popup } from "@wso2is/react-components";
 import React, { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Divider, Grid, Header, Icon, Popup, Progress } from "semantic-ui-react";
+import { Divider, Grid, Header, Icon, Progress } from "semantic-ui-react";
 import { getAccountStatusShields } from "../../../configs";
 import { UIConstants } from "../../../constants";
 import { ProfileCompletion, ProfileCompletionStatus } from "../../../models";

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -27,13 +27,20 @@ import {
 import { SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { ProfileUtils, CommonUtils as ReusableCommonUtils } from "@wso2is/core/utils";
 import { Field, Forms, Validation } from "@wso2is/forms";
-import { EditAvatarModal, LinkButton, PrimaryButton, UserAvatar, useMediaContext } from "@wso2is/react-components";
+import {
+    EditAvatarModal,
+    LinkButton,
+    Popup,
+    PrimaryButton,
+    UserAvatar,
+    useMediaContext
+} from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
 import moment from "moment";
 import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { DropdownItemProps, Form, Grid, Icon, List, Placeholder, Popup } from "semantic-ui-react";
+import { DropdownItemProps, Form, Grid, Icon, List, Placeholder } from "semantic-ui-react";
 import { updateProfileImageURL, updateProfileInfo } from "../../api";
 import { AppConstants, CommonConstants, UIConstants } from "../../constants";
 import { commonConfig, profileConfig } from "../../extensions";

--- a/apps/myaccount/src/components/shared/user-avatar.tsx
+++ b/apps/myaccount/src/components/shared/user-avatar.tsx
@@ -16,12 +16,13 @@
  * under the License.
  */
 
+import { Popup } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
-import { Button, Dimmer, Form, Icon, Modal, Popup } from "semantic-ui-react";
+import { Button, Dimmer, Form, Icon, Modal } from "semantic-ui-react";
 import { Avatar, AvatarProps } from "./avatar";
 import { updateProfileInfo } from "../../api";
 import { getThirdPartyLogos } from "../../configs";

--- a/modules/form/.eslintrc.js
+++ b/modules/form/.eslintrc.js
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,7 +14,6 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
 
 module.exports = {

--- a/modules/form/jest.config.ts
+++ b/modules/form/jest.config.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/modules/form/src/addons/query-params.tsx
+++ b/modules/form/src/addons/query-params.tsx
@@ -20,8 +20,8 @@ import { FormInputLabel, Popup } from "@wso2is/react-components";
 import filter from "lodash-es/filter";
 import isEmpty from "lodash-es/isEmpty";
 import isEqual from "lodash-es/isEqual";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { Button, Form, Icon, Label, Message } from "semantic-ui-react";
+import React, { ChangeEvent, FunctionComponent, ReactElement, SyntheticEvent, useEffect, useState } from "react";
+import { Button, Form, Icon, InputOnChangeData, Label, Message } from "semantic-ui-react";
 
 interface QueryParametersPropsInterface {
     label?: string | ReactElement;
@@ -41,8 +41,8 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
 
     const { label, name, value, onChange } = props;
 
-    const QUERY_PARAMETER_SEPARATOR = "&";
-    const SPECIAL_CHARACTERS = [ ",", "&", "=", "?" ];
+    const QUERY_PARAMETER_SEPARATOR: string = "&";
+    const SPECIAL_CHARACTERS: string[] = [ ",", "&", "=", "?" ];
 
     const [ queryParamName, setQueryParamName ] = useState<string>("");
     const [ queryParamValue, setQueryParamValue ] = useState<string>("");
@@ -118,23 +118,23 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
      *
      * @param e - keypress event.
      */
-    const keyPressed = (e) => {
-        const key = e.which || e.charCode || e.keyCode;
+    const keyPressed = (e: KeyboardEvent) => {
+        const key: number = e.which || e.charCode || e.keyCode;
 
         if (key === 13) {
             handleQueryParameterAdd(e);
         }
     };
 
-    const handleQueryParameterAdd = (event) => {
+    const handleQueryParameterAdd = (event: KeyboardEvent | SyntheticEvent) => {
         event.preventDefault();
         if (isEmpty(queryParamName) || isEmpty(queryParamValue)) {
             return;
         }
         setErrorMessage("");
-        let isError = false;
+        let isError: boolean = false;
 
-        SPECIAL_CHARACTERS.map((c) => {
+        SPECIAL_CHARACTERS.map((c: string) => {
             if (queryParamValue.includes(c) || queryParamName.includes(c)) {
                 setErrorMessage("Cannot include \"" + c + "\" as a query parameter.");
                 isError = true;
@@ -146,13 +146,13 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
             value: queryParamValue
         } ];
 
-        queryParams.forEach(function (queryParam) {
-            const existing = output.filter((item) => {
+        queryParams.forEach(function (queryParam: QueryParameter) {
+            const existing: QueryParameter[] = output.filter((item: QueryParameter) => {
                 return item.name == queryParam.name;
             });
 
             if (existing.length) {
-                const existingIndex = output.indexOf(existing[0]);
+                const existingIndex: number = output.indexOf(existing[0]);
 
                 output[existingIndex].value = queryParam.value + " " + output[existingIndex].value;
             } else {
@@ -170,7 +170,7 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
         if (isEmpty(queryParameter)) {
             return;
         }
-        setQueryParams(filter(queryParams, queryParam => !isEqual(queryParam,
+        setQueryParams(filter(queryParams, (queryParam: QueryParameter) => !isEqual(queryParam,
             buildQueryParameter(queryParameter))));
     };
 
@@ -190,7 +190,7 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
                     value={ queryParamName }
                     focus
                     placeholder="name"
-                    onChange={ (event, data) => setQueryParamName(data.value) }
+                    onChange={ (_event: ChangeEvent, data: InputOnChangeData) => setQueryParamName(data.value) }
                     onKeyDown={ keyPressed }
                 />
                 <Form.Input
@@ -198,13 +198,13 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
                     value={ queryParamValue }
                     focus
                     placeholder="value"
-                    onChange={ (event, data) => setQueryParamValue(data.value) }
+                    onChange={ (_event: ChangeEvent, data: InputOnChangeData) => setQueryParamValue(data.value) }
                     onKeyDown={ keyPressed }
                 />
                 <Popup
                     trigger={
                         (<Button
-                            onClick={ (e) => handleQueryParameterAdd(e) }
+                            onClick={ (e: SyntheticEvent) => handleQueryParameterAdd(e) }
                             icon="add"
                             type="button"
                             disabled={ false }
@@ -217,7 +217,7 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
             </Form.Group>
             <Message visible={ errorMessage !== "" } error content={ errorMessage } />
             {
-                queryParams && queryParams?.map((eachQueryParam, index) => {
+                queryParams && queryParams?.map((eachQueryParam: QueryParameter, index: number) => {
                     const queryParameter: string = eachQueryParam.name + "=" + eachQueryParam.value;
 
                     return (

--- a/modules/form/src/addons/query-params.tsx
+++ b/modules/form/src/addons/query-params.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,12 +16,12 @@
  * under the License.
  */
 
-import { FormInputLabel } from "@wso2is/react-components";
+import { FormInputLabel, Popup } from "@wso2is/react-components";
 import filter from "lodash-es/filter";
 import isEmpty from "lodash-es/isEmpty";
 import isEqual from "lodash-es/isEqual";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { Button, Form, Icon, Label, Message, Popup } from "semantic-ui-react";
+import { Button, Form, Icon, Label, Message } from "semantic-ui-react";
 
 interface QueryParametersPropsInterface {
     label?: string | ReactElement;
@@ -55,10 +55,10 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
     useEffect(() => {
         fireOnChangeEvent(queryParams, onChange);
     }, [ queryParams ]);
-    
+
     /**
      * Build query parameter object from the given string form.
-     * @param queryParameter Query parameter in the string form.
+     * @param  Query - parameter in the string form.
      */
     const buildQueryParameter = (queryParameter: string): QueryParameter => {
         return {
@@ -81,8 +81,8 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
     /**
      * Trigger provided onChange handler with provided query parameters.
      *
-     * @param queryParams QueryParameters.
-     * @param onChange onChange handler.
+     * @param queryParams - QueryParameters.
+     * @param onChange - onChange handler.
      */
     const fireOnChangeEvent = (
         queryParams: QueryParameter[],
@@ -98,7 +98,7 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
     /**
      * Update input field values for query parameter.
      *
-     * @param queryParam QueryParameter.
+     * @param queryParam - QueryParameter.
      */
     const updateQueryParameterInputFields = (queryParam: QueryParameter) => {
         setQueryParamName(queryParam?.name);
@@ -111,14 +111,16 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
     useEffect(() => {
         if (isEmpty(value)) return;
         setQueryParams(value.split(QUERY_PARAMETER_SEPARATOR)?.map(buildQueryParameter));
-    }, [value]);
+    }, [ value ]);
 
     /**
      * Enter button option.
-     * @param e keypress event.
+     *
+     * @param e - keypress event.
      */
     const keyPressed = (e) => {
         const key = e.which || e.charCode || e.keyCode;
+
         if (key === 13) {
             handleQueryParameterAdd(e);
         }
@@ -131,6 +133,7 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
         }
         setErrorMessage("");
         let isError = false;
+
         SPECIAL_CHARACTERS.map((c) => {
             if (queryParamValue.includes(c) || queryParamName.includes(c)) {
                 setErrorMessage("Cannot include \"" + c + "\" as a query parameter.");
@@ -138,16 +141,19 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
             }
         });
         if (isError) return;
-        const output: QueryParameter[] = [{
+        const output: QueryParameter[] = [ {
             name: queryParamName,
             value: queryParamValue
-        }];
+        } ];
+
         queryParams.forEach(function (queryParam) {
             const existing = output.filter((item) => {
                 return item.name == queryParam.name;
             });
+
             if (existing.length) {
                 const existingIndex = output.indexOf(existing[0]);
+
                 output[existingIndex].value = queryParam.value + " " + output[existingIndex].value;
             } else {
                 output.push(queryParam);
@@ -171,11 +177,11 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
     return (
         <React.Fragment>
             { label
-                ? <FormInputLabel htmlFor={ name }>
+                ? (<FormInputLabel htmlFor={ name }>
                     <span style={ { display: "flex", marginBottom: 10 } }>
                         { label }
                     </span>
-                </FormInputLabel>
+                </FormInputLabel>)
                 : null
             }
             <Form.Group inline widths="equal" unstackable={ true }>
@@ -213,6 +219,7 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
             {
                 queryParams && queryParams?.map((eachQueryParam, index) => {
                     const queryParameter: string = eachQueryParam.name + "=" + eachQueryParam.value;
+
                     return (
                         <Label key={ index }>
                             { queryParameter }

--- a/modules/form/src/addons/scopes.tsx
+++ b/modules/form/src/addons/scopes.tsx
@@ -16,11 +16,12 @@
  * under the License.
  */
 
+import { Popup } from "@wso2is/react-components";
 import filter from "lodash-es/filter";
 import isEmpty from "lodash-es/isEmpty";
 import isEqual from "lodash-es/isEqual";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { Button, Form, Icon, InputOnChangeData, Label, Message, Popup } from "semantic-ui-react";
+import { Button, Form, Icon, InputOnChangeData, Label, Message } from "semantic-ui-react";
 
 interface ScopesPropsInterface {
     /**
@@ -33,11 +34,11 @@ interface ScopesPropsInterface {
     label?: string | ReactElement;
     /**
      * Scope values.
-     */    
+     */
     value: string;
     /**
      * Are scopes mandatory.
-     */    
+     */
     required: boolean;
     /**
      * Callback for onChange
@@ -70,14 +71,14 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
     props: ScopesPropsInterface
 ) => {
 
-    const { 
+    const {
         defaultValue,
-        label, 
-        value, 
+        label,
+        value,
         required,
         onChange,
         onBlur,
-        placeholder 
+        placeholder
     } = props;
 
     const SCOPE_SEPARATOR: string = " ";
@@ -92,17 +93,17 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
     useEffect(() => {
         if (isEmpty(value)) {
             return;
-        } 
+        }
         setScopes(value.split(SCOPE_SEPARATOR)?.map(buildScope));
     }, [ value ]);
-     
+
     /**
       * Called when `scopes` is changed.
       */
     useEffect(() => {
         fireOnChangeEvent(scopes, onChange);
     }, [ scopes ]);
-    
+
     /**
       * Build scope object from the given string form.
       *
@@ -119,7 +120,7 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
       * Build scope string value, from it's object form.
       */
     const buildScopeString = (scope: ScopeInterface): string => scope.value;
- 
+
     /**
       * Build scopes string value, from scopes object list.
       */
@@ -128,13 +129,13 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
 
     /**
       * Trigger provided onChange handler with provided scopes.
-      * 
+      *
       * @param scopes - Scopes.
-      * @param onChange - onChange handler. 
+      * @param onChange - onChange handler.
       */
-    const fireOnChangeEvent = (scopes: ScopeInterface[], onChange: (event: React.ChangeEvent<HTMLInputElement>) 
+    const fireOnChangeEvent = (scopes: ScopeInterface[], onChange: (event: React.ChangeEvent<HTMLInputElement>)
          => void): void => {
-            
+
         onChange(
              {
                  target: {
@@ -146,7 +147,7 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
 
     /**
       * Update input field values for scope.
-      * 
+      *
       * @param scope - Scope.
       */
     const updateScopeInputFields = (scope: ScopeInterface): void => {
@@ -158,13 +159,13 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
      * @param e - keypress event.
      */
     const keyPressed = (e: React.KeyboardEvent<HTMLInputElement>): void => {
- 
+
         if (e.key === "Enter" ) {
             handleScopeAdd(e);
         }
     };
 
-    const handleScopeAdd = (event: React.MouseEvent<HTMLButtonElement, MouseEvent> 
+    const handleScopeAdd = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>
         | React.KeyboardEvent<HTMLInputElement>): void => {
         event.preventDefault();
         if (isEmpty(scopeValue)) {
@@ -175,25 +176,25 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
         const output: ScopeInterface[] = [ {
             value: scopeValue
         } ];
- 
+
         scopes.forEach(function(scope: ScopeInterface) {
             const existing: ScopeInterface[] = output.filter((item: any) => {
                 return item.value == scope.value;
             });
- 
+
             if (existing.length) {
                 return;
             } else {
                 output.push(scope);
             }
         });
- 
+
         setScopes(output);
         updateScopeInputFields({
             value: ""
         });
     };
- 
+
     const handleLabelRemove = (scopeParam: string): void => {
 
         if (isEmpty(scopeParam)) {
@@ -212,7 +213,7 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
                     </div>
                 )
             }
-            <Form.Group inline widths="equal" unstackable={ true }> 
+            <Form.Group inline widths="equal" unstackable={ true }>
                 <Form.Input
                     fluid
                     value={ scopeValue }
@@ -251,7 +252,7 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
                             <Label
                                 key={ index }
                             >
-                                { scope } 
+                                { scope }
                             </Label>
                         );
                     } else {

--- a/modules/form/src/components/__tests__/form.test.tsx
+++ b/modules/form/src/components/__tests__/form.test.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -31,16 +31,16 @@ describe("Test if the Forms is working fine", () => {
                 isDefault: true,
                 isRequired: true,
                 isValue: true,
-                type: "text",
-                name: "First Name"
+                name: "First Name",
+                type: "text"
             },
             {
                 ariaLabel: "Submit",
                 fieldType: "primary-btn",
-                name: "submit",
                 isDefault: false,
                 isRequired: false,
                 isValue: true,
+                name: "submit",
                 type: "submit"
             }
         ]));
@@ -49,7 +49,8 @@ describe("Test if the Forms is working fine", () => {
         expect(getByText(FieldTestConstants.TEXT_FIELD_LABEL)).toBeInTheDocument();
 
         // check if the text box with the mentioned placeholder value is displayed
-        const textBox = getByPlaceholderText(FieldTestConstants.TEXT_FIELD_PLACEHOLDER);
+        const textBox: HTMLElement = getByPlaceholderText(FieldTestConstants.TEXT_FIELD_PLACEHOLDER);
+
         expect(textBox).toBeInTheDocument();
 
         // check if the submit button is displayed
@@ -59,7 +60,8 @@ describe("Test if the Forms is working fine", () => {
         expect(getByDisplayValue(FieldTestConstants.TEXT_FIELD_VALUE)).toBeInTheDocument();
 
         // check if the value of the text box changes
-        const NEW_VALUE = "new value";
+        const NEW_VALUE: string = "new value";
+
         fireEvent.change(textBox, { target: { value: NEW_VALUE } });
         expect(getByDisplayValue(NEW_VALUE)).toBeInTheDocument();
 
@@ -102,16 +104,16 @@ describe("Test if the Forms is working fine", () => {
                 isDefault: true,
                 isRequired: true,
                 isValue: true,
-                type: "text",
-                name: "First Name"
+                name: "First Name",
+                type: "text"
             },
             {
                 ariaLabel: "Submit",
                 fieldType: "primary-btn",
-                name: "submit",
                 isDefault: false,
                 isRequired: false,
                 isValue: true,
+                name: "submit",
                 type: "submit"
             }
         ]));
@@ -131,21 +133,21 @@ describe("Test if the Forms is working fine", () => {
                     isDefault: true,
                     isRequired: true,
                     isValue: true,
-                    type: "text",
-                    name: "First Name"
+                    name: "First Name",
+                    type: "text"
                 },
                 {
                     ariaLabel: "Submit",
                     fieldType: "primary-btn",
-                    name: "submit",
                     isDefault: false,
                     isRequired: false,
                     isValue: true,
+                    name: "submit",
                     type: "submit"
                 }
             ]));
 
-            const textBox = getByPlaceholderText(FieldTestConstants.TEXT_FIELD_PLACEHOLDER);
+            const textBox: HTMLElement = getByPlaceholderText(FieldTestConstants.TEXT_FIELD_PLACEHOLDER);
 
             // check if required error message is correctly displayed
             fireEvent.change(textBox, { target: { value: "" } });
@@ -172,16 +174,16 @@ describe("Test if the Forms is working fine", () => {
                 isDefault: true,
                 isRequired: true,
                 isValue: true,
-                type: "password",
-                name: "First Name"
+                name: "First Name",
+                type: "password"
             },
             {
                 ariaLabel: "Submit",
                 fieldType: "primary-btn",
-                name: "submit",
                 isDefault: false,
                 isRequired: false,
                 isValue: true,
+                name: "submit",
                 type: "submit"
             }
         ]));
@@ -196,12 +198,14 @@ describe("Test if the Forms is working fine", () => {
         expect(getByText(FieldTestConstants.SUBMIT)).toBeInTheDocument();
 
         // check if the password box with the mentioned value is displayed
-        const passwordBox = getByDisplayValue(FieldTestConstants.PASSWORD_VALUE);
+        const passwordBox: HTMLElement = getByDisplayValue(FieldTestConstants.PASSWORD_VALUE);
+
         expect(passwordBox).toBeInTheDocument();
 
         // check if the value of the password box changes
         FieldTestConstants.listen.mockReset();
-        const NEW_VALUE = "new value";
+        const NEW_VALUE: string = "new value";
+
         fireEvent.change(passwordBox, { target: { value: NEW_VALUE } });
         expect(await findByDisplayValue(NEW_VALUE)).toBeInTheDocument();
 
@@ -216,7 +220,8 @@ describe("Test if the Forms is working fine", () => {
         expect(await findByText(FieldTestConstants.PASSWORD_VALIDATION_FAILED)).toBeInTheDocument();
 
         // check if show/hide is working fine
-        let showButton = container.getElementsByClassName("eye link icon")[ 0 ];
+        let showButton: Element = container.getElementsByClassName("eye link icon")[ 0 ];
+
         expect(passwordBox).toHaveAttribute("type", "password");
         expect(showButton).toBeInTheDocument();
 
@@ -227,7 +232,8 @@ describe("Test if the Forms is working fine", () => {
         expect(getByText(FieldTestConstants.HIDE_PASSWORD)).toBeInTheDocument();
 
         // check if toggling works fine
-        const hideButton = container.getElementsByClassName("eye slash link icon")[ 0 ];
+        const hideButton: Element = container.getElementsByClassName("eye slash link icon")[ 0 ];
+
         expect(passwordBox).toHaveAttribute("type", "text");
         expect(hideButton).toBeInTheDocument();
 

--- a/modules/form/src/components/__tests__/test-form.tsx
+++ b/modules/form/src/components/__tests__/test-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -29,7 +29,7 @@ export interface FormTestFields extends FormFieldPropsInterface {
 }
 
 const getForm = (testFields: FormTestFields[]): ReactElement => {
-    const form = {
+    const form: Record<string, any> = {
         button: {
             onClick: FieldTestConstants.onClick,
             type: "button" as const,
@@ -42,7 +42,7 @@ const getForm = (testFields: FormTestFields[]): ReactElement => {
         password: {
             hidePassword: FieldTestConstants.HIDE_PASSWORD,
             label: FieldTestConstants.PASSWORD_LABEL,
-            listen: (value) => { FieldTestConstants.listen(value); },
+            listen: (value: string) => { FieldTestConstants.listen(value); },
             name: FieldTestConstants.PASSWORD_NAME,
             placeholder: FieldTestConstants.PASSWORD_PLACEHOLDER,
             required: true,
@@ -80,8 +80,10 @@ const getForm = (testFields: FormTestFields[]): ReactElement => {
     };
 
     const formFields: FormFieldPropsInterface[] = [];
-    testFields.forEach((testField) => {
-        const tempFormField = form[testField.type];
+
+    testFields.forEach((testField: FormFieldPropsInterface) => {
+        const tempFormField: any = form[testField.type];
+
         if (tempFormField.required) {
             testField.isRequired ? tempFormField.required = true : tempFormField.required = false;
         }
@@ -95,9 +97,9 @@ const getForm = (testFields: FormTestFields[]): ReactElement => {
     });
 
     return (
-        <Form uncontrolledForm onSubmit={ (value) => FieldTestConstants.onSubmit(value) }>
+        <Form uncontrolledForm onSubmit={ (value: Record<string, string>) => FieldTestConstants.onSubmit(value) }>
             {
-                formFields.map((formField, index) => {
+                formFields.map((formField: FormFieldPropsInterface, index: number) => {
                     return (
                         <Field key={ index } { ...formField } />
                     );

--- a/modules/form/src/components/adapters.tsx
+++ b/modules/form/src/components/adapters.tsx
@@ -24,6 +24,7 @@ import {
     DangerButton,
     LinkButton,
     Password,
+    Popup,
     PrimaryButton
 } from "@wso2is/react-components";
 import omit from "lodash-es/omit";

--- a/modules/form/src/components/adapters.tsx
+++ b/modules/form/src/components/adapters.tsx
@@ -30,8 +30,17 @@ import {
 import omit from "lodash-es/omit";
 import React, { ClipboardEvent, FormEvent, KeyboardEvent, ReactElement } from "react";
 import { FieldRenderProps } from "react-final-form";
-// eslint-disable-next-line max-len
-import { Checkbox, CheckboxProps, DropdownProps, Form, Icon, Input, InputOnChangeData, Popup, Select, TextAreaProps } from "semantic-ui-react";
+import {
+    Checkbox,
+    CheckboxProps,
+    DropdownProps,
+    Form,
+    Icon,
+    Input,
+    InputOnChangeData,
+    Select,
+    TextAreaProps
+} from "semantic-ui-react";
 import { QueryParameters, Scopes } from "../addons";
 import {
     CheckboxAdapterPropsInterface,

--- a/modules/form/src/components/field-checkbox-legacy.tsx
+++ b/modules/form/src/components/field-checkbox-legacy.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -42,9 +42,9 @@ export interface FieldCheckboxLegacyPropsInterface extends FormFieldPropsInterfa
  * Implementation of the Checkbox Field component.
  * @deprecated Use `Field.Checkbox` instead.
  *
- * @param {FieldCheckboxLegacyPropsInterface} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @returns
  */
 export const FieldCheckboxLegacy = (props: FieldCheckboxLegacyPropsInterface): ReactElement => {
 
@@ -69,7 +69,7 @@ export const FieldCheckboxLegacy = (props: FieldCheckboxLegacyPropsInterface): R
         <>
             <FinalFormField
                 key={ testId }
-                parse={ value => value === undefined
+                parse={ (value: any) => value === undefined
                     ? setCheckboxValue(!(props?.childFieldProps?.value?.length == 0)) : setCheckboxValue(value) }
                 type="checkbox"
                 name={ props.name }

--- a/modules/form/src/components/field-checkbox.tsx
+++ b/modules/form/src/components/field-checkbox.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -46,9 +46,9 @@ export interface FieldCheckboxPropsInterface extends FormFieldPropsInterface, Te
 /**
  * Implementation of the Checkbox Field component.
  *
- * @param {FieldCheckboxPropsInterface} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @returns
  */
 export const FieldCheckbox: FunctionComponent<FieldCheckboxPropsInterface> = (
     props: FieldCheckboxPropsInterface

--- a/modules/form/src/components/field-color-picker.tsx
+++ b/modules/form/src/components/field-color-picker.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -46,9 +46,9 @@ export interface FieldColorPickerPropsInterface extends FormFieldPropsInterface,
 /**
  * Implementation of the Color Picker component.
  *
- * @param {FieldColorPickerPropsInterface} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @returns
  */
 export const FieldColorPicker: FunctionComponent<FieldColorPickerPropsInterface> = (
     props: FieldColorPickerPropsInterface
@@ -63,7 +63,8 @@ export const FieldColorPicker: FunctionComponent<FieldColorPickerPropsInterface>
 
     /**
      * Resolves the input message.
-     * @return {ReactElement}
+     *
+     * @returns
      */
     const resolveInputFieldMessage = (): ReactElement => {
         switch (message.type) {
@@ -100,7 +101,7 @@ export const FieldColorPicker: FunctionComponent<FieldColorPickerPropsInterface>
                 key={ testId }
                 type="text"
                 name={ name }
-                parse={ value => value }
+                parse={ (value: any) => value }
                 component={ ColorPickerAdapter }
                 { ...props }
             />

--- a/modules/form/src/components/field-dropdown.tsx
+++ b/modules/form/src/components/field-dropdown.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,6 +17,7 @@
  */
 
 import { Hint, Message } from "@wso2is/react-components";
+import { FieldState } from "final-form";
 import React, { ReactElement } from "react";
 import { Field as FinalFormField } from "react-final-form";
 import { SelectAdapter } from "./adapters";
@@ -41,11 +42,12 @@ export interface FieldDropdownPropsInterface extends FormFieldPropsInterface {
 
 /**
  * Implementation of the Dropdown Field component.
- * @param props
+ *
+ * @param props - Props injected to the component.
  */
 export const FieldDropdown = (props: FieldDropdownPropsInterface): ReactElement => {
 
-    const { [ "data-testid" ]: testId, initialValue, ...rest } = props;
+    const { [ "data-testid" ]: testId, _initialValue, ...rest } = props;
 
     const resolveInputFieldMessage = () => {
         switch (props.message.type) {
@@ -82,9 +84,9 @@ export const FieldDropdown = (props: FieldDropdownPropsInterface): ReactElement 
                 key={ testId }
                 type="dropdown"
                 name={ props.name }
-                parse={ value => value }
+                parse={ (value: any) => value }
                 component={ SelectAdapter }
-                validate={ (value, allValues, meta) =>
+                validate={ (value: any, _allValues: Record<string, unknown>, meta: FieldState<any>) =>
                     getValidation(value, meta, props.type, props.required)
                 }
                 { ...rest }

--- a/modules/form/src/components/field-input.tsx
+++ b/modules/form/src/components/field-input.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,6 +17,7 @@
  */
 
 import { Hint, Message } from "@wso2is/react-components";
+import { FieldState } from "final-form";
 import React, { ReactElement } from "react";
 import { Field as FinalFormField } from "react-final-form";
 import { CopyFieldAdapter, PasswordFieldAdapter, TextFieldAdapter } from "./adapters";
@@ -68,20 +69,17 @@ export interface FieldInputPropsInterface extends FormFieldPropsInterface {
 
 /**
  * Implementation of the Input Field component.
- * @param props
+ * @param props - Props injected to the component.
  */
 export const FieldInput = (props: FieldInputPropsInterface): ReactElement => {
-    
+
     const {
         inputType,
-        hint,
-        maxLength,
-        message,
         validation,
         [ "data-testid" ]: testId,
         ...rest
     } = props;
-    
+
     const inputFieldGenerator = () => {
         if (inputType == FieldInputTypes.INPUT_PASSWORD) {
             return (
@@ -89,9 +87,9 @@ export const FieldInput = (props: FieldInputPropsInterface): ReactElement => {
                     key={ testId }
                     type="password"
                     name={ props.name }
-                    parse={ value => value }
+                    parse={ (value: any) => value }
                     component={ PasswordFieldAdapter }
-                    validate={ (value, allValues, meta) =>
+                    validate={ (value: any, _allValues: Record<string, unknown>, meta: FieldState<any>) =>
                         getValidation(value, meta, "password", props.required, inputType, validation)
                     }
                     { ...rest }
@@ -103,9 +101,9 @@ export const FieldInput = (props: FieldInputPropsInterface): ReactElement => {
                     key={ testId }
                     type="text"
                     name={ props.name }
-                    parse={ value => value }
+                    parse={ (value: any) => value }
                     component={ CopyFieldAdapter }
-                    validate={ (value, allValues, meta) =>
+                    validate={ (value: any, _allValues: Record<string, unknown>, meta: FieldState<any>) =>
                         getValidation(value, meta, "text", props.required, inputType, validation)
                     }
                     { ...rest }
@@ -117,9 +115,9 @@ export const FieldInput = (props: FieldInputPropsInterface): ReactElement => {
                     key={ testId }
                     type="number"
                     name={ props.name }
-                    parse={ value => value }
+                    parse={ (value: any) => value }
                     component={ TextFieldAdapter }
-                    validate={ (value, allValues, meta) =>
+                    validate={ (value: any, _allValues: Record<string, unknown>, meta: FieldState<any>) =>
                         getValidation(value, meta, "text", props.required, inputType, validation)
                     }
                     { ...rest }
@@ -131,9 +129,9 @@ export const FieldInput = (props: FieldInputPropsInterface): ReactElement => {
                     key={ testId }
                     type="text"
                     name={ props.name }
-                    parse={ value => value }
+                    parse={ (value: any) => value }
                     component={ TextFieldAdapter }
-                    validate={ (value, allValues, meta) =>
+                    validate={ (value: any, _allValues: Record<string, unknown>, meta: FieldState<any>) =>
                         getValidation(value, meta, "text", props.required, inputType, validation)
                     }
                     { ...props }

--- a/modules/form/src/components/field-query-params.tsx
+++ b/modules/form/src/components/field-query-params.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -36,8 +36,9 @@ export interface FieldQueryParamsProps extends FormFieldPropsInterface {
 }
 
 /**
- * @param {FieldQueryParamsProps} props
- * @return {ReactElement | ReactNode}
+ * @param props - Props injected to the component.
+ *
+ * @returns
  */
 export const FieldQueryParams: FunctionComponent<FieldQueryParamsProps> = (
     props: FieldQueryParamsProps

--- a/modules/form/src/components/field-radio.tsx
+++ b/modules/form/src/components/field-radio.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -46,9 +46,9 @@ export interface FieldRadioPropsInterface extends FormFieldPropsInterface, Ident
 /**
  * Implementation of the Radio Field component.
  *
- * @param {FieldRadioPropsInterface} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @returns
  */
 export const FieldRadio: FunctionComponent<FieldRadioPropsInterface> = (
     props: FieldRadioPropsInterface

--- a/modules/form/src/components/field-textarea.tsx
+++ b/modules/form/src/components/field-textarea.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,6 +17,7 @@
  */
 
 import { Hint, Message } from "@wso2is/react-components";
+import { FieldState } from "final-form";
 import React, { ReactElement } from "react";
 import { Field as FinalFormField } from "react-final-form";
 import { TextAreaAdapter } from "./adapters";
@@ -53,7 +54,7 @@ export interface FieldTextareaPropsInterface extends FormFieldPropsInterface {
 
 /**
  * Implementation of the Textarea Field component.
- * @param props
+ * @param props - Props injected to the component.
  */
 export const FieldTextarea = (props: FieldTextareaPropsInterface): ReactElement => {
 
@@ -94,9 +95,9 @@ export const FieldTextarea = (props: FieldTextareaPropsInterface): ReactElement 
                 key={ testId }
                 type="textarea"
                 name={ props.name }
-                parse={ value => value }
+                parse={ (value: any) => value }
                 component={ TextAreaAdapter }
-                validate={ (value,allValues, meta) =>
+                validate={ (value: any, _allValues: Record<string, unknown>, meta: FieldState<any>) =>
                     getValidation(value, meta, "textarea", props.required, props.type, props.validation)
                 }
                 { ...rest }

--- a/modules/form/src/components/form.tsx
+++ b/modules/form/src/components/form.tsx
@@ -16,10 +16,12 @@
  * under the License.
  */
 
+import { FormApi } from "final-form";
 import React, {
     ForwardRefExoticComponent,
     PropsWithChildren,
     ReactElement,
+    ReactNode,
     cloneElement,
     forwardRef,
     useImperativeHandle,
@@ -55,19 +57,19 @@ export interface FormPropsInterface extends FormProps {
  * @param props - Props injected to the component.
  */
 export const Form: ForwardRefExoticComponent<PropsWithChildren<FormPropsInterface>> =
-    forwardRef((props: PropsWithChildren<FormProps>, ref): ReactElement => {
+    forwardRef((props: PropsWithChildren<FormProps>, ref: React.ForwardedRef<unknown>): ReactElement => {
 
         const { id, noValidate, triggerSubmit, ...other } = props;
         const { children, onSubmit, uncontrolledForm, ...rest } = other;
 
-        const formRef = useRef(null);
-        const childNodes = React.Children.toArray(children);
+        const formRef: React.MutableRefObject<any> = useRef(null);
+        const childNodes: ReactNode[] = React.Children.toArray(children);
 
         const skipFinalTypes = (type: string): boolean => {
 
-            const typeToBeSkipped = [ "FieldDropdown" ];
+            const typeToBeSkipped: string[] = [ "FieldDropdown" ];
 
-            return typeToBeSkipped.some((skipType) => {
+            return typeToBeSkipped.some((skipType: string) => {
                 return type === skipType;
             });
         };
@@ -96,7 +98,7 @@ export const Form: ForwardRefExoticComponent<PropsWithChildren<FormPropsInterfac
                  * @see {@link https://final-form.org/docs/react-final-form/faq}
                  */
                 if (formRef) {
-                    const submission = new Event("submit", {
+                    const submission: Event = new Event("submit", {
                         bubbles: true,
                         cancelable: true
                     });
@@ -106,7 +108,7 @@ export const Form: ForwardRefExoticComponent<PropsWithChildren<FormPropsInterfac
             }
         }));
 
-        const addPropsToChild = (childNodes, formRenderProps: FormRenderProps) => {
+        const addPropsToChild = (childNodes: ReactNode[], formRenderProps: FormRenderProps): ReactNode[] => {
 
             return childNodes.map((child: any) => {
 
@@ -116,20 +118,20 @@ export const Form: ForwardRefExoticComponent<PropsWithChildren<FormPropsInterfac
 
                 const { form, handleSubmit, pristine, submitting, values, initialValues } = formRenderProps;
 
-                const parentFormProps = { form, handleSubmit, initialValues, pristine, submitting, values };
-                const childFieldProps = child.props;
+                const parentFormProps: any = { form, handleSubmit, initialValues, pristine, submitting, values };
+                const childFieldProps: any = child.props;
                 const childProps: any = { childFieldProps, parentFormProps };
 
                 // Check whether children of this element is valid
                 // and is type array.
-                const hasChildrenAndIsValid = Array.isArray(child.props?.children) &&
+                const hasChildrenAndIsValid: boolean = Array.isArray(child.props?.children) &&
                 child.props?.children.every(React.isValidElement) &&
                 child.props.children.length > 0;
 
                 // If the react element has only 1 child, the react top level
                 // API parses the children as a single object instead of type
                 // array.
-                const hasOnlyOneChild = (typeof child.props?.children === "object");
+                const hasOnlyOneChild: boolean = (typeof child.props?.children === "object");
 
                 if (uncontrolledForm) {
                     if ((hasChildrenAndIsValid || hasOnlyOneChild) && !skipFinalTypes(child.type.name)) {
@@ -149,9 +151,9 @@ export const Form: ForwardRefExoticComponent<PropsWithChildren<FormPropsInterfac
 
         };
 
-        const renderComponents = (childNodes, formRenderProps: FormRenderProps) => {
+        const renderComponents = (childNodes: ReactNode[], formRenderProps: FormRenderProps) => {
 
-            const modifiedChildNodes = addPropsToChild(childNodes, formRenderProps);
+            const modifiedChildNodes: ReactNode[] = addPropsToChild(childNodes, formRenderProps);
 
             return modifiedChildNodes.map((child: any, index: number) => {
                 if (!child) {
@@ -174,7 +176,7 @@ export const Form: ForwardRefExoticComponent<PropsWithChildren<FormPropsInterfac
 
         return (
             <FinalForm
-                onSubmit={ (values, form) => onSubmit(values, form) }
+                onSubmit={ (values: Record<string, any>, form: FormApi<Record<string, any>>) => onSubmit(values, form) }
                 keepDirtyOnReinitialize={ true }
                 render={ (formRenderProps: FormRenderProps) => {
 

--- a/modules/form/src/components/index.ts
+++ b/modules/form/src/components/index.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/modules/form/src/components/wizard.tsx
+++ b/modules/form/src/components/wizard.tsx
@@ -16,7 +16,8 @@
  * under the License.
  */
 
-import React, { ReactElement, useEffect, useState } from "react";
+import { FormApi } from "final-form";
+import React, { ReactElement, ReactNode, useEffect, useState } from "react";
 import { FormProps } from "react-final-form";
 import { Form } from ".";
 import { WizardPage } from "./wizardPage";
@@ -82,7 +83,7 @@ export const Wizard= (props: WizardFormInterface ): ReactElement => {
         }
     }, []);
 
-    const handlNext = (values): void => {
+    const handlNext = (values: any): void => {
         setPage(Math.min(page + 1,children.length-1));
         setValues(values);
         changePage(Math.min(page + 1,children.length-1));
@@ -93,8 +94,8 @@ export const Wizard= (props: WizardFormInterface ): ReactElement => {
         changePage(Math.max(page - 1,0));
     };
 
-    const handleSubmit = (values,form )=> {
-        const isLastPage = page === React.Children.count(children) - 1;
+    const handleSubmit = (values: any,form: FormApi<Record<string, any>> )=> {
+        const isLastPage: boolean = page === React.Children.count(children) - 1;
 
         if (isLastPage) {
             return onSubmit(values,form);
@@ -107,13 +108,13 @@ export const Wizard= (props: WizardFormInterface ): ReactElement => {
         triggerPrevious(handlPrevious);
     }
 
-    const  validate = values => {
+    const  validate = (values: any) => {
         const activePage:any = React.Children.toArray(children)[page];
 
         return activePage.props.validate ? activePage.props.validate(values) : {};
     };
 
-    const activePage = React.Children.toArray(children)[page];
+    const activePage: ReactNode = React.Children.toArray(children)[page];
 
     return (
         <Form

--- a/modules/form/src/components/wizard2.tsx
+++ b/modules/form/src/components/wizard2.tsx
@@ -16,7 +16,18 @@
  * under the License.
  */
 
-import React, { ReactElement, forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { FormApi } from "final-form";
+import React, {
+    ForwardRefExoticComponent,
+    MutableRefObject,
+    ReactElement,
+    RefAttributes,
+    forwardRef,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    useState
+} from "react";
 import { FormProps } from "react-final-form";
 import { Form } from "./form";
 import { WizardPage } from "./wizardPage";
@@ -42,7 +53,7 @@ interface ImperativeWizardProps extends FormProps {
  * @param ref - Component ref.
  * @returns Functional component.
  */
-const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
+const ImperativeWizard = (props: ImperativeWizardProps, ref: React.ForwardedRef<unknown>): ReactElement => {
 
     const {
         id,
@@ -57,7 +68,7 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
 
     // Form reference to trigger the form submit externally
     // on each page submission.
-    const formRef = useRef(null);
+    const formRef: MutableRefObject<any> = useRef(null);
 
     const absoluteChildCount: number = React.Children.count(children);
     const lastPageIndex: number = absoluteChildCount - 1;
@@ -88,7 +99,7 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
     };
 
     const gotoNextPage = (): void => {
-        const nextIndex = Math.min(currentPageIndex + 1, lastPageIndex);
+        const nextIndex: number = Math.min(currentPageIndex + 1, lastPageIndex);
 
         setCurrentPageIndex(nextIndex);
         if (formRef) {
@@ -102,7 +113,7 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
 
     const getCurrentPageNumber = () => currentPageIndex;
 
-    const handleSubmit = (values, form) => {
+    const handleSubmit = (values: any, form: FormApi<Record<string, any>>) => {
         if (currentPageIndex === lastPageIndex) {
             return onSubmit(values, form);
         } else {
@@ -138,4 +149,8 @@ const ImperativeWizard = (props: ImperativeWizardProps, ref): ReactElement => {
 
 ImperativeWizard.Page = WizardPage;
 
-export const Wizard2 = forwardRef(ImperativeWizard);
+export const Wizard2: ForwardRefExoticComponent<Pick<
+    ImperativeWizardProps,
+    keyof ImperativeWizardProps
+> &
+    RefAttributes<unknown>> = forwardRef(ImperativeWizard);

--- a/modules/form/src/components/wizardPage.tsx
+++ b/modules/form/src/components/wizardPage.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,13 +16,13 @@
  * under the License.
  */
 
-import React, { ReactElement } from "react";
+import React, { PropsWithChildren, ReactElement } from "react";
 
 /**
  * Implementation of the WizardPage component.
- * @param props
+ * @param props - Props injected to the component.
  */
-export const WizardPage = (props): ReactElement => {
+export const WizardPage = (props: PropsWithChildren): ReactElement => {
 
     const { children } = props;
 

--- a/modules/form/src/components/wizardPage.tsx
+++ b/modules/form/src/components/wizardPage.tsx
@@ -22,7 +22,7 @@ import React, { PropsWithChildren, ReactElement } from "react";
  * Implementation of the WizardPage component.
  * @param props - Props injected to the component.
  */
-export const WizardPage = (props: PropsWithChildren): ReactElement => {
+export const WizardPage = (props: PropsWithChildren<Record<string, any>>): ReactElement => {
 
     const { children } = props;
 

--- a/modules/forms/src/components/field.tsx
+++ b/modules/forms/src/components/field.tsx
@@ -18,6 +18,7 @@
 
 import classNames from "classnames";
 import React, { ReactElement } from "react";
+// eslint-disable-next-line no-restricted-imports
 import { Button, Divider, Form, Icon, Popup, Radio } from "semantic-ui-react";
 import { Password } from "./password";
 import { QueryParameters } from "./query-parameters";
@@ -63,7 +64,7 @@ interface InnerFieldPropsInterface {
 
 /**
  * This produces a InnerField component.
- * 
+ *
  * @param props - The props for the InnerField component.
  */
 export const InnerField = React.forwardRef((props: InnerFieldPropsInterface, ref: React.Ref<any>): JSX.Element => {
@@ -86,7 +87,7 @@ export const InnerField = React.forwardRef((props: InnerFieldPropsInterface, ref
 
     /**
      * Generates a semantic Form element.
-     * 
+     *
      * @param inputField - The input field to be generated to a semantic Form element.
      */
     const formFieldGenerator = (inputField: FormField): JSX.Element => {
@@ -272,6 +273,7 @@ export const InnerField = React.forwardRef((props: InnerFieldPropsInterface, ref
                                     header={ hint.header }
                                     content={ hint.content }
                                     trigger={ field }
+                                    popper={ <div style={ { filter: "none" } }></div> }
                                 />
                             );
                         } else {
@@ -377,6 +379,7 @@ export const InnerField = React.forwardRef((props: InnerFieldPropsInterface, ref
                                     header={ checkbox.hint.header }
                                     content={ checkbox.hint.content }
                                     trigger={ field }
+                                    popper={ <div style={ { filter: "none" } }></div> }
                                 />
                             );
                         } else {

--- a/modules/forms/src/components/password.tsx
+++ b/modules/forms/src/components/password.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useState } from "react";
+// eslint-disable-next-line no-restricted-imports
 import { Form, Icon, Popup, SemanticWIDTHS } from "semantic-ui-react";
 import { filterPassedProps } from "../utils";
 

--- a/modules/forms/src/components/query-parameters.tsx
+++ b/modules/forms/src/components/query-parameters.tsx
@@ -20,6 +20,7 @@ import filter from "lodash-es/filter";
 import isEmpty from "lodash-es/isEmpty";
 import isEqual from "lodash-es/isEqual";
 import React, { FunctionComponent, useEffect, useState } from "react";
+// eslint-disable-next-line no-restricted-imports
 import { Button, Form, Icon, Label, Message, Popup } from "semantic-ui-react";
 
 interface QueryParametersPropsInterface {
@@ -121,7 +122,7 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
 
     /**
      * Enter button option.
-     * 
+     *
      * @param e - The keypress event.
      */
     const keyPressed = (e) => {
@@ -228,6 +229,7 @@ export const QueryParameters: FunctionComponent<QueryParametersPropsInterface> =
                     position="top center"
                     content="Add key value pair"
                     inverted
+                    popper={ <div style={ { filter: "none" } }></div> }
                 />
             </Form.Group>
 

--- a/modules/forms/src/components/scopes.tsx
+++ b/modules/forms/src/components/scopes.tsx
@@ -20,8 +20,9 @@ import filter from "lodash-es/filter";
 import isEmpty from "lodash-es/isEmpty";
 import isEqual from "lodash-es/isEqual";
 import React, { FunctionComponent, useEffect, useState } from "react";
+// eslint-disable-next-line no-restricted-imports
 import { Button, Form, Icon, Label, Message, Popup } from "semantic-ui-react";
- 
+
  interface ScopesPropsInterface {
     /**
       * Initial value of the scopes field.
@@ -45,7 +46,7 @@ import { Button, Form, Icon, Label, Message, Popup } from "semantic-ui-react";
     */
      onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
  }
- 
+
  interface ScopeInterface {
     /**
       * Value of the scopes field.
@@ -62,7 +63,7 @@ import { Button, Form, Icon, Label, Message, Popup } from "semantic-ui-react";
  */
 export const Scopes: FunctionComponent<ScopesPropsInterface> = (
     props: ScopesPropsInterface) => {
- 
+
     const {
         value,
         defaultValue,
@@ -70,9 +71,9 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
         onBlur,
         onChange
     } = props;
- 
+
     const SCOPE_SEPARATOR: string = " ";
- 
+
     const [ scopeValue, setScopeValue ] = useState<string>("");
     const [ scopes, setScopes ] = useState<ScopeInterface[]>([]);
 
@@ -82,19 +83,19 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
     useEffect(() => {
         if (isEmpty(value)) {
             return;
-        } 
-     
+        }
+
         setScopes(value.split(SCOPE_SEPARATOR)?.map(buildScope));
     }, [ value ]);
-     
+
     /**
       * Called when `scopes` is changed.
       */
     useEffect(() => {
-             
+
         fireOnChangeEvent(scopes, onChange);
     }, [ scopes ]);
- 
+
     /**
       * Build scope object from the given string form.
       *
@@ -106,27 +107,27 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
             value: scope
         };
     };
- 
+
     /**
       * Build scope string value, from it's object form.
       */
     const buildScopeString = (scope: ScopeInterface) => scope.value;
- 
+
     /**
       * Build scopes string value, from scopes object list.
       */
     const buildScopesString = (scopes: ScopeInterface[]): string =>
         scopes?.map(buildScopeString)?.join(SCOPE_SEPARATOR);
- 
+
     /**
       * Trigger provided onChange handler with provided scopes.
-      * 
+      *
       * @param scopes - Scopes.
-      * @param onChange - onChange handler. 
+      * @param onChange - onChange handler.
       */
-    const fireOnChangeEvent = (scopes: ScopeInterface[], onChange: (event: React.ChangeEvent<HTMLInputElement>) 
+    const fireOnChangeEvent = (scopes: ScopeInterface[], onChange: (event: React.ChangeEvent<HTMLInputElement>)
          => void) => {
- 
+
         onChange(
              {
                  target: {
@@ -135,70 +136,70 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
              } as React.ChangeEvent<HTMLInputElement>
         );
     };
- 
+
     /**
       * Update input field values for scope.
-      * 
+      *
       * @param scope - Scope.
       */
     const updateScopeInputFields = (scope: ScopeInterface) => {
         setScopeValue(scope?.value);
     };
- 
+
     /**
       * Enter button option.
       * @param e - keypress event.
       */
     const keyPressed = (e: React.KeyboardEvent<HTMLInputElement>): void => {
- 
+
         if (e.key === "Enter" ) {
             handleScopeAdd(e);
         }
     };
- 
+
     const handleScopeAdd = (event) => {
         event.preventDefault();
         if (isEmpty(scopeValue)) {
             return;
         }
-             
+
         const output: ScopeInterface[] = [ {
             value: scopeValue
         } ];
- 
+
         scopes.forEach(function(scope) {
             const existing = output.filter((item) => {
                 return item.value == scope.value;
             });
- 
+
             if (existing.length) {
                 return;
             } else {
                 output.push(scope);
             }
         });
- 
+
         setScopes(output);
- 
+
         updateScopeInputFields({
             value: ""
         });
     };
- 
+
     const handleLabelRemove = (scopeParam: string) => {
-         
+
         if (isEmpty(scopeParam)) {
             return;
         }
-         
+
         setScopes(filter(scopes, scope => !isEqual(scope,
             buildScope(scopeParam))));
     };
- 
+
     return (
         <>
             <Form.Group inline widths="equal" unstackable={ true }>
- 
+
                 <Form.Input
                     fluid
                     value={ scopeValue }
@@ -209,7 +210,7 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
                     } }
                     onKeyDown={ keyPressed }
                 />
- 
+
                 <Popup
                     trigger={
                         (
@@ -225,6 +226,7 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
                     /** TODO : Add this value from a translation */
                     content="Add scope"
                     inverted
+                    popper={ <div style={ { filter: "none" } }></div> }
                 />
             </Form.Group>
 
@@ -238,7 +240,7 @@ export const Scopes: FunctionComponent<ScopesPropsInterface> = (
                             <Label
                                 key={ index }
                             >
-                                { scope } 
+                                { scope }
                             </Label>
                         );
                     } else {

--- a/modules/react-components/src/components/accordion/segmented-accordion/segmented-accordion-title.tsx
+++ b/modules/react-components/src/components/accordion/segmented-accordion/segmented-accordion-title.tsx
@@ -26,11 +26,11 @@ import {
     CheckboxProps,
     Grid,
     Icon,
-    Popup,
     Segment,
     SemanticICONS
 } from "semantic-ui-react";
 import { GenericIcon, GenericIconProps } from "../../icon";
+import { Popup } from "../../popup";
 import { EmphasizedSegment } from "../../section";
 
 /**

--- a/modules/react-components/src/components/avatar/user-avatar.tsx
+++ b/modules/react-components/src/components/avatar/user-avatar.tsx
@@ -26,10 +26,10 @@ import {
 } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { Popup } from "semantic-ui-react";
 import { Avatar, AvatarPropsInterface } from "./avatar";
 import GravatarLogo from "../../assets/images/gravatar-logo.png";
 import DummyUser from "../../assets/images/user.png";
+import { Popup } from "../popup";
 
 /**
  * Prop types for the user avatar component.
@@ -114,7 +114,7 @@ export const UserAvatar: FunctionComponent<UserAvatarPropsInterface> = (
     /**
      * Resolves the top label image.
      *
-     * @returns the resolved image 
+     * @returns the resolved image
      */
     const resolveTopLabel = (): string => {
         if (isGravatarURL()) {

--- a/modules/react-components/src/components/card/info-card.tsx
+++ b/modules/react-components/src/components/card/info-card.tsx
@@ -19,9 +19,10 @@
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { FunctionComponent, MouseEvent, PropsWithChildren, ReactElement, ReactNode } from "react";
-import { Card, CardProps, Icon, Label, Popup } from "semantic-ui-react";
+import { Card, CardProps, Icon, Label } from "semantic-ui-react";
 import { LinkButton } from "../button";
 import { GenericIcon, GenericIconProps, GenericIconSizes } from "../icon";
+import { Popup } from "../popup";
 import { Tooltip } from "../typography";
 
 /**

--- a/modules/react-components/src/components/card/labeled-card.tsx
+++ b/modules/react-components/src/components/card/labeled-card.tsx
@@ -19,8 +19,9 @@
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { FunctionComponent, ReactElement } from "react";
-import { Card, CardProps, Label, LabelProps, Popup, SemanticSIZES } from "semantic-ui-react";
+import { Card, CardProps, Label, LabelProps, SemanticSIZES } from "semantic-ui-react";
 import { GenericIcon, GenericIconProps, GenericIconSizes } from "../icon";
+import { Popup } from "../popup";
 
 /**
  * Proptypes for the labeled card component.

--- a/modules/react-components/src/components/card/template-card.tsx
+++ b/modules/react-components/src/components/card/template-card.tsx
@@ -19,8 +19,9 @@
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { CSSProperties, FunctionComponent, MouseEvent, ReactElement, ReactNode, useState } from "react";
-import { Card, CardProps, Icon, Label, Popup } from "semantic-ui-react";
+import { Card, CardProps, Icon, Label } from "semantic-ui-react";
 import { GenericIcon, GenericIconProps, GenericIconSizes } from "../icon";
+import { Popup } from "../popup";
 
 /**
  * Proptypes for the template card component.
@@ -189,7 +190,7 @@ export const TemplateCard: FunctionComponent<TemplateCardPropsInterface> = (
      * @param tag - Tag to be rendered.
      * @param as - Render type.
      * @param index - Tag index in array.
-     * @returns the tag component for the corresponding render type 
+     * @returns the tag component for the corresponding render type
      */
     const renderTag = (tag: TemplateCardTagInterface | string, as: "icon" | "label" | "default",
         index: number): ReactElement => {

--- a/modules/react-components/src/components/danger-zone/danger-zone.tsx
+++ b/modules/react-components/src/components/danger-zone/danger-zone.tsx
@@ -18,8 +18,9 @@
 
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import React, { FunctionComponent, ReactElement, SyntheticEvent } from "react";
-import { Button, Checkbox, CheckboxProps, Header, Popup, Segment } from "semantic-ui-react";
+import { Button, Checkbox, CheckboxProps, Header, Segment } from "semantic-ui-react";
 import { useMediaContext } from "../media";
+import { Popup } from "../popup";
 
 /**
  * Danger zone component Prop types.

--- a/modules/react-components/src/components/index.ts
+++ b/modules/react-components/src/components/index.ts
@@ -50,6 +50,7 @@ export * from "./page-header";
 export * from "./pagination";
 export * from "./pickers";
 export * from "./placeholder";
+export * from "./popup";
 export * from "./renderer";
 export * from "./route";
 export * from "./section";

--- a/modules/react-components/src/components/input/advanced-search.tsx
+++ b/modules/react-components/src/components/input/advanced-search.tsx
@@ -29,9 +29,10 @@ import React, {
     useRef,
     useState
 } from "react";
-import { Button, Divider, Icon, Input, InputProps, Popup, PopupProps } from "semantic-ui-react";
+import { Button, Divider, Icon, Input, InputProps, PopupProps } from "semantic-ui-react";
 import { ReactComponent as CrossIcon } from "../../assets/images/cross-icon.svg";
 import { GenericIcon } from "../icon";
+import { Popup } from "../popup";
 import { Heading } from "../typography";
 
 /**

--- a/modules/react-components/src/components/input/copy-input-field.tsx
+++ b/modules/react-components/src/components/input/copy-input-field.tsx
@@ -20,7 +20,8 @@ import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso
 import { CommonUtils } from "@wso2is/core/utils";
 import classNames from "classnames";
 import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useRef, useState } from "react";
-import { Button, Icon, Input, Popup } from "semantic-ui-react";
+import { Button, Icon, Input } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 /**
  * Copy to clipboard input field props.

--- a/modules/react-components/src/components/input/dynamic-field.tsx
+++ b/modules/react-components/src/components/input/dynamic-field.tsx
@@ -19,7 +19,8 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms, useTrigger } from "@wso2is/forms";
 import React, { FunctionComponent, ReactElement, useEffect, useRef, useState } from "react";
-import { Button, Divider, Label, List, Message, Popup } from "semantic-ui-react";
+import { Button, Divider, Label, List, Message } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 /**
  * Type of key-value object
@@ -528,7 +529,7 @@ export const DynamicField: FunctionComponent<DynamicFieldPropsInterface> = (
                                                                 icon="trash"
                                                                 onClick={ () => {
                                                                     setEditIndex(null);
-                                                                    const tempFields: Map<number, KeyValue> 
+                                                                    const tempFields: Map<number, KeyValue>
                                                                         = new Map(fields);
 
                                                                     tempFields.delete(mapIndex);

--- a/modules/react-components/src/components/input/inline-edit-field.tsx
+++ b/modules/react-components/src/components/input/inline-edit-field.tsx
@@ -18,7 +18,8 @@
 
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { Grid, GridColumn, Icon, Input, InputOnChangeData, Popup } from "semantic-ui-react";
+import { Grid, GridColumn, Icon, Input, InputOnChangeData } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 export interface InlineEditInputPropsInterface extends IdentifiableComponentInterface, TestableComponentInterface {
     text: string;
@@ -34,7 +35,7 @@ export interface InlineEditInputPropsInterface extends IdentifiableComponentInte
 
 /**
  * Inline edit input field component.
- * 
+ *
  * @param props - props required for the inline edit component.
  * @returns inline edit input component
  */
@@ -74,14 +75,14 @@ export const InlineEditInput: FunctionComponent<InlineEditInputPropsInterface> =
             setRegExValidation(regEx);
         }
     }, [ validation ]);
-    
+
     return (
         editMode
             ? (
                 <Grid verticalAlign="middle">
                     <Grid.Row columns={ 2 }>
                         <GridColumn width={ 12 }>
-                            <Input 
+                            <Input
                                 fluid
                                 size="mini"
                                 placeholder={ inputPlaceholderText }
@@ -89,7 +90,7 @@ export const InlineEditInput: FunctionComponent<InlineEditInputPropsInterface> =
                                 error={ fieldError }
                                 maxLength={ maxLength }
                                 onChange={ (
-                                    event: React.ChangeEvent<HTMLInputElement>, 
+                                    event: React.ChangeEvent<HTMLInputElement>,
                                     data: InputOnChangeData ) => {
                                     setTextValue(data.value.trim());
                                 } }
@@ -116,7 +117,7 @@ export const InlineEditInput: FunctionComponent<InlineEditInputPropsInterface> =
 
                                                 return;
                                             }
-                                        
+
                                             onEdit(false);
                                             setEditMode(false);
                                             onChangesSaved(textValue);

--- a/modules/react-components/src/components/input/password.tsx
+++ b/modules/react-components/src/components/input/password.tsx
@@ -18,7 +18,8 @@
 
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import React, { useState } from "react";
-import { Form, Icon, Popup, SemanticWIDTHS } from "semantic-ui-react";
+import { Form, Icon, SemanticWIDTHS } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 /**
  * Password prop types

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -20,9 +20,10 @@ import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso
 import { URLUtils } from "@wso2is/core/utils";
 import React, { FunctionComponent, ReactElement, ReactNode, useCallback, useEffect, useState } from "react";
 import { Trans } from "react-i18next";
-import { Button, Grid, Icon, Input, Label, Popup } from "semantic-ui-react";
+import { Button, Grid, Icon, Input, Label } from "semantic-ui-react";
 import { LinkButton } from "../button";
 import { LabelWithPopup } from "../label";
+import { Popup } from "../popup";
 import { Hint } from "../typography";
 
 export interface URLInputPropsInterface extends IdentifiableComponentInterface, TestableComponentInterface {
@@ -245,7 +246,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
 
         /*
          * If the entered URL is valid and it is intended to be an origin URL,
-         * and it has a trailing "/" at the end, it is sliced to get the valid origin. 
+         * and it has a trailing "/" at the end, it is sliced to get the valid origin.
         */
         if (urlValid && onlyOrigin && url.charAt(url.length - 1) === "/") {
             url = url.slice(0, -1);
@@ -526,10 +527,10 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                                 { !restrictSecondaryContent && (
                                     <>
                                         <a onClick={ () => setShowMore(!showMore) }>
-                                            &nbsp;{ showMore 
+                                            &nbsp;{ showMore
                                                 ? (showLessContent
                                                     ? showLessContent
-                                                    : "Show less") 
+                                                    : "Show less")
                                                 : (showMoreContent
                                                     ? showMoreContent
                                                     : "Show more") }
@@ -598,7 +599,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
 
         if (!validURL) {
             return (
-                <Label 
+                <Label
                     data-componentid={ `${ componentId }-valid-url-error-message` }
                     basic
                     className="prompt"
@@ -690,7 +691,7 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
                         trigger={
                             <span style={ { color: "red", textDecoration: "line-through" } }>{ protocol }</span>
                         }
-                        content={ 
+                        content={
                             insecureURLDescription
                                 ? insecureURLDescription
                                 : "The entered URL is a non-TLS URL. Please proceed with caution." }

--- a/modules/react-components/src/components/label/label-with-popup.tsx
+++ b/modules/react-components/src/components/label/label-with-popup.tsx
@@ -19,7 +19,8 @@
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { FunctionComponent, ReactElement, ReactNode } from "react";
-import { Divider, Grid, Label, LabelProps, Popup, PopupProps } from "semantic-ui-react";
+import { Divider, Grid, Label, LabelProps, PopupProps } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 export interface LabelWithPopupPropsInterface extends IdentifiableComponentInterface, LabelProps {
     /**

--- a/modules/react-components/src/components/list/resource-list/resource-list-item.tsx
+++ b/modules/react-components/src/components/list/resource-list/resource-list-item.tsx
@@ -26,12 +26,12 @@ import {
     Icon,
     List,
     ListItemProps,
-    Popup,
     SemanticFLOATS,
     SemanticICONS,
     SemanticWIDTHS,
     StrictGridRowProps
 } from "semantic-ui-react";
+import { Popup } from "../../popup";
 
 /**
  * Proptypes for the resource list item component.

--- a/modules/react-components/src/components/popup/index.tsx
+++ b/modules/react-components/src/components/popup/index.tsx
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./popup";

--- a/modules/react-components/src/components/popup/popup.tsx
+++ b/modules/react-components/src/components/popup/popup.tsx
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { ReactElement } from "react";
+// eslint-disable-next-line no-restricted-imports
+import { PopupProps, Popup as SemanticPopup } from "semantic-ui-react";
+
+/**
+ * A wrapper for the semantic Popup component.
+ *
+ * @param props - Popup Props
+ *
+ * @returns
+ */
+export const Popup = (props: PopupProps): ReactElement => {
+    return (
+        <SemanticPopup
+            popper={ <div style={ { filter: "none" } }></div> }
+            { ...props }
+        />
+    );
+};
+
+Popup.Content = SemanticPopup.Content;
+Popup.Header = SemanticPopup.Header;

--- a/modules/react-components/src/components/renderer/certificate.tsx
+++ b/modules/react-components/src/components/renderer/certificate.tsx
@@ -24,7 +24,8 @@ import {
 } from "@wso2is/core/models";
 import moment from "moment";
 import React, { Fragment, FunctionComponent, ReactElement } from "react";
-import { Divider, Grid, Icon, Popup, Segment, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
+import { Divider, Grid, Icon, Segment, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 /**
  * Prop types of the `Certificate` component.

--- a/modules/react-components/src/components/switcher/switcher.tsx
+++ b/modules/react-components/src/components/switcher/switcher.tsx
@@ -18,7 +18,8 @@
 
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, { FC, PropsWithChildren, ReactElement, useEffect, useState } from "react";
-import { Button, ButtonGroupProps, ButtonProps, Popup } from "semantic-ui-react";
+import { Button, ButtonGroupProps, ButtonProps } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 // These interface names are confusing?!
 // FIXME: {@link StrictSwitcher} properties makes no sense since there's optional!

--- a/modules/react-components/src/components/table/data-table/data-table-column-selector.tsx
+++ b/modules/react-components/src/components/table/data-table/data-table-column-selector.tsx
@@ -19,10 +19,11 @@
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import cloneDeep from "lodash-es/cloneDeep";
 import React, { FormEvent, FunctionComponent, ReactElement } from "react";
-import { Checkbox, Form, Popup } from "semantic-ui-react";
+import { Checkbox, Form } from "semantic-ui-react";
 import { TableColumnInterface } from "./data-table";
 import { ReactComponent as ColumnIcon } from "../../../assets/images/column-icon.svg";
 import { GenericIcon, GenericIconProps } from "../../icon";
+import { Popup } from "../../popup";
 import { Heading } from "../../typography";
 
 export interface DataTableColumnSelectorInterface extends IdentifiableComponentInterface,
@@ -85,7 +86,7 @@ export const DataTableColumnSelector: FunctionComponent<DataTableColumnSelectorI
      * Checks if the column selector should be rendered or not.
      *
      * @param columns - Table columns.
-     * @returns whether the column selector should be rendered 
+     * @returns whether the column selector should be rendered
      */
     const isColumnSelectorValid = (columns: TableColumnInterface[]): boolean => {
         return columns.some((column: TableColumnInterface) => column.allowToggleVisibility)
@@ -100,12 +101,12 @@ export const DataTableColumnSelector: FunctionComponent<DataTableColumnSelectorI
      */
     const handleColumnVisibilityChange = (e: FormEvent<HTMLInputElement>, { uniqueId }: { uniqueId: string }): void => {
         const clone: TableColumnInterface[] = cloneDeep(columns);
-        
+
         clone.forEach((column: TableColumnInterface) => {
             if (column.id !== uniqueId) {
                 return;
             }
-            
+
             column.hidden = !column.hidden;
         });
 

--- a/modules/react-components/src/components/table/data-table/data-table.tsx
+++ b/modules/react-components/src/components/table/data-table/data-table.tsx
@@ -16,10 +16,10 @@
  * under the License.
  */
 
-import { 
+import {
     IdentifiableComponentInterface,
     LoadingStateOptionsInterface,
-    TestableComponentInterface 
+    TestableComponentInterface
 } from "@wso2is/core/models";
 import classNames from "classnames";
 import get from "lodash-es/get";
@@ -32,7 +32,6 @@ import {
     Header,
     Icon,
     Placeholder,
-    Popup,
     SemanticICONS,
     SemanticWIDTHS,
     Table,
@@ -50,6 +49,7 @@ import { DataTableRow } from "./data-table-row";
 import { Avatar } from "../../avatar";
 import { GenericIconProps } from "../../icon";
 import { Media } from "../../media";
+import { Popup } from "../../popup";
 
 /**
  * Interface for the Data Table sub components.

--- a/modules/react-components/src/components/transfer/transfer-list-item.tsx
+++ b/modules/react-components/src/components/transfer/transfer-list-item.tsx
@@ -18,7 +18,8 @@
 
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import React, { FunctionComponent, ReactElement, ReactNode } from "react";
-import { Checkbox, Icon, Label, LabelProps, Popup, SemanticCOLORS, Table, TableRowProps } from "semantic-ui-react";
+import { Checkbox, Icon, Label, LabelProps, SemanticCOLORS, Table, TableRowProps } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 /**
  * Proptypes for the transfer list item label.

--- a/modules/react-components/src/components/typography/hint.tsx
+++ b/modules/react-components/src/components/typography/hint.tsx
@@ -20,7 +20,8 @@ import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso
 import classNames from "classnames";
 import isObject from "lodash-es/isObject";
 import React, { PropsWithChildren, ReactElement } from "react";
-import { Icon, Popup, PopupProps, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
+import { Icon, PopupProps, SemanticCOLORS, SemanticICONS } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 /**
  * Heading component prop types.
@@ -117,7 +118,7 @@ export const Hint: React.FunctionComponent<PropsWithChildren<HintPropsInterface>
      * @returns Popup props.
      */
     const resolvePopupOptions = (): PopupProps => {
-        
+
         // If `popupOptions` are externally propvided, merge it with the default.
         if (popupOptions && isObject(popupOptions)) {
             return {

--- a/modules/react-components/src/components/typography/tooltip.tsx
+++ b/modules/react-components/src/components/typography/tooltip.tsx
@@ -19,7 +19,8 @@
 import { IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { PropsWithChildren, ReactElement } from "react";
-import { Popup, PopupProps } from "semantic-ui-react";
+import { PopupProps } from "semantic-ui-react";
+import { Popup } from "../popup";
 
 /**
  * Tooltip component prop types.


### PR DESCRIPTION
### Purpose
> This PR
- introduces a new component in the `react-components` module that wraps Semantic's `Popup` component and uses `<div style={{ filter: "none" }}>/<div>` as the `popper`.
- introduces an es-lint rule that makes it illegal to import `Popup` from Semantic.
- migrates existing Semantic `Popup` usages to the new component

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
