### PR TITLE
Add organization discovery for b2b login flow

### DIFF
--- a/.changeset/fifty-toys-sip.md
+++ b/.changeset/fifty-toys-sip.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add organization discovery for b2b login flow

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -478,7 +478,13 @@ error.504=Error 504 - Gateway Timeout
 
 # Organization Login
 organization.login=Organization Login
-organization.name=Name of the Organization
+organization.name=Organization name
+organization.email=Organization email
+invalid.organization.discovery.input=Unable to identify the organization. Please check if the provided email domain is correct or provide the organization name to continue.
+discovery.input.cannot.be.empty=Email cannot be empty.
+organization.name.cannot.be.empty=Organization name cannot be empty.
+provide.organization.name=Provide organization name
+provide.email.address=Provide email address
 
 # SCIM Attributes
 VXNlcm5hbWU_=Username

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -474,6 +474,11 @@ error.504=Fehler 504 - Timeout von Gateway
 # Organization Login
 organization.login=Organisation Login
 organization.name=Name der Organisation
+invalid.organization.discovery.input=Die Organisation konnte nicht identifiziert werden. Bitte geben Sie den Namen der Organisation an, um fortzufahren.
+discovery.input.cannot.be.empty=E-Mail darf nicht leer sein.
+organization.name.cannot.be.empty=Der Name der Organisation darf nicht leer sein.
+provide.organization.name=Geben Sie den Namen der Organisation an
+provide.email.address=E-Mail-Adresse angeben
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nutzername

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -473,7 +473,12 @@ error.504=Error 504 - Tiempo de espera de la puerta de enlace agotado
 
 # Organization Login
 organization.login=Inicio de sesiÃ³n de la organizaciÃ³n
-organization.name=Nombre de la organizaciÃ³n
+organization.name=Nombre de la Organización
+invalid.organization.discovery.input=No se puede identificar la organización. Proporcione el nombre de la organización para continuar.
+discovery.input.cannot.be.empty=El correo electrónico no puede estar vacío.
+organization.name.cannot.be.empty=El nombre de la organización no puede estar vacío.
+provide.organization.name=Proporcionar el nombre de la organización
+provide.email.address=Proporcionar dirección de correo electrónico
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nombre de usuario

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -474,6 +474,11 @@ error.504=Erreur 504 - DÃ©lai d'expiration de la passerelle
 # Organization Login
 organization.login=Connexion de l'organisation
 organization.name=Nom de l'organisation
+invalid.organization.discovery.input=Impossible d'identifier l'organisation. Veuillez fournir le nom de l'organisation pour continuer.
+discovery.input.cannot.be.empty=L'e-mail ne peut pas être vide.
+organization.name.cannot.be.empty=Le nom de l'organisation ne peut pas être vide.
+provide.organization.name=Fournir le nom de l'organisation
+provide.email.address=Fournir une adresse e-mail
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nom d'utilisateur

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -479,6 +479,7 @@ discovery.input.cannot.be.empty=電子メールを空にすることはできま
 organization.name.cannot.be.empty=組織名を空にすることはできません。
 provide.organization.name=組織名を入力してください
 provide.email.address=メールアドレスを入力してください
+provide.email.address2=メールアドレスを入力してください
 
 ## SCIM Attributes
 VXNlcm5hbWU_=ユーザー名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -479,7 +479,6 @@ discovery.input.cannot.be.empty=電子メールを空にすることはできま
 organization.name.cannot.be.empty=組織名を空にすることはできません。
 provide.organization.name=組織名を入力してください
 provide.email.address=メールアドレスを入力してください
-provide.email.address2=メールアドレスを入力してください
 
 ## SCIM Attributes
 VXNlcm5hbWU_=ユーザー名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -472,7 +472,13 @@ error.504=エラー 504 - ゲートウェイのタイムアウト
 
 ## Organization Login
 organization.login=組織ログイン
-organization.name=組織の名前
+organization.name=組織名
+organization.email=組織の電子メール
+invalid.organization.discovery.input=組織を特定できません。指定された電子メール ドメインが正しいかどうかを確認するか、組織名を指定して続行してください。
+discovery.input.cannot.be.empty=電子メールを空にすることはできません。
+organization.name.cannot.be.empty=組織名を空にすることはできません。
+provide.organization.name=組織名を入力してください
+provide.email.address=メールアドレスを入力してください
 
 ## SCIM Attributes
 VXNlcm5hbWU_=ユーザー名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -472,7 +472,13 @@ error.504=エラー 504 - ゲートウェイのタイムアウト
 
 ## Organization Login
 organization.login=組織ログイン
-organization.name=組織の名前
+organization.name=組織名
+organization.email=組織の電子メール
+invalid.organization.discovery.input=組織を特定できません。指定された電子メール ドメインが正しいかどうかを確認するか、組織名を入力して続行してください。
+discovery.input.cannot.be.empty=電子メールを空にすることはできません。
+organization.name.cannot.be.empty=組織名を空にすることはできません。
+provide.organization.name=組織名を入力してください
+provide.email.address=メールアドレスを入力してください
 
 ## SCIM Attributes
 VXNlcm5hbWU_=ユーザー名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -472,13 +472,7 @@ error.504=エラー 504 - ゲートウェイのタイムアウト
 
 ## Organization Login
 organization.login=組織ログイン
-organization.name=組織名
-organization.email=組織の電子メール
-invalid.organization.discovery.input=組織を特定できません。指定された電子メール ドメインが正しいかどうかを確認するか、組織名を指定して続行してください。
-discovery.input.cannot.be.empty=電子メールを空にすることはできません。
-organization.name.cannot.be.empty=組織名を空にすることはできません。
-provide.organization.name=組織名を入力してください
-provide.email.address=メールアドレスを入力してください
+organization.name=組織の名前
 
 ## SCIM Attributes
 VXNlcm5hbWU_=ユーザー名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -473,7 +473,12 @@ error.504=Erro 504 - Tempo limite do gateway
 
 # Organization Login
 organization.login=Login da organizaÃ§Ã£o
-organization.name=Nome da organizaÃ§Ã£o
+organization.name=Nome da organização
+invalid.organization.discovery.input=Não foi possível identificar a organização. Forneça o nome da organização para continuar.
+discovery.input.cannot.be.empty=O e-mail não pode ficar vazio.
+organization.name.cannot.be.empty=O nome da organização não pode ficar vazio.
+provide.organization.name=Forneça o nome da organização
+provide.email.address=Forneça endereço de e-mail
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nome de usuÃ¡rio

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -472,7 +472,13 @@ error.504=错误504-网关超时
 
 ## Organization Login
 organization.login=组织登录
-organization.name=组织名称
+organization.name=机构名称
+organization.email=组织邮箱
+invalid.organization.discovery.input=无法识别该组织。请检查提供的电子邮件域是否正确或提供组织名称以继续。
+discovery.input.cannot.be.empty=电子邮件不能为空。
+organization.name.cannot.be.empty=组织名称不能为空。
+provide.organization.name=提供组织名称
+provide.email.address=提供电子邮件地址
 
 ## SCIM Attributes
 VXNlcm5hbWU_=用户名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -472,13 +472,7 @@ error.504=错误504-网关超时
 
 ## Organization Login
 organization.login=组织登录
-organization.name=机构名称
-organization.email=组织邮箱
-invalid.organization.discovery.input=无法识别该组织。请检查提供的电子邮件域是否正确或提供组织名称以继续。
-discovery.input.cannot.be.empty=电子邮件不能为空。
-organization.name.cannot.be.empty=组织名称不能为空。
-provide.organization.name=提供组织名称
-provide.email.address=提供电子邮件地址
+organization.name=组织名称
 
 ## SCIM Attributes
 VXNlcm5hbWU_=用户名

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
@@ -368,6 +368,11 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org_discovery.do</servlet-name>
+        <jsp-file>/org_discovery.jsp</jsp-file>
+    </servlet>
+
+    <servlet>
         <servlet-name>select_org.do</servlet-name>
         <jsp-file>/select_org.jsp</jsp-file>
     </servlet>
@@ -430,6 +435,11 @@
     <servlet-mapping>
         <servlet-name>org_name.do</servlet-name>
         <url-pattern>/org_name.do</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>org_discovery.do</servlet-name>
+        <url-pattern>/org_discovery.do</url-pattern>
     </servlet-mapping>
 
     <servlet-mapping>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -125,7 +125,7 @@
             <%
                 List<String> langSwitcherEnabledServlets = Arrays.asList("/oauth2_login.do", "/oauth2_error.do",
                     "/confirmregistration.do", "/confirmrecovery.do", "/claims.do", "/oauth2_consent.do",
-                    "/fido2-auth.jsp", "/email_otp.do", "/org_name.do", "/retry.do", "/totp_enroll.do", "/backup_code.do", "/device.do", "/error.do");
+                    "/fido2-auth.jsp", "/email_otp.do", "/org_name.do", "/org_discovery.do", "/retry.do", "/totp_enroll.do", "/backup_code.do", "/device.do", "/error.do");
                 if (langSwitcherEnabledServlets.contains(request.getServletPath())) {
             %>
                 <jsp:include page="language-switcher.jsp"/>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -70,10 +70,6 @@
       <%
          }
       %>
-      <!--[if lt IE 9]>
-      <script src="js/html5shiv.min.js"></script>
-      <script src="js/respond.min.js"></script>
-      <![endif]-->
    </head>
    <body class="login-portal layout authentication-portal-layout">
       <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -1,0 +1,192 @@
+<%--
+   ~ Copyright (c) 2023, WSO2 Inc. (http://www.wso2.com).
+   ~
+   ~ WSO2 Inc. licenses this file to you under the Apache License,
+   ~ Version 2.0 (the "License"); you may not use this file except
+   ~ in compliance with the License.
+   ~ You may obtain a copy of the License at
+   ~
+   ~ http://www.apache.org/licenses/LICENSE-2.0
+   ~
+   ~ Unless required by applicable law or agreed to in writing,
+   ~ software distributed under the License is distributed on an
+   ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   ~ KIND, either express or implied.  See the License for the
+   ~ specific language governing permissions and limitations
+   ~ under the License.
+   --%>
+<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="java.io.File" %>
+<%@ page import="java.util.Map" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
+<%@ include file="includes/localize.jsp" %>
+<%@ include file="includes/init-url.jsp" %>
+<%-- Branding Preferences --%>
+<jsp:directive.include file="includes/branding-preferences.jsp"/>
+<%
+   String idp = request.getParameter("idp");
+   String authenticator = request.getParameter("authenticator");
+   String sessionDataKey = request.getParameter(Constants.SESSION_DATA_KEY);
+
+   String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
+   String authenticationFailed = "false";
+
+   // Log the actual error for localized error fallbacks
+   boolean isErrorFallbackLocale = !userLocale.toLanguageTag().equals("en_US");
+
+   if (Boolean.parseBoolean(request.getParameter(Constants.AUTH_FAILURE))) {
+       authenticationFailed = "true";
+       if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
+           errorMessage = request.getParameter(Constants.AUTH_FAILURE_MSG);
+           if (errorMessage.equalsIgnoreCase("authentication.fail.message")) {
+               errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
+           } else if (errorMessage.equalsIgnoreCase("Can't identify organization")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.input");
+           } else if (isErrorFallbackLocale) {
+               errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle,"error.retry");
+           }
+       }
+   }
+%>
+<%-- Data for the layout from the page --%>
+<%
+   layoutData.put("containerSize", "medium");
+%>
+<html lang="en-US">
+   <head>
+      <%-- header --%>
+      <%
+         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
+         if (headerFile.exists()) {
+      %>
+      <jsp:include page="extensions/header.jsp"/>
+      <%
+         } else {
+      %>
+      <jsp:include page="includes/header.jsp"/>
+      <%
+         }
+      %>
+      <!--[if lt IE 9]>
+      <script src="js/html5shiv.min.js"></script>
+      <script src="js/respond.min.js"></script>
+      <![endif]-->
+   </head>
+   <body class="login-portal layout authentication-portal-layout">
+      <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
+         <layout:component componentName="ProductHeader">
+            <%-- product-title --%>
+            <%
+               File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+               if (productTitleFile.exists()) {
+            %>
+            <jsp:include page="extensions/product-title.jsp"/>
+            <%
+               } else {
+            %>
+            <jsp:include page="includes/product-title.jsp"/>
+            <%
+               }
+            %>
+         </layout:component>
+         <layout:component componentName="MainSection">
+            <div class="ui segment">
+               <%-- page content --%>
+               <h2><%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> <%= StringUtils.isNotBlank(idp) ? idp : AuthenticationEndpointUtil.i18n(resourceBundle, "organization.login") %></h2>
+               <div class="ui divider hidden"></div>
+               <%
+                  if ("true".equals(authenticationFailed)) {
+               %>
+               <div class="ui negative message" id="failed-msg"><%=Encode.forHtmlContent(errorMessage)%></div>
+               <div class="ui divider hidden"></div>
+               <%
+               }
+               %>
+               <div id="alertDiv"></div>
+               <form class="ui large form" id="org_form" name="org_form" action="<%=commonauthURL%>" method="POST">
+                    <div class="field m-0 text-left required">
+                        <label><%=AuthenticationEndpointUtil.i18n(resourceBundle, "organization.email")%></label>
+                    </div>
+                    <input type="text" id='orgDiscovery' name="orgDiscovery" size='30'/>
+
+                    <div class="mt-1" id="discoveryInputError" style="display: none;">
+                        <i class="red exclamation circle fitted icon"></i>
+                        <span class="validation-error-message" id="discoveryInputErrorText">
+                            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "discovery.input.cannot.be.empty")%>
+                        </span>
+                    </div>
+                    <input id="prompt" name="prompt" type="hidden" value="orgName">
+                    <input id="idp" name="idp" type="hidden" value="<%=Encode.forHtmlAttribute(idp)%>"/>
+                    <input id="authenticator" name="authenticator" type="hidden" value="<%=Encode.forHtmlAttribute(authenticator)%>"/>
+                    <input id="sessionDataKey" name="sessionDataKey" type="hidden" value="<%=Encode.forHtmlAttribute(sessionDataKey)%>"/>
+                    <div class="ui divider hidden"></div>
+                    <input type="submit" id="submitButton" onclick="submitDiscovery(); return false;"
+                        value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "submit")%>"
+                        class="ui primary large fluid button" />
+                    <div class="ui horizontal divider">
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
+                    </div>
+                    <div class="social-login blurring social-dimmer">
+                        <input type="submit" id="orgNameButton" onclick="enterOrgName();" class="ui fluid button"
+                            value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "provide.organization.name")%>">
+                    </div>
+               </form>
+            </div>
+         </layout:component>
+         <layout:component componentName="ProductFooter">
+            <%-- product-footer --%>
+            <%
+               File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+               if (productFooterFile.exists()) {
+            %>
+                <jsp:include page="extensions/product-footer.jsp"/>
+            <%
+                } else {
+            %>
+                <jsp:include page="includes/product-footer.jsp"/>
+            <%
+            }
+            %>
+         </layout:component>
+      </layout:main>
+      <%-- footer --%>
+      <%
+         File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
+         if (footerFile.exists()) {
+         %>
+            <jsp:include page="extensions/footer.jsp"/>
+        <%
+        } else {
+        %>
+        <jsp:include page="includes/footer.jsp"/>
+        <%
+        }
+        %>
+
+      <script type="text/javascript">
+         function enterOrgName() {
+            document.getElementById("orgDiscovery").disabled = true;
+            document.getElementById("org_form").submit();
+         }
+
+         function submitDiscovery() {
+            // Show error message when discovery input is empty.
+            if (document.getElementById("orgDiscovery").value.length <= 0) {
+                showEmptyDiscoveryInputErrorMessage();
+                return;
+            }
+            document.getElementById("prompt").remove();
+            document.getElementById("org_form").submit();
+         }
+
+         // Function to show error message when discovery input is empty.
+         function showEmptyDiscoveryInputErrorMessage() {
+            var discoveryInputError = $("#discoveryInputError");
+            discoveryInputError.show();
+         }
+      </script>
+   </body>
+</html>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -143,7 +143,7 @@
                             <div class="ui horizontal divider"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%></div>
                             <div class="social-login blurring social-dimmer">
                                 <input type="submit" id="discoveryButton" onclick="promptDiscovery();" class="ui fluid button"
-                                    value="Provide email address">
+                                    value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "provide.email.address")%>">
                             </div>
                         <% } %>
                     </form>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -55,6 +55,7 @@
             }
         }
     }
+    boolean isOrgDiscoveryEnabled = Boolean.parseBoolean(request.getParameter("orgDiscoveryEnabled"));
 %>
 
 <%-- Data for the layout from the page --%>
@@ -120,17 +121,31 @@
 
 
                     <form class="ui large form" id="pin_form" name="pin_form" action="<%=commonauthURL%>" method="GET">
-                        <p><%=AuthenticationEndpointUtil.i18n(resourceBundle, "organization.name")%>:</p>
+                        <div class="field m-0 text-left required">
+                            <label><%=AuthenticationEndpointUtil.i18n(resourceBundle, "organization.name")%></label>
+                        </div>
                         <input type="text" id='ORG_NAME' name="org" size='30'/>
+                        <div class="mt-1" id="emptyOrganizationNameError" style="display: none;">
+                            <i class="red exclamation circle fitted icon"></i>
+                            <span class="validation-error-message" id="emptyOrganizationNameErrorText">
+                                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "organization.name.cannot.be.empty")%>
+                            </span>
+                        </div>
+                        <input id="prompt" name="prompt" type="hidden" value="orgDiscovery">
                         <input id="idp" name="idp" type="hidden" value="<%=Encode.forHtmlAttribute(idp)%>"/>
                         <input id="authenticator" name="authenticator" type="hidden" value="<%=Encode.forHtmlAttribute(authenticator)%>"/>
                         <input id="sessionDataKey" name="sessionDataKey" type="hidden" value="<%=Encode.forHtmlAttribute(sessionDataKey)%>"/>
                         <div class="ui divider hidden"></div>
-                        <div class="align-right buttons">
-                            <button type="submit" class="ui primary large fluid button">
-                                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "submit")%>
-                            </button>
-                        </div>
+                        <input type="submit" id="submitButton" onclick="submitOrgName(); return false;"
+                            value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "submit")%>"
+                            class="ui primary large fluid button" />
+                        <% if (isOrgDiscoveryEnabled) { %>
+                            <div class="ui horizontal divider"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%></div>
+                            <div class="social-login blurring social-dimmer">
+                                <input type="submit" id="discoveryButton" onclick="promptDiscovery();" class="ui fluid button"
+                                    value="Provide email address">
+                            </div>
+                        <% } %>
                     </form>
 
                 </div>
@@ -168,5 +183,27 @@
         <%
             }
         %>
+        <script type="text/javascript">
+            function promptDiscovery() {
+                document.getElementById("ORG_NAME").disabled = true;
+                document.getElementById("pin_form").submit();
+            }
+
+            function submitOrgName() {
+                // Show error message when organization name is empty.
+                if (document.getElementById("ORG_NAME").value.length <= 0) {
+                    showEmptyOrganizationNameErrorMessage();
+                    return;
+                }
+                    document.getElementById("prompt").remove();
+                    document.getElementById("pin_form").submit();
+                 }
+
+            // Function to show error message when organization name is empty.
+            function showEmptyOrganizationNameErrorMessage() {
+                var emptyOrganizationNameError = $("#emptyOrganizationNameError");
+                emptyOrganizationNameError.show();
+            }
+        </script>
     </body>
 </html>

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -462,6 +462,11 @@
     </servlet>
 
     <servlet>
+        <servlet-name>org_discovery.do</servlet-name>
+        <jsp-file>/org_discovery.jsp</jsp-file>
+    </servlet>
+
+    <servlet>
         <servlet-name>select_org.do</servlet-name>
         <jsp-file>/select_org.jsp</jsp-file>
     </servlet>
@@ -525,6 +530,11 @@
         <servlet-name>org_name.do</servlet-name>
         <url-pattern>/org_name.do</url-pattern>
     </servlet-mapping>
+
+    <servlet>
+        <servlet-name>org_discovery.do</servlet-name>
+        <jsp-file>/org_discovery.jsp</jsp-file>
+    </servlet>
 
     <servlet-mapping>
         <servlet-name>select_org.do</servlet-name>


### PR DESCRIPTION
Issue https://github.com/wso2/product-is/issues/16379
BE changes will be added with https://github.com/wso2-extensions/identity-auth-organization-login/pull/30

UI when organization discovery is enabled:
<img width="574" alt="Screen Shot 2023-10-15 at 5 06 44 PM" src="https://github.com/wso2/identity-apps/assets/24982871/9f10d41a-6edc-4128-b683-050ed6bf4184">

Error displayed when unable to identify organization name from the provided email domain:
<img width="632" alt="Screen Shot 2023-10-15 at 5 08 19 PM" src="https://github.com/wso2/identity-apps/assets/24982871/b3a6a3b1-2c77-4627-a79b-190d08c42bcc">

UI to enter organization name instead of going with discovery:
<img width="561" alt="Screen Shot 2023-10-12 at 3 46 17 PM" src="https://github.com/wso2/identity-apps/assets/24982871/104ee87c-6439-4146-bb93-512b0d2cded2">

UI when organization discovery is disabled:
<img width="583" alt="Screen Shot 2023-10-12 at 4 11 20 PM" src="https://github.com/wso2/identity-apps/assets/24982871/83ff3f41-816b-4e10-bd14-d4ee5994c4fc">

