### PR TITLE
Hide SMS-OTP authenticator in sub organization level

### DIFF
--- a/apps/console/src/features/identity-providers/pages/identity-providers.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-providers.tsx
@@ -44,6 +44,8 @@ import {
     UIConstants,
     history
 } from "../../core";
+import { OrganizationType } from "../../organizations/constants";
+import { useGetOrganizationType } from "../../organizations/hooks/use-get-organization-type";
 import { getAuthenticatorTags, getAuthenticators, getIdentityProviderList } from "../api";
 import { AuthenticatorGrid, IdentityProviderList, handleGetIDPListCallError } from "../components";
 import { IdentityProviderManagementConstants } from "../constants";
@@ -120,6 +122,7 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (props: IDPP
     const [ showFilteredList, setShowFilteredList ] = useState<boolean>(false);
     const [ isPaginating, setIsPaginating ] = useState<boolean>(false);
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
+    const orgType: OrganizationType = useGetOrganizationType();
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
@@ -165,6 +168,11 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (props: IDPP
 
                     if (authenticator.id === IdentityProviderManagementConstants.MAGIC_LINK_AUTHENTICATOR_ID) {
                         authenticator.tags = [ AuthenticatorLabels.PASSWORDLESS ];
+                    }
+
+                    if (authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID &&
+                        orgType === OrganizationType.SUBORGANIZATION) {
+                        return false;
                     }
 
                     const authenticatorConfig: AuthenticatorExtensionsConfigInterface = get(
@@ -251,6 +259,11 @@ const IdentityProvidersPage: FunctionComponent<IDPPropsInterface> = (props: IDPP
 
                         if (authenticator.id === IdentityProviderManagementConstants.MAGIC_LINK_AUTHENTICATOR_ID) {
                             authenticator.tags = [ AuthenticatorLabels.PASSWORDLESS ];
+                        }
+
+                        if (authenticator.id === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID &&
+                            orgType === OrganizationType.SUBORGANIZATION) {
+                            return false;
                         }
 
                         if (filter?.startsWith("tag")) {


### PR DESCRIPTION
### Purpose
> This PR introduces the improvement to hide the SMS-OTP authenticator at the sub-organization level.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
