### PR TITLE
Force `light` theme in Oxygen UI provider

### DIFF
--- a/apps/console/src/index.tsx
+++ b/apps/console/src/index.tsx
@@ -77,7 +77,7 @@ const RootWithConfig = (): ReactElement => {
     }
 
     return (
-        <ThemeProvider theme={ AsgardeoTheme }>
+        <ThemeProvider theme={ AsgardeoTheme } defaultMode="light">
             <Provider store={ store }>
                 <BrowserRouter>
                     <AuthProvider

--- a/apps/myaccount/src/providers/branding-preference-provider.tsx
+++ b/apps/myaccount/src/providers/branding-preference-provider.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,7 +25,6 @@ import { useGetBrandingPreference } from "../api";
 import { generateAsgardeoTheme } from "../branding/theme";
 import { BrandingPreferenceContext, BrandingPreferenceContextProps } from "../contexts";
 import { BrandingPreferenceMeta } from "../meta";
-
 
 /**
  * Props interface for the BrandingPreferenceProvider.

--- a/apps/myaccount/src/providers/branding-preference-provider.tsx
+++ b/apps/myaccount/src/providers/branding-preference-provider.tsx
@@ -102,7 +102,7 @@ export const BrandingPreferenceProvider = (props: PropsWithChildren<BrandingPref
                 { injectBaseTheme() }
                 { injectBrandingCSSSkeleton() }
             </Helmet>
-            <ThemeProvider theme={ generateAsgardeoTheme(contextValues) }>
+            <ThemeProvider theme={ generateAsgardeoTheme(contextValues) } defaultMode="light">
                 { children }
             </ThemeProvider>
         </BrandingPreferenceContext.Provider>


### PR DESCRIPTION
### Purpose

The console is intermittently switching to MUI's dark theme.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
