### PR TITLE
Prevent deletion and updating permission of "Administrator" role in sub organizations

### DIFF
--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
@@ -23,6 +23,7 @@ import { ConfirmationModal, DangerZone, DangerZoneGroup, EmphasizedSegment } fro
 import React, { ChangeEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { Dispatch } from "redux";
 import { Button, Divider, Form, Grid, InputOnChangeData } from "semantic-ui-react";
 import { AppConstants, AppState, SharedUserStoreUtils, history } from "../../../core";
 import { PRIMARY_USERSTORE_PROPERTY_VALUES } from "../../../userstores";
@@ -31,6 +32,7 @@ import { OrganizationRoleManagementConstants } from "../../constants";
 import {
     OrganizationResponseInterface,
     OrganizationRoleInterface,
+    OrganizationRoleListResponseInterface,
     PatchOrganizationRoleDataInterface
 } from "../../models";
 
@@ -67,7 +69,7 @@ interface BasicRoleProps extends TestableComponentInterface {
  */
 export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: BasicRoleProps): ReactElement => {
     const { t } = useTranslation();
-    const dispatch = useDispatch();
+    const dispatch: Dispatch = useDispatch();
 
     const {
         roleId,
@@ -103,7 +105,7 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
             return;
         }
         fetchUserstoreRegEx()
-            .then((response) => {
+            .then((response: string) => {
                 setUserStoreRegEx(response);
                 setRegExLoading(false);
             });
@@ -209,7 +211,7 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
         <>
             <EmphasizedSegment padded="very">
                 <Forms
-                    onSubmit={ (values) => {
+                    onSubmit={ (values: Map<string, FormValue>) => {
                         updateRoleName(values);
                     } }
                 >
@@ -253,14 +255,14 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
                                         value={ nameValue }
                                         validation={ async (value: string, validation: Validation) => {
                                             if (value) {
-                                                const filter = "name eq " + value.toString();
+                                                const filter: string = "name eq " + value.toString();
 
                                                 await getOrganizationRoles(
                                                     currentOrganization.id,
                                                     filter,
                                                     10,
                                                     null
-                                                ).then(response => {
+                                                ).then((response: OrganizationRoleListResponseInterface) => {
                                                     if (response?.Resources && response?.Resources?.length !== 0) {
                                                         if (response?.Resources[0]?.id !== roleId) {
                                                             validation.isValid = false;

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role-basic.tsx
@@ -325,7 +325,8 @@ export const BasicRoleDetails: FunctionComponent<BasicRoleProps> = (props: Basic
             {
                 (
                     !isReadOnly &&
-                    roleObject?.displayName !== OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME
+                    (roleObject?.displayName !== OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME &&
+                    roleObject?.displayName !== OrganizationRoleManagementConstants.ORG_ADMIN_ROLE_NAME)
                 ) && (
                     <DangerZoneGroup sectionHeader="Danger Zone">
                         <DangerZone

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role.tsx
@@ -18,7 +18,7 @@
 
 import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { SBACInterface } from "@wso2is/core/models";
-import { ContentLoader, ResourceTab } from "@wso2is/react-components";
+import { ContentLoader, ResourceTab, ResourceTabPaneInterface } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -59,7 +59,7 @@ export const EditOrganizationRole: FunctionComponent<EditRoleProps> = (props: Ed
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const [ isGroup, setIsGroup ] = useState<boolean>(false);
 
-    const isReadOnly = useMemo(() => {
+    const isReadOnly: boolean = useMemo(() => {
         return !hasRequiredScopes(featureConfig?.roles, featureConfig?.roles?.scopes?.update, allowedScopes)
                 || roleObject?.displayName === OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME;
     }, [ featureConfig?.roles, roleObject,
@@ -78,7 +78,7 @@ export const EditOrganizationRole: FunctionComponent<EditRoleProps> = (props: Ed
     }, [ roleObject ]);
 
     const resolveResourcePanes = () => {
-        const panes = [
+        const panes: ResourceTabPaneInterface[] = [
             {
                 menuItem: t("console:manage.features.roles.edit.menuItems.basic"),
                 render: () => (

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role.tsx
@@ -98,7 +98,10 @@ export const EditOrganizationRole: FunctionComponent<EditRoleProps> = (props: Ed
                 render: () => (
                     <ResourceTab.Pane controlledSegmentation attached={ false }>
                         <RolePermissionDetails
-                            isReadOnly={ isReadOnly }
+                            isReadOnly={ 
+                                isReadOnly || 
+                                roleObject?.displayName === OrganizationRoleManagementConstants.ORG_ADMIN_ROLE_NAME 
+                            }
                             data-testid="role-mgt-edit-role-permissions"
                             isGroup={ false }
                             roleObject={ roleObject }

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-role.tsx
@@ -18,7 +18,7 @@
 
 import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { SBACInterface } from "@wso2is/core/models";
-import { ResourceTab } from "@wso2is/react-components";
+import { ContentLoader, ResourceTab } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -84,7 +84,10 @@ export const EditOrganizationRole: FunctionComponent<EditRoleProps> = (props: Ed
                 render: () => (
                     <ResourceTab.Pane controlledSegmentation attached={ false }>
                         <BasicRoleDetails
-                            isReadOnly={ isReadOnly }
+                            isReadOnly={ 
+                                isReadOnly || 
+                                roleObject?.displayName === OrganizationRoleManagementConstants.ORG_ADMIN_ROLE_NAME 
+                            }
                             data-testid="role-mgt-edit-role-basic"
                             roleId={ roleId }
                             isGroup={ isGroup }
@@ -143,6 +146,6 @@ export const EditOrganizationRole: FunctionComponent<EditRoleProps> = (props: Ed
     };
 
     return (
-        <ResourceTab panes={ resolveResourcePanes() } />
+        roleObject ? <ResourceTab panes={ resolveResourcePanes() } /> : <ContentLoader/>
     );
 };

--- a/apps/console/src/features/organizations/components/organization-role-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-role-list.tsx
@@ -1,14 +1,14 @@
 /**
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by organizationlicable law or agreed to in writing,
+ * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied. See the License for the
@@ -20,7 +20,6 @@ import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
 import {
     AlertLevels,
-    IdentifiableComponentInterface,
     LoadableComponentInterface,
     SBACInterface,
     TestableComponentInterface
@@ -38,10 +37,12 @@ import {
     TableColumnInterface,
     useConfirmationModalAlert
 } from "@wso2is/react-components";
+import { AxiosError } from "axios";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { Dispatch } from "redux";
 import { Header, Icon, SemanticICONS } from "semantic-ui-react";
 import {
     AppConstants,
@@ -62,8 +63,7 @@ import { OrganizationRoleListItemInterface } from "../models";
 interface OrganizationRolesListPropsInterface
     extends SBACInterface<FeatureConfigInterface>,
         LoadableComponentInterface,
-        TestableComponentInterface,
-        IdentifiableComponentInterface {
+        TestableComponentInterface {
     /**
      * Advanced Search component.
      */
@@ -138,13 +138,12 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
         showListItemActions,
         isSetStrongerAuth,
         isRenderedOnPortal,
-        ["data-testid"]: testId,
-        ["data-componentid"]: componentId
+        ["data-testid"]: testId
     } = props;
 
     const { t } = useTranslation();
 
-    const dispatch = useDispatch();
+    const dispatch: Dispatch<any> = useDispatch();
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
 
@@ -158,7 +157,7 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
     /**
      * Redirects to the organization role edit page when the edit button is clicked.
      *
-     * @param {string} organizationId - Organization id.
+     * @param organizationId - Organization id.
      */
     const handleOrganizationEdit = (organizationId: string): void => {
         history.push({
@@ -171,7 +170,7 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
     /**
      * Deletes an organization when the delete organization button is clicked.
      *
-     * @param {string} roleId - Selected Role id.
+     * @param roleId - Selected Role id.
      */
     const handleOrganizationDelete = (roleId: string): void => {
         deleteOrganizationRole(organizationId, roleId)
@@ -193,7 +192,7 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
                 setShowDeleteConfirmationModal(false);
                 onOrganizationRoleDelete();
             })
-            .catch((error) => {
+            .catch((error: AxiosError) => {
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(
                         setAlert({
@@ -228,7 +227,7 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
     /**
      * Resolves data table columns.
      *
-     * @return {TableColumnInterface[]}
+     * @returns TableColumnInterface[] Table columns.
      */
     const resolveTableColumns = (): TableColumnInterface[] => {
         return [
@@ -274,7 +273,7 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
     /**
      * Resolves data table actions.
      *
-     * @return {TableActionsInterface[]}
+     * @returns TableActionsInterface[] Table actions.
      */
     const resolveTableActions = (): TableActionsInterface[] => {
         if (!showListItemActions) {
@@ -335,7 +334,7 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
     /**
      * Resolve the relevant placeholder.
      *
-     * @return {React.ReactElement}
+     * @returns React.ReactElement Placeholder.
      */
     const showPlaceholders = (): ReactElement => {
         // When the search returns empty.
@@ -454,7 +453,6 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
  * Default props for the component.
  */
 OrganizationRoleList.defaultProps = {
-    "data-componentid": "organization-roles",
     "data-testid": "organization-role-list",
     selection: true,
     showListItemActions: true

--- a/apps/console/src/features/organizations/components/organization-role-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-role-list.tsx
@@ -318,7 +318,8 @@ export const OrganizationRoleList: FunctionComponent<OrganizationRolesListPropsI
                         featureConfig?.organizationsRoles,
                         featureConfig?.organizationsRoles?.scopes?.delete,
                         allowedScopes
-                    ) || role.displayName === OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME;
+                    ) || role.displayName === OrganizationRoleManagementConstants.ORG_CREATOR_ROLE_NAME
+                    || role.displayName === OrganizationRoleManagementConstants.ORG_ADMIN_ROLE_NAME;
                 },
                 icon: (): SemanticICONS => "trash alternate",
                 onClick: (e: SyntheticEvent, role: OrganizationRoleListItemInterface): void => {

--- a/apps/console/src/features/organizations/constants/organization-constants.ts
+++ b/apps/console/src/features/organizations/constants/organization-constants.ts
@@ -44,7 +44,7 @@ export class OrganizationManagementConstants {
         status: "ACTIVE"
     };
 
-    public static readonly ORGANIZATION_ROUTES = "organizations";
+    public static readonly ORGANIZATION_ROUTES: string = "organizations";
 }
 
 export enum ORGANIZATION_TYPE {
@@ -65,20 +65,20 @@ export class OrganizationRoleManagementConstants {
         .set("ORGANIZATION_ROLE_DELETE", "organization-roles.delete")
         .set("ORGANIZATION_ROLE_READ", "organization-roles.read");
 
-    public static readonly SUPER_ADMIN_PERMISSION_KEY = "/permission/protected";
-    public static readonly ORG_CREATOR_ROLE_NAME = "org-creator";
-    public static readonly ORG_ADMIN_ROLE_NAME = "Administrator";
+    public static readonly SUPER_ADMIN_PERMISSION_KEY: string = "/permission/protected";
+    public static readonly ORG_CREATOR_ROLE_NAME: string = "org-creator";
+    public static readonly ORG_ADMIN_ROLE_NAME: string = "Administrator";
 }
 
-export const APPLICATION_DOMAIN = "Application/";
-export const INTERNAL_DOMAIN = "Internal";
-export const PRIMARY_DOMAIN = "Primary";
-export const ROLE_VIEW_PATH = "/organization-roles/";
+export const APPLICATION_DOMAIN: string = "Application/";
+export const INTERNAL_DOMAIN: string = "Internal";
+export const PRIMARY_DOMAIN: string = "Primary";
+export const ROLE_VIEW_PATH: string = "/organization-roles/";
 
-export const ORGANIZATION_NAME_MIN_LENGTH = 3;
-export const ORGANIZATION_NAME_MAX_LENGTH = 32;
-export const ORGANIZATION_DESCRIPTION_MIN_LENGTH = 3;
-export const ORGANIZATION_DESCRIPTION_MAX_LENGTH = 300;
+export const ORGANIZATION_NAME_MIN_LENGTH: number = 3;
+export const ORGANIZATION_NAME_MAX_LENGTH: number = 32;
+export const ORGANIZATION_DESCRIPTION_MIN_LENGTH: number = 3;
+export const ORGANIZATION_DESCRIPTION_MAX_LENGTH: number = 300;
 
 /**
  * Contains all the possible types of organizations.

--- a/apps/console/src/features/organizations/constants/organization-constants.ts
+++ b/apps/console/src/features/organizations/constants/organization-constants.ts
@@ -67,6 +67,7 @@ export class OrganizationRoleManagementConstants {
 
     public static readonly SUPER_ADMIN_PERMISSION_KEY = "/permission/protected";
     public static readonly ORG_CREATOR_ROLE_NAME = "org-creator";
+    public static readonly ORG_ADMIN_ROLE_NAME = "Administrator";
 }
 
 export const APPLICATION_DOMAIN = "Application/";


### PR DESCRIPTION
### Purpose
> This PR hides the option to delete the `Administrator` role or update its permissions in the sub-organizations.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
