### PR TITLE
Improve application edit tab extensions

### DIFF
--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -738,6 +738,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
      */
     const resolveTabPanes = (): ResourceTabPaneInterface[] => {
         const panes: ResourceTabPaneInterface[] = [];
+        const extensionPanes: ResourceTabPaneInterface[] = [];
 
         if (!tabPaneExtensions && applicationConfig.editApplication.extendTabs
             && application?.templateId !== ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
@@ -751,7 +752,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
             && application?.templateId !== ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
             && application?.templateId !== ApplicationManagementConstants.CUSTOM_APPLICATION_PASSIVE_STS
             && application?.templateId !== ApplicationManagementConstants.CUSTOM_APPLICATION_SAML) {
-            panes.push(...tabPaneExtensions);
+            extensionPanes.push(...tabPaneExtensions);
         }
 
         if (featureConfig) {
@@ -886,6 +887,12 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                      render: InfoTabPane
                  });
             }
+
+            extensionPanes.forEach(
+                (extensionPane: ResourceTabPaneInterface) => {
+                    panes.splice(extensionPane.index, 0, extensionPane);
+                }
+            );
 
             return panes;
         }

--- a/modules/react-components/src/components/tab/resource-tab/resource-tab.tsx
+++ b/modules/react-components/src/components/tab/resource-tab/resource-tab.tsx
@@ -43,6 +43,7 @@ export interface ResourceTabPaneInterface {
     render?: () => React.ReactNode
     "data-tabid"?: string
     componentId?: string
+    index?: number
 }
 
 /**


### PR DESCRIPTION
### Purpose
> In current tab extensions, we can only add the tab extensions at the start. This change will support adding extended tabs in a given index