### PR TITLE
Add email OTP as first factor

### DIFF
--- a/java/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -18,6 +18,7 @@
 
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.captcha.util.CaptchaUtil" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.Map" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
@@ -68,6 +69,13 @@
     layoutData.put("containerSize", "medium");
 %>
 
+<%
+    boolean reCaptchaEnabled = false;
+    if (request.getParameter("reCaptcha") != null && Boolean.parseBoolean(request.getParameter("reCaptcha"))) {
+        reCaptchaEnabled = true;
+    }
+%>
+
 <html lang="en-US">
 <head>
     <%-- header --%>
@@ -84,6 +92,31 @@
     <script src="js/html5shiv.min.js"></script>
     <script src="js/respond.min.js"></script>
     <![endif]-->
+
+    <%
+        if (reCaptchaEnabled) {
+    %>
+    <script src="https://recaptcha.net/recaptcha/api.js" async defer></script>
+    <%
+        }
+    %>
+    <script type="text/javascript">
+        function submitForm() {
+            var code = document.getElementById("OTPCode").value;
+            if (code == "") {
+                document.getElementById('alertDiv').innerHTML
+                    = '<div id="error-msg" class="ui negative message"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.enter.code")%></div>'
+                    +'<div class="ui divider hidden"></div>';
+            } else {
+                if ($('#codeForm').data("submitted") === true) {
+                    console.warn("Prevented a possible double submit event");
+                } else {
+                    $('#codeForm').data("submitted", true);
+                    $('#codeForm').submit();
+                }
+            }
+        }
+    </script>
 </head>
 
 <body class="login-portal layout email-otp-portal-layout">
@@ -175,6 +208,24 @@
                                     value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "authenticate")%>"
                                     class="ui primary button"/>
                             </div>
+                        <%
+                            if (reCaptchaEnabled) {
+                                String reCaptchaKey = CaptchaUtil.reCaptchaSiteKey();
+                        %>
+                            <div class="field">
+                                <div class="g-recaptcha"
+                                    data-sitekey="<%=Encode.forHtmlAttribute(reCaptchaKey)%>"
+                                    data-testid="login-page-g-recaptcha"
+                                    data-bind="authenticate"
+                                    data-callback="submitForm"
+                                    data-theme="light"
+                                    data-tabindex="-1"
+                                >
+                                </div>
+                            </div>
+                        <%
+                            }
+                        %>
                     </form>
                 </div>
             </div>
@@ -205,19 +256,9 @@
     <script type="text/javascript">
         $(document).ready(function () {
             $('#authenticate').click(function () {
-                var code = document.getElementById("OTPCode").value;
-                if (code == "") {
-                    document.getElementById('alertDiv').innerHTML
-                        = '<div id="error-msg" class="ui negative message"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "error.enter.code")%></div>'
-                            +'<div class="ui divider hidden"></div>';
-                } else {
-                    if ($('#codeForm').data("submitted") === true) {
-                        console.warn("Prevented a possible double submit event");
-                    } else {
-                        $('#codeForm').data("submitted", true);
-                        $('#codeForm').submit();
-                    }
-                }
+                <% if (!reCaptchaEnabled) { %>
+                    submitForm();
+                <% } %>
             });
         });
 


### PR DESCRIPTION
### Purpose

This PR sets the email OTP authenticator as a first factor authenticator and provides google recaptcha for the email OTP submitting page if SSO Login recaptcha is enabled. If the SSO Login recaptcha is enabled, the query paramater reCaptcha=true is appended to the URL. Based on the query parameter, recaptcha is added to the form.

### Related Issues
- Issue https://github.com/wso2/product-is/issues/15581

### Related PRs
- https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/156

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
