### PR TITLE
Navigate back to multi-option page from a specific MFA option

### DIFF
--- a/java/apps/authentication-portal/src/main/webapp/backup-code.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/backup-code.jsp
@@ -168,7 +168,7 @@
                     <%
                         String multiOptionURI=request.getParameter("multiOptionURI");
                         if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) { %>
-                            <a class="ui button secondary" id="goBackLink" href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
+                            <a class="ui primary basic button link-button" id="goBackLink" href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
                                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
                             </a>
                     <%  } %>

--- a/java/apps/authentication-portal/src/main/webapp/emailAddressCapture.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/emailAddressCapture.jsp
@@ -157,6 +157,18 @@
                         </div>
                     </form>
                 </div>
+                <div class="ui divider hidden"></div>
+                <%
+                    String multiOptionURI = request.getParameter("multiOptionURI");
+                    if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
+                %>
+                    <a class="ui primary basic button link-button" id="goBackLink"
+                    href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
+                    </a>
+                <%
+                    }
+                %>
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter">

--- a/java/apps/authentication-portal/src/main/webapp/emailAddressCapture.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/emailAddressCapture.jsp
@@ -17,6 +17,7 @@
 --%>
 
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.Map" %>

--- a/java/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -17,6 +17,7 @@
 --%>
 
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="org.wso2.carbon.identity.captcha.util.CaptchaUtil" %>
 <%@ page import="java.io.File" %>

--- a/java/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -230,6 +230,18 @@
                         %>
                     </form>
                 </div>
+                <div class="ui divider hidden"></div>
+                <%
+                    String multiOptionURI = request.getParameter("multiOptionURI");
+                    if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
+                %>
+                    <a class="ui primary basic button link-button" id="goBackLink"
+                    href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
+                    </a>
+                <%
+                    }
+                %>
             </div>
         </layout:component>
         <layout:component componentName="ProductFooter">

--- a/java/apps/authentication-portal/src/main/webapp/enableTOTP.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/enableTOTP.jsp
@@ -17,6 +17,7 @@
 --%>
 
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.Map" %>

--- a/java/apps/authentication-portal/src/main/webapp/enableTOTP.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/enableTOTP.jsp
@@ -139,6 +139,18 @@
                             </div>
                         </form>
                     </div>
+                    <div class="ui divider hidden"></div>
+                    <%
+                        String multiOptionURI = request.getParameter("multiOptionURI");
+                        if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
+                    %>
+                        <a class="ui primary basic button link-button" id="goBackLink"
+                        href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
+                            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
+                        </a>
+                    <%
+                        }
+                    %>
                 </div>
             </layout:component>
             <layout:component componentName="ProductFooter">

--- a/java/apps/authentication-portal/src/main/webapp/mobile.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/mobile.jsp
@@ -151,6 +151,18 @@
                             </div>
                         </form>
                     </div>
+                    <div class="ui divider hidden"></div>
+                    <%
+                        String multiOptionURI = request.getParameter("multiOptionURI");
+                        if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
+                    %>
+                        <a class="ui primary basic button link-button" id="goBackLink"
+                        href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
+                            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
+                        </a>
+                    <%
+                        }
+                    %>
                 </div>
             </layout:component>
             <layout:component componentName="ProductFooter">

--- a/java/apps/authentication-portal/src/main/webapp/smsOtp.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/smsOtp.jsp
@@ -164,6 +164,18 @@
                             <input type='hidden' name='resendCode' id='resendCode' value='false'/>
                         </form>
                     </div>
+                    <div class="ui divider hidden"></div>
+                    <%
+                        String multiOptionURI = request.getParameter("multiOptionURI");
+                        if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
+                    %>
+                        <a class="ui primary basic button link-button" id="goBackLink"
+                        href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
+                            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
+                        </a>
+                    <%
+                        }
+                    %>
                 </div>
             </layout:component>
             <layout:component componentName="ProductFooter">

--- a/java/apps/authentication-portal/src/main/webapp/smsOtp.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/smsOtp.jsp
@@ -18,6 +18,7 @@
 
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="org.wso2.carbon.identity.authenticator.smsotp.SMSOTPConstants" %>
 <%@ page import="java.io.File" %>

--- a/java/apps/authentication-portal/src/main/webapp/totp.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/totp.jsp
@@ -203,15 +203,7 @@
                                         onclick="return requestTOTPToken();">
                                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "get.verification.code")%>
                                         </a>
-                                    <% } else {
-                                        String multiOptionURI = request.getParameter("multiOptionURI");
-                                        if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
-                                    %>
-                                        <a class="ui button secondary" id="goBackLink"
-                                            href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
-                                                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
-                                        </a>
-                                    <% } } %>
+                                    <% } %>
                                 </div>
                                 <div class="six wide column mobile center aligned tablet right aligned computer right aligned buttons tablet no-margin-right-last-child computer no-margin-right-last-child">
                                     <input type="submit" value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "authenticate")%>" class="ui primary button">
@@ -222,7 +214,7 @@
                         <div class="ui divider hidden"></div>
                         <%
                             String multiOptionURI = request.getParameter("multiOptionURI");
-                            if (multiOptionURI != null && isSendVerificationCodeByEmailEnabled && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
+                            if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
                         %>
                             <a class="ui primary basic button link-button" id="goBackLink"
                             href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>

--- a/java/apps/authentication-portal/src/main/webapp/totp.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/totp.jsp
@@ -224,7 +224,7 @@
                             String multiOptionURI = request.getParameter("multiOptionURI");
                             if (multiOptionURI != null && isSendVerificationCodeByEmailEnabled && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
                         %>
-                            <a class="ui button secondary" id="goBackLink"
+                            <a class="ui primary basic button link-button" id="goBackLink"
                             href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
                                 <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
                             </a>


### PR DESCRIPTION
Related Issue
https://github.com/wso2/product-is/issues/16252

When the MFA is enabled, only totp authenticator shows a button to go back to multi-option page. Adding the same behaviour to following pages to make them consistent.
- sms OTP
- email OTP
- enable TOTP
- add mobile number
- add email address

![Screenshot 2023-08-20 at 23 32 02](https://github.com/wso2/identity-apps/assets/46132469/e2ebb9c1-1ba0-4dc6-9013-57de51b6197e)

![Screenshot 2023-08-20 at 23 35 32](https://github.com/wso2/identity-apps/assets/46132469/98f6a69d-510a-4bf6-9e11-b4ab8fa3154a)

![Screenshot 2023-08-20 at 23 37 12](https://github.com/wso2/identity-apps/assets/46132469/67463dba-6906-4157-a1f9-c7f8cfe759cf)

![Screenshot 2023-08-20 at 23 40 52](https://github.com/wso2/identity-apps/assets/46132469/d550b088-7418-4e7a-8a4b-e642409bdc46)

![Screenshot 2023-08-20 at 23 45 08](https://github.com/wso2/identity-apps/assets/46132469/3618b289-6a8f-4eab-bd54-a5f5b914a3ad)


