### PR TITLE
Enable reCaptcha to email OTP authenticator

### DIFF
--- a/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -49,6 +49,12 @@
             if (errorMessage.equalsIgnoreCase("authentication.fail.message")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry.code.invalid");
             }
+            if (errorMessage.equalsIgnoreCase("token.expired")) {
+            	errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.code.expired.resend");
+            }
+            if (errorMessage.equalsIgnoreCase("token.expired.email.sent")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.token.expired.email.sent");
+            }
         }
     }
 %>
@@ -184,6 +190,8 @@
                             <div class="align-right buttons">
                                 <%
                                     if ("true".equals(authenticationFailed)) {
+                                        String authFailureMsg = request.getParameter("authFailureMsg");
+                                        if (!"token.expired.email.sent".equals(authFailureMsg)) {
                                 %>
                                 <a 
                                     class="ui button secondary" 
@@ -192,7 +200,7 @@
                                     onkeypress="javascript: if (window.event.keyCode === 13) resendOtp()"
                                 id="resend"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "resend.code")%>
                                 </a>
-                                <% } %>
+                                <% } }%>
                                 <input type="button" name="authenticate" id="authenticate"
                                     value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "authenticate")%>"
                                     class="ui primary button"/>

--- a/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -193,10 +193,10 @@
                                         String authFailureMsg = request.getParameter("authFailureMsg");
                                         if (!"token.expired.email.sent".equals(authFailureMsg)) {
                                 %>
-                                <a 
-                                    class="ui button secondary" 
-                                    onclick="resendOtp()" 
-                                    tabindex="0" 
+                                <a
+                                    class="ui button secondary"
+                                    onclick="resendOtp()"
+                                    tabindex="0"
                                     onkeypress="javascript: if (window.event.keyCode === 13) resendOtp()"
                                 id="resend"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "resend.code")%>
                                 </a>


### PR DESCRIPTION
### Purpose
> Enabling reCaptcha to the email OTP entering page of the email OTP authenticator

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
