### PR TITLE
Keep last selected tab active upon refresh when editing groups

### DIFF
--- a/.changeset/warm-students-hammer.md
+++ b/.changeset/warm-students-hammer.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add group management context. Keep last selected tab active upon refresh when editing groups.

--- a/apps/console/src/features/groups/components/edit-group/edit-group.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group.tsx
@@ -23,6 +23,7 @@ import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } 
 import { useTranslation } from "react-i18next";
 // TODO: Move to shared components.
 import { useSelector } from "react-redux";
+import { TabProps } from "semantic-ui-react";
 import { BasicGroupDetails } from "./edit-group-basic";
 import { EditGroupRoles } from "./edit-group-roles";
 import { GroupUsersList } from "./edit-group-users";
@@ -33,6 +34,7 @@ import { OrganizationUtils } from "../../../organizations/utils";
 import { getUsersList } from "../../../users/api";
 import { UserBasicInterface, UserListInterface } from "../../../users/models";
 import { GroupConstants } from "../../constants";
+import useGroupManagement from "../../hooks/use-group-management";
 import { GroupsInterface, GroupsMemberInterface } from "../../models";
 
 /**
@@ -78,6 +80,7 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
     } = props;
 
     const { t } = useTranslation();
+    const { activeTab, updateActiveTab } = useGroupManagement();
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
 
@@ -213,7 +216,12 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
 
     return (
         <ResourceTab
-            isLoading={ isLoading } 
-            panes={ resolveResourcePanes() } />
+            activeIndex={ activeTab }
+            isLoading={ isLoading }
+            onTabChange={ (event: React.MouseEvent<HTMLDivElement>, data: TabProps) => {
+                updateActiveTab(data.activeIndex as number);
+            } }
+            panes={ resolveResourcePanes() }
+        />
     );
 };

--- a/apps/console/src/features/groups/context/group-management-context.tsx
+++ b/apps/console/src/features/groups/context/group-management-context.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Context, createContext } from "react";
+
+/**
+ * Props interface for GroupManagementContext.
+ */
+export interface GroupManagementContextProps {
+    /**
+     * Active tab id.
+     */
+    activeTab: number;
+    /**
+     * Update active tab.
+     * @param tab - Active tab id.
+     */
+    updateActiveTab: (tab: number) => void;
+}
+
+/**
+ * Context object for managing groups.
+ */
+const GroupManagementContext: Context<GroupManagementContextProps> =
+    createContext< null | GroupManagementContextProps >(null);
+
+/**
+ * Display name for the GroupManagementContext.
+ */
+GroupManagementContext.displayName = "GroupManagementContext";
+
+export default GroupManagementContext;

--- a/apps/console/src/features/groups/hooks/use-group-management.ts
+++ b/apps/console/src/features/groups/hooks/use-group-management.ts
@@ -32,7 +32,7 @@ const useGroupManagement = (): UseGroupManagementInterface => {
     const context: GroupManagementContextProps = useContext(GroupManagementContext);
 
     if (context === undefined) {
-        throw new Error("UseGroupManagement must be used within a GroupManagementProvider");
+        throw new Error("useGroupManagement must be used within a GroupManagementProvider");
     }
 
     return context;

--- a/apps/console/src/features/groups/hooks/use-group-management.ts
+++ b/apps/console/src/features/groups/hooks/use-group-management.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useContext } from "react";
+import GroupManagementContext, { GroupManagementContextProps } from "../context/group-management-context";
+
+/**
+ * Interface for the return type of the `useGroupManagement` hook.
+ */
+export type UseGroupManagementInterface = GroupManagementContextProps;
+
+/**
+ * Hook that provides access to the group management context.
+ * @returns An object containing the group management context.
+ */
+const useGroupManagement = (): UseGroupManagementInterface => {
+    const context: GroupManagementContextProps = useContext(GroupManagementContext);
+
+    if (context === undefined) {
+        throw new Error("UseGroupManagement must be used within a GroupManagementProvider");
+    }
+
+    return context;
+};
+
+export default useGroupManagement;

--- a/apps/console/src/features/groups/pages/group-edit.tsx
+++ b/apps/console/src/features/groups/pages/group-edit.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,6 +25,7 @@ import { AppConstants, AppState, FeatureConfigInterface, history } from "../../c
 import { getGroupById } from "../api";
 import { EditGroup } from "../components";
 import { GroupsInterface } from "../models";
+import GroupManagementProvider from "../providers/group-management-provider";
 
 const GroupEditPage: FunctionComponent<any> = (): ReactElement => {
 
@@ -72,29 +73,31 @@ const GroupEditPage: FunctionComponent<any> = (): ReactElement => {
     };
 
     return (
-        <TabPageLayout
-            isLoading={ isGroupDetailsRequestLoading }
-            title={
-                group && group.displayName ?
-                    group.displayName :
-                    t("console:manage.pages.groupsEdit.title")
-            }
-            pageTitle={ t("console:manage.pages.groupsEdit.title") }
-            backButton={ {
-                onClick: handleBackButtonClick,
-                text: t("console:manage.pages.groupsEdit.backButton", { type: "groups" })
-            } }
-            titleTextAlign="left"
-            bottomMargin={ false }
-        >
-            <EditGroup
+        <GroupManagementProvider>
+            <TabPageLayout
                 isLoading={ isGroupDetailsRequestLoading }
-                group={ group }
-                groupId={ roleId }
-                onGroupUpdate={ onGroupUpdate }
-                featureConfig={ featureConfig }
-            />
-        </TabPageLayout>
+                title={
+                    group && group.displayName ?
+                        group.displayName :
+                        t("console:manage.pages.rolesEdit.title")
+                }
+                pageTitle={ t("console:manage.pages.rolesEdit.title") }
+                backButton={ {
+                    onClick: handleBackButtonClick,
+                    text: t("console:manage.pages.rolesEdit.backButton", { type: "groups" })
+                } }
+                titleTextAlign="left"
+                bottomMargin={ false }
+            >
+                <EditGroup
+                    isLoading={ isGroupDetailsRequestLoading }
+                    group={ group }
+                    groupId={ roleId }
+                    onGroupUpdate={ onGroupUpdate }
+                    featureConfig={ featureConfig }
+                />
+            </TabPageLayout>
+        </GroupManagementProvider>
     );
 };
 

--- a/apps/console/src/features/groups/providers/group-management-provider.tsx
+++ b/apps/console/src/features/groups/providers/group-management-provider.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent, PropsWithChildren, ReactElement, useState } from "react";
+import GroupManagementContext from "../context/group-management-context";
+
+/**
+ * Props interface for the Group management provider.
+ */
+export type GroupManagementProviderProps = PropsWithChildren;
+
+/**
+ * React context provider for the group management context.
+ * This provider must be added at the root of the features to make the context available throughout the feature.
+ *
+ * @example
+ * <GroupManagementProvider>
+ *    <Feature />
+ * </GroupManagementProvider>
+ *
+ * @param props - Props injected to the component.
+ * @returns Group management context instance.
+ */
+const GroupManagementProvider: FunctionComponent<GroupManagementProviderProps> = (
+    props: GroupManagementProviderProps
+): ReactElement => {
+    const { children } = props;
+    const [ activeTab, setActiveTab ] = useState<number>(0);
+
+    return (
+        <GroupManagementContext.Provider
+            value={ {
+                activeTab,
+                updateActiveTab: setActiveTab
+            } }
+        >
+            { children }
+        </GroupManagementContext.Provider>
+    );
+};
+
+export default GroupManagementProvider;


### PR DESCRIPTION
### Purpose
- Keep last selected tab active upon refresh when editing groups.
- Add group management context.

### Related Issues
- wso2/product-is#17318

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
