### PR TITLE
Use external data to render header extensions

### DIFF
--- a/apps/console/src/extensions/configs/common.tsx
+++ b/apps/console/src/extensions/configs/common.tsx
@@ -31,7 +31,8 @@ export const commonConfig: CommonConfig = {
         customClassName: ""
     },
     header: {
-        getHeaderExtensions: (): Promise<HeaderExtension[]> => Promise.resolve([]),
+        getHeaderExtensions: (_tenantDomain: string,
+            _associatedTenants: any[]): Promise<HeaderExtension[]> => Promise.resolve([]),
         getHeaderSubPanelExtensions: (): HeaderSubPanelItemInterface[] => [],
         getUserDropdownLinkExtensions: (
             _tenantDomain: string,

--- a/apps/console/src/extensions/configs/common.tsx
+++ b/apps/console/src/extensions/configs/common.tsx
@@ -31,8 +31,10 @@ export const commonConfig: CommonConfig = {
         customClassName: ""
     },
     header: {
-        getHeaderExtensions: (_tenantDomain: string,
-            _associatedTenants: any[]): Promise<HeaderExtension[]> => Promise.resolve([]),
+        getHeaderExtensions: (
+            _tenantDomain: string,
+            _associatedTenants: any[]
+        ): Promise<HeaderExtension[]> => Promise.resolve([]),
         getHeaderSubPanelExtensions: (): HeaderSubPanelItemInterface[] => [],
         getUserDropdownLinkExtensions: (
             _tenantDomain: string,

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -32,8 +32,10 @@ export interface CommonConfig {
          * Get the extensions for the header.
          * @returns Header extensions.
          */
-        getHeaderExtensions: (tenantDomain: string,
-            associatedTenants: any[]) => Promise<HeaderExtension[]>;
+        getHeaderExtensions: (
+            tenantDomain: string,
+            associatedTenants: any[]
+        ) => Promise<HeaderExtension[]>;
         /**
          * Get the extensions for the Header sub panel.
          * These will come along with the `Manage` & `Develop` links.

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -32,7 +32,8 @@ export interface CommonConfig {
          * Get the extensions for the header.
          * @returns Header extensions.
          */
-        getHeaderExtensions: () => Promise<HeaderExtension[]>;
+        getHeaderExtensions: (tenantDomain: string,
+            associatedTenants: any[]) => Promise<HeaderExtension[]>;
         /**
          * Get the extensions for the Header sub panel.
          * These will come along with the `Manage` & `Develop` links.

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -191,7 +191,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                 }
                 setHeaderExtensions(response);
             });
-    }, [  tenantDomain, associatedTenants ]);
+    }, [ tenantDomain, associatedTenants ]);
 
     /**
      * Check if there are applications registered and set the value to local storage.

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -184,13 +184,14 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
      * Get the header extensions.
      */
     useEffect(() => {
-        commonConfig?.header?.getHeaderExtensions().then((response: HeaderExtension[]) => {
-            if (isPrivilegedUser) {
-                response.pop();
-            }
-            setHeaderExtensions(response);
-        });
-    }, []);
+        commonConfig?.header?.getHeaderExtensions(tenantDomain, associatedTenants)
+            .then((response: HeaderExtension[]) => {
+                if (isPrivilegedUser) {
+                    response.pop();
+                }
+                setHeaderExtensions(response);
+            });
+    }, [  tenantDomain, associatedTenants ]);
 
     /**
      * Check if there are applications registered and set the value to local storage.


### PR DESCRIPTION
### Purpose
> Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. Remove this placeholder when you're editing.

`tenantDomain` and `associatedTenants` are already available when the header component is rendered, but the current implementation of `headerExtensions` doesn't utilise those values. This causes extension components to make another network call to get those values unnecessarily.

This PR to fix that issue i.e make `headerExtensions` functions use already fetch variables instead of sending another network call.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
