### PR TITLE
Fix API Resource UI access control to support system APIs

### DIFF
--- a/.changeset/metal-clouds-flash.md
+++ b/.changeset/metal-clouds-flash.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix API Resource UI access control to support system APIs

--- a/apps/console/src/features/api-resources/components/api-resource-panes/permission-api-resource.tsx
+++ b/apps/console/src/features/api-resources/components/api-resource-panes/permission-api-resource.tsx
@@ -137,7 +137,7 @@ export const PermissionAPIResource: FunctionComponent<PermissionAPIResourceInter
                     </Grid>
                     <Grid xs={ 4 } alignItems="flex-end">
                         {
-                            permissionList?.length !== 0
+                            permissionList?.length !== 0 && !isReadOnly
                                 && (<PrimaryButton
                                     data-componentid={ `${componentId}-add-permission-button` }
                                     size="medium"

--- a/apps/console/src/features/api-resources/constants/api-resources-constants.ts
+++ b/apps/console/src/features/api-resources/constants/api-resources-constants.ts
@@ -37,6 +37,11 @@ export class APIResourcesConstants {
     public static readonly DEFAULT_TOTAL_PAGES: number = 10;
     public static readonly API_RESOURCE_DIR: string = "api-resources";
 
+    // API Resource types.
+    public static readonly SYSTEM: string = "SYSTEM";
+    public static readonly SYSTEM_ORG: string = "SYSTEM_ORG";
+    public static readonly SYSTEM_FEATURE: string = "SYSTEM_FEATURE";
+
     /**
      * Get the API resource paths as a map.
      *

--- a/apps/console/src/features/api-resources/models/api-resources.ts
+++ b/apps/console/src/features/api-resources/models/api-resources.ts
@@ -58,6 +58,10 @@ export interface APIResourceInterface {
      */
     requiresAuthorization?: boolean;
     /**
+     * Type of the API resource.
+     */
+    type?: string;
+    /**
      * List of scopes associate with the API resource.
      */
     scopes?: APIResourcePermissionInterface[],

--- a/apps/console/src/features/api-resources/pages/api-resource-edit.tsx
+++ b/apps/console/src/features/api-resources/pages/api-resource-edit.tsx
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertInterface, AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmptyPlaceholder, TabPageLayout } from "@wso2is/react-components";
@@ -28,6 +27,7 @@ import { AppState, FeatureConfigInterface,getEmptyPlaceholderIllustrations, hist
 import { useAPIResourceDetails } from "../api";
 import { EditAPIResource } from "../components";
 import { APIResourcesConstants } from "../constants";
+import { APIResourceUtils } from "../utils/api-resource-utils";
 
 /**
  * Prop-types for the API resources page component.
@@ -75,8 +75,10 @@ const APIResourcesEditPage: FunctionComponent<APIResourcesEditPageInterface> = (
      * The following useEffect is used to handle if the user has the required scopes to update the API resource
      */
     useEffect(() => {
-        if (!hasRequiredScopes(
-            featureConfig?.apiResources, featureConfig?.apiResources?.scopes?.update, allowedScopes)) {
+        const updateForbidden: boolean = !APIResourceUtils.isAPIResourceUpdateAllowed(featureConfig, allowedScopes);
+        const isSytemAPIResource: boolean = APIResourceUtils.isSystemAPI(apiResourceData?.type);
+
+        if (updateForbidden || isSytemAPIResource) {
             setReadOnly(true);
         }
     }, [ apiResourceData ]);

--- a/apps/console/src/features/api-resources/utils/api-resource-utils.ts
+++ b/apps/console/src/features/api-resources/utils/api-resource-utils.ts
@@ -17,8 +17,8 @@
  */
 
 import { hasRequiredScopes } from "@wso2is/core/helpers";
-import { APIResourcesConstants } from "../constants/api-resources-constants";
 import { FeatureConfigInterface } from "../../core";
+import { APIResourcesConstants } from "../constants/api-resources-constants";
 
 export class APIResourceUtils {
 
@@ -96,4 +96,4 @@ export class APIResourceUtils {
             || type === APIResourcesConstants.SYSTEM_ORG
             || type === APIResourcesConstants.SYSTEM_FEATURE;
     }
- }
+}

--- a/apps/console/src/features/api-resources/utils/api-resource-utils.ts
+++ b/apps/console/src/features/api-resources/utils/api-resource-utils.ts
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { hasRequiredScopes } from "@wso2is/core/helpers";
+import { APIResourcesConstants } from "../constants/api-resources-constants";
+import { FeatureConfigInterface } from "../../core";
+
+export class APIResourceUtils {
+
+    /**
+     * Private constructor to avoid object instantiation from outside
+     * the class.
+     */
+    private constructor() { }
+
+    /**
+     * Check whether the API resource read is allowed.
+     * 
+     * @param featureConfig - Feature config.
+     * @param allowedScopes - Allowed scopes.
+     * @returns True if the API resource read is allowed.
+     */
+    public static isAPIResourceReadAllowed(featureConfig: FeatureConfigInterface,
+        allowedScopes: string): boolean {
+
+        return hasRequiredScopes(featureConfig?.apiResources,
+            featureConfig?.apiResources?.scopes?.read, allowedScopes);
+    }
+
+    /**
+     * Check whether the API resource update is allowed.
+     * 
+     * @param featureConfig - Feature config.
+     * @param allowedScopes - Allowed scopes.
+     * @returns True if the API resource update is allowed.
+     */
+    public static isAPIResourceUpdateAllowed(featureConfig: FeatureConfigInterface,
+        allowedScopes: string): boolean {
+
+        return hasRequiredScopes(featureConfig?.apiResources,
+            featureConfig?.apiResources?.scopes?.update, allowedScopes);
+    }
+
+    /**
+     * Check whether the API resource create is allowed.
+     * 
+     * @param featureConfig - Feature config.
+     * @param allowedScopes - Allowed scopes.
+     * @returns True if the API resource create is allowed.
+     */
+    public static isAPIResourceCreateAllowed(featureConfig: FeatureConfigInterface,
+        allowedScopes: string): boolean {
+
+        return hasRequiredScopes(featureConfig?.apiResources,
+            featureConfig?.apiResources?.scopes?.create, allowedScopes);
+    }
+
+    /**
+     * Check whether the API resource delete is allowed.
+     * 
+     * @param featureConfig - Feature config.
+     * @param allowedScopes - Allowed scopes.
+     * @returns True if the API resource delete is allowed.
+     */
+    public static isAPIResourceDeleteAllowed(featureConfig: FeatureConfigInterface,
+        allowedScopes: string): boolean {
+
+        return hasRequiredScopes(featureConfig?.apiResources,
+            featureConfig?.apiResources?.scopes?.delete, allowedScopes);
+    }
+
+    /**
+     * Check whether the API resource is a system API.
+     * 
+     * @param type - API Resource type.
+     * @returns True if the API resource is a system API.
+     */
+    public static isSystemAPI(type: string): boolean {
+
+        return type === APIResourcesConstants.SYSTEM
+            || type === APIResourcesConstants.SYSTEM_ORG
+            || type === APIResourcesConstants.SYSTEM_FEATURE;
+    }
+ }


### PR DESCRIPTION
### Purpose
> Make system API resources read only in list view and edit view.

Related Issue - https://github.com/wso2/product-is/issues/17238

List view -
<img width="1354" alt="Screenshot 2023-10-27 at 12 48 22" src="https://github.com/wso2/identity-apps/assets/56070320/e181b74a-49fc-4565-85a8-d8fdfbde9e07">

Edit view -
<img width="1352" alt="Screenshot 2023-10-27 at 12 51 07" src="https://github.com/wso2/identity-apps/assets/56070320/8333ec5c-b28a-43f7-a9e8-4b902362b925">
<img width="1346" alt="Screenshot 2023-10-27 at 12 51 11" src="https://github.com/wso2/identity-apps/assets/56070320/2c26e989-2c23-4667-b50d-794ada987782">

