### PR TITLE
Call overloaded resolveUser method

### DIFF
--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -148,7 +148,7 @@
         application.getInitParameter(IdentityManagementEndpointConstants.ConfigConstants.USER_PORTAL_URL), tenantDomain);
     }
 
-    User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain, isSaaSApp);
+    User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain);
 
     if (StringUtils.isEmpty(username)) {
         request.setAttribute("error", true);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -116,7 +116,7 @@
     Map<String, Claim> uniquePIIs = null;
 
     SelfRegistrationMgtClient selfRegistrationMgtClient = new SelfRegistrationMgtClient();
-    User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain, isSaaSApp);
+    User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain);
 
     ApplicationDataRetrievalClient applicationDataRetrievalClient = new ApplicationDataRetrievalClient();
     try {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -106,7 +106,7 @@
         tenantDomain = srtenantDomain;
     }
 
-    User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain, isSaaSApp);
+    User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain);
 
     if (skipSignUpEnableCheck) {
         consentPurposeGroupName = "JIT";


### PR DESCRIPTION
### Purpose
Use a overloaded resolveUser method in the self-registration flow which will resolve the complete username instead of tenant-aware username. 

Should be merged after merging following prs and bumping carbon-identity-framework version
- https://github.com/wso2/carbon-identity-framework/pull/4920
- https://github.com/wso2-extensions/identity-governance/pull/761

### Related issue
- https://github.com/wso2/product-is/issues/16500


