### PR TITLE
Handle empty basename in webpack configs

### DIFF
--- a/.changeset/odd-crabs-carry.md
+++ b/.changeset/odd-crabs-carry.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+---
+
+Fix issues with handling empty app basename

--- a/apps/console/src/auth.html
+++ b/apps/console/src/auth.html
@@ -131,7 +131,7 @@
                 animation-iteration-count: infinite;
             }
         </style>
-        <script src="/<%= htmlWebpackPlugin.options.basename %>/startup-config.js"></script>
+        <script src="/<%= htmlWebpackPlugin.options.basename ? htmlWebpackPlugin.options.basename + '/' : '' %>startup-config.js"></script>
         <script>
             function preLoaderResolver() {
                 var trifactaPreLoader = document.getElementById("trifacta-pre-loader");
@@ -211,9 +211,12 @@
 
                     var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
 
+                    var basePath = applicationDomain.replace(/\/+$/, '') + getOrganizationPath();
+                    var baseRedirectURL = "<%= htmlWebpackPlugin.options.basename%>" ? basePath + '/' + "<%= htmlWebpackPlugin.options.basename%>" : basePath;
+
                     var authConfig = {
-                        signInRedirectURL: applicationDomain.replace(/\/+$/, '') + getOrganizationPath() + "/<%= htmlWebpackPlugin.options.basename %>",
-                        signOutRedirectURL: applicationDomain.replace(/\/+$/, '') + getOrganizationPath() + "/<%= htmlWebpackPlugin.options.basename %>",
+                        signInRedirectURL: baseRedirectURL,
+                        signOutRedirectURL: baseRedirectURL,
                         clientID: "CONSOLE",
                         baseUrl: getApiPath(),
                         responseMode: "query",
@@ -279,7 +282,7 @@
         <script
             async
             onload="onAuthScriptLoad();"
-            src="/<%= htmlWebpackPlugin.options.basename %>/auth-spa-0.3.3.min.js"
+            src="/<%= htmlWebpackPlugin.options.basename ? htmlWebpackPlugin.options.basename + '/' : '' %>auth-spa-0.3.3.min.js"
         ></script>
     </head>
     <body onload="preLoaderResolver()">

--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -138,7 +138,9 @@
                 animation-iteration-count: infinite;
             }
         </style>
-        <script src="/<%= htmlWebpackPlugin.options.basename %>/startup-config.js"></script>
+        <script
+            src="/<%= htmlWebpackPlugin.options.basename ? htmlWebpackPlugin.options.basename + '/' : '' %>startup-config.js"
+        ></script>
         <script>
             function preLoaderResolver() {
                 var trifactaPreLoader = document.getElementById("trifacta-pre-loader");
@@ -219,8 +221,8 @@
                 var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
 
                 var authConfig = {
-                    signInRedirectURL: applicationDomain.replace(/\/+$/, '') + getOrganizationPath() + "/"
-                        + "<%= htmlWebpackPlugin.options.basename %>",
+                    signInRedirectURL: applicationDomain.replace(/\/+$/, '') + getOrganizationPath() 
+                        + "<%= htmlWebpackPlugin.options.basename ? '/' + htmlWebpackPlugin.options.basename : ''%>",
                     signOutRedirectURL: applicationDomain.replace(/\/+$/, '') + getOrganizationPath(),
                     clientID: "<%= htmlWebpackPlugin.options.clientID %>",
                     baseUrl: getApiPath(),
@@ -278,8 +280,9 @@
     <script>
         if(!authorizationCode) {
             var authSPAJS = document.createElement("script");
+            var authScriptSrc = "<%= htmlWebpackPlugin.options.basename ? '/' + htmlWebpackPlugin.options.basename + '/auth-spa-0.3.3.min.js' : '/auth-spa-0.3.3.min.js'%>";
 
-            authSPAJS.setAttribute("src", "/<%= htmlWebpackPlugin.options.basename %>/auth-spa-0.3.3.min.js");
+            authSPAJS.setAttribute("src", authScriptSrc);
             authSPAJS.setAttribute("async", "false");
 
             let head = document.head;

--- a/apps/myaccount/src/auth.html
+++ b/apps/myaccount/src/auth.html
@@ -131,7 +131,7 @@
                 animation-iteration-count: infinite;
             }
         </style>
-        <script src="/<%= htmlWebpackPlugin.options.basename %>/startup-config.js"></script>
+        <script src="/<%= htmlWebpackPlugin.options.basename ? htmlWebpackPlugin.options.basename + '/' : '' %>startup-config.js"></script>
         <script>
             var userAccessedPath = window.location.href;
 
@@ -188,10 +188,12 @@
                     }
 
                     var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
+                    var basePath = applicationDomain.replace(/\/+$/, '');
+                    var baseRedirectURL = "<%= htmlWebpackPlugin.options.basename%>" ? basePath + '/' + "<%= htmlWebpackPlugin.options.basename%>" : basePath;
 
                     var authConfig = {
-                        signInRedirectURL: applicationDomain.replace(/\/+$/, '') + "/<%= htmlWebpackPlugin.options.basename %>",
-                        signOutRedirectURL: applicationDomain.replace(/\/+$/, '') + "/<%= htmlWebpackPlugin.options.basename %>",
+                        signInRedirectURL: baseRedirectURL,
+                        signOutRedirectURL: baseRedirectURL,
                         clientID: "MY_ACCOUNT",
                         baseUrl: getApiPath(),
                         responseMode: "query",
@@ -225,7 +227,7 @@
         <script
             async
             onload="onAuthScriptLoad();"
-            src="/<%= htmlWebpackPlugin.options.basename %>/auth-spa-0.3.3.min.js"
+            src="/<%= htmlWebpackPlugin.options.basename ? htmlWebpackPlugin.options.basename + '/' : '' %>auth-spa-0.3.3.min.js"
         ></script>
     </head>
     <body onload="preLoaderResolver()">

--- a/apps/myaccount/src/index.jsp
+++ b/apps/myaccount/src/index.jsp
@@ -139,7 +139,7 @@
                 animation-iteration-count: infinite;
             }
         </style>
-        <script src="/<%= htmlWebpackPlugin.options.basename %>/startup-config.js"></script>
+        <script src="/<%= htmlWebpackPlugin.options.basename ? htmlWebpackPlugin.options.basename + '/' : '' %>startup-config.js"></script>
         <script>
             var userAccessedPath = window.location.href;
             var userTenant = userAccessedPath.split("/" + startupConfig.tenantPrefix + "/")[1] ?  userAccessedPath.split("/" + startupConfig.tenantPrefix + "/")[1].split("/")[0] : null;
@@ -202,7 +202,8 @@
                 var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
 
                 var authConfig = {
-                    signInRedirectURL: applicationDomain.replace(/\/+$/, '')  + "/<%= htmlWebpackPlugin.options.basename %>",
+                    signInRedirectURL: applicationDomain.replace(/\/+$/, '')  
+                        + "<%= htmlWebpackPlugin.options.basename ? '/' + htmlWebpackPlugin.options.basename : ''%>",
                     signOutRedirectURL: applicationDomain.replace(/\/+$/, ''),
                     clientID: "<%= htmlWebpackPlugin.options.clientID %>",
                     baseUrl: getApiPath(),
@@ -227,10 +228,11 @@
         }
     </script>
     <script>
-        if(!authorizationCode) {
+        if (!authorizationCode) {
             var authSPAJS = document.createElement("script");
+            var authScriptSrc = "<%= htmlWebpackPlugin.options.basename ? '/' + htmlWebpackPlugin.options.basename + '/auth-spa-0.3.3.min.js' : '/auth-spa-0.3.3.min.js'%>";
 
-            authSPAJS.setAttribute("src", "/<%= htmlWebpackPlugin.options.basename %>/auth-spa-0.3.3.min.js");
+            authSPAJS.setAttribute("src", authScriptSrc);
             authSPAJS.setAttribute("async", "false");
 
             let head = document.head;


### PR DESCRIPTION
### Purpose
> $subject
When the app basename is empty, erroneous paths are resolved for resource files.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
