### PR TITLE
Hide login page registration link

### DIFF
--- a/.changeset/spicy-snails-walk.md
+++ b/.changeset/spicy-snails-walk.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Hide registration link from IS

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -1033,10 +1033,6 @@
                     <% }
                     String clientId = request.getParameter("client_id");
                     String urlParameters = "";
-                    boolean enableLoginPageEarlySignupLink = false;
-                    if (!StringUtils.isBlank(application.getInitParameter("EnableLoginPageEarlySignupLink"))) {
-                        enableLoginPageEarlySignupLink = Boolean.parseBoolean(application.getInitParameter("EnableLoginPageEarlySignupLink"));
-                    }
                     if (!isSelfSignUpEnabledInTenant
                             && StringUtils.isNotBlank(application.getInitParameter("AccountRegisterEndpointURL"))
                             && (StringUtils.equals("CONSOLE",clientId)

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -1033,7 +1033,11 @@
                     <% }
                     String clientId = request.getParameter("client_id");
                     String urlParameters = "";
-                    if ((StringUtils.equals("CONSOLE",clientId)
+                    boolean enableLoginPageEarlySignupLink = false;
+                    if (!StringUtils.isBlank(application.getInitParameter("EnableLoginPageEarlySignupLink"))) {
+                        enableLoginPageEarlySignupLink = Boolean.parseBoolean(application.getInitParameter("EnableLoginPageEarlySignupLink"));
+                    }
+                    if (!isSelfSignUpEnabledInTenant && enableLoginPageEarlySignupLink && (StringUtils.equals("CONSOLE",clientId)
                             || (StringUtils.equals("MY_ACCOUNT",clientId)
                             && StringUtils.equals(tenantForTheming, IdentityManagementEndpointConstants.SUPER_TENANT)))
                             && !StringUtils.equals("true", promptAccountLinking)) {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -1037,7 +1037,9 @@
                     if (!StringUtils.isBlank(application.getInitParameter("EnableLoginPageEarlySignupLink"))) {
                         enableLoginPageEarlySignupLink = Boolean.parseBoolean(application.getInitParameter("EnableLoginPageEarlySignupLink"));
                     }
-                    if (!isSelfSignUpEnabledInTenant && enableLoginPageEarlySignupLink && (StringUtils.equals("CONSOLE",clientId)
+                    if (!isSelfSignUpEnabledInTenant
+                            && StringUtils.isNotBlank(application.getInitParameter("AccountRegisterEndpointURL"))
+                            && (StringUtils.equals("CONSOLE",clientId)
                             || (StringUtils.equals("MY_ACCOUNT",clientId)
                             && StringUtils.equals(tenantForTheming, IdentityManagementEndpointConstants.SUPER_TENANT)))
                             && !StringUtils.equals("true", promptAccountLinking)) {

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -71,6 +71,13 @@
         <param-value>true</param-value>
     </context-param-->
 
+    {% if authenticationendpoint.enable_login_page_early_signup_link is defined %}
+    <context-param>
+        <param-name>EnableLoginPageEarlySignupLink</param-name>
+        <param-value>{{ authenticationendpoint.enable_login_page_early_signup_link }}</param-value>
+    </context-param>
+    {% endif %}
+
     {% if authenticationendpoint.registration_url is defined %}
     <context-param>
         <param-name>AccountRegisterEndpointURL</param-name>

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -71,13 +71,6 @@
         <param-value>true</param-value>
     </context-param-->
 
-    {% if authenticationendpoint.enable_login_page_early_signup_link is defined %}
-    <context-param>
-        <param-name>EnableLoginPageEarlySignupLink</param-name>
-        <param-value>{{ authenticationendpoint.enable_login_page_early_signup_link }}</param-value>
-    </context-param>
-    {% endif %}
-
     {% if authenticationendpoint.registration_url is defined %}
     <context-param>
         <param-name>AccountRegisterEndpointURL</param-name>


### PR DESCRIPTION
### Purpose
> Remove `Don't have an account? Register` link from the login page in IS

### Related Issues
- https://github.com/wso2/product-is/issues/17433

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
