### PR TITLE
Add client id and organization as query params to the redirect URL of the Asgardeo Try It application

### DIFF
--- a/apps/console/src/extensions/components/getting-started/components/login-playground-wizard.tsx
+++ b/apps/console/src/extensions/components/getting-started/components/login-playground-wizard.tsx
@@ -286,11 +286,14 @@ export const LoginPlaygroundWizard: FunctionComponent<LoginPlaygroundWizardProps
         setShowApplicationCreationScreen(true);
         
         const modifiedApplication: MainApplicationInterface = cloneDeep(LoginApplicationTemplate.application);
-
+        const queryParams: URLSearchParams = new URLSearchParams([ [ "client_id", tryItAppClientId],
+            ["org", tenantDomain] ]);
+        const loginPlaygroundURLWithQueryParams: string = `${asgardeoLoginPlaygroundURL}/?${queryParams}`;
+        
         modifiedApplication.inboundProtocolConfiguration.oidc.clientId = tryItAppClientId;
-        modifiedApplication.inboundProtocolConfiguration.oidc.callbackURLs = [ asgardeoLoginPlaygroundURL ];
+        modifiedApplication.inboundProtocolConfiguration.oidc.callbackURLs = [ loginPlaygroundURLWithQueryParams ];
         modifiedApplication.inboundProtocolConfiguration.oidc.allowedOrigins = [ asgardeoLoginPlaygroundURL ];
-        modifiedApplication.accessUrl = asgardeoLoginPlaygroundURL;
+        modifiedApplication.accessUrl = loginPlaygroundURLWithQueryParams;
 
         /**
          * Creating the try it app on demand

--- a/apps/console/src/extensions/components/getting-started/components/login-playground-wizard.tsx
+++ b/apps/console/src/extensions/components/getting-started/components/login-playground-wizard.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -286,8 +286,8 @@ export const LoginPlaygroundWizard: FunctionComponent<LoginPlaygroundWizardProps
         setShowApplicationCreationScreen(true);
         
         const modifiedApplication: MainApplicationInterface = cloneDeep(LoginApplicationTemplate.application);
-        const queryParams: URLSearchParams = new URLSearchParams([ [ "client_id", tryItAppClientId],
-            ["org", tenantDomain] ]);
+        const queryParams: URLSearchParams = new URLSearchParams([ [ "client_id", tryItAppClientId ],
+            [ "org", tenantDomain ] ]);
         const loginPlaygroundURLWithQueryParams: string = `${asgardeoLoginPlaygroundURL}/?${queryParams}`;
         
         modifiedApplication.inboundProtocolConfiguration.oidc.clientId = tryItAppClientId;


### PR DESCRIPTION
### Purpose
In order to ensure the correct functionality of the Asgardeo Try It app with changes in the PR, the authorized redirect URL should be changed to include the client id and the organization.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
