### PR TITLE
Stop allowing unlimited length for urls

### DIFF
--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -879,7 +879,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                                                                 fieldName.toLowerCase().includes("uri")
                                                                 || fieldName.toLowerCase().includes("url")
                                                             )
-                                                                ? -1
+                                                                ? 1024
                                                                 : 30
                                                     }
                                                 />
@@ -934,7 +934,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                             <List.Content>
                                 {
                                     (
-                                        !commonConfig.userProfilePage.showEmail 
+                                        !commonConfig.userProfilePage.showEmail
                                         ||  usernameConfig?.enableValidator === "false"
                                     )
                                     &&  fieldName.toLowerCase() === "username"


### PR DESCRIPTION
### Purpose
> $subject. Adding the max limit as 1024 since it is the max length supported by DB

### Related Issues
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/391

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
