### PR TITLE
Fix notification alerts in Edit SMS OTP connection page.

### DIFF
--- a/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
+++ b/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
@@ -131,14 +131,16 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
     const handleAuthenticatorConfigFormSubmit = (values: MultiFactorAuthenticatorInterface): void => {
         setIsSubmitting(true);
 
+        const i18nKeyForMFAuthenticator: string = getI18nKeyForMultiFactorAuthenticator(authenticator);
+
         updateMultiFactorAuthenticatorDetails(authenticator.id, values)
             .then(() => {
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider" +
-                        ".notifications.updateEmailOTPAuthenticator.success.description"),
+                        ".notifications." + i18nKeyForMFAuthenticator + ".success.description"),
                     level: AlertLevels.SUCCESS,
                     message: t("console:develop.features.authenticationProvider.notifications." +
-                        "updateEmailOTPAuthenticator.success.message")
+                        i18nKeyForMFAuthenticator + ".success.message")
                 }));
 
                 onUpdate(authenticator.id);
@@ -147,28 +149,39 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(addAlert({
                         description: t("console:develop.features.authenticationProvider" +
-                            ".notifications.updateEmailOTPAuthenticator.error.description",
+                            ".notifications." + i18nKeyForMFAuthenticator + ".error.description",
                         { description: error.response.data.description }),
                         level: AlertLevels.ERROR,
                         message: t("console:develop.features.authenticationProvider" +
-                            ".notifications.updateEmailOTPAuthenticator.error.message")
+                            ".notifications." + i18nKeyForMFAuthenticator + ".error.message")
                     }));
 
                     return;
                 }
 
                 dispatch(addAlert({
-                    description: t("console:develop.features.authenticationProvider.notifications" +
-                        ".updateEmailOTPAuthenticator.genericError.description"),
+                    description: t("console:develop.features.authenticationProvider.notifications." +
+                        i18nKeyForMFAuthenticator + ".genericError.description"),
                     level: AlertLevels.ERROR,
-                    message: t("console:develop.features.authenticationProvider.notifications" +
-                        ".updateEmailOTPAuthenticator.genericError.message")
+                    message: t("console:develop.features.authenticationProvider.notifications." +
+                        i18nKeyForMFAuthenticator + ".genericError.message")
                 }));
             })
             .finally(() => {
                 setIsSubmitting(false);
             });
     };
+
+    const getI18nKeyForMultiFactorAuthenticator =
+        (authenticator: MultiFactorAuthenticatorInterface | AuthenticatorInterface) => {
+            if(authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID){
+                return "updateSMSOTPAuthenticator";
+            } else if (authenticator.id === IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID){
+                return "updateEmailOTPAuthenticator";
+            } else {
+                return "updateGenericAuthenticator";
+            }
+        };
 
     /**
      * Authenticator settings tab content.

--- a/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
+++ b/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
@@ -176,7 +176,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
         (authenticator: MultiFactorAuthenticatorInterface | AuthenticatorInterface) => {
             if (authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID) {
                 return "updateSMSOTPAuthenticator";
-            } else if (authenticator.id === IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID){
+            } else if (authenticator.id === IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID) {
                 return "updateEmailOTPAuthenticator";
             } else {
                 return "updateGenericAuthenticator";

--- a/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
+++ b/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
@@ -131,16 +131,16 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
     const handleAuthenticatorConfigFormSubmit = (values: MultiFactorAuthenticatorInterface): void => {
         setIsSubmitting(true);
 
-        const i18nKeyForMFAuthenticator: string = getI18nKeyForMultiFactorAuthenticator(authenticator);
+        const i18nKeyForMFAAuthenticator: string = getI18nKeyForMultiFactorAuthenticator(authenticator);
 
         updateMultiFactorAuthenticatorDetails(authenticator.id, values)
             .then(() => {
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider" +
-                        ".notifications." + i18nKeyForMFAuthenticator + ".success.description"),
+                        ".notifications." + i18nKeyForMFAAuthenticator + ".success.description"),
                     level: AlertLevels.SUCCESS,
                     message: t("console:develop.features.authenticationProvider.notifications." +
-                        i18nKeyForMFAuthenticator + ".success.message")
+                        i18nKeyForMFAAuthenticator + ".success.message")
                 }));
 
                 onUpdate(authenticator.id);
@@ -149,11 +149,11 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(addAlert({
                         description: t("console:develop.features.authenticationProvider" +
-                            ".notifications." + i18nKeyForMFAuthenticator + ".error.description",
+                            ".notifications." + i18nKeyForMFAAuthenticator + ".error.description",
                         { description: error.response.data.description }),
                         level: AlertLevels.ERROR,
                         message: t("console:develop.features.authenticationProvider" +
-                            ".notifications." + i18nKeyForMFAuthenticator + ".error.message")
+                            ".notifications." + i18nKeyForMFAAuthenticator + ".error.message")
                     }));
 
                     return;
@@ -161,10 +161,10 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
 
                 dispatch(addAlert({
                     description: t("console:develop.features.authenticationProvider.notifications." +
-                        i18nKeyForMFAuthenticator + ".genericError.description"),
+                        i18nKeyForMFAAuthenticator + ".genericError.description"),
                     level: AlertLevels.ERROR,
                     message: t("console:develop.features.authenticationProvider.notifications." +
-                        i18nKeyForMFAuthenticator + ".genericError.message")
+                        i18nKeyForMFAAuthenticator + ".genericError.message")
                 }));
             })
             .finally(() => {
@@ -174,7 +174,7 @@ export const EditMultiFactorAuthenticator: FunctionComponent<EditMultiFactorAuth
 
     const getI18nKeyForMultiFactorAuthenticator =
         (authenticator: MultiFactorAuthenticatorInterface | AuthenticatorInterface) => {
-            if(authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID){
+            if (authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID) {
                 return "updateSMSOTPAuthenticator";
             } else if (authenticator.id === IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID){
                 return "updateEmailOTPAuthenticator";

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1808,6 +1808,8 @@ export interface ConsoleNS {
                     updateFederatedAuthenticator: Notification;
                     updateFederatedAuthenticators: Notification;
                     updateEmailOTPAuthenticator: Notification;
+                    updateSMSOTPAuthenticator: Notification;
+                    updateGenericAuthenticator: Notification;
                     updateIDP: Notification;
                     updateIDPCertificate: Notification;
                     updateIDPRoleMappings: Notification;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -4126,6 +4126,34 @@ export const console: ConsoleNS = {
                             message: "Update successful"
                         }
                     },
+                    updateSMSOTPAuthenticator: {
+                        error: {
+                            description: "{{ description }}",
+                            message: "Update error"
+                        },
+                        genericError: {
+                            description: "An error occurred while updating the SMS OTP connector.",
+                            message: "Update error"
+                        },
+                        success: {
+                            description: "Successfully updated the SMS OTP connector.",
+                            message: "Update successful"
+                        }
+                    },
+                    updateGenericAuthenticator: {
+                        error: {
+                            description: "{{ description }}",
+                            message: "Update error"
+                        },
+                        genericError: {
+                            description: "An error occurred while updating the connector.",
+                            message: "Update error"
+                        },
+                        success: {
+                            description: "Successfully updated the connector.",
+                            message: "Update successful"
+                        }
+                    },
                     updateFederatedAuthenticator: {
                         error: {
                             description: "{{ description }}",


### PR DESCRIPTION
### Purpose
> Fixes the issue where notification alerts in the edit SMS OTP connection page are displayed as email OTP alerts.

![unnamed](https://user-images.githubusercontent.com/27700915/215867550-44fd0f3e-27f8-4c09-bf2f-ceeb66b3fe9c.png)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
