### PR TITLE
Remove enabled Tag from the section

### DIFF
--- a/apps/console/src/features/private-key-jwt/pages/private-key-jwt-config.tsx
+++ b/apps/console/src/features/private-key-jwt/pages/private-key-jwt-config.tsx
@@ -70,7 +70,6 @@ export const PrivateKeyJWTConfig: FunctionComponent<PrivateKeyJWTConfigPageInter
             ) }
             onPrimaryActionClick={ handleSelection }
             primaryAction={ "Configure" }
-            connectorEnabled={ isLoading ? undefined : tokenReuseData.enableTokenReuse }
         >
             <Divider hidden/>
         </Section>)


### PR DESCRIPTION
### Purpose
This gives the impression that private key jwt client authentication is disabled. But what is actually disabled is the token reuse. IMO we don't need the enable/disable status in this screen