### PR TITLE
Hide the action to choose other authentication options in email OTP when multi auth is unavailable

### DIFF
--- a/.changeset/fair-jokes-hammer.md
+++ b/.changeset/fair-jokes-hammer.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Hide action to choose another authentication option when multi auth is unavailable

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -32,6 +32,32 @@
 <%-- Branding Preferences --%>
 <jsp:directive.include file="includes/branding-preferences.jsp"/>
 
+<%!
+    private boolean isMultiAuthAvailable(String multiOptionURI) {
+        boolean isMultiAuthAvailable = true;
+        if (multiOptionURI == null || multiOptionURI.equals("null")) {
+            isMultiAuthAvailable = false;
+        } else {
+            int authenticatorIndex = multiOptionURI.indexOf("authenticators=");
+            if (authenticatorIndex == -1) {
+                isMultiAuthAvailable = false;
+            } else {
+                String authenticators = multiOptionURI.substring(authenticatorIndex + 15);
+                int authLastIndex = authenticators.indexOf("&") != -1 ? authenticators.indexOf("&") : authenticators.length();
+                authenticators = authenticators.substring(0, authLastIndex);
+                List<String> authList = new ArrayList<>(Arrays.asList(authenticators.split("%3B")));
+                if (authList.size() < 2) {
+                    isMultiAuthAvailable = false;
+                }
+                else if (authList.size() == 2 && authList.contains("backup-code-authenticator%3ALOCAL")) {
+                    isMultiAuthAvailable = false;
+                }
+            }
+        }
+        return isMultiAuthAvailable;
+    }
+%>
+
 <%
     request.getSession().invalidate();
     String queryString = request.getQueryString();
@@ -266,7 +292,8 @@
                 <div class="ui divider hidden"></div>
                 <%
                     String multiOptionURI = request.getParameter("multiOptionURI");
-                    if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI)) {
+                    if (multiOptionURI != null && AuthenticationEndpointUtil.isValidURL(multiOptionURI) &&
+                    isMultiAuthAvailable(multiOptionURI)) {
                 %>
                     <a class="ui primary basic button link-button" id="goBackLink"
                     href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>


### PR DESCRIPTION
### Purpose
Hid the action, `Choose a different option` when multiple authentication options are not allowed.

### Related Issues
- https://github.com/wso2/product-is/issues/17619

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
