### PR TITLE
Hide the SMS-OTP authenticator in sign in methods landing page for sub organizations

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-landing.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-landing.tsx
@@ -18,6 +18,8 @@
 
 import { SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { Heading, InfoCard, useMediaContext } from "@wso2is/react-components";
+import { OrganizationType } from "../../../../organizations/constants";
+import { useGetOrganizationType } from "../../../../organizations/hooks/use-get-organization-type";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -68,6 +70,7 @@ export const SignInMethodLanding: FunctionComponent<SignInMethodLandingPropsInte
     const { isMobileViewport } = useMediaContext();
 
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
+    const orgType: OrganizationType = useGetOrganizationType();
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
@@ -169,7 +172,8 @@ export const SignInMethodLanding: FunctionComponent<SignInMethodLandingPropsInte
                                     } }
                                 />
                             ) }
-                            { !hiddenOptions.includes(LoginFlowTypes.SECOND_FACTOR_SMS_OTP) && (
+                            { (!hiddenOptions.includes(LoginFlowTypes.SECOND_FACTOR_SMS_OTP) &&
+                                orgType !== OrganizationType.SUBORGANIZATION) && (
                                 <InfoCard
                                     fluid
                                     data-testid="sms-otp-mfa-flow-card"

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-landing.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-landing.tsx
@@ -18,14 +18,14 @@
 
 import { SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { Heading, InfoCard, useMediaContext } from "@wso2is/react-components";
-import { OrganizationType } from "../../../../organizations/constants";
-import { useGetOrganizationType } from "../../../../organizations/hooks/use-get-organization-type";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Grid, Segment } from "semantic-ui-react";
 import { AppState, ConfigReducerStateInterface, EventPublisher, FeatureConfigInterface } from "../../../../core";
 import { IdentityProviderManagementConstants } from "../../../../identity-providers";
+import { OrganizationType } from "../../../../organizations/constants";
+import { useGetOrganizationType } from "../../../../organizations/hooks/use-get-organization-type";
 import { getAuthenticatorIcons } from "../../../configs";
 import { LoginFlowTypes } from "../../../models";
 

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-landing.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-landing.tsx
@@ -172,29 +172,31 @@ export const SignInMethodLanding: FunctionComponent<SignInMethodLandingPropsInte
                                     } }
                                 />
                             ) }
-                            { (!hiddenOptions.includes(LoginFlowTypes.SECOND_FACTOR_SMS_OTP) &&
-                                orgType !== OrganizationType.SUBORGANIZATION) && (
-                                <InfoCard
-                                    fluid
-                                    data-testid="sms-otp-mfa-flow-card"
-                                    image={ getAuthenticatorIcons().smsOTP }
-                                    imageSize="mini"
-                                    header={ t(
-                                        "console:develop.features.applications.edit.sections" +
-                                        ".signOnMethod.sections.landing.flowBuilder.types.smsOTP.heading"
-                                    ) }
-                                    description={ t(
-                                        "console:develop.features.applications.edit.sections" +
-                                        ".signOnMethod.sections.landing.flowBuilder.types.smsOTP.description"
-                                    ) }
-                                    onClick={ () => {
-                                        eventPublisher.publish("application-begin-sign-in-sms-otp-mfa", {
-                                            "client-id": clientId
-                                        } );
-                                        onLoginFlowSelect(LoginFlowTypes.SECOND_FACTOR_SMS_OTP);
-                                    } }
-                                />
-                            ) }
+                            { 
+                                (!hiddenOptions.includes(LoginFlowTypes.SECOND_FACTOR_SMS_OTP) &&
+                                    orgType !== OrganizationType.SUBORGANIZATION) && (
+                                    <InfoCard
+                                        fluid
+                                        data-testid="sms-otp-mfa-flow-card"
+                                        image={ getAuthenticatorIcons().smsOTP }
+                                        imageSize="mini"
+                                        header={ t(
+                                            "console:develop.features.applications.edit.sections" +
+                                            ".signOnMethod.sections.landing.flowBuilder.types.smsOTP.heading"
+                                        ) }
+                                        description={ t(
+                                            "console:develop.features.applications.edit.sections" +
+                                            ".signOnMethod.sections.landing.flowBuilder.types.smsOTP.description"
+                                        ) }
+                                        onClick={ () => {
+                                            eventPublisher.publish("application-begin-sign-in-sms-otp-mfa", {
+                                                "client-id": clientId
+                                            } );
+                                            onLoginFlowSelect(LoginFlowTypes.SECOND_FACTOR_SMS_OTP);
+                                        } }
+                                    />
+                                ) 
+                            }
                         </div>
                     </Grid.Column>
                     <Grid.Column computer={ 8 } tablet={ 16 } mobile={ 16 } className="flow-options-column">


### PR DESCRIPTION
### Purpose
> This PR introduces a fix to hide the SMS-OTP authenticator in the sign-in methods landing page for sub-organizations.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
