### PR TITLE
Enable SMS OTP as first factor

### DIFF
--- a/.changeset/healthy-ladybugs-peel.md
+++ b/.changeset/healthy-ladybugs-peel.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Enable SMS OTP as first factor

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authentication-step.tsx
@@ -163,7 +163,6 @@ export const AuthenticationStep: FunctionComponent<AuthenticationStepPropsInterf
 
         step.options.map((option: AuthenticatorInterface) => {
             if ([ IdentityProviderManagementConstants.TOTP_AUTHENTICATOR,
-                IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR,
                 IdentityProviderManagementConstants.BACKUP_CODE_AUTHENTICATOR,
                 IdentityProviderManagementConstants.SESSION_EXECUTOR_AUTHENTICATOR ]
                 .includes(option.authenticator)) {

--- a/apps/console/src/features/applications/constants/application-management.ts
+++ b/apps/console/src/features/applications/constants/application-management.ts
@@ -322,7 +322,9 @@ export class ApplicationManagementConstants {
         IdentityProviderManagementConstants.FIDO_AUTHENTICATOR,
         IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR,
         IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID,
-        IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR
+        IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR,
+        IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR,
+        IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID
     ];
 
     // Second factor authenticators.
@@ -360,6 +362,11 @@ export class ApplicationManagementConstants {
     public static readonly EMAIL_OTP_HANDLERS: string[] = [
         ...ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS,
         ...ApplicationManagementConstants.SOCIAL_AUTHENTICATORS
+    ];
+
+    // Authenticators that can handle SMS OTP.
+    public static readonly SMS_OTP_HANDLERS: string[] = [
+        ...ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS
     ];
 
     // Enterprise EIDP Authenticators

--- a/apps/console/src/features/applications/utils/sign-in-method-utils.ts
+++ b/apps/console/src/features/applications/utils/sign-in-method-utils.ts
@@ -208,6 +208,11 @@ export class SignInMethodUtils {
             return this.hasSpecificFactorsInSteps(ApplicationManagementConstants.EMAIL_OTP_HANDLERS, leftSideSteps);
         }
 
+        // If the adding authenticator is SMS OTP, evaluate if there are valid handlers in previous steps.
+        if (authenticatorId === IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID) {
+            return this.hasSpecificFactorsInSteps(ApplicationManagementConstants.SMS_OTP_HANDLERS, leftSideSteps);
+        }
+
         return this.hasSpecificFactorsInSteps(ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS,
             leftSideSteps);
     }

--- a/apps/console/src/features/authentication-flow-builder/providers/authentication-flow-provider.tsx
+++ b/apps/console/src/features/authentication-flow-builder/providers/authentication-flow-provider.tsx
@@ -345,26 +345,23 @@ const AuthenticationFlowProvider = (props: PropsWithChildren<AuthenticationFlowP
             // TODO: setShowHandlerDisclaimerModal(true);
         }
 
+        const isFirstFactorAuth: boolean = 
+            ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS.includes(authenticatorId);
+        const isSecondFactorAuth: boolean = 
+            ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticatorId);
+        const isValidSecondFactorAddition: boolean = SignInMethodUtils.isSecondFactorAdditionValid(
+            authenticator.defaultAuthenticator.authenticatorId,
+            stepIndex,
+            steps
+        );
+        
         // If the adding option is a second factor, and if the adding step is the first or there are no
         // first factor authenticators in previous steps, show a warning and stop adding the option.
-        if (
-            (ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticatorId)
-            && !ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS.includes(authenticatorId)
-            && (stepIndex === 0 
-                || !SignInMethodUtils.isSecondFactorAdditionValid(
-                    authenticator.defaultAuthenticator.authenticatorId,
-                    stepIndex,
-                    steps
-                ))) 
-            || (
-                ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticatorId)
-                && ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS.includes(authenticatorId)
-                && (stepIndex !== 0 
-                    && !SignInMethodUtils.isSecondFactorAdditionValid(
-                        authenticator.defaultAuthenticator.authenticatorId,
-                        stepIndex,
-                        steps
-                    ))
+        if ( 
+            isSecondFactorAuth
+            && (
+                (!isFirstFactorAuth && (stepIndex === 0 || !isValidSecondFactorAddition))
+                || (isFirstFactorAuth && stepIndex !== 0 && !isValidSecondFactorAddition)
             )
         ) {
             dispatch(

--- a/apps/console/src/features/authentication-flow-builder/providers/authentication-flow-provider.tsx
+++ b/apps/console/src/features/authentication-flow-builder/providers/authentication-flow-provider.tsx
@@ -348,13 +348,24 @@ const AuthenticationFlowProvider = (props: PropsWithChildren<AuthenticationFlowP
         // If the adding option is a second factor, and if the adding step is the first or there are no
         // first factor authenticators in previous steps, show a warning and stop adding the option.
         if (
-            ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticatorId) &&
-            (stepIndex === 0 ||
-                !SignInMethodUtils.isSecondFactorAdditionValid(
+            (ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticatorId)
+            && !ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS.includes(authenticatorId)
+            && (stepIndex === 0 
+                || !SignInMethodUtils.isSecondFactorAdditionValid(
                     authenticator.defaultAuthenticator.authenticatorId,
                     stepIndex,
                     steps
-                ))
+                ))) 
+            || (
+                ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticatorId)
+                && ApplicationManagementConstants.FIRST_FACTOR_AUTHENTICATORS.includes(authenticatorId)
+                && (stepIndex !== 0 
+                    && !SignInMethodUtils.isSecondFactorAdditionValid(
+                        authenticator.defaultAuthenticator.authenticatorId,
+                        stepIndex,
+                        steps
+                    ))
+            )
         ) {
             dispatch(
                 addAlert({


### PR DESCRIPTION
### Purpose

$subject

This fix enables the following two configurations for the sign-in steps.

- SMS OTP as the primary factor
<img width="1154" alt="Screenshot 2023-10-27 at 17 57 52" src="https://github.com/wso2/identity-apps/assets/28347418/dec08b77-6ad2-4ac6-b38a-0714524f72e0">

- Identifier First + SMS OTP
<img width="1183" alt="Screenshot 2023-10-27 at 17 58 10" src="https://github.com/wso2/identity-apps/assets/28347418/a3602c65-5b33-4fa3-84dc-b1ce920183a0">

### Related Issues
- https://github.com/wso2/product-is/issues/16383

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
