### PR TITLE
Display array values with separator

### DIFF
--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -107,7 +107,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
 
     const activeForm: string = useSelector((state: AppState) => state.global.activeForm);
 
-    const [ profileInfo, setProfileInfo ] = useState(new Map<string, string>());
+    const [ profileInfo, setProfileInfo ] = useState(new Map<string, string | string[]>());
     const [ profileSchema, setProfileSchema ] = useState<ProfileSchema[]>();
     const [ isEmailPending, setEmailPending ] = useState<boolean>(false);
     const [ showEditAvatarModal, setShowEditAvatarModal ] = useState<boolean>(false);
@@ -530,7 +530,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
         const attrKey: string = "userName";
 
         if (attrKey in value) {
-            const oldValue: string = profileInfo?.get(schema?.name);
+            const oldValue: string = profileInfo?.get(schema?.name) as string;
 
             if (oldValue?.indexOf("/") > -1) {
                 const fragments: string[] = oldValue.split("/");
@@ -592,7 +592,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
      */
     const resolveProfileInfoSchemaValue = (schema: ProfileSchema): string => {
 
-        let schemaFormValue: string = profileInfo.get(schema.name);
+        let schemaFormValue: string | string[] = profileInfo.get(schema.name);
 
         /**
          * Remove the user-store-name prefix from the userName
@@ -602,7 +602,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
          * USER-STORE/userNameString to userNameString
          */
         if (schema.name === "userName") {
-            schemaFormValue = getUserNameWithoutDomain(schemaFormValue);
+            schemaFormValue = getUserNameWithoutDomain(schemaFormValue as string);
         }
         // Check if schemaFormValue is an array
         if (Array.isArray(schemaFormValue)) {

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -604,6 +604,10 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
         if (schema.name === "userName") {
             schemaFormValue = getUserNameWithoutDomain(schemaFormValue);
         }
+        // Check if schemaFormValue is an array
+        if (Array.isArray(schemaFormValue)) {
+            schemaFormValue = schemaFormValue.join(", ");
+        }
 
         return schemaFormValue;
 


### PR DESCRIPTION
### Purpose
> If a multi-valued attribute is present in the SCIM2 enterprise user schema, the myaccount portal user profile lists the array values without any separator in-between. This PR fixes this issue.

![image](https://github.com/wso2/identity-apps/assets/46979289/33d558b8-ea50-4af9-baae-6c9dd81298d7)


### Related Issues
- Issue https://github.com/wso2/product-is/issues/15503

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
