### PR TITLE
Unify self signup UX

### DIFF
--- a/.changeset/thirty-eagles-guess.md
+++ b/.changeset/thirty-eagles-guess.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Unify self signup UX

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -664,27 +664,6 @@
         </div>
     </div>
 
-    <% if (isSelfSignUpEPAvailable && !isIdentifierFirstLogin(inputType) && !isLoginHintAvailable(inputType) && isSelfSignUpEnabledInTenant && isSelfSignUpEnabledInTenantPreferences) { %>
-        <div class="mt-0">
-            <div class="buttons">
-                <button
-                    type="button"
-                    <% if(StringUtils.isNotBlank(selfSignUpOverrideURL)) { %>
-                    onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(selfSignUpOverrideURL)%>';"
-                    <% } else { %>
-                    onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(getRegistrationUrl(accountRegistrationEndpointURL, srURLEncodedURL, urlParameters))%>';"
-                    <% } %>
-                    class="ui large fluid button secondary"
-                    id="registerLink"
-                    role="button"
-                    data-testid="login-page-create-account-button"
-                >
-                    <%=AuthenticationEndpointUtil.i18n(resourceBundle, "create.an.account")%>
-                </button>
-            </div>
-        </div>
-    <% } %>
-
     <% if (isIdentifierFirstLogin(inputType) && !StringUtils.equals("true", promptAccountLinking)) { %>
         <div class="field external-link-container text-small mt-4">
             <%=AuthenticationEndpointUtil.i18n(resourceBundle, "not.you")%>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -1033,10 +1033,7 @@
                     <% }
                     String clientId = request.getParameter("client_id");
                     String urlParameters = "";
-                    if ((StringUtils.equals("CONSOLE",clientId)
-                            || (StringUtils.equals("MY_ACCOUNT",clientId)
-                            && StringUtils.equals(tenantForTheming, IdentityManagementEndpointConstants.SUPER_TENANT)))
-                            && !StringUtils.equals("true", promptAccountLinking)) {
+                    if (!StringUtils.equals("true", promptAccountLinking)) {
                             String recoveryEPAvailable = application.getInitParameter("EnableRecoveryEndpoint");
                             String enableSelfSignUpEndpoint = application.getInitParameter("EnableSelfSignUpEndpoint");
                             Boolean isRecoveryEPAvailable = false;
@@ -1070,6 +1067,8 @@
                                 }
                             }
                         %>
+
+                        <% if (isSelfSignUpEPAvailable && !isIdentifierFirstLogin(inputType) && !isLoginHintAvailable(inputType) && isSelfSignUpEnabledInTenant && isSelfSignUpEnabledInTenantPreferences) { %>
                             <div class="mt-4">
                                 <div class="mt-3 external-link-container text-small">
                                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "dont.have.an.account")%>
@@ -1086,6 +1085,8 @@
                                     </a>
                                 </div>
                             </div>
+                        <% } %>
+
                             <% }
                             if (!StringUtils.equals("CONSOLE",clientId)
                                     && !StringUtils.equals("MY_ACCOUNT",clientId) && !hasLocalLoginOptions && hasFederatedOptions &&


### PR DESCRIPTION
### Purpose

$subject

With this change, when the self signup enabled, the option to create a new account will be displayed as follows.

<img width="1505" alt="Screenshot 2023-10-27 at 07 48 58" src="https://github.com/wso2/identity-apps/assets/41533942/d7b77462-88fa-4cbb-b812-aec8b8ff39a7">

### Related Issues
- https://github.com/wso2/product-is/issues/17159

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
