### PR TITLE
Update magic link notifcation page message

### DIFF
--- a/java/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/java/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -345,7 +345,6 @@ fido.authenticator=Security Key
 magic.link.heading=Check your inbox!
 magic.link.content=Click the link we sent to your email to sign in.
 magic.link=Magic Link
-magic.link.info=Use the same browser to open the link.
 
 # Backup Code authentication
 error.backup.code.not.enabled=All your Backup Codes are used or Backup codes are not enabled on your profile. Enable backup codes to proceed with the Backup Code authentication flow.

--- a/java/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/java/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -340,7 +340,6 @@ fido.authenticator=Clef de sécurité
 magic.link.heading=Vérifiez votre boéte de réceptioné!
 magic.link.content=Cliquez sur le lien que nous vous avons envoyé par e-mail pour vous connecter.
 magic.link=Lien magique
-magic.link.info=Utilisez le méme navigateur pour ouvrir le lien.
 
 # Backup Code authentication
 error.backup.code.not.enabled=Tous vos codes de secours sont utilisés ou les codes de secours ne sont pas activés sur votre profil. Activez les codes de secours pour poursuivre le flux d'authentification du code de secours.

--- a/java/apps/authentication-portal/src/main/webapp/magic_link_notification.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/magic_link_notification.jsp
@@ -73,7 +73,6 @@
             <p>
                 <%=AuthenticationEndpointUtil.i18n(resourceBundle,
                         "magic.link.content")%>
-                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "magic.link.info" )%>
             </p>
         </div>
     </div>


### PR DESCRIPTION
### Purpose
* $subject
* With https://github.com/wso2/carbon-identity-framework/pull/4587 feature, users no longer need to use the same browser to log in with MagicLink authenticator. Therefore updated the magic line notification page message according to that modification.