### PR TITLE
Directly Redirect to Email OTP Page when it is the sole second factor configured

### DIFF
--- a/.changeset/chilled-garlics-think.md
+++ b/.changeset/chilled-garlics-think.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Directly Redirect to Email OTP Page when it is the sole second factor configured

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -78,7 +78,6 @@
     private static final String BACKUP_CODE_AUTHENTICATOR = "backup-code-authenticator";
     private static final String SMS_OTP_AUTHENTICATOR = "sms-otp-authenticator";
     private static final String EMAIL_OTP_AUTHENTICATOR = "email-otp-authenticator";
-
     private static final String TOTP_AUTHENTICATOR = "totp";
     private static final String ENTERPRISE_LOGIN_KEY = "isEnterpriseLoginEnabled";
     private static final String ENTERPRISE_API_RELATIVE_PATH = "/api/asgardeo-enterprise-login/v1/business-user-login/";

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -77,6 +77,8 @@
     private static final String USER_TYPE_ASGARDEO = "asg";
     private static final String BACKUP_CODE_AUTHENTICATOR = "backup-code-authenticator";
     private static final String SMS_OTP_AUTHENTICATOR = "sms-otp-authenticator";
+    private static final String EMAIL_OTP_AUTHENTICATOR = "email-otp-authenticator";
+
     private static final String TOTP_AUTHENTICATOR = "totp";
     private static final String ENTERPRISE_LOGIN_KEY = "isEnterpriseLoginEnabled";
     private static final String ENTERPRISE_API_RELATIVE_PATH = "/api/asgardeo-enterprise-login/v1/business-user-login/";
@@ -207,7 +209,15 @@
                 response.sendRedirect(directTo);
 
                 return;
-            } else if (localAuthenticatorNames.contains(SMS_OTP_AUTHENTICATOR)) {
+            } else if (localAuthenticatorNames.contains(EMAIL_OTP_AUTHENTICATOR)) {
+                String directTo = commonauthURL + "?idp=LOCAL&authenticator=" + EMAIL_OTP_AUTHENTICATOR + "&sessionDataKey="
+                    + Encode.forUriComponent(request.getParameter("sessionDataKey")) + multiOptionURIParam;
+                response.sendRedirect(directTo);
+
+                return;
+            }
+            
+            else if (localAuthenticatorNames.contains(SMS_OTP_AUTHENTICATOR)) {
                 String directTo = commonauthURL + "?idp=LOCAL&authenticator=" + SMS_OTP_AUTHENTICATOR + "&sessionDataKey="
                     + Encode.forUriComponent(request.getParameter("sessionDataKey")) + multiOptionURIParam;
                 response.sendRedirect(directTo);

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -214,9 +214,7 @@
                 response.sendRedirect(directTo);
 
                 return;
-            }
-            
-            else if (localAuthenticatorNames.contains(SMS_OTP_AUTHENTICATOR)) {
+            } else if (localAuthenticatorNames.contains(SMS_OTP_AUTHENTICATOR)) {
                 String directTo = commonauthURL + "?idp=LOCAL&authenticator=" + SMS_OTP_AUTHENTICATOR + "&sessionDataKey="
                     + Encode.forUriComponent(request.getParameter("sessionDataKey")) + multiOptionURIParam;
                 response.sendRedirect(directTo);


### PR DESCRIPTION
### Purpose

$subject

https://github.com/wso2/identity-apps/assets/41533942/422b7d9d-95b4-457a-83f5-582e5fe12237

### Related Issues
- https://github.com/wso2/product-is/issues/17557

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
