### PR TITLE
Prevent rendering `Organization SSO` template

### DIFF
--- a/apps/console/src/features/identity-providers/constants/identity-provider-constants.ts
+++ b/apps/console/src/features/identity-providers/constants/identity-provider-constants.ts
@@ -63,7 +63,7 @@ export class IdentityProviderConstants {
 
     /**
      * data-tabIds of the panes in the IdP settings
-     * 
+     *
      */
     public static readonly ADVANCED_TAB_ID: string  = "advanced";
     public static readonly ATTRIBUTES_TAB_ID: string  = "attributes";
@@ -80,3 +80,4 @@ export const GOOGLE_IDP_NAME: string  = "Google";
 export const GOOGLE_IDP_ID: string  = "8ea23303-49c0-4253-b81f-82c0fe6fb4a0";
 export const OIDC_IDP_ID: string  = "oidc-idp";
 export const ENTERPRISE_IDP_ID: string  = "enterprise-idp";
+export const ORG_ENTERPRISE_IDP_ID: string  = "organization-enterprise-idp";

--- a/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
@@ -46,7 +46,6 @@ import {
     getEmptyPlaceholderIllustrations,
     history
 } from "../../core";
-import { OrganizationType } from "../../organizations/constants";
 import { AuthenticatorCreateWizardFactory } from "../components/wizards";
 import { getIdPIcons } from "../configs";
 import { IdentityProviderManagementConstants } from "../constants";
@@ -93,8 +92,6 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
         (state: AppState) => state.identityProvider.meta.authenticators);
     const identityProviderTemplates: IdentityProviderTemplateItemInterface[] = useSelector(
         (state: AppState) => state.identityProvider?.groupedTemplates);
-    const orgType: OrganizationType = useSelector((state: AppState) =>
-        state?.organization?.organizationType);
 
     const [ showWizard, setShowWizard ] = useState<boolean>(false);
     const [ templateType, setTemplateType ] = useState<string>(undefined);
@@ -311,7 +308,7 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
             return template.tags
                 .some((selectedLabel: string) => filterLabels.includes(selectedLabel));
         };
-        
+
         const templatesClone: IdentityProviderTemplateCategoryInterface[] = cloneDeep(originalCategorizedTemplates);
 
         templatesClone.map((category: IdentityProviderTemplateCategoryInterface) => {
@@ -473,14 +470,9 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
                                                 template: IdentityProviderTemplateInterface,
                                                 templateIndex: number
                                             ) => {
-                                                const isOrgIdp: boolean = template.templateId === "organi" +
-                                                    "zation-enterprise-idp";
-
-                                                if (isOrgIdp && !isOrganizationManagementEnabled) {
-                                                    return null;
-                                                }
-
-                                                if (isOrgIdp && orgType === OrganizationType.SUBORGANIZATION) {
+                                                // if the template is "organization-enterprise-idp",
+                                                // then prevent rendering it.
+                                                if (template.id === "organization-enterprise-idp") {
                                                     return null;
                                                 }
 
@@ -488,7 +480,7 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
                                                     <ResourceGrid.Card
                                                         key={ templateIndex }
                                                         resourceName={
-                                                            template.name === "Enterprise" ? "Standard-Based IdP" 
+                                                            template.name === "Enterprise" ? "Standard-Based IdP"
                                                                 : template.name
                                                         }
                                                         isResourceComingSoon={ template.comingSoon }

--- a/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
+++ b/apps/console/src/features/identity-providers/pages/identity-provider-template.tsx
@@ -48,7 +48,7 @@ import {
 } from "../../core";
 import { AuthenticatorCreateWizardFactory } from "../components/wizards";
 import { getIdPIcons } from "../configs";
-import { IdentityProviderManagementConstants } from "../constants";
+import { IdentityProviderManagementConstants, ORG_ENTERPRISE_IDP_ID } from "../constants";
 import {
     FederatedAuthenticatorListItemInterface,
     IdentityProviderTemplateCategoryInterface,
@@ -472,7 +472,7 @@ const IdentityProviderTemplateSelectPage: FunctionComponent<IdentityProviderTemp
                                             ) => {
                                                 // if the template is "organization-enterprise-idp",
                                                 // then prevent rendering it.
-                                                if (template.id === "organization-enterprise-idp") {
+                                                if (template.id === ORG_ENTERPRISE_IDP_ID) {
                                                     return null;
                                                 }
 


### PR DESCRIPTION
### Purpose
> Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. Remove this placeholder when you're editing.

Currently, the 'Organization SSO` connection template is visible in the "Create a New Connection" page which may cause confusion for end users. This PR prevents it from rendering in the "Create a New Connection" page.

### Related Issues
- n/a

### Related PRs
- n/a

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
