### PR TITLE
Fix: UI does not hide option to delete the everyone role

### DIFF
--- a/.changeset/real-ears-pump.md
+++ b/.changeset/real-ears-pump.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/core": patch
+"@wso2is/myaccount": patch
+---
+
+Remove delete action of the `everyone` role

--- a/apps/console/src/features/roles/components/edit-role/edit-role.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role.tsx
@@ -76,6 +76,7 @@ export const EditRole: FunctionComponent<EditRoleProps> = (props: EditRoleProps)
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
 
     const [ isAdminRole, setIsAdminRole ] = useState<boolean>(false);
+    const [ isEveryoneRole, setIsEveryoneRole ] = useState<boolean>(false);
 
     const isSubOrg: boolean = organizationType === OrganizationType.SUBORGANIZATION;
 
@@ -86,6 +87,8 @@ export const EditRole: FunctionComponent<EditRoleProps> = (props: EditRoleProps)
         if(roleObject) {
             setIsAdminRole(roleObject.displayName === RoleConstants.ADMIN_ROLE ||
                 roleObject.displayName === RoleConstants.ADMIN_GROUP);
+            setIsEveryoneRole(roleObject.displayName === RoleConstants.EVERYONE_ROLE ||
+                roleObject.displayName === RoleConstants.EVERYONE_GROUP);
         }
     }, [ roleObject ]);
 
@@ -96,7 +99,7 @@ export const EditRole: FunctionComponent<EditRoleProps> = (props: EditRoleProps)
                 render: () => (
                     <ResourceTab.Pane controlledSegmentation attached={ false }>
                         <BasicRoleDetails
-                            isReadOnly={ isSubOrg || isAdminRole
+                            isReadOnly={ isSubOrg || isAdminRole || isEveryoneRole
                                 || !hasRequiredScopes(
                                     featureConfig?.roles, featureConfig?.roles?.scopes?.update, allowedScopes) }
                             role={ roleObject }

--- a/apps/console/src/features/roles/components/role-list.tsx
+++ b/apps/console/src/features/roles/components/role-list.tsx
@@ -272,7 +272,8 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
             },
             {
                 hidden: (role: RolesInterface) => isSubOrg || (role?.displayName === RoleConstants.ADMIN_ROLE ||
-                    role?.displayName === RoleConstants.ADMIN_GROUP)
+                    role?.displayName === RoleConstants.ADMIN_GROUP) || (role?.displayName === 
+                        RoleConstants.EVERYONE_ROLE || role?.displayName === RoleConstants.EVERYONE_GROUP)
                     || !hasRequiredScopes(featureConfig?.roles, featureConfig?.roles?.scopes?.delete, allowedScopes),
                 icon: (): SemanticICONS => "trash alternate",
                 onClick: (e: SyntheticEvent, role: RolesInterface): void => {

--- a/modules/core/src/constants/role-constants.ts
+++ b/modules/core/src/constants/role-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -24,8 +24,6 @@ export class RoleConstants {
     /**
      * Private constructor to avoid object instantiation from outside
      * the class.
-     *
-     * @hideconstructor
      */
     /* eslint-disable @typescript-eslint/no-empty-function */
     private constructor() { }
@@ -33,10 +31,15 @@ export class RoleConstants {
     // API errors
     public static readonly ROLES_FETCH_REQUEST_INVALID_RESPONSE_CODE_ERROR: string = "Received an invalid " +
         "status code while retrieving user roles.";
+
     public static readonly ROLES_FETCH_REQUEST_ERROR: string = "An error occurred while fetching the " +
         "user roles.";
 
     // Admin role display names.
     public static readonly ADMIN_ROLE: string = "admin";
     public static readonly ADMIN_GROUP: string = "Internal/admin";
+
+    // Everyone role display names.
+    public static readonly EVERYONE_ROLE: string = "everyone";
+    public static readonly EVERYONE_GROUP: string = "Internal/everyone";
 }

--- a/modules/core/src/constants/role-constants.ts
+++ b/modules/core/src/constants/role-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
### Purpose
> These changes will hide the delete action for `everyone` role from the UI.

### Related Issues
- https://github.com/wso2/product-is/issues/17547

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
