### PR TITLE
Change doc link

### DIFF
--- a/apps/console/src/features/private-key-jwt/pages/private-key-jwt-config-edit.tsx
+++ b/apps/console/src/features/private-key-jwt/pages/private-key-jwt-config-edit.tsx
@@ -181,7 +181,7 @@ export const PrivateKeyJWTConfigEditPage: FunctionComponent<IdentifiableComponen
                 <>
                     { t("console:manage.features.jwtPrivateKeyConfiguration.description" ) }
                     <DocumentationLink
-                        link={ getLink("manage.validation.passwordValidation.learnMore") }
+                        link={ getLink("manage.privateKeyJWT.learnMore") }
                     >
                         { t("common:learnMore") }
                     </DocumentationLink>


### PR DESCRIPTION
### Purpose
The current doc is pointing to the validation doc page, this fix will change to the actual page.
