### PR TITLE
[maintainance] Set JWKS Endpoint URL on Connection configurations as optional

### DIFF
--- a/.changeset/sweet-ladybugs-appear.md
+++ b/.changeset/sweet-ladybugs-appear.md
@@ -1,0 +1,11 @@
+---
+"@wso2is/console": patch
+"@wso2is/form": patch
+---
+
+@asgardeo/console:
+- Set JWKS Endpoint URL as optional field.
+- Add support to remove the JWKS Endpoint URL value.
+
+@wso2is/form:
+- Allow to run function validations when input field has no value.

--- a/apps/console/src/features/authentication/utils/authenticate-utils.ts
+++ b/apps/console/src/features/authentication/utils/authenticate-utils.ts
@@ -53,8 +53,7 @@ export class AuthenticateUtils {
             clientID: window["AppUtils"]?.getConfig()?.clientID,
             clockTolerance: window[ "AppUtils" ]?.getConfig().idpConfigs?.clockTolerance,
             disableTrySignInSilently: new URL(location.href).searchParams.get("disable_silent_sign_in") === "true",
-            enableOIDCSessionManagement: window["AppUtils"]?.getConfig().idpConfigs?.enableOIDCSessionManagement
-                ?? true,
+            enableOIDCSessionManagement: false,
             enablePKCE: window["AppUtils"]?.getConfig()?.idpConfigs?.enablePKCE ?? true,
             endpoints: {
                 authorizationEndpoint: window["AppUtils"]?.getConfig()?.idpConfigs?.authorizeEndpointURL,

--- a/apps/console/src/features/connections/components/edit/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/idp-certificates/idp-certificates.tsx
@@ -199,7 +199,9 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
      */
     const onJWKSFormSubmit = (values: Record<string, any>) => {
 
-        const operation: string = editingIDP?.certificate?.jwksUri ? "REPLACE" : "ADD";
+        const operation: string = editingIDP?.certificate?.jwksUri
+            ? jwksValue ? "REPLACE" : "REMOVE"
+            : "ADD";
 
         const PATCH_OBJECT: CertificatePatchRequestInterface[] = [
             {
@@ -261,7 +263,6 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
             onSubmit={ onJWKSFormSubmit }
         >
             <Field.Input
-                required
                 hint={ (
                     <React.Fragment>
                         A JSON Web Key (JWK) Set is a JSON object that represents a set of JWKs. The JSON
@@ -274,7 +275,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                 inputType="url"
                 width={ 16 }
                 validation={ (value: string) => {
-                    if (!value || !FormValidation.url(value)) {
+                    if (value && !FormValidation.url(value)) {
                         setIsJwksValueValid(false);
 
                         return t("console:develop.features.applications.forms.inboundSAML" +
@@ -309,7 +310,6 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     label={ t("common:update") }
                     disabled={
                         (
-                            !jwksValue ||
                             !isJwksValueValid ||
                             jwksValue === editingIDP?.certificate?.jwksUri
                         ) ||

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
@@ -198,14 +198,16 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
      */
     const onJWKSFormSubmit = (values: Record<string, any>) => {
 
-        const operation: string = editingIDP?.certificate?.jwksUri ? "REPLACE" : "ADD";
+        const operation: string = editingIDP?.certificate?.jwksUri
+            ? jwksValue ? "REPLACE" : "REMOVE"
+            : "ADD";
 
-        const PATCH_OBJECT: CertificatePatchRequestInterface[] = [ 
+        const PATCH_OBJECT: CertificatePatchRequestInterface[] = [
             {
                 "operation": operation,
                 "path": "/certificate/jwksUri",
                 "value": values.jwks_endpoint
-            } 
+            }
         ];
 
         setIsSubmitting(true);
@@ -258,9 +260,8 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
             uncontrolledForm={ true }
             initialValues={ { jwks_endpoint: editingIDP?.certificate?.jwksUri } }
             onSubmit={ onJWKSFormSubmit }
-        > 
+        >
             <Field.Input
-                required
                 hint={ (
                     <React.Fragment>
                         A JSON Web Key (JWK) Set is a JSON object that represents a set of JWKs. The JSON
@@ -273,7 +274,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                 inputType="url"
                 width={ 16 }
                 validation={ (value: string) => {
-                    if (!value || !FormValidation.url(value)) {
+                    if (value && !FormValidation.url(value)) {
                         setIsJwksValueValid(false);
 
                         return t("console:develop.features.applications.forms.inboundSAML" +
@@ -307,7 +308,6 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     label={ t("common:update") }
                     disabled={
                         (
-                            !jwksValue ||
                             !isJwksValueValid ||
                             jwksValue === editingIDP?.certificate?.jwksUri
                         ) ||
@@ -369,7 +369,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
 
     /**
      * Checks if the IDP is a trusted token issuer and has no certificates to display an alert.
-     * 
+     *
      * @returns `true` if the IDP is a trusted token issuer and has no certificates, `false` otherwise.
      */
     const shouldShowNoCertificatesAlert = (): boolean => isTrustedTokenIssuer && !editingIDP?.certificate;
@@ -385,7 +385,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     shouldShowNoCertificatesAlert() && (
                         <Grid xs={ 12 }>
                             <Alert severity="error">
-                                { t("console:develop.features.authenticationProvider.forms.certificateSection." + 
+                                { t("console:develop.features.authenticationProvider.forms.certificateSection." +
                                     "noCertificateAlert", { productName: config.ui.productName } ) }
                             </Alert>
                         </Grid>
@@ -402,12 +402,12 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                                 onChange={ onSelectionChange }
                                 options={ [
                                     {
-                                        label: t("console:develop.features.authenticationProvider.forms." + 
+                                        label: t("console:develop.features.authenticationProvider.forms." +
                                             "certificateSection.certificateEditSwitch.jwks"),
                                         value: ("jwks" as CertificateConfigurationMode)
                                     },
                                     {
-                                        label: t("console:develop.features.authenticationProvider.forms." + 
+                                        label: t("console:develop.features.authenticationProvider.forms." +
                                             "certificateSection.certificateEditSwitch.pem"),
                                         value: ("certificates" as CertificateConfigurationMode)
                                     }

--- a/modules/form/src/utils/validate.ts
+++ b/modules/form/src/utils/validate.ts
@@ -114,10 +114,6 @@ export const getValidation = (
         return FieldConstants.FIELD_REQUIRED_ERROR;
     }
 
-    if (!value) {
-        return;
-    }
-
     if (validation instanceof Promise) {
         validation(value, allValues).then((message: string) => {
             return message;
@@ -126,6 +122,10 @@ export const getValidation = (
 
     if (typeof(validation) === "function") {
         return validation(value, allValues);
+    }
+
+    if (!value) {
+        return;
     }
 
     return getDefaultValidation(field, fieldType, value);


### PR DESCRIPTION
### Purpose
When updating a connection the JWKS Endpoint URL is set as mandatory. With this PR the following issue will be fixed:
- Set the `JWKS Endpoint URL` field as optional.
- Enabling the `Update` button when removing the existent value on the `JWKS Endpoint URL` field.
- Send a `REMOVE` operation on the PATCH request to update the connection when removing the existent value on the field:
```
curl -X 'PATCH' 'https://localhost:9443/t/:tenant-name/api/server/v1/identity-providers/:id' \
  -H 'Content-Type: application/json' \
  --data-raw '[
    {
      "operation": "REMOVE",
      "path": "/certificate/jwksUri",
      "value":""
    }
  ]'
```
- Handle JWKS state changes properly based on result of validation function (currently, functions defined on the `validation` property of the field are not executed when the field has no value).

### Screenshots

![274399408-243c3cdc-3f1b-46d5-9069-12b4af783475](https://github.com/wso2/identity-apps/assets/25959096/ec390cf3-78d6-4ea8-8ea0-f1154c5db437)


### Related Issues
- Fixes https://github.com/wso2/product-is/issues/17142

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
