### PR TITLE
Hide organization switch grant for tenants

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -36,7 +36,16 @@ import get from "lodash-es/get";
 import intersection from "lodash-es/intersection";
 import isEmpty from "lodash-es/isEmpty";
 import union from "lodash-es/union";
-import React, { Fragment, FunctionComponent, MouseEvent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
+import React, { 
+    Fragment, 
+    FunctionComponent, 
+    MouseEvent, 
+    MutableRefObject, 
+    ReactElement, 
+    useEffect, 
+    useRef, 
+    useState 
+} from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Button, Container, Divider, Form, Grid, Label, List } from "semantic-ui-react";
@@ -568,10 +577,10 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @returns a list of options for radio.
      */
     const getAllowedListForAccessToken = (metadataProp: MetadataPropertyInterface, isBinding?: boolean): any[] => {
-        const allowedList = [];
+        const allowedList: any[] = [];
 
         if (metadataProp) {
-            metadataProp.options.map((ele) => {
+            metadataProp.options.map((ele: string) => {
                 if ((ele === "Default") && !isBinding) {
                     allowedList.push({
                         hint: {
@@ -596,7 +605,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
             });
         }
 
-        return allowedList.sort((a, b) => {
+        return allowedList.sort((a: any, b: any) => {
             if (a.label < b.label) return -1;
             if (a.label > b.label) return 1;
 
@@ -754,7 +763,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
                     grant[ "index" ] = index ?? Infinity;
                 }
-                allowedList.sort(({ index: a }, { index: b }) => a - b);
+                allowedList.sort(({ index: a }: any, { index: b }: any) => a - b);
             }
         }
 
@@ -1983,7 +1992,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                     }
                                     type="checkbox"
                                     listen={ (values: Map<string, FormValue>): void => {
-                                        const encryptionEnabled: boolean = values.get("encryption").includes("enableEncryption");
+                                        const encryptionEnabled: boolean = values.get("encryption")
+                                            .includes("enableEncryption");
 
                                         if (!encryptionEnabled) {
                                             resolveInitialIDTokenEncryptionValues();

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -48,7 +48,7 @@ import React, {
 } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Button, Container, Divider, Form, Grid, Label, List } from "semantic-ui-react";
+import { Button, Container, Divider, DropdownProps, Form, Grid, Label, List } from "semantic-ui-react";
 import { applicationConfig } from "../../../../extensions";
 import { AppState, ConfigReducerStateInterface } from "../../../core";
 import { OrganizationType } from "../../../organizations/constants";
@@ -535,8 +535,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @param isLabel - Flag to determine if label.
      * @returns the list of options for radio & dropdown.
      */
-    const getAllowedList = (metadataProp: MetadataPropertyInterface, isLabel?: boolean): any[] => {
-        const allowedList: any[] = [];
+    const getAllowedList = (metadataProp: MetadataPropertyInterface, isLabel?: boolean): DropdownProps[] | number => {
+        const allowedList: DropdownProps[] = [];
 
         if (metadataProp) {
             if (isLabel) {

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -36,12 +36,13 @@ import get from "lodash-es/get";
 import intersection from "lodash-es/intersection";
 import isEmpty from "lodash-es/isEmpty";
 import union from "lodash-es/union";
-import React, { Fragment, FunctionComponent, MouseEvent, ReactElement, useEffect, useRef, useState } from "react";
+import React, { Fragment, FunctionComponent, MouseEvent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Button, Container, Divider, Form, Grid, Label, List } from "semantic-ui-react";
 import { applicationConfig } from "../../../../extensions";
 import { AppState, ConfigReducerStateInterface } from "../../../core";
+import { OrganizationType } from "../../../organizations/constants";
 import { getGeneralIcons } from "../../configs";
 import { ApplicationManagementConstants } from "../../constants";
 import CustomApplicationTemplate
@@ -152,6 +153,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
     const isClientSecretHashEnabled: boolean = useSelector((state: AppState) =>
         state.config.ui.isClientSecretHashEnabled);
+    const orgType: OrganizationType = useSelector((state: AppState) => 
+        state?.organization?.organizationType);    
 
     const [ isEncryptionEnabled, setEncryptionEnable ] = useState(false);
     const [ callBackUrls, setCallBackUrls ] = useState("");
@@ -184,29 +187,29 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     ] = useState<boolean>(false);
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
 
-    const clientSecret = useRef<HTMLElement>();
-    const grant = useRef<HTMLElement>();
-    const url = useRef<HTMLDivElement>();
-    const allowedOrigin = useRef<HTMLDivElement>();
-    const supportPublicClients = useRef<HTMLElement>();
-    const pkce = useRef<HTMLElement>();
-    const bindingType = useRef<HTMLElement>();
-    const type = useRef<HTMLElement>();
-    const validateTokenBinding = useRef<HTMLElement>();
-    const revokeAccessToken = useRef<HTMLElement>();
-    const userAccessTokenExpiryInSeconds = useRef<HTMLElement>();
-    const applicationAccessTokenExpiryInSeconds = useRef<HTMLElement>();
-    const refreshToken = useRef<HTMLElement>();
-    const expiryInSeconds = useRef<HTMLElement>();
-    const audience = useRef<HTMLElement>();
-    const encryption = useRef<HTMLElement>();
-    const algorithm = useRef<HTMLElement>();
-    const method = useRef<HTMLElement>();
-    const idExpiryInSeconds = useRef<HTMLElement>();
-    const backChannelLogoutUrl = useRef<HTMLElement>();
-    const frontChannelLogoutUrl = useRef<HTMLElement>();
-    const enableRequestObjectSignatureValidation = useRef<HTMLElement>();
-    const scopeValidator = useRef<HTMLElement>();
+    const clientSecret: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const grant: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const url: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
+    const allowedOrigin: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
+    const supportPublicClients: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const pkce: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const bindingType: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const type: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const validateTokenBinding: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const revokeAccessToken: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const userAccessTokenExpiryInSeconds: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const applicationAccessTokenExpiryInSeconds: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const refreshToken: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const expiryInSeconds: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const audience: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const encryption: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const algorithm: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const method: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const idExpiryInSeconds: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const backChannelLogoutUrl: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const frontChannelLogoutUrl: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const enableRequestObjectSignatureValidation: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const scopeValidator: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
     const [ isSPAApplication, setSPAApplication ] = useState<boolean>(false);
     const [ isOIDCWebApplication, setOIDCWebApplication ] = useState<boolean>(false);
     const [ isMobileApplication, setMobileApplication ] = useState<boolean>(false);
@@ -250,9 +253,9 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * If you inspect the relevant field you will see that those value should
      * be the same when we are passing it down to the component.
      */
-    const PKCE_KEY = "PKCE";
-    const ENABLE_PKCE_CHECKBOX_VALUE = "mandatory";
-    const SUPPORT_PKCE_PLAIN_ALGORITHM_VALUE = "supportPlainTransformAlgorithm";
+    const PKCE_KEY: string = "PKCE";
+    const ENABLE_PKCE_CHECKBOX_VALUE: string = "mandatory";
+    const SUPPORT_PKCE_PLAIN_ALGORITHM_VALUE: string = "supportPlainTransformAlgorithm";
 
     /**
      * The listener handler for the enable PKCE toggle form field. This function
@@ -374,7 +377,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         }
     }, [ selectedGrantTypes, isGrantChanged ]);
 
-    const isHideRefreshTokenGrantType = (selectedGrantTypes): boolean => {
+    const isHideRefreshTokenGrantType = (selectedGrantTypes: string[]): boolean => {
         if (selectedGrantTypes?.length === 0 || (selectedGrantTypes?.includes("implicit")
             && selectedGrantTypes?.length === 1)) {
             return true;
@@ -467,7 +470,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         let grants: string[] = values.get("grant") as string[];
 
         if (isHideRefreshTokenGrantType(selectedGrantTypes)) {
-            grants = grants.filter(grant => grant != "refresh_token");
+            grants = grants.filter((grant: string) => grant != "refresh_token");
         }
         setSelectedGrantTypes(grants);
         setGrantChanged(!isGrantChanged);
@@ -524,11 +527,11 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @returns the list of options for radio & dropdown.
      */
     const getAllowedList = (metadataProp: MetadataPropertyInterface, isLabel?: boolean): any[] => {
-        const allowedList = [];
+        const allowedList: any[] = [];
 
         if (metadataProp) {
             if (isLabel) {
-                metadataProp.options.map((ele) => {
+                metadataProp.options.map((ele: string) => {
                     allowedList.push({
                         hint: {
                             content: getMetadataHints(ele)
@@ -538,7 +541,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                     });
                 });
             } else {
-                metadataProp.options.map((ele) => {
+                metadataProp.options.map((ele: string) => {
                     allowedList.push({ text: ele, value: ele });
                 });
             }
@@ -546,7 +549,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         if (isLabel) {
             // if the list related to a label then sort the values in
             // alphabetical order using a ascending comparator.
-            return allowedList.sort((a, b) => {
+            return allowedList.sort((a: any, b: any) => {
                 if (a.label < b.label) return -1;
                 if (a.label > b.label) return 1;
 
@@ -667,7 +670,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      */
     const getAllowedGranTypeList = (metadataProp: GrantTypeMetaDataInterface): any[] => {
 
-        const allowedList = [];
+        const allowedList: any[] = [];
 
         if (metadataProp) {
             metadataProp.options.map(({ name, displayName }: GrantTypeInterface) => {
@@ -680,7 +683,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
                 // Hides the organization switch grant type if the organization management feature disabled.
                 if (name === ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT
-                    && !isOrganizationManagementEnabled) {
+                    && (!isOrganizationManagementEnabled || orgType === OrganizationType.TENANT)) {
                     return;
                 }
 
@@ -710,7 +713,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                  * If there's no description provided in {@link getGrantTypeHintDescription}
                  * then we will not attach any hint popups.
                  */
-                const description = getGrantTypeHintDescription(name);
+                const description: string = getGrantTypeHintDescription(name);
 
                 if (description) {
                     grant.hint = {
@@ -747,7 +750,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
             if (arrangement && arrangement.size === allowedList.length) {
                 for (const grant of allowedList) {
-                    const index = arrangement.get(grant.value);
+                    const index: number = arrangement.get(grant.value);
 
                     grant[ "index" ] = index ?? Infinity;
                 }
@@ -758,9 +761,9 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         // Remove disabled grant types from the sorted list.
         if (applicationConfig.inboundOIDCForm.disabledGrantTypes
             && applicationConfig.inboundOIDCForm.disabledGrantTypes[template.id]) {
-            const disabledGrantTypes = applicationConfig.inboundOIDCForm.disabledGrantTypes[template.id];
+            const disabledGrantTypes: string[] = applicationConfig.inboundOIDCForm.disabledGrantTypes[template.id];
 
-            return allowedList.filter((grant) => !disabledGrantTypes.includes(grant.value));
+            return allowedList.filter((grant: any) => !disabledGrantTypes.includes(grant.value));
         }
 
         return allowedList;
@@ -773,7 +776,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @returns a list of PKCE options.
      */
     const findPKCE = (pckeConfig: OAuth2PKCEConfigurationInterface): string[] => {
-        const selectedValues = [];
+        const selectedValues: string[] = [];
 
         if (pckeConfig.mandatory) {
             selectedValues.push(ENABLE_PKCE_CHECKBOX_VALUE);
@@ -1045,7 +1048,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @param url - Allowed origin.
      */
     const handleAllowOrigin = (url: string): void => {
-        let allowedURLs = allowedOrigins;
+        let allowedURLs: string = allowedOrigins;
 
         if (allowedURLs !== "") {
             allowedURLs = allowedURLs + "," + url;
@@ -1175,7 +1178,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
      * @param value - expiry time as a string.
      */
     const isValidExpiryTime = (value: string) => {
-        const numberValue = Math.floor(Number(value.toString()));
+        const numberValue: number = Math.floor(Number(value.toString()));
 
         return (numberValue !== Infinity && String(numberValue) === value && numberValue > 0);
     };
@@ -1205,7 +1208,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                         value={ selectedGrantTypes ?? initialValues?.grantTypes }
                         readOnly={ readOnly }
                         enableReinitialize={ true }
-                        listen={ (values) => handleGrantTypeChange(values) }
+                        listen={ (values: Map<string, FormValue>) => handleGrantTypeChange(values) }
                         data-testid={ `${ testId }-grant-type-checkbox-group` }
                     />
                     {
@@ -1385,7 +1388,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                             <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 } className="field">
                                 <div ref={ allowedOrigin } />
                                 <URLInput
-                                    handleAddAllowedOrigin={ (url) => handleAllowOrigin(url) }
+                                    handleAddAllowedOrigin={ (url: string) => handleAllowOrigin(url) }
                                     urlState={ allowedOrigins }
                                     setURLState={ setAllowedOrigins }
                                     onlyOrigin={ true }
@@ -1575,7 +1578,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                         children={ getAllowedListForAccessToken(metadata.accessTokenBindingType, true) }
                         readOnly={ readOnly }
                         data-testid={ `${ testId }-access-token-type-radio-group` }
-                        listen={ (values) => {
+                        listen={ (values: Map<string, FormValue>) => {
                             setIsTokenBindingTypeSelected(
                                 values.get("bindingType") !== SupportedAccessTokenBindingTypes.NONE
                             );
@@ -1980,7 +1983,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                     }
                                     type="checkbox"
                                     listen={ (values: Map<string, FormValue>): void => {
-                                        const encryptionEnabled = values.get("encryption").includes("enableEncryption");
+                                        const encryptionEnabled: boolean = values.get("encryption").includes("enableEncryption");
 
                                         if (!encryptionEnabled) {
                                             resolveInitialIDTokenEncryptionValues();
@@ -2723,7 +2726,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                     setShowURLError(true);
                     scrollToInValidField("url");
                 } else {
-                    submitOrigin((origin) => {
+                    submitOrigin((origin: string) => {
 
                         isExpiryTimesTooLowModalShown = isExpiryTimesTooLow(values, url, origin);
 
@@ -2759,8 +2762,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 <Forms
                     onSubmit={ handleFormSubmit }
                     onSubmitError={ (requiredFields: Map<string, boolean>, validFields: Map<string, Validation>) => {
-                        const iterator = requiredFields.entries();
-                        let result = iterator.next();
+                        const iterator: IterableIterator<[string, boolean]> = requiredFields.entries();
+                        let result: any = iterator.next();
 
                         while (!result.done) {
                             if (!result.value[ 1 ] || !validFields.get(result.value[ 0 ]).isValid) {


### PR DESCRIPTION
### Purpose
> This PR introduces the fix to hide the organization switch grant under allowed grant types in the application edit section for the tenants.

![image](https://user-images.githubusercontent.com/30111554/208829057-cf56a0d3-2d29-4991-a368-c08edc221971.png)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
