### PR TITLE
Fix danger zone subheader taking full width in medium and large screen sizes

### DIFF
--- a/.changeset/gorgeous-dolls-occur.md
+++ b/.changeset/gorgeous-dolls-occur.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/theme": patch
+---
+
+Fix danger zone subheader taking full width in medium and large screen sizes

--- a/.changeset/warm-lemons-drop.md
+++ b/.changeset/warm-lemons-drop.md
@@ -1,5 +1,8 @@
 ---
 "@wso2is/theme": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/identity-apps-core": patch
 ---
 
 Fix danger zone subheader taking full width in medium and large screen sizes

--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,4 @@ tests/dist/
 .project
 .repository/
 apps/console/src/extensions/i18n/tmp/**
-.nx  
+.nx

--- a/modules/theme/src/themes/default/elements/segment.overrides
+++ b/modules/theme/src/themes/default/elements/segment.overrides
@@ -83,6 +83,12 @@
         border: 1px solid @red;
         border-radius: @defaultBorderRadius;
 
+        @media only screen and (max-width: 1512px) {
+            .header {
+                max-width: 75%;
+            }
+        }
+
         .sub-header {
             margin-top: 5px;
         }


### PR DESCRIPTION
### Purpose

$subject

Macbook Pro

<img width="1502" alt="Screenshot 2023-11-02 at 11 10 51" src="https://github.com/wso2/identity-apps/assets/41533942/65433a4c-0fa7-432f-82ab-1a122954ec9e">

Extended Monitor

![Screenshot 2023-11-02 at 11 13 47](https://github.com/wso2/identity-apps/assets/41533942/edb47b5e-c3a5-4cf4-826c-e2320590a37c)

### Related Issues
- https://github.com/wso2/product-is/issues/17171

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
