### PR TITLE
Restrict SMS OTP in the login flow customisation section at the sub organization level

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
@@ -60,6 +60,7 @@ import { Authenticators } from "./authenticators";
 import { AppState, EventPublisher, getEmptyPlaceholderIllustrations } from "../../../../../core";
 import {
     GenericAuthenticatorInterface,
+    IdentityProviderManagementConstants,
     IdentityProviderManagementUtils,
     IdentityProviderTemplateCategoryInterface,
     IdentityProviderTemplateInterface,
@@ -199,9 +200,14 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
             return;
         }
 
-        setFilteredAuthenticators(authenticators);
-
-        extractAuthenticatorLabels(authenticators);
+        // Remove SMS OTP authenticator from the list at the sub org level.
+        const filteredAuthenticators: GenericAuthenticatorInterface[] = (orgType === OrganizationType.SUBORGANIZATION) 
+            ? authenticators.filter((authenticator: GenericAuthenticatorInterface) => {       
+                return authenticator.name !== IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID; })
+            : authenticators;
+        
+        setFilteredAuthenticators(filteredAuthenticators);
+        extractAuthenticatorLabels(filteredAuthenticators);
     }, [ authenticators ]);
 
     /**


### PR DESCRIPTION
### Purpose
> This PR restricts the SMS OTP option in the step based login flow customization section at the sub-organization level.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
