### PR TITLE
Keep last selected tab active upon refresh when editing users

### DIFF
--- a/.changeset/early-tigers-hunt.md
+++ b/.changeset/early-tigers-hunt.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add user management context. Keep last selected tab active upon refresh when editing users.

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -27,6 +27,7 @@ import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
+import { TabProps } from "semantic-ui-react";
 import { UserGroupsList } from "./user-groups-edit";
 import { UserProfile } from "./user-profile";
 import { UserRolesList } from "./user-roles-list";
@@ -38,6 +39,7 @@ import { AppState, store } from "../../core/store";
 import { useGetCurrentOrganizationType } from "../../organizations/hooks/use-get-organization-type";
 import { ConnectorPropertyInterface } from "../../server-configurations/models";
 import { UserManagementConstants } from "../constants";
+import useUserManagement from "../hooks/use-user-management";
 
 interface EditUserPropsInterface extends SBACInterface<FeatureConfigInterface> {
     /**
@@ -86,6 +88,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     } = props;
 
     const { t } = useTranslation();
+    const { activeTab, updateActiveTab } = useUserManagement();
     const dispatch: Dispatch = useDispatch();
     const { isSuperOrganization } = useGetCurrentOrganizationType();
 
@@ -258,7 +261,11 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
 
     return (
         <ResourceTab
+            activeIndex={ activeTab }
             isLoading={ isLoading }
+            onTabChange={ (event: React.MouseEvent<HTMLDivElement>, data: TabProps) => {
+                updateActiveTab(data.activeIndex as number);
+            } }
             panes={ panes() }
         />
     );

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -109,7 +109,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     useEffect(() => {
         //Since the parent component is refreshing twice we are doing a deep equals operation on the user object to
         //see if they are the same values. If they are the same values we do not do anything.
-        //This makes sure the child components or side effects depending on the user object won't 
+        //This makes sure the child components or side effects depending on the user object won't
         //re-render or re-trigger.
         if (!selectedUser || isEqual(user, selectedUser)) {
             return;

--- a/apps/console/src/features/users/context/user-management-context.tsx
+++ b/apps/console/src/features/users/context/user-management-context.tsx
@@ -36,7 +36,7 @@ export interface UserManagementContextProps {
 /**
  * Context object for managing users.
  */
-const UserManagementContext: Context<UserManagementContextProps> = 
+const UserManagementContext: Context<UserManagementContextProps> =
     createContext< null | UserManagementContextProps >(null);
 
 /**

--- a/apps/console/src/features/users/context/user-management-context.tsx
+++ b/apps/console/src/features/users/context/user-management-context.tsx
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Context, createContext } from "react";
+
+/**
+ * Props interface for UserManagementContext.
+ */
+export interface UserManagementContextProps {
+    /**
+     * Active tab id.
+     */
+    activeTab: number;
+    /**
+     * Update active tab.
+     * @param tab - Active tab id.
+     */
+    updateActiveTab: (tab: number) => void;
+}
+
+/**
+ * Context object for managing users.
+ */
+const UserManagementContext: Context<UserManagementContextProps> = 
+    createContext< null | UserManagementContextProps >(null);
+
+/**
+ * Display name for the UserManagementContext.
+ */
+UserManagementContext.displayName = "UserManagementContext";
+
+export default UserManagementContext;

--- a/apps/console/src/features/users/hooks/use-user-management.ts
+++ b/apps/console/src/features/users/hooks/use-user-management.ts
@@ -32,7 +32,7 @@ const useUserManagement = (): UseUserManagementInterface => {
     const context: UserManagementContextProps = useContext(UserManagementContext);
 
     if (context === undefined) {
-        throw new Error("UseUserManagement must be used within a UserManagementProvider");
+        throw new Error("useUserManagement must be used within a UserManagementProvider");
     }
 
     return context;

--- a/apps/console/src/features/users/hooks/use-user-management.ts
+++ b/apps/console/src/features/users/hooks/use-user-management.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useContext } from "react";
+import UserManagementContext, { UserManagementContextProps } from "../context/user-management-context";
+
+/**
+ * Interface for the return type of the `useUserManagement` hook.
+ */
+export type UseUserManagementInterface = UserManagementContextProps;
+
+/**
+ * Hook that provides access to the user management context.
+ * @returns An object containing the user management context.
+ */
+const useUserManagement = (): UseUserManagementInterface => {
+    const context: UserManagementContextProps = useContext(UserManagementContext);
+
+    if (context === undefined) {
+        throw new Error("UseUserManagement must be used within a UserManagementProvider");
+    }
+
+    return context;
+};
+
+export default useUserManagement;

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -367,8 +367,8 @@ const UserEditPage = (): ReactElement => {
                                                     }
                                                 >
                                                     It seems like the selected email is not registered on Gravatar.
-                                                    Sign up for a Gravatar account by visiting 
-                                                    <a href="https://www.gravatar.com"> Gravatar Official Website</a> 
+                                                    Sign up for a Gravatar account by visiting
+                                                    <a href="https://www.gravatar.com"> Gravatar Official Website</a>
                                                     or use one of the following.
                                                 </Trans>
                                             ),

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -39,6 +39,7 @@ import { ServerConfigurationsConstants } from "../../server-configurations/const
 import { ConnectorPropertyInterface, GovernanceConnectorInterface } from "../../server-configurations/models";
 import { getUserDetails, updateUserInfo } from "../api";
 import { EditUser } from "../components/edit-user";
+import UserManagementProvider from "../providers/user-management-provider";
 import { UserManagementUtils } from "../utils";
 
 /**
@@ -251,173 +252,179 @@ const UserEditPage = (): ReactElement => {
     };
 
     return (
-        <TabPageLayout
-            isLoading={ isUserDetailsRequestLoading }
-            title={ (
-                <>
-                    {
-                        user?.active !== undefined
-                            ? (
-                                <>
-                                    {
-                                        user?.active
-                                            ? (
-                                                <Popup
-                                                    trigger={ (
-                                                        <Icon
-                                                            className="mr-2 ml-0 vertical-aligned-baseline"
-                                                            size="small"
-                                                            name="circle"
-                                                            color="green"
-                                                        />
-                                                    ) }
-                                                    content={ t("common:enabled") }
-                                                    inverted
-                                                />
-                                            ) : (
-                                                <Popup
-                                                    trigger={ (
-                                                        <Icon
-                                                            className="mr-2 ml-0 vertical-aligned-baseline"
-                                                            size="small"
-                                                            name="circle"
-                                                            color="orange"
-                                                        />
-                                                    ) }
-                                                    content={ t("common:disabled") }
-                                                    inverted
-                                                />
-                                            )
-                                    }
-                                    { resolveUserDisplayName(user, null, "Administrator") }
-
-                                </>
-                            ) : (
-                                <>
-                                    { resolveUserDisplayName(user, null, "Administrator") }
-                                </>
-                            )
-                    }
-                </>
-            ) }
-            pageTitle="Edit User"
-            description={ t("" + user.emails && user.emails !== undefined ? resolvePrimaryEmail(user?.emails) :
-                user.userName) }
-            image={ (
-                <UserAvatar
-                    editable={
-                        hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
-                    }
-                    name={ resolveUserDisplayName(user) }
-                    size="tiny"
-                    image={ user?.profileUrl }
-                    onClick={ () =>
-                        hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
-                        && setShowEditAvatarModal(true)
-                    }
-                />
-            ) }
-            loadingStateOptions={ {
-                count: 5,
-                imageType: "circular"
-            } }
-            backButton={ {
-                "data-testid": "user-mgt-edit-user-back-button",
-                onClick: handleBackButtonClick,
-                text: getBackButtonText()
-            } }
-            titleTextAlign="left"
-            bottomMargin={ false }
-        >
-            <EditUser
-                featureConfig={ featureConfig }
-                user={ user }
-                handleUserUpdate={ handleUserUpdate }
-                readOnlyUserStores={ readOnlyUserStoresList }
-                connectorProperties={ connectorProperties }
+        <UserManagementProvider>
+            <TabPageLayout
                 isLoading={ isUserDetailsRequestLoading }
-                isReadOnlyUserStoresLoading={ isReadOnlyUserStoresLoading }
-            />
-            {
-                showEditAvatarModal && (
-                    <EditAvatarModal
-                        open={ showEditAvatarModal }
+                title={ (
+                    <>
+                        {
+                            user?.active !== undefined
+                                ? (
+                                    <>
+                                        {
+                                            user?.active
+                                                ? (
+                                                    <Popup
+                                                        trigger={ (
+                                                            <Icon
+                                                                className="mr-2 ml-0 vertical-aligned-baseline"
+                                                                size="small"
+                                                                name="circle"
+                                                                color="green"
+                                                            />
+                                                        ) }
+                                                        content={ t("common:enabled") }
+                                                        inverted
+                                                    />
+                                                ) : (
+                                                    <Popup
+                                                        trigger={ (
+                                                            <Icon
+                                                                className="mr-2 ml-0 vertical-aligned-baseline"
+                                                                size="small"
+                                                                name="circle"
+                                                                color="orange"
+                                                            />
+                                                        ) }
+                                                        content={ t("common:disabled") }
+                                                        inverted
+                                                    />
+                                                )
+                                        }
+                                        { resolveUserDisplayName(user, null, "Administrator") }
+
+                                    </>
+                                ) : (
+                                    <>
+                                        { resolveUserDisplayName(user, null, "Administrator") }
+                                    </>
+                                )
+                        }
+                    </>
+                ) }
+                pageTitle="Edit User"
+                description={ t("" + user.emails && user.emails !== undefined ? resolvePrimaryEmail(user?.emails) :
+                    user.userName) }
+                image={ (
+                    <UserAvatar
+                        editable={
+                            hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
+                        }
                         name={ resolveUserDisplayName(user) }
-                        emails={ resolveUserEmails(user?.emails) }
-                        onClose={ () => setShowEditAvatarModal(false) }
-                        closeOnDimmerClick={ false }
-                        onCancel={ () => setShowEditAvatarModal(false) }
-                        onSubmit={ handleAvatarEditModalSubmit }
-                        imageUrl={ profileInfo?.profileUrl }
-                        isSubmitting={ isSubmitting }
-                        heading={ t("console:common.modals.editAvatarModal.heading") }
-                        submitButtonText={ t("console:common.modals.editAvatarModal.primaryButton") }
-                        cancelButtonText={ t("console:common.modals.editAvatarModal.secondaryButton") }
-                        translations={ {
-                            gravatar: {
-                                errors: {
-                                    noAssociation: {
-                                        content: (
-                                            <Trans
-                                                i18nKey={
-                                                    "console:common.modals.editAvatarModal.content.gravatar" +
-                                                    "errors.noAssociation.content"
-                                                }
-                                            >
-                                                It seems like the selected email is not registered on Gravatar.
-                                                Sign up for a Gravatar account by visiting 
-                                                <a href="https://www.gravatar.com"> Gravatar Official Website</a> 
-                                                or use one of the following.
-                                            </Trans>
-                                        ),
-                                        header: t("console:common.modals.editAvatarModal.content.gravatar.errors" +
-                                            ".noAssociation.header")
-                                    }
-                                },
-                                heading: t("console:common.modals.editAvatarModal.content.gravatar.heading")
-                            },
-                            hostedAvatar: {
-                                heading: t("console:common.modals.editAvatarModal.content.hostedAvatar.heading"),
-                                input: {
+                        size="tiny"
+                        image={ user?.profileUrl }
+                        onClick={ () =>
+                            hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
+                            && setShowEditAvatarModal(true)
+                        }
+                    />
+                ) }
+                loadingStateOptions={ {
+                    count: 5,
+                    imageType: "circular"
+                } }
+                backButton={ {
+                    "data-testid": "user-mgt-edit-user-back-button",
+                    onClick: handleBackButtonClick,
+                    text: getBackButtonText()
+                } }
+                titleTextAlign="left"
+                bottomMargin={ false }
+            >
+                <EditUser
+                    featureConfig={ featureConfig }
+                    user={ user }
+                    handleUserUpdate={ handleUserUpdate }
+                    readOnlyUserStores={ readOnlyUserStoresList }
+                    connectorProperties={ connectorProperties }
+                    isLoading={ isUserDetailsRequestLoading }
+                    isReadOnlyUserStoresLoading={ isReadOnlyUserStoresLoading }
+                />
+                {
+                    showEditAvatarModal && (
+                        <EditAvatarModal
+                            open={ showEditAvatarModal }
+                            name={ resolveUserDisplayName(user) }
+                            emails={ resolveUserEmails(user?.emails) }
+                            onClose={ () => setShowEditAvatarModal(false) }
+                            closeOnDimmerClick={ false }
+                            onCancel={ () => setShowEditAvatarModal(false) }
+                            onSubmit={ handleAvatarEditModalSubmit }
+                            imageUrl={ profileInfo?.profileUrl }
+                            isSubmitting={ isSubmitting }
+                            heading={ t("console:common.modals.editAvatarModal.heading") }
+                            submitButtonText={ t("console:common.modals.editAvatarModal.primaryButton") }
+                            cancelButtonText={ t("console:common.modals.editAvatarModal.secondaryButton") }
+                            translations={ {
+                                gravatar: {
                                     errors: {
-                                        http: {
-                                            content: t("console:common.modals.editAvatarModal.content." +
-                                                "hostedAvatar.input.errors.http.content"),
-                                            header: t("console:common.modals.editAvatarModal.content." +
-                                                "hostedAvatar.input.errors.http.header")
-                                        },
-                                        invalid: {
-                                            content: t("console:common.modals.editAvatarModal.content." +
-                                                "hostedAvatar.input.errors.invalid.content"),
-                                            pointing: t("console:common.modals.editAvatarModal.content." +
-                                                "hostedAvatar.input.errors.invalid.pointing")
+                                        noAssociation: {
+                                            content: (
+                                                <Trans
+                                                    i18nKey={
+                                                        "console:common.modals.editAvatarModal.content.gravatar" +
+                                                        "errors.noAssociation.content"
+                                                    }
+                                                >
+                                                    It seems like the selected email is not registered on Gravatar.
+                                                    Sign up for a Gravatar account by visiting 
+                                                    <a href="https://www.gravatar.com"> Gravatar Official Website</a> 
+                                                    or use one of the following.
+                                                </Trans>
+                                            ),
+                                            header: t("console:common.modals.editAvatarModal.content.gravatar.errors" +
+                                                ".noAssociation.header")
                                         }
                                     },
-                                    hint: t("console:common.modals.editAvatarModal.content.hostedAvatar.input.hint"),
-                                    placeholder: t("console:common.modals.editAvatarModal.content." +
-                                        "hostedAvatar.input.placeholder"),
-                                    warnings: {
-                                        dataURL: {
-                                            content: t("console:common.modals.editAvatarModal.content." +
-                                                "hostedAvatar.input.warnings.dataURL.content"),
-                                            header: t("console:common.modals.editAvatarModal.content." +
-                                                "hostedAvatar.input.warnings.dataURL.header")
+                                    heading: t("console:common.modals.editAvatarModal.content.gravatar.heading")
+                                },
+                                hostedAvatar: {
+                                    heading: t("console:common.modals.editAvatarModal.content.hostedAvatar.heading"),
+                                    input: {
+                                        errors: {
+                                            http: {
+                                                content: t("console:common.modals.editAvatarModal.content." +
+                                                    "hostedAvatar.input.errors.http.content"),
+                                                header: t("console:common.modals.editAvatarModal.content." +
+                                                    "hostedAvatar.input.errors.http.header")
+                                            },
+                                            invalid: {
+                                                content: t("console:common.modals.editAvatarModal.content." +
+                                                    "hostedAvatar.input.errors.invalid.content"),
+                                                pointing: t("console:common.modals.editAvatarModal.content." +
+                                                    "hostedAvatar.input.errors.invalid.pointing")
+                                            }
+                                        },
+                                        hint: t(
+                                            "console:common.modals.editAvatarModal.content.hostedAvatar.input.hint"
+                                        ),
+                                        placeholder: t("console:common.modals.editAvatarModal.content." +
+                                            "hostedAvatar.input.placeholder"),
+                                        warnings: {
+                                            dataURL: {
+                                                content: t("console:common.modals.editAvatarModal.content." +
+                                                    "hostedAvatar.input.warnings.dataURL.content"),
+                                                header: t("console:common.modals.editAvatarModal.content." +
+                                                    "hostedAvatar.input.warnings.dataURL.header")
+                                            }
                                         }
                                     }
+                                },
+                                systemGenAvatars: {
+                                    heading: t(
+                                        "console:common.modals.editAvatarModal.content.systemGenAvatars.heading"
+                                    ),
+                                    types: {
+                                        initials: t("console:common.modals.editAvatarModal.content.systemGenAvatars." +
+                                            "types.initials")
+                                    }
                                 }
-                            },
-                            systemGenAvatars: {
-                                heading: t("console:common.modals.editAvatarModal.content.systemGenAvatars.heading"),
-                                types: {
-                                    initials: t("console:common.modals.editAvatarModal.content.systemGenAvatars." +
-                                        "types.initials")
-                                }
-                            }
-                        } }
-                    />
-                )
-            }
-        </TabPageLayout>
+                            } }
+                        />
+                    )
+                }
+            </TabPageLayout>
+        </UserManagementProvider>
     );
 };
 

--- a/apps/console/src/features/users/providers/user-management-provider.tsx
+++ b/apps/console/src/features/users/providers/user-management-provider.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent, PropsWithChildren, ReactElement, useState } from "react";
+import UserManagementContext from "../context/user-management-context";
+
+/**
+ * Props interface for the User management provider.
+ */
+export type UserManagementProviderProps = PropsWithChildren;
+
+/**
+ * React context provider for the user management context.
+ * This provider must be added at the root of the features to make the context available throughout the feature.
+ *
+ * @example
+ * <UserManagementProvider>
+ *    <Feature />
+ * </UserManagementProvider>
+ *
+ * @param props - Props injected to the component.
+ * @returns User management context instance.
+ */
+const UserManagementProvider: FunctionComponent<UserManagementProviderProps> = (
+    props: UserManagementProviderProps
+): ReactElement => {
+    const { children } = props;
+    const [ activeTab, setActiveTab ] = useState<number>(0);
+
+    return (
+        <UserManagementContext.Provider
+            value={ {
+                activeTab,
+                updateActiveTab: setActiveTab
+            } }
+        >
+            { children }
+        </UserManagementContext.Provider>
+    );
+};
+
+export default UserManagementProvider;


### PR DESCRIPTION
### Purpose
- Keep last selected tab active upon refresh when editing users.
- Add user management context.

### Related Issues
- wso2/product-is#17322

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
