### PR TITLE
Add userTenant ("ut") to authz endpoint by refereing "/t/<tenant-Domain>"

### DIFF
--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -40,6 +40,8 @@
             var userAccessedPath = window.location.href;
             var applicationDomain = window.location.origin;
 
+            var userTenant = userAccessedPath.split("/t/")[1] ?  userAccessedPath.split("/t/")[1].split("/")[0] : null;
+            userTenant = userTenant ?  userTenant.split("?")[0] : null;
             var serverOrigin = "<%= htmlWebpackPlugin.options.serverUrl %>";
             var authorizationCode = "<%= htmlWebpackPlugin.options.authorizationCode %>" != "null"
                                         ? "<%= htmlWebpackPlugin.options.authorizationCode %>"
@@ -100,7 +102,7 @@
                     storage: "webWorker",
                     enablePKCE: true,
                     endpoints: {
-                        authorizationEndpoint: getApiPath("/t/carbon.super/oauth2/authorize?ut=" + getOrganizationName())
+                        authorizationEndpoint: getApiPath(userTenant ? "/t/carbon.super/oauth2/authorize?ut="+userTenant.replace(/\/+$/, '') : "/t/carbon.super/oauth2/authorize")
                     }
                 }
 


### PR DESCRIPTION
### Purpose
issue: https://github.com/wso2/product-is/issues/16534

Root Cause:
User Tenant (ut) is the actual hint when the user trying to access any Saas application[1].
For example, the Console application is on Super Tenant but sub-tenant users also can access it via https://localhost:9443/t/test.com/console

Currently, we are checking for "/o/" in the request URL which is not used at the moment. Instead of this, we need to refer "/t/"

[1] - https://github.com/wso2/carbon-identity-framework/blob/6fa4a90a688dd4c52f4e558f34bf1f9fcddc3599/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/handler/request/impl/DefaultRequestCoordinator.java#L612


### Related Issues
- https://github.com/wso2/product-is/issues/16534

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
