### PR TITLE
Add recaptcha to email OTP page

### DIFF
--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -314,6 +314,7 @@ invalid.organization.name=Invalid Organization Name
 enter.code.sent.smsotp=Enter the code sent to your mobile phone
 auth.with.smsotp=Authenticating with SMS OTP
 error.code.expired.resend=The code entered is expired. Click Resend Code to continue.
+error.recaptcha.failed=The recaptcha verification failed. Please try again.
 error.send.sms=Unable to send OTP to your phone number
 error.wrong.code=The code entered is incorrect. Authentication Failed!
 error.failed.with.smsotp=Failed Authentication with SMSOTP

--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -314,7 +314,6 @@ invalid.organization.name=Invalid Organization Name
 enter.code.sent.smsotp=Enter the code sent to your mobile phone
 auth.with.smsotp=Authenticating with SMS OTP
 error.code.expired.resend=The code entered is expired. Click Resend Code to continue.
-error.recaptcha.failed=The recaptcha verification failed. Please try again.
 error.send.sms=Unable to send OTP to your phone number
 error.wrong.code=The code entered is incorrect. Authentication Failed!
 error.failed.with.smsotp=Failed Authentication with SMSOTP

--- a/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -55,9 +55,6 @@
             if (errorMessage.equalsIgnoreCase("token.expired.email.sent")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.token.expired.email.sent");
             }
-            if (errorMessage.equalsIgnoreCase("recaptcha.failed")) {
-                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.recaptcha.failed");
-            }
         }
     }
 %>
@@ -92,7 +89,6 @@
 
     <%
         if (reCaptchaEnabled) {
-
     %>
     <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <%

--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -335,15 +335,15 @@ export class ApplicationManagementConstants {
     // First factor authenticators.
     public static readonly FIRST_FACTOR_AUTHENTICATORS: string[] = [
         IdentityProviderManagementConstants.BASIC_AUTHENTICATOR,
-        IdentityProviderManagementConstants.FIDO_AUTHENTICATOR
+        IdentityProviderManagementConstants.FIDO_AUTHENTICATOR,
+        IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR,
+        IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID
     ];
 
     // Second factor authenticators.
     public static readonly SECOND_FACTOR_AUTHENTICATORS: string[] = [
         IdentityProviderManagementConstants.TOTP_AUTHENTICATOR,
         IdentityProviderManagementConstants.TOTP_AUTHENTICATOR_ID,
-        IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR,
-        IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID,
         IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR,
         IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID
     ];

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/email-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/email-otp-authenticator-form.tsx
@@ -98,6 +98,10 @@ interface EmailOTPAuthenticatorFormInitialValuesInterface {
      * Allow OTP token to have 0-9 characters only.
      */
     EmailOTP_OtpRegex_UseNumericChars: boolean;
+    /**
+     * Enable recaptcha for email OTP.
+     */
+    EmailOTP_RecaptchaEnable: boolean;
 }
 
 /**
@@ -116,6 +120,10 @@ interface EmailOTPAuthenticatorFormFieldsInterface {
      * Allow OTP token to have 0-9 characters only field.
      */
     EmailOTP_OtpRegex_UseNumericChars: CommonAuthenticatorFormFieldInterface;
+    /**
+     * Enable recaptcha for email OTP.
+     */
+    EmailOTP_RecaptchaEnable: CommonAuthenticatorFormFieldInterface;
 }
 
 /**
@@ -134,6 +142,10 @@ export interface EmailOTPAuthenticatorFormErrorValidationsInterface {
      * Allow OTP token to have 0-9 characters only field.
      */
     EmailOTP_OtpRegex_UseNumericChars: string;
+    /**
+     * Enable recaptcha for email OTP.
+     */
+    EmailOTP_RecaptchaEnable: string;
 }
 
 const FORM_ID: string = "email-otp-authenticator-form";
@@ -165,6 +177,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
 
     // SMS OTP length unit is set to digits or characters according to the state of this variable
     const [ isOTPNumeric, setIsOTPNumeric ] = useState<boolean>();
+    const [ isRecaptchaEnabled, setIsRecaptchaEnabled ] = useState<boolean>();
 
     /**
      * Flattens and resolved form initial values and field metadata.
@@ -221,6 +234,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
         });
 
         setIsOTPNumeric(resolvedInitialValues.EmailOTP_OtpRegex_UseNumericChars);
+        setIsRecaptchaEnabled(resolvedInitialValues.EmailOTP_RecaptchaEnable);
         setFormFields(resolvedFormFields);
         setInitialValues(resolvedInitialValues);
     }, [ originalInitialValues ]);
@@ -378,6 +392,28 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                     }
                 </Label>
             </Field.Input>
+            <Field.Checkbox
+                ariaLabel="Enable recaptcha for email OTP"
+                name="EmailOTP_RecaptchaEnable"
+                label={
+                    t("console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".emailOTP.recaptchaEnable.label")
+                }
+                hint={
+                    (<Trans
+                        i18nKey={
+                            "console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                            ".emailOTP.recaptchaEnable.hint"
+                        }
+                    >
+                        Enable Recaptcha for Email OTP.
+                    </Trans>)
+                }
+                readOnly={ readOnly }
+                width={ 12 }
+                data-testid={ `${ testId }-otp-recaptcha-enable` }
+                listen={ (e:boolean) => {setIsRecaptchaEnabled(e);} }
+            />
             <Field.Checkbox
                 ariaLabel="Use numeric characters for OTP"
                 name="EmailOTP_OtpRegex_UseNumericChars"

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -91,7 +91,7 @@ export const console: ConsoleNS = {
             },
             featureAnnouncements: {
                 organizations: {
-                    message: "Introducing B2B organizations. Start building your B2B platform by onboarding your " + 
+                    message: "Introducing B2B organizations. Start building your B2B platform by onboarding your " +
                     "partner/customer organizations.",
                     buttons: {
                         tryout: "Try It Out"
@@ -1123,7 +1123,7 @@ export const console: ConsoleNS = {
                                                 " the <1>mobile number</1> to configure <3>SMS OTP</3> with the" +
                                                 " following connections.",
                                                 singleIdp: "Asgardeo requires the user's profile containing the"+
-                                                " <1>mobile number</1> to configure <3>SMS OTP</3> with" + 
+                                                " <1>mobile number</1> to configure <3>SMS OTP</3> with" +
                                                 " <5>{{idpName}}</5> connection."
                                             }
                                         }
@@ -3219,7 +3219,7 @@ export const console: ConsoleNS = {
                                 }
                             },
                             secretValidityPeriod: {
-                                hint: "The validity period of the generated client secret in seconds. A new client secret " + 
+                                hint: "The validity period of the generated client secret in seconds. A new client secret " +
                                     "will be generated after this time.",
                                 label: "Client Secret Validity Period",
                                 placeholder: "Enter the Validity Period for the Client Secret.",
@@ -3291,6 +3291,13 @@ export const console: ConsoleNS = {
                                 label: "Use only numeric characters for OTP",
                                 validations: {
                                     required: "Use only numeric characters for OTP is a required field."
+                                }
+                            },
+                            recaptchaEnable: {
+                                hint: "Please clear this checkbox to enable recaptcha for email OTP.",
+                                label: "Enable Recaptcha",
+                                validations: {
+                                    required: "Enable Recaptcha is a required field."
                                 }
                             }
                         },
@@ -4472,11 +4479,11 @@ export const console: ConsoleNS = {
                                 heading: "Name"
                             },
                             preRequisites: {
-                                configureAppleSignIn: "See Apple's guide on configuring your environment for" + 
+                                configureAppleSignIn: "See Apple's guide on configuring your environment for" +
                                 " Sign in with Apple.",
                                 configureReturnURL: "Add the following URL as a <1>Return URL</1>.",
                                 configureWebDomain: "Use the following as a <1>Web Domain</1>.",
-                                getCredentials: "Before you begin, create a <1>Sign in With Apple</1> enabled" + 
+                                getCredentials: "Before you begin, create a <1>Sign in With Apple</1> enabled" +
                                     " application on <3>Apple Developer Portal</3> with a <5>Services ID</5> and a" +
                                     " <5>Private Key</5>.",
                                 heading: "Prerequisite"


### PR DESCRIPTION
### Purpose
This PR provides google recaptcha validation for the email OTP submitting page if recaptcha is enabled at the email OTP connector.

### Related Issues
- https://github.com/wso2/product-is/issues/15581

### Related PRs
- https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/156

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
