### PR TITLE
Change SMS OTP UI to enable/disable SMS OTP feature.

### DIFF
--- a/apps/console/src/features/core/store/reducers/config.ts
+++ b/apps/console/src/features/core/store/reducers/config.ts
@@ -108,6 +108,7 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
             me: "",
             multiFactorAuthenticators: "",
             myAccountConfigMgt: "",
+            notificationSenders:"",
             oidcScopes: "",
             organizations: "",
             passwordHistory: "",

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -1294,7 +1294,6 @@ export const getIDPConnectedApps = (idpId: string): Promise<any> => {
  */
 export const getSMSNotificationSenders = (): Promise<any> => {
 
-    console.log(store.getState())
     const requestConfig = {
         headers: {
             "Accept": "application/json",

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -1301,8 +1301,7 @@ export const getSMSNotificationSenders = (): Promise<any> => {
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        //TODO - get URL from configs
-        url: "https://api.asg.io/t/laki/api/server/v1/notification-senders/sms"
+        url: store.getState().config.endpoints.notificationSenders + "/sms"
     };
 
     return httpClient(requestConfig)
@@ -1347,8 +1346,7 @@ export const addSMSPublisher = (): Promise<any> => {
         },
         data: smsProvider,
         method: HttpMethods.POST,
-        //TODO - get URL from configs
-        url: "https://api.asg.io/t/laki/api/server/v1/notification-senders/sms"
+        url: store.getState().config.endpoints.notificationSenders + "/sms"
     };
 
     return httpClient(requestConfig)
@@ -1378,8 +1376,7 @@ export const deleteSMSPublisher = (): Promise<any> => {
             "Content-Type": "application/json"
         },
         method: HttpMethods.DELETE,
-        //TODO - get URL from configs
-        url: "https://api.asg.io/t/laki/api/server/v1/notification-senders/sms/SMSPublisher"
+        url: store.getState().config.endpoints.notificationSenders + "/sms/SMSPublisher"
     };
 
     return httpClient(requestConfig)

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -337,7 +337,7 @@ export const updateFederatedAuthenticator = (
 
     const { authenticatorId, ...rest } = authenticator;
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: rest,
         headers: {
             "Accept": "application/json",
@@ -350,13 +350,13 @@ export const updateFederatedAuthenticator = (
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update identity provider: " + idpId));
             }
 
             return Promise.resolve(response.data as IdentityProviderInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -370,7 +370,7 @@ export const updateFederatedAuthenticator = (
  */
 export const getFederatedAuthenticatorDetails = (idpId: string, authenticatorId: string): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -382,7 +382,7 @@ export const getFederatedAuthenticatorDetails = (idpId: string, authenticatorId:
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(
                     new Error("Failed to get federated authenticator details for: " + authenticatorId)
@@ -390,7 +390,7 @@ export const getFederatedAuthenticatorDetails = (idpId: string, authenticatorId:
             }
 
             return Promise.resolve(response.data as FederatedAuthenticatorListItemInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -403,7 +403,7 @@ export const getFederatedAuthenticatorDetails = (idpId: string, authenticatorId:
  */
 export const getFederatedAuthenticatorMeta = (id: string): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -414,13 +414,13 @@ export const getFederatedAuthenticatorMeta = (id: string): Promise<any> => {
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to get federated authenticator meta details for: " + id));
             }
 
             return Promise.resolve(response.data as FederatedAuthenticatorMetaInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -432,7 +432,7 @@ export const getFederatedAuthenticatorMeta = (id: string): Promise<any> => {
  */
 export const getFederatedAuthenticatorsList = (): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -443,13 +443,13 @@ export const getFederatedAuthenticatorsList = (): Promise<any> => {
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to get federated authenticators list"));
             }
 
             return Promise.resolve(response.data as FederatedAuthenticatorMetaInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -463,7 +463,7 @@ export const getFederatedAuthenticatorsList = (): Promise<any> => {
  */
 export const getFederatedAuthenticatorMetadata = (authenticatorId: string): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -475,14 +475,14 @@ export const getFederatedAuthenticatorMetadata = (authenticatorId: string): Prom
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to get federated authenticator metadata for: "
                     + authenticatorId));
             }
 
             return Promise.resolve(response.data as FederatedAuthenticatorMetaInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -495,7 +495,7 @@ export const getFederatedAuthenticatorMetadata = (authenticatorId: string): Prom
  */
 export const getOutboundProvisioningConnectorMetadata = (connectorId: string): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -507,14 +507,14 @@ export const getOutboundProvisioningConnectorMetadata = (connectorId: string): P
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to get outbound provisioning connector metadata for: "
                     + connectorId));
             }
 
             return Promise.resolve(response.data as OutboundProvisioningConnectorMetaInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -528,7 +528,7 @@ export const getOutboundProvisioningConnectorMetadata = (connectorId: string): P
  */
 export const getOutboundProvisioningConnector = (idpId: string, connectorId: string): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -540,14 +540,14 @@ export const getOutboundProvisioningConnector = (idpId: string, connectorId: str
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to get outbound provisioning connector for: "
                     + connectorId));
             }
 
             return Promise.resolve(response.data as OutboundProvisioningConnectorInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -566,7 +566,7 @@ export const updateOutboundProvisioningConnector = (
 
     const { connectorId, ...rest } = connector;
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: rest,
         headers: {
             "Accept": "application/json",
@@ -579,13 +579,13 @@ export const updateOutboundProvisioningConnector = (
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update identity provider: " + idpId));
             }
 
             return Promise.resolve(response.data as IdentityProviderInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -602,7 +602,7 @@ export const updateJITProvisioningConfigs = (
     configs: JITProvisioningResponseInterface
 ): Promise<IdentityProviderInterface> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: configs,
         headers: {
             "Accept": "application/json",
@@ -615,7 +615,7 @@ export const updateJITProvisioningConfigs = (
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update jit configuration: " + idpId));
             }
@@ -637,7 +637,7 @@ export const getJITProvisioningConfigs = (
     idpId: string
 ): Promise<IdentityProviderInterface> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -648,7 +648,7 @@ export const getJITProvisioningConfigs = (
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to get jit configuration: " + idpId));
             }
@@ -679,7 +679,7 @@ export const updateClaimsConfigs = (
     configs: IdentityProviderClaimsInterface
 ): Promise<IdentityProviderInterface> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: configs,
         headers: {
             "Accept": "application/json",
@@ -691,7 +691,7 @@ export const updateClaimsConfigs = (
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update identity provider: " + idpId));
             }
@@ -719,7 +719,7 @@ export const updateClaimsConfigs = (
  */
 export const getIdentityProviderTemplateList = (limit?: number, offset?: number,
     filter?: string): Promise<IdentityProviderTemplateListResponseInterface> => {
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -766,7 +766,7 @@ export const getIdentityProviderTemplateList = (limit?: number, offset?: number,
  * @returns A promise containing the response.
  */
 export const getIdentityProviderTemplate = (templateId: string): Promise<IdentityProviderTemplateInterface> => {
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -813,7 +813,7 @@ export const updateIDPRoleMappings = (
     mappings: IdentityProviderRolesInterface
 ): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: mappings,
         headers: {
             "Accept": "application/json",
@@ -825,13 +825,13 @@ export const updateIDPRoleMappings = (
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update identity provider: " + idpId));
             }
 
             return Promise.resolve(response.data as IdentityProviderInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -844,7 +844,7 @@ export const updateIDPRoleMappings = (
  */
 export const getLocalAuthenticators = (): Promise<LocalAuthenticatorInterface[]> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -887,7 +887,7 @@ export const getLocalAuthenticators = (): Promise<LocalAuthenticatorInterface[]>
  */
 export const getLocalAuthenticator = (id: string): Promise<AuthenticatorInterface> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Content-Type": "application/json"
@@ -931,7 +931,7 @@ export const getLocalAuthenticator = (id: string): Promise<AuthenticatorInterfac
  */
 export const getAuthenticators = (filter?: string, type?: AuthenticatorTypes): Promise<AuthenticatorInterface[]> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -989,7 +989,7 @@ export const getAuthenticators = (filter?: string, type?: AuthenticatorTypes): P
  */
 export const getAuthenticatorTags = (): Promise<string[]> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -1032,7 +1032,7 @@ export const getAuthenticatorTags = (): Promise<string[]> => {
  */
 export const getMultiFactorAuthenticatorDetails = (id: string): Promise<MultiFactorAuthenticatorInterface> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -1079,7 +1079,7 @@ export const updateMultiFactorAuthenticatorDetails = (
     payload: MultiFactorAuthenticatorInterface
 ): Promise<MultiFactorAuthenticatorInterface> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: {
             operation: "UPDATE",
             properties: payload.properties
@@ -1123,7 +1123,7 @@ export const updateMultiFactorAuthenticatorDetails = (
  * @returns A promise containing the response.
  */
 export const getOutboundProvisioningConnectorsList = (): Promise<OutboundProvisioningConnectorListItemInterface[]> => {
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -1134,13 +1134,13 @@ export const getOutboundProvisioningConnectorsList = (): Promise<OutboundProvisi
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to fetch outbound provisioning connectors"));
             }
 
             return Promise.resolve(response.data as OutboundProvisioningConnectorListItemInterface[]);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -1157,7 +1157,7 @@ export const updateIDPCertificate = <T = Record<string, unknown>>(
     data: T
 ): Promise<IdentityProviderInterface> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data,
         headers: {
             "Accept": "application/json",
@@ -1169,7 +1169,7 @@ export const updateIDPCertificate = <T = Record<string, unknown>>(
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update identity provider: " + idpId));
             }
@@ -1198,7 +1198,7 @@ export const updateOutboundProvisioningConnectors = <T = Record<string,unknown>>
     idpId: string
 ): Promise<OutboundProvisioningConnectorListItemInterface> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: connectorList,
         headers: {
             "Accept": "application/json",
@@ -1210,13 +1210,13 @@ export const updateOutboundProvisioningConnectors = <T = Record<string,unknown>>
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update identity provider: " + idpId));
             }
 
             return Promise.resolve(response.data as IdentityProviderInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -1233,7 +1233,7 @@ export const updateFederatedAuthenticators = (
     idpId: string
 ): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: authenticatorList,
         headers: {
             "Accept": "application/json",
@@ -1245,13 +1245,13 @@ export const updateFederatedAuthenticators = (
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update identity provider: " + idpId));
             }
 
             return Promise.resolve(response.data as IdentityProviderInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -1264,7 +1264,7 @@ export const updateFederatedAuthenticators = (
  */
 export const getIDPConnectedApps = (idpId: string): Promise<any> => {
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -1275,7 +1275,7 @@ export const getIDPConnectedApps = (idpId: string): Promise<any> => {
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(
                     new Error("Failed to get connected apps for the IDP: " + idpId)
@@ -1283,7 +1283,7 @@ export const getIDPConnectedApps = (idpId: string): Promise<any> => {
             }
 
             return Promise.resolve(response.data as ConnectedAppsInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -1339,8 +1339,8 @@ export const addSMSPublisher = (): Promise<NotificationSenderSMSInterface> => {
                 value: "choreo"
             }
         ],
-        provider: "Dummy_provider",
-        providerURL: "https://api.dummy.com"
+        provider: "choreo",
+        providerURL: "https://console.choreo.dev/"
     };
 
     const requestConfig: RequestConfigInterface = {

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -16,10 +16,10 @@
  * under the License.
  */
 
-import { AsgardeoSPAClient, HttpClientInstance } from "@asgardeo/auth-react";
+import { AsgardeoSPAClient, HttpClientInstance, HttpRequestConfig } from "@asgardeo/auth-react";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { HttpMethods } from "@wso2is/core/models";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { identityProviderConfig } from "../../../extensions/configs";
 import { store } from "../../core";
 import useRequest, {
@@ -57,7 +57,8 @@ import {
  */
 const httpClient: HttpClientInstance = AsgardeoSPAClient.getInstance().httpRequest
     .bind(AsgardeoSPAClient.getInstance());
-const httpClientAll = AsgardeoSPAClient.getInstance().httpRequestAll.bind(AsgardeoSPAClient.getInstance());
+const httpClientAll: (config: HttpRequestConfig[]) => Promise<AxiosResponse> =
+    AsgardeoSPAClient.getInstance().httpRequestAll.bind(AsgardeoSPAClient.getInstance());
 
 /**
  * Creates Identity Provider.
@@ -210,7 +211,7 @@ export const getAllIdentityProvidersDetail = (
     ids: Set<string>
 ): Promise<IdentityProviderResponseInterface[]> => {
 
-    const requests: RequestConfigInterface[] = [];
+    const requests: AxiosRequestConfig[] = [];
 
     for (const id of ids) {
         requests.push({

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -47,7 +47,8 @@ import {
     MultiFactorAuthenticatorInterface,
     OutboundProvisioningConnectorInterface,
     OutboundProvisioningConnectorListItemInterface,
-    OutboundProvisioningConnectorMetaInterface
+    OutboundProvisioningConnectorMetaInterface,
+    NotificationSenderSMSInterface
 } from "../models";
 
 /**
@@ -73,7 +74,7 @@ export const createIdentityProvider = <T = Record<string, unknown>> (identityPro
         method: HttpMethods.POST,
         url: store.getState().config.endpoints.identityProviders
     };
-    
+
     return httpClient(requestConfig)
         .then((response) => {
             if ((response.status !== 201)) {
@@ -1222,7 +1223,7 @@ export const updateOutboundProvisioningConnectors = <T = Record<string,unknown>>
 /**
  * Update a federated authenticators list of a specified IDP.
  *
- * @param authenticatorList - 
+ * @param authenticatorList -
  * @param idpId - ID of the Identity Provider.
  * @returns A promise containing the response.
  */
@@ -1281,6 +1282,115 @@ export const getIDPConnectedApps = (idpId: string): Promise<any> => {
             }
 
             return Promise.resolve(response.data as ConnectedAppsInterface);
+        }).catch((error) => {
+            return Promise.reject(error);
+        });
+};
+
+/**
+ * Get all sms notification senders with name SMSPublisher.
+ *
+ * @returns  A promise containing the response.
+ */
+export const getSMSPublisher = (): Promise<any> => {
+
+    console.log(store.getState())
+    const requestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        //TODO - get URL from configs
+        url: "https://api.asg.io/t/laki/api/server/v1/notification-senders/sms/SMSPublisher"
+    };
+
+    return httpClient(requestConfig)
+        .then((response) => {
+            if (response.status !== 200) {
+                return Promise.reject(
+                    new Error("Failed to get SMS Notification Sender : SMSPublisher")
+                );
+            }
+            return Promise.resolve(response.data as NotificationSenderSMSInterface);
+        }).catch((error) => {
+            return Promise.reject(error);
+        });
+};
+
+/**
+ * Add sms notification senders with name SMSPublisher.
+ *
+ * @returns  A promise containing the response.
+ */
+export const addSMSPublisher = (): Promise<any> => {
+
+    //SMS Notification sender with name SMSPublisher.
+    const smsProvider: NotificationSenderSMSInterface = {
+        name: "SMSPublisher",
+        provider: "Dummy_provider",
+        providerURL: "https://api.dummy.com",
+        contentType: "FORM",
+        properties: [
+            {
+                key: "channel.type",
+                value: "choreo"
+            }
+        ]
+    };
+
+    const requestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        data: smsProvider,
+        method: HttpMethods.POST,
+        //TODO - get URL from configs
+        url: "https://api.asg.io/t/laki/api/server/v1/notification-senders/sms"
+    };
+
+    return httpClient(requestConfig)
+        .then((response) => {
+            if (response.status !== 201) {
+                return Promise.reject(
+                    new Error("Failed to add SMS Notification Sender : SMSPublisher")
+                );
+            }
+            return Promise.resolve(response.data as NotificationSenderSMSInterface);
+        }).catch((error) => {
+            return Promise.reject(error);
+        });
+};
+
+/**
+ * Delete sms notification senders with name SMSPublisher.
+ *
+ * @returns  A promise containing the response.
+ */
+export const deleteSMSPublisher = (): Promise<any> => {
+
+    const requestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.DELETE,
+        //TODO - get URL from configs
+        url: "https://api.asg.io/t/laki/api/server/v1/notification-senders/sms/SMSPublisher"
+    };
+
+    return httpClient(requestConfig)
+        .then((response) => {
+            if (response.status !== 204) {
+                return Promise.reject(
+                    new Error("Failed to delete SMS Notification Sender : SMSPublisher")
+                );
+            }
+            return Promise.resolve(response.data);
         }).catch((error) => {
             return Promise.reject(error);
         });

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -210,7 +210,7 @@ export const getAllIdentityProvidersDetail = (
     ids: Set<string>
 ): Promise<IdentityProviderResponseInterface[]> => {
 
-    const requests = [];
+    const requests: RequestConfigInterface[] = [];
 
     for (const id of ids) {
         requests.push({
@@ -287,7 +287,11 @@ export const deleteIdentityProvider = (id: string): Promise<any> => {
 export const updateIdentityProviderDetails = (idp: IdentityProviderInterface): Promise<any> => {
 
     const { id, ...rest } = idp;
-    const replaceOps = [];
+    const replaceOps: {
+        operation: string;
+        path: string;
+        value: string
+    }[] = [];
 
     for (const key in rest) {
         if(rest[key] !== undefined) {

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -1194,7 +1194,7 @@ export const updateIDPCertificate = <T = Record<string, unknown>>(
 /**
  * Update the outbound provisioning connectors list of a specified IDP.
  *
- * @param connectorList -
+ * @param connectorList - Outbound provisioning connectors list of the IDP.
  * @param idpId - ID of the Identity Provider.
  * @returns A promise containing the response.
  */

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -195,13 +195,13 @@ export const getIdentityProviderDetail = (id: string): Promise<any> => {
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to get idp details from: "));
             }
 
             return Promise.resolve(response.data as IdentityProviderResponseInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -256,7 +256,7 @@ export const getAllIdentityProvidersDetail = (
  * @returns A promise containing the response.
  */
 export const deleteIdentityProvider = (id: string): Promise<any> => {
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
@@ -267,13 +267,13 @@ export const deleteIdentityProvider = (id: string): Promise<any> => {
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 204) {
                 return Promise.reject(new Error("Failed to delete the identity provider."));
             }
 
             return Promise.resolve(response);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };
@@ -300,7 +300,7 @@ export const updateIdentityProviderDetails = (idp: IdentityProviderInterface): P
     }
 
 
-    const requestConfig = {
+    const requestConfig: RequestConfigInterface = {
         data: replaceOps,
         headers: {
             "Accept": "application/json",
@@ -312,13 +312,13 @@ export const updateIdentityProviderDetails = (idp: IdentityProviderInterface): P
     };
 
     return httpClient(requestConfig)
-        .then((response) => {
+        .then((response: AxiosResponse) => {
             if (response.status !== 200) {
                 return Promise.reject(new Error("Failed to update identity provider: " + id));
             }
 
             return Promise.resolve(response.data as IdentityProviderInterface);
-        }).catch((error) => {
+        }).catch((error: AxiosError) => {
             return Promise.reject(error);
         });
 };

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -1306,7 +1306,7 @@ export const useSMSNotificationSenders = <Data = NotificationSenderSMSInterface[
         url: store.getState().config.endpoints.notificationSenders + "/sms"
     };
 
-    const {data, error, isValidating, mutate} = useRequest<Data, Error>(requestConfig);
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(requestConfig);
 
     return {
         data,
@@ -1326,25 +1326,25 @@ export const addSMSPublisher = (): Promise<NotificationSenderSMSInterface> => {
 
     //SMS Notification sender with name SMSPublisher.
     const smsProvider: NotificationSenderSMSInterface = {
-        name: "SMSPublisher",
-        provider: "Dummy_provider",
-        providerURL: "https://api.dummy.com",
         contentType: "FORM",
+        name: "SMSPublisher",
         properties: [
             {
                 key: "channel.type",
                 value: "choreo"
             }
-        ]
+        ],
+        provider: "Dummy_provider",
+        providerURL: "https://api.dummy.com"
     };
 
     const requestConfig: RequestConfigInterface = {
+        data: smsProvider,
         headers: {
             "Accept": "application/json",
             "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
             "Content-Type": "application/json"
         },
-        data: smsProvider,
         method: HttpMethods.POST,
         url: store.getState().config.endpoints.notificationSenders + "/sms"
     };
@@ -1360,6 +1360,7 @@ export const addSMSPublisher = (): Promise<NotificationSenderSMSInterface> => {
                     response,
                     response.config);
             }
+
             return Promise.resolve(response.data as NotificationSenderSMSInterface);
         }).catch((error: AxiosError) => {
             throw new IdentityAppsApiException(
@@ -1400,6 +1401,7 @@ export const deleteSMSPublisher = (): Promise<void> => {
                     response,
                     response.config);
             }
+
             return Promise.resolve(response.data);
         }).catch((error: AxiosError) => {
             throw new IdentityAppsApiException(

--- a/apps/console/src/features/identity-providers/api/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/api/identity-provider.ts
@@ -1292,7 +1292,7 @@ export const getIDPConnectedApps = (idpId: string): Promise<any> => {
  *
  * @returns  A promise containing the response.
  */
-export const getSMSPublisher = (): Promise<any> => {
+export const getSMSNotificationSenders = (): Promise<any> => {
 
     console.log(store.getState())
     const requestConfig = {
@@ -1303,17 +1303,17 @@ export const getSMSPublisher = (): Promise<any> => {
         },
         method: HttpMethods.GET,
         //TODO - get URL from configs
-        url: "https://api.asg.io/t/laki/api/server/v1/notification-senders/sms/SMSPublisher"
+        url: "https://api.asg.io/t/laki/api/server/v1/notification-senders/sms"
     };
 
     return httpClient(requestConfig)
         .then((response) => {
             if (response.status !== 200) {
                 return Promise.reject(
-                    new Error("Failed to get SMS Notification Sender : SMSPublisher")
+                    new Error("Failed to get SMS Notification Senders")
                 );
             }
-            return Promise.resolve(response.data as NotificationSenderSMSInterface);
+            return Promise.resolve(response.data as NotificationSenderSMSInterface[]);
         }).catch((error) => {
             return Promise.reject(error);
         });

--- a/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
+++ b/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
@@ -19,10 +19,12 @@
 import { AlertLevels, LoadableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ContentLoader, EmphasizedSegment, ResourceTab } from "@wso2is/react-components";
+import { AxiosError } from "axios";
 import get from "lodash-es/get";
 import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
 import { Grid, Menu, SemanticShorthandItem, TabPaneProps } from "semantic-ui-react";
 import { AuthenticatorFormFactory } from "./forms/factories";
 import {
@@ -91,7 +93,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
         [ "data-testid" ]: testId
     } = props;
 
-    const dispatch = useDispatch();
+    const dispatch: Dispatch = useDispatch();
 
     const { t } = useTranslation();
 
@@ -150,7 +152,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
 
                 onUpdate(authenticator.id);
             })
-            .catch((error) => {
+            .catch((error: AxiosError) => {
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(addAlert({
                         description: t("console:develop.features.authenticationProvider" +

--- a/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
+++ b/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
@@ -265,26 +265,6 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
             });
         }
 
-        /**
-        // If the MFA is SMS OTP, add the SMS Provider tab.
-        if (authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID) {
-            panes.push({
-                menuItem: (
-                    <Menu.Item disabled key="messages" className="upcoming-item">
-                        <Trans
-                            i18nKey={
-                                "console:develop.features.authenticationProvider.edit.smsOTP.smsProvider.tabName"
-                            }
-                        >
-                            SMS Provider <span className="coming-soon-label">(Coming Soon)</span>
-                        </Trans>
-                    </Menu.Item>
-                ),
-                render: null
-            });
-        }
-         **/
-
         return panes;
     };
 

--- a/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
+++ b/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
@@ -265,6 +265,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
             });
         }
 
+        /**
         // If the MFA is SMS OTP, add the SMS Provider tab.
         if (authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID) {
             panes.push({
@@ -282,6 +283,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
                 render: null
             });
         }
+         **/
 
         return panes;
     };

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -28,7 +28,7 @@ import React, { FunctionComponent, ReactElement, useEffect, useState } from "rea
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
-import { Checkbox, Label } from "semantic-ui-react";
+import { Checkbox, CheckboxProps, Label } from "semantic-ui-react";
 import { addSMSPublisher, deleteSMSPublisher, useSMSNotificationSenders } from "../../../api";
 import { IdentityProviderManagementConstants } from "../../../constants";
 import {
@@ -246,13 +246,16 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
         if (!notificationSendersListFetchRequestError) {
             if (notificationSendersList) {
                 let enableSMSOTP: boolean = false;
+
                 for (const notificationSender of notificationSendersList) {
                     const channelValues: {
                         key:string;
                         value:string;
                     }[] = notificationSender.properties ? notificationSender.properties : [];
-                    if (notificationSender.name === 'SMSPublisher' &&
-                        (channelValues.filter(prop => prop.key === 'channel.type' && prop.value === 'choreo').length > 0)
+
+                    if (notificationSender.name === "SMSPublisher" &&
+                        (channelValues.filter(prop => prop.key === "channel.type" && prop.value === "choreo")
+                            .length > 0)
                     ) {
                         enableSMSOTP = true;
                         break;
@@ -269,7 +272,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                 message: notificationSendersListFetchRequestError?.response.data.message || "Error Occurred."
             }));
         }
-    }, [ originalInitialValues, notificationSendersList, notificationSendersListFetchRequestError]);
+    }, [ originalInitialValues, notificationSendersList, notificationSendersListFetchRequestError ]);
 
     /**
      * Prepare form values for submitting.
@@ -287,7 +290,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                 const moderatedName: string = name.replace(/_/g, ".");
 
                 if (name === IdentityProviderManagementConstants.AUTHENTICATOR_INIT_VALUES_SMS_OTP_EXPIRY_TIME_KEY){
-                    const timeInSeconds = value * 60;
+                    const timeInSeconds: number = value * 60;
 
                     properties.push({
                         name: moderatedName,
@@ -386,11 +389,11 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
      * @param event - Event.
      * @param data - Data.
      */
-    const handleUpdateSMSPublisher = (event, data) => {
+    const handleUpdateSMSPublisher = (data: CheckboxProps) => {
 
         if (data.checked) {
             // Add SMS Publisher when enabling the feature.
-            addSMSPublisher().then((response: NotificationSenderSMSInterface) => {
+            addSMSPublisher().then(() => {
                 setEnableSMSOTP(true);
                 setIsReadOnly(false);
             }).catch((error: IdentityAppsApiException) => {
@@ -400,7 +403,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                     level: AlertLevels.ERROR,
                     message: error?.response.data.message || "Error Occurred."
                 }));
-            })
+            });
         } else {
             // Delete SMS Publisher when enabling the feature.
             deleteSMSPublisher().then(() => {
@@ -413,7 +416,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                     level: AlertLevels.ERROR,
                     message: error?.response.data.message || "Error Occurred."
                 }));
-            })
+            });
         }
     }
 
@@ -429,7 +432,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
         >
             <Message
                 type={ "info" }
-                content={"Enable from here to use SMS OTP"}
+                content={ "Enable from here to use SMS OTP" }
                 width={ 13 }
                 />
             <Checkbox
@@ -437,9 +440,10 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                 label={
                    "Enable SMS OTP"
                 }
-                data-componentid="branding-preference-publish-toggle"
+                data-componentid="sms-otp-enable-toggle"
                 checked={ isEnableSMSOTP }
-                onChange={ (event, data): void => handleUpdateSMSPublisher(event, data) }
+                onChange={ (event, data):
+                    void => handleUpdateSMSPublisher(data) }
                 className="feature-toggle"
             />
             <Field.Input

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -37,8 +37,8 @@ import {
     CommonAuthenticatorFormInitialValuesInterface,
     CommonAuthenticatorFormMetaInterface,
     CommonAuthenticatorFormPropertyInterface,
-    CommonPluggableComponentPropertyInterface,
-    NotificationSenderSMSInterface
+    CommonPluggableComponentMetaPropertyInterface,
+    CommonPluggableComponentPropertyInterface
 } from "../../../models";
 
 /**
@@ -200,7 +200,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
 
         originalInitialValues.properties.forEach((value: CommonAuthenticatorFormPropertyInterface) => {
             const meta: CommonAuthenticatorFormFieldMetaInterface = metadata?.properties
-                .find((meta) => meta.key === value.key);
+                .find((meta: CommonPluggableComponentMetaPropertyInterface) => meta.key === value.key);
 
             const moderatedName: string = value.name.replace(/\./g, "_");
 
@@ -254,10 +254,12 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                     }[] = notificationSender.properties ? notificationSender.properties : [];
 
                     if (notificationSender.name === "SMSPublisher" &&
-                        (channelValues.filter(prop => prop.key === "channel.type" && prop.value === "choreo")
+                        (channelValues.filter((prop : { key:string, value:string }) => 
+                            prop.key === "channel.type" && prop.value === "choreo")
                             .length > 0)
                     ) {
                         enableSMSOTP = true;
+
                         break;
                     }
                 }
@@ -389,7 +391,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
      * @param event - Event.
      * @param data - Data.
      */
-    const handleUpdateSMSPublisher = (data: CheckboxProps) => {
+    const handleUpdateSMSPublisher = ( event: React.FormEvent<HTMLInputElement>, data: CheckboxProps) => {
 
         if (data.checked) {
             // Add SMS Publisher when enabling the feature.
@@ -418,13 +420,13 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                 }));
             });
         }
-    }
+    };
 
     return (
         <Form
             id={ FORM_ID }
             uncontrolledForm={ false }
-            onSubmit={ (values) => {
+            onSubmit={ (values: Record<string, any>) => {
                 onSubmit(getUpdatedConfigurations(values as SMSOTPAuthenticatorFormInitialValuesInterface));
             } }
             initialValues={ initialValues }
@@ -434,16 +436,16 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                 type={ "info" }
                 content={ "Enable from here to use SMS OTP" }
                 width={ 13 }
-                />
+            />
             <Checkbox
                 toggle
                 label={
-                   "Enable SMS OTP"
+                    "Enable SMS OTP"
                 }
                 data-componentid="sms-otp-enable-toggle"
                 checked={ isEnableSMSOTP }
-                onChange={ (event, data):
-                    void => handleUpdateSMSPublisher(data) }
+                onChange={ (event: React.FormEvent<HTMLInputElement>, data: CheckboxProps):
+                    void => handleUpdateSMSPublisher(event, data) }
                 className="feature-toggle"
             />
             <Field.Input

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-import { TestableComponentInterface, AlertLevels } from "@wso2is/core/models";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
+import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/form";
 import { Code, Message } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
@@ -25,13 +26,11 @@ import isBoolean from "lodash-es/isBoolean";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { Divider, Icon, Label } from "semantic-ui-react";
-import { IdentityProviderManagementConstants } from "../../../constants";
-import { Checkbox } from "semantic-ui-react";
-import { addAlert } from "@wso2is/core/store";
-import { AxiosError } from "axios";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
+import { Checkbox, Label } from "semantic-ui-react";
+import { addSMSPublisher, deleteSMSPublisher, useSMSNotificationSenders } from "../../../api";
+import { IdentityProviderManagementConstants } from "../../../constants";
 import {
     CommonAuthenticatorFormFieldInterface,
     CommonAuthenticatorFormFieldMetaInterface,
@@ -41,7 +40,6 @@ import {
     CommonPluggableComponentPropertyInterface,
     NotificationSenderSMSInterface
 } from "../../../models";
-import { useSMSNotificationSenders, addSMSPublisher, deleteSMSPublisher } from "../../../api";
 
 /**
  * Interface for SMS OTP Authenticator Form props.
@@ -178,8 +176,8 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
     // SMS OTP length unit is set to digits or characters according to the state of this variable
     const [ isOTPNumeric, setIsOTPNumeric ] = useState<boolean>();
 
-    const [ isEnableSMSOTP, setEnableSMSOTP ] = useState<Boolean>(false);
-    const [ isReadOnly, setIsReadOnly ] = useState<Boolean>(true)
+    const [ isEnableSMSOTP, setEnableSMSOTP ] = useState<boolean>(false);
+    const [ isReadOnly, setIsReadOnly ] = useState<boolean>(true);
 
     const dispatch: Dispatch = useDispatch();
 
@@ -208,7 +206,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
 
             // Converting expiry time from seconds to minutes
             if(moderatedName === IdentityProviderManagementConstants.AUTHENTICATOR_INIT_VALUES_SMS_OTP_EXPIRY_TIME_KEY){
-                const expiryTimeInMinutes = Math.round(parseInt(value.value,10) / 60);
+                const expiryTimeInMinutes: number = Math.round(parseInt(value.value,10) / 60);
 
                 resolvedInitialValues = {
                     ...resolvedInitialValues,
@@ -247,9 +245,12 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
 
         if (!notificationSendersListFetchRequestError) {
             if (notificationSendersList) {
-                let enableSMSOTP = false;
+                let enableSMSOTP: boolean = false;
                 for (const notificationSender of notificationSendersList) {
-                    const channelValues = notificationSender.properties ? notificationSender.properties : [];
+                    const channelValues: {
+                        key:string;
+                        value:string;
+                    }[] = notificationSender.properties ? notificationSender.properties : [];
                     if (notificationSender.name === 'SMSPublisher' &&
                         (channelValues.filter(prop => prop.key === 'channel.type' && prop.value === 'choreo').length > 0)
                     ) {
@@ -426,13 +427,18 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
             initialValues={ initialValues }
             validate={ validateForm }
         >
+            <Message
+                type={ "info" }
+                content={"Enable from here to use SMS OTP"}
+                width={ 13 }
+                />
             <Checkbox
                 toggle
                 label={
                    "Enable SMS OTP"
                 }
                 data-componentid="branding-preference-publish-toggle"
-                checked={ isEnableSMSOTP.valueOf() }
+                checked={ isEnableSMSOTP }
                 onChange={ (event, data): void => handleUpdateSMSPublisher(event, data) }
                 className="feature-toggle"
             />

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -178,8 +178,8 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
     // SMS OTP length unit is set to digits or characters according to the state of this variable
     const [ isOTPNumeric, setIsOTPNumeric ] = useState<boolean>();
 
-    const [ isEnableSMSOTP, setEnableSMSOTP ] = useState<boolean>(false);
-    const [ isReadOnly, setIsReadOnly ] = useState<boolean>(true)
+    const [ isEnableSMSOTP, setEnableSMSOTP ] = useState<Boolean>(false);
+    const [ isReadOnly, setIsReadOnly ] = useState<Boolean>(true)
 
     const dispatch: Dispatch = useDispatch();
 
@@ -432,7 +432,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                    "Enable SMS OTP"
                 }
                 data-componentid="branding-preference-publish-toggle"
-                checked={ isEnableSMSOTP }
+                checked={ isEnableSMSOTP.valueOf() }
                 onChange={ (event, data): void => handleUpdateSMSPublisher(event, data) }
                 className="feature-toggle"
             />

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -40,7 +40,7 @@ import {
     CommonPluggableComponentPropertyInterface,
     NotificationSenderSMSInterface
 } from "../../../models";
-import { getSMSPublisher, addSMSPublisher, deleteSMSPublisher } from "../../../api/identity-provider"
+import { getSMSNotificationSenders, addSMSPublisher, deleteSMSPublisher } from "../../../api/identity-provider"
 
 /**
  * Interface for SMS OTP Authenticator Form props.
@@ -239,10 +239,17 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
         setFormFields(resolvedFormFields);
         setInitialValues(resolvedInitialValues);
 
-        getSMSPublisher().then((response: NotificationSenderSMSInterface) => {
-            const channelValues = response.properties ? response.properties : [];
-            const enableSMSOTP = channelValues.filter(prop => prop.key === 'channel.type'
-                && prop.value === 'choreo').length > 0
+        getSMSNotificationSenders().then((response: NotificationSenderSMSInterface[]) => {
+            let enableSMSOTP = false;
+            for (const notificationSender of response) {
+                const channelValues = notificationSender.properties ? notificationSender.properties : [];
+                if (notificationSender.name === 'SMSPublisher' &&
+                    (channelValues.filter(prop => prop.key === 'channel.type' && prop.value === 'choreo').length > 0)
+                ) {
+                    enableSMSOTP = true;
+                    break;
+                }
+            }
             setEnableSMSOTP(enableSMSOTP);
             setIsReadOnly(!enableSMSOTP);
         }).catch((error: AxiosError) => {

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/form";
@@ -254,7 +253,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                     }[] = notificationSender.properties ? notificationSender.properties : [];
 
                     if (notificationSender.name === "SMSPublisher" &&
-                        (channelValues.filter((prop : { key:string, value:string }) => 
+                        (channelValues.filter((prop : { key:string, value:string }) =>
                             prop.key === "channel.type" && prop.value === "choreo")
                             .length > 0)
                     ) {
@@ -268,10 +267,13 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
             }
         } else {
             dispatch(addAlert({
-                description: notificationSendersListFetchRequestError?.response.data.description ||
-                    "Error occurred while trying to get SMS OTP configuration.",
+                description: t("console:develop.features.authenticationProvider" +
+                    ".forms.authenticatorSettings.smsOTP.errorNotifications" +
+                    ".notificationSendersRetrievalError.description"),
                 level: AlertLevels.ERROR,
-                message: notificationSendersListFetchRequestError?.response.data.message || "Error Occurred."
+                message:t("console:develop.features.authenticationProvider" +
+                    ".forms.authenticatorSettings.smsOTP.errorNotifications" +
+                    ".notificationSendersRetrievalError.message")
             }));
         }
     }, [ originalInitialValues, notificationSendersList, notificationSendersListFetchRequestError ]);
@@ -398,12 +400,13 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
             addSMSPublisher().then(() => {
                 setEnableSMSOTP(true);
                 setIsReadOnly(false);
-            }).catch((error: IdentityAppsApiException) => {
+            }).catch(() => {
                 dispatch(addAlert({
-                    description: error.response.data.description ||
-                        "Error occurred while trying to enable SMS OTP.",
+                    description: t("console:develop.features.authenticationProvider" +
+                        ".forms.authenticatorSettings.smsOTP.errorNotifications.smsPublisherCreationError.description"),
                     level: AlertLevels.ERROR,
-                    message: error?.response.data.message || "Error Occurred."
+                    message: t("console:develop.features.authenticationProvider" +
+                        ".forms.authenticatorSettings.smsOTP.errorNotifications.smsPublisherCreationError.message")
                 }));
             });
         } else {
@@ -411,12 +414,13 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
             deleteSMSPublisher().then(() => {
                 setEnableSMSOTP(false);
                 setIsReadOnly(true);
-            }).catch((error: IdentityAppsApiException) => {
+            }).catch(() => {
                 dispatch(addAlert({
-                    description: error?.response.data.description ||
-                        "Error occurred while trying to disable SMS OTP.",
+                    description: t("console:develop.features.authenticationProvider" +
+                        ".forms.authenticatorSettings.smsOTP.errorNotifications.smsPublisherDeletionError.description"),
                     level: AlertLevels.ERROR,
-                    message: error?.response.data.message || "Error Occurred."
+                    message: t("console:develop.features.authenticationProvider" +
+                        ".forms.authenticatorSettings.smsOTP.errorNotifications.smsPublisherDeletionError.message")
                 }));
             });
         }
@@ -434,13 +438,26 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
         >
             <Message
                 type={ "info" }
-                content={ "Enable from here to use SMS OTP" }
-                width={ 13 }
-            />
+            >
+                { t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                ".smsOTP.enableRequiredNote.messagePart1") }
+                <a href="https://console.choreo.dev/">
+                    { t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                    ".smsOTP.enableRequiredNote.linkToChoreoText") }</a>
+                { t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                    ".smsOTP.enableRequiredNote.messagePart2") }
+                <a href="https://wso2.com/asgardeo/docs/guides/authentication/mfa/add-smsotp-login/">
+                    { t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                    ".smsOTP.enableRequiredNote.linkToGuideText") }</a>
+                { t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                    ".smsOTP.enableRequiredNote.messagePart3") }
+            </Message>
             <Checkbox
                 toggle
-                label={
-                    "Enable SMS OTP"
+                label={ (!isEnableSMSOTP ? t("console:develop.features.authenticationProvider" +
+                        ".forms.authenticatorSettings.smsOTP.smsOtpEnableDisableToggle.labelEnable") :
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                    ".smsOTP.smsOtpEnableDisableToggle.labelDisable"))
                 }
                 data-componentid="sms-otp-enable-toggle"
                 checked={ isEnableSMSOTP }

--- a/apps/console/src/features/identity-providers/configs/endpoints.ts
+++ b/apps/console/src/features/identity-providers/configs/endpoints.ts
@@ -31,6 +31,7 @@ export const getIDPResourceEndpoints = (serverHost: string): IDPResourceEndpoint
         authenticators: `${ serverHost }/api/server/v1/authenticators`,
         identityProviders: `${ serverHost }/api/server/v1/identity-providers`,
         localAuthenticators: `${ serverHost }/api/server/v1/configs/authenticators`,
-        multiFactorAuthenticators: getServerConfigurationsResourceEndpoints(serverHost).multiFactorAuthenticators
+        multiFactorAuthenticators: getServerConfigurationsResourceEndpoints(serverHost).multiFactorAuthenticators,
+        notificationSenders: `${ serverHost }/api/server/v1/notification-senders`
     };
 };

--- a/apps/console/src/features/identity-providers/configs/endpoints.ts
+++ b/apps/console/src/features/identity-providers/configs/endpoints.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,8 +22,8 @@ import { IDPResourceEndpointsInterface } from "../models";
 /**
  * Get the resource endpoints for the IDP Management feature.
  *
- * @param {string} serverHost - Server Host.
- * @return {IDPResourceEndpointsInterface}
+ * @param string - Server Host.
+ * @returns IDPResourceEndpointsInterface.
  */
 export const getIDPResourceEndpoints = (serverHost: string): IDPResourceEndpointsInterface => {
     return {

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -39,7 +39,7 @@ import { IdentityProviderTemplateLoadingStrategies } from "../models";
  */
 export class IdentityProviderManagementConstants {
 
-    public static readonly MAXIMUM_NUMBER_OF_LIST_ITEMS_TO_SHOW_INSIDE_CALLOUTS = 3;
+    public static readonly MAXIMUM_NUMBER_OF_LIST_ITEMS_TO_SHOW_INSIDE_CALLOUTS: number = 3;
 
     /**
      * Identifier for the local IDP.
@@ -49,13 +49,13 @@ export class IdentityProviderManagementConstants {
     /**
      * Doc key for the IDP overview page.
      */
-    public static readonly IDP_OVERVIEW_DOCS_KEY = `${
+    public static readonly IDP_OVERVIEW_DOCS_KEY: string = `${
         DocumentationConstants.PORTAL_DOCS_KEY }["Identity Providers"]["Overview"]`;
 
     /**
      * Doc key for the IDP edit page.
      */
-    public static readonly IDP_EDIT_OVERVIEW_DOCS_KEY = `${
+    public static readonly IDP_EDIT_OVERVIEW_DOCS_KEY: string = `${
         DocumentationConstants.PORTAL_DOCS_KEY }["Identity Providers"]["Edit Identity Provider"]["Overview"]`;
 
     /**
@@ -67,18 +67,18 @@ export class IdentityProviderManagementConstants {
     /**
      * Key for the URL search param for IDP state.
      */
-    public static readonly IDP_STATE_URL_SEARCH_PARAM_KEY = "state";
+    public static readonly IDP_STATE_URL_SEARCH_PARAM_KEY: string = "state";
 
     /**
      * URL Search param for newly created IDPs.
      */
-    public static readonly NEW_IDP_URL_SEARCH_PARAM = `?${
+    public static readonly NEW_IDP_URL_SEARCH_PARAM: string = `?${
         IdentityProviderManagementConstants.IDP_STATE_URL_SEARCH_PARAM_KEY }=new`;
 
     /**
      * Key for the URL search param for IDP create wizard trigger.
      */
-    public static readonly IDP_CREATE_WIZARD_TRIGGER_URL_SEARCH_PARAM_KEY = "open";
+    public static readonly IDP_CREATE_WIZARD_TRIGGER_URL_SEARCH_PARAM_KEY: string = "open";
 
     /**
      * Set of IDP template Ids.
@@ -290,7 +290,7 @@ export class IdentityProviderManagementConstants {
     /**
      * Doc key for the IDP create page.
     **/
-    public static readonly IDP_TEMPLATES_CREATE_DOCS_KEY = `${
+    public static readonly IDP_TEMPLATES_CREATE_DOCS_KEY: string = `${
         DocumentationConstants.PORTAL_DOCS_KEY }["Identity Providers"]["Create New Identity Provider"]`;
 
     public static readonly IDENTITY_PROVIDER_TEMPLATE_FETCH_INVALID_STATUS_CODE_ERROR: string = "Received an " +
@@ -430,7 +430,7 @@ export class IdentityProviderManagementConstants {
     public static readonly MICROSOFT_AUTHENTICATOR_DISPLAY_NAME: string = "Microsoft";
 
     // Keys for the initial values of Email OTP Authenticator
-    public static readonly AUTHENTICATOR_INIT_VALUES_EMAIL_OTP_EXPIRY_TIME_KEY = "EmailOTP_ExpiryTime";
+    public static readonly AUTHENTICATOR_INIT_VALUES_EMAIL_OTP_EXPIRY_TIME_KEY: string = "EmailOTP_ExpiryTime";
 
     // Authenticator Endpoints
     public static readonly MICROSOFT_AUTHENTICATION_ENDPOINT_URL: string =
@@ -441,12 +441,12 @@ export class IdentityProviderManagementConstants {
     "https://login.microsoftonline.com/common/oauth2/v2.0/token";
 
     // Keys for the initial values of SMS OTP Authenticator
-    public static readonly AUTHENTICATOR_INIT_VALUES_SMS_OTP_EXPIRY_TIME_KEY = "SmsOTP_ExpiryTime";
+    public static readonly AUTHENTICATOR_INIT_VALUES_SMS_OTP_EXPIRY_TIME_KEY: string = "SmsOTP_ExpiryTime";
 
     /**
      * Identity provider create limit reached error.
     **/
-    public static readonly ERROR_CREATE_LIMIT_REACHED = new IdentityAppsError(
+    public static readonly ERROR_CREATE_LIMIT_REACHED: IdentityAppsError = new IdentityAppsError(
         "IDP-60035",
         "console:develop.features.idp.notifications.apiLimitReachedError.error.description",
         "console:develop.features.idp.notifications.apiLimitReachedError.error.message",
@@ -456,7 +456,7 @@ export class IdentityProviderManagementConstants {
     /**
      * AuthenticationProvider Connections create limit reached error.
     **/
-     public static readonly ERROR_CREATE_LIMIT_REACHED_IDP = new IdentityAppsError(
+     public static readonly ERROR_CREATE_LIMIT_REACHED_IDP: IdentityAppsError = new IdentityAppsError(
          "IDP-60035",
          "console:develop.features.authenticationProvider.notifications.apiLimitReachedError.error.description",
          "console:develop.features.authenticationProvider.notifications.apiLimitReachedError.error.message",
@@ -467,6 +467,7 @@ export class IdentityProviderManagementConstants {
 
      public static readonly ERROR_IN_CREATING_SMS_NOTIFICATION_SENDER: string = "An error occurred while adding SMS " +
             "Notification Sender";
+
      public static readonly ERROR_IN_DELETING_SMS_NOTIFICATION_SENDER: string = "An error occurred while deleting " +
             "SMS Notification Sender";
 }

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -464,4 +464,9 @@ export class IdentityProviderManagementConstants {
      )
 
      public static readonly SHOW_PREDEFINED_TEMPLATES_IN_EXPERT_MODE_SETUP: boolean = false;
+
+     public static readonly ERROR_IN_CREATING_SMS_NOTIFICATION_SENDER: string = "Failed to add SMS " +
+            "Notification Senders";
+     public static readonly ERROR_IN_DELETING_SMS_NOTIFICATION_SENDER: string = "Failed to delete SMS " +
+            "Notification Senders";
 }

--- a/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-management-constants.ts
@@ -465,8 +465,8 @@ export class IdentityProviderManagementConstants {
 
      public static readonly SHOW_PREDEFINED_TEMPLATES_IN_EXPERT_MODE_SETUP: boolean = false;
 
-     public static readonly ERROR_IN_CREATING_SMS_NOTIFICATION_SENDER: string = "Failed to add SMS " +
-            "Notification Senders";
-     public static readonly ERROR_IN_DELETING_SMS_NOTIFICATION_SENDER: string = "Failed to delete SMS " +
-            "Notification Senders";
+     public static readonly ERROR_IN_CREATING_SMS_NOTIFICATION_SENDER: string = "An error occurred while adding SMS " +
+            "Notification Sender";
+     public static readonly ERROR_IN_DELETING_SMS_NOTIFICATION_SENDER: string = "An error occurred while deleting " +
+            "SMS Notification Sender";
 }

--- a/apps/console/src/features/identity-providers/models/endpoints.ts
+++ b/apps/console/src/features/identity-providers/models/endpoints.ts
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the License); you may not use this file except
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -10,7 +10,7 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.

--- a/apps/console/src/features/identity-providers/models/endpoints.ts
+++ b/apps/console/src/features/identity-providers/models/endpoints.ts
@@ -25,4 +25,6 @@ export interface IDPResourceEndpointsInterface {
     identityProviders: string;
     localAuthenticators: string;
     multiFactorAuthenticators: string;
+    notificationSenders: string;
+
 }

--- a/apps/console/src/features/identity-providers/models/endpoints.ts
+++ b/apps/console/src/features/identity-providers/models/endpoints.ts
@@ -26,5 +26,4 @@ export interface IDPResourceEndpointsInterface {
     localAuthenticators: string;
     multiFactorAuthenticators: string;
     notificationSenders: string;
-
 }

--- a/apps/console/src/features/identity-providers/models/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/models/identity-provider.ts
@@ -302,6 +302,20 @@ export interface IdentityProviderTemplateCategoryViewConfigInterface {
 }
 
 /**
+ * Interface for SMS Notification Sender Details.
+ * **/
+export interface NotificationSenderSMSInterface {
+    name: string;
+    provider: string;
+    providerURL: string;
+    contentType: string;
+    properties?: {
+        key:string;
+        value:string;
+    }[];
+}
+
+/**
  * Enum for IDP template loading strategies.
  *
  * @readonly

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1377,6 +1377,31 @@ export interface ConsoleNS {
                                     range: string;
                                 };
                             };
+                            smsOtpEnableDisableToggle: {
+                                labelEnable: string;
+                                labelDisable: string;
+                            };
+                            enableRequiredNote: {
+                                messagePart1: string;
+                                messagePart2: string;
+                                messagePart3: string;
+                                linkToChoreoText: string;
+                                linkToGuideText: string;
+                            };
+                            errorNotifications: {
+                                notificationSendersRetrievalError: {
+                                    message: string;
+                                    description: string;
+                                };
+                                smsPublisherCreationError: {
+                                    message: string;
+                                    description: string;
+                                };
+                                smsPublisherDeletionError: {
+                                    message: string;
+                                    description: string;
+                                };
+                            }
                         }
                         facebook: {
                             callbackUrl: FormAttributes;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -3250,6 +3250,32 @@ export const console: ConsoleNS = {
                                     invalid: "Allowed OTP resend attempt count should be an integer.",
                                     range: "Allowed OTP resend attempt count should be between 0 & 100."
                                 }
+                            },
+                            smsOtpEnableDisableToggle: {
+                                labelEnable: "Enable SMS OTP",
+                                labelDisable: "Disable SMS OTP "
+                            },
+                            enableRequiredNote: {
+                                messagePart1: "Asgardeo publishes events to ",
+                                messagePart2: " to enable SMS OTP, where Choreo webhooks will be used to " +
+                                    "integrate with multiple services to publish OTP Notifications. Follow the ",
+                                messagePart3: " to configure Choreo webhooks for Asgardeo publish events.",
+                                linkToChoreoText: "Choreo",
+                                linkToGuideText: "Add SMS OTP Guide"
+                            },
+                            errorNotifications: {
+                                notificationSendersRetrievalError: {
+                                    message: "Error Occurred",
+                                    description: "Error occurred while trying to get SMS OTP configuration."
+                                },
+                                smsPublisherCreationError: {
+                                    message: "Error Occurred",
+                                    description: "Error occurred while trying to enable SMS OTP."
+                                },
+                                smsPublisherDeletionError: {
+                                    message: "Error Occurred",
+                                    description: "Error occurred while trying to disable SMS OTP."
+                                }
                             }
                         },
                         facebook: {


### PR DESCRIPTION
**Purpose**

This is to do the following UI modifications to SMS OTP UI. 

-  add a toggle to enable/disable SMS OTP.
-  Hide/Show the SMS OTP configuration edit form based on the SMS OTP enable/disable status.
-  Remove provider coming soon tab from the SMS OTP configurations window.
