### PR TITLE
Lock pnpm version to 7.30.0 in PR builder

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -44,7 +44,7 @@ jobs:
         id: setup-pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: latest
+          version: 7.30.0
           run_install: false
 
       - name: 🎈 Get pnpm store directory
@@ -104,7 +104,7 @@ jobs:
       - name: 🥡 Setup pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: latest
+          version: 7.30.0
           run_install: false
 
       - name: 🎈 Get pnpm store directory
@@ -153,7 +153,7 @@ jobs:
       - name: 🥡 Setup pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: latest
+          version: 7.30.0
           run_install: false
 
       - name: 🎈 Get pnpm store directory
@@ -224,7 +224,7 @@ jobs:
       - name: 🥡 Setup pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: latest
+          version: 7.30.0
           run_install: false
 
       - name: 🎈 Get pnpm store directory

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ lts/* ]
+        pnpm-version: [ 7.30.0 ]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -44,7 +45,7 @@ jobs:
         id: setup-pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: 7.30.0
+          version: ${{ matrix.pnpm-version }}
           run_install: false
 
       - name: 🎈 Get pnpm store directory
@@ -81,6 +82,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ lts/* ]
+        pnpm-version: [ 7.30.0 ]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -104,7 +106,7 @@ jobs:
       - name: 🥡 Setup pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: 7.30.0
+          version: ${{ matrix.pnpm-version }}
           run_install: false
 
       - name: 🎈 Get pnpm store directory
@@ -139,6 +141,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ lts/* ]
+        pnpm-version: [ 7.30.0 ]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -153,7 +156,7 @@ jobs:
       - name: 🥡 Setup pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: 7.30.0
+          version: ${{ matrix.pnpm-version }}
           run_install: false
 
       - name: 🎈 Get pnpm store directory
@@ -198,6 +201,7 @@ jobs:
         node-version: [ lts/* ]
         maven-version: [ 3.8.6 ]
         java-version: [ 1.8 ]
+        pnpm-version: [ 7.30.0 ]
     steps:
       - name: ⬇️ Checkout
         id: checkout
@@ -224,7 +228,7 @@ jobs:
       - name: 🥡 Setup pnpm
         uses: pnpm/action-setup@v2.1.0
         with:
-          version: 7.30.0
+          version: ${{ matrix.pnpm-version }}
           run_install: false
 
       - name: 🎈 Get pnpm store directory

--- a/README.md
+++ b/README.md
@@ -19,16 +19,12 @@ End-user apps in WSO2 Identity Server
 ### Setup Development Environment
 
 1. Install NodeJS LTS(Latest Stable Version) from [https://nodejs.org/en/download/](https://nodejs.org/en/download/).
-2. Install the latest version of [pnpm](https://pnpm.io/).
+2. Install [pnpm](https://pnpm.io/).
+
+    > Note: Due to lockfile compatibility issue, **pnpm v8.0.0 and above are currently not supported.**
 
     ```shell
-    corepack enable
-    ```
-
-    This will install pnpm on your system. However, it probably would not be the latest version. Hence, to upgrade it, check the [latest pnpm version](https://github.com/pnpm/pnpm/releases/latest) and run:
-
-    ```shell
-    corepack prepare pnpm@<version> --activate
+    corepack prepare pnpm@7.x.x --activate
     ```
 
     Or, follow the other [recommended installation options](https://pnpm.io/installation).


### PR DESCRIPTION
### Purpose
> Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. Remove this placeholder when you're editing.

[pnpm v8](https://github.com/pnpm/pnpm/releases/tag/v8.0.0) was released yesterday and it has dropped support for lockfileVersion 5.4 . Since identity-apps pr builder had been configured to get the latest PNPM version, pnpm v8 hasn't recognised the lockfile committed.

This PR is to lock the PNPM version used in the PR builder to 7.30.0 until pnpm v8 becomes mature enough.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
