### PR TITLE
Display specific error message in emailotp.jsp page for expired otp submission

### DIFF
--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -319,6 +319,7 @@ error.wrong.code=The code entered is incorrect. Authentication Failed!
 error.failed.with.smsotp=Failed Authentication with SMSOTP
 error.smsotp.disabled=SMS OTP is not enabled in your profile. Enable SMS OTP to proceed.
 error.token.expired=The code entered is expired. Authentication Failed!
+error.token.expired.email.sent=The code entered is expired. Please check inbox for a new OTP.
 error.user.not.found.smsotp=User not found in the directory. Cannot proceed further without SMS OTP authentication.
 error.resent.count.exceeded=Your SMS resend count has exceeded. Please contact the administrator for assistance.
 error.sms.quota.exceeded=Your SMS quota has exceeded. Please contact the administrator for assistance.

--- a/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -48,6 +48,12 @@
             if (errorMessage.equalsIgnoreCase("authentication.fail.message")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry.code.invalid");
             }
+            if (errorMessage.equalsIgnoreCase("token.expired")) {
+            	errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.code.expired.resend");
+            }
+            if (errorMessage.equalsIgnoreCase("token.expired.email.sent")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.token.expired.email.sent");
+            }
         }
     }
 %>
@@ -149,15 +155,17 @@
                             <div class="align-right buttons">
                                 <%
                                     if ("true".equals(authenticationFailed)) {
+                                        String authFailureMsg = request.getParameter("authFailureMsg");
+                                        if (!"token.expired.email.sent".equals(authFailureMsg)) {
                                 %>
-                                <a 
-                                    class="ui button secondary" 
-                                    onclick="resendOtp()" 
-                                    tabindex="0" 
+                                <a
+                                    class="ui button secondary"
+                                    onclick="resendOtp()"
+                                    tabindex="0"
                                     onkeypress="javascript: if (window.event.keyCode === 13) resendOtp()"
                                 id="resend"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "resend.code")%>
                                 </a>
-                                <% } %>
+                                <% } }%>
                                 <input type="button" name="authenticate" id="authenticate"
                                     value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "authenticate")%>"
                                     class="ui primary button"/>


### PR DESCRIPTION
### Purpose

Redirect URL has been built with the query param `&authFailure=true&authFailureMsg=token.expired` whenever a user enters an OTP after the OTP has expired. The error message has been handled in emailotp.jsp file to display a specific error message whenever the user tries to authenticate using an OTP after the OTP has expired.

### Related PR

- https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/154

### Related Issue
- https://github.com/wso2/product-is/issues/15541