### PR TITLE
Fix issue denoting of subject identifiying step in step-based-flow

### DIFF
--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -265,6 +265,25 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
         const steps: AuthenticationStepInterface[] = [ ...authenticationSteps ];
 
         const hasStepsWithOptions: boolean = steps.some((step: AuthenticationStepInterface) => !isEmpty(step.options));
+        let hasFoundTheSubjectIdentifiableStep: boolean = false;
+
+        authenticationSteps.forEach((step: AuthenticationStepInterface) => {
+            step.options.map((option: AuthenticatorInterface) => {
+                const isSubjectIdentifiableAuthenticator: boolean = ![
+                    IdentityProviderManagementConstants.TOTP_AUTHENTICATOR,
+                    IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR,
+                    IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR,
+                    IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR
+                ].includes(option.authenticator);
+
+                if (isSubjectIdentifiableAuthenticator) {
+                    if (step.id !== subjectStepId && !hasFoundTheSubjectIdentifiableStep) {
+                        setSubjectStepId(step.id);
+                        hasFoundTheSubjectIdentifiableStep = true;
+                    }
+                }
+            });
+        });
 
         if (hasStepsWithOptions) {
             onAuthenticationSequenceChange(false, authenticationSteps);
@@ -273,6 +292,33 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
         }
         onAuthenticationSequenceChange(true, authenticationSteps);
     }, [ authenticationSteps ]);
+
+    /**
+     * This identifies what should be the subject identifier for the current authentication steps and set it as
+     * subject id. This resolves the issue of subject identifier always been step 01.
+     */
+    useEffect(() => {
+        let hasFoundTheSubjectIdentifiableStep: boolean = false;
+
+        authenticationSteps.forEach((step: AuthenticationStepInterface) => {
+            step.options.map((option: AuthenticatorInterface) => {
+                const isSubjectIdentifiableAuthenticator: boolean = ![
+                    IdentityProviderManagementConstants.TOTP_AUTHENTICATOR,
+                    IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR,
+                    IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR,
+                    IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR
+                ].includes(option.authenticator);
+
+                if (isSubjectIdentifiableAuthenticator) {
+                    if (step.id !== subjectStepId && !hasFoundTheSubjectIdentifiableStep) {
+                        setSubjectStepId(step.id);
+                        hasFoundTheSubjectIdentifiableStep = true;
+                    }
+                }
+            });
+        });
+    }, [ authenticationSteps ]);
+
 
     /**
      * Validates if the addition to the step is valid.
@@ -395,7 +441,7 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
         }
 
         const defaultAuthenticator: FederatedAuthenticatorInterface = authenticator.authenticators.find(
-            (item: FederatedAuthenticatorInterface) => 
+            (item: FederatedAuthenticatorInterface) =>
                 item.authenticatorId === authenticator.defaultAuthenticator.authenticatorId
         );
 


### PR DESCRIPTION
### Purpose
> There was an issue happens whenever we only have non-subject identifying authenticator in step 01 of step based flow, where it cannot identify which step includes the subject identifying authenticator. This PR fixes it by checking what should be the subject identifying step on each step change.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
