### PR TITLE
Hide requested OIDC scopes from the UI

### DIFF
--- a/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
+++ b/apps/authentication-portal/src/main/webapp/oauth2_consent.jsp
@@ -29,6 +29,7 @@
 <%@ page import="org.wso2.carbon.identity.oauth.IdentityOAuthAdminException" %>
 <%@ page import="org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl" %>
 <%@ page import="java.io.File" %>
+<%@ page import="java.net.URLDecoder" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
@@ -76,11 +77,18 @@
     boolean userClaimsConsentOnly = Boolean.parseBoolean(request.getParameter(Constants.USER_CLAIMS_CONSENT_ONLY));
 
     List<String> openIdScopes = null;
+    String requestedOIDCScopeString = URLDecoder.decode(queryParamMap.get("requested_oidc_scopes"), "UTF-8");
+    
     if (!userClaimsConsentOnly && displayScopes && StringUtils.isNotBlank(scopeString)) {
-            // Remove "openid" from the scope list to display.
-           openIdScopes = Stream.of(scopeString.split(" "))
-                    .filter(x -> !StringUtils.equalsIgnoreCase(x, "openid"))
-                    .collect(Collectors.toList());
+        if (StringUtils.isNotBlank(requestedOIDCScopeString)) {
+            // Remove oidc scopes from the scope list to display.
+            Set<String> requestedOIDCScopes = Set.of(requestedOIDCScopeString.split(" "));
+            openIdScopes = Stream.of(scopeString.split(" "))
+                .filter(x -> !requestedOIDCScopes.contains(x.toLowerCase()))
+                .collect(Collectors.toList());
+        } else {
+            openIdScopes = Stream.of(scopeString.split(" ")).collect(Collectors.toList());
+        }
     }
 %>
 


### PR DESCRIPTION
### Purpose
> Since OIDC scopes are only for claim request it shouldn't be shown under permissions. Therefore, this PR will hide OIDC scopes from the UI.

### Related Issues
- https://github.com/wso2/product-is/issues/15200

### Related PRs
This modification is approved in the following PR and got merged before merging the related backend fix. Therefore, it got reverted back.
- https://github.com/wso2/identity-apps/pull/3714

Please merge this PR after after merging the following PR which is for bumping identity-inbound-auth-oauth version that has the related backend fix.
- https://github.com/wso2/product-is/pull/15468

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
