### PR TITLE
Enabling SMS Authenticator in console app.

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-landing.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-landing.tsx
@@ -69,7 +69,7 @@ export const SignInMethodLanding: FunctionComponent<SignInMethodLandingPropsInte
 
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
-    const eventPublisher = EventPublisher.getInstance();
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     return (
         <Segment basic loading={ isLoading } data-testid={ testId } className="sign-in-method-landing">
@@ -166,6 +166,28 @@ export const SignInMethodLanding: FunctionComponent<SignInMethodLandingPropsInte
                                             "client-id": clientId
                                         });
                                         onLoginFlowSelect(LoginFlowTypes.SECOND_FACTOR_EMAIL_OTP);
+                                    } }
+                                />
+                            ) }
+                            { !hiddenOptions.includes(LoginFlowTypes.SECOND_FACTOR_SMS_OTP) && (
+                                <InfoCard
+                                    fluid
+                                    data-testid="sms-otp-mfa-flow-card"
+                                    image={ getAuthenticatorIcons().smsOTP }
+                                    imageSize="mini"
+                                    header={ t(
+                                        "console:develop.features.applications.edit.sections" +
+                                        ".signOnMethod.sections.landing.flowBuilder.types.smsOTP.heading"
+                                    ) }
+                                    description={ t(
+                                        "console:develop.features.applications.edit.sections" +
+                                        ".signOnMethod.sections.landing.flowBuilder.types.smsOTP.description"
+                                    ) }
+                                    onClick={ () => {
+                                        eventPublisher.publish("application-begin-sign-in-sms-otp-mfa", {
+                                            "client-id": clientId
+                                        } );
+                                        onLoginFlowSelect(LoginFlowTypes.SECOND_FACTOR_SMS_OTP);
                                     } }
                                 />
                             ) }

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -279,9 +279,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
     return (
         <Fragment data-testid={ testId }>
             { heading && <Heading as="h6">{ heading }</Heading> }
-            { authenticators.filter((authenticator: GenericAuthenticatorInterface) => {
-                return !authenticator?.name.includes(IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR);
-            }).map((authenticator: GenericAuthenticatorInterface, index: number) => (
+            { authenticators.map((authenticator: GenericAuthenticatorInterface, index: number) => (
                 <Popup
                     hoverable
                     hideOnScroll

--- a/apps/console/src/features/identity-providers/pages/identity-providers.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-providers.tsx
@@ -159,11 +159,6 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (props: IDPP
                         return;
                     }
 
-                    // TODO: Remove this filter to display SMS OTP once the backend changes are complete.
-                    if(authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID){
-                        return;
-                    }
-
                     if (authenticator.id === IdentityProviderManagementConstants.FIDO_AUTHENTICATOR_ID) {
                         authenticator.tags = [ ...identityProviderConfig.filterFidoTags(authenticator?.tags) ];
                     }
@@ -247,11 +242,6 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (props: IDPP
                     response.filter((authenticator: AuthenticatorInterface) => {
                         // Removes hidden authenticators.
                         if (config?.ui?.hiddenAuthenticators?.includes(authenticator.name)) {
-                            return;
-                        }
-
-                        // TODO: Remove this filter to display SMS OTP once the backend changes are complete.
-                        if(authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID){
                             return;
                         }
 


### PR DESCRIPTION
### Purpose
> Enabling SMS OTP Authenticator in the console app.
reverting: https://github.com/wso2/identity-apps/pull/3378/commits/203d41c4f8d7db7f84411344553c45e1bf0f5e0b and https://github.com/wso2/identity-apps/pull/3604