### PR TITLE
Display only the permissions of allowed API resources for roles with application audience

### DIFF
--- a/.changeset/popular-scissors-repair.md
+++ b/.changeset/popular-scissors-repair.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Display only the permissions of allowed API resources for roles with application audience

--- a/apps/console/src/features/api-resources/api/api-resources.ts
+++ b/apps/console/src/features/api-resources/api/api-resources.ts
@@ -21,11 +21,13 @@ import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { HttpMethods } from "@wso2is/core/models";
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import useRequest, {
+    RequestConfigInterface,
     RequestErrorInterface,
     RequestResultInterface
 } from "../../core/hooks/use-request";
 import { store } from "../../core/store";
-import { APIResourceInterface, APIResourcePermissionInterface, APIResourcesListInterface, 
+import { APIResourceInterface, APIResourcePermissionInterface, APIResourcesListInterface,
+    AuthorizedAPIListItemInterface,
     UpdatedAPIResourceInterface } from "../models";
 
 /**
@@ -37,7 +39,7 @@ const httpClient: HttpClientInstance = AsgardeoSPAClient.getInstance()
 /**
  * Get API resources for the identifier validation.
  * Only to be used for the identifier validation.
- * 
+ *
  * @param filter - filter.
  * @returns `Promise<APIResourcesListInterface | IdentityAppsApiException>`
  */
@@ -122,7 +124,7 @@ export const useAPIResources = <Data = APIResourcesListInterface, Error = Reques
 };
 
 /**
- * 
+ *
  * @param apiResourceId - id of the API resource
  * @returns `Promise<APIResourceInterface>`
  * @throws `IdentityAppsApiException`
@@ -157,7 +159,7 @@ export const useAPIResourceDetails = <Data = APIResourceInterface, Error = Reque
 /**
  * Get permissions of an API resource for the permission validation.
  * Only to be used for the permission validation.
- * 
+ *
  * @param filter - filter.
  * @returns `Promise<APIResourcePermissionInterface[]>`
  * @throws `IdentityAppsApiException`
@@ -244,13 +246,13 @@ export const deleteAPIResource = (apiResourceId: string): Promise<null | Identit
 
 /**
  * Update an API resource.
- * 
+ *
  * @param apiResourceId - UUID of the API resource that needed to be updated.
  * @param updateAPIResourceBody - Body of the API resource that needed to be updated.
  * @returns `Promise<null | IdentityAppsApiException>`
  */
 export const updateAPIResource = (
-    apiResourceId: string, 
+    apiResourceId: string,
     updateAPIResourceBody: UpdatedAPIResourceInterface
 ): Promise<null | IdentityAppsApiException> => {
 
@@ -277,7 +279,7 @@ export const updateAPIResource = (
 
 /**
  * Create an API resource.
- * 
+ *
  * @param apiResourceBody - Body of the API resource that needed to be created.
  * @returns `Promise<null | IdentityAppsApiException>`
  */
@@ -308,13 +310,13 @@ export const createAPIResource = (
 
 /**
  * Delete a scope from an API resource.
- * 
+ *
  * @param apiResourceId - UUID of the API resource.
  * @param deleteScopeName - Name of the scope that needs to be deleted.
  * @returns `Promise<null | IdentityAppsApiException>`
  */
 export const deleteScopeFromAPIResource = (
-    apiResourceId: string, 
+    apiResourceId: string,
     deletingScopeName: string
 ): Promise<null | IdentityAppsApiException> => {
 
@@ -336,4 +338,33 @@ export const deleteScopeFromAPIResource = (
                 error.response,
                 error.config);
         });
+};
+
+/**
+ * Get the authorized APIs of the application with authorized permissions.
+ *
+ * @param appId - Application ID.
+ *
+ * @returns A promise containing the response.
+ */
+export const useGetAuthorizedAPIList = <Data = AuthorizedAPIListItemInterface[], Error = RequestErrorInterface>(
+    applicationId: string
+): RequestResultInterface<Data, Error> => {
+    const requestConfig: RequestConfigInterface = {
+        method: HttpMethods.GET,
+        url: `${ store.getState().config.endpoints.applications }/${ applicationId }/authorized-apis`
+    };
+
+    /**
+     * Pass `null` if the `apiResourceId` is not available. This will prevent the request from being called.
+     */
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(applicationId ? requestConfig : null);
+
+    return {
+        data,
+        error: error,
+        isLoading: !error && !data,
+        isValidating,
+        mutate
+    };
 };

--- a/apps/console/src/features/api-resources/api/api-resources.ts
+++ b/apps/console/src/features/api-resources/api/api-resources.ts
@@ -21,14 +21,12 @@ import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { HttpMethods } from "@wso2is/core/models";
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import useRequest, {
-    RequestConfigInterface,
     RequestErrorInterface,
     RequestResultInterface
 } from "../../core/hooks/use-request";
 import { store } from "../../core/store";
-import { APIResourceInterface, APIResourcePermissionInterface, APIResourcesListInterface,
-    AuthorizedAPIListItemInterface,
-    UpdatedAPIResourceInterface } from "../models";
+import { APIResourceInterface, APIResourcePermissionInterface, APIResourcesListInterface, UpdatedAPIResourceInterface }
+    from "../models";
 
 /**
  * Get an axios instance.
@@ -338,33 +336,4 @@ export const deleteScopeFromAPIResource = (
                 error.response,
                 error.config);
         });
-};
-
-/**
- * Get the authorized APIs of the application with authorized permissions.
- *
- * @param appId - Application ID.
- *
- * @returns A promise containing the response.
- */
-export const useGetAuthorizedAPIList = <Data = AuthorizedAPIListItemInterface[], Error = RequestErrorInterface>(
-    applicationId: string
-): RequestResultInterface<Data, Error> => {
-    const requestConfig: RequestConfigInterface = {
-        method: HttpMethods.GET,
-        url: `${ store.getState().config.endpoints.applications }/${ applicationId }/authorized-apis`
-    };
-
-    /**
-     * Pass `null` if the `apiResourceId` is not available. This will prevent the request from being called.
-     */
-    const { data, error, isValidating, mutate } = useRequest<Data, Error>(applicationId ? requestConfig : null);
-
-    return {
-        data,
-        error: error,
-        isLoading: !error && !data,
-        isValidating,
-        mutate
-    };
 };

--- a/apps/console/src/features/api-resources/api/useGetAuthorizedAPIList.ts
+++ b/apps/console/src/features/api-resources/api/useGetAuthorizedAPIList.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HttpMethods } from "@wso2is/core/models";
+import useRequest, { RequestConfigInterface, RequestErrorInterface, RequestResultInterface }
+    from "../../core/hooks/use-request";
+import { store } from "../../core/store";
+import { AuthorizedAPIListItemInterface } from "../models/api-resources";
+
+/**
+ * Get the authorized APIs of the application with authorized permissions.
+ *
+ * @param appId - Application ID.
+ *
+ * @returns A promise containing the response.
+ */
+export const useGetAuthorizedAPIList = <Data = AuthorizedAPIListItemInterface[], Error = RequestErrorInterface>(
+    applicationId: string
+): RequestResultInterface<Data, Error> => {
+    const requestConfig: RequestConfigInterface = {
+        method: HttpMethods.GET,
+        url: `${ store.getState().config.endpoints.applications }/${ applicationId }/authorized-apis`
+    };
+
+    /**
+     * Pass `null` if the `apiResourceId` is not available. This will prevent the request from being called.
+     */
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(applicationId ? requestConfig : null);
+
+    return {
+        data,
+        error: error,
+        isLoading: !error && !data,
+        isValidating,
+        mutate
+    };
+};
+

--- a/apps/console/src/features/api-resources/models/api-resources.ts
+++ b/apps/console/src/features/api-resources/models/api-resources.ts
@@ -258,3 +258,24 @@ export interface APIResourceEndpointsInterface {
      */
     scopes: string;
 }
+
+/**
+ * Interface to contain scope information
+ */
+export interface ScopeInterface {
+    id: string;
+    displayName?: string;
+    name?: string;
+    description?: string;
+}
+
+/**
+ * Interface to store authorized API list item.
+ */
+export interface AuthorizedAPIListItemInterface {
+    id: string,
+    identifier: string,
+    displayName: string,
+    policyId: string,
+    authorizedScopes: ScopeInterface[]
+}

--- a/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
@@ -226,7 +226,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                         const selectedAPIResource: AuthorizedAPIListItemInterface =
                             authorizedAPIListForApplication.find(
                                 (api: AuthorizedAPIListItemInterface) => api.id === apiResource.id
-                        );
+                            );
 
                         selectedAPIResourcesList.push({
                             id: selectedAPIResource.id,

--- a/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
@@ -50,10 +50,11 @@ import { Dispatch } from "redux";
 import { DropdownProps } from "semantic-ui-react";
 import { RenderChip } from "./edit-role-common/render-chip";
 import { RoleAPIResourcesListItem } from "./edit-role-common/role-api-resources-list-item";
+import { useGetAuthorizedAPIList } from "../../../api-resources/api";
 import { getAPIResourceDetailsBulk, updateRoleDetails, useAPIResourceDetails, useAPIResourcesList } from "../../api";
-import { RoleConstants } from "../../constants/role-constants";
+import { RoleAudienceTypes, RoleConstants } from "../../constants/role-constants";
 import { PatchRoleDataInterface, PermissionUpdateInterface, SelectedPermissionsInterface } from "../../models";
-import { APIResourceInterface, ScopeInterface } from "../../models/apiResources";
+import { APIResourceInterface, AuthorizedAPIListItemInterface, ScopeInterface } from "../../models/apiResources";
 
 /**
  * Interface to capture permission edit props.
@@ -82,7 +83,7 @@ interface RolePermissionDetailProps extends IdentifiableComponentInterface {
  */
 export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetailProps> = (props:
     RolePermissionDetailProps): ReactElement => {
-    
+
     const {
         isReadOnly,
         role,
@@ -118,17 +119,29 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
         error: selectedAPIResourceFetchRequestError
     } = useAPIResourceDetails(selectedAPIResourceId);
 
+    const {
+        data: authorizedAPIListForApplication,
+        isLoading: isAuthorizedAPIListForApplicationLoading,
+        error: authorizedAPIListForApplicationError
+    } = useGetAuthorizedAPIList(
+        role.audience.type.toUpperCase() === RoleAudienceTypes.APPLICATION ? role.audience.value : null
+    );
+
     useEffect(() => {
-        !isReadOnly 
+        !isReadOnly
             ? getExistingAPIResources()
             : null;
     }, [ role ]);
 
     /**
      * Show error if the API resource fetch request failed.
-     */ 
+     */
     useEffect(() => {
-        if ( selectedAPIResourceFetchRequestError ||  apiResourcsListFetchRequestError) {
+        if (
+            selectedAPIResourceFetchRequestError ||
+            apiResourcsListFetchRequestError ||
+            authorizedAPIListForApplicationError
+        ) {
             dispatch(
                 addAlert({
                     description: t("console:manage.features.roles.addRoleWizard.forms.rolePermission." +
@@ -144,28 +157,44 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
     useEffect(() => {
         const options: DropdownProps[] = [];
 
-        apiResourcesList?.apiResources?.map((apiResource: APIResourceInterface) => {
-            if (!selectedAPIResources.find((selectedAPIResource: APIResourceInterface) => 
-                selectedAPIResource?.id === apiResource?.id)) {
-                options.push({
-                    key: apiResource?.id,
-                    text: apiResource?.name,
-                    value: apiResource?.id
-                });
-            }
-        });
+        if (role.audience.type.toUpperCase() === RoleAudienceTypes.ORGANIZATION) {
+            // API resources list options when role audience is "organization".
+            apiResourcesList?.apiResources?.map((apiResource: APIResourceInterface) => {
+                if (!selectedAPIResources.find((selectedAPIResource: APIResourceInterface) =>
+                    selectedAPIResource?.id === apiResource?.id)) {
+                    options.push({
+                        key: apiResource.id,
+                        text: apiResource.name,
+                        value: apiResource.id
+                    });
+                }
+            });
+        } else {
+            // API resources list options when role audience is "application".
+            authorizedAPIListForApplication?.map((api: AuthorizedAPIListItemInterface) => {
+                if (
+                    !selectedAPIResources.find((selectedAPIResource: APIResourceInterface) =>
+                        selectedAPIResource?.id === api?.id)) {
+                    options.push({
+                        key: api.id,
+                        text: api.displayName,
+                        value: api.id
+                    });
+                }
+            });
+        }
 
         setAPIResourcesListOptions(options);
-    }, [ apiResourcesList, selectedAPIResources ]);
+    }, [ authorizedAPIListForApplication, apiResourcesList, selectedAPIResources ]);
 
     /**
      * Add API resource to the selected API resources list.
      */
     useEffect(() => {
-        if (selectedAPIResource 
-            && !isSelectedAPIResourceFetchRequestLoading 
+        if (selectedAPIResource
+            && !isSelectedAPIResourceFetchRequestLoading
             && !isSelectedAPIResourceFetchRequestValidating) {
-            
+
             if (!selectedAPIResources.find(
                 (apiResource: APIResourceInterface) => selectedAPIResource?.id === apiResource?.id)) {
                 setSelectedAPIResources([ selectedAPIResource, ...selectedAPIResources ]);
@@ -178,7 +207,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
     useEffect(() => {
         getAPIResourceById(initialAPIResourceIds);
     }, [ initialAPIResourceIds ]);
-        
+
     const getAPIResourceById = async (initialAPIResourceIds: string[]): Promise<void> => {
         const apiResourceIds: string[] = initialAPIResourceIds;
 
@@ -188,7 +217,25 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
 
         getAPIResourceDetailsBulk(apiResourceIds)
             .then((response: APIResourceInterface[]) => {
-                setSelectedAPIResources(response);
+                if (role.audience.type.toUpperCase() === RoleAudienceTypes.ORGANIZATION) {
+                    setSelectedAPIResources(response);
+                } else {
+                    const selectedAPIResourcesList: APIResourceInterface[] = [];
+
+                    response.map((apiResource: APIResourceInterface) => {
+                        const selectedAPIResource: AuthorizedAPIListItemInterface =
+                            authorizedAPIListForApplication.find(
+                                (api: AuthorizedAPIListItemInterface) => api.id === apiResource.id
+                        );
+
+                        selectedAPIResourcesList.push({
+                            id: selectedAPIResource.id,
+                            name: selectedAPIResource.displayName,
+                            scopes: selectedAPIResource.authorizedScopes
+                        });
+                    });
+                    setSelectedAPIResources(selectedAPIResourcesList);
+                }
             })
             .catch(() => {
                 handleAlerts({
@@ -213,9 +260,9 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                 // Populate the selected permissions list.
                 if (!currentPermissions.find((selectedPermission: SelectedPermissionsInterface) =>
                     selectedPermission.apiResourceId === apiResourceId)) {
-                    // Found a new API resource id.                 
+                    // Found a new API resource id.
                     uniqueAPIResourceIds.push(apiResourceId);
-                    
+
                     // Add it to the selected API resources list.
                     currentPermissions.push({
                         apiResourceId: apiResourceId,
@@ -228,7 +275,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                 } else {
                     // Found a matching API resource id
                     const index: number = currentPermissions.findIndex(
-                        (selectedPermission: SelectedPermissionsInterface) => 
+                        (selectedPermission: SelectedPermissionsInterface) =>
                             selectedPermission.apiResourceId === apiResourceId
                     );
 
@@ -241,7 +288,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                 }
             }
         });
-        
+
         setInitialAPIResourceIds(uniqueAPIResourceIds);
         setSelectedPermissions(currentPermissions);
         setInitialSelectedPermissions(currentPermissions);
@@ -303,11 +350,11 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
     /**
      * The following function handles the search query for the groups list.
      */
-    const searchAPIResources: DebouncedFunc<(query: string) => void> = 
+    const searchAPIResources: DebouncedFunc<(query: string) => void> =
         useCallback(debounce((query: string) => {
             setAPIResourceSearchQuery(
-                !isEmpty(query) 
-                    ? `name co ${query}` 
+                !isEmpty(query)
+                    ? `name co ${query}`
                     : null
             );
             mutateAPIResourcesListFetchRequest().finally(() => {
@@ -317,10 +364,28 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
 
     /**
      * Handles the selection of an API resource.
+     *
+     * Only retrieve the API resource details when the role audience is "organization",
+     * else add the API resource to the selected API resources list from the authorized API list.
      */
     const onAPIResourceSelected = (event: SyntheticEvent<HTMLElement>, data: DropdownProps): void => {
         event.preventDefault();
-        setSelectedAPIResourceId(data.value.toString());
+        if (role.audience.type.toUpperCase() === RoleAudienceTypes.ORGANIZATION) {
+            setSelectedAPIResourceId(data.value.toString());
+        } else {
+            const selectedAPIResource: AuthorizedAPIListItemInterface = authorizedAPIListForApplication.find(
+                (api: AuthorizedAPIListItemInterface) => api.id === data.value.toString()
+            );
+
+            setSelectedAPIResources([
+                {
+                    id: selectedAPIResource.id,
+                    name: selectedAPIResource.displayName,
+                    scopes: selectedAPIResource.authorizedScopes
+                },
+                ...selectedAPIResources
+            ]);
+        }
         setAPIResourceSearchQuery(undefined);
     };
 
@@ -334,10 +399,10 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
 
     const onChangeScopes = (apiResource: APIResourceInterface, scopes: ScopeInterface[]): void => {
         const selectedScopes: SelectedPermissionsInterface[] = selectedPermissions.filter(
-            (selectedPermission: SelectedPermissionsInterface) => 
+            (selectedPermission: SelectedPermissionsInterface) =>
                 selectedPermission.apiResourceId !== apiResource.id
         );
-        
+
         selectedScopes.push(
             {
                 apiResourceId: apiResource.id,
@@ -368,8 +433,8 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
         <Grid container direction="column" justifyContent="center" alignItems="flex-start" spacing={ 2 }>
             <Grid xs={ 8 }>
                 <Form
-                    id={ componentId } 
-                    uncontrolledForm={ false } 
+                    id={ componentId }
+                    uncontrolledForm={ false }
                     onSubmit={ undefined }
                 >
                     <Field.Dropdown
@@ -397,7 +462,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
             </Grid>
             <Grid xs={ 12 }>
                 {
-                    selectedAPIResources?.length > 0 
+                    selectedAPIResources?.length > 0
                         ? (
                             <div className="role-permission-list field">
                                 <label className="form-label">
@@ -408,16 +473,17 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                                     className="mt-2"
                                     data-componentid={ componentId }
                                     basic
-                                    loading={ 
+                                    loading={
                                         selectedAPIResourceId &&
-                                        (isSelectedAPIResourceFetchRequestLoading 
-                                            || isSelectedAPIResourceFetchRequestValidating) 
+                                        (isSelectedAPIResourceFetchRequestLoading
+                                            || isSelectedAPIResourceFetchRequestValidating
+                                            || isAuthorizedAPIListForApplicationLoading)
                                     }
                                 >
                                     {
                                         selectedAPIResources?.map((apiResource: APIResourceInterface) => {
                                             return (
-                                                <RoleAPIResourcesListItem 
+                                                <RoleAPIResourcesListItem
                                                     key={ apiResource?.id }
                                                     apiResource={ apiResource }
                                                     onChangeScopes={ onChangeScopes }
@@ -432,7 +498,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                                                             selectedPermission.apiResourceId === apiResource?.id)
                                                         ?.scopes
                                                     }
-                                                /> 
+                                                />
                                             );
                                         })
                                     }
@@ -458,10 +524,10 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                 />
             ) }
             renderTags={ (
-                value: RolePermissionInterface[], 
+                value: RolePermissionInterface[],
                 getTagProps: AutocompleteRenderGetTagProps
             ) => value.map((option: RolePermissionInterface, index: number) => (
-                <RenderChip 
+                <RenderChip
                     { ...getTagProps({ index }) }
                     key={ index }
                     className="pt-5 m-1"

--- a/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
@@ -50,7 +50,7 @@ import { Dispatch } from "redux";
 import { DropdownProps } from "semantic-ui-react";
 import { RenderChip } from "./edit-role-common/render-chip";
 import { RoleAPIResourcesListItem } from "./edit-role-common/role-api-resources-list-item";
-import { useGetAuthorizedAPIList } from "../../../api-resources/api";
+import { useGetAuthorizedAPIList } from "../../../api-resources/api/useGetAuthorizedAPIList";
 import { getAPIResourceDetailsBulk, updateRoleDetails, useAPIResourceDetails, useAPIResourcesList } from "../../api";
 import { RoleAudienceTypes, RoleConstants } from "../../constants/role-constants";
 import { PatchRoleDataInterface, PermissionUpdateInterface, SelectedPermissionsInterface } from "../../models";


### PR DESCRIPTION
### Purpose
Display only the permissions of allowed API resources for roles with …

### Related Issues
- https://github.com/wso2/product-is/issues/17481

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5128

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
