### PR TITLE
Add `zh` to the lang map

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/localize.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/localize.jsp
@@ -43,6 +43,7 @@
     supportedLanguages.put("es", "ES");
     supportedLanguages.put("pt", "PT");
     supportedLanguages.put("de", "DE");
+    supportedLanguages.put("zh", "CN");
     supportedLanguages.put("ja", "JP");
 
     // Check cookie for the user selected language first

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/localize.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/localize.jsp
@@ -43,6 +43,7 @@
     supportedLanguages.put("es", "ES");
     supportedLanguages.put("pt", "PT");
     supportedLanguages.put("de", "DE");
+    supportedLanguages.put("zh", "CN");
     supportedLanguages.put("ja", "JP");
 
     // Check cookie for the user selected language first


### PR DESCRIPTION
### Purpose
`zh` was missed in the supported language map to resole URL placeholders.

### Related Issues
- https://github.com/wso2/product-is/issues/17615

### Related PRs
- https://github.com/wso2/identity-apps/pull/4515

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
