### PR TITLE
Skip validations if the inputs are readonly

### DIFF
--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -1413,7 +1413,8 @@
             var firstNameUserInput = document.getElementById("firstNameUserInput");
             var lastNameUserInput = document.getElementById("lastNameUserInput");
 
-            if ( firstNameUserInput.value.trim() === "" ||  lastNameUserInput.value.trim() === "")  {
+            if ( (!!firstNameUserInput &&  firstNameUserInput.value.trim() === "")
+                || ( !!lastNameUserInput && lastNameUserInput.value.trim() === ""))  {
                 return false;
             }
 


### PR DESCRIPTION
### Purpose
> When JIT Provisioning enabled with "Prompt for password and consent" option or "Prompt for consent" option, firstNameUserInput and lastNameUserInput elements are not available. Hence the Sign-Up is not enabled when the privacy policy check box is ticked.

### Related Issues
- https://github.com/wso2/product-is/issues/17602

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
