### PR TITLE
Fix role patch user operation path

### DIFF
--- a/.changeset/little-fishes-battle.md
+++ b/.changeset/little-fishes-battle.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change role pactch path

--- a/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
@@ -262,7 +262,7 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
                 "Operations": []
             },
             method: "PATCH",
-            path: "v2/Roles/" + role.id
+            path: "/v2/Roles/" + role.id
         };
         
         removedGroupsOptions?.map((group: GroupsInterface) => {

--- a/apps/console/src/features/roles/components/edit-role/edit-role-users.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-users.tsx
@@ -260,7 +260,7 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
                 "Operations": []
             },
             method: "PATCH",
-            path: "v2/Roles/" + role.id
+            path: "/v2/Roles/" + role.id
         };
         
         removedUsersOptions?.map((user: UserBasicInterface) => {


### PR DESCRIPTION
### Purpose
The roles patch operation is currently targeting `v2/roles`, which the backend does not recognize due to the absence of a leading slash.

### Related Issues
- 