### PR TITLE
Use `lock` file in PR builder CI

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: 🧩 Install Dependencies
         id: install-dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: 🦄 Lint Changed Files
         id: lint-changed-with-eslint
@@ -123,7 +123,7 @@ jobs:
 
       - name: 🧩 Install Dependencies
         id: install-dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: 👷 Build Re-usable Modules
         id: build-reusable-modules
@@ -172,7 +172,7 @@ jobs:
 
       - name: 🧩 Install Dependencies
         id: install-dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: 👷 Build Re-usable Modules
         id: build-reusable-modules
@@ -243,7 +243,7 @@ jobs:
 
       - name: 🧩 Install Dependencies
         id: install-dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: 🏗️ Maven Build
         id: build-with-maven

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,6 +857,7 @@ importers:
       '@types/testing-library__jest-dom': ^5.14.3
       '@typescript-eslint/eslint-plugin': ^4.17.0
       '@typescript-eslint/parser': ^4.17.0
+      '@wso2is/core': ^1.6.141
       babel-polyfill: ^6.26.0
       classnames: ^2.2.6
       eslint: ^7.20.0
@@ -872,6 +873,7 @@ importers:
       ts-node: ^10.8.1
       typescript: ^4.6.4
     dependencies:
+      '@wso2is/core': link:../core
       classnames: 2.3.1
       lodash-es: 4.17.21
       semantic-ui-react: 2.1.3
@@ -11064,7 +11066,7 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -11072,7 +11074,7 @@ packages:
   /axios/0.26.1:
     resolution: {integrity: sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==}
     dependencies:
-      follow-redirects: 1.15.1
+      follow-redirects: 1.15.1_debug@4.3.4
     transitivePeerDependencies:
       - debug
     dev: false
@@ -15698,6 +15700,7 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: true
 
   /follow-redirects/1.15.1_debug@4.3.4:
     resolution: {integrity: sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==}


### PR DESCRIPTION
### Purpose

PR builder CI has `--no-frozen-lockfile` flag in `pnpm installs` which ignores failures if the `pnpm-lock` is out of sync. But Jenkins considers this which causes unexpected failures.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
