### PR TITLE
Set JWKS Endpoint URL on Connection configurations as optiona

### DIFF
--- a/apps/console/src/features/applications/api/application.ts
+++ b/apps/console/src/features/applications/api/application.ts
@@ -64,8 +64,8 @@ const httpClientAll: (config: HttpRequestConfig[]) => Promise<AxiosResponse[]> =
 /**
  * Gets the basic information about the application.
  *
+ * @deprecated Use `useGetApplication` SWR hook instead.
  * @param id - ID of the application.
- *
  * @returns A promise containing the response.
  */
 export const getApplicationDetails = (id: string): Promise<any> => {
@@ -208,7 +208,7 @@ export const useApplicationList = <Data = ApplicationListInterface, Error = Requ
     shouldFetch: boolean = true
 ): RequestResultInterface<Data, Error> => {
 
-    const requestConfig: AxiosRequestConfig = shouldFetch 
+    const requestConfig: AxiosRequestConfig = shouldFetch
         ? {
             headers: {
                 "Accept": "application/json",

--- a/apps/console/src/features/applications/api/use-get-application.ts
+++ b/apps/console/src/features/applications/api/use-get-application.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AxiosRequestConfig } from "axios";
+import { HttpMethods } from "modules/core/src/models";
+import useRequest, { RequestErrorInterface, RequestResultInterface } from "../../core/hooks/use-request";
+import { store } from "../../core/store";
+import { ApplicationInterface } from "../models/application";
+
+/**
+ * Hook to get the application details from the API.
+ *
+ * @param id - ID of the application.
+ * @param shouldFetch - Condition to check if data should be fetched.
+ * @returns Response as a promise.
+ */
+export const useGetApplication = <Data = ApplicationInterface, Error = RequestErrorInterface>(
+    id: string,
+    shouldFetch: boolean = true
+): RequestResultInterface<Data, Error> => {
+
+    const requestConfig: AxiosRequestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        url: `${ store.getState().config.endpoints.applications }/${ id }`
+    };
+
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(shouldFetch ? requestConfig : null);
+
+    return {
+        data,
+        error: error,
+        isLoading: !error && !data,
+        isValidating,
+        mutate
+    };
+};

--- a/apps/console/src/features/applications/components/edit-application.tsx
+++ b/apps/console/src/features/applications/components/edit-application.tsx
@@ -186,7 +186,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
-    const isFragmentApp: boolean = application.advancedConfigurations?.fragment || false;
+    const isFragmentApp: boolean = application?.advancedConfigurations?.fragment || false;
 
     /**
      * Called when an application updates.
@@ -927,7 +927,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                      render: InfoTabPane
                  });
             }
-            
+
             extensionPanes.forEach(
                 (extensionPane: ResourceTabPaneInterface) => {
                     panes.splice(extensionPane.index, 0, extensionPane);

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -67,6 +67,7 @@ import { setAuthProtocolMeta } from "../../store";
 import { ApplicationManagementUtils } from "../../utils/application-management-utils";
 import { InboundFormFactory } from "../forms";
 import { ApplicationCreateWizard } from "../wizard";
+import { useGetApplication } from "../../api/use-get-application";
 
 /**
  * Prop-types for the applications settings component.
@@ -182,6 +183,10 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
     const { getLink } = useDocumentation();
 
     const dispatch: Dispatch = useDispatch();
+
+    const {
+        mutate: mutateApplicationGetRequest,
+    } = useGetApplication(application.id);
 
     const authProtocolMeta: AuthProtocolMetaInterface = useSelector(
         (state: AppState) => state.application.meta.protocolMeta);
@@ -344,6 +349,8 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         updateApplicationDetails({ id: appId, ...values.general })
             .then(async () => {
                 await handleInboundConfigFormSubmit(values.inbound, selectedProtocol);
+
+                mutateApplicationGetRequest();
             })
             .catch((error: AxiosError) => {
                 if (error.response && error.response.data && error.response.data.description) {

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
@@ -211,15 +211,10 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
                         mode={ flowModeToSwitch }
                         open={ showAuthenticationFlowModeSwitchDisclaimerModal }
                         onPrimaryActionClick={ () => {
-                            const previousFlowMode: AuthenticationFlowBuilderModesInterface = activeFlowMode;
-        
                             setActiveFlowMode(flowModeToSwitch);
                             setFlowModeToSwitch(null);
                             setShowAuthenticationFlowModeSwitchDisclaimerModal(false);
-        
-                            if (previousFlowMode.id === FlowModes[1].id) {
-                                refetchApplication();
-                            }
+                            refetchApplication();
                         } }
                         onClose={ () => {
                             setFlowModeToSwitch(null);

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-visual-editor.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-visual-editor.tsx
@@ -120,6 +120,7 @@ const AuthenticationFlowVisualEditor: FunctionComponent<AuthenticationFlowVisual
         defaultAuthenticationSequence,
         isAdaptiveAuthAvailable,
         isValidAuthenticationFlow,
+        refetchApplication,
         removeSignInOption,
         removeSignInStep,
         revertAuthenticationSequenceToDefault,
@@ -342,7 +343,8 @@ const AuthenticationFlowVisualEditor: FunctionComponent<AuthenticationFlowVisual
                         )
                     })
                 );
-            });
+            })
+            .finally(() => refetchApplication());
     };
 
     return (

--- a/apps/console/src/features/authentication-flow-builder/providers/authentication-flow-provider.tsx
+++ b/apps/console/src/features/authentication-flow-builder/providers/authentication-flow-provider.tsx
@@ -145,6 +145,13 @@ const AuthenticationFlowProvider = (props: PropsWithChildren<AuthenticationFlowP
     }, []);
 
     /**
+     * When `application` state changes, update the `authenticationSequence`.
+     */
+    useEffect(() => {
+        setAuthenticationSequence(application?.authenticationSequence);
+    }, [ application ]);
+
+    /**
      * Separates out the different authenticators to their relevant categories.
      */
     useEffect(() => {
@@ -169,10 +176,10 @@ const AuthenticationFlowProvider = (props: PropsWithChildren<AuthenticationFlowP
                 );
             }
 
-            authenticator.image = authenticator.idp === AuthenticatorCategories.LOCAL || 
-            authenticator.defaultAuthenticator?.authenticatorId === 
+            authenticator.image = authenticator.idp === AuthenticatorCategories.LOCAL ||
+            authenticator.defaultAuthenticator?.authenticatorId ===
             AuthenticatorManagementConstants.ORGANIZATION_ENTERPRISE_AUTHENTICATOR_ID
-                ? authenticator.image 
+                ? authenticator.image
                 : ConnectionsManagementUtils
                     .resolveConnectionResourcePath(
                         connectionResourcesUrl, authenticator.image);

--- a/apps/console/src/features/authentication/utils/authenticate-utils.ts
+++ b/apps/console/src/features/authentication/utils/authenticate-utils.ts
@@ -49,8 +49,7 @@ export class AuthenticateUtils {
             clientID: window["AppUtils"]?.getConfig()?.clientID,
             clockTolerance: window[ "AppUtils" ]?.getConfig().idpConfigs?.clockTolerance,
             disableTrySignInSilently: new URL(location.href).searchParams.get("disable_silent_sign_in") === "true",
-            enableOIDCSessionManagement: window["AppUtils"]?.getConfig().idpConfigs?.enableOIDCSessionManagement
-                ?? true,
+            enableOIDCSessionManagement: false,
             enablePKCE: window["AppUtils"]?.getConfig()?.idpConfigs?.enablePKCE ?? true,
             endpoints: {
                 authorizationEndpoint: window["AppUtils"]?.getConfig()?.idpConfigs?.authorizeEndpointURL,

--- a/apps/console/src/features/connections/components/edit/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/idp-certificates/idp-certificates.tsx
@@ -198,14 +198,16 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
      */
     const onJWKSFormSubmit = (values: Record<string, any>) => {
 
-        const operation: string = editingIDP?.certificate?.jwksUri ? "REPLACE" : "ADD";
+        const operation: string = editingIDP?.certificate?.jwksUri
+            ? jwksValue ? "REPLACE" : "REMOVE"
+            : "ADD";
 
-        const PATCH_OBJECT: CertificatePatchRequestInterface[] = [ 
+        const PATCH_OBJECT: CertificatePatchRequestInterface[] = [
             {
                 "operation": operation,
                 "path": "/certificate/jwksUri",
                 "value": values.jwks_endpoint
-            } 
+            }
         ];
 
         setIsSubmitting(true);
@@ -258,9 +260,8 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
             uncontrolledForm={ true }
             initialValues={ { jwks_endpoint: editingIDP?.certificate?.jwksUri } }
             onSubmit={ onJWKSFormSubmit }
-        > 
+        >
             <Field.Input
-                required
                 hint={ (
                     <React.Fragment>
                         A JSON Web Key (JWK) Set is a JSON object that represents a set of JWKs. The JSON
@@ -273,7 +274,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                 inputType="url"
                 width={ 16 }
                 validation={ (value: string) => {
-                    if (!value || !FormValidation.url(value)) {
+                    if (value && !FormValidation.url(value)) {
                         setIsJwksValueValid(false);
 
                         return t("console:develop.features.applications.forms.inboundSAML" +
@@ -307,7 +308,6 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     label={ t("common:update") }
                     disabled={
                         (
-                            !jwksValue ||
                             !isJwksValueValid ||
                             jwksValue === editingIDP?.certificate?.jwksUri
                         ) ||
@@ -369,7 +369,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
 
     /**
      * Checks if the IDP is a trusted token issuer and has no certificates to display an alert.
-     * 
+     *
      * @returns `true` if the IDP is a trusted token issuer and has no certificates, `false` otherwise.
      */
     const shouldShowNoCertificatesAlert = (): boolean => isTrustedTokenIssuer && !editingIDP?.certificate;
@@ -385,7 +385,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     shouldShowNoCertificatesAlert() && (
                         <Grid xs={ 12 }>
                             <Alert severity="error">
-                                { t("console:develop.features.authenticationProvider.forms.certificateSection." + 
+                                { t("console:develop.features.authenticationProvider.forms.certificateSection." +
                                     "noCertificateAlert", { productName: config.ui.productName } ) }
                             </Alert>
                         </Grid>
@@ -402,12 +402,12 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                                 onChange={ onSelectionChange }
                                 options={ [
                                     {
-                                        label: t("console:develop.features.authenticationProvider.forms." + 
+                                        label: t("console:develop.features.authenticationProvider.forms." +
                                             "certificateSection.certificateEditSwitch.jwks"),
                                         value: ("jwks" as CertificateConfigurationMode)
                                     },
                                     {
-                                        label: t("console:develop.features.authenticationProvider.forms." + 
+                                        label: t("console:develop.features.authenticationProvider.forms." +
                                             "certificateSection.certificateEditSwitch.pem"),
                                         value: ("certificates" as CertificateConfigurationMode)
                                     }

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
@@ -198,14 +198,16 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
      */
     const onJWKSFormSubmit = (values: Record<string, any>) => {
 
-        const operation: string = editingIDP?.certificate?.jwksUri ? "REPLACE" : "ADD";
+        const operation: string = editingIDP?.certificate?.jwksUri
+            ? jwksValue ? "REPLACE" : "REMOVE"
+            : "ADD";
 
-        const PATCH_OBJECT: CertificatePatchRequestInterface[] = [ 
+        const PATCH_OBJECT: CertificatePatchRequestInterface[] = [
             {
                 "operation": operation,
                 "path": "/certificate/jwksUri",
                 "value": values.jwks_endpoint
-            } 
+            }
         ];
 
         setIsSubmitting(true);
@@ -258,9 +260,8 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
             uncontrolledForm={ true }
             initialValues={ { jwks_endpoint: editingIDP?.certificate?.jwksUri } }
             onSubmit={ onJWKSFormSubmit }
-        > 
+        >
             <Field.Input
-                required
                 hint={ (
                     <React.Fragment>
                         A JSON Web Key (JWK) Set is a JSON object that represents a set of JWKs. The JSON
@@ -273,7 +274,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                 inputType="url"
                 width={ 16 }
                 validation={ (value: string) => {
-                    if (!value || !FormValidation.url(value)) {
+                    if (value && !FormValidation.url(value)) {
                         setIsJwksValueValid(false);
 
                         return t("console:develop.features.applications.forms.inboundSAML" +
@@ -307,7 +308,6 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     label={ t("common:update") }
                     disabled={
                         (
-                            !jwksValue ||
                             !isJwksValueValid ||
                             jwksValue === editingIDP?.certificate?.jwksUri
                         ) ||
@@ -369,7 +369,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
 
     /**
      * Checks if the IDP is a trusted token issuer and has no certificates to display an alert.
-     * 
+     *
      * @returns `true` if the IDP is a trusted token issuer and has no certificates, `false` otherwise.
      */
     const shouldShowNoCertificatesAlert = (): boolean => isTrustedTokenIssuer && !editingIDP?.certificate;
@@ -385,7 +385,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     shouldShowNoCertificatesAlert() && (
                         <Grid xs={ 12 }>
                             <Alert severity="error">
-                                { t("console:develop.features.authenticationProvider.forms.certificateSection." + 
+                                { t("console:develop.features.authenticationProvider.forms.certificateSection." +
                                     "noCertificateAlert", { productName: config.ui.productName } ) }
                             </Alert>
                         </Grid>
@@ -402,12 +402,12 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                                 onChange={ onSelectionChange }
                                 options={ [
                                     {
-                                        label: t("console:develop.features.authenticationProvider.forms." + 
+                                        label: t("console:develop.features.authenticationProvider.forms." +
                                             "certificateSection.certificateEditSwitch.jwks"),
                                         value: ("jwks" as CertificateConfigurationMode)
                                     },
                                     {
-                                        label: t("console:develop.features.authenticationProvider.forms." + 
+                                        label: t("console:develop.features.authenticationProvider.forms." +
                                             "certificateSection.certificateEditSwitch.pem"),
                                         value: ("certificates" as CertificateConfigurationMode)
                                     }

--- a/modules/form/src/utils/validate.ts
+++ b/modules/form/src/utils/validate.ts
@@ -108,10 +108,6 @@ export const getValidation = (
         return FieldConstants.FIELD_REQUIRED_ERROR;
     }
 
-    if (!value) {
-        return;
-    }
-
     if (validation instanceof Promise) {
         validation(value, allValues).then((message: string) => {
             return message;
@@ -120,6 +116,10 @@ export const getValidation = (
 
     if (typeof(validation) === "function") {
         return validation(value, allValues);
+    }
+
+    if (!value) {
+        return;
     }
 
     return getDefaultValidation(field, fieldType, value);


### PR DESCRIPTION
### Purpose
When updating a connection the JWKS Endpoint URL is set as mandatory. With this PR the following issue will be fixed:
- Set the `JWKS Endpoint URL` field as optional.
- Enabling the `Update` button when removing the existent value on the `JWKS Endpoint URL` field.
- Send a `REMOVE` operation on the PATCH request to update the connection when removing the existent value on the field:
```
curl -X 'PATCH' 'https://localhost:9443/t/:tenant-name/api/server/v1/identity-providers/:id' \
  -H 'Content-Type: application/json' \
  --data-raw '[
    {
      "operation": "REMOVE",
      "path": "/certificate/jwksUri",
      "value":""
    }
  ]'
```
- Handle JWKS state changes properly based on result of validation function (currently, functions defined on the `validation` property of the field are not executed when the field has no value).

### Screenshots

![274399408-243c3cdc-3f1b-46d5-9069-12b4af783475](https://github.com/wso2/identity-apps/assets/25959096/ec390cf3-78d6-4ea8-8ea0-f1154c5db437)


### Related Issues
- https://github.com/wso2/product-is/issues/17142

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
