### PR TITLE
Remove carbon.ui dependency

### DIFF
--- a/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
+++ b/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
@@ -125,7 +125,7 @@
     <filter>
         <filter-name>ContentTypeBasedCachePreventionFilter</filter-name>
         <filter-class>
-           org.wso2.carbon.ui.filters.cache.ContentTypeBasedCachePreventionFilter
+           org.wso2.carbon.tomcat.ext.filter.ContentTypeBasedCachePreventionFilter
         </filter-class>
         <init-param>
            <param-name>patterns</param-name>

--- a/apps/authentication-portal/src/main/webapp/add-security-questions.jsp
+++ b/apps/authentication-portal/src/main/webapp/add-security-questions.jsp
@@ -24,7 +24,6 @@
 <%@ page import="org.wso2.carbon.identity.recovery.ui.IdentityManagementAdminClient" %>
 <%@ page import="org.wso2.carbon.identity.recovery.model.ChallengeQuestion" %>
 <%@ page import="org.wso2.carbon.utils.ServerConstants" %>
-<%@ page import="org.wso2.carbon.ui.CarbonUIUtil" %>
 <%@ page import="org.wso2.carbon.CarbonConstants" %>
 <%@ page import="java.nio.charset.StandardCharsets" %>
 <%@ page import="java.util.ResourceBundle" %>

--- a/apps/recovery-portal/src/main/webapp/WEB-INF/web.xml
+++ b/apps/recovery-portal/src/main/webapp/WEB-INF/web.xml
@@ -67,7 +67,7 @@
     <filter>
         <filter-name>ContentTypeBasedCachePreventionFilter</filter-name>
         <filter-class>
-           org.wso2.carbon.ui.filters.cache.ContentTypeBasedCachePreventionFilter
+           org.wso2.carbon.tomcat.ext.filter.ContentTypeBasedCachePreventionFilter
         </filter-class>
         <init-param>
            <param-name>patterns</param-name>

--- a/components/org.wso2.identity.apps.common/pom.xml
+++ b/components/org.wso2.identity.apps.common/pom.xml
@@ -103,7 +103,6 @@
 
             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",
             org.wso2.carbon.core; version="${carbon.kernel.imp.pkg.version.range}",
-            org.wso2.carbon.ui; version="${carbon.kernel.imp.pkg.version.range}",
             org.wso2.carbon.utils; version="${carbon.kernel.imp.pkg.version.range}",
             org.wso2.carbon.context.*; version="${carbon.kernel.imp.pkg.version.range}",
             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",

--- a/components/org.wso2.identity.apps.common/pom.xml
+++ b/components/org.wso2.identity.apps.common/pom.xml
@@ -49,6 +49,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.registry.core</artifactId>
         </dependency>
         <dependency>
@@ -98,6 +102,7 @@
             org.apache.commons.logging; version="${commons-logging.imp.pkg.version.range}",
 
             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",
+            org.wso2.carbon.core; version="${carbon.kernel.imp.pkg.version.range}",
             org.wso2.carbon.ui; version="${carbon.kernel.imp.pkg.version.range}",
             org.wso2.carbon.utils; version="${carbon.kernel.imp.pkg.version.range}",
             org.wso2.carbon.context.*; version="${carbon.kernel.imp.pkg.version.range}",

--- a/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
+++ b/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
@@ -25,21 +25,19 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.core.ServerStartupObserver;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
 import org.wso2.carbon.identity.oauth.listener.OAuthApplicationMgtListener;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.registry.core.service.RegistryService;
-import org.wso2.carbon.ui.CarbonSSOSessionManager;
 import org.wso2.identity.apps.common.listner.AppPortalApplicationMgtListener;
 import org.wso2.identity.apps.common.listner.AppPortalOAuthAppMgtListener;
-import org.wso2.identity.apps.common.util.AppPortalConstants;
 import org.wso2.identity.apps.common.util.AppPortalUtils;
 
 import java.util.HashSet;
@@ -101,12 +99,9 @@ public class AppsCommonServiceComponent {
                 }
             }
 
-            for (AppPortalConstants.AppPortal appPortal : AppPortalConstants.AppPortal.values()) {
-                log.info(appPortal.getName() + " URL : " + IdentityUtil
-                        .getServerURL(appPortal.getEndpoint(), true, true));
-            }
-
-            log.info("Identity apps common service component activated successfully.");
+            // AppsCommonServiceStartupObserver will wait until server startup is completed
+            bundleContext.registerService(ServerStartupObserver.class.getName(),
+                new AppsCommonServiceStartupObserver(), null);
         } catch (Throwable e) {
             log.error("Failed to activate identity apps common service component.", e);
         }
@@ -187,21 +182,6 @@ public class AppsCommonServiceComponent {
     }
 
     protected void unsetIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
-
-    }
-
-    @Reference(name = "carbon.sso.session.manager.service",
-               service = CarbonSSOSessionManager.class,
-               cardinality = ReferenceCardinality.MANDATORY,
-               policy = ReferencePolicy.DYNAMIC,
-               unbind = "unsetCarbonSSOSessionManager")
-    protected void setCarbonSSOSessionManager(CarbonSSOSessionManager carbonSSOSessionManager) {
-
-        // Reference CarbonSSOSessionManager service to guarantee that this component will wait until management
-        // console URL is already added to the log.
-    }
-
-    protected void unsetCarbonSSOSessionManager(CarbonSSOSessionManager carbonSSOSessionManager) {
 
     }
 

--- a/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceStartupObserver.java
+++ b/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceStartupObserver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.apps.common.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.core.ServerStartupObserver;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.identity.apps.common.util.AppPortalConstants;
+
+/**
+ * Use to log the portal endpoints.
+ * This component will wait until server startup is completed
+ */
+public class AppsCommonServiceStartupObserver implements ServerStartupObserver {
+
+    private static final Log log = LogFactory.getLog(AppsCommonServiceStartupObserver.class);
+
+    @Override
+    public void completingServerStartup() {
+        // Do nothing
+    }
+
+    @Override
+    public void completedServerStartup() {
+
+        for (AppPortalConstants.AppPortal appPortal : AppPortalConstants.AppPortal.values()) {
+            log.info(appPortal.getName() + " URL : " + IdentityUtil
+                .getServerURL(appPortal.getEndpoint(), true, true));
+        }
+        log.info("Identity apps common service component activated successfully.");
+    }
+
+}

--- a/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -206,7 +206,7 @@
     <filter>
         <filter-name>ContentTypeBasedCachePreventionFilter</filter-name>
         <filter-class>
-           org.wso2.carbon.ui.filters.cache.ContentTypeBasedCachePreventionFilter
+           org.wso2.carbon.tomcat.ext.filter.ContentTypeBasedCachePreventionFilter
         </filter-class>
         <init-param>
            <param-name>patterns</param-name>
@@ -465,7 +465,7 @@
         <servlet-name>select_org.do</servlet-name>
         <jsp-file>/select_org.jsp</jsp-file>
     </servlet>
-    
+
     <servlet-mapping>
         <servlet-name>totp_enroll.do</servlet-name>
         <url-pattern>/totp_enroll.do</url-pattern>

--- a/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -101,7 +101,7 @@
     <filter>
         <filter-name>ContentTypeBasedCachePreventionFilter</filter-name>
         <filter-class>
-           org.wso2.carbon.ui.filters.cache.ContentTypeBasedCachePreventionFilter
+           org.wso2.carbon.tomcat.ext.filter.ContentTypeBasedCachePreventionFilter
         </filter-class>
         <init-param>
            <param-name>patterns</param-name>

--- a/pom.xml
+++ b/pom.xml
@@ -353,11 +353,6 @@
                 <version>${org.wso2.carbon.identity.outbound.auth.oidc}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.ui</artifactId>
-                <version>${carbon.kernel.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.identity</groupId>
                 <artifactId>org.wso2.carbon.identity.mgt</artifactId>
                 <version>${carbon.identity.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -662,8 +662,8 @@
         <commons-logging.imp.pkg.version.range>[1.2, 2.0)</commons-logging.imp.pkg.version.range>
 
         <carbon.identity.version>5.0.7</carbon.identity.version>
-        <carbon.kernel.version>4.9.0</carbon.kernel.version>
-        <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
+        <carbon.kernel.version>4.9.1</carbon.kernel.version>
+        <carbon.kernel.imp.pkg.version.range>[4.9.1, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
         <carbon.commons.version>4.7.22</carbon.commons.version>


### PR DESCRIPTION
### Purpose
org.wso2.carbon.ui dependency is removed from identity-apps repo

Note: The order portal URLs logged into the terminal will change as a result of this.

### Related Issues
- https://github.com/wso2/product-is/issues/15520

### Related PRs
- (None)
