### PR TITLE
Validate recovery endpoint callback URL with regex

### DIFF
--- a/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
@@ -153,8 +153,8 @@
                 onHide: function () {
                     <%
                     try {
-                        if (Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
-                                .RECOVERY_CALLBACK_REGEX)) {
+                        if (callback != null && Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants
+                            .ConnectorConfig.RECOVERY_CALLBACK_REGEX)) {
                     %>
                         location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";
                     <%

--- a/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
@@ -153,7 +153,7 @@
                 onHide: function () {
                     <%
                     try {
-                        if (!Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
+                        if (Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
                                 .RECOVERY_CALLBACK_REGEX)) {
                     %>
                         location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";

--- a/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-notify.jsp
@@ -29,6 +29,8 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.RecoveryInitiatingRequest" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.User" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
+<%@ page import="org.wso2.carbon.identity.recovery.util.Utils" %>
+<%@ page import="org.wso2.carbon.identity.recovery.IdentityRecoveryConstants" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.net.URISyntaxException" %>
 <%@ page import="java.net.URLEncoder" %>
@@ -151,7 +153,8 @@
                 onHide: function () {
                     <%
                     try {
-                        if (callback != null) {
+                        if (!Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
+                                .RECOVERY_CALLBACK_REGEX)) {
                     %>
                         location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";
                     <%

--- a/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-notify.jsp
@@ -107,7 +107,7 @@
                 onHide: function () {
                     <%
                     try {
-                        if (!Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
+                        if (Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
                             .RECOVERY_CALLBACK_REGEX)) {
                     %>
                         location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";

--- a/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-notify.jsp
@@ -21,6 +21,8 @@
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.recovery.util.Utils" %>
+<%@ page import="org.wso2.carbon.identity.recovery.IdentityRecoveryConstants" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.net.URISyntaxException" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
@@ -105,7 +107,8 @@
                 onHide: function () {
                     <%
                     try {
-                        if (callback != null) {
+                        if (!Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
+                            .RECOVERY_CALLBACK_REGEX)) {
                     %>
                         location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";
                     <%

--- a/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-notify.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-notify.jsp
@@ -107,8 +107,8 @@
                 onHide: function () {
                     <%
                     try {
-                        if (Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
-                            .RECOVERY_CALLBACK_REGEX)) {
+                        if (callback != null && Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants
+                            .ConnectorConfig.RECOVERY_CALLBACK_REGEX)) {
                     %>
                         location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";
                     <%

--- a/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
@@ -123,8 +123,8 @@
                 onHide: function () {
                     <%
                     try {
-                        if (Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
-                            .RECOVERY_CALLBACK_REGEX)) {
+                        if (callback != null && Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants
+                            .ConnectorConfig.RECOVERY_CALLBACK_REGEX)) {
                     %>
                     location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";
                     <%

--- a/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
@@ -20,6 +20,8 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.CallBackValidator" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityRecoveryException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.recovery.util.Utils" %>
+<%@ page import="org.wso2.carbon.identity.recovery.IdentityRecoveryConstants" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.net.URISyntaxException" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
@@ -121,7 +123,8 @@
                 onHide: function () {
                     <%
                     try {
-                        if (callback != null) {
+                        if (!Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
+                            .RECOVERY_CALLBACK_REGEX)) {
                     %>
                     location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";
                     <%

--- a/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
@@ -123,7 +123,7 @@
                 onHide: function () {
                     <%
                     try {
-                        if (!Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
+                        if (Utils.validateCallbackURL(callback, tenantDomain, IdentityRecoveryConstants.ConnectorConfig
                             .RECOVERY_CALLBACK_REGEX)) {
                     %>
                     location.href = "<%= IdentityManagementEndpointUtil.getURLEncodedCallback(callback)%>";


### PR DESCRIPTION
### Purpose
Fix the issue where the recover endpoint callback URL not getting validated with the given callback URL regex. 

URLs with the callback URL such as `https://localhost:9443/accountrecoveryendpoint/recoverpassword.do?callback=http://google.com/` could get through at the moment.

This effort will fix that issue by validating it with the given regex.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
