### PR TITLE
Introduce admin advisory banner to authentication endpoint

### DIFF
--- a/java/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -1,7 +1,7 @@
 <%--
-  ~ Copyright (c) 2014, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2014, WSO2 LLC. (http://www.wso2.com) All Rights Reserved.
   ~
-  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
@@ -20,6 +20,7 @@
 <%@ page import="org.apache.cxf.jaxrs.provider.json.JSONProvider" %>
 <%@ page import="org.apache.cxf.jaxrs.client.WebClient" %>
 <%@ page import="org.apache.http.HttpStatus" %>
+<%@ page import="org.json.JSONObject" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.client.SelfUserRegistrationResource" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
@@ -37,12 +38,15 @@
 <%@ page import="static org.wso2.carbon.identity.core.util.IdentityUtil.getServerURL" %>
 <%@ page import="org.apache.commons.codec.binary.Base64" %>
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
+<%@ page import="org.apache.commons.logging.Log" %>
+<%@ page import="org.apache.commons.logging.LogFactory" %>
 <%@ page import="java.nio.charset.Charset" %>
 <%@ page import="org.wso2.carbon.base.ServerConfiguration" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.EndpointConfigManager" %>
 <%@ page import="org.wso2.carbon.identity.core.URLBuilderException" %>
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.AdminAdvisoryDataRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApplicationDataRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApplicationDataRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
@@ -133,8 +137,28 @@
     private static final String ACCOUNT_RECOVERY_ENDPOINT = "/accountrecoveryendpoint";
     private static final String ACCOUNT_RECOVERY_ENDPOINT_RECOVER = "/recoveraccountrouter.do";
     private static final String ACCOUNT_RECOVERY_ENDPOINT_REGISTER = "/register.do";
+    private static final String CONSOLE = "Console";
+    private Log log = LogFactory.getLog(this.getClass());
 %>
+
 <%
+    Boolean isAdminBannerAllowedInSP = CONSOLE.equals(request.getParameter("sp"));
+    Boolean isAdminAdvisoryBannerEnabledInTenant = false;
+    String adminAdvisoryBannerContentOfTenant = "";
+    
+    try {
+        if (isAdminBannerAllowedInSP) {
+            AdminAdvisoryDataRetrievalClient adminBannerPreferenceRetrievalClient =
+                new AdminAdvisoryDataRetrievalClient();
+            JSONObject adminAdvisoryBannerConfig = adminBannerPreferenceRetrievalClient
+                .getAdminAdvisoryBannerData(tenantDomain);
+            isAdminAdvisoryBannerEnabledInTenant = adminAdvisoryBannerConfig.getBoolean("enableBanner");
+            adminAdvisoryBannerContentOfTenant = adminAdvisoryBannerConfig.getString("bannerContent");
+        }
+    } catch (Exception e) {
+        log.error("Error in displaying admin advisory banner", e);
+    }
+    
     String emailUsernameEnable = application.getInitParameter("EnableEmailUserName");
     Boolean isEmailUsernameEnabled = false;
     String usernameLabel = "username";
@@ -290,6 +314,12 @@
         </form>
     </div>
     <div class="ui divider hidden"></div>
+<% } %>
+
+<% if (isAdminBannerAllowedInSP && isAdminAdvisoryBannerEnabledInTenant) { %>
+    <div class="ui warning message" data-componentid="login-page-admin-session-advisory-banner">
+        <%=Encode.forHtmlContent(adminAdvisoryBannerContentOfTenant)%>
+    </div>
 <% } %>
 
 <form class="ui large form" action="<%=loginFormActionURL%>" method="post" id="loginForm">


### PR DESCRIPTION
## Purpose
This PR introduces the admin advisory banner to authentication endpoint by integrating the banner to `basicauth.jsp`. This will display the admin advisory banner in the Console app login page for product IS and Admin Portal for product APIM. 
Currently, the banner component can only be enabled through the management console.

### Related Issues
- Issue https://github.com/wso2/product-is/issues/15521

### Related PRs
- PR https://github.com/wso2/carbon-identity-framework/pull/4536
- PR https://github.com/wso2/carbon-kernel/pull/3560
- PR https://github.com/wso2/identity-api-server/pull/441
- PR https://github.com/wso2/product-is/pull/15700

`Console app login page`
![image](https://user-images.githubusercontent.com/46979289/233558958-03564052-1c44-47b2-a83f-897d9841007c.png)

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
