### PR TITLE
Improve Myaccount and Console Urls to support Super Tenant Required in Url Config

### DIFF
--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -51,6 +51,9 @@
     {% if console.super_tenant_proxy_name is defined %}
         "superTenantProxy" : "{{ console.super_tenant_proxy_name }}",
     {% endif %}
+    {% if tenant_context.require_super_tenant_in_urls is defined %}
+        "superTenantRequiredInUrl" : "{{ tenant_context.require_super_tenant_in_urls }}",
+    {% endif %}
     {% if console.doc_site_path is defined %}
     "docSiteUrl": "{{ console.doc_site_path }}",
     {% endif %}

--- a/apps/console/src/index.jsp
+++ b/apps/console/src/index.jsp
@@ -10,6 +10,7 @@
 <%= htmlWebpackPlugin.options.contentType %>
 <%= htmlWebpackPlugin.options.importUtil %>
 <%= htmlWebpackPlugin.options.importOwaspEncode %>
+<%= htmlWebpackPlugin.options.getSuperTenantRequiredInUrlConfig %>
 
 <script>
     var userAccessedPath = window.location.href;
@@ -60,7 +61,7 @@
             .pre-loader-logo {
                 margin-top: -0.1rem;
             }
-    
+
             .content-loader {
                 display: flex;
                 flex-direction: column;
@@ -68,24 +69,24 @@
                 align-items: center;
                 user-select: none;
             }
-    
+
             .content-loader .ui.loader {
                 display: block;
                 position: relative;
                 margin-top: 10px;
                 margin-bottom: 25px;
             }
-    
+
             @keyframes loader {
                 0% {
                     transform: rotate(0)
                 }
-    
+
                 to {
                     transform: rotate(1turn)
                 }
             }
-    
+
             .content-loader .ui.loader:before {
                 content: "";
                 display: block;
@@ -94,7 +95,7 @@
                 border: .2em solid rgba(0,0,0,.1);
                 border-radius: 500rem;
             }
-    
+
             .content-loader .ui.loader:after {
                 content: "";
                 position: absolute;
@@ -146,7 +147,7 @@
                 var trifactaPreLoader = document.getElementById("trifacta-pre-loader");
                 var defaultPreLoader = document.getElementById("default-pre-loader");
                 var loader = document.getElementById("loader");
-        
+
                 if (startupConfig.enableDefaultPreLoader) {
                     defaultPreLoader.style.display = 'block';
                     trifactaPreLoader.style.display = 'none';
@@ -188,6 +189,12 @@
 
                     return serverOrigin;
                 }
+                function appendSuperTenantProxyToUrl() {
+                    if (startupConfig.superTenantProxy == "carbon.super" && "<%= htmlWebpackPlugin.options.isSuperTenantRequiredInUrl %>" === "false") {
+                        return false;
+                    }
+                    return true;
+                }
 
                 /**
                  * Get the organization name.
@@ -221,7 +228,7 @@
                 var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
 
                 var authConfig = {
-                    signInRedirectURL: applicationDomain.replace(/\/+$/, '') + getOrganizationPath() 
+                    signInRedirectURL: applicationDomain.replace(/\/+$/, '') + getOrganizationPath()
                         + "<%= htmlWebpackPlugin.options.basename ? '/' + htmlWebpackPlugin.options.basename : ''%>",
                     signOutRedirectURL: applicationDomain.replace(/\/+$/, '') + getOrganizationPath(),
                     clientID: "<%= htmlWebpackPlugin.options.clientID %>",
@@ -230,13 +237,13 @@
                     scope: ["openid SYSTEM profile"],
                     storage: "webWorker",
                     endpoints: {
-                        authorizationEndpoint: getApiPath(userTenant 
+                        authorizationEndpoint: getApiPath(userTenant
                             ? "/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oauth2/authorize" + "?ut="+userTenant.replace(/\/+$/, '') + (utype ? "&utype="+ utype : '')
-                            : "/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oauth2/authorize"),
+                            : appendSuperTenantProxyToUrl() ? "/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oauth2/authorize" : "/oauth2/authorize"),
                         clockTolerance: 300,
                         jwksEndpointURL: undefined,
-                        logoutEndpointURL: getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/logout"),
-                        oidcSessionIFrameEndpointURL: getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/checksession"),
+                        logoutEndpointURL: getApiPath(appendSuperTenantProxyToUrl() ? "/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/logout" : "/oidc/logout"),
+                        oidcSessionIFrameEndpointURL: getApiPath(appendSuperTenantProxyToUrl() ? "/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/checksession" : "/oidc/checksession"),
                         tokenEndpointURL: undefined,
                         tokenRevocationEndpointURL: undefined
                     },

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -522,8 +522,9 @@ export const AppUtils: any = (function() {
                         && _config.idpConfigs.authorizeEndpointURL
                         && _config.idpConfigs.authorizeEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                                + "/", _config.superTenantRequiredInUrl ?
+                                this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                                 ? this.getTenantName()
                                 : this.getOrganizationName()
@@ -534,8 +535,9 @@ export const AppUtils: any = (function() {
                         && _config.idpConfigs.jwksEndpointURL
                         && _config.idpConfigs.jwksEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                                + "/", _config.superTenantRequiredInUrl ?
+                                this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                                 ? this.getTenantName()
                                 : ""),
@@ -543,8 +545,9 @@ export const AppUtils: any = (function() {
                         && _config.idpConfigs.logoutEndpointURL
                         && _config.idpConfigs.logoutEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                                + "/", _config.superTenantRequiredInUrl ?
+                                this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                                 ? this.getTenantName()
                                 : ""),
@@ -552,8 +555,9 @@ export const AppUtils: any = (function() {
                         && _config.idpConfigs.oidcSessionIFrameEndpointURL
                         && _config.idpConfigs.oidcSessionIFrameEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                                + "/", _config.superTenantRequiredInUrl ?
+                                this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                                 ? this.getTenantName()
                                 : ""),
@@ -561,8 +565,9 @@ export const AppUtils: any = (function() {
                         && _config.idpConfigs.tokenEndpointURL
                         && _config.idpConfigs.tokenEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                                + "/", _config.superTenantRequiredInUrl ?
+                                this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                                 ? this.getTenantName()
                                 : ""),
@@ -570,8 +575,9 @@ export const AppUtils: any = (function() {
                         && _config.idpConfigs.tokenRevocationEndpointURL
                         && _config.idpConfigs.tokenRevocationEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                                + "/", _config.superTenantRequiredInUrl ?
+                                this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                                 ? this.getTenantName()
                                 : ""),
@@ -579,8 +585,9 @@ export const AppUtils: any = (function() {
                         && _config.idpConfigs.wellKnownEndpointURL
                         && _config.idpConfigs.wellKnownEndpointURL
                             .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                            .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                            .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                                + "/", _config.superTenantRequiredInUrl ?
+                                this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                             .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                                 ? this.getTenantName()
                                 : "")

--- a/apps/console/webpack.config.ts
+++ b/apps/console/webpack.config.ts
@@ -187,6 +187,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%@ page import=\"static org.wso2.carbon.identity.application." +
                     "authentication.framework.util.FrameworkUtils.isOrganizationManagementEnabled\"%>"
                     : "",
+                getSuperTenantRequiredInUrlConfig: !isDeployedOnExternalTomcatServer
+                    ? "<%@ page import=\"static org.wso2.carbon.identity.core.util." +
+                    "IdentityTenantUtil.isSuperTenantRequiredInUrl\"%>"
+                    : "",
                 hash: true,
                 importStringUtils: "<%@ page import=\"org.apache.commons.lang.StringUtils\" %>",
                 importSuperTenantConstant: !isDeployedOnExternalTomcatServer
@@ -206,6 +210,9 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     : "false",
                 isOrganizationManagementEnabled: !isDeployedOnExternalTomcatServer
                     ? "<%= isOrganizationManagementEnabled() %>"
+                    : "false",
+                isSuperTenantRequiredInUrl: !isDeployedOnExternalTomcatServer
+                    ? "<%= isSuperTenantRequiredInUrl() %>"
                     : "false",
                 minify: false,
                 publicPath: baseHref,
@@ -241,6 +248,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%@ page import=\"static org.wso2.carbon.identity.application." +
                     "authentication.framework.util.FrameworkUtils.isAdaptiveAuthenticationAvailable\"%>"
                     : "",
+                getSuperTenantRequiredInUrlConfig: !isDeployedOnExternalTomcatServer
+                    ? "<%@ page import=\"static org.wso2.carbon.identity.core.util." +
+                    "IdentityTenantUtil.isSuperTenantRequiredInUrl\"%>"
+                    : "",
                 hash: true,
                 importOwaspEncode: "<%@ page import=\"org.owasp.encoder.Encode\" %>",
                 importSuperTenantConstant: !isDeployedOnExternalTomcatServer
@@ -258,6 +269,9 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                 inject: false,
                 isAdaptiveAuthenticationAvailable: !isDeployedOnExternalTomcatServer
                     ? "<%= isAdaptiveAuthenticationAvailable() %>"
+                    : "false",
+                isSuperTenantRequiredInUrl: !isDeployedOnExternalTomcatServer
+                    ? "<%= isSuperTenantRequiredInUrl() %>"
                     : "false",
                 minify: false,
                 publicPath: baseHref,

--- a/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
+++ b/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
@@ -89,7 +89,9 @@
     {% if myaccount.super_tenant_proxy_name is defined %}
         "superTenantProxy" : "{{ myaccount.super_tenant_proxy_name }}",
     {% endif %}
-    "superTenantRequired" : false,
+    {% if tenant_context.require_super_tenant_in_urls is defined %}
+        "superTenantRequiredInUrl" : "{{ tenant_context.require_super_tenant_in_urls }}",
+    {% endif %}
     {% if myaccount.idp_configs is defined %}
     "idpConfigs": {
         {% if myaccount.idp_configs.items() is defined %}

--- a/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
+++ b/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
@@ -89,6 +89,7 @@
     {% if myaccount.super_tenant_proxy_name is defined %}
         "superTenantProxy" : "{{ myaccount.super_tenant_proxy_name }}",
     {% endif %}
+    "superTenantRequired" : false,
     {% if myaccount.idp_configs is defined %}
     "idpConfigs": {
         {% if myaccount.idp_configs.items() is defined %}

--- a/apps/myaccount/src/index.jsp
+++ b/apps/myaccount/src/index.jsp
@@ -10,6 +10,7 @@
 <%= htmlWebpackPlugin.options.contentType %>
 <%= htmlWebpackPlugin.options.importUtil %>
 <%= htmlWebpackPlugin.options.importOwaspEncode %>
+<%= htmlWebpackPlugin.options.getSuperTenantRequiredInUrlConfig %>
 
 <script>
     var userAccessedPath = window.location.href;
@@ -198,9 +199,15 @@
 
                     return serverOrigin;
                 }
+                function appendSuperTenantProxyToUrl() {
+                    if (startupConfig.superTenantProxy == "carbon.super" && "<%= htmlWebpackPlugin.options.isSuperTenantRequiredInUrl %>" === "false") {
+                        return false;
+                    }
+                    return true;
+                }
 
                 var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
-                var superTenantRequiredinUrl = false;
+                var superTenantRequiredinUrl = "<%= htmlWebpackPlugin.options.isSuperTenantRequiredInUrl %>" === "true";
 
                 var authConfig = {
                     signInRedirectURL: applicationDomain.replace(/\/+$/, '')
@@ -212,11 +219,11 @@
                     scope: ["openid SYSTEM"],
                     storage: "webWorker",
                     endpoints: {
-                        authorizationEndpoint: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oauth2/authorize") : superTenantRequiredinUrl == "true" ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oauth2/authorize") : getApiPath("/oauth2/authorize"),
+                        authorizationEndpoint: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oauth2/authorize") : appendSuperTenantProxyToUrl() ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oauth2/authorize") : getApiPath("/oauth2/authorize"),
                         clockTolerance: 300,
                         jwksEndpointURL: undefined,
-                        logoutEndpointURL: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oidc/logout") : superTenantRequiredinUrl == "true" ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/logout") : getApiPath("/oidc/logout"),
-                        oidcSessionIFrameEndpointURL: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oidc/checksession") : superTenantRequiredinUrl == "true" ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/checksession") : "/oidc/checksession",
+                        logoutEndpointURL: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oidc/logout") : appendSuperTenantProxyToUrl() ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/logout") : getApiPath("/oidc/logout"),
+                        oidcSessionIFrameEndpointURL: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oidc/checksession") : appendSuperTenantProxyToUrl() ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/checksession") : "/oidc/checksession",
                         tokenEndpointURL: undefined,
                         tokenRevocationEndpointURL: undefined,
                     },

--- a/apps/myaccount/src/index.jsp
+++ b/apps/myaccount/src/index.jsp
@@ -61,7 +61,7 @@
             .pre-loader-logo {
                 margin-top: -0.1rem;
             }
-    
+
             .content-loader {
                 display: flex;
                 flex-direction: column;
@@ -69,24 +69,24 @@
                 align-items: center;
                 user-select: none;
             }
-    
+
             .content-loader .ui.loader {
                 display: block;
                 position: relative;
                 margin-top: 10px;
                 margin-bottom: 25px;
             }
-    
+
             @keyframes loader {
                 0% {
                     transform: rotate(0)
                 }
-    
+
                 to {
                     transform: rotate(1turn)
                 }
             }
-    
+
             .content-loader .ui.loader:before {
                 content: "";
                 display: block;
@@ -95,7 +95,7 @@
                 border: .2em solid rgba(0,0,0,.1);
                 border-radius: 500rem;
             }
-    
+
             .content-loader .ui.loader:after {
                 content: "";
                 position: absolute;
@@ -149,7 +149,7 @@
                 var trifactaPreLoader = document.getElementById("trifacta-pre-loader");
                 var defaultPreLoader = document.getElementById("default-pre-loader");
                 var loader = document.getElementById("loader");
-        
+
                 if (userTenant && userTenant == startupConfig.superTenantProxy) {
                     if (startupConfig.enableDefaultPreLoader) {
                         defaultPreLoader.style.display = 'block';
@@ -166,7 +166,7 @@
             // Handles myaccount tenanted signout before auth sdk get loaded
             var applicationDomain = window.location.origin;
             var isSignOutSuccess = userAccessedPath.includes("sign_out_success");
-            
+
             if(isSignOutSuccess && userTenant) {
                 if (startupConfig.subdomainApplication) {
                     window.location.href = applicationDomain + "/" + startupConfig.tenantPrefix + "/" + userTenant;
@@ -200,9 +200,10 @@
                 }
 
                 var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
+                var superTenantRequiredinUrl = false;
 
                 var authConfig = {
-                    signInRedirectURL: applicationDomain.replace(/\/+$/, '')  
+                    signInRedirectURL: applicationDomain.replace(/\/+$/, '')
                         + "<%= htmlWebpackPlugin.options.basename ? '/' + htmlWebpackPlugin.options.basename : ''%>",
                     signOutRedirectURL: applicationDomain.replace(/\/+$/, ''),
                     clientID: "<%= htmlWebpackPlugin.options.clientID %>",
@@ -211,17 +212,17 @@
                     scope: ["openid SYSTEM"],
                     storage: "webWorker",
                     endpoints: {
-                        authorizationEndpoint: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oauth2/authorize") : getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oauth2/authorize"),
+                        authorizationEndpoint: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oauth2/authorize") : superTenantRequiredinUrl == "true" ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oauth2/authorize") : getApiPath("/oauth2/authorize"),
                         clockTolerance: 300,
                         jwksEndpointURL: undefined,
-                        logoutEndpointURL: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oidc/logout") : getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/logout"),
-                        oidcSessionIFrameEndpointURL: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oidc/checksession") : getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/checksession"),
+                        logoutEndpointURL: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oidc/logout") : superTenantRequiredinUrl == "true" ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/logout") : getApiPath("/oidc/logout"),
+                        oidcSessionIFrameEndpointURL: userTenant ? getApiPath("/" + startupConfig.tenantPrefix + "/" + userTenant + startupConfig.pathExtension + "/oidc/checksession") : superTenantRequiredinUrl == "true" ? getApiPath("/" + startupConfig.tenantPrefix + "/" + startupConfig.superTenantProxy + startupConfig.pathExtension + "/oidc/checksession") : "/oidc/checksession",
                         tokenEndpointURL: undefined,
                         tokenRevocationEndpointURL: undefined,
                     },
                     enablePKCE: true
                 }
-                
+
                 auth.initialize(authConfig);
                 auth.signIn();
             }

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -394,7 +394,9 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.authorizeEndpointURL
                     && _config.idpConfigs.authorizeEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                            + "/", _config.superTenantRequiredInUrl ?
+                            this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -402,7 +404,9 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.jwksEndpointURL
                     && _config.idpConfigs.jwksEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                            + "/", _config.superTenantRequiredInUrl ?
+                            this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -410,7 +414,9 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.logoutEndpointURL
                     && _config.idpConfigs.logoutEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                            + "/", _config.superTenantRequiredInUrl ?
+                            this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -418,7 +424,9 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.oidcSessionIFrameEndpointURL
                     && _config.idpConfigs.oidcSessionIFrameEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                            + "/", _config.superTenantRequiredInUrl ?
+                            this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName() !== this.getSuperTenant()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -426,7 +434,9 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.tokenEndpointURL
                     && _config.idpConfigs.tokenEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                            + "/", _config.superTenantRequiredInUrl ?
+                            this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -434,7 +444,9 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.tokenRevocationEndpointURL
                     && _config.idpConfigs.tokenRevocationEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                            + "/", _config.superTenantRequiredInUrl ?
+                            this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -442,7 +454,9 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.wellKnownEndpointURL
                     && _config.idpConfigs.wellKnownEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER
+                            + "/", _config.superTenantRequiredInUrl ?
+                            this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy())

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -394,8 +394,7 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.authorizeEndpointURL
                     && _config.idpConfigs.authorizeEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -403,8 +402,7 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.jwksEndpointURL
                     && _config.idpConfigs.jwksEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -412,8 +410,7 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.logoutEndpointURL
                     && _config.idpConfigs.logoutEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -421,8 +418,7 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.oidcSessionIFrameEndpointURL
                     && _config.idpConfigs.oidcSessionIFrameEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName() !== this.getSuperTenant()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -430,8 +426,7 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.tokenEndpointURL
                     && _config.idpConfigs.tokenEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -439,8 +434,7 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.tokenRevocationEndpointURL
                     && _config.idpConfigs.tokenRevocationEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy()),
@@ -448,8 +442,7 @@ export const AppUtils = (function() {
                     && _config.idpConfigs.wellKnownEndpointURL
                     && _config.idpConfigs.wellKnownEndpointURL
                         .replace(SERVER_ORIGIN_IDP_URL_PLACEHOLDER, _config.serverOrigin)
-                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER, this.getTenantPrefix())
-                        .replace(SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getSuperTenantProxy())
+                        .replace(TENANT_PREFIX_IDP_URL_PLACEHOLDER + "/" + SUPER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER + "/", _config.superTenantRequired ? this.getTenantPrefix() + "/" + this.getSuperTenantProxy() + "/" : "")
                         .replace(USER_TENANT_DOMAIN_IDP_URL_PLACEHOLDER, this.getTenantName()
                             ? this.getTenantName()
                             : this.getSuperTenantProxy())

--- a/apps/myaccount/webpack.config.ts
+++ b/apps/myaccount/webpack.config.ts
@@ -233,6 +233,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%@ page import=\"static org.wso2.carbon.identity.application." +
                     "authentication.framework.util.FrameworkUtils.isOrganizationManagementEnabled\"%>"
                     : "",
+                getSuperTenantRequiredInUrlConfig: !isDeployedOnExternalTomcatServer
+                    ? "<%@ page import=\"static org.wso2.carbon.identity.core.util." +
+                    "IdentityTenantUtil.isSuperTenantRequiredInUrl\"%>"
+                    : "",
                 hash: true,
                 importStringUtils: "<%@ page import=\"org.apache.commons.lang.StringUtils\" %>",
                 importSuperTenantConstant: !isDeployedOnExternalTomcatServer
@@ -249,6 +253,9 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     : "",
                 isOrganizationManagementEnabled: !isDeployedOnExternalTomcatServer
                     ? "<%= isOrganizationManagementEnabled() %>"
+                    : "false",
+                isSuperTenantRequiredInUrl: !isDeployedOnExternalTomcatServer
+                    ? "<%= isSuperTenantRequiredInUrl() %>"
                     : "false",
                 minify: false,
                 publicPath: baseHref,
@@ -284,6 +291,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                     ? "<%@ page import=\"static org.wso2.carbon.identity.application." +
                     "authentication.framework.util.FrameworkUtils.isOrganizationManagementEnabled\"%>"
                     : "",
+                getSuperTenantRequiredInUrlConfig: !isDeployedOnExternalTomcatServer
+                    ? "<%@ page import=\"static org.wso2.carbon.identity.core.util." +
+                    "IdentityTenantUtil.isSuperTenantRequiredInUrl\"%>"
+                    : "",
                 hash: true,
                 importOwaspEncode: "<%@ page import=\"org.owasp.encoder.Encode\" %>",
                 importSuperTenantConstant: !isDeployedOnExternalTomcatServer
@@ -301,6 +312,9 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
                 inject: false,
                 isOrganizationManagementEnabled: !isDeployedOnExternalTomcatServer
                     ? "<%= isOrganizationManagementEnabled() %>"
+                    : "false",
+                isSuperTenantRequiredInUrl: !isDeployedOnExternalTomcatServer
+                    ? "<%= isSuperTenantRequiredInUrl() %>"
                     : "false",
                 minify: false,
                 publicPath: baseHref,


### PR DESCRIPTION
This PR changes the myaccount and console urls according to the `superTenantRequiredInUrl` config. 
These changes are required for myaccount console login if https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/244 is merged.

Related issue: https://github.com/wso2/product-is/issues/16906