### PR TITLE
[maintaiance] Change Switcher components by RadioGroups to avoid confusions about expected behaviors

### DIFF
--- a/.changeset/dirty-shoes-pretend.md
+++ b/.changeset/dirty-shoes-pretend.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change Switcher components by RadioGroups to avoid confusions about expected behaviors.

--- a/apps/console/src/features/connections/models/connection.ts
+++ b/apps/console/src/features/connections/models/connection.ts
@@ -667,7 +667,7 @@ export interface CertificatePatchRequestInterface {
 }
 
 /**
- * Interface for from values of the connection general details step
+ * Interface for form values of the connection general details step
  */
 export interface GeneralDetailsFormValuesInterface {
     /**
@@ -721,4 +721,21 @@ export interface OutboundProvisioningConnectorMetaDataInterface {
      * Icon for the connector.
      */
     icon: any;
+}
+
+/**
+ * Interface for form values of the connection settings
+ */
+export interface ConnectionFormValuesInterface {
+    name?: string;
+    NameIDType?: string;
+    RequestMethod?: string;
+    clientId?: string;
+    clientSecret?: string;
+    authorizationEndpointUrl?: string;
+    tokenEndpointUrl?: string;
+    jwks_endpoint?: string;
+    IdPEntityId?: string;
+    SPEntityId?: string;
+    SSOUrl?: string;
 }

--- a/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/idp-certificates/idp-certificates.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,7 +17,11 @@
  */
 
 import Alert from "@oxygen-ui/react/Alert";
+import FormControl from "@oxygen-ui/react/FormControl";
+import FormControlLabel from "@oxygen-ui/react/FormControlLabel";
 import Grid from "@oxygen-ui/react/Grid";
+import Radio from "@oxygen-ui/react/Radio";
+import RadioGroup from "@oxygen-ui/react/RadioGroup";
 import { AccessControlConstants, Show } from "@wso2is/access-control";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
@@ -29,12 +33,10 @@ import {
     Code,
     EmphasizedSegment,
     Hint,
-    PrimaryButton,
-    Switcher,
-    SwitcherOptionProps
+    PrimaryButton
 } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
+import React, { ChangeEvent, FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
@@ -82,15 +84,15 @@ const FORM_ID: string = "idp-certificate-jwks-input-form";
  *
  *  +======================================================================+
  *  |                                                                      |
- *  |   (?) Below is the {@link Switcher} component. When user clicks      |
- *  |       on one switch it will change the subcomponent input type.      |
+ *  |   (?) Below is the {@link RadioGroup} component. When user clicks    |
+ *  |       on one option it will change the subcomponent input type.      |
  *  |                                                                      |
- *  |   +==============+====================+                              |
- *  |   |   JWKS URL   | Upload Certificate |                              |
- *  |   +==============+====================+                              |
+ *  |   +===================================+                              |
+ *  |   | () JWKS URL () Upload Certificate |                              |
+ *  |   +===================================+                              |
  *  |                                                                      |
  *  |                                                                      |
- *  |   (?) Based on the switcher selection the sub component appearance   |
+ *  |   (?) Based on the radio selection the sub component appearance      |
  *  |       will change. For example: if you select JWKS URL it will       |
  *  |       only render a input field to get the URL.                      |
  *  |                                                                      |
@@ -180,8 +182,8 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
         }
     };
 
-    const onSelectionChange = ({ value }: SwitcherOptionProps): void => {
-        setSelectedConfigurationMode(value as CertificateConfigurationMode);
+    const onSelectionChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setSelectedConfigurationMode((event.target as HTMLInputElement).value as CertificateConfigurationMode);
     };
 
     const openAddCertificatesWizard = (): void => {
@@ -198,14 +200,16 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
      */
     const onJWKSFormSubmit = (values: Record<string, any>) => {
 
-        const operation: string = editingIDP?.certificate?.jwksUri ? "REPLACE" : "ADD";
+        const operation: string = editingIDP?.certificate?.jwksUri
+            ? jwksValue ? "REPLACE" : "REMOVE"
+            : "ADD";
 
-        const PATCH_OBJECT: CertificatePatchRequestInterface[] = [ 
+        const PATCH_OBJECT: CertificatePatchRequestInterface[] = [
             {
                 "operation": operation,
                 "path": "/certificate/jwksUri",
                 "value": values.jwks_endpoint
-            } 
+            }
         ];
 
         setIsSubmitting(true);
@@ -258,9 +262,8 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
             uncontrolledForm={ true }
             initialValues={ { jwks_endpoint: editingIDP?.certificate?.jwksUri } }
             onSubmit={ onJWKSFormSubmit }
-        > 
+        >
             <Field.Input
-                required
                 hint={ (
                     <React.Fragment>
                         A JSON Web Key (JWK) Set is a JSON object that represents a set of JWKs. The JSON
@@ -273,7 +276,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                 inputType="url"
                 width={ 16 }
                 validation={ (value: string) => {
-                    if (!value || !FormValidation.url(value)) {
+                    if (value && !FormValidation.url(value)) {
                         setIsJwksValueValid(false);
 
                         return t("console:develop.features.applications.forms.inboundSAML" +
@@ -307,7 +310,6 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     label={ t("common:update") }
                     disabled={
                         (
-                            !jwksValue ||
                             !isJwksValueValid ||
                             jwksValue === editingIDP?.certificate?.jwksUri
                         ) ||
@@ -369,7 +371,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
 
     /**
      * Checks if the IDP is a trusted token issuer and has no certificates to display an alert.
-     * 
+     *
      * @returns `true` if the IDP is a trusted token issuer and has no certificates, `false` otherwise.
      */
     const shouldShowNoCertificatesAlert = (): boolean => isTrustedTokenIssuer && !editingIDP?.certificate;
@@ -385,7 +387,7 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                     shouldShowNoCertificatesAlert() && (
                         <Grid xs={ 12 }>
                             <Alert severity="error">
-                                { t("console:develop.features.authenticationProvider.forms.certificateSection." + 
+                                { t("console:develop.features.authenticationProvider.forms.certificateSection." +
                                     "noCertificateAlert", { productName: config.ui.productName } ) }
                             </Alert>
                         </Grid>
@@ -394,25 +396,32 @@ export const IdpCertificates: FunctionComponent<IdpCertificatesV2Props> = (props
                 <Grid direction="column" container spacing={ 3 } xs={ 12 }>
                     { isJWKSEnabled && isPEMEnabled && (
                         <Grid md={ 12 } lg={ 6 }>
-                            <Switcher
-                                widths={ "two" }
-                                compact
-                                data-testid={ `${ testId }-switcher` }
-                                selectedValue={ selectedConfigurationMode }
-                                onChange={ onSelectionChange }
-                                options={ [
-                                    {
-                                        label: t("console:develop.features.authenticationProvider.forms." + 
-                                            "certificateSection.certificateEditSwitch.jwks"),
-                                        value: ("jwks" as CertificateConfigurationMode)
-                                    },
-                                    {
-                                        label: t("console:develop.features.authenticationProvider.forms." + 
-                                            "certificateSection.certificateEditSwitch.pem"),
-                                        value: ("certificates" as CertificateConfigurationMode)
-                                    }
-                                ] }
-                            />
+                            <FormControl>
+                                <RadioGroup
+                                    row
+                                    name="certificate-type"
+                                    onChange={ onSelectionChange }
+                                    data-testid={ `${ testId }-radio-group` }
+                                    value={ selectedConfigurationMode }
+                                >
+                                    <FormControlLabel
+                                        control={ <Radio checked={ selectedConfigurationMode === "jwks" } /> }
+                                        label={
+                                            t("console:develop.features.authenticationProvider.forms." +
+                                            "certificateSection.certificateEditSwitch.jwks")
+                                        }
+                                        value="jwks"
+                                    />
+                                    <FormControlLabel
+                                        control={ <Radio checked={ selectedConfigurationMode === "certificates" } /> }
+                                        label={
+                                            t("console:develop.features.authenticationProvider.forms." +
+                                            "certificateSection.certificateEditSwitch.pem")
+                                        }
+                                        value="certificates"
+                                    />
+                                </RadioGroup>
+                            </FormControl>
                         </Grid>
                     ) }
                     <Grid md={ 12 } lg={ 6 }>

--- a/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/enterprise-idp-create-wizard.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import { IdentityAppsError } from "@wso2is/core/errors";
 import { AlertLevels, IdentifiableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
@@ -33,8 +34,6 @@ import {
     PrimaryButton,
     SelectionCard,
     Steps,
-    Switcher,
-    SwitcherOptionProps,
     XMLFileStrategy,
     useDocumentation,
     useWizardAlert
@@ -46,6 +45,7 @@ import isEmpty from "lodash-es/isEmpty";
 import kebabCase from "lodash-es/kebabCase";
 
 import React, {
+    ChangeEvent,
     FC,
     MutableRefObject,
     PropsWithChildren,
@@ -438,7 +438,7 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
 
     const wizardCommonFirstPage = () => (
         <WizardPage
-            validate={ (values: any) => {
+            validate={ (values: IdentityProviderFormValuesInterface) => {
                 const errors: FormErrors = {};
 
                 errors.name = composeValidators(required, length(IDP_NAME_LENGTH))(values.name);
@@ -464,10 +464,10 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                 minLength={ IDP_NAME_LENGTH.min }
                 required={ true }
                 width={ 15 }
-                format = { (values: any) => {
-                    return values.toString().trimStart();
+                format = { (values: string) => {
+                    return values.trimStart();
                 } }
-                validation={ (values: any) => {
+                validation={ (values: string) => {
                     let errors: "";
 
                     errors = composeValidators(required, length(IDP_NAME_LENGTH))(values);
@@ -577,20 +577,27 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                 <Grid.Row columns={ 1 }>
                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
                         <p><b>Mode of configuration</b></p>
-                        <Switcher
-                            compact
-                            data-testid={ `${ testId }-form-wizard-saml-config-switcher` }
-                            className={ "mt-1" }
-                            selectedValue={ selectedSamlConfigMode }
-                            onChange={ ({ value }: SwitcherOptionProps) => setSelectedSamlConfigMode(value as any) }
-                            options={ [ {
-                                label: "Manual Configuration",
-                                value: "manual"
-                            }, {
-                                label: "File Based Configuration",
-                                value: "file"
-                            } ] }
-                        />
+                        <FormControl>
+                            <RadioGroup
+                                row
+                                name="configuration-mode"
+                                onChange={ (event: ChangeEvent<HTMLInputElement>) =>
+                                    setSelectedSamlConfigMode((event.target as HTMLInputElement).value as any) }
+                                data-testid={ `${ testId }-form-wizard-saml-config-radio-group` }
+                                value={ selectedSamlConfigMode }
+                            >
+                                <FormControlLabel
+                                    control={ <Radio /> }
+                                    label="Manual Configuration"
+                                    value="manual"
+                                />
+                                <FormControlLabel
+                                    control={ <Radio /> }
+                                    label="File Based Configuration"
+                                    value="file"
+                                />
+                            </RadioGroup>
+                        </FormControl>
                     </Grid.Column>
                 </Grid.Row>
             </Grid>
@@ -755,21 +762,26 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
                         <p><b>Mode of certificate configuration</b></p>
                         { (selectedProtocol === "oidc") && (
-                            <Switcher
-                                compact
-                                disabledMessage="This feature will be enabled soon."
-                                className={ "mt-1" }
-                                defaultOptionValue={ "jwks" }
-                                selectedValue={ selectedCertInputType }
-                                onChange={ ({ value }: SwitcherOptionProps) => setSelectedCertInputType(value as any) }
-                                options={ [ {
-                                    label: "JWKS endpoint",
-                                    value: "jwks"
-                                }, {
-                                    label: "Use PEM certificate",
-                                    value: "pem"
-                                } ] }
-                            />
+                            <FormControl>
+                                <RadioGroup
+                                    row
+                                    name="certificate-type"
+                                    onChange={ (event: ChangeEvent<HTMLInputElement>) =>
+                                        setSelectedCertInputType((event.target as HTMLInputElement).value as any) }
+                                    value={ selectedCertInputType }
+                                >
+                                    <FormControlLabel
+                                        control={ <Radio /> }
+                                        label="JWKS endpoint"
+                                        value="jwks"
+                                    />
+                                    <FormControlLabel
+                                        control={ <Radio /> }
+                                        label="Use PEM certificate"
+                                        value="pem"
+                                    />
+                                </RadioGroup>
+                            </FormControl>
                         ) }
                     </Grid.Column>
                 </Grid.Row>
@@ -811,7 +823,7 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
                             /**
                              * If there's pasted content or a file, but it hasn't been serialized
                              * and if it's not valid then we must disable the next button. This condition
-                             * implies =\> that when the input is optional but the user tries to enter
+                             * implies that when the input is optional but the user tries to enter
                              * invalid content to the picker we can't enable next because it's invalid.
                              */
                             setNextShouldBeDisabled(
@@ -906,11 +918,11 @@ export const EnterpriseIDPCreateWizard: FC<EnterpriseIDPCreateWizardProps> = (
         let docLink: string = undefined;
 
         if (selectedProtocol === AuthProtocolTypes.SAML) {
-            docLink = getLink("develop.connections.newConnection.enterprise.saml.learnMore");
+            docLink = getLink("develop.connections.newConnection.enterprise.samlLearnMore");
         }
 
         if (selectedProtocol === AuthProtocolTypes.OIDC) {
-            docLink = getLink("develop.connections.newConnection.enterprise.oidc.learnMore");
+            docLink = getLink("develop.connections.newConnection.enterprise.oidcLearnMore");
         }
 
         return (
@@ -1109,7 +1121,7 @@ const ifFieldsHave = (errors: FormErrors): boolean => {
     return !Object.keys(errors).every((k: string) => !errors[ k ]);
 };
 
-const required = (value: any) => {
+const required = (value: string) => {
     if (!value) {
         return "This is a required field";
     }

--- a/apps/console/src/features/identity-providers/components/wizards/trusted-token-issuer/trusted-token-issuer-create-wizard.tsx
+++ b/apps/console/src/features/identity-providers/components/wizards/trusted-token-issuer/trusted-token-issuer-create-wizard.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,7 +17,11 @@
  */
 
 import Alert from "@oxygen-ui/react/Alert";
+import FormControl from "@oxygen-ui/react/FormControl";
+import FormControlLabel from "@oxygen-ui/react/FormControlLabel";
 import Grid from "@oxygen-ui/react/Grid";
+import Radio from "@oxygen-ui/react/Radio";
+import RadioGroup from "@oxygen-ui/react/RadioGroup";
 import { IdentityAppsError } from "@wso2is/core/errors";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
@@ -35,8 +39,6 @@ import {
     PickerResult,
     PrimaryButton,
     Steps,
-    Switcher,
-    SwitcherOptionProps,
     useDocumentation,
     useWizardAlert
 } from "@wso2is/react-components";
@@ -44,6 +46,7 @@ import { FormValidation } from "@wso2is/validation";
 import { AxiosError, AxiosResponse } from "axios";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
+    ChangeEvent,
     FC,
     MutableRefObject,
     PropsWithChildren,
@@ -128,20 +131,6 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
-    // Options list for the certificate type switcher.
-    const certificateOptions: [SwitcherOptionProps, SwitcherOptionProps] = [ 
-        {
-            label: t("console:develop.features.authenticationProvider." +
-                "templates.trustedTokenIssuer.forms.jwksUrl.optionLabel"),
-            value: CertificateType.JWKS
-        }, 
-        {
-            label: t("console:develop.features.authenticationProvider." +
-                "templates.trustedTokenIssuer.forms.pem.optionLabel"),
-            value: CertificateType.PEM
-        } 
-    ];
-
     /**
      * Initial values of the form.
      */
@@ -177,7 +166,7 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
 
     /**
      * Get the list of steps for the wizard.
-     * 
+     *
      * @returns `TrustedTokenIssuerWizardStepInterface[]`
      */
     const getWizardSteps = (): TrustedTokenIssuerWizardStepInterface[] => [
@@ -191,14 +180,14 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
             content: certificatesPage(),
             icon: getIdentityProviderWizardStepIcons().general,
             name: TrsutedTokenIssuerWizardStep.CERTIFICATES,
-            title: t("console:develop.features.authenticationProvider.templates.trustedTokenIssuer.forms.steps." + 
+            title: t("console:develop.features.authenticationProvider.templates.trustedTokenIssuer.forms.steps." +
                 "certificate")
         }
     ];
 
     /**
      * Check if the typed IDP name is already taken.
-     *  
+     *
      * @param userInput - User input for the IDP name.
      * @returns `true` if the IDP name is already taken else `false`.
      */
@@ -208,17 +197,37 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
 
     /**
      * Check whether loop back call is allowed or not.
-     * 
+     *
      * @param value - URL to check.
      */
-    const isLoopBackCall = (value: string): string => 
-        !(URLUtils.isLoopBackCall(value) && commonConfig?.blockLoopBackCalls) 
-            ? undefined 
+    const isLoopBackCall = (value: string): string =>
+        !(URLUtils.isLoopBackCall(value) && commonConfig?.blockLoopBackCalls)
+            ? undefined
             : t("console:develop.features.idp.forms.common.internetResolvableErrorMessage");
 
     /**
+     * Handles the option changed event.
+     */
+    const onSelectionChange = (event: ChangeEvent<HTMLInputElement>): void => {
+        const value: string = (event.target as HTMLInputElement).value;
+
+        switch (value) {
+            case CertificateType.JWKS:
+                setFinishShouldBeDisabled(jwksUrl === null);
+
+                break;
+            case CertificateType.PEM:
+                setFinishShouldBeDisabled(!isPemCertValid);
+
+                break;
+        }
+
+        setSelectedCertInputType(value as CertificateType);
+    };
+
+    /**
      * Create the token issuer body.
-     * 
+     *
      * @param values - Form values
      * @returns - `IdentityProviderFormValuesInterface`
      */
@@ -244,7 +253,7 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
                     "/libs/themes/default/assets/images/identity-providers/trusted-token-issuer-illustration.svg";
             }
         }
-        
+
         // Populate certificate settings.
         identityProvider[ "certificate" ][ "jwksUri" ] = jwksUrl ?? "";
         identityProvider[ "certificate" ][ "certificates" ] = [ pemString ? btoa(pemString) : "" ];
@@ -254,7 +263,7 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
 
     /**
      * Handle the form submit action.
-     * 
+     *
      * @param values - Form values
      */
     const handleFormSubmit = (values: IdentityProviderFormValuesInterface) => {
@@ -293,10 +302,10 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
                     ? IdentityProviderManagementConstants.ERROR_CREATE_LIMIT_REACHED
                     : IdentityProviderManagementConstants.ERROR_CREATE_LIMIT_REACHED_IDP;
 
-                if (error?.response?.status === 403 && 
+                if (error?.response?.status === 403 &&
                     error?.response?.data?.code ===identityAppsError.getErrorCode()) {
                     setOpenLimitReachedModal(true);
-        
+
                     return;
                 }
 
@@ -326,7 +335,7 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
             });
 
     };
-    
+
     /**
      * This function returns the first page of the wizard.
      *
@@ -356,7 +365,7 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
                         errorMsg = t("console:develop.features.authenticationProvider." +
                             "forms.generalDetails.name.validations.duplicate");
                     }
-                    
+
                     if (!FormValidation.isValidResourceName(values)) {
                         errorMsg = t("console:develop.features.authenticationProvider." +
                             "templates.enterprise.validation.invalidName", { idpName: values });
@@ -428,10 +437,10 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
             />
         </WizardPage>
     );
-    
+
     /**
      * This function returns the certificates page of the wizard.
-     * 
+     *
      * @returns `ReactElement`
      */
     const certificatesPage = () => (
@@ -449,27 +458,27 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
                             { t("console:develop.features.authenticationProvider." +
                                 "templates.trustedTokenIssuer.forms.certificateType.label") }
                         </div>
-                        <Switcher
-                            compact
-                            defaultOptionValue={ certificateOptions[0].value }
-                            selectedValue={ selectedCertInputType }
-                            onChange={ ({ value }: SwitcherOptionProps) => {
-                                
-                                switch (value) {
-                                    case CertificateType.JWKS:
-                                        setFinishShouldBeDisabled(jwksUrl === null);
-
-                                        break;
-                                    case CertificateType.PEM:
-                                        setFinishShouldBeDisabled(!isPemCertValid);
-
-                                        break;
-                                }
-                                        
-                                setSelectedCertInputType(value as CertificateType);
-                            } }
-                            options={ certificateOptions }
-                        />
+                        <FormControl>
+                            <RadioGroup
+                                row
+                                name="certificate-type"
+                                onChange={ onSelectionChange }
+                                value={ selectedCertInputType }
+                            >
+                                <FormControlLabel
+                                    control={ <Radio /> }
+                                    label={ t("console:develop.features.authenticationProvider.templates." +
+                                        "trustedTokenIssuer.forms.jwksUrl.optionLabel") }
+                                    value={ CertificateType.JWKS }
+                                />
+                                <FormControlLabel
+                                    control={ <Radio /> }
+                                    label={ t("console:develop.features.authenticationProvider.templates." +
+                                        "trustedTokenIssuer.forms.pem.optionLabel") }
+                                    value={ CertificateType.PEM }
+                                />
+                            </RadioGroup>
+                        </FormControl>
                     </Grid>
                 </Grid>
                 <Grid xs={ 12 }>
@@ -492,12 +501,12 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
                                 "templates.trustedTokenIssuer.forms.jwksUrl.hint") }
                             validation={ (values: string) => {
                                 let errorMsg: string;
-            
+
                                 if (!FormValidation.url(values)) {
                                     errorMsg = t("console:develop.features.authenticationProvider." +
                                         "templates.trustedTokenIssuer.forms.jwksUrl.validation.notValid");
                                 }
-                                
+
                                 if(!errorMsg) {
                                     errorMsg = isLoopBackCall(values);
                                 }
@@ -562,12 +571,12 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
 
     /**
      * Resolves the documentation link when a protocol is selected.
-     * 
+     *
      * @returns Documentation link.
      */
     const resolveDocumentationLink = (): ReactElement => (
         <DocumentationLink
-            link={ getLink("develop.connections.newConnection.enterprise.saml.learnMore") }
+            link={ getLink("develop.connections.newConnection.trustedTokenIssuer.learnMore") }
         >
             { t("common:learnMore") }
         </DocumentationLink>
@@ -586,17 +595,17 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
             { openLimitReachedModal &&
                 (
                     <TierLimitReachErrorModal
-                        actionLabel={ t("console:develop.features.idp.notifications.tierLimitReachedError." + 
+                        actionLabel={ t("console:develop.features.idp.notifications.tierLimitReachedError." +
                             "emptyPlaceholder.action") }
                         handleModalClose={ handleLimitReachedModalClose }
                         header={ t("console:develop.features.idp.notifications.tierLimitReachedError.heading") }
-                        description={ t("console:develop.features.idp.notifications.tierLimitReachedError." + 
+                        description={ t("console:develop.features.idp.notifications.tierLimitReachedError." +
                             "emptyPlaceholder.subtitles") }
-                        message={ t("console:develop.features.idp.notifications.tierLimitReachedError." + 
+                        message={ t("console:develop.features.idp.notifications.tierLimitReachedError." +
                             "emptyPlaceholder.title") }
                         openModal={ openLimitReachedModal }
                     />
-                ) 
+                )
             }
             <Modal
                 open={ !openLimitReachedModal }
@@ -670,9 +679,9 @@ export const TrustedTokenIssuerCreateWizard: FC<TrustedTokenIssuerCreateWizardPr
                     data-componentid={ `${ componentId }-modal-actions` }
                 >
                     <Grid container>
-                        <Grid 
-                            xs={ 6 } 
-                            container 
+                        <Grid
+                            xs={ 6 }
+                            container
                             justifyContent="flex-start"
                         >
                             <LinkButton


### PR DESCRIPTION
### Purpose
Replacing `<Switcher>` components with vanilla `<RadioGroup>` components to improve the user experience and avoid confusion about the expected behavior.

### Affected flows:

- Create Trusted Token Issuer Connection:

     ![wizard-token-issuer](https://github.com/wso2-enterprise/asgardeo-apps/assets/55197812/4dc3365d-07ea-408f-8519-0750f38da23c)
- Create OIDC Standard-Based IdP Connection:

     ![wizard-idp-oidc](https://github.com/wso2-enterprise/asgardeo-apps/assets/55197812/793d9977-e5b9-4e3e-9010-b02c507b2fa9)
- Create SAML Standard-Based IdP Connection:

     ![wizard-idp-saml](https://github.com/wso2-enterprise/asgardeo-apps/assets/55197812/ec07748a-4fa3-4775-b75f-8cadbcbde2fa)

### Related Issues
- https://github.com/wso2/product-is/issues/17145

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
