### PR TITLE
Increase the limit value of application fetch request when mapping application roles with application names

### DIFF
--- a/apps/console/src/features/application-roles/pages/application-roles.tsx
+++ b/apps/console/src/features/application-roles/pages/application-roles.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/features/application-roles/pages/application-roles.tsx
+++ b/apps/console/src/features/application-roles/pages/application-roles.tsx
@@ -119,7 +119,7 @@ const ApplicationRolesPage = (props: ApplicationRolesPageInterface): ReactElemen
             return;
         }
 
-        getApplicationList(null, null, null)
+        getApplicationList(100, null, null)
             .then((response: ApplicationListInterface) => {
                 mapApplicationListWithApplicationRoles(response.applications, roles);
                 setError(false);


### PR DESCRIPTION
### Purpose
This PR increases the limit value of application fetch request when mapping application roles with application names. It will resolve the issue https://github.com/wso2-enterprise/wso2-iam-internal/issues/933 where some of the applications are not fetched when displaying the application roles because the default limit value of application fetch request is 30.

This is a temporary fix which will be properly fixed once the authorization server is unified with Asgardeo instead of being a separate microservice.

### Related Issues
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/933
- https://github.com/wso2-enterprise/asgardeo-product/issues/20206

### Related PRs
- https://github.com/wso2-enterprise/asgardeo-apps/pull/848

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
