### PR TITLE
Revert layout changes in files not including branding-preference.jsp

### DIFF
--- a/java/apps/authentication-portal/src/main/webapp/errors/error.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_400.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_400.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_401.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_401.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_403.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_403.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_404.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_404.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_405.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_405.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_408.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_408.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_410.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_410.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_500.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_500.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_502.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_502.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_503.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_503.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/authentication-portal/src/main/webapp/errors/error_504.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/errors/error_504.jsp
@@ -45,18 +45,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -65,18 +63,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_400.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_400.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_401.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_401.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
-            <%-- product-title --%>
+        <layout:component componentName="ProductHeader" >
+        <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_403.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_403.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_404.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_404.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_405.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_405.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_408.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_408.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_410.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_410.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_500.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_500.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_502.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_502.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_503.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_503.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/recovery-portal/src/main/webapp/errors/error_504.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/errors/error_504.jsp
@@ -44,18 +44,16 @@
 </head>
 <body class="login-portal layout authentication-portal-layout">
     <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-        <layout:component componentName="ProductHeader">
+        <layout:component componentName="ProductHeader" >
             <%-- product-title --%>
             <%
-            String productTitleFilePath = "extensions/product-title.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                productTitleFilePath = "includes/product-title.jsp";
-            }
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
             %>
-            <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="../extensions/product-title.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-title.jsp"/>
+            <% } %>
         </layout:component>
         <layout:component componentName="MainSection" >
             <div class="ui segment">
@@ -64,18 +62,16 @@
                 </div>
             </div>
         </layout:component>
-        <layout:component componentName="ProductFooter">
+        <layout:component componentName="ProductFooter" >
             <%-- product-footer --%>
             <%
-            String productFooterFilePath = "extensions/product-footer.jsp";
-            if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-            }
-            if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                productFooterFilePath = "includes/product-footer.jsp";
-            }
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
             %>
-            <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="../extensions/product-footer.jsp"/>
+            <% } else { %>
+                <jsp:include page="../includes/product-footer.jsp"/>
+            <% } %>
         </layout:component>
     </layout:main>
 

--- a/java/apps/x509-certificate-authentication-portal/src/main/webapp/x509CertificateError.jsp
+++ b/java/apps/x509-certificate-authentication-portal/src/main/webapp/x509CertificateError.jsp
@@ -110,18 +110,16 @@
 
     <body class="login-portal layout x509-certificate-portal-layout">
         <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
-            <layout:component componentName="ProductHeader">
-                <%-- product-title --%>
+            <layout:component componentName="ProductHeader" >
+                <!-- product-title -->
                 <%
-                String productTitleFilePath = "extensions/product-title.jsp";
-                if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                    productTitleFilePath = customLayoutFileRelativeBasePath + "/product-title.jsp";
-                }
-                if (!new File(getServletContext().getRealPath(productTitleFilePath)).exists()) {
-                    productTitleFilePath = "includes/product-title.jsp";
-                }
+                    File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                    if (productTitleFile.exists()) {
                 %>
-                <jsp:include page="<%= productTitleFilePath %>" />
+                <jsp:include page="extensions/product-title.jsp"/>
+                <% } else { %>
+                <jsp:include page="includes/product-title.jsp"/>
+                <% } %>
             </layout:component>
             <layout:component componentName="MainSection" >
                 <div class="ui segment">
@@ -135,18 +133,16 @@
                     <div id="alertDiv"></div>
                 </div>
             </layout:component>
-            <layout:component componentName="ProductFooter">
-                <%-- product-footer --%>
+            <layout:component componentName="ProductFooter" >
+                <!-- product-footer -->
                 <%
-                String productFooterFilePath = "extensions/product-footer.jsp";
-                if (StringUtils.isNotBlank(customLayoutFileRelativeBasePath)) {
-                    productFooterFilePath = customLayoutFileRelativeBasePath + "/product-footer.jsp";
-                }
-                if (!new File(getServletContext().getRealPath(productFooterFilePath)).exists()) {
-                    productFooterFilePath = "includes/product-footer.jsp";
-                }
+                    File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                    if (productFooterFile.exists()) {
                 %>
-                <jsp:include page="<%= productFooterFilePath %>" />
+                <jsp:include page="extensions/product-footer.jsp"/>
+                <% } else { %>
+                <jsp:include page="includes/product-footer.jsp"/>
+                <% } %>
             </layout:component>
         </layout:main>
 


### PR DESCRIPTION
### Purpose

With PR [1]  layout changes were added to authentication portal and recovery portal. Currently we have not added new branding capability to  x509-certificate-authentication-portal since it only consists of an error page and no other UI. Therefore the added layout changes will be reverted in this error page. Also error pages in authentication portal and recovery portal do not have branding included. So reverting those as well.

### Related PRs
- Related PR https://github.com/wso2/identity-apps/pull/3956

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
