### PR TITLE
Improve self contained IDF resolving

### DIFF
--- a/java/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/login.jsp
@@ -34,6 +34,7 @@
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.AUTHENTICATION_MECHANISM_NOT_CONFIGURED" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.ENABLE_AUTHENTICATION_WITH_REST_API" %>
 <%@ page import="static org.wso2.carbon.identity.application.authentication.endpoint.util.Constants.ERROR_WHILE_BUILDING_THE_ACCOUNT_RECOVERY_ENDPOINT_URL" %>
+<%@ page import="static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.INITIATE_IDENTIFIER_FIRST" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityProviderDataRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityProviderDataRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
@@ -272,7 +273,8 @@
                     %>
                         <%@ include file="openid.jsp" %>
                     <%
-                        } else if (localAuthenticatorNames.contains(IDENTIFIER_EXECUTOR)) {
+                        } else if (localAuthenticatorNames.contains(IDENTIFIER_EXECUTOR)
+                            || "true".equals(request.getParameter(INITIATE_IDENTIFIER_FIRST))) {
                             hasLocalLoginOptions = true;
                     %>
                         <%@ include file="identifierauth.jsp" %>

--- a/pom.xml
+++ b/pom.xml
@@ -658,7 +658,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.25.250</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.259-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 7.0.0]</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.core.service.version>1.0.0
         </identity.organization.management.core.service.version>


### PR DESCRIPTION
### Purpose
Currently magic link and email otp authenticators support first factor login. That is through the self-contained IDF improvement. In there we have the user resolving logic at the particular authenticator (i.e. in magiclink or email otp) however the user identifier is retrieved using the Identifier first frontend code. This is done with the `authenticators` request parameter passed with the value of `IdentifierExecutor:LOCAL`. Due to this some flows recognize this as the IDF is in the authentication sequence and raise issues. This could lead to unexpected failures in the authentication flow.

Hence this PR introduces a new query parameter to trigger the IDF frontend. Login page should capture this parameter and when present should trigger the Identifier First UI.

### Related Issues
- https://github.com/wso2/product-is/issues/16321

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/4812

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
