### PR TITLE
Hide organization switch button when the organization is disabled

### DIFF
--- a/.changeset/twenty-ducks-hug.md
+++ b/.changeset/twenty-ducks-hug.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Hide organization switch button when the organization is disabled.

--- a/apps/console/src/features/organizations/components/organization-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-list.tsx
@@ -426,8 +426,9 @@ export const OrganizationList: FunctionComponent<OrganizationListPropsInterface>
 
                     return !isFeatureEnabled(
                         featureConfig?.organizations,
-                        OrganizationManagementConstants.FEATURE_DICTIONARY.get("ORGANIZATION_UPDATE")) ||
-                        !isAuthorized || !isActive;
+                        OrganizationManagementConstants.FEATURE_DICTIONARY.get("ORGANIZATION_UPDATE"))
+                        || !isAuthorized
+                        || !isActive;
                 },
                 icon: (): SemanticICONS => "exchange",
                 onClick: (event: SyntheticEvent, organization: OrganizationInterface) => {

--- a/apps/console/src/features/organizations/components/organization-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-list.tsx
@@ -416,6 +416,7 @@ export const OrganizationList: FunctionComponent<OrganizationListPropsInterface>
                 hidden: (organization: OrganizationInterface): boolean => {
 
                     let isAuthorized: boolean = false;
+                    const isActive: boolean = organization.status === "ACTIVE";
 
                     authorizedList?.organizations?.map((org: OrganizationInterface) => {
                         if (org.id === organization.id) {
@@ -425,7 +426,8 @@ export const OrganizationList: FunctionComponent<OrganizationListPropsInterface>
 
                     return !isFeatureEnabled(
                         featureConfig?.organizations,
-                        OrganizationManagementConstants.FEATURE_DICTIONARY.get("ORGANIZATION_UPDATE")) || !isAuthorized;
+                        OrganizationManagementConstants.FEATURE_DICTIONARY.get("ORGANIZATION_UPDATE")) ||
+                        !isAuthorized || !isActive;
                 },
                 icon: (): SemanticICONS => "exchange",
                 onClick: (event: SyntheticEvent, organization: OrganizationInterface) => {
@@ -487,7 +489,7 @@ export const OrganizationList: FunctionComponent<OrganizationListPropsInterface>
                 hidden: (organization: OrganizationInterface): boolean => {
 
                     let isAuthorized: boolean = false;
-                    
+
                     authorizedList?.organizations?.map((org: OrganizationInterface) => {
                         if (org.id === organization.id) {
                             isAuthorized = true;


### PR DESCRIPTION
### Purpose
> Hide organization switch button when the organization is disabled

### Related Issues
- https://github.com/wso2/product-is/issues/16797

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
