### PR TITLE
Fix being redirected to 404 page when switching between tenants

### DIFF
--- a/apps/console/src/features/core/utils/app-utils.ts
+++ b/apps/console/src/features/core/utils/app-utils.ts
@@ -129,11 +129,11 @@ export class AppUtils {
     }
 
     /**
-     * Check if the auth callback URL belongs to another tenant or organization.
+     * Check if the auth callback URL belongs to another tenant.
      *
      * @param authCallbackURL - The auth callback URL.
      *
-     * @returns If the auth callback URL belongs to another tenant or organization.
+     * @returns If the auth callback URL belongs to another tenant.
      */
     public static isAuthCallbackURLFromAnotherTenant(authCallbackURL: string): boolean {
         const tenantDomain: string = store.getState().config.deployment.tenant;

--- a/apps/console/src/features/core/utils/app-utils.ts
+++ b/apps/console/src/features/core/utils/app-utils.ts
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -33,7 +33,6 @@ export class AppUtils {
      * Private constructor to avoid object instantiation from outside
      * the class.
      *
-     * @hideconstructor
      */
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     private constructor() { }
@@ -41,7 +40,7 @@ export class AppUtils {
     /**
      * Get the logged in user's preferences.
      *
-     * @return {StorageIdentityAppsSettingsInterface}
+     * @returns - User preferences.
      */
     public static getUserPreferences(): StorageIdentityAppsSettingsInterface {
         const tenantName: string = store.getState().config.deployment.tenant;
@@ -51,8 +50,8 @@ export class AppUtils {
             return;
         }
 
-        let preferences = {};
-        
+        let preferences: Record<string, StorageIdentityAppsSettingsInterface> = {};
+
         try {
             preferences = JSON.parse(LocalStorageUtils.getValueFromLocalStorage(tenantName));
         } catch (e) {
@@ -64,7 +63,7 @@ export class AppUtils {
 
     /**
      * Sets the user preferences in the local storage.
-     * @param {StorageIdentityAppsSettingsInterface} preferences
+     * @param preferences - User preferences.
      */
     public static setUserPreferences(preferences: StorageIdentityAppsSettingsInterface): void {
         const tenantName: string = store.getState().config.deployment.tenant;
@@ -83,7 +82,7 @@ export class AppUtils {
     /**
      * Get the consensually hidden routes.
      *
-     * @return {string[]}
+     * @returns Hidden routes.
      */
     public static getHiddenRoutes(): string[] {
 
@@ -103,7 +102,7 @@ export class AppUtils {
     /**
      * Set a consensually hidden route.
      *
-     * @param {string} routeId - Route ID.
+     * @param routeId - Route ID.
      */
     public static setHiddenRoute(routeId: string): void {
         const userPreferences: StorageIdentityAppsSettingsInterface = AppUtils.getUserPreferences();
@@ -112,7 +111,7 @@ export class AppUtils {
             return;
         }
 
-        const hiddenRoutes = this.getHiddenRoutes();
+        const hiddenRoutes: string[] = this.getHiddenRoutes();
 
         const newPref: StorageIdentityAppsSettingsInterface = cloneDeep(userPreferences);
 
@@ -127,5 +126,26 @@ export class AppUtils {
     public static onChunkLoadError(): void {
 
         dispatchEvent(new Event(AppConstants.CHUNK_LOAD_ERROR_EVENT));
+    }
+
+    /**
+     * Check if the auth callback URL belongs to another tenant or organization.
+     *
+     * @param authCallbackURL - The auth callback URL.
+     *
+     * @returns If the auth callback URL belongs to another tenant or organization.
+     */
+    public static isAuthCallbackURLFromAnotherTenant(authCallbackURL: string): boolean {
+        const tenantDomain: string = store.getState().config.deployment.tenant;
+        const tenantRegex: RegExp = new RegExp("/t/(.+)/");
+        const matches: RegExpExecArray = tenantRegex.exec(authCallbackURL);
+
+        const tenantFromURL: string = matches?.[ 1 ];
+
+        if (tenantFromURL === tenantDomain || !tenantFromURL) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/apps/console/src/features/core/utils/app-utils.ts
+++ b/apps/console/src/features/core/utils/app-utils.ts
@@ -137,12 +137,13 @@ export class AppUtils {
      */
     public static isAuthCallbackURLFromAnotherTenant(authCallbackURL: string): boolean {
         const tenantDomain: string = store.getState().config.deployment.tenant;
-        const tenantRegex: RegExp = new RegExp("/t/(.+)/");
+        const tenantName: string = window["AppUtils"].getConfig().superTenant === tenantDomain ? "" : tenantDomain;
+        const tenantRegex: RegExp = new RegExp("t/([^/]+)/");
         const matches: RegExpExecArray = tenantRegex.exec(authCallbackURL);
 
-        const tenantFromURL: string = matches?.[ 1 ];
+        const tenantFromURL: string = matches?.[ 1 ] ?? "";
 
-        if (tenantFromURL === tenantDomain || !tenantFromURL) {
+        if (tenantFromURL === tenantName) {
             return false;
         }
 

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -557,7 +557,8 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                                     AuthenticationCallbackUrl ===
                                     `${ window[ "AppUtils" ].getConfig()
                                         .appBaseWithTenant
-                                    }/`)
+                                    }/`) ||
+                                AppUtils.isAuthCallbackURLFromAnotherTenant(AuthenticationCallbackUrl)
                                 ? AppConstants.getAppHomePath()
                                 : AuthenticationCallbackUrl;
 
@@ -582,7 +583,8 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                     AuthenticationCallbackUrl === AppConstants.getAppLoginPath() ||
                     (window[ "AppUtils" ].getConfig().organizationName &&
                         AuthenticationCallbackUrl ===
-                        `${ window[ "AppUtils" ].getConfig().appBaseWithTenant }/`)
+                        `${ window[ "AppUtils" ].getConfig().appBaseWithTenant }/`) ||
+                    AppUtils.isAuthCallbackURLFromAnotherTenant(AuthenticationCallbackUrl)
                     ? AppConstants.getAppHomePath()
                     : AuthenticationCallbackUrl;
 


### PR DESCRIPTION
### Purpose
> This PR introduces a method to check if the auth callback URL belongs to a different tenant and if so, redirects the user to the home path.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
