### PR TITLE
Change portugese-brazil to portugese-portugal in language dialect

### DIFF
--- a/.changeset/nice-ads-mate.md
+++ b/.changeset/nice-ads-mate.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/i18n": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+---
+
+Change portugese-brazil to portugese-portugal in language dropdown

--- a/modules/i18n/src/translations/pt-BR/meta.ts
+++ b/modules/i18n/src/translations/pt-BR/meta.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -21,7 +21,7 @@ import { LocaleMeta } from "../../models";
 
 export const meta: LocaleMeta = {
     code: "pt-BR",
-    flag: "br",
-    name: "Português (Brazil)",
+    flag: "pt",
+    name: "Português (Portugal)",
     namespaces: [ I18nModuleConstants.COMMON_NAMESPACE, I18nModuleConstants.MY_ACCOUNT_NAMESPACE ]
 };


### PR DESCRIPTION
### Purpose
> Change portugese-brazil to `portugese-portugal` in language dialect
<img width="294" alt="Screenshot 2023-11-13 at 13 57 36" src="https://github.com/wso2/identity-apps/assets/27746285/19727f78-66b0-4ec8-93d7-60add2b351a7">

### Related Issues
- https://github.com/wso2/product-is/issues/17754

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
