### PR TITLE
Update recovery portal to v2

### DIFF
--- a/.changeset/quick-kangaroos-drive.md
+++ b/.changeset/quick-kangaroos-drive.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Update recovery portal for recovery v2 API

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
@@ -26,8 +26,8 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.PasswordRecoveryApiV1" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.passwordrecovery.v1.*" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.PasswordRecoveryApiV2" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.passwordrecovery.v2.*" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.UsernameRecoveryApi" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.*" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
@@ -93,13 +93,13 @@
 
     RecoveryInitRequest recoveryInitRequest = new RecoveryInitRequest();
     recoveryInitRequest.setClaims(claimDTOList);
-    PasswordRecoveryApiV1 passwordRecoveryApiV1 = new PasswordRecoveryApiV1();
+    PasswordRecoveryApiV2 passwordRecoveryApiV2 = new PasswordRecoveryApiV2();
     try {
         Map<String, String> requestHeaders = new HashedMap();
         if (recaptchaResponse != null) {
             requestHeaders.put("g-recaptcha-response", recaptchaResponse);
         }
-        List<AccountRecoveryType> accountRecoveryTypes = passwordRecoveryApiV1.
+        List<AccountRecoveryType> accountRecoveryTypes = passwordRecoveryApiV2.
                 initiatePasswordRecovery(recoveryInitRequest, tenantDomain, requestHeaders);
         if (accountRecoveryTypes == null) {
             request.setAttribute("callback", callback);
@@ -108,7 +108,7 @@
                         response);
             return;
         }
-        IdentityManagementEndpointUtil.addReCaptchaHeaders(request, passwordRecoveryApiV1.getApiClient().getResponseHeaders());
+        IdentityManagementEndpointUtil.addReCaptchaHeaders(request, passwordRecoveryApiV2.getApiClient().getResponseHeaders());
         for (AccountRecoveryType accountRecoveryType : accountRecoveryTypes) {
             if (accountRecoveryType.getMode().equals("recoverWithNotifications")) {
                 isNotificationBasedRecoveryEnabled = true;

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
@@ -26,8 +26,8 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.List" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.PasswordRecoveryApiV2" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.passwordrecovery.v2.*" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.RecoveryApiV2" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.*" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.UsernameRecoveryApi" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.*" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
@@ -93,13 +93,13 @@
 
     RecoveryInitRequest recoveryInitRequest = new RecoveryInitRequest();
     recoveryInitRequest.setClaims(claimDTOList);
-    PasswordRecoveryApiV2 passwordRecoveryApiV2 = new PasswordRecoveryApiV2();
+    RecoveryApiV2 recoveryApiV2 = new RecoveryApiV2();
     try {
         Map<String, String> requestHeaders = new HashedMap();
         if (recaptchaResponse != null) {
             requestHeaders.put("g-recaptcha-response", recaptchaResponse);
         }
-        List<AccountRecoveryType> accountRecoveryTypes = passwordRecoveryApiV2.
+        List<AccountRecoveryType> accountRecoveryTypes = recoveryApiV2.
                 initiatePasswordRecovery(recoveryInitRequest, tenantDomain, requestHeaders);
         if (accountRecoveryTypes == null) {
             request.setAttribute("callback", callback);
@@ -108,7 +108,7 @@
                         response);
             return;
         }
-        IdentityManagementEndpointUtil.addReCaptchaHeaders(request, passwordRecoveryApiV2.getApiClient().getResponseHeaders());
+        IdentityManagementEndpointUtil.addReCaptchaHeaders(request, recoveryApiV2.getApiClient().getResponseHeaders());
         for (AccountRecoveryType accountRecoveryType : accountRecoveryTypes) {
             if (accountRecoveryType.getMode().equals("recoverWithNotifications")) {
                 isNotificationBasedRecoveryEnabled = true;

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/recovery.jsp
@@ -25,7 +25,7 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApiException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.UsernameRecoveryApi" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.PasswordRecoveryApiV1" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.PasswordRecoveryApiV2" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.Claim" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.UserClaim" %>
 <%@ page import="org.wso2.carbon.user.core.util.UserCoreUtil" %>
@@ -35,7 +35,7 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.Property" %>
 <%@ page import="java.net.URLEncoder" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.passwordrecovery.v1.*" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.passwordrecovery.v2.*" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClientException" %>
 
@@ -165,14 +165,14 @@
         String recoveryCode = request.getParameter("recoveryCode");
         String notificationChannel = "";
 
-        PasswordRecoveryApiV1 passwordRecoveryApiV1 = new PasswordRecoveryApiV1();
+        PasswordRecoveryApiV2 passwordRecoveryApiV2 = new PasswordRecoveryApiV2();
         if (recoveryOption.equals("SECURITY_QUESTIONS")) {
             username = IdentityManagementEndpointUtil.getFullQualifiedUsername(username, tenantDomain, null);
             request.setAttribute("callback", callback);
             request.setAttribute("sessionDataKey", sessionDataKey);
             request.setAttribute("username", username);
             session.setAttribute("username", username);
-            IdentityManagementEndpointUtil.addReCaptchaHeaders(request, passwordRecoveryApiV1.
+            IdentityManagementEndpointUtil.addReCaptchaHeaders(request, passwordRecoveryApiV2.
                     getApiClient().getResponseHeaders());
             request.getRequestDispatcher("challenge-question-request.jsp?username=" + username).forward(request,
                     response);
@@ -195,7 +195,7 @@
             recoveryRequest.setRecoveryCode(recoveryCode);
             try {
                 Map<String, String> requestHeaders = new HashedMap();
-                RecoveryResponse recoveryResponse = passwordRecoveryApiV1.recoverPassword(recoveryRequest,
+                RecoveryResponse recoveryResponse = passwordRecoveryApiV2.recoverPassword(recoveryRequest,
                         tenantDomain, requestHeaders);
                 notificationChannel = recoveryResponse.getNotificationChannel();
                 request.setAttribute("callback", callback);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/recovery.jsp
@@ -25,7 +25,7 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApiException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.UsernameRecoveryApi" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.PasswordRecoveryApiV2" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.RecoveryApiV2" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.Claim" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.UserClaim" %>
 <%@ page import="org.wso2.carbon.user.core.util.UserCoreUtil" %>
@@ -35,7 +35,7 @@
 <%@ page import="java.util.Map" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.Property" %>
 <%@ page import="java.net.URLEncoder" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.passwordrecovery.v2.*" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.*" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClientException" %>
 
@@ -165,14 +165,14 @@
         String recoveryCode = request.getParameter("recoveryCode");
         String notificationChannel = "";
 
-        PasswordRecoveryApiV2 passwordRecoveryApiV2 = new PasswordRecoveryApiV2();
+        RecoveryApiV2 recoveryApiV2 = new RecoveryApiV2();
         if (recoveryOption.equals("SECURITY_QUESTIONS")) {
             username = IdentityManagementEndpointUtil.getFullQualifiedUsername(username, tenantDomain, null);
             request.setAttribute("callback", callback);
             request.setAttribute("sessionDataKey", sessionDataKey);
             request.setAttribute("username", username);
             session.setAttribute("username", username);
-            IdentityManagementEndpointUtil.addReCaptchaHeaders(request, passwordRecoveryApiV2.
+            IdentityManagementEndpointUtil.addReCaptchaHeaders(request, recoveryApiV2.
                     getApiClient().getResponseHeaders());
             request.getRequestDispatcher("challenge-question-request.jsp?username=" + username).forward(request,
                     response);
@@ -195,7 +195,7 @@
             recoveryRequest.setRecoveryCode(recoveryCode);
             try {
                 Map<String, String> requestHeaders = new HashedMap();
-                RecoveryResponse recoveryResponse = passwordRecoveryApiV2.recoverPassword(recoveryRequest,
+                RecoveryResponse recoveryResponse = recoveryApiV2.recoverPassword(recoveryRequest,
                         tenantDomain, requestHeaders);
                 notificationChannel = recoveryResponse.getNotificationChannel();
                 request.setAttribute("callback", callback);

--- a/identity-apps-core/pom.xml
+++ b/identity-apps-core/pom.xml
@@ -673,7 +673,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.25.308</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.402</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 7.0.0]</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.core.service.version>1.0.0
         </identity.organization.management.core.service.version>


### PR DESCRIPTION
### Purpose
We have introduced a new recovery v2 API and disabled the v1 API. Hence, we need to update the usages of v1 in the recovery portal to v2.

### Related Issues
- https://github.com/wso2/product-is/issues/16926

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/4993

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
