### PR TITLE
Change layout resolving logic

### DIFF
--- a/java/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -53,7 +53,7 @@
     String selfSignUpOverrideURL = "";
     String passwordRecoveryOverrideURL = "";
     String layout = "default";
-    String layoutFileRelativePath = "";
+    String layoutFileRelativePath = "includes/layouts/default/body.ser";
     String customLayoutFileRelativeBasePath = "";
     Map<String, Object> layoutData = new HashMap<String, Object>();
     String productName = "WSO2 Identity Server";

--- a/java/apps/authentication-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -19,6 +19,31 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>
 
+<%-- This part is maintained for backward compatibility --%>
+<%
+    // Change the layout name to activate another layout
+    layout = "default";
+
+    // Activate the "custom" layout if exists
+    if (config.getServletContext().getResource("extensions/layouts/custom/body.ser") != null) {
+        layout = "custom";
+    }
+    
+    if (!layout.equals("custom")) {
+        if (layout.equals("default")) {
+            layoutFileRelativePath = "includes/layouts/" + layout + "/body.ser";
+        } else {
+            layoutFileRelativePath = "extensions/layouts/" + layout + "/body.ser";
+            if (config.getServletContext().getResource(layoutFileRelativePath) == null) {
+                layout = "default";
+                layoutFileRelativePath = "includes/layouts/default/body.ser";
+            }
+        }
+    } else {
+        layoutFileRelativePath = "extensions/layouts/custom/body.ser";
+    }
+%>
+
 <%-- Layout Resolver --%>
 <%
 
@@ -49,16 +74,6 @@
                     }
                 }
             }
-        }
-    }
-
-    if (StringUtils.isBlank(layoutFileRelativePath)) {
-        // This is maintained for backward compatibility.
-        if (config.getServletContext().getResource("extensions/layouts/custom/body.ser") != null) {
-            layout = "custom";
-            layoutFileRelativePath = "extensions/layouts/custom/body.ser";
-        } else {
-            layoutFileRelativePath = "includes/layouts/default/body.ser";
         }
     }
 %>

--- a/java/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -53,7 +53,7 @@
     String selfSignUpOverrideURL = "";
     String passwordRecoveryOverrideURL = "";
     String layout = "default";
-    String layoutFileRelativePath = "";
+    String layoutFileRelativePath = "includes/layouts/default/body.ser";
     String customLayoutFileRelativeBasePath = "";
     Map<String, Object> layoutData = new HashMap<String, Object>();
     String productName = "WSO2 Identity Server";

--- a/java/apps/recovery-portal/src/main/webapp/includes/layout-resolver.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/includes/layout-resolver.jsp
@@ -19,6 +19,31 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="java.util.HashMap" %>
 
+<%-- This part is maintained for backward compatibility --%>
+<%
+    // Change the layout name to activate another layout
+    layout = "default";
+
+    // Activate the "custom" layout if exists
+    if (config.getServletContext().getResource("extensions/layouts/custom/body.ser") != null) {
+        layout = "custom";
+    }
+    
+    if (!layout.equals("custom")) {
+        if (layout.equals("default")) {
+            layoutFileRelativePath = "includes/layouts/" + layout + "/body.ser";
+        } else {
+            layoutFileRelativePath = "extensions/layouts/" + layout + "/body.ser";
+            if (config.getServletContext().getResource(layoutFileRelativePath) == null) {
+                layout = "default";
+                layoutFileRelativePath = "includes/layouts/default/body.ser";
+            }
+        }
+    } else {
+        layoutFileRelativePath = "extensions/layouts/custom/body.ser";
+    }
+%>
+
 <%-- Layout Resolver --%>
 <%
 
@@ -49,16 +74,6 @@
                     }
                 }
             }
-        }
-    }
-
-    if (StringUtils.isBlank(layoutFileRelativePath)) {
-        // This is maintained for backward compatibility.
-        if (config.getServletContext().getResource("extensions/layouts/custom/body.ser") != null) {
-            layout = "custom";
-            layoutFileRelativePath = "extensions/layouts/custom/body.ser";
-        } else {
-            layoutFileRelativePath = "includes/layouts/default/body.ser";
         }
     }
 %>


### PR DESCRIPTION
### Purpose
 Some account recovery API requests are failing when the tenant domain is not specified in the request. If the tenant domain is not specified, it is set to null and following this, the newly added layout resolving logic gives an error.

### Related Issues
- Issue https://github.com/wso2/product-is/issues/16088

### Related PRs
- Related PR https://github.com/wso2/identity-apps/pull/3943

