### PR TITLE
Fix issues with form reset in the password validation form

### DIFF
--- a/apps/console/src/features/validation/pages/validation-config-edit.tsx
+++ b/apps/console/src/features/validation/pages/validation-config-edit.tsx
@@ -87,7 +87,6 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
         undefined
     );
     const [ isLoading, setIsLoading ] = useState<boolean>(true);
-    const [ resetForm, setResetForm ] = useState<number>(0);
 
     const [ passwordHistoryEnabled, setPasswordHistoryEnabled ] = useState<
         boolean
@@ -349,7 +348,6 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
             .then(() => {
                 mutateValidationConfigFetchRequest();
                 mutatePasswordHistoryCount();
-                setResetForm((state: number) => state + 1);
                 dispatch(
                     addAlert({
                         description: t(
@@ -449,7 +447,6 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
                                                 )
                                             }
                                             enableReInitialize={ true }
-                                            key={ resetForm }
                                         >
                                             { isRuleType && (
                                                 <div className="validation-configurations-form">


### PR DESCRIPTION
### Purpose
> Fix the issue of the initial value being briefly shown during form update in the password validation form.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
