### PR TITLE
Add new optional prop to header component

### DIFF
--- a/apps/console/src/extensions/configs/common.tsx
+++ b/apps/console/src/extensions/configs/common.tsx
@@ -17,7 +17,7 @@
  */
 
 import { HeaderExtension, HeaderLinkCategoryInterface } from "@wso2is/react-components";
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 import { CommonConfig } from "./models";
 import { HeaderSubPanelItemInterface } from "../../features/core/components";
 
@@ -37,7 +37,7 @@ export const commonConfig: CommonConfig = {
             _associatedTenants: any[]
         ): Promise<HeaderExtension[]> => Promise.resolve([]),
         getHeaderSubPanelExtensions: (): HeaderSubPanelItemInterface[] => [],
-        getUserDropdownFooterExtensions: (): ReactElement => <></>,
+        getUserDropdownFooterExtensions: (): ReactElement => null,
         getUserDropdownLinkExtensions: (
             _tenantDomain: string,
             _associatedTenants: any[]): Promise<HeaderLinkCategoryInterface[]> => Promise.resolve([]),

--- a/apps/console/src/extensions/configs/common.tsx
+++ b/apps/console/src/extensions/configs/common.tsx
@@ -17,6 +17,7 @@
  */
 
 import { HeaderExtension, HeaderLinkCategoryInterface } from "@wso2is/react-components";
+import React, { ReactElement } from "react";
 import { CommonConfig } from "./models";
 import { HeaderSubPanelItemInterface } from "../../features/core/components";
 
@@ -36,6 +37,7 @@ export const commonConfig: CommonConfig = {
             _associatedTenants: any[]
         ): Promise<HeaderExtension[]> => Promise.resolve([]),
         getHeaderSubPanelExtensions: (): HeaderSubPanelItemInterface[] => [],
+        getUserDropdownFooterExtensions: (): ReactElement => <></>,
         getUserDropdownLinkExtensions: (
             _tenantDomain: string,
             _associatedTenants: any[]): Promise<HeaderLinkCategoryInterface[]> => Promise.resolve([]),

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -17,6 +17,7 @@
  */
 
 import { HeaderExtension, HeaderLinkCategoryInterface } from "@wso2is/react-components";
+import { ReactElement } from "react";
 import { HeaderSubPanelItemInterface } from "../../../features/core/components";
 import { FeatureConfigInterface } from "../../../features/core/models";
 
@@ -52,6 +53,12 @@ export interface CommonConfig {
          */
         getUserDropdownLinkExtensions: (tenantDomain: string,
             associatedTenants: any[]) => Promise<HeaderLinkCategoryInterface[]>;
+        /**
+         * Get the user dropdown footer extensions.
+         *
+         * @returns A ReactElement that renders the footer.
+         */
+        getUserDropdownFooterExtensions: () => ReactElement;
         /**
          * Should the app switcher be shown as nine dots dropdown.
          */

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -481,6 +481,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             fluid={ fluid }
             isProfileInfoLoading={ isProfileInfoLoading }
             isPrivilegedUser={ isPrivilegedUser }
+            userDropdownFooter={ commonConfig?.header?.getUserDropdownFooterExtensions() }
             userDropdownLinks={
                 compact([
                     !commonConfig?.header?.renderAppSwitcherAsDropdown && {

--- a/modules/react-components/src/components/header/header.tsx
+++ b/modules/react-components/src/components/header/header.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -81,6 +81,7 @@ export interface HeaderPropsInterface extends IdentifiableComponentInterface, Te
     showUserDropdownTriggerBars?: boolean;
     userDropdownIcon?: any;
     userDropdownInfoAction?: React.ReactNode;
+    userDropdownFooter?: React.ReactNode;
     userDropdownLinks?: HeaderLinkCategoryInterface[];
     /**
      * User dropdown pointing direction.
@@ -195,6 +196,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
         onLinkedAccountSwitch,
         onSidePanelToggleClick,
         userDropdownIcon,
+        userDropdownFooter,
         userDropdownLinks,
         userDropdownPointing,
         onAvatarClick,
@@ -704,6 +706,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                                                 </Item.Group>
                                                 { renderLinkedAccounts(linkedAccounts) }
                                                 { renderUserDropdownLinks() }
+                                                { userDropdownFooter }
                                             </Dropdown.Menu>
                                         }
                                     </Dropdown>

--- a/modules/react-components/src/components/header/header.tsx
+++ b/modules/react-components/src/components/header/header.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
### Purpose

This change will allow a new optional prop called `userDropdownFooter` to be applied to the header component, so that user dropdown in the header can have a footer component.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
