### PR TITLE
Disable share application button when there are no sub organizations created

### DIFF
--- a/apps/console/src/features/applications/components/modals/application-share-modal.tsx
+++ b/apps/console/src/features/applications/components/modals/application-share-modal.tsx
@@ -563,7 +563,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                     { t("common:cancel") }
                 </LinkButton>
                 <PrimaryButton
-                    disabled={ !checkedUnassignedListItems }
+                    disabled={ !checkedUnassignedListItems || (shareType === ShareType.SHARE_SELECTED && !subOrganizationList) }
                     onClick={ () => {
                         handleShareApplication();
                     } }

--- a/apps/console/src/features/applications/components/modals/application-share-modal.tsx
+++ b/apps/console/src/features/applications/components/modals/application-share-modal.tsx
@@ -29,10 +29,12 @@ import {
     TransferList,
     TransferListItem
 } from "@wso2is/react-components";
+import { AxiosError } from "axios";
 import differenceBy from "lodash-es/differenceBy";
 import escapeRegExp from "lodash-es/escapeRegExp";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
+    FormEvent,
     FunctionComponent,
     useCallback,
     useEffect,
@@ -40,6 +42,7 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { Dispatch } from "redux";
 import {
     Divider,
     Modal,
@@ -55,6 +58,7 @@ import {
 } from "../../../organizations/api";
 import {
     OrganizationInterface,
+    OrganizationResponseInterface,
     ShareApplicationRequestInterface
 } from "../../../organizations/models";
 import { ShareWithOrgStatus } from "../../constants";
@@ -109,10 +113,10 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
         ...rest
     } = props;
 
-    const dispatch = useDispatch();
+    const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
 
-    const currentOrganization = useSelector(
+    const currentOrganization: OrganizationResponseInterface = useSelector(
         (state: AppState) => state.organization.organization
     );
 
@@ -149,7 +153,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
         [ sharedOrganizationList ]
     );
 
-    const handleShareApplication = useCallback(async () => {
+    const handleShareApplication: () => Promise<void> = useCallback(async () => {
         let shareAppData: ShareApplicationRequestInterface;
         let removedOrganization: OrganizationInterface[];
 
@@ -161,7 +165,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
             let addedOrganizations: string[];
 
             if (isSharedWithAll === ShareWithOrgStatus.TRUE) {
-                addedOrganizations = checkedUnassignedListItems.map((org) => org.id);
+                addedOrganizations = checkedUnassignedListItems.map((org: OrganizationInterface) => org.id);
 
                 await unshareApplication(applicationId, currentOrganization.id);
 
@@ -170,7 +174,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                     checkedUnassignedListItems,
                     sharedOrganizationList,
                     "id"
-                ).map(organization => organization.id);
+                ).map((organization: OrganizationInterface) => organization.id);
 
                 removedOrganization = differenceBy(
                     sharedOrganizationList,
@@ -191,7 +195,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                 applicationId,
                 shareAppData
             )
-                .then(_response => {
+                .then(() => {
                     onClose(null, null);
                     dispatch(
                         addAlert({
@@ -210,7 +214,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                         "client-id": clientId
                     });
                 })
-                .catch(error => {
+                .catch((error: AxiosError) => {
                     onClose(null, null);
                     if (error.response.data.message) {
                         dispatch(
@@ -244,13 +248,13 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                 })
                 .finally(() => onApplicationSharingCompleted());
 
-            removedOrganization?.forEach(removedOrganization => {
+            removedOrganization?.forEach((removedOrganization: OrganizationInterface) => {
                 stopSharingApplication(
                     currentOrganization.id,
                     applicationId,
                     removedOrganization.id
                 )
-                    .then(_response => {
+                    .then(() => {
                         onClose(null, null);
                         dispatch(
                             addAlert({
@@ -270,7 +274,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                             "client-id": clientId
                         });
                     })
-                    .catch(error => {
+                    .catch((error: AxiosError) => {
                         onClose(null, null);
                         if (error.response.data.message) {
                             dispatch(
@@ -328,7 +332,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                         "client-id": clientId
                     });
                 })
-                .catch(error => {
+                .catch((error: AxiosError) => {
                     onClose(null, null);
                     if (error.response.data.message) {
                         dispatch(
@@ -373,15 +377,15 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
         shareType
     ]);
 
-    const handleUnselectedListSearch = (e, { value }) => {
-        let isMatch = false;
-        const filteredOrganizationList = [];
+    const handleUnselectedListSearch = (e: FormEvent<HTMLInputElement>, { value }: { value: string }) => {
+        let isMatch: boolean = false;
+        const filteredOrganizationList: OrganizationInterface[] = [];
 
         if (!isEmpty(value)) {
-            const re = new RegExp(escapeRegExp(value), "i");
+            const re: RegExp = new RegExp(escapeRegExp(value), "i");
 
             subOrganizationList &&
-                subOrganizationList.map(organization => {
+                subOrganizationList.map((organization: OrganizationInterface) => {
                     isMatch = re.test(organization.name);
                     if (isMatch) {
                         filteredOrganizationList.push(organization);
@@ -394,10 +398,10 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
         }
     };
 
-    const handleUnassignedItemCheckboxChange = organization => {
-        const checkedOrganizations = [ ...checkedUnassignedListItems ];
-        const index = checkedOrganizations.findIndex(
-            org => org.id === organization.id
+    const handleUnassignedItemCheckboxChange = (organization: OrganizationInterface) => {
+        const checkedOrganizations: OrganizationInterface[] = [ ...checkedUnassignedListItems ];
+        const index: number = checkedOrganizations.findIndex(
+            (org: OrganizationInterface) => org.id === organization.id
         );
 
         if (index !== -1) {
@@ -409,7 +413,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
         }
     };
 
-    const handleHeaderCheckboxChange = useCallback(() => {
+    const handleHeaderCheckboxChange: () => void = useCallback(() => {
         if (checkedUnassignedListItems.length === subOrganizationList.length) {
             setCheckedUnassignedListItems([]);
 
@@ -494,12 +498,12 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                             ) }
                         >
                             { tempOrganizationList?.map(
-                                (organization, index) => {
-                                    const organizationName =
+                                (organization: OrganizationInterface, index: number) => {
+                                    const organizationName: string =
                                             organization?.name;
-                                    const isChecked =
+                                    const isChecked: boolean =
                                             checkedUnassignedListItems.findIndex(
-                                                org =>
+                                                (org: OrganizationInterface) =>
                                                     org.id === organization.id
                                             ) !== -1;
 
@@ -563,7 +567,10 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                     { t("common:cancel") }
                 </LinkButton>
                 <PrimaryButton
-                    disabled={ !checkedUnassignedListItems || (shareType === ShareType.SHARE_SELECTED && !subOrganizationList) }
+                    disabled={ 
+                        !checkedUnassignedListItems || 
+                        (shareType === ShareType.SHARE_SELECTED && !subOrganizationList) 
+                    }
                     onClick={ () => {
                         handleShareApplication();
                     } }


### PR DESCRIPTION
### Purpose
> This PR hides the application share button in the application edit section when there are no sub-organizations created.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
