### PR TITLE
Make Backup Codes enabled by default

### DIFF
--- a/.changeset/nice-geese-leave.md
+++ b/.changeset/nice-geese-leave.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Make Backup Codes enabled by default

--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/backup-code-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/backup-code-authenticator.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/backup-code-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/backup-code-authenticator.tsx
@@ -662,7 +662,7 @@ export const BackupCodeAuthenticator : FunctionComponent<BackupCodeProps> = (
                                             size="small"
                                             color="grey"
                                             name="add"
-                                            disabled={ isLoading || (!isMFAConfigured && isSuperTenantLogin) }
+                                            disabled={ isLoading }
                                             data-testid={ `${componentid}-init-button` }
                                         />)
                                     }
@@ -673,21 +673,6 @@ export const BackupCodeAuthenticator : FunctionComponent<BackupCodeProps> = (
                         </List.Content>
                     </Grid.Column>
                 </Grid.Row>
-                { !isMFAConfigured && isSuperTenantLogin ? (
-                    <Grid.Row columns={ 1 }>
-                        <Grid.Column width={ 1 } className="first-column" verticalAlign="middle">
-                        </Grid.Column>
-                        <Grid.Column width={ 12 } className="first-column" verticalAlign="middle">
-                            <Message className="display-flex" size="tiny" info>
-                                <Icon name="info" color="teal" corner />
-                                <Message.Content className="tiny">
-                                    { t(translateKey + "messages.disabledMessage") }
-                                </Message.Content>
-                            </Message>
-                        </Grid.Column>
-                    </Grid.Row>) :
-                    null
-                }
             </Grid>
         </>
     );


### PR DESCRIPTION
### Purpose
 Enable Backup Codes by default. So this pr removes the validations available for backup code

### Related Issues
- https://github.com/wso2/product-is/issues/17491

Screenshot
<img width="1149" alt="Screenshot 2023-11-10 at 19 08 18" src="https://github.com/wso2/identity-apps/assets/50905371/1943a77f-433c-4e0f-a0b6-7b42b6831dbf">

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


