### PR TITLE
Add self signup URL text to the branding.

### DIFF
--- a/.changeset/stale-onions-suffer.md
+++ b/.changeset/stale-onions-suffer.md
@@ -2,6 +2,7 @@
 "@wso2is/myaccount": patch
 "@wso2is/console": patch
 "@wso2is/i18n": patch
+"@wso2is/identity-apps-core": patch
 ---
 
 Add self signup URL text to the branding.

--- a/.changeset/stale-onions-suffer.md
+++ b/.changeset/stale-onions-suffer.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/myaccount": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add self signup URL text to the branding.

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -1147,6 +1147,11 @@ export interface Extensions {
                                 label: string;
                                 placeholder: string;
                             };
+                            selfSignUpURL: {
+                                hint: string;
+                                label: string;
+                                placeholder: string;
+                            };
                             termsOfUseURL: {
                                 hint: string;
                                 label: string;

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -1332,6 +1332,11 @@ export const extensions: Extensions = {
                                 label: "Privacy Policy",
                                 placeholder: "https://myapp.com/{{locale}}/privacy-policy"
                             },
+                            selfSignUpURL: {
+                                hint: "Link to your organization's Self Signup webpage. You can use placeholders like <1>{{lang}}</1>, <3>{{country}}</3>, or <5>{{locale}}</5> to customize the URL for different regions or languages.",
+                                label: "Self Signup",
+                                placeholder: "https://myapp.com/self-signup"
+                            },
                             termsOfUseURL: {
                                 hint: "Link to an agreement that your customers must agree to and abide by in order to use your organization's applications or other services. You can use placeholders like <1>{{lang}}</1>, <3>{{country}}</3>, or <5>{{locale}}</5> to customize the URL for different regions or languages.",
                                 label: "Terms of Service",

--- a/apps/console/src/extensions/i18n/resources/fr-FR/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/fr-FR/extensions.ts
@@ -1333,6 +1333,11 @@ export const extensions: Extensions = {
                                 label: "politique de confidentialité",
                                 placeholder: "https://myapp.com/{{locale}}/privacy-policy"
                             },
+                            selfSignUpURL: {
+                                hint: "Lien vers la page Web d'auto-inscription de votre organisation. Vous pouvez utiliser des espaces réservés comme <1>{{lang}}</1>, <3>{{country}}</3>, ou <5>{{locale}}</5> pour personnaliser l'URL pour différentsrégions ou langues.",
+                                label: "Auto-inscription",
+                                placeholder: "https://myapp.com/self-signup"
+                            },
                             termsOfUseURL: {
                                 hint: "Lien vers un accord que vos clients doivent accepter et respecter afin d'utiliser les applications ou d'autres services de votre organisation.Vous pouvez utiliser des espaces réservés comme <1>{{lang}}</1>, <3>{{country}}</3>, ou <5>{{locale}}</5> pour personnaliser l'URL pour différentsrégions ou langues.",
                                 label: "Conditions d'utilisation",

--- a/apps/console/src/extensions/i18n/resources/si-LK/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/si-LK/extensions.ts
@@ -1314,6 +1314,11 @@ export const extensions: Extensions = {
                                 label: "රහස්යතා ප්රතිපත්තිය",
                                 placeholder: "https://myapp.com/{{locale}}/privacy-policy"
                             },
+                            selfSignUpURL: {
+                                hint: "ඔබේ සංවිධානයේ ස්වයං ලියාපදිංචි වීමේ වෙබ් පිටුවට සම්බන්ධ වන්න. විවිධ කලාප හෝ භාෂා සඳහා URL අභිරුචිකරණය කිරීමට <1>{{lang}}</1>, <3>{{country}}</3>, හෝ <5>{{locale}}</5> placeholders භාවිතා කළ හැකිය.",
+                                label: "ස්වයං ලියාපදිංචි වීම",
+                                placeholder: "https://myapp.com/self-signup"
+                            },
                             termsOfUseURL: {
                                 hint: "ඔබේ ආයෝජන යෙදුම් හෝ වෙනත් සේවාවන් භාවිතා කිරීම සඳහා ඔබේ ගනුදෙනුකරුවන් ඊට එකඟ වී පිළිපැදිය යුතු ගිවිසුමකට සම්බන්ධ වන්න. විවිධ කලාප හෝ භාෂා සඳහා URL අභිරුචිකරණය කිරීමට <1>{{lang}}</1>, <3>{{country}}</3>, හෝ <5>{{locale}}</5> placeholders භාවිතා කළ හැකිය.",
                                 label: "සේවා කොන්දේසි",

--- a/apps/console/src/features/branding/components/advanced/advance-form.tsx
+++ b/apps/console/src/features/branding/components/advanced/advance-form.tsx
@@ -95,6 +95,7 @@ export const AdvanceForm: FunctionComponent<AdvanceFormPropsInterface> = forward
     const [ privacyPolicyURL, setPrivacyPolicyURL ] = useState<string>(initialValues.urls.privacyPolicyURL);
     const [ termsOfUseURL, setTermsOfUseURL ] = useState<string>(initialValues.urls.termsOfUseURL);
     const [ cookiePolicyURL, setCookiePolicyURL ] = useState<string>(initialValues.urls.cookiePolicyURL);
+    const [ selfSignUpURL, setSelfSignUpURL ] = useState<string>(initialValues.urls.selfSignUpURL);
 
     /**
      * Broadcast values to the outside when internals change.
@@ -107,6 +108,7 @@ export const AdvanceForm: FunctionComponent<AdvanceFormPropsInterface> = forward
                 ...initialValues.urls,
                 cookiePolicyURL: cookiePolicyURL,
                 privacyPolicyURL: privacyPolicyURL,
+                selfSignUpURL: selfSignUpURL,
                 termsOfUseURL: termsOfUseURL
             }
         });
@@ -257,6 +259,33 @@ export const AdvanceForm: FunctionComponent<AdvanceFormPropsInterface> = forward
                 width={ 16 }
                 data-testid={ `${ componentId }-cookie-policy-url` }
                 validation={ validateTemplatableURLs }
+            />
+            <Field.Input
+                ariaLabel="Branding preference self signup URL"
+                inputType="url"
+                name="urls.selfSignUpURL"
+                label={ t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.label") }
+                placeholder={
+                    t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.placeholder")
+                }
+                hint={ (
+                    <Trans
+                        i18nKey="extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.hint"
+                    >
+                        Link to your organization&apos;s Self Signup webpage. You can use placeholders like
+                        <Code>&#123;&#123;lang&#125;&#125;</Code>, <Code>&#123;&#123;country&#125;&#125;</Code>,
+                        or <Code>&#123;&#123;locale&#125;&#125;</Code> to customize the URL for different
+                        regions or languages.
+                    </Trans>
+                ) }
+                required={ false }
+                value={ initialValues.urls.selfSignUpURL }
+                readOnly={ readOnly }
+                maxLength={ BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MAX_LENGTH }
+                minLength={ BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MIN_LENGTH }
+                listen={ (value: string) =>  setSelfSignUpURL(value) }
+                width={ 16 }
+                data-testid={ `${ componentId }-self-signup-url` }
             />
         </Form>
     );

--- a/apps/console/src/features/branding/components/branding-preference-tabs.tsx
+++ b/apps/console/src/features/branding/components/branding-preference-tabs.tsx
@@ -291,6 +291,7 @@ export const BrandingPreferenceTabs: FunctionComponent<BrandingPreferenceTabsInt
                         urls: {
                             cookiePolicyURL: brandingPreference.urls?.cookiePolicyURL,
                             privacyPolicyURL: brandingPreference.urls?.privacyPolicyURL,
+                            selfSignUpURL: brandingPreference.urls?.selfSignUpURL,
                             termsOfUseURL: brandingPreference.urls?.termsOfUseURL
                         }
                     } }

--- a/apps/console/src/features/branding/models/branding-preferences.ts
+++ b/apps/console/src/features/branding/models/branding-preferences.ts
@@ -159,6 +159,10 @@ export interface BrandingPreferenceURLInterface {
      * Link for Cookie Policy.
      */
     cookiePolicyURL: string;
+    /**
+     * Link for Self Sign Up.
+     */
+    selfSignUpURL?: string;
 }
 
 /**

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -670,7 +670,7 @@
                 <button
                     type="button"
                     <% if(StringUtils.isNotBlank(selfSignUpOverrideURL)) { %>
-                    onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(selfSignUpOverrideURL)%>';"
+                    onclick="window.location.href='<%=i18nLink(userLocale, selfSignUpOverrideURL)%>';"
                     <% } else { %>
                     onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(getRegistrationUrl(accountRegistrationEndpointURL, srURLEncodedURL, urlParameters))%>';"
                     <% } %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/identifierauth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/identifierauth.jsp
@@ -327,7 +327,7 @@ if (!StringUtils.equals("CONSOLE",clientId)
             <button
                 type="button"
                 <% if(StringUtils.isNotBlank(selfSignUpOverrideURL)) { %>
-                onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(selfSignUpOverrideURL)%>';"
+                onclick="window.location.href='<%=i18nLink(userLocale, selfSignUpOverrideURL)%>';"
                 <% } else { %>
                 onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(getRegistrationUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, urlParameters))%>';"
                 <% } %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -1113,7 +1113,7 @@
                                         <button
                                             type="button"
                                             <% if(StringUtils.isNotBlank(selfSignUpOverrideURL)) { %>
-                                            onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(selfSignUpOverrideURL)%>';"
+                                            onclick="window.location.href='<%=i18nLink(userLocale, selfSignUpOverrideURL)%>';"
                                             <% } else { %>
                                             onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(getRegistrationUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, urlParameters))%>';"
                                             <% } %>


### PR DESCRIPTION
### Purpose
Add self signup URL text to the branding.

### Screen-record
https://github.com/wso2/identity-apps/assets/46097917/409315d2-b826-4da8-9851-b92244f2ec16

### Related Issues
- https://github.com/wso2/product-is/issues/17639

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
