### PR TITLE
Fix Recovery Portal Header Title

### DIFF
--- a/java/apps/recovery-portal/src/main/webapp/includes/header.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/includes/header.jsp
@@ -78,6 +78,6 @@
 <% if (StringUtils.isNotBlank(siteTitle)) { %>
     <%=StringEscapeUtils.escapeHtml4(siteTitle)%>
 <% } else { %>
-    <title><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Wso2.identity.server")%></title>
+    <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Wso2.identity.server")%>
 <% } %>
 </title>


### PR DESCRIPTION
### Purpose
> The issue regarding the showcase of `<title>` tag in the header title of the Recover Username and Recover Password pages is fixed by this PR.

- Now, when a user navigates to the Recover Username and Recover Password pages, the header title is shown as "WSO2 Identity Server" as follows.

https://github.com/wso2/identity-apps/assets/57411348/05cbcec5-6c1f-4db3-ac89-dda1ebf5671c

### Related Issues
- https://github.com/wso2/product-is/issues/16083

### Related PRs
- (None)

### Approach
- Removed the extra `<title>` tag inside the header.jsp of the recovery portal.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
