### PR TITLE
View parameters in adaptive auth templates as code segments

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/template-description.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/template-description.tsx
@@ -113,38 +113,44 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
 
     };
 
-    const getParameters = () : string[] => {
-        const params = [];
+    const getParameters = (): string[] => {
+        const params : string[] = [];
+        
         if (isObject(template.parametersDescription)) {
-            Object.entries(template.parametersDescription).map(([param]) => {
+            Object.entries(template.parametersDescription).map(([ param ]) => {
                 params.push(param);
             });
         }
+
         return params;
-    }
+    };
 
     const generatePrerequisite = (prerequisite: string, params: Array<string>): ReactElement => {
-        const sentenceArray = prerequisite.split(" ");
-        const modified = [];
-        let content = ""
-        sentenceArray.map((word, index) => {
+        const sentenceArray: string[] = prerequisite.split(" ");
+        const modified: ReactElement[] = [];
+        let content: string = "";
+
+        sentenceArray.map((word: string, index: number) => {
             if (params.includes(word)) {
-                modified.push(<span key={index}>{content} </span>)
-                modified.push(<span key={index}><Code>{word}</Code> </span>)
-                content = ""
+                modified.push(<span key={ index }>{ content } </span>);
+                modified.push(
+                    <span key={ index }>
+                        <Code>{ word }</Code> 
+                    </span>
+                );
+                content = "";
             } else {
                 content = content.concat(word + " ");
             }
         });
-        modified.push(<span>{content}</span>)
+        modified.push(<span>{ content }</span>);
+        
         return (
             <p>
-                <React.Fragment>
-                    {modified.map((element) => element)}
-                </React.Fragment>
+                { modified.map((element: ReactElement) => element) }
             </p>
         );
-    }
+    };
     
     return (
         <Modal open={ open } onClose={ onClose } dimmer="blurring" size="small">
@@ -165,7 +171,8 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
                             </h4>
                             <List>
                                 { template.preRequisites.map((prerequisite: string, index: number) => {
-                                    const params = getParameters();
+                                    const params: string[] = getParameters();
+                                    
                                     return (
                                         <List.Item key={ index }>
                                             <List.Icon name="check circle outline" color="green"/>
@@ -202,7 +209,9 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
                                         .map(([ param, description ], index: number) => {
                                             return (
                                                 <Table.Row key={ index }>
-                                                    <Table.Cell><Code>{ param }</Code></Table.Cell>
+                                                    <Table.Cell>
+                                                        <Code>{ param }</Code>
+                                                    </Table.Cell>
                                                     <Table.Cell>{ description }</Table.Cell>
                                                 </Table.Row>
                                             );

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/template-description.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/template-description.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -54,9 +54,9 @@ interface TemplateDescriptionPropsInterface {
 /**
  * The modal that contains template description.
  *
- * @param {TemplateDescriptionPropsInterface} props React component props.
+ * @param props - React component props.
  *
- * @returns {ReactElement} Template Description component.
+ * @returns Template Description component.
  */
 export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInterface> = (
     props: TemplateDescriptionPropsInterface
@@ -73,7 +73,7 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
 
     /**
      * Resolves the documentation link when a template is selected.
-     * @return {React.ReactElement}
+     * @returns the resolved documentation link.
      */
     const resolveDocumentationLink = (): ReactElement => {
         const templateName: string = template?.name;
@@ -117,7 +117,7 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
         const params : string[] = [];
         
         if (isObject(template.parametersDescription)) {
-            Object.entries(template.parametersDescription).map(([ param ]) => {
+            Object.entries(template.parametersDescription).map(([ param ]: string[]) => {
                 params.push(param);
             });
         }
@@ -206,7 +206,7 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
                                 </Table.Header>
                                 <Table.Body>
                                     { Object.entries(template.parametersDescription)
-                                        .map(([ param, description ], index: number) => {
+                                        .map(([ param, description ]: [ string, string ], index: number) => {
                                             return (
                                                 <Table.Row key={ index }>
                                                     <Table.Cell>
@@ -232,7 +232,11 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
                             </h4>
                             {
                                 Object.entries(template.defaultStepsDescription)
-                                    .map(([ step, description ], index: number, steps) => {
+                                    .map((
+                                        [ step, description ]: [ string, string ], 
+                                        index: number, 
+                                        steps: [string, string][]
+                                    ) => {
                                         return (
                                             <div className="stepper" key={ `${ index }-${ step }` }>
                                                 <div className="step-number">{ index + 1 }</div>
@@ -261,9 +265,9 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
                             <Message
                                 type="info"
                                 content={
-                                    <a target="_blank" href={ template.helpLink } rel="noreferrer">
+                                    (<a target="_blank" href={ template.helpLink } rel="noreferrer">
                                         { template.helpLink }
-                                    </a>
+                                    </a>)
                                 }
                             />
                         </>

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/template-description.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/script-based-flow/template-description.tsx
@@ -17,6 +17,7 @@
  */
 
 import {
+    Code,
     CodeEditor,
     DocumentationLink,
     LinkButton,
@@ -111,6 +112,39 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
         );
 
     };
+
+    const getParameters = () : string[] => {
+        const params = [];
+        if (isObject(template.parametersDescription)) {
+            Object.entries(template.parametersDescription).map(([param]) => {
+                params.push(param);
+            });
+        }
+        return params;
+    }
+
+    const generatePrerequisite = (prerequisite: string, params: Array<string>): ReactElement => {
+        const sentenceArray = prerequisite.split(" ");
+        const modified = [];
+        let content = ""
+        sentenceArray.map((word, index) => {
+            if (params.includes(word)) {
+                modified.push(<span key={index}>{content} </span>)
+                modified.push(<span key={index}><Code>{word}</Code> </span>)
+                content = ""
+            } else {
+                content = content.concat(word + " ");
+            }
+        });
+        modified.push(<span>{content}</span>)
+        return (
+            <p>
+                <React.Fragment>
+                    {modified.map((element) => element)}
+                </React.Fragment>
+            </p>
+        );
+    }
     
     return (
         <Modal open={ open } onClose={ onClose } dimmer="blurring" size="small">
@@ -131,10 +165,11 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
                             </h4>
                             <List>
                                 { template.preRequisites.map((prerequisite: string, index: number) => {
+                                    const params = getParameters();
                                     return (
                                         <List.Item key={ index }>
                                             <List.Icon name="check circle outline" color="green"/>
-                                            <List.Content>{ prerequisite }</List.Content>
+                                            <List.Content>{ generatePrerequisite(prerequisite, params) }</List.Content>
                                         </List.Item>
                                     );
                                 }) }
@@ -167,7 +202,7 @@ export const TemplateDescription: FunctionComponent<TemplateDescriptionPropsInte
                                         .map(([ param, description ], index: number) => {
                                             return (
                                                 <Table.Row key={ index }>
-                                                    <Table.Cell>{ param }</Table.Cell>
+                                                    <Table.Cell><Code>{ param }</Code></Table.Cell>
                                                     <Table.Cell>{ description }</Table.Cell>
                                                 </Table.Row>
                                             );


### PR DESCRIPTION
### Purpose
> After this implementation, the parameters related to the adaptive auth scripts will be displayed as code segments in adaptive auth template window.

Before:
<img width="744" alt="Screenshot 2023-02-15 at 11 12 10" src="https://user-images.githubusercontent.com/50801227/218944072-588a3116-d836-427c-af0d-d3111dafe3f1.png">

After:
<img width="744" alt="Screenshot 2023-02-15 at 11 10 33" src="https://user-images.githubusercontent.com/50801227/218944119-d32400c3-af95-49ad-a2e4-a0fc603a209c.png">

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/14966

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
