### PR TITLE
Enable back missing connection edit UI fields in JIT provisioning and Advanced config sections

### DIFF
--- a/.changeset/real-bulldogs-push.md
+++ b/.changeset/real-bulldogs-push.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Enable back missing connection edit UI fields in JIT provisioning and Advanced config sections

--- a/apps/console/src/extensions/configs/identity-provider.tsx
+++ b/apps/console/src/extensions/configs/identity-provider.tsx
@@ -223,7 +223,7 @@ export const identityProviderConfig: IdentityProviderConfig = {
 
             return undefined;
         },
-        showAdvancedSettings: false,
+        showAdvancedSettings: true,
         showJitProvisioning: true,
         showOutboundProvisioning: true
     },
@@ -270,12 +270,12 @@ export const identityProviderConfig: IdentityProviderConfig = {
         enableJitProvisioningField: {
             show: true
         },
-        menuItemName: "Advanced",
+        menuItemName: "Just-in-Time Provisioning",
         provisioningSchemeField: {
-            show: false
+            show: true
         },
         userstoreDomainField: {
-            show: false
+            show: true
         }
     },
     templates: {


### PR DESCRIPTION
### Purpose
Following differences can be seen in the connection edit pages.

- Just-in-Time provisioning tab is missing and is moved into the Advanced tab.
- In the new console, JIT provisioning can be enabled/ disabled, but rest of the configs are missing (i.e. changing userstore and provisioning scheme).
- Advanced tab now only contains JIT settings and doesn't have fields like Federation Hub, Home Realm Identifier and Alias.

This PR is to enable back the tabs in the previous connection edit pages.

### Related Issues
- https://github.com/wso2/product-is/issues/17126

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
