### PR TITLE
Set tenant domain for untenanted email usernames in resend email flow

### DIFF
--- a/java/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -201,8 +201,10 @@
 
         ResendCodeRequestDTO selfRegistrationRequest = new ResendCodeRequestDTO();
         UserDTO userDTO = AuthenticationEndpointUtil.getUser(resendUsername);
-        int atIndex = resendUsername.lastIndexOf('@');
-        if (atIndex == -1) {
+        int firstIndex = resendUsername.indexOf('@');
+        int lastIndex = resendUsername.lastIndexOf('@');
+        // Username doesn't have a tenant domain OR username is an email which doesn't have tenant domain.
+        if ((lastIndex == -1) || (firstIndex == lastIndex)) {
             userDTO.setTenantDomain(request.getParameter("tenantDomain"));
         }
         selfRegistrationRequest.setUser(userDTO);


### PR DESCRIPTION
### Purpose

This fix will cover email usernames without tenant domain cases of this PR https://github.com/wso2/identity-apps/pull/3885

### Related issues
- https://github.com/wso2/product-is/issues/15701