### PR TITLE
Remove redundant callback URL validation

### DIFF
--- a/.changeset/many-moles-occur.md
+++ b/.changeset/many-moles-occur.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Remove redundant callback URL validation.

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery-complete.jsp
@@ -20,7 +20,6 @@
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
-<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.CallBackValidator" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityRecoveryException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ page import="java.io.File" %>
@@ -39,27 +38,6 @@
 <%
     String callback = (String) request.getAttribute("callback");
     String username = request.getParameter("username");
-    CallBackValidator callBackValidator = new CallBackValidator();
-    try {
-        if (!callBackValidator.isValidCallbackURL(callback, tenantDomain)) {
-            request.setAttribute("error", true);
-            request.setAttribute("errorMsg", "Configured callback URL does not match with the provided callback " +
-                    "URL in the request.");
-            if (!StringUtils.isBlank(username)) {
-                request.setAttribute("username", username);
-            }
-            request.getRequestDispatcher("error.jsp").forward(request, response);
-            return;
-        }
-    } catch (IdentityRecoveryException e) {
-        request.setAttribute("error", true);
-        request.setAttribute("errorMsg", "Callback URL validation failed. " + e.getMessage());
-        if (!StringUtils.isBlank(username)) {
-            request.setAttribute("username", username);
-        }
-        request.getRequestDispatcher("error.jsp").forward(request, response);
-        return;
-    }
 %>
 
 <%-- Data for the layout from the page --%>


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/16906

In the recovery flows the callback URL validation is performed from https://github.com/wso2/identity-apps/blob/master/identity-apps-core/apps/recovery-portal/src/main/webapp/recovery.jsp#L83. So this is a redundant check and also it is not working properly. 