### PR TITLE
Fix connection password field remain required even if the field disabled

### DIFF
--- a/.changeset/sour-cows-kick.md
+++ b/.changeset/sour-cows-kick.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix connection password field remain required even if the field disabled

--- a/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-connection-details-user-store.tsx
@@ -325,7 +325,7 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
                                                         type="password"
                                                         disabled={ !isPasswordEditing }
                                                         key={ index }
-                                                        required={ true }
+                                                        required={ isPasswordEditing }
                                                         label={ name }
                                                         requiredErrorMessage={
                                                             `${property.description.split("#")[ 0 ]} is  required`


### PR DESCRIPTION
### Purpose

$subject

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
