### PR TITLE
Enable missing SAML configs in traditional web app template

### DIFF
--- a/apps/console/src/extensions/configs/application.tsx
+++ b/apps/console/src/extensions/configs/application.tsx
@@ -170,7 +170,7 @@ export const applicationConfig: ApplicationConfig = {
             showIncludeTenantDomain: false,
             showIncludeUserstoreDomainRole: false,
             showIncludeUserstoreDomainSubject: false,
-            showRoleAttribute: false,
+            showRoleAttribute: true,
             showRoleMapping: false,
             showSubjectAttribute: false,
             showUseMappedLocalSubject: false
@@ -583,7 +583,7 @@ export const applicationConfig: ApplicationConfig = {
             // Hide delete button for Enterprise IDP Login Applications.
             return !(application.name.startsWith("WSO2_LOGIN_FOR_") || isEnterpriseLoginMgt === "true");
         },
-        showProvisioningSettings: false
+        showProvisioningSettings: true
     },
     excludeIdentityClaims: true,
     excludeSubjectClaim: true,
@@ -638,9 +638,9 @@ export const applicationConfig: ApplicationConfig = {
     },
     inboundSAMLForm: {
         artifactBindingAllowed:false,
-        showApplicationQualifier: false,
+        showApplicationQualifier: true,
         showAttributeConsumingServiceIndex: false,
-        showQueryRequestProfile: false
+        showQueryRequestProfile: true
     },
     marketingConsent: {
         getBannerComponent: (): ReactElement =>

--- a/apps/console/src/features/applications/components/forms/inbound-saml-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-saml-form.tsx
@@ -314,6 +314,11 @@ export const InboundSAMLForm: FunctionComponent<InboundSAMLFormPropsInterface> =
                 label: "HTTP Redirect",
                 readOnly: true,
                 value: "HTTP_REDIRECT"
+            },
+            {
+                label: "Artifact",
+                readOnly: false,
+                value: "ARTIFACT"
             }
         ];
 


### PR DESCRIPTION
### Purpose
> Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. Remove this placeholder when you're editing.

This PR enables the following missing configurations in SAML traditional web app template.

- Logout Return URL or regex - previously  in SLO profile section in old console
- Role Claim URI - previously in user attributes tab in old console
- Inbound and outbound configurations - previously provisioning tab in old console
- Service provider qualifier - previously in the protocol section in old console
- Enable assertion query request profile - previously in the protocol section in old console
- Enable SAML2 artifact binding option - previously in the protocol section in old console

### Related Issues
- https://github.com/wso2/product-is/issues/16714

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
