### PR TITLE
Restrict SMS OTP being added as the first step

### DIFF
--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -342,7 +342,9 @@ export class ApplicationManagementConstants {
         IdentityProviderManagementConstants.TOTP_AUTHENTICATOR,
         IdentityProviderManagementConstants.TOTP_AUTHENTICATOR_ID,
         IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR,
-        IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID
+        IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID,
+        IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR,
+        IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID
     ];
 
     // Known social authenticators.


### PR DESCRIPTION
### Purpose
SMS OTP authenticator should only be allowed to add to the second or higher step in the login flow. This fix is to define it as a second factor authenticator so that it cannot be added to the first step.

### Related Issues
- https://github.com/wso2/product-is/issues/15335

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
