### PR TITLE
Improve the application selection dropdown under Application audience role creation

### DIFF
--- a/.changeset/itchy-experts-raise.md
+++ b/.changeset/itchy-experts-raise.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Improve the application selection dropdown under Application audience role creation

--- a/apps/console/src/features/applications/models/application.ts
+++ b/apps/console/src/features/applications/models/application.ts
@@ -41,6 +41,7 @@ export interface ApplicationBasicInterface {
     templateId?: string;
     isManagementApp?: boolean;
     advancedConfigurations?: AdvancedConfigurationsInterface;
+    associatedRoles?: AssociatedRolesInterface;
 }
 
 export enum ApplicationAccessTypes {

--- a/apps/console/src/features/roles/components/wizard-updated/role-basics.tsx
+++ b/apps/console/src/features/roles/components/wizard-updated/role-basics.tsx
@@ -98,7 +98,6 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
      */
     const ROLES_TAB_INDEX: number = 5;
 
-
     const {
         data: applicationList,
         isLoading: isApplicationListFetchRequestLoading,

--- a/apps/console/src/features/roles/components/wizard-updated/role-basics.tsx
+++ b/apps/console/src/features/roles/components/wizard-updated/role-basics.tsx
@@ -93,12 +93,18 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
 
     const noApplicationsAvailable: MutableRefObject<boolean> = useRef<boolean>(false);
 
+    /**
+     * Index of the roles tab.
+     */
+    const ROLES_TAB_INDEX: number = 5;
+
+
     const {
         data: applicationList,
         isLoading: isApplicationListFetchRequestLoading,
         error: applicationListFetchRequestError,
         mutate: mutateApplicationListFetchRequest
-    } = useApplicationList("clientId", null, null, applicationSearchQuery);
+    } = useApplicationList("clientId,associatedRoles.allowedAudience", null, null, applicationSearchQuery);
 
     const {
         data: rolesList,
@@ -137,10 +143,26 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
                     content: (
                         <ListItemText 
                             primary={ application.name } 
-                            secondary={ t("console:manage.features.roles.addRoleWizard.forms.roleBasicDetails." + 
-                                "assignedApplication.applicationSubTitle.application") } 
+                            secondary={ 
+                                application?.associatedRoles?.allowedAudience === RoleAudienceTypes.ORGANIZATION
+                                    ? (
+                                        <>
+                                            { t("console:manage.features.roles.addRoleWizard.forms.roleBasicDetails." + 
+                                                "assignedApplication.applicationSubTitle.application") }
+                                            <Link
+                                                data-componentid={ `${componentId}-link-navigate-roles` }
+                                                onClick={ () => navigateToApplicationEdit(application?.id) }
+                                                external={ false }
+                                            >
+                                                Change the audience
+                                            </Link>
+                                        </>
+                                    ) : t("console:manage.features.roles.addRoleWizard.forms.roleBasicDetails." + 
+                                        "assignedApplication.applicationSubTitle.organization")
+                            } 
                         />
                     ),
+                    disabled: application?.associatedRoles?.allowedAudience === RoleAudienceTypes.ORGANIZATION,
                     key: application.id,
                     text: application.name,
                     value: application.id
@@ -203,6 +225,15 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
      * Navigate to the API Resources page.
      */
     const navigateToApplications = () => history.push(AppConstants.getPaths().get("APPLICATIONS"));
+
+    /**
+     * Navigate to the Applications Edit page.
+     */
+    const navigateToApplicationEdit = (appId: string) => 
+        history.push({
+            pathname: AppConstants.getPaths().get("APPLICATION_SIGN_IN_METHOD_EDIT")
+                .replace(":id", appId).replace(":tabName", `#tab=${ ROLES_TAB_INDEX }`)
+        });
 
     /**
      * Validates the Form.

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -10167,7 +10167,7 @@ export const console: ConsoleNS = {
                                 label: "Assigned application",
                                 placeholder: "Select application to assign the role",
                                 applicationSubTitle: {
-                                    application: "Support application-scoped roles",
+                                    application: "Support application-scoped roles ",
                                     organization: "Support organization-scoped roles"
                                 },
                                 validations: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -10167,7 +10167,7 @@ export const console: ConsoleNS = {
                                 label: "Assigned application",
                                 placeholder: "Select application to assign the role",
                                 applicationSubTitle: {
-                                    application: "Support application-scoped roles ",
+                                    application: "Support application-scoped roles. ",
                                     organization: "Support organization-scoped roles"
                                 },
                                 validations: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -8398,7 +8398,7 @@ export const console: ConsoleNS = {
                                 label: "Application attribuée",
                                 placeholder: "Sélectionnez l'application pour attribuer le rôle",
                                 applicationSubTitle: {
-                                    application: "Prise en charge des rôles à application",
+                                    application: "Prise en charge des rôles à application ",
                                     organization: "Rôles de soutien à l'organisation"
                                 },
                                 validations: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -8398,7 +8398,7 @@ export const console: ConsoleNS = {
                                 label: "Application attribuée",
                                 placeholder: "Sélectionnez l'application pour attribuer le rôle",
                                 applicationSubTitle: {
-                                    application: "Prise en charge des rôles à application ",
+                                    application: "Prise en charge des rôles à application. ",
                                     organization: "Rôles de soutien à l'organisation"
                                 },
                                 validations: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -8219,7 +8219,7 @@ export const console: ConsoleNS = {
                                 label: "පවරා ඇති අයදුම්පත",
                                 placeholder: "භූමිකාව පැවරීම සඳහා අයදුම්පත තෝරන්න",
                                 applicationSubTitle: {
-                                    application: "අයදුම්පත් සහිත භූමිකාවන් සහාය",
+                                    application: "අයදුම්පත් සහිත භූමිකාවන් සහාය ",
                                     organization: "සංවිධාන භූමිකාවන් සහාය"
                                 },
                                 validations: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -8219,7 +8219,7 @@ export const console: ConsoleNS = {
                                 label: "පවරා ඇති අයදුම්පත",
                                 placeholder: "භූමිකාව පැවරීම සඳහා අයදුම්පත තෝරන්න",
                                 applicationSubTitle: {
-                                    application: "අයදුම්පත් සහිත භූමිකාවන් සහාය ",
+                                    application: "අයදුම්පත් සහිත භූමිකාවන් සහාය. ",
                                     organization: "සංවිධාන භූමිකාවන් සහාය"
                                 },
                                 validations: {


### PR DESCRIPTION
### Purpose
Improve the application selection dropdown under Application audience role creation.

Currently, we can select applications with `organization` audience when creating an `application audience role` and this displays an error after creation. This PR disables showing the applications with `organization` audience when selecting an application for `application audience role` creation and provides an option to navigate to change the audience.

<img width="831" alt="Screenshot 2023-11-01 at 11 02 34" src="https://github.com/wso2/identity-apps/assets/27746285/34452da2-6b8a-4724-bb9d-140f00f16f2e">


### Related Issues
- https://github.com/wso2/product-is/issues/17351

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
