### PR TITLE
Add extended routes for Roles pages

### DIFF
--- a/.changeset/poor-weeks-prove.md
+++ b/.changeset/poor-weeks-prove.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add extended routes for Roles pages

--- a/apps/console/.env.local
+++ b/apps/console/.env.local
@@ -10,6 +10,9 @@ ENABLE_ANALYZER=false
 ANALYZER_PORT=8889
 LOG_LEVEL=none
 
+WDS_SOCKET_PORT=9001
+WDS_SOCKET_HOST=localhost
+
 # ----------------------------------------------------------------------------------
 #  If the app is intended to be deployed on an external server (tomcat/static)
 #  outside of the Identity Server runtime. Set this variable to "tomcat" | "static"

--- a/apps/console/src/features/core/configs/routes.tsx
+++ b/apps/console/src/features/core/configs/routes.tsx
@@ -237,34 +237,6 @@ export const getAppViewRoutes = (useExtendedRoutes: boolean = false): RouteInter
                         category: "extensions:manage.sidePanel.categories.userManagement",
                         children: [
                             {
-                                component: lazy(() => import("../../roles/pages/role-edit")),
-                                exact: true,
-                                icon: {
-                                    icon: getSidePanelIcons().childIcon
-                                },
-                                id: "rolesEdit",
-                                name: "console:manage.features.sidePanel.editRoles",
-                                path: AppConstants.getPaths().get("ROLE_EDIT"),
-                                protected: true,
-                                showOnSidePanel: false
-                            }
-                        ],
-                        component: lazy(() => import("../../roles/pages/role")),
-                        exact: true,
-                        icon: {
-                            icon: getSidePanelIcons().applicationRoles
-                        },
-                        id: "roles",
-                        name: "console:manage.features.sidePanel.roles",
-                        order: 7,
-                        path: AppConstants.getPaths().get("ROLES"),
-                        protected: true,
-                        showOnSidePanel: true
-                    },
-                    {
-                        category: "extensions:manage.sidePanel.categories.userManagement",
-                        children: [
-                            {
                                 component: lazy(() => import("../../application-roles/pages/application-role-edit")),
                                 exact: true,
                                 icon: {
@@ -279,6 +251,8 @@ export const getAppViewRoutes = (useExtendedRoutes: boolean = false): RouteInter
                         ],
                         component: lazy(() => import("../../application-roles/pages/application-roles")),
                         exact: true,
+                        featureStatus: "NEW",
+                        featureStatusLabel: "common:new",
                         icon: {
                             icon: getSidePanelIcons().roles
                         },
@@ -1081,6 +1055,76 @@ export const getAppViewRoutes = (useExtendedRoutes: boolean = false): RouteInter
                 path: AppConstants.getPaths().get("USERSTORES"),
                 protected: true,
                 showOnSidePanel: true
+            },
+            {
+                category: "extensions:manage.sidePanel.categories.userManagement",
+                children: [
+                    {
+                        component: lazy(() => import("../../application-roles/pages/application-roles")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().childIcon
+                        },
+                        id: "applicationRoles",
+                        name: "Application Roles",
+                        path: AppConstants.getPaths().get("APPLICATION_ROLES_SUB"),
+                        protected: true,
+                        showOnSidePanel: false
+                    },
+                    {
+                        component: lazy(() => import("../../application-roles/pages/application-role-edit")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().childIcon
+                        },
+                        id: "applicationRolesEdit",
+                        name: "Edit Application Role",
+                        path: AppConstants.getPaths().get("APPLICATION_ROLES_EDIT_SUB"),
+                        protected: true,
+                        showOnSidePanel: false
+                    },
+                    {
+                        component: lazy(() =>
+                            import("../../../features/organizations/pages/organization-roles")
+                        ),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().roles
+                        },
+                        id: "organization-roles",
+                        name: "Organization Roles",
+                        path: AppConstants.getPaths().get("ORGANIZATION_ROLES"),
+                        protected: true,
+                        showOnSidePanel: false
+                    },
+                    {
+                        component: lazy(() =>
+                            import("../../../features/organizations/pages/organization-roles-edit")
+                        ),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().roles
+                        },
+                        id: "organization-roles-edit",
+                        name: "organization Roles Edit",
+                        path: AppConstants.getPaths().get("ORGANIZATION_ROLE_UPDATE"),
+                        protected: true,
+                        showOnSidePanel: false
+                    }
+                ],
+                component: lazy(() => import("../../parent-roles/parent-roles")),
+                exact: true,
+                featureStatus: "NEW",
+                featureStatusLabel: "common:new",
+                icon: {
+                    icon: getSidePanelIcons().applicationRoles
+                },
+                id: "roles",
+                name: "Roles",
+                order: 7,
+                path: AppConstants.getPaths().get("ROLES"),
+                protected: true,
+                showOnSidePanel: true
             }
         );
     } else {
@@ -1226,6 +1270,34 @@ export const getAppViewRoutes = (useExtendedRoutes: boolean = false): RouteInter
                 name: "console:manage.features.sidePanel.userstores",
                 order: 9,
                 path: AppConstants.getPaths().get("USERSTORES"),
+                protected: true,
+                showOnSidePanel: true
+            },
+            {
+                category: "extensions:manage.sidePanel.categories.userManagement",
+                children: [
+                    {
+                        component: lazy(() => import("../../roles/pages/role-edit")),
+                        exact: true,
+                        icon: {
+                            icon: getSidePanelIcons().childIcon
+                        },
+                        id: "rolesEdit",
+                        name: "console:manage.features.sidePanel.editRoles",
+                        path: AppConstants.getPaths().get("ROLE_EDIT"),
+                        protected: true,
+                        showOnSidePanel: false
+                    }
+                ],
+                component: lazy(() => import("../../roles/pages/role")),
+                exact: true,
+                icon: {
+                    icon: getSidePanelIcons().applicationRoles
+                },
+                id: "userRoles",
+                name: "console:manage.features.sidePanel.roles",
+                order: 7,
+                path: AppConstants.getPaths().get("ROLES"),
                 protected: true,
                 showOnSidePanel: true
             }

--- a/apps/console/src/features/core/utils/route-utils.ts
+++ b/apps/console/src/features/core/utils/route-utils.ts
@@ -350,6 +350,11 @@ export class RouteUtils {
             },
             {
                 category: manage,
+                id: "userRoles",
+                parent: userManagement
+            },
+            {
+                category: manage,
                 id: "roles",
                 parent: userManagement
             },

--- a/apps/console/webpack.config.ts
+++ b/apps/console/webpack.config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020-2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -128,9 +128,12 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
 
     // Dev Server Options.
     const devServerPort: number = process.env.DEV_SERVER_PORT || config.devServer?.port;
-    const devServerHost: number = process.env.DEV_SERVER_HOST || config.devServer?.host;
+    const devServerHost: string = process.env.DEV_SERVER_HOST || config.devServer?.host;
     const isDevServerHostCheckDisabled: boolean = process.env.DISABLE_DEV_SERVER_HOST_CHECK === "true";
     const isESLintPluginDisabled: boolean = process.env.DISABLE_ESLINT_PLUGIN === "true";
+    const devServerWebSocketHost: string = process.env.WDS_SOCKET_HOST;
+    const devServerWebSocketPath: string = process.env.WDS_SOCKET_PATH;
+    const devServerWebSocketPort: string = process.env.WDS_SOCKET_PORT;
 
     // Configurations resolved from deployment.config.json.
     const theme: string = DeploymentConfig.ui.theme.name || "default";
@@ -611,7 +614,15 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
         // This has resulted in issues such as development in cloud environment or subdomains impossible.
         allowedHosts: isDevServerHostCheckDisabled ? "all" : "auto",
         client: {
-            overlay: false
+            overlay: false,
+            webSocketURL: {
+                // Enable custom sockjs pathname for websocket connection to hot reloading server.
+                // Enable custom sockjs hostname, pathname and port for websocket connection
+                // to hot reloading server.
+                hostname: devServerWebSocketHost,
+                pathname: devServerWebSocketPath,
+                port: devServerWebSocketPort
+            }
         },
         devMiddleware: {
             ...config.devServer?.devMiddleware,


### PR DESCRIPTION
### Purpose
> $subject
Fix hot reload issue for Console App

- Updated the route id for the identity-apps end `/roles` route to `userRoles`. This is to accommodate feature on/off through the app-constants file. 

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
