### PR TITLE
Fix Unable to Sign in with Ethereum as getting a 500 Internal Server Error

### DIFF
--- a/.changeset/silver-vans-study.md
+++ b/.changeset/silver-vans-study.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix ethereum idp connector template issue

--- a/apps/console/src/features/connections/components/create/add-connection-wizard.tsx
+++ b/apps/console/src/features/connections/components/create/add-connection-wizard.tsx
@@ -315,7 +315,8 @@ export const CreateConnectionWizard: FC<CreateConnectionWizardPropsInterface> = 
 
         connection.name = values?.name.toString();
         connection.templateId = template.templateId;
-        connection.federatedAuthenticators.authenticators[ 0 ].properties = updatedProperties;
+        connection.federatedAuthenticators.authenticators[ 0 ].properties = connection.federatedAuthenticators
+            .authenticators[ 0 ].properties.concat(updatedProperties);
 
         // Allow to set empty client ID and client secret but make the authenticator disabled.
         if (values?.clientId) {


### PR DESCRIPTION
### Purpose
> Fix Unable to Sign in with Ethereum as getting a 500 Internal Server Error

### Related Issues
- [Unable to Sign in with Ethereum as getting a 500 Internal Server](https://github.com/wso2/product-is/issues/17498)


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
