### PR TITLE
Fix Issues Occurring Due to Not Initialising SignatureUtil Class

### DIFF
--- a/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -107,6 +107,7 @@
                 contentValueInJson.put("username", username);
                 contentValueInJson.put("createdTime", System.currentTimeMillis());
                 contentValueInJson.put("flowType", AUTO_LOGIN_FLOW_TYPE);
+                SignatureUtil.init();
                 if (StringUtils.isNotBlank(cookieDomain)) {
                     contentValueInJson.put("domain", cookieDomain);
                 }

--- a/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -243,6 +243,7 @@
                     contentValueInJson.put("username", username);
                     contentValueInJson.put("createdTime", System.currentTimeMillis());
                     contentValueInJson.put("flowType", AUTO_LOGIN_FLOW_TYPE);
+                    SignatureUtil.init();
                     if (StringUtils.isNotBlank(cookieDomain)) {
                         contentValueInJson.put("domain", cookieDomain);
                     }

--- a/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
+++ b/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
@@ -112,6 +112,7 @@
             contentValueInJson.put("username", username);
             contentValueInJson.put("createdTime", System.currentTimeMillis());
             contentValueInJson.put("flowType", AUTO_LOGIN_FLOW_TYPE);
+            SignatureUtil.init();
             if (StringUtils.isNotBlank(cookieDomain)) {
                 contentValueInJson.put("domain", cookieDomain);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -690,7 +690,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.21.30</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.24.8</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.service.version>1.0.65</identity.organization.management.service.version>
         <identity.org.mgt.version.range>[1.0.65, 2.0.0)</identity.org.mgt.version.range>


### PR DESCRIPTION
## Purpose
- Fix issues occurring due to not initialising SignatureUtil class
- This PR will also change the carbon identity framework version to 5.24.8 which is the version used in master branch of carbon-apimgt [1]
- Related Issue: https://github.com/wso2/api-manager/issues/2142

## Approach
- Initialise SignatureUtil before using its functions

[1] https://github.com/wso2/carbon-apimgt/blob/master/pom.xml#L1986
