### PR TITLE
Set the shared app name to readonly for sub-organizations

### DIFF
--- a/.changeset/ninety-bears-travel.md
+++ b/.changeset/ninety-bears-travel.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Set the shared app name to readonly for sub-organizations

--- a/apps/console/src/features/applications/components/forms/general-details-form.tsx
+++ b/apps/console/src/features/applications/components/forms/general-details-form.tsx
@@ -30,6 +30,7 @@ import { useSelector } from "react-redux";
 import { Divider } from "semantic-ui-react";
 import { applicationConfig } from "../../../../extensions";
 import { AppConstants, AppState, UIConfigInterface } from "../../../core";
+import { OrganizationType } from "../../../organizations/constants";
 import { useMyAccountStatus } from "../../api";
 import { ApplicationManagementConstants } from "../../constants";
 import { ApplicationInterface } from "../../models";
@@ -169,6 +170,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
     const [ isM2MApplication, setM2MApplication ] = useState<boolean>(false);
 
     const isSubOrg: boolean = window[ "AppUtils" ].getConfig().organizationName;
+    const orgType: OrganizationType = useSelector((state: AppState) => state?.organization?.organizationType);
 
     /**
      * Prepare form values for submitting.
@@ -332,7 +334,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                             ".placeholder")
                     }
                     value={ name }
-                    readOnly={ readOnly }
+                    readOnly={ readOnly || orgType === OrganizationType.SUBORGANIZATION }
                     validation ={ (value: string) => validateName(value.toString().trim()) }
                     maxLength={ ApplicationManagementConstants.FORM_FIELD_CONSTRAINTS.APP_NAME_MAX_LENGTH }
                     minLength={ 3 }
@@ -440,7 +442,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                         width={ 16 }
                     /> ) : null
             }
-            { 
+            {
                 !isM2MApplication && (
                     <Field.Input
                         ariaLabel={
@@ -470,9 +472,9 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                         data-testid={ `${ testId }-application-access-url-input` }
                         hint={ t("console:develop.features.applications.forms.generalDetails.fields.accessUrl.hint") }
                         width={ 16 }
-                    />) 
+                    />)
             }
-            
+
             <Field.Button
                 form={ FORM_ID }
                 size="small"


### PR DESCRIPTION
### Purpose
Set the shared app name to readonly for sub-organizations

### Related Issues
- https://github.com/wso2/product-is/issues/17101

### Related PRs
- https://github.com/wso2-extensions/identity-organization-management/pull/269

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
