### PR TITLE
Disable legacy login flow editor by default

### DIFF
--- a/.changeset/rotten-windows-try.md
+++ b/.changeset/rotten-windows-try.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": minor
+---
+
+Disable `applications.loginFlow.legacyEditor` by default

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
@@ -187,7 +187,9 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
                                 onClose={ () => {
                                     setIsScriptEditorSidePanelDrawerOpen(false);
                                 } }
-                                className="script-editor-drawer"
+                                className={
+                                    classNames("script-editor-drawer", { "standalone": !isLegacyEditorEnabled })
+                                }
                                 drawerIcon={ <CodeWindowIcon height={ 16 } width={ 16 } /> }
                                 panel={ isAdaptiveAuthAvailable && <ScriptEditorSidePanel /> }
                                 panelControlsLabel={ t("console:loginFlow.scriptEditor.panelHeader") }

--- a/apps/console/src/features/authentication-flow-builder/components/sign-in-methods.scss
+++ b/apps/console/src/features/authentication-flow-builder/components/sign-in-methods.scss
@@ -53,9 +53,17 @@
     }
 
     .script-editor-drawer {
-        top: var(--asg-auth-flow-builder-script-editor-drawer-offset);
         right: -2px;
-        height: calc(100% - (var(--asg-auth-flow-builder-script-editor-drawer-offset) - 1px));
+
+        &.standalone {
+            border-top: none;
+            border-bottom: none;
+        }
+
+        &:not(.standalone) {
+            top: var(--asg-auth-flow-builder-script-editor-drawer-offset);
+            height: calc(100% - (var(--asg-auth-flow-builder-script-editor-drawer-offset) - 1px));
+        }
 
         &.side-panel-drawer.open .MuiDrawer-paper {
             width: var(--asg-auth-flow-builder-script-side-panel-drawer-width);

--- a/apps/console/src/features/authentication-flow-builder/constants/editor-constants.ts
+++ b/apps/console/src/features/authentication-flow-builder/constants/editor-constants.ts
@@ -16,6 +16,6 @@
  * under the License.
  */
 
-export const LEGACY_EDITOR_FEATURE_ID: string = "authenticationFlowLegacyEditor";
+export const LEGACY_EDITOR_FEATURE_ID: string = "applications.loginFlow.legacyEditor";
 
-export const VISUAL_EDITOR_FEATURE_ID: string = "authenticationFlowVisualEditor";
+export const VISUAL_EDITOR_FEATURE_ID: string = "applications.loginFlow.visualEditor";

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -368,7 +368,9 @@
                 }
             },
             "applications": {
-                "disabledFeatures": [""],
+                "disabledFeatures": [
+                    "applications.loginFlow.legacyEditor"
+                ],
                 "enabled": true,
                 "scopes": {
                     "feature": [


### PR DESCRIPTION
### Purpose

Going forward we are only shipping the visual editor by default.

<img width="1229" alt="Screenshot 2023-10-26 at 01 14 35" src="https://github.com/wso2/identity-apps/assets/25959096/89cdffec-f270-4ffe-aabd-45c193097780">

### Related Issues
- https://github.com/wso2/product-is/issues/17219

### Related PRs
- Framework Changes: https://github.com/wso2/carbon-identity-framework/pull/5061

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
