### PR TITLE
Add error page to handle fido failures

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -432,6 +432,7 @@ fido.cancel=Cancel
 fido.submit=Submit
 fido.authenticator=Passkey
 provisioned.user.not.found=No user account linked to this sign-in was found in our system.
+fido.error.title=Failed Authentication with Passkey
 
 # Magic Link
 magic.link.heading=Check your inbox!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -427,6 +427,7 @@ fido.cancel=Stornieren
 fido.submit=Einreichen
 fido.authenticator=Hauptschlüssel
 provisioned.user.not.found=In unserem System wurde kein mit dieser Anmeldung verknüpftes Benutzerkonto gefunden.
+fido.error.title=Authentifizierung mit Passkey fehlgeschlagen
 
 # Magic Link
 magic.link.heading=Überprüfen Sie Ihren Posteingang!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -427,6 +427,7 @@ fido.cancel=Cancelar
 fido.submit=Entregar
 fido.authenticator=Llave maestra
 provisioned.user.not.found=No se encontró en nuestro sistema ninguna cuenta de usuario vinculada a este inicio de sesión.
+fido.error.title=Autenticación fallida con clave de acceso
 
 # Magic Link
 magic.link.heading=¡Revisa tu correo!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -428,6 +428,7 @@ fido.cancel=Annuler
 fido.submit=Soumettre
 fido.authenticator=Clé d'accès
 provisioned.user.not.found=Aucun compte utilisateur lié à cette connexion n'a été trouvé dans notre système.
+fido.error.title=Échec de l'authentification avec mot de passe
 
 # Magic Link
 magic.link.heading=Vérifiez votre boîte de réception !

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -426,6 +426,7 @@ fido.cancel=Cancel
 fido.submit=キャンセル
 fido.authenticator=パスキー
 provisioned.user.not.found=このサインインにリンクされたユーザー アカウントがシステム内に見つかりませんでした。
+fido.error.title=パスキーによる認証の失敗
 
 ## Magic Link
 magic.link.heading=受信箱をチェックしてください！

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -427,6 +427,7 @@ fido.cancel=Cancelar
 fido.submit=Enviar
 fido.authenticator=Chave de acesso
 provisioned.user.not.found=Nenhuma conta de usuário vinculada a este login foi encontrada em nosso sistema.
+fido.error.title=Falha na autenticação com senha
 
 # Magic Link
 magic.link.heading=Verifique sua caixa de entrada!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -426,6 +426,7 @@ fido.cancel=取消
 fido.submit=提交
 fido.authenticator=万能钥匙
 provisioned.user.not.found=我们的系统中未找到与此登录关联的用户帐户。
+fido.error.title=使用密钥进行身份验证失败
 
 ## Magic Link
 magic.link.heading=检查你的收件箱！

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-error.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-error.jsp
@@ -1,0 +1,135 @@
+<%--
+  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
+
+<%@ page import="org.apache.commons.text.StringEscapeUtils" %>
+<%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="java.io.File" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
+<%@ include file="includes/localize.jsp" %>
+
+<%-- Include tenant context --%>
+<jsp:directive.include file="includes/init-url.jsp"/>
+
+<%-- Branding Preferences --%>
+<jsp:directive.include file="includes/branding-preferences.jsp"/>
+
+<%
+    session.invalidate();
+
+    String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
+    String authenticationFailed = "false";
+
+    if (Boolean.parseBoolean(request.getParameter(Constants.AUTH_FAILURE))) {
+        authenticationFailed = "true";
+
+        if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
+            errorMessage = request.getParameter(Constants.AUTH_FAILURE_MSG);
+
+            if (errorMessage.equalsIgnoreCase("provisioned.user.not.found")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "provisioned.user.not.found");
+            } 
+        }
+    }
+%>
+
+<%-- Data for the layout from the page --%>
+<%
+    layoutData.put("isResponsePage", true);
+    layoutData.put("isErrorResponse", true);
+%>
+
+<html lang="en-US">
+<head>
+    <%-- header --%>
+    <%
+        File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
+        if (headerFile.exists()) {
+    %>
+    <jsp:include page="extensions/header.jsp"/>
+    <% } else { %>
+    <jsp:include page="includes/header.jsp"/>
+    <% } %>
+</head>
+<body class="login-portal layout authentication-portal-layout">
+    <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
+        <layout:component componentName="ProductHeader">
+            <%-- product-title --%>
+            <%
+                File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                if (productTitleFile.exists()) {
+            %>
+            <jsp:include page="extensions/product-title.jsp"/>
+            <% } else { %>
+            <jsp:include page="includes/product-title.jsp"/>
+            <% } %>
+        </layout:component>
+        <layout:component componentName="MainSection">
+                <div class="ui orange attached segment mt-3">
+                    <h3 class="ui header text-center slogan-message mt-3 mb-6">
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "fido.error.title")%>
+                    </h3>
+                    <%
+                        if ("true".equals(authenticationFailed)) {
+                    %>
+                        <p class="portal-tagline-description">
+                            <%=Encode.forHtmlContent(errorMessage)%>
+                        </p>
+                        <div class="ui divider hidden"></div>
+                    <% } %>
+                </div>
+                <div class="ui bottom attached warning message">
+                    <p class="text-left mt-0">
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "need.help.contact.us")%>
+                        <a href="mailto:<%= StringEscapeUtils.escapeHtml4(supportEmail) %>" target="_blank">
+                            <span class="orange-text-color button"><%= StringEscapeUtils.escapeHtml4(supportEmail) %></span>
+                        </a> 
+                
+                    </p>
+                    <div class="ui divider hidden"></div>
+                </div>
+            </layout:component>
+        <layout:component componentName="ProductFooter">
+            <%-- product-footer --%>
+            <%
+                File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                if (productFooterFile.exists()) {
+            %>
+            <jsp:include page="extensions/product-footer.jsp"/>
+            <% } else { %>
+            <jsp:include page="includes/product-footer.jsp"/>
+            <% } %>
+        </layout:component>
+        <layout:dynamicComponent filePathStoringVariableName="pathOfDynamicComponent">
+            <jsp:include page="${pathOfDynamicComponent}" />
+        </layout:dynamicComponent>
+    </layout:main>
+
+    <%-- footer --%>
+    <%
+        File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
+        if (footerFile.exists()) {
+    %>
+    <jsp:include page="extensions/footer.jsp"/>
+    <% } else { %>
+    <jsp:include page="includes/footer.jsp"/>
+    <% } %>
+</body>
+</html>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-error.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-error.jsp
@@ -21,7 +21,6 @@
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="java.io.File" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 <%@ include file="includes/localize.jsp" %>
 
@@ -35,10 +34,10 @@
     session.invalidate();
 
     String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
-    String authenticationFailed = "false";
+    Boolean authenticationFailed = false;
 
     if (Boolean.parseBoolean(request.getParameter(Constants.AUTH_FAILURE))) {
-        authenticationFailed = "true";
+        authenticationFailed = true;
 
         if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
             errorMessage = request.getParameter(Constants.AUTH_FAILURE_MSG);
@@ -63,22 +62,32 @@
         File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
         if (headerFile.exists()) {
     %>
-    <jsp:include page="extensions/header.jsp"/>
+        <jsp:include page="extensions/header.jsp"/>
     <% } else { %>
-    <jsp:include page="includes/header.jsp"/>
+        <jsp:include page="includes/header.jsp"/>
+    <% } %>
+
+    <%-- analytics --%>
+    <%
+        File analyticsFile = new File(getServletContext().getRealPath("extensions/analytics.jsp"));
+        if (analyticsFile.exists()) {
+    %>
+        <jsp:include page="extensions/analytics.jsp"/>
+    <% } else { %>
+        <jsp:include page="includes/analytics.jsp"/>
     <% } %>
 </head>
 <body class="login-portal layout authentication-portal-layout">
-    <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
+    <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>">
         <layout:component componentName="ProductHeader">
             <%-- product-title --%>
             <%
                 File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
                 if (productTitleFile.exists()) {
             %>
-            <jsp:include page="extensions/product-title.jsp"/>
+                <jsp:include page="extensions/product-title.jsp"/>
             <% } else { %>
-            <jsp:include page="includes/product-title.jsp"/>
+                <jsp:include page="includes/product-title.jsp"/>
             <% } %>
         </layout:component>
         <layout:component componentName="MainSection">
@@ -87,7 +96,7 @@
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "fido.error.title")%>
                     </h3>
                     <%
-                        if ("true".equals(authenticationFailed)) {
+                        if (authenticationFailed) {
                     %>
                         <p class="portal-tagline-description">
                             <%=Encode.forHtmlContent(errorMessage)%>
@@ -101,7 +110,6 @@
                         <a href="mailto:<%= StringEscapeUtils.escapeHtml4(supportEmail) %>" target="_blank">
                             <span class="orange-text-color button"><%= StringEscapeUtils.escapeHtml4(supportEmail) %></span>
                         </a> 
-                
                     </p>
                     <div class="ui divider hidden"></div>
                 </div>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -130,7 +130,7 @@
                 List<String> langSwitcherEnabledServlets = Arrays.asList("/oauth2_login.do", "/oauth2_error.do",
                     "/confirmregistration.do", "/confirmrecovery.do", "/claims.do", "/oauth2_consent.do",
                     "/fido2-auth.jsp", "/fido2-identifierfirst.jsp", "/fido2-enroll.jsp", "/fido2-passkey-status.jsp",
-                    "/email_otp.do", "/org_name.do", "/org_discovery.do", "/retry.do", "/totp_enroll.do",
+                    "/fido2-error.jsp", "/email_otp.do", "/org_name.do", "/org_discovery.do", "/retry.do", "/totp_enroll.do",
                     "/backup_code.do", "/device.do", "/error.do");
                 if (langSwitcherEnabledServlets.contains(request.getServletPath())) {
             %>


### PR DESCRIPTION
### Purpose

- $Subject
- Sample error message[1]
- Relates to https://github.com/wso2/product-is/issues/17425

### Related PRs
- https://github.com/wso2-extensions/identity-local-auth-fido/pull/118
- https://github.com/wso2/carbon-identity-framework/pull/5118

### References 

- [1] Error page 
<img width="441" alt="Screenshot 2023-11-01 at 09 06 56" src="https://github.com/wso2/identity-apps/assets/47135592/15090b63-7328-4bc3-8dea-b4aefa9114e5">

> 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
