### PR TITLE
Unify list loading behavior

### DIFF
--- a/apps/console/src/features/oidc-scopes/pages/oidc-scopes.tsx
+++ b/apps/console/src/features/oidc-scopes/pages/oidc-scopes.tsx
@@ -223,10 +223,10 @@ const OIDCScopesPage: FunctionComponent<OIDCScopesPageInterface> = (
                 sortStrategy={ sortBy }
                 onSortOrderChange={ handleSortOrderChange }
                 onSortStrategyChange={ handleSortStrategyChange }
+                isLoading={ isScopeListFetchRequestLoading }
             >
                 <OIDCScopeList
                     featureConfig={ featureConfig }
-                    isLoading={ isScopeListFetchRequestLoading }
                     list={ filteredScopeList ?? scopeList }
                     onScopeDelete={ () => mutateScopeListFetchRequest() }
                     onEmptyListPlaceholderActionClick={ () => setShowWizard(true) }

--- a/apps/console/src/features/roles/pages/role.tsx
+++ b/apps/console/src/features/roles/pages/role.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,15 +17,23 @@
  */
 
 import { AccessControlConstants, Show } from "@wso2is/access-control";
-import { AlertInterface, AlertLevels, RoleListInterface, RolesInterface } from "@wso2is/core/models";
+import { 
+    AlertInterface,
+    AlertLevels,
+    RoleListInterface,
+    RolesInterface,
+    UserstoreListResponseInterface
+} from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ListLayout, PageLayout, PrimaryButton } from "@wso2is/react-components";
+import { AxiosResponse } from "axios";
 import find from "lodash-es/find";
 import React, { ReactElement, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
 import { Dropdown, DropdownItemProps, DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
-import { AdvancedSearchWithBasicFilters, UIConstants, store } from "../../core";
+import { AdvancedSearchWithBasicFilters, UIConstants } from "../../core";
 import { CreateRoleWizard, RoleList } from "../../roles";
 import { getRolesList } from "../../roles/api";
 import { getUserStoreList } from "../../userstores/api";
@@ -72,16 +80,16 @@ const filterOptions: DropdownItemProps[] = [
 /**
  * React component to list User Roles.
  *
- * @return {ReactElement}
+ * @returns Roles page component.
  */
 const RolesPage = (): ReactElement => {
-    const dispatch = useDispatch();
+    const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
 
     const [ listItemLimit, setListItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);
     const [ listOffset, setListOffset ] = useState<number>(0);
     const [ showWizard, setShowWizard ] = useState<boolean>(false);
-    const [ isListUpdated, setListUpdated ] = useState(false);
+    const [ , setListUpdated ] = useState(false);
     // TODO: Check the usage and delete if not required.
     const [ , setUserStoresList ] = useState([]);
     const [ userStore ] = useState(undefined);
@@ -108,12 +116,12 @@ const RolesPage = (): ReactElement => {
         setRoleListFetchRequestLoading(true);
 
         getRolesList(userStore)
-            .then((response) => {
+            .then((response: AxiosResponse<RoleListInterface>) => {
                 if (response.status === 200) {
-                    const roleResources = response.data.Resources;
+                    const roleResources: RolesInterface[] = response.data.Resources;
 
                     if (roleResources && roleResources instanceof Array) {
-                        const updatedResources = roleResources.filter((role: RolesInterface) => {
+                        const updatedResources: RolesInterface[] = roleResources.filter((role: RolesInterface) => {
                             if (filterBy === "all") {
                                 return role.displayName;
                             } else if (APPLICATION_DOMAIN === filterBy) {
@@ -138,7 +146,7 @@ const RolesPage = (): ReactElement => {
      * The following function fetch the user store list and set it to the state.
      */
     const getUserStores = () => {
-        const storeOptions = [
+        const storeOptions: DropdownItemProps[] = [
             {
                 key: -2,
                 text: "All user stores",
@@ -150,18 +158,18 @@ const RolesPage = (): ReactElement => {
                 value: "primary"
             }
         ];
-        let storeOption = {
+        let storeOption: DropdownItemProps = {
             key: null,
             text: "",
             value: ""
         };
 
         getUserStoreList()
-            .then((response) => {
+            .then((response: AxiosResponse<UserstoreListResponseInterface[]>) => {
                 if (storeOptions.length === 0) {
                     storeOptions.push(storeOption);
                 }
-                response.data.map((store, index) => {
+                response.data.map((store: UserstoreListResponseInterface, index: number) => {
                     storeOption = {
                         key: index,
                         text: store.name,
@@ -179,11 +187,11 @@ const RolesPage = (): ReactElement => {
     /**
      * Sets the list sorting strategy.
      *
-     * @param {React.SyntheticEvent<HTMLElement>} event - The event.
-     * @param {DropdownProps} data - Dropdown data.
+     * @param event - The event.
+     * @param data - Dropdown data.
      */
     const handleListSortingStrategyOnChange = (event: SyntheticEvent<HTMLElement>, data: DropdownProps): void => {
-        setListSortingStrategy(find(ROLES_SORTING_OPTIONS, (option) => {
+        setListSortingStrategy(find(ROLES_SORTING_OPTIONS, (option: DropdownItemProps) => {
             return data.value === option.value;
         }));
     };
@@ -198,20 +206,19 @@ const RolesPage = (): ReactElement => {
         setSearchQuery(searchQuery);
 
         searchRoleList(searchData)
-            .then((response) => {
+            .then((response: AxiosResponse<RoleListInterface>) => {
 
                 if (response.status === 200) {
-                    const results = response?.data?.Resources;
+                    const results: RolesInterface[] = response?.data?.Resources;
 
-                    let updatedResults = [];
+                    let updatedResults: RolesInterface[] = [];
 
                     if (results) {
                         updatedResults = results;
                     }
 
-                    const updatedData = {
-                        ...results,
-                        ...results?.data?.Resources,
+                    const updatedData: RoleListInterface = {
+                        ...response.data,
                         Resources: updatedResults
                     };
 
@@ -224,11 +231,11 @@ const RolesPage = (): ReactElement => {
     /**
      * Util method to paginate retrieved role list.
      *
-     * @param offsetValue pagination offset value
-     * @param itemLimit pagination item limit
+     * @param offsetValue - pagination offset value.
+     * @param itemLimit - pagination item limit.
      */
     const setRolesPage = (offsetValue: number, itemLimit: number, roleList: RoleListInterface) => {
-        const updatedData = {
+        const updatedData: RoleListInterface = {
             ...roleList,
             ...roleList.Resources,
             Resources: roleList?.Resources?.slice(offsetValue, itemLimit + offsetValue)
@@ -238,7 +245,7 @@ const RolesPage = (): ReactElement => {
     };
 
     const handlePaginationChange = (event: React.MouseEvent<HTMLAnchorElement>, data: PaginationProps) => {
-        const offsetValue = (data.activePage as number - 1) * listItemLimit;
+        const offsetValue: number = (data.activePage as number - 1) * listItemLimit;
 
         setListOffset(offsetValue);
         setRolesPage(offsetValue, listItemLimit, initialRolList);
@@ -256,7 +263,7 @@ const RolesPage = (): ReactElement => {
     /**
      * Dispatches the alert object to the redux store.
      *
-     * @param {AlertInterface} alert - Alert object.
+     * @param alert - Alert object.
      */
     const handleAlerts = (alert: AlertInterface) => {
         dispatch(addAlert(alert));
@@ -286,7 +293,7 @@ const RolesPage = (): ReactElement => {
      * Handles the `onFilter` callback action from the
      * roles search component.
      *
-     * @param {string} query - Search query.
+     * @param query - Search query.
      */
     const handleUserFilter = (query: string): void => {
         if (query === null || query === "displayName sw ") {
@@ -385,6 +392,7 @@ const RolesPage = (): ReactElement => {
                         }
                         totalPages={ Math.ceil(initialRolList?.Resources?.length / listItemLimit) }
                         totalListSize={ initialRolList?.Resources?.length }
+                        isLoading={ isRoleListFetchRequestLoading }
                     >
                         <RoleList
                             advancedSearch={ (
@@ -419,7 +427,6 @@ const RolesPage = (): ReactElement => {
                             data-testid="role-mgt-roles-list"
                             handleRoleDelete={ handleOnDelete }
                             isGroup={ false }
-                            isLoading={ isRoleListFetchRequestLoading }
                             onEmptyListPlaceholderActionClick={ () => setShowWizard(true) }
                             onSearchQueryClear={ handleSearchQueryClear }
                             roleList={ paginatedRoles }

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -653,6 +653,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 paginationOptions={ {
                     disableNextButton: !isNextPageAvailable
                 } }
+                isLoading={ isUserListRequestLoading }
             >
                 { userStoreError
                     ? (<EmptyPlaceholder
@@ -701,7 +702,6 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                         usersList={ usersList }
                         onUserDelete={ onUserDelete }
                         userMetaListContent={ userListMetaContent }
-                        isLoading={ isUserListRequestLoading }
                         realmConfigs={ realmConfigs }
                         onEmptyListPlaceholderActionClick={ () => setShowWizard(true) }
                         onSearchQueryClear={ handleSearchQueryClear }

--- a/apps/console/src/features/userstores/pages/user-stores.tsx
+++ b/apps/console/src/features/userstores/pages/user-stores.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,6 +24,7 @@ import { ListLayout, PageLayout, PrimaryButton } from "@wso2is/react-components"
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
+import { Dispatch } from "redux";
 import { DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
 import { userstoresConfig } from "../../../extensions/configs/userstores";
 import {
@@ -48,9 +49,9 @@ type UserStoresPageInterface = TestableComponentInterface;
 /**
  * This renders the Userstores page.
  *
- * @param {UserStoresPageInterface} props - Props injected to the component.
+ * @param props - Props injected to the component.
  *
- * @return {React.ReactElement}
+ * @returns User Stores page.
  */
 const UserStores: FunctionComponent<UserStoresPageInterface> = (
     props: UserStoresPageInterface
@@ -65,7 +66,11 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
     /**
      * Sets the attributes by which the list can be sorted.
      */
-    const SORT_BY = [
+    const SORT_BY: {
+        key: number;
+        text: string;
+        value: string;
+    }[] = [
         {
             key: 0,
             text: t("common:name"),
@@ -91,17 +96,17 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
     const [ searchQuery, setSearchQuery ] = useState("");
     const [ triggerClearQuery, setTriggerClearQuery ] = useState<boolean>(false);
 
-    const dispatch = useDispatch();
+    const dispatch: Dispatch = useDispatch();
 
     const [ resetPagination, setResetPagination ] = useTrigger();
 
     /**
      * Fetches all userstores.
      *
-     * @param {number} limit.
-     * @param {string} sort.
-     * @param {number} offset.
-     * @param {string} filter.
+     * @param limit - Limit per page.
+     * @param sort - SortBy.
+     * @param offset - Offset.
+     * @param filter - FilterBy.
      */
     const fetchUserStores = (limit?: number, sort?: string, offset?: number, filter?: string) => {
         const params: QueryParams = {
@@ -112,11 +117,11 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
         };
 
         setIsLoading(true);
-        getUserStores(params).then(response => {
+        getUserStores(params).then((response: UserStoreListItem[]) => {
             setUserStores(response);
             setFilteredUserStores(response);
             setIsLoading(false);
-        }).catch(error => {
+        }).catch((error: any) => {
             setIsLoading(false);
             dispatch(addAlert(
                 {
@@ -142,11 +147,11 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
     /**
      * This slices and returns a portion of the list.
      *
-     * @param {number} list.
-     * @param {number} limit.
-     * @param {number} offset.
+     * @param list - List to be paginated.
+     * @param limit - Limit per page.
+     * @param offset - Offset value.
      *
-     * @return {UserStoreListItem[]} Paginated list.
+     * @returns Paginated list.
      */
     const paginate = (list: UserStoreListItem[], limit: number, offset: number): UserStoreListItem[] => {
         return list?.slice(offset, offset + limit);
@@ -155,8 +160,8 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
     /**
      * Handles the change in the number of items to display.
      *
-     * @param {React.MouseEvent<HTMLAnchorElement>} event.
-     * @param {DropdownProps} data.
+     * @param event - Click event.
+     * @param data - Dropdown data.
      */
     const handleItemsPerPageDropdownChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
         setListItemLimit(data.value as number);
@@ -165,8 +170,8 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
     /**
      * This paginates.
      *
-     * @param {React.MouseEvent<HTMLAnchorElement>} event.
-     * @param {PaginationProps} data.
+     * @param event - Click event.
+     * @param data - Pagination data.
      */
     const handlePaginationChange = (event: React.MouseEvent<HTMLAnchorElement>, data: PaginationProps) => {
         setOffset((data.activePage as number - 1) * listItemLimit);
@@ -175,7 +180,7 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
     /**
      * Handles sort order change.
      *
-     * @param {boolean} isAscending.
+     * @param isAscending - Sort order.
      */
     const handleSortOrderChange = (isAscending: boolean) => {
         setSortOrder(isAscending);
@@ -184,17 +189,21 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
     /**
      * Handle sort strategy change.
      *
-     * @param {React.SyntheticEvent<HTMLElement>} event.
-     * @param {DropdownProps} data.
+     * @param event - Click event.
+     * @param data - Dropdown data.
      */
     const handleSortStrategyChange = (event: React.SyntheticEvent<HTMLElement>, data: DropdownProps) => {
-        setSortBy(SORT_BY.filter(option => option.value === data.value)[ 0 ]);
+        setSortBy(SORT_BY.filter((option: {
+            key: number;
+            text: string;
+            value: string;
+        }) => option.value === data.value)[ 0 ]);
     };
 
     /**
      * Handles the `onFilter` callback action from the search component.
      *
-     * @param {string} query - Search query.
+     * @param query - Search query.
      */
     const handleUserstoreFilter = (query: string): void => {
         // TODO: Implement once the API is ready
@@ -290,6 +299,7 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
                 showTopActionPanel={ isLoading || !(!searchQuery && filteredUserStores?.length <= 0) }
                 totalPages={ Math.ceil(filteredUserStores?.length / listItemLimit) }
                 totalListSize={ filteredUserStores?.length }
+                isLoading={ isLoading }
                 data-testid={ `${ testId }-list-layout` }
             >
                 <UserStoresList
@@ -329,7 +339,6 @@ const UserStores: FunctionComponent<UserStoresPageInterface> = (
                             data-testid={ `${ testId }-advanced-search` }
                         />)
                     }
-                    isLoading={ isLoading }
                     list={ paginate(filteredUserStores, listItemLimit, offset) }
                     onEmptyListPlaceholderActionClick={
                         () => history.push(AppConstants.getPaths().get("USERSTORE_TEMPLATES"))

--- a/apps/console/src/features/workflow-approvals/pages/approvals.tsx
+++ b/apps/console/src/features/workflow-approvals/pages/approvals.tsx
@@ -22,7 +22,8 @@ import { ListLayout, PageLayout } from "@wso2is/react-components";
 import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
-import { Dropdown, DropdownProps, Input, PaginationProps, SemanticCOLORS } from "semantic-ui-react";
+import { Dispatch } from "redux";
+import { Dropdown, DropdownItemProps, DropdownProps, Input, PaginationProps, SemanticCOLORS } from "semantic-ui-react";
 import { AppState, FeatureConfigInterface, UIConstants } from "../../core";
 import { fetchPendingApprovals, updatePendingApprovalStatus } from "../api";
 import { ApprovalsList } from "../components";
@@ -50,7 +51,7 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
 
     const { t } = useTranslation();
 
-    const dispatch = useDispatch();
+    const dispatch: Dispatch = useDispatch();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
@@ -62,7 +63,7 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
     const [ filterStatus, setFilterStatus ] = useState<string>(ApprovalStatus.ALL);
     const [ searchResult, setSearchResult ] = useState<number>(undefined);
 
-    const APPROVAL_OPTIONS = [
+    const APPROVAL_OPTIONS: DropdownItemProps[] = [
         {
             key: 1,
             text: "All",
@@ -111,11 +112,11 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
      *
      * @param shallowUpdate - A flag to specify if only the statuses should be updated.
      */
-    const getApprovals = (shallowUpdate = false): void => {
+    const getApprovals = (shallowUpdate: boolean = false): void => {
         setApprovalListRequestLoading(true);
 
         fetchPendingApprovals(null, null, filterStatus)
-            .then((response) => {
+            .then((response: ApprovalTaskListItemInterface[]) => {
                 if (!shallowUpdate) {
                     setApprovals(response);
                     setTempApprovals(response);
@@ -123,17 +124,17 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
                     return;
                 }
 
-                const approvalsFromState = [ ...approvals ];
-                const approvalsFromResponse = [ ...response ];
-                const filteredApprovals = [];
+                const approvalsFromState: ApprovalTaskListItemInterface[] = [ ...approvals ];
+                const approvalsFromResponse: ApprovalTaskListItemInterface[] = [ ...response ];
+                const filteredApprovals: ApprovalTaskListItemInterface[] = [];
 
                 // Compare the approvals list in the state with the new response
                 // and update the new statuses. When the status of the approval is changed,
                 // it has to be dropped from the list if the filter status is not `ALL`.
                 // Therefore the matching entries are extracted out to the `filteredApprovals` array
                 // and are set to the state.
-                approvalsFromState.forEach((fromState) => {
-                    approvalsFromResponse.forEach((fromResponse) => {
+                approvalsFromState.forEach((fromState: ApprovalTaskListItemInterface) => {
+                    approvalsFromResponse.forEach((fromResponse: ApprovalTaskListItemInterface) => {
                         if (fromState.id === fromResponse.id) {
                             fromState.status = fromResponse.status;
                             filteredApprovals.push(fromState);
@@ -144,7 +145,7 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
                 setApprovals(filteredApprovals);
                 setTempApprovals(filteredApprovals);
             })
-            .catch((error) => {
+            .catch((error: any) => {
                 if (error.response && error.response.data && error.response.detail) {
                     dispatch(addAlert({
                         description: t(
@@ -258,7 +259,7 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
             .then(() => {
                 getApprovals(false);
             })
-            .catch((error) => {
+            .catch((error: any) => {
                 if (error.response && error.response.data && error.response.detail) {
                     dispatch(addAlert({
                         description: t(
@@ -292,12 +293,14 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
      *
      * @param event - event
      */
-    const searchApprovalList = (event) => {
-        const changeValue = event.target.value;
+    const searchApprovalList = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const changeValue: string = event.target.value;
 
         if (changeValue.length > 0) {
-            const searchResult = approvals.filter((item) =>
-                item.name.toLowerCase().indexOf(changeValue.toLowerCase()) !== -1);
+            const searchResult: ApprovalTaskListItemInterface[] = approvals
+                .filter((item: ApprovalTaskListItemInterface) =>
+                    item.name.toLowerCase().indexOf(changeValue.toLowerCase()) !== -1
+                );
 
             setTempApprovals(searchResult);
 
@@ -325,6 +328,7 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
                 showTopActionPanel={ isApprovalListRequestLoading || !(approvals?.length == 0) }
                 totalPages={ Math.ceil(approvals.length / listItemLimit) }
                 totalListSize={ approvals.length }
+                isLoading={ isApprovalListRequestLoading }
                 data-testid={ `${ testId }-list-layout` }
                 rightActionPanel={
                     (<Dropdown
@@ -352,12 +356,11 @@ const ApprovalsPage: FunctionComponent<ApprovalsPageInterface> = (
             >
                 <ApprovalsList
                     filterStatus={ filterStatus }
-                    onChangeStatusFilter={ (status) => setFilterStatus(status) }
+                    onChangeStatusFilter={ (status: string) => setFilterStatus(status) }
                     searchResult={ searchResult }
                     getApprovalsList={ getApprovals }
                     updateApprovalStatus={ updateApprovalStatus }
                     featureConfig={ featureConfig }
-                    isLoading={ isApprovalListRequestLoading }
                     list={ paginate(tempApprovals, listItemLimit, offset) }
                     resolveApprovalTagColor={ resolveApprovalTagColor }
                     data-testid={ `${ testId }-list` }

--- a/modules/core/src/constants/ui-constants.ts
+++ b/modules/core/src/constants/ui-constants.ts
@@ -42,7 +42,7 @@ export class UIConstants {
     public static readonly API_RETRIEVAL_ERROR_ALERT_MESSAGE: string = "Retrieval Error";
 
     /**
-     * Default list item size for resources such as applications, IdPs etc.
+     * Default loading list rows count for resources such as applications, IdPs etc.
      */
-    public static readonly DEFAULT_RESOURCE_LIST_ITEM_LIMIT: number = 10;
+    public static readonly DEFAULT_RESOURCE_LIST_LOADING_ITEM_LIMIT: number = 4;
 }

--- a/modules/react-components/src/layouts/list.tsx
+++ b/modules/react-components/src/layouts/list.tsx
@@ -296,7 +296,7 @@ export const ListLayout: FunctionComponent<PropsWithChildren<ListLayoutPropsInte
                         <DataTable
                             isLoading={ true }
                             loadingStateOptions={ {
-                                count: defaultListItemLimit ?? UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT,
+                                count: defaultListItemLimit ?? UIConstants.DEFAULT_RESOURCE_LIST_LOADING_ITEM_LIMIT,
                                 imageType: "square"
                             } }
                             columns={ [] }


### PR DESCRIPTION
### Purpose
- `isLoading` state passed to outer `ListLayout` component rather than the inner components.
- Renamed the UI constant used for rendering loading placeholders.
- Reduced the loading rows count to 4.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
