### PR TITLE
Support asynchronous rendering of header extensions

### DIFF
--- a/apps/console/src/extensions/configs/common.tsx
+++ b/apps/console/src/extensions/configs/common.tsx
@@ -28,7 +28,7 @@ export const commonConfig: CommonConfig = {
     checkForUIResourceScopes: false,
     enableOrganizationAssociations: false,
     header: {
-        getHeaderExtensions: (): HeaderExtension[] => [],
+        getHeaderExtensions: (): Promise<HeaderExtension[]> => Promise.resolve([]),
         getHeaderSubPanelExtensions: (): HeaderSubPanelItemInterface[] => [],
         getUserDropdownLinkExtensions: (
             _tenantDomain: string,

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -32,7 +32,7 @@ export interface CommonConfig {
          * Get the extensions for the header.
          * @returns Header extensions.
          */
-        getHeaderExtensions: () => HeaderExtension[];
+        getHeaderExtensions: () => Promise<HeaderExtension[]>;
         /**
          * Get the extensions for the Header sub panel.
          * These will come along with the `Manage` & `Develop` links.

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -29,6 +29,7 @@ import {
     Announcement,
     AppSwitcher,
     GenericIcon,
+    HeaderExtension,
     HeaderLinkCategoryInterface,
     Logo,
     ProductBrand,
@@ -128,7 +129,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
 
     const [ announcement, setAnnouncement ] = useState<AnnouncementBannerInterface>(undefined);
     const [ headerLinks, setHeaderLinks ] = useState<HeaderLinkCategoryInterface[]>([]);
-
+    const [ headerExtensions, setHeaderExtensions ] = useState<HeaderExtension[]>([]);
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
     /**
@@ -169,6 +170,16 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                 setHeaderLinks(response);
             } );
     }, [ tenantDomain, associatedTenants ]);
+
+    useEffect(() => {
+        commonConfig?.header?.getHeaderExtensions().then((response: HeaderExtension[]) => {
+            // Remove upgrade button if the user is a privileged user.
+            if (isPrivilegedUser) {
+                response.pop();
+            }
+            setHeaderExtensions(response);
+        });
+    }, []);
 
     /**
      * Check if there are applications registered and set the value to local storage.
@@ -443,7 +454,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             extensions={
                 // Remove false values. Needed for `&&` operator.
                 compact([
-                    ...commonConfig?.header?.getHeaderExtensions(),
+                    ...headerExtensions,
                     showAppSwitchButton && commonConfig?.header?.renderAppSwitcherAsDropdown && {
                         component: renderAppSwitcher(),
                         floated: "right"

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -171,9 +171,11 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             } );
     }, [ tenantDomain, associatedTenants ]);
 
+    /**
+     * Get the header extensions.
+     */
     useEffect(() => {
         commonConfig?.header?.getHeaderExtensions().then((response: HeaderExtension[]) => {
-            // Remove upgrade button if the user is a privileged user.
             if (isPrivilegedUser) {
                 response.pop();
             }


### PR DESCRIPTION
### Purpose

Currently it's only possible to render the static components in header extensions and there's no support for rendering header extensions when async code is involved in conditional rendering. 

This PR is to support rendering the header extensions with async conditional rendering

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
