### PR TITLE
Remove filtering from availableEmailTemplates

### DIFF
--- a/.changeset/quick-crews-guess.md
+++ b/.changeset/quick-crews-guess.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add enable custom email template config

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1567,6 +1567,11 @@
         {% if console.ui.is_request_path_authentication_enabled is defined %}
         "isRequestPathAuthenticationEnabled": {{ console.ui.is_request_path_authentication_enabled }},
         {% endif %}
+        {% if console.ui.enableEmailCustomTemplate is defined %}
+            "enableEmailCustomTemplate": {{ console.ui.enableEmailCustomTemplate }},
+        {% else %}
+            "enableEmailCustomTemplate": true,
+        {% endif %}
         {% if console.ui.is_left_navigation_categorized is defined %}
         "isLeftNavigationCategorized": {{ console.ui.is_left_navigation_categorized }},
         {% endif %}

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1567,10 +1567,10 @@
         {% if console.ui.is_request_path_authentication_enabled is defined %}
         "isRequestPathAuthenticationEnabled": {{ console.ui.is_request_path_authentication_enabled }},
         {% endif %}
-        {% if console.ui.enableEmailCustomTemplate is defined %}
-            "enableEmailCustomTemplate": {{ console.ui.enableEmailCustomTemplate }},
+        {% if console.ui.enable_custom_email_templates is defined %}
+            "enableCustomEmailTemplates": {{ console.ui.enable_custom_email_templates }},
         {% else %}
-            "enableEmailCustomTemplate": true,
+            "enableCustomEmailTemplates": true,
         {% endif %}
         {% if console.ui.is_left_navigation_categorized is defined %}
         "isLeftNavigationCategorized": {{ console.ui.is_left_navigation_categorized }},

--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -274,7 +274,7 @@ export class Config {
                 defaultLogoUrl: window[ "AppUtils" ]?.getConfig()?.ui?.emailTemplates?.defaultLogoUrl,
                 defaultWhiteLogoUrl: window[ "AppUtils" ]?.getConfig()?.ui?.emailTemplates?.defaultWhiteLogoUrl
             },
-            enableEmailCustomTemplate: window[ "AppUtils" ]?.getConfig()?.ui?.enableEmailCustomTemplate,
+            enableCustomEmailTemplates: window[ "AppUtils" ]?.getConfig()?.ui?.enableCustomEmailTemplates,
             features: window[ "AppUtils" ]?.getConfig()?.ui?.features,
             googleOneTapEnabledTenants: window["AppUtils"]?.getConfig()?.ui?.googleOneTapEnabledTenants,
             gravatarConfig: window[ "AppUtils" ]?.getConfig()?.ui?.gravatarConfig,

--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -274,6 +274,7 @@ export class Config {
                 defaultLogoUrl: window[ "AppUtils" ]?.getConfig()?.ui?.emailTemplates?.defaultLogoUrl,
                 defaultWhiteLogoUrl: window[ "AppUtils" ]?.getConfig()?.ui?.emailTemplates?.defaultWhiteLogoUrl
             },
+            enableEmailCustomTemplate: window[ "AppUtils" ]?.getConfig()?.ui?.enableEmailCustomTemplate,
             features: window[ "AppUtils" ]?.getConfig()?.ui?.features,
             googleOneTapEnabledTenants: window["AppUtils"]?.getConfig()?.ui?.googleOneTapEnabledTenants,
             gravatarConfig: window[ "AppUtils" ]?.getConfig()?.ui?.gravatarConfig,
@@ -296,7 +297,6 @@ export class Config {
             isRequestPathAuthenticationEnabled:
                 window[ "AppUtils" ]?.getConfig()?.ui?.isRequestPathAuthenticationEnabled,
             isSAASDeployment: window[ "AppUtils" ]?.getConfig()?.ui?.isSAASDeployment,
-            enableEmailCustomTemplate: window[ "AppUtils" ]?.getConfig()?.ui?.enableEmailCustomTemplate,
             isSignatureValidationCertificateAliasEnabled:
                 window[ "AppUtils" ]?.getConfig()?.ui?.isSignatureValidationCertificateAliasEnabled,
             listAllAttributeDialects: window[ "AppUtils" ]?.getConfig()?.ui?.listAllAttributeDialects,

--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -296,6 +296,7 @@ export class Config {
             isRequestPathAuthenticationEnabled:
                 window[ "AppUtils" ]?.getConfig()?.ui?.isRequestPathAuthenticationEnabled,
             isSAASDeployment: window[ "AppUtils" ]?.getConfig()?.ui?.isSAASDeployment,
+            enableEmailCustomTemplate: window[ "AppUtils" ]?.getConfig()?.ui?.enableEmailCustomTemplate,
             isSignatureValidationCertificateAliasEnabled:
                 window[ "AppUtils" ]?.getConfig()?.ui?.isSignatureValidationCertificateAliasEnabled,
             listAllAttributeDialects: window[ "AppUtils" ]?.getConfig()?.ui?.listAllAttributeDialects,

--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -331,6 +331,10 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      */
     isSAASDeployment: boolean;
     /**
+         * Enable/Disable email custom template feature
+         */
+        enableEmailCustomTemplate: boolean;
+    /**
      * Enable signature validation certificate alias.
      */
     isSignatureValidationCertificateAliasEnabled?: boolean;

--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -331,9 +331,9 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      */
     isSAASDeployment: boolean;
     /**
-         * Enable/Disable email custom template feature
-         */
-        enableEmailCustomTemplate: boolean;
+     * Enable/Disable custom email template feature
+     */
+    enableCustomEmailTemplates: boolean;
     /**
      * Enable signature validation certificate alias.
      */

--- a/apps/console/src/features/core/store/reducers/config.ts
+++ b/apps/console/src/features/core/store/reducers/config.ts
@@ -182,6 +182,7 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
                 defaultLogoUrl: "",
                 defaultWhiteLogoUrl: ""
             },
+            enableEmailCustomTemplate: undefined,
             features: {
                 applications: null,
                 approvals: null,
@@ -243,7 +244,6 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
             isMarketingConsentBannerEnabled: undefined,
             isRequestPathAuthenticationEnabled: undefined,
             isSAASDeployment: undefined,
-            enableEmailCustomTemplate: undefined,
             isSignatureValidationCertificateAliasEnabled: undefined,
             listAllAttributeDialects: undefined,
             privacyPolicyConfigs: null,

--- a/apps/console/src/features/core/store/reducers/config.ts
+++ b/apps/console/src/features/core/store/reducers/config.ts
@@ -182,7 +182,7 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
                 defaultLogoUrl: "",
                 defaultWhiteLogoUrl: ""
             },
-            enableEmailCustomTemplate: undefined,
+            enableCustomEmailTemplates: undefined,
             features: {
                 applications: null,
                 approvals: null,

--- a/apps/console/src/features/core/store/reducers/config.ts
+++ b/apps/console/src/features/core/store/reducers/config.ts
@@ -243,6 +243,7 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
             isMarketingConsentBannerEnabled: undefined,
             isRequestPathAuthenticationEnabled: undefined,
             isSAASDeployment: undefined,
+            enableEmailCustomTemplate: undefined,
             isSignatureValidationCertificateAliasEnabled: undefined,
             listAllAttributeDialects: undefined,
             privacyPolicyConfigs: null,

--- a/apps/console/src/features/email-management/pages/email-customization.tsx
+++ b/apps/console/src/features/email-management/pages/email-customization.tsx
@@ -71,8 +71,8 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
 
     const emailTemplates: Record<string, string>[] = useSelector(
         (state: AppState) => state.config.deployment.extensions.emailTemplates) as Record<string, string>[];
-    const enableEmailCustomTemplate: boolean = useSelector(
-        (state: AppState) => state?.config?.ui?.enableEmailCustomTemplate);
+    const enableCustomEmailTemplates: boolean = useSelector(
+        (state: AppState) => state?.config?.ui?.enableCustomEmailTemplates);
 
     const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
@@ -98,7 +98,7 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
         // the deployment.toml file. The below code will map the email template
         // types with the config's displayName and description.
         const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList
-            ? (!enableEmailCustomTemplate
+            ? (!enableCustomEmailTemplates
                 ? emailTemplatesList.filter((template: EmailTemplateType) =>
                     emailTemplates?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id)
                 )

--- a/apps/console/src/features/email-management/pages/email-customization.tsx
+++ b/apps/console/src/features/email-management/pages/email-customization.tsx
@@ -71,6 +71,8 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
 
     const emailTemplates: Record<string, string>[] = useSelector(
         (state: AppState) => state.config.deployment.extensions.emailTemplates) as Record<string, string>[];
+    const enableEmailCustomTemplate: boolean = useSelector(
+            (state: AppState) => state?.config?.ui?.enableEmailCustomTemplate);
 
     const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
@@ -90,26 +92,29 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
     } = useEmailTemplate(selectedEmailTemplateId, selectedLocale);
 
     useEffect(() => {
-        // As of now, we need to show only the used email templates, and we don't have a good displayName and
-        // description coming from the backend for the email template types. So as we agreed to filter only the used
-        // templates, and we will use the displayName and description from the email template types config defined in
-        // the deployment.toml file. The below code will first filter all the email templates and map the email template
-        // types with the config's displayName and description.
-        const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList?.filter(
-            (template: EmailTemplateType) => {
-                return emailTemplates?.find((emailTemplate: Record<string, string>) =>
-                    emailTemplate.id === template.id);
-            })
-            .map((template: EmailTemplateType) => {
-                const mappedTemplate: Record<string, string> = emailTemplates
-                    ?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id);
+            // we don't have a good displayName and description coming from the backend
+            // for the email template types. So as we agreed use the displayName and
+            // description from the email template types config defined in
+            // the deployment.toml file. The below code will map the email template
+            // types with the config's displayName and description.
+            const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList
+                ? (!enableEmailCustomTemplate
+                    ? emailTemplatesList.filter((template: EmailTemplateType) =>
+                        emailTemplates?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id)
+                    )
+                    : emailTemplatesList
+                ).map((template: EmailTemplateType) => {
+                    const mappedTemplate: Record<string, string> = emailTemplates?.find(
+                        (emailTemplate: Record<string, string>) => emailTemplate.id === template.id
+                    );
 
-                return {
-                    ...template,
-                    description: mappedTemplate?.description || `${ template.displayName } Template`,
-                    displayName: mappedTemplate?.displayName || template.displayName
-                };
-            });
+                    return {
+                        ...template,
+                        description: mappedTemplate?.description || `${template.displayName} Template`,
+                        displayName: mappedTemplate?.displayName || template.displayName
+                    };
+                })
+                : [];
 
         setAvailableEmailTemplatesList(availableEmailTemplates);
 

--- a/apps/console/src/features/email-management/pages/email-customization.tsx
+++ b/apps/console/src/features/email-management/pages/email-customization.tsx
@@ -72,7 +72,7 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
     const emailTemplates: Record<string, string>[] = useSelector(
         (state: AppState) => state.config.deployment.extensions.emailTemplates) as Record<string, string>[];
     const enableEmailCustomTemplate: boolean = useSelector(
-            (state: AppState) => state?.config?.ui?.enableEmailCustomTemplate);
+        (state: AppState) => state?.config?.ui?.enableEmailCustomTemplate);
 
     const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
@@ -92,29 +92,29 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
     } = useEmailTemplate(selectedEmailTemplateId, selectedLocale);
 
     useEffect(() => {
-            // we don't have a good displayName and description coming from the backend
-            // for the email template types. So as we agreed use the displayName and
-            // description from the email template types config defined in
-            // the deployment.toml file. The below code will map the email template
-            // types with the config's displayName and description.
-            const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList
-                ? (!enableEmailCustomTemplate
-                    ? emailTemplatesList.filter((template: EmailTemplateType) =>
-                        emailTemplates?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id)
-                    )
-                    : emailTemplatesList
-                ).map((template: EmailTemplateType) => {
-                    const mappedTemplate: Record<string, string> = emailTemplates?.find(
-                        (emailTemplate: Record<string, string>) => emailTemplate.id === template.id
-                    );
+        // we don't have a good displayName and description coming from the backend
+        // for the email template types. So as we agreed use the displayName and
+        // description from the email template types config defined in
+        // the deployment.toml file. The below code will map the email template
+        // types with the config's displayName and description.
+        const availableEmailTemplates: EmailTemplateType[] = emailTemplatesList
+            ? (!enableEmailCustomTemplate
+                ? emailTemplatesList.filter((template: EmailTemplateType) =>
+                    emailTemplates?.find((emailTemplate: Record<string, string>) => emailTemplate.id === template.id)
+                )
+                : emailTemplatesList
+            ).map((template: EmailTemplateType) => {
+                const mappedTemplate: Record<string, string> = emailTemplates?.find(
+                    (emailTemplate: Record<string, string>) => emailTemplate.id === template.id
+                );
 
-                    return {
-                        ...template,
-                        description: mappedTemplate?.description || `${template.displayName} Template`,
-                        displayName: mappedTemplate?.displayName || template.displayName
-                    };
-                })
-                : [];
+                return {
+                    ...template,
+                    description: mappedTemplate?.description || `${template.displayName} Template`,
+                    displayName: mappedTemplate?.displayName || template.displayName
+                };
+            })
+            : [];
 
         setAvailableEmailTemplatesList(availableEmailTemplates);
 

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -221,6 +221,7 @@
             "defaultLogoUrl": "/libs/themes/default/assets/images/branding/logo.svg",
             "defaultWhiteLogoUrl": "/libs/themes/default/assets/images/branding/logo-white.svg"
         },
+        "enableEmailCustomTemplate": true,
         "appFaviconPath": "/assets/images/branding/favicon.ico",
         "isGOTEnabledForSuperTenantOnly": true,
         "showAppSwitchButton": true,
@@ -964,7 +965,6 @@
         "isRequestPathAuthenticationEnabled": false,
         "isLeftNavigationCategorized": true,
         "isSAASDeployment": false,
-        "enableEmailCustomTemplate": true,
         "isSignatureValidationCertificateAliasEnabled": false,
         "listAllAttributeDialects": true,
         "privacyPolicyConfigs": {},

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -964,6 +964,7 @@
         "isRequestPathAuthenticationEnabled": false,
         "isLeftNavigationCategorized": true,
         "isSAASDeployment": false,
+        "enableEmailCustomTemplate": true,
         "isSignatureValidationCertificateAliasEnabled": false,
         "listAllAttributeDialects": true,
         "privacyPolicyConfigs": {},

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -221,7 +221,7 @@
             "defaultLogoUrl": "/libs/themes/default/assets/images/branding/logo.svg",
             "defaultWhiteLogoUrl": "/libs/themes/default/assets/images/branding/logo-white.svg"
         },
-        "enableEmailCustomTemplate": true,
+        "enableCustomEmailTemplates": true,
         "appFaviconPath": "/assets/images/branding/favicon.ico",
         "isGOTEnabledForSuperTenantOnly": true,
         "showAppSwitchButton": true,


### PR DESCRIPTION
### Purpose
> Even though we receive custom email types from the API, we only display the templates that exist in the config file. As a result, custom templates don't display in the browser. To resolve this issue, we are removing the filter from availableEmailTemplates

### Related Issues
- [Issue `#1` or (None)](https://github.com/wso2/product-is/issues/17250)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
