### PR TITLE
Hide connected apps tab if the audience is application.

### DIFF
--- a/.changeset/large-tools-prove.md
+++ b/.changeset/large-tools-prove.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Hide connected apps tab if the audience is application.

--- a/apps/console/src/features/roles/components/edit-role/edit-role.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role.tsx
@@ -150,7 +150,7 @@ export const EditRole: FunctionComponent<EditRoleProps> = (props: EditRoleProps)
                 )
             },
             // Hide connected apps tab if the audience is application.
-            roleObject?.audience.type === RoleAudienceTypes.ORGANIZATION.toLocaleLowerCase()
+            roleObject?.audience?.type === RoleAudienceTypes.ORGANIZATION.toLocaleLowerCase()
                 ? {
                     menuItem: t("console:manage.features.roles.edit.menuItems.connectedApps"),
                     render: () => (

--- a/apps/console/src/features/roles/components/edit-role/edit-role.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role.tsx
@@ -31,6 +31,7 @@ import { UpdatedRolePermissionDetails } from "./edit-role-permission";
 import { RoleUsersList } from "./edit-role-users";
 import { AppState, FeatureConfigInterface } from "../../../core";
 import { useGetOrganizationType } from "../../../organizations/hooks/use-get-organization-type";
+import { RoleAudienceTypes } from "../../constants";
 
 /**
  * Captures props needed for edit role component
@@ -148,20 +149,23 @@ export const EditRole: FunctionComponent<EditRoleProps> = (props: EditRoleProps)
                     </ResourceTab.Pane>
                 )
             },
-            {
-                menuItem: t("console:manage.features.roles.edit.menuItems.connectedApps"),
-                render: () => (
-                    <ResourceTab.Pane controlledSegmentation attached={ false }>
-                        <RoleConnectedApps
-                            isReadOnly={ !hasRequiredScopes(
-                                featureConfig?.roles, featureConfig?.roles?.scopes?.update, allowedScopes) }
-                            role={ roleObject }
-                            onRoleUpdate={ onRoleUpdate }
-                            tabIndex={ 4 }
-                        />
-                    </ResourceTab.Pane>
-                )
-            }
+            // Hide connected apps tab if the audience is application.
+            roleObject?.audience.type === RoleAudienceTypes.ORGANIZATION.toLocaleLowerCase()
+                ? {
+                    menuItem: t("console:manage.features.roles.edit.menuItems.connectedApps"),
+                    render: () => (
+                        <ResourceTab.Pane controlledSegmentation attached={ false }>
+                            <RoleConnectedApps
+                                isReadOnly={ !hasRequiredScopes(
+                                    featureConfig?.roles, featureConfig?.roles?.scopes?.update, allowedScopes) }
+                                role={ roleObject }
+                                onRoleUpdate={ onRoleUpdate }
+                                tabIndex={ 4 }
+                            />
+                        </ResourceTab.Pane>
+                    )
+                }
+                : null
         ];
 
         return panes;


### PR DESCRIPTION
### Purpose
Hide connected apps tab if the audience is application.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
