### PR TITLE
Add i18n Key Check before Governance Connector Display

### DIFF
--- a/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-connector-form.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-connector-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-connector-form.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-connector-form.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,23 +18,41 @@
 
 import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { I18n } from "@wso2is/i18n";
-import { Hint, PrimaryButton, RenderInput, RenderToggle } from "@wso2is/react-components";
+import { 
+    Hint, 
+    PrimaryButton, 
+    RenderInput, 
+    RenderToggle 
+} from "@wso2is/react-components";
 import camelCase from "lodash-es/camelCase";
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Field, reduxForm } from "redux-form";
-import { Divider, Form, Grid } from "semantic-ui-react";
+import { 
+    Field, 
+    reduxForm 
+} from "redux-form";
+import { 
+    Divider, 
+    Form, 
+    Grid 
+} from "semantic-ui-react";
 import { serverConfigurationConfig } from "../../../../extensions";
-import { AppState, FeatureConfigInterface } from "../../../core";
+import { 
+    AppState, 
+    FeatureConfigInterface 
+} from "../../../core";
 import { ServerConfigurationsConstants } from "../../constants";
-import { ConnectorPropertyInterface, GovernanceConnectorInterface } from "../../models";
+import { 
+    ConnectorPropertyInterface, 
+    GovernanceConnectorInterface 
+} from "../../models";
 import { GovernanceConnectorUtils } from "../../utils";
 
 /**
  * Determine the matching Form component based on the property attributes.
  *
- * @param property
+ * @param property - Connector property.
  */
 const getFieldComponent = (property: ConnectorPropertyInterface) => {
     if (property.value === "true" || property.value === "false") {
@@ -47,7 +65,7 @@ const getFieldComponent = (property: ConnectorPropertyInterface) => {
 /**
  * Returns if teh connector property is a toggle or not.
  *
- * @param {ConnectorPropertyInterface} property Connector property.
+ * @param property - Connector property.
  */
 const isToggle = (property: ConnectorPropertyInterface) => {
     return property.value === "true" || property.value === "false";
@@ -77,21 +95,21 @@ interface DynamicConnectorFormPropsInterface {
 /**
  * Dynamically render governance connector forms.
  *
- * @param props
- * @constructor
+ * @param props - Dynamic connector form properties.
  */
 const DynamicConnectorForm = (props: DynamicConnectorFormPropsInterface) => {
     const { connector, isSubmitting, handleSubmit, [ "data-testid" ]: testId } = props;
     const properties: ConnectorPropertyInterface[] = props.props.properties;
 
-    const formValues = useSelector((state: AppState) => state.form[ props.form ].values);
-
-    const { t } = useTranslation();
+    const formValues: Record<string, string | boolean> 
+        = useSelector((state: AppState) => state.form[ props.form ].values);
+    
+    const { t, i18n } = useTranslation();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
 
-    const isReadOnly = useMemo(() => (
+    const isReadOnly: boolean = useMemo(() => (
         !hasRequiredScopes(
             featureConfig?.attributeDialects, featureConfig?.attributeDialects?.scopes?.update, allowedScopes)
     ), [ featureConfig, allowedScopes ]);
@@ -99,13 +117,25 @@ const DynamicConnectorForm = (props: DynamicConnectorFormPropsInterface) => {
     return (
         <Form onSubmit={ handleSubmit }>
             { <Grid padded={ true }>
-                { properties?.map((property, index) => {
-                    const fieldLabel = t("console:manage.features.governanceConnectors.connectorCategories." + 
+                { properties?.map((property: ConnectorPropertyInterface, index: number) => {
+                    const fieldLabelKey: string = "console:manage.features.governanceConnectors.connectorCategories." + 
                         camelCase(connector?.category) + ".connectors."+camelCase(connector?.name) + 
-                        ".properties."+camelCase(property?.name)+".label");
-                    const fieldHint = t("console:manage.features.governanceConnectors.connectorCategories." + 
+                        ".properties."+camelCase(property?.name)+".label";
+                    let fieldLabel: string = property?.displayName;
+
+                    if (i18n.exists(fieldLabelKey)) {
+                        fieldLabel = t(fieldLabelKey);
+                    } 
+
+                    const fieldHintKey: string = "console:manage.features.governanceConnectors.connectorCategories." + 
                         camelCase(connector?.category)+".connectors."+camelCase(connector?.name) + 
-                        ".properties."+camelCase(property?.name)+".hint");
+                        ".properties."+camelCase(property?.name)+".hint";
+                    let fieldHint: string = property?.description;
+
+                    if (i18n.exists(fieldHintKey)) {
+                        fieldHint = t(fieldHintKey);
+                    }                  
+                    
 
                     return (
                         <Grid.Row
@@ -225,14 +255,14 @@ const DynamicConnectorForm = (props: DynamicConnectorFormPropsInterface) => {
     );
 };
 
-const validate = (values) => {
-    const errors = {};
+const validate = (values: Record<string, string>) => {
+    const errors: Record<string, string> = {};
 
-    const allowedIdleTimeSpanName = GovernanceConnectorUtils.encodeConnectorPropertyName(
+    const allowedIdleTimeSpanName: string = GovernanceConnectorUtils.encodeConnectorPropertyName(
         ServerConfigurationsConstants.ALLOWED_IDLE_TIME_SPAN_IN_DAYS
     );
 
-    const allowedIdleTimeSpan = parseInt(values[ allowedIdleTimeSpanName ]);
+    const allowedIdleTimeSpan: number = parseInt(values[ allowedIdleTimeSpanName ]);
 
     if (allowedIdleTimeSpan < 0) {
         errors[ allowedIdleTimeSpanName ]
@@ -270,7 +300,7 @@ const validate = (values) => {
                 ServerConfigurationsConstants.MULTI_ATTRIBUTE_CLAIM_LIST
             )
         ] = I18n.instance.t("console:manage.features.governanceConnectors.form.errors.format");
-    }
+    }  
 
     return errors;
 };

--- a/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-governance-connector.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-governance-connector.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-governance-connector.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connectors/dynamic-governance-connector.tsx
@@ -1,7 +1,7 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,22 +16,47 @@
  * under the License.
  */
 
-import { AlertLevels, IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
+import { 
+    AlertLevels, 
+    IdentifiableComponentInterface, 
+    TestableComponentInterface 
+} from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { Message, Text } from "@wso2is/react-components";
+import { 
+    Message, 
+    Text 
+} from "@wso2is/react-components";
 import camelCase from "lodash-es/camelCase";
 import get from "lodash-es/get";
 import kebabCase from "lodash-es/kebabCase";
-import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import React, { 
+    Dispatch, 
+    FunctionComponent, 
+    ReactElement, 
+    ReactNode, 
+    useEffect, 
+    useState 
+} from "react";
+import { 
+    Trans, 
+    useTranslation 
+} from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Icon } from "semantic-ui-react";
 import DynamicConnectorForm from "./dynamic-connector-form";
+import { 
+    IdentityAppsApiException 
+} from "../../../../../../../modules/core/dist/types/exceptions/identity-apps-api-exception";
+import { AddAlertAction } from "../../../../../../../modules/core/dist/types/store/actions/types/global";
 import { serverConfigurationConfig } from "../../../../extensions";
 import { updateGovernanceConnector } from "../../api";
 import { getGovernanceConnectorIllustrations } from "../../configs";
 import { ServerConfigurationsConstants } from "../../constants";
-import { GovernanceConnectorInterface } from "../../models";
+import { 
+    ConnectorPropertyInterface, 
+    GovernanceConnectorInterface, 
+    UpdateGovernanceConnectorConfigInterface 
+} from "../../models";
 import { GovernanceConnectorUtils } from "../../utils";
 
 /**
@@ -45,9 +70,9 @@ interface DynamicGovernanceConnectorProps extends TestableComponentInterface, Id
 /**
  * Dynamic governance connector component.
  *
- * @param {DynamicGovernanceConnectorProps} props - Props injected to the dynamic connector component.
+ * @param props - Props injected to the dynamic connector component.
  *
- * @return {React.ReactElement}
+ * @returns React.ReactElement
  */
 export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConnectorProps> = (
     props: DynamicGovernanceConnectorProps
@@ -60,9 +85,13 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
         [ "data-testid" ]: testId
     } = props;
 
-    const dispatch = useDispatch();
+    const dispatch: Dispatch<AddAlertAction<{
+            description: string;
+            level: AlertLevels;
+            message: string;
+        }>> = useDispatch();
 
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
 
     const [ connectorIllustration, setConnectorIllustration ] = useState<string>(undefined);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
@@ -81,7 +110,7 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
         setConnectorIllustration(illustration);
     }, [ connector, getGovernanceConnectorIllustrations ]);
 
-    const handleUpdateError = (error) => {
+    const handleUpdateError = (error: IdentityAppsApiException) => {
         if (error.response && error.response.data && error.response.data.detail) {
             dispatch(
                 addAlert({
@@ -114,12 +143,12 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
         }
     };
 
-    const handleSubmit = (values) => {
-        const data = {
+    const handleSubmit = (values: Record<string, string | boolean>) => {
+        const data: UpdateGovernanceConnectorConfigInterface = {
             operation: "UPDATE",
             properties: []
-        };
-
+        };        
+        
         for (const key in values) {
             data.properties.push({
                 name: GovernanceConnectorUtils.decodeConnectorPropertyName(key),
@@ -157,7 +186,7 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
 
                 onUpdate();
             })
-            .catch((error) => {
+            .catch((error: IdentityAppsApiException) => {
                 handleUpdateError(error);
             })
             .finally(() => {
@@ -166,9 +195,9 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
     };
 
     const getConnectorInitialValues = (connector: GovernanceConnectorInterface) => {
-        const values = {};
+        const values: Record<string, string | boolean>= {};
 
-        connector?.properties.map((property) => {
+        connector?.properties.map((property: ConnectorPropertyInterface) => {
             if (property.value === "true") {
                 values[ GovernanceConnectorUtils.encodeConnectorPropertyName(property.name) ] = true;
             } else if (property.value === "false") {
@@ -187,7 +216,8 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
             connector={ connector }
             props={ {
                 properties: connector.properties.filter(
-                    (property => serverConfigurationConfig.connectorPropertiesToShow.includes(property.name)
+                    ((property: ConnectorPropertyInterface) => 
+                        serverConfigurationConfig.connectorPropertiesToShow.includes(property.name)
                         || serverConfigurationConfig.connectorPropertiesToShow
                             .includes(ServerConfigurationsConstants.ALL)))
             } }
@@ -201,8 +231,8 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
     /**
      * Resolve connector title.
      *
-     * @param {GovernanceConnectorInterface} connector - Connector object.
-     * @returns {ReactNode}
+     * @param connector - Connector object.
+     * @returns ReactNode
      */
     const resolveConnectorTitle = (connector: GovernanceConnectorInterface): ReactNode => {
 
@@ -210,15 +240,22 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
             return null;
         }
 
-        return t("console:manage.features.governanceConnectors.connectorCategories." +
-            camelCase(connector?.category) + ".connectors." + camelCase(connector?.name) + ".friendlyName");
+        const connectorTitleKey: string = "console:manage.features.governanceConnectors.connectorCategories." +
+            camelCase(connector?.category) + ".connectors." + camelCase(connector?.name) + ".friendlyName";
+        let connectorTitle: string = connector?.friendlyName;
+
+        if (i18n.exists(connectorTitleKey)) {
+            connectorTitle = t(connectorTitleKey);
+        }
+        
+        return connectorTitle;
     };
 
     /**
      * Resolve connector description.
      *
-     * @param {GovernanceConnectorInterface} connector - Connector object.
-     * @returns {ReactNode}
+     * @param connector - Connector object.
+     * @returns ReactNode
      */
     const resolveConnectorDescription = (connector: GovernanceConnectorInterface): ReactNode => {
 
@@ -240,8 +277,8 @@ export const DynamicGovernanceConnector: FunctionComponent<DynamicGovernanceConn
     /**
      * Resolve connector message.
      *
-     * @param {GovernanceConnectorInterface} connector - Connector object.
-     * @returns {ReactNode}
+     * @param connector - Connector object.
+     * @returns ReactNode
      */
     const resolveConnectorMessage = (connector: GovernanceConnectorInterface): ReactNode => {
 


### PR DESCRIPTION
### Purpose
> When the backend of a  new/ (or existing) governance connector is implemented (or changed) and the front end `i18n` module is not yet updated with the changes, the Console will display the details retrieved by the API call. 

> Ex: Newly connected Suborganization Self Service connector.
- Before
<img width="1512" alt="Screenshot 2023-08-09 at 11 38 37" src="https://github.com/wso2/product-is/assets/57411348/444283e7-ea69-4440-a6c7-c0d1b077d869">

- After
<img width="1512" alt="Screenshot 2023-08-10 at 13 54 28" src="https://github.com/wso2/identity-apps/assets/57411348/259d9c37-7b58-4b31-a7b6-b58c7597509a">

### Approach
- The `i18n` key availability will be checked by the `i18n.exists('my.key')` function.
- If it's not available the value retrieved by the API call will be returned.

### Related Issues
- https://github.com/wso2/product-is/issues/16419

### Related PRs
- (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
