### PR TITLE
Set tenant domain for untenanted usernames in resend email flow

### DIFF
--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -177,6 +177,10 @@
 
         ResendCodeRequestDTO selfRegistrationRequest = new ResendCodeRequestDTO();
         UserDTO userDTO = AuthenticationEndpointUtil.getUser(resendUsername);
+        int atIndex = resendUsername.lastIndexOf('@');
+        if (atIndex == -1) {
+            userDTO.setTenantDomain(request.getParameter("tenantDomain"));
+        }
         selfRegistrationRequest.setUser(userDTO);
 
         PropertyDTO propertyDTO = new PropertyDTO();


### PR DESCRIPTION
### Purpose

Self registration resend email flow is breaking for tenanted enviornments, when username without the tenant name is used. This effort added a step to check if the username is tenanted and if so, the usual flow will be continued. If not, the tenant domain specified in the request will be set as the user's tenant domain.

### Related issues
- https://github.com/wso2/product-is/issues/15701

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
