### PR TITLE
Set application roles tab read-only in suborgs

### DIFF
--- a/.changeset/lemon-comics-care.md
+++ b/.changeset/lemon-comics-care.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Set application roles tab read-only in suborgs

--- a/apps/console/src/features/roles/components/application-roles.tsx
+++ b/apps/console/src/features/roles/components/application-roles.tsx
@@ -112,6 +112,9 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
     const path: string[] = history.location.pathname.split("/");
     const appId: string = path[path.length - 1].split("#")[0];
 
+    const isSubOrg: boolean = window[ "AppUtils" ].getConfig().organizationName;
+    const isReadOnly: boolean = !!isSubOrg;
+
     /**
      * Fetch application roles on component load and audience switch.
      */
@@ -305,6 +308,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
                                     onChange={ () => promptAudienceSwitchWarning(RoleAudienceTypes.ORGANIZATION) }
                                     label={ t("extensions:develop.applications.edit.sections.rolesV2.organization") }
                                     data-componentid={ `${ componentId }-organization-audience-checkbox` }
+                                    disabled={ isReadOnly }
                                 />
                                 <FormControlLabel
                                     checked={ roleAudience === RoleAudienceTypes.APPLICATION }
@@ -312,6 +316,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
                                     onChange={ () => promptAudienceSwitchWarning(RoleAudienceTypes.APPLICATION) }
                                     label={ t("extensions:develop.applications.edit.sections.rolesV2.application") }
                                     data-componentid={ `${ componentId }-application-audience-checkbox` }
+                                    disabled={ isReadOnly }
                                 />
                             </FormGroup>
                         </Grid.Column>
@@ -340,6 +345,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
                             <Autocomplete
                                 multiple
                                 disableCloseOnSelect
+                                readOnly={ isReadOnly }
                                 loading={ isLoading }
                                 options={ roleList }
                                 value={ selectedRoles ?? [] }
@@ -349,8 +355,8 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
                                 renderInput={ (params: AutocompleteRenderInputParams) => (
                                     <TextField
                                         { ...params }
-                                        placeholder={ t("extensions:develop.applications.edit.sections." +
-                                            "rolesV2.searchPlaceholder") }
+                                        placeholder={ !isReadOnly && t("extensions:develop.applications.edit." +
+                                            "sections.rolesV2.searchPlaceholder") }
                                     />
                                 ) }
                                 onChange={ (event: SyntheticEvent, roles: BasicRoleInterface[]) => {
@@ -454,19 +460,23 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
                             
                         </Grid.Column>
                     </Grid.Row>
-                    <Grid.Row className="mt-4">
-                        <Grid.Column width={ 16 }>
-                            <PrimaryButton
-                                size="small"
-                                loading={ isSubmitting }
-                                onClick={ () => updateRoles() }
-                                ariaLabel="Roles update button"
-                                data-componentid={ `${ componentId }-update-button` }
-                            >
-                                { t("common:update") }
-                            </PrimaryButton>
-                        </Grid.Column>
-                    </Grid.Row>
+                    {
+                        !isReadOnly && (
+                            <Grid.Row className="mt-4">
+                                <Grid.Column width={ 16 }>
+                                    <PrimaryButton
+                                        size="small"
+                                        loading={ isSubmitting }
+                                        onClick={ () => updateRoles() }
+                                        ariaLabel="Roles update button"
+                                        data-componentid={ `${ componentId }-update-button` }
+                                    >
+                                        { t("common:update") }
+                                    </PrimaryButton>
+                                </Grid.Column>
+                            </Grid.Row>
+                        )
+                    }
                 </Grid>
             </EmphasizedSegment>
             <ConfirmationModal

--- a/apps/console/src/features/roles/components/application-roles.tsx
+++ b/apps/console/src/features/roles/components/application-roles.tsx
@@ -25,6 +25,7 @@ import FormControlLabel from "@oxygen-ui/react/FormControlLabel";
 import FormGroup from "@oxygen-ui/react/FormGroup";
 import Radio from "@oxygen-ui/react/Radio";
 import TextField from "@oxygen-ui/react/TextField";
+import { OrganizationType } from "@wso2is/common";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import {
@@ -54,6 +55,7 @@ import { ApplicationInterface } from "../../applications/models";
 import {
     history
 } from "../../core";
+import { useGetOrganizationType } from "../../organizations/hooks/use-get-organization-type";
 import { getApplicationRolesByAudience } from "../api/roles";
 import { RoleAudienceTypes } from "../constants/role-constants";
 import {
@@ -92,6 +94,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
     const { t } = useTranslation();
     const dispatch: Dispatch<any> = useDispatch();
     const { getLink } = useDocumentation();
+    const orgType: OrganizationType = useGetOrganizationType();
 
     const [ isLoading, setIsLoading ] = useState<boolean>(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
@@ -112,8 +115,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
     const path: string[] = history.location.pathname.split("/");
     const appId: string = path[path.length - 1].split("#")[0];
 
-    const isSubOrg: boolean = window[ "AppUtils" ].getConfig().organizationName;
-    const isReadOnly: boolean = !!isSubOrg;
+    const isReadOnly: boolean = orgType === OrganizationType.SUBORGANIZATION;
 
     /**
      * Fetch application roles on component load and audience switch.


### PR DESCRIPTION
### Purpose
$subject
<img width="1676" alt="Screenshot 2023-10-29 at 18 16 22" src="https://github.com/wso2/identity-apps/assets/42619922/170e07bd-b04e-4ecd-9a63-8b123ce26bbd">

### Related Issues
- https://github.com/wso2/product-is/issues/17358

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
