### PR TITLE
Stop applying DARK theme to the console

### DIFF
--- a/.changeset/pretty-items-rule.md
+++ b/.changeset/pretty-items-rule.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/myaccount": patch
+"@wso2is/console": patch
+---
+
+Change theme storing variable names in localstorage

--- a/apps/console/src/index.tsx
+++ b/apps/console/src/index.tsx
@@ -78,7 +78,7 @@ const RootWithConfig = (): ReactElement => {
     }
 
     return (
-        <ThemeProvider theme={ AsgardeoTheme } defaultMode="light">
+        <ThemeProvider theme={ AsgardeoTheme } defaultMode="light" modeStorageKey="console-oxygen-mode">
             <Provider store={ store }>
                 <BrowserRouter>
                     <AuthProvider

--- a/apps/myaccount/src/providers/branding-preference-provider.tsx
+++ b/apps/myaccount/src/providers/branding-preference-provider.tsx
@@ -101,7 +101,11 @@ export const BrandingPreferenceProvider = (props: PropsWithChildren<BrandingPref
                 { injectBaseTheme() }
                 { injectBrandingCSSSkeleton() }
             </Helmet>
-            <ThemeProvider theme={ generateAsgardeoTheme(contextValues) } defaultMode="light">
+            <ThemeProvider 
+                theme={ generateAsgardeoTheme(contextValues) } 
+                defaultMode="light"  
+                modeStorageKey="myaccount-oxygen-mode"
+            >
                 { children }
             </ThemeProvider>
         </BrandingPreferenceContext.Provider>


### PR DESCRIPTION
### Purpose
When we enable the DARK theme for an organization through the console, visiting the tenanted myaccount reveals that the myaccount color theme is dark. Upon logging into the console, you can observe that the console theme partially converts to DARK mode.

The root cause of this issue lies in the use of the oxygen-mode variable to store the theme in local storage. When logging into myaccount, it resolves the branding API request and automatically enables the dark theme, saving it in local storage. Subsequently, when logging into the console, it reads the local storage oxygen-mode and attempts to change the light theme to dark. This behavior is not as expected, resulting in a broken DARK theme in the console. This issue is specific to IS because both the console and myaccount applications share the same domain.

`From this PR I forced to use a different variable to store and read theme in console and myaccount.`
