### PR TITLE
Add tenant mismatch error message in Email OTP error page

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtpError.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtpError.jsp
@@ -66,7 +66,7 @@
                     errorMessage = String.format(AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.account.temporarly.locked"), unlockTime);
                 }
             } else if (errorMessage.equalsIgnoreCase(EmailOTPAuthenticatorConstants.ERROR_TENANT_MISMATCH_MSG)) {
-                errorMessage = "Application you are trying to access does not allow users from your organization.";
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "user.tenant.domain.mismatch.message");
             }
         }
     }

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtpError.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtpError.jsp
@@ -18,6 +18,7 @@
 
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.authenticator.emailotp.EmailOTPAuthenticatorConstants" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.Map" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
@@ -64,6 +65,8 @@
                 if (unlockTime != null) {
                     errorMessage = String.format(AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.account.temporarly.locked"), unlockTime);
                 }
+            } else if (errorMessage.equalsIgnoreCase(EmailOTPAuthenticatorConstants.ERROR_TENANT_MISMATCH_MSG)) {
+                errorMessage = "Application you are trying to access does not allow users from your organization.";
             }
         }
     }


### PR DESCRIPTION
### Purpose
> Add error message for tenant domain mismatch

Should be merged after,
https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/167