### PR TITLE
Fix IWA NTLM Authenticator Name at Login page

### DIFF
--- a/java/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/java/apps/authentication-portal/src/main/webapp/login.jsp
@@ -505,7 +505,7 @@
                                 <button class="ui blue labeled icon button fluid"
                                     onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
-                                        'IWAAuthenticator')"
+                                        'IwaNTLMAuthenticator')"
                                     id="icon-<%=iconId%>"
                                     title="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> IWA">
                                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> <strong>IWA</strong>


### PR DESCRIPTION
When configuring an application with multi option login with iwa-ntlm connector and another authenticator, after choosing the IWA option it gets redirected to the commonauth endpoint with the parameter `authenticator= IWAAuthenticator`. 

With the change https://github.com/wso2/carbon-identity-framework/pull/1860, we have changed the iwa ntlm authenticator name from `IWAAuthenticator` to `IwaNTLMAuthenticator` but have missed to change at the place where we resolve the URL for commonauth redirection. 

With this PR the commonauth redirection url will contain the correct parameter.

Resolves: https://github.com/wso2/product-is/issues/16246