### PR TITLE
Remove API authorization policy for M2M applications

### DIFF
--- a/.changeset/pretty-meals-roll.md
+++ b/.changeset/pretty-meals-roll.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Remove API authorization policy for M2M applications

--- a/apps/console/src/extensions/configs/application.tsx
+++ b/apps/console/src/extensions/configs/application.tsx
@@ -406,7 +406,7 @@ export const applicationConfig: ApplicationConfig = {
                         ),
                         render: () => (
                             <ResourceTab.Pane controlledSegmentation>
-                                <APIAuthorization />
+                                <APIAuthorization templateId={ application?.templateId } />
                             </ResourceTab.Pane>
                         )
                     }

--- a/apps/console/src/features/applications/components/api-authorization/api-authorization.tsx
+++ b/apps/console/src/features/applications/components/api-authorization/api-authorization.tsx
@@ -17,7 +17,7 @@
  */
 
 import { hasRequiredScopes } from "@wso2is/core/helpers";
-import { AlertInterface, AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import {
     ConfirmationModal,
@@ -54,15 +54,27 @@ import {
 } from "../../models/api-authorization";
 
 /**
+ * Prop types for the API resources list component.
+ */
+interface APIAuthorizationResourcesProps extends
+    SBACInterface<FeatureConfigInterface>, IdentifiableComponentInterface {
+    /**
+     * Template ID.
+     */
+    templateId: string;
+}
+
+/**
  * API Authorization component.
  * 
  * @param props - Props related to API authorization component.
  */
-export const APIAuthorization: FunctionComponent<IdentifiableComponentInterface> = (
-    props: IdentifiableComponentInterface
+export const APIAuthorization: FunctionComponent<APIAuthorizationResourcesProps> = (
+    props: APIAuthorizationResourcesProps
 ): ReactElement => {
 
     const {
+        templateId,
         ["data-componentid"]: componentId
     } = props;
 
@@ -362,6 +374,7 @@ export const APIAuthorization: FunctionComponent<IdentifiableComponentInterface>
                 <Divider hidden />
                 <SubscribedAPIResources
                     appId={ appId }
+                    templateId={ templateId }
                     allAPIResourcesListData={ allAPIResourcesListData?.apiResources }
                     allAPIResourcesFetchRequestError={ allAPIResourcesFetchRequestError }
                     allAuthorizedScopes={ allAuthorizedScopes }
@@ -418,6 +431,7 @@ export const APIAuthorization: FunctionComponent<IdentifiableComponentInterface>
             {
                 isAuthorizeAPIResourceWizardOpen && (
                     <AuthorizeAPIResource 
+                        templateId={ templateId }
                         subscribedAPIResourcesListData={ subscribedAPIResourcesListData }
                         closeWizard={ (): void => setIsAuthorizeAPIResourceWizardOpen(false) }
                         handleCreateAPIResource= { handleCreateAPIResource } />

--- a/apps/console/src/features/applications/components/api-authorization/subscribed-api-resources.tsx
+++ b/apps/console/src/features/applications/components/api-authorization/subscribed-api-resources.tsx
@@ -42,6 +42,7 @@ import { APIResourcesConstants } from "../../../api-resources/constants";
 import { APIResourceInterface } from "../../../api-resources/models";
 import { FeatureConfigInterface } from "../../../core";
 import { Policy } from "../../constants/api-authorization";
+import { ApplicationTemplateIdTypes } from "../../models";
 import {
     AuthorizedAPIListItemInterface,
     AuthorizedPermissionListItemInterface
@@ -56,6 +57,10 @@ interface SubscribedAPIResourcesProps extends
      * Application ID.
      */
     appId: string;
+    /**
+     * Template ID.
+     */
+    templateId: string;
     /**
      * List of all API Resources
      */
@@ -110,6 +115,7 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
 
     const {
         appId,
+        templateId,
         allAPIResourcesListData,
         allAPIResourcesFetchRequestError,
         allAuthorizedScopes,
@@ -137,6 +143,7 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
     const [ searchedSubscribedAPIResources, setSearchedSubscribedAPIResources ] = 
         useState<AuthorizedAPIListItemInterface[]>(null);
     const [ copyScopesValue, setCopyScopesValue ] = useState<string>(null);
+    const [ m2mApplication, setM2MApplication ] = useState<boolean>(false);
 
     /**
      * Initialize the subscribed API Resources list to the searched list.
@@ -157,6 +164,15 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
             );
         }
     }, [ allAuthorizedScopes ]);
+
+    /**
+     * Check whether the application is an M2M application.
+     */
+    useEffect(() => {
+        if (templateId === ApplicationTemplateIdTypes.M2M_APPLICATION) {
+            setM2MApplication(true);
+        }
+    }, [ templateId ]);
 
     /**
      * Navigate to the API Resources page.
@@ -293,17 +309,21 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
                             </Header.Subheader>
                         </Header.Content>
                     </Grid.Column>
-                    <Grid.Column width={ 8 }>
-                        {
-                            subscribedAPIResource.identifier
-                                ? (
-                                    <Header.Subheader>
-                                        { renderPolicyForAPIResource(subscribedAPIResource.policyId) }
-                                    </Header.Subheader>
-                                )
-                                : null
-                        }
-                    </Grid.Column>
+                    {
+                        !m2mApplication && (
+                            <Grid.Column width={ 8 }>
+                                {
+                                    subscribedAPIResource.identifier
+                                        ? (
+                                            <Header.Subheader>
+                                                { renderPolicyForAPIResource(subscribedAPIResource.policyId) }
+                                            </Header.Subheader>
+                                        )
+                                        : null
+                                }
+                            </Grid.Column>
+                        )
+                    }
                 </Grid.Row>
             </Grid>
         </Header>

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -912,6 +912,9 @@ export interface ConsoleNS {
                             stopSharingNotification: Notification
                             getSharedOrganizations: Notification;
                         };
+                        apiAuthorization: {
+                            m2mPolicyMessage: string;
+                        }
                     };
                 };
                 forms: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1443,6 +1443,9 @@ export const console: ConsoleNS = {
                                 }
                             },
                             tabName: "Sign-in Method"
+                        },
+                        apiAuthorization: {
+                            m2mPolicyMessage: "All the authorized scopes of an API resource are available for an M2M application despite the authorization policy specified for the resource."
                         }
                     }
                 },

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -1470,6 +1470,9 @@ export const console: ConsoleNS = {
                                 }
                             },
                             tabName: "Méthode de connexion"
+                        },
+                        apiAuthorization: {
+                            m2mPolicyMessage: "Toutes les étendues autorisées d'une ressource API sont disponibles pour une application M2M malgré la politique d'autorisation spécifiée pour la ressource."
                         }
                     }
                 },

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -1440,6 +1440,9 @@ export const console: ConsoleNS = {
                                 }
                             },
                             tabName: "පුරනය වීමේ ක්‍රමය"
+                        },
+                        apiAuthorization: {
+                            m2mPolicyMessage: "සම්පත සඳහා නිශ්චිතව දක්වා ඇති අවසර ප්‍රතිපත්තිය නොතකා API සම්පතක සියලුම බලයලත් විෂය පථයන් M2M යෙදුමක් සඳහා ලබා ගත හැකිය."
                         }
                     }
                 },


### PR DESCRIPTION
### Purpose

Since RBAC policy is not supported for an M2M application, the option to set RBAC or No Authorization policy as the authorization policy was removed from API subscription wizard in M2M templates.

<img width="600" alt="Screenshot 2023-10-25 at 16 59 53" src="https://github.com/wso2/identity-apps/assets/28347418/1df46cd0-a13a-4699-8f6b-37b0a81b4a59">


<img width="600" alt="Screenshot 2023-10-25 at 12 17 01" src="https://github.com/wso2/identity-apps/assets/28347418/6f89ef77-180f-49ee-a2d4-b6f799d2ef52">

### Related Issues
- https://github.com/wso2/product-is/issues/17006

### Related PRs
- https://github.com/wso2/identity-apps/pull/4255

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
