### PR TITLE
Fix login page error for multi option login when authentication endpoint is hosted externally

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -163,13 +163,24 @@
     String multiOptionURIParam = "";
     if (localAuthenticatorNames.size() > 1 || idpAuthenticatorMapping != null && idpAuthenticatorMapping.size() > 1) {
         String baseURL;
-        try {
-            baseURL = ServiceURLBuilder.create().addPath(request.getRequestURI()).build().getRelativePublicURL();
-        } catch (URLBuilderException e) {
-            request.setAttribute(STATUS, AuthenticationEndpointUtil.i18n(resourceBundle, "internal.error.occurred"));
-            request.setAttribute(STATUS_MSG, AuthenticationEndpointUtil.i18n(resourceBundle, "error.when.processing.authentication.request"));
-            request.getRequestDispatcher("error.do").forward(request, response);
-            return;
+        // Check whether authentication endpoint is hosted externally.
+        String isHostedExternally = application.getInitParameter("IsHostedExternally");
+        if (Boolean.parseBoolean(isHostedExternally)) {
+            String requestURI = request.getRequestURI();
+            if (StringUtils.isNotBlank(requestURI)) {
+                requestURI = requestURI.startsWith("/") ? requestURI : "/" + requestURI;
+                requestURI = requestURI.endsWith("/") ? requestURI.substring(0, requestURI.length() - 1) : requestURI;
+            }
+            baseURL = requestURI;
+        } else {
+            try {
+                baseURL = ServiceURLBuilder.create().addPath(request.getRequestURI()).build().getRelativePublicURL();
+            } catch (URLBuilderException e) {
+                request.setAttribute(STATUS, AuthenticationEndpointUtil.i18n(resourceBundle, "internal.error.occurred"));
+                request.setAttribute(STATUS_MSG, AuthenticationEndpointUtil.i18n(resourceBundle, "error.when.processing.authentication.request"));
+                request.getRequestDispatcher("error.do").forward(request, response);
+                return;
+            }
         }
     
         // Build the query string using the parameter map since the query string can contain fewer parameters


### PR DESCRIPTION
## Purpose
> Fix login page error for multi option login when authentication endpoint is hosted externally due to a NPE in `DefaultServiceURLBuilder`.

## Approach
> When authentication endpoint is hosted externally, `DefaultServiceURLBuilder` throws NPE when fetching the port. To fix this, we are checking a context parameter to check whether authentication endpoint is hosted externally. If that context param is set to true, requestURI is used as relative public URL directly without building it using `DefaultServiceURLBuilder`. (Reason for using `DefaultServiceURLBuilder` initially is to support tenant qualified URLs. So we are preserving that behaviour when the context parameter is not set to true)

Related Issues -
https://github.com/wso2/product-is/issues/16640