### PR TITLE
Fix Secondary User Store Group Creation UI Issue

### DIFF
--- a/apps/console/src/features/groups/components/wizard/group-assign-users.tsx
+++ b/apps/console/src/features/groups/components/wizard/group-assign-users.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -36,6 +36,7 @@ import React, { FunctionComponent, ReactElement, useEffect, useState } from "rea
 import { useTranslation } from "react-i18next";
 import { Grid, Icon, Input, Modal, Table } from "semantic-ui-react";
 import { UIConstants, UserBasicInterface, getEmptyPlaceholderIllustrations, getUsersList } from "../../../core";
+import { UserListInterface } from "../../../users";
 import { GroupsMemberInterface } from "../../models";
 
 /**
@@ -111,10 +112,10 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
 
     const getList = (limit: number, offset: number, filter: string, attribute: string, userStore: string) => {
         getUsersList(limit, offset, filter, attribute, userStore)
-            .then((response) => {
-                const responseUsers = response.Resources;
+            .then((response: UserListInterface) => {
+                const responseUsers: UserBasicInterface[] = response.Resources;
 
-                responseUsers.sort((userObject, comparedUserObject) =>
+                responseUsers.sort((userObject: UserBasicInterface, comparedUserObject: UserBasicInterface) =>
                     userObject.name?.givenName?.localeCompare(comparedUserObject.name?.givenName)
                 );
                 setUsersList(responseUsers);
@@ -124,15 +125,15 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
                     const selectedUserList: UserBasicInterface[] = [];
 
                     if (responseUsers && responseUsers instanceof Array ) {
-                        responseUsers.slice().reverse().forEach(user => {
-                            assignedUsers.forEach(assignedUser => {
+                        responseUsers.slice().reverse().forEach((user: UserBasicInterface) => {
+                            assignedUsers.forEach((assignedUser: GroupsMemberInterface) => {
                                 if (user.id === assignedUser.value) {
                                     selectedUserList.push(user);
                                     responseUsers.splice(responseUsers.indexOf(user), 1);
                                 }
                             });
                         });
-                        selectedUserList.sort((userObject, comparedUserObject) =>
+                        selectedUserList.sort((userObject: UserBasicInterface, comparedUserObject: any) =>
                             userObject.name?.givenName?.localeCompare(comparedUserObject.name?.givenName)
                         );
                         setSelectedUsers(selectedUserList);
@@ -144,17 +145,17 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
                     const selectedUserList: UserBasicInterface[] = [];
 
                     if (responseUsers && responseUsers instanceof Array ) {
-                        responseUsers.forEach(user => {
-                            initialValues.forEach(assignedUser => {
+                        responseUsers.forEach((user: UserBasicInterface) => {
+                            initialValues.forEach((assignedUser: UserBasicInterface) => {
                                 if (user.id === assignedUser.id) {
                                     selectedUserList.push(user);
                                 }
                             });
                         });
-                        selectedUserList.sort((userObject, comparedUserObject) =>
+                        selectedUserList.sort((userObject:UserBasicInterface, comparedUserObject: UserBasicInterface) =>
                             userObject.name?.givenName?.localeCompare(comparedUserObject.name?.givenName)
                         );
-                        setUsersList(responseUsers.filter(function(user) {
+                        setUsersList(responseUsers.filter(function(user: UserBasicInterface) {
                             return selectedUserList.indexOf(user) == -1;
                         }));
                         setSelectedUsers(selectedUserList);
@@ -182,11 +183,11 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
      * The following method accepts a Map and returns the values as a string.
      *
      * @param attributeMap - IterableIterator<string>
-     * @return string
+     * @returns string
      */
     const generateAttributesString = (attributeMap: IterableIterator<string>) => {
-        const attArray = [];
-        const iterator1 = attributeMap[Symbol.iterator]();
+        const attArray: any[] = [];
+        const iterator1: IterableIterator<string> = attributeMap[Symbol.iterator]();
 
         for (const attribute of iterator1) {
             if (attribute !== "") {
@@ -199,15 +200,15 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
 
     useEffect(() => {
         if (userListMetaContent) {
-            const attributes = generateAttributesString(userListMetaContent.values());
+            const attributes: string = generateAttributesString(userListMetaContent.values());
 
             getList(listItemLimit, 0, null, attributes, userStore);
 
         }
     }, [ listItemLimit, userStore ]);
 
-    const handleUnassignedItemCheckboxChange = (role) => {
-        const checkedGroups = [ ...checkedUnassignedListItems ];
+    const handleUnassignedItemCheckboxChange = (role: any) => {
+        const checkedGroups: UserBasicInterface[] = [ ...checkedUnassignedListItems ];
 
         if (checkedGroups.includes(role)) {
             checkedGroups.splice(checkedGroups.indexOf(role), 1);
@@ -218,14 +219,14 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
         }
     };
 
-    const handleSearchFieldChange = (e, { value }) => {
-        let isMatch = false;
+    const handleSearchFieldChange = (e: any, { value }: { value: any }) => {
+        let isMatch: boolean = false;
         const filteredGroupList: UserBasicInterface[] = [];
 
         if (!isEmpty(value)) {
-            const re = new RegExp(escapeRegExp(value), "i");
+            const re: RegExp = new RegExp(escapeRegExp(value), "i");
 
-            usersList && usersList.map((user) => {
+            usersList && usersList.map((user: UserBasicInterface) => {
                 isMatch = re.test(user.userName);
                 if (isMatch) {
                     filteredGroupList.push(user);
@@ -237,8 +238,8 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
         }
     };
 
-    const handleAssignedItemCheckboxChange = (role) => {
-        const checkedGroups = [ ...checkedAssignedListItems ];
+    const handleAssignedItemCheckboxChange = (role: any) => {
+        const checkedGroups: UserBasicInterface[] = [ ...checkedAssignedListItems ];
 
         if (checkedGroups.includes(role)) {
             checkedGroups.splice(checkedGroups.indexOf(role), 1);
@@ -250,16 +251,16 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
     };
 
     const addUser = () => {
-        const addedGroups = [ ...tempUserList ];
+        const addedGroups: UserBasicInterface[] = [ ...tempUserList ];
 
         if (checkedUnassignedListItems?.length > 0) {
-            checkedUnassignedListItems.map((user) => {
+            checkedUnassignedListItems.map((user: UserBasicInterface) => {
                 if (!(tempUserList.includes(user))) {
                     addedGroups.push(user);
                 }
             });
         }
-        setUsersList(usersList.filter(user => (
+        setUsersList(usersList.filter((user: UserBasicInterface) => (
             checkedUnassignedListItems.indexOf(user) === -1
         )));
         setTempUserList(addedGroups);
@@ -267,10 +268,10 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
     };
 
     const removeUser = () => {
-        const removedUsers = [ ...tempUserList ];
+        const removedUsers: UserBasicInterface[] = [ ...tempUserList ];
 
         if (checkedAssignedListItems?.length > 0) {
-            checkedAssignedListItems.map(user => {
+            checkedAssignedListItems.map((user: UserBasicInterface) => {
                 removedUsers.splice(removedUsers.indexOf(user), 1);
                 usersList.push(user);
             });
@@ -290,14 +291,14 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
         setAddNewUserModalView(false);
     };
 
-    const handleAssignedUserListSearch = (e, { value }) => {
-        let isMatch = false;
+    const handleAssignedUserListSearch = (e: any, { value }: { value: any }) => {
+        let isMatch: boolean = false;
         const filteredUserList: UserBasicInterface[] = [];
 
         if (!isEmpty(value)) {
-            const re = new RegExp(escapeRegExp(value), "i");
+            const re: RegExp = new RegExp(escapeRegExp(value), "i");
 
-            selectedUsers && selectedUsers.map((user) => {
+            selectedUsers && selectedUsers.map((user: UserBasicInterface) => {
                 isMatch = re.test(user.userName);
                 if (isMatch) {
                     filteredUserList.push(user);
@@ -361,7 +362,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
                             "transferList.list.emptyPlaceholders.default") }
                     >
                         {
-                            usersList?.map((user, index)=> {
+                            usersList?.map((user: UserBasicInterface, index: number)=> {
                                 return (
                                     <TransferListItem
                                         handleItemChange={ () =>
@@ -394,7 +395,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
                             "transferList.list.emptyPlaceholders.default") }
                     >
                         {
-                            tempUserList?.map((user, index)=> {
+                            tempUserList?.map((user: UserBasicInterface, index: number)=> {
                                 return (
                                     <TransferListItem
                                         handleItemChange={ () =>
@@ -478,7 +479,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
                                                         </Table.Header>
                                                         <Table.Body>
                                                             {
-                                                                selectedUsers?.map((user) => {
+                                                                selectedUsers?.map((user: UserBasicInterface) => {
                                                                     return (
                                                                         <Table.Row key={ user.id }>
                                                                             <Table.Cell collapsing>
@@ -568,7 +569,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
                                             "transferList.list.emptyPlaceholders.default") }
                                     >
                                         {
-                                            usersList?.map((user, index)=> {
+                                            usersList?.map((user: UserBasicInterface, index: number)=> {
                                                 return (
                                                     <TransferListItem
                                                         handleItemChange={ () =>
@@ -602,7 +603,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
                                             "transferList.list.emptyPlaceholders.default") }
                                     >
                                         {
-                                            tempUserList?.map((user, index)=> {
+                                            tempUserList?.map((user: UserBasicInterface, index: number)=> {
                                                 return (
                                                     <TransferListItem
                                                         handleItemChange={ () =>

--- a/apps/console/src/features/groups/components/wizard/group-assign-users.tsx
+++ b/apps/console/src/features/groups/components/wizard/group-assign-users.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -44,7 +44,7 @@ import { GroupsMemberInterface } from "../../models";
  */
 interface AddGroupUserProps extends TestableComponentInterface {
     triggerSubmit?: boolean;
-    onSubmit?: (values: any) => void;
+    onSubmit?: (values: UserBasicInterface[]) => void;
     assignedUsers?: GroupsMemberInterface[];
     isEdit: boolean;
     userStore?: string;
@@ -133,8 +133,9 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
                                 }
                             });
                         });
-                        selectedUserList.sort((userObject: UserBasicInterface, comparedUserObject: any) =>
-                            userObject.name?.givenName?.localeCompare(comparedUserObject.name?.givenName)
+                        selectedUserList.sort(
+                            (userObject: UserBasicInterface, comparedUserObject: UserBasicInterface) =>
+                                userObject.name?.givenName?.localeCompare(comparedUserObject.name?.givenName)
                         );
                         setSelectedUsers(selectedUserList);
                         setTempUserList(selectedUserList);
@@ -186,7 +187,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
      * @returns string
      */
     const generateAttributesString = (attributeMap: IterableIterator<string>) => {
-        const attArray: any[] = [];
+        const attArray: string[] = [];
         const iterator1: IterableIterator<string> = attributeMap[Symbol.iterator]();
 
         for (const attribute of iterator1) {
@@ -207,7 +208,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
         }
     }, [ listItemLimit, userStore ]);
 
-    const handleUnassignedItemCheckboxChange = (role: any) => {
+    const handleUnassignedItemCheckboxChange = (role: UserBasicInterface) => {
         const checkedGroups: UserBasicInterface[] = [ ...checkedUnassignedListItems ];
 
         if (checkedGroups.includes(role)) {
@@ -219,7 +220,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
         }
     };
 
-    const handleSearchFieldChange = (e: any, { value }: { value: any }) => {
+    const handleSearchFieldChange = (e: React.FormEvent<HTMLInputElement>, { value }: { value: string }) => {
         let isMatch: boolean = false;
         const filteredGroupList: UserBasicInterface[] = [];
 
@@ -238,7 +239,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
         }
     };
 
-    const handleAssignedItemCheckboxChange = (role: any) => {
+    const handleAssignedItemCheckboxChange = (role: UserBasicInterface) => {
         const checkedGroups: UserBasicInterface[] = [ ...checkedAssignedListItems ];
 
         if (checkedGroups.includes(role)) {
@@ -291,7 +292,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
         setAddNewUserModalView(false);
     };
 
-    const handleAssignedUserListSearch = (e: any, { value }: { value: any }) => {
+    const handleAssignedUserListSearch = (e: React.FormEvent<HTMLInputElement>, { value }: { value: string }) => {
         let isMatch: boolean = false;
         const filteredUserList: UserBasicInterface[] = [];
 

--- a/apps/console/src/features/groups/components/wizard/group-assign-users.tsx
+++ b/apps/console/src/features/groups/components/wizard/group-assign-users.tsx
@@ -204,7 +204,7 @@ export const AddGroupUsers: FunctionComponent<AddGroupUserProps> = (props: AddGr
             getList(listItemLimit, 0, null, attributes, userStore);
 
         }
-    }, [ listItemLimit ]);
+    }, [ listItemLimit, userStore ]);
 
     const handleUnassignedItemCheckboxChange = (role) => {
         const checkedGroups = [ ...checkedUnassignedListItems ];

--- a/modules/react-components/src/components/popup/popup.tsx
+++ b/modules/react-components/src/components/popup/popup.tsx
@@ -18,7 +18,7 @@
 
 import React, { ReactElement } from "react";
 // eslint-disable-next-line no-restricted-imports
-import { PopupProps, Popup as SemanticPopup } from "semantic-ui-react";
+import { PopupContentProps, PopupHeaderProps, PopupProps, Popup as SemanticPopup } from "semantic-ui-react";
 
 /**
  * A wrapper for the semantic Popup component.
@@ -27,7 +27,11 @@ import { PopupProps, Popup as SemanticPopup } from "semantic-ui-react";
  *
  * @returns
  */
-export const Popup = (props: PopupProps): ReactElement => {
+export const Popup: {
+    (props: PopupProps): ReactElement;
+    Content: React.FC<PopupContentProps>;
+    Header: React.FC<PopupHeaderProps>;
+} = (props: PopupProps): ReactElement => {
     return (
         <SemanticPopup
             popper={ <div style={ { filter: "none" } }></div> }


### PR DESCRIPTION
### Purpose
> The issue regarding the invalid user list display while creating a new group for a secondary user store is fixed by this PR.

- Now, when the user store is changed in the group creation form, the `Assign Users` list gets changed according to the user store as follows.

https://github.com/wso2/identity-apps/assets/57411348/1c1592eb-e22f-49d9-b3bf-d4e77aefdb25

### Related Issues
- https://github.com/wso2/product-is/issues/16239

### Related PRs
- (None)

### Approach
- Added the `userStore` variable into the dependency array of the `useEffect` hook that retrieves the user list inside the form.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
