### PR TITLE
Fix Email Template Issue due to Inconsistent locale Format

### DIFF
--- a/apps/console/src/features/email-templates/components/forms/add-email-template-form.tsx
+++ b/apps/console/src/features/email-templates/components/forms/add-email-template-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -22,7 +22,7 @@ import { Field, FormValue, Forms } from "@wso2is/forms";
 import { Message } from "@wso2is/react-components";
 import { AxiosError, AxiosResponse } from "axios";
 import * as CountryLanguage from "country-language";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { Dispatch, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Button, DropdownItemProps, Form, Grid } from "semantic-ui-react";
@@ -52,8 +52,7 @@ interface AddEmailTemplateFormPropsInterface extends TestableComponentInterface 
 /**
  * Form to handle ADD/EDIT of a locale based email template.
  *
- * @param {AddEmailTemplateFormPropsInterface} props - props required for component.
- * @return {React.ReactElement}
+ * @param props - props required for component.
  */
 export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsInterface> = (
     props: AddEmailTemplateFormPropsInterface
@@ -66,7 +65,7 @@ export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsIn
         [ "data-testid" ]: testId
     } = props;
 
-    const dispatch = useDispatch();
+    const dispatch: Dispatch<any> = useDispatch();
 
     const { t } = useTranslation();
 
@@ -87,12 +86,12 @@ export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsIn
         const locales: string[] = CountryLanguage.getLocales(true);
         const localeDropDown: DropdownItemProps[] = [];
 
-        locales.forEach((locale, index) => {
-            const countryCode = locale.split("-")[ 1 ];
-            const languageCode = locale.split("-")[ 0 ];
+        locales.forEach((locale: string, index: number) => {
+            const countryCode: string = locale.split("-")[ 1 ];
+            const languageCode: string = locale.split("-")[ 0 ];
 
-            const language = CountryLanguage.getLanguage(languageCode).name;
-            const country = CountryLanguage.getCountry(countryCode).name;
+            const language: string = CountryLanguage.getLanguage(languageCode).name;
+            const country: string = CountryLanguage.getCountry(countryCode).name;
 
             localeDropDown.push({
                 flag: countryCode.toLowerCase(),
@@ -116,7 +115,7 @@ export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsIn
         getTemplateDetails(templateTypeId, templateId)
             .then((response: AxiosResponse<EmailTemplate>) => {
                 if (response.status === 200) {
-                    const templateDetails = response.data;
+                    const templateDetails: EmailTemplate = response.data;
 
                     setLocale(templateDetails.id);
                     setSubject(templateDetails.subject);
@@ -207,7 +206,7 @@ export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsIn
                     }));
                 }
             })
-            .catch(error => {
+            .catch((error: any) => {
                 dispatch(addAlert<AlertInterface>({
                     description: error.response.data.description,
                     level: AlertLevels.ERROR,
@@ -269,7 +268,7 @@ export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsIn
                                                 ".validations.empty")
                                         }
                                         required={ true }
-                                        children={ localeList ? localeList.map(list => {
+                                        children={ localeList ? localeList.map((list: DropdownItemProps) => {
                                             return {
                                                 "data-testid": list.value as string,
                                                 key: list.key as string,

--- a/apps/console/src/features/email-templates/components/forms/add-email-template-form.tsx
+++ b/apps/console/src/features/email-templates/components/forms/add-email-template-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,9 +22,10 @@ import { Field, FormValue, Forms } from "@wso2is/forms";
 import { Message } from "@wso2is/react-components";
 import { AxiosError, AxiosResponse } from "axios";
 import * as CountryLanguage from "country-language";
-import React, { Dispatch, FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
 import { Button, DropdownItemProps, Form, Grid } from "semantic-ui-react";
 import { AppConstants, history } from "../../../core";
 import { createLocaleTemplate, getTemplateDetails, replaceLocaleTemplateContent } from "../../api";
@@ -65,7 +66,7 @@ export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsIn
         [ "data-testid" ]: testId
     } = props;
 
-    const dispatch: Dispatch<any> = useDispatch();
+    const dispatch: Dispatch = useDispatch();
 
     const { t } = useTranslation();
 
@@ -206,7 +207,7 @@ export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsIn
                     }));
                 }
             })
-            .catch((error: any) => {
+            .catch((error: AxiosError) => {
                 dispatch(addAlert<AlertInterface>({
                     description: error.response.data.description,
                     level: AlertLevels.ERROR,

--- a/apps/console/src/features/email-templates/components/forms/add-email-template-form.tsx
+++ b/apps/console/src/features/email-templates/components/forms/add-email-template-form.tsx
@@ -278,7 +278,7 @@ export const AddEmailTemplateForm: FunctionComponent<AddEmailTemplateFormPropsIn
                                             };
                                         }) : [] }
                                         listen={ (values: Map<string, FormValue>) => {
-                                            setLocale(values.get("locale").toString());
+                                            setLocale(values.get("locale").toString().replace("-", "_"));
                                         } }
                                         search
                                         value={ locale }


### PR DESCRIPTION
### Purpose
This PR fixes the issue of email templates not working due to different locale formats. The email templates created from the console app are of the format `language-country`. But the locale format supported by IS is `language_country`. This PR changes the locale format to the latter format.

### Related Issues
- https://github.com/wso2/product-is/issues/15794

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
