### PR TITLE
Remove filtering from availableEmailTemplates

### DIFF
--- a/apps/console/src/extensions/configs/administrator.ts
+++ b/apps/console/src/extensions/configs/administrator.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/extensions/configs/administrator.ts
+++ b/apps/console/src/extensions/configs/administrator.ts
@@ -20,5 +20,6 @@ import { AdministratorConfig } from "./models/administrator";
 
 export const administratorConfig: AdministratorConfig = {
     adminRoleName: "admin",
-    enableAdminInvite: false
+    enableAdminInvite: false,
+    enableEmailCustomTemplate: true
 };

--- a/apps/console/src/extensions/configs/administrator.ts
+++ b/apps/console/src/extensions/configs/administrator.ts
@@ -20,6 +20,5 @@ import { AdministratorConfig } from "./models/administrator";
 
 export const administratorConfig: AdministratorConfig = {
     adminRoleName: "admin",
-    enableAdminInvite: false,
-    enableEmailCustomTemplate: true
+    enableAdminInvite: false
 };

--- a/apps/console/src/extensions/configs/models/administrator.ts
+++ b/apps/console/src/extensions/configs/models/administrator.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/extensions/configs/models/administrator.ts
+++ b/apps/console/src/extensions/configs/models/administrator.ts
@@ -19,4 +19,5 @@
 export interface AdministratorConfig {
     adminRoleName: string;
     enableAdminInvite: boolean;
+    enableEmailCustomTemplate: boolean;
 }

--- a/apps/console/src/extensions/configs/models/administrator.ts
+++ b/apps/console/src/extensions/configs/models/administrator.ts
@@ -19,5 +19,4 @@
 export interface AdministratorConfig {
     adminRoleName: string;
     enableAdminInvite: boolean;
-    enableEmailCustomTemplate: boolean;
 }

--- a/apps/console/src/features/email-management/pages/email-customization.tsx
+++ b/apps/console/src/features/email-management/pages/email-customization.tsx
@@ -33,7 +33,6 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { TabProps } from "semantic-ui-react";
-import { administratorConfig } from "../../../extensions/configs/administrator";
 import BrandingPreferenceProvider from "../../branding/providers/branding-preference-provider";
 import { AppConstants, AppState, FeatureConfigInterface, I18nConstants } from "../../core";
 import { history } from "../../core/helpers";

--- a/apps/console/src/features/email-management/pages/email-customization.tsx
+++ b/apps/console/src/features/email-management/pages/email-customization.tsx
@@ -94,26 +94,23 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
     } = useEmailTemplate(selectedEmailTemplateId, selectedLocale);
 
     useEffect(() => {
-        // As of now, we need to show only the used email templates, and we don't have a good displayName and
-        // description coming from the backend for the email template types. So as we agreed to filter only the used
-        // templates, and we will use the displayName and description from the email template types config defined in
-        // the deployment.toml file. The below code will first filter all the email templates and map the email template
+        // we don't have a good displayName and description coming from the backend
+        // for the email template types. So as we agreed use the displayName and
+        // description from the email template types config defined in
+        // the deployment.toml file. The below code will map the email template
         // types with the config's displayName and description.
-        const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList?.filter(
-            (template: EmailTemplateType) => {
-                return emailTemplates?.find((emailTemplate: Record<string, string>) =>
-                    emailTemplate.id === template.id);
-            })
-            .map((template: EmailTemplateType) => {
-                const mappedTemplate: Record<string, string> = emailTemplates
-                    ?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id);
+        const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList
+          ? emailTemplatesList.map((template: EmailTemplateType) => {
+              const mappedTemplate: Record<string, string> | undefined = emailTemplates
+                ?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id);
 
-                return {
-                    ...template,
-                    description: mappedTemplate?.description || `${ template.displayName } Template`,
-                    displayName: mappedTemplate?.displayName || template.displayName
-                };
-            });
+              return {
+                ...template,
+                description: mappedTemplate?.description || `${template.displayName} Template`,
+                displayName: mappedTemplate?.displayName || template.displayName,
+              };
+            })
+          : [];
 
         setAvailableEmailTemplatesList(availableEmailTemplates);
 

--- a/apps/console/src/features/email-management/pages/email-customization.tsx
+++ b/apps/console/src/features/email-management/pages/email-customization.tsx
@@ -33,6 +33,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { TabProps } from "semantic-ui-react";
+import { administratorConfig } from "../../../extensions/configs/administrator";
 import BrandingPreferenceProvider from "../../branding/providers/branding-preference-provider";
 import { AppConstants, AppState, FeatureConfigInterface, I18nConstants } from "../../core";
 import { history } from "../../core/helpers";
@@ -100,9 +101,15 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
         // the deployment.toml file. The below code will map the email template
         // types with the config's displayName and description.
         const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList
-            ? emailTemplatesList.map((template: EmailTemplateType) => {
-                const mappedTemplate: Record<string, string> | undefined = emailTemplates
-                    ?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id);
+            ? (!administratorConfig.enableEmailCustomTemplate
+                ? emailTemplatesList.filter((template: EmailTemplateType) =>
+                    emailTemplates?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id)
+                )
+                : emailTemplatesList
+            ).map((template: EmailTemplateType) => {
+                const mappedTemplate: Record<string, string> = emailTemplates?.find(
+                    (emailTemplate: Record<string, string>) => emailTemplate.id === template.id
+                );
 
                 return {
                     ...template,

--- a/apps/console/src/features/email-management/pages/email-customization.tsx
+++ b/apps/console/src/features/email-management/pages/email-customization.tsx
@@ -100,17 +100,17 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
         // the deployment.toml file. The below code will map the email template
         // types with the config's displayName and description.
         const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList
-          ? emailTemplatesList.map((template: EmailTemplateType) => {
-              const mappedTemplate: Record<string, string> | undefined = emailTemplates
-                ?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id);
+            ? emailTemplatesList.map((template: EmailTemplateType) => {
+                const mappedTemplate: Record<string, string> | undefined = emailTemplates
+                    ?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id);
 
-              return {
-                ...template,
-                description: mappedTemplate?.description || `${template.displayName} Template`,
-                displayName: mappedTemplate?.displayName || template.displayName,
-              };
+                return {
+                    ...template,
+                    description: mappedTemplate?.description || `${template.displayName} Template`,
+                    displayName: mappedTemplate?.displayName || template.displayName
+                };
             })
-          : [];
+            : [];
 
         setAvailableEmailTemplatesList(availableEmailTemplates);
 

--- a/apps/console/src/features/email-management/pages/email-customization.tsx
+++ b/apps/console/src/features/email-management/pages/email-customization.tsx
@@ -78,6 +78,7 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
         (state: AppState) => state.config.deployment.extensions.emailTemplates) as Record<string, string>[];
 
     const dispatch: Dispatch = useDispatch();
+    const isEnableCustomEmailTemplates: boolean = window[ "AppUtils" ]?.getConfig()?.ui?.enableEmailCustomTemplate;
     const { t } = useTranslation();
     const { getLink } = useDocumentation();
 
@@ -101,7 +102,7 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
         // the deployment.toml file. The below code will map the email template
         // types with the config's displayName and description.
         const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList
-            ? (!administratorConfig.enableEmailCustomTemplate
+            ? (!isEnableCustomEmailTemplates
                 ? emailTemplatesList.filter((template: EmailTemplateType) =>
                     emailTemplates?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id)
                 )

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -220,6 +220,7 @@
             "defaultWhiteLogoUrl": "/libs/themes/default/assets/images/branding/logo-white.svg"
         },
         "appFaviconPath": "/assets/images/branding/favicon.ico",
+        "enableEmailCustomTemplate": true,
         "isGOTEnabledForSuperTenantOnly": true,
         "showAppSwitchButton": true,
         "features": {


### PR DESCRIPTION
### Purpose
> Even though we receive custom email types from the API, we only display the templates that exist in the config file. As a result, custom templates don't display in the browser. To resolve this issue, we are removing the filter from availableEmailTemplates

### Related Issues
- https://github.com/wso2/product-is/issues/17250

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
