### PR TITLE
Modify Username Validation to Support Non SaaS behaviour

### DIFF
--- a/java/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/java/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -97,7 +97,7 @@
 
 
     try {
-        usernameValidityResponse = selfRegistrationMgtClient.checkUsernameValidityStatus(user, skipSignUpEnableCheck);
+        usernameValidityResponse = selfRegistrationMgtClient.checkUsernameValidityStatus(user, skipSignUpEnableCheck, isSaaSApp);
     } catch (SelfRegistrationMgtClientException e) {
         request.setAttribute("error", true);
         request.setAttribute("errorMsg", IdentityManagementEndpointUtil


### PR DESCRIPTION
Add new parameter isSaaSApp to username validation logic during self registration to support non-saas username inputs.

Related Issue: https://github.com/wso2/product-is/issues/16228