### PR TITLE
Fix 400 - Bad Request when updating user attributes in non OAuth applications

### DIFF
--- a/.changeset/modern-humans-do.md
+++ b/.changeset/modern-humans-do.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Prevent sending oidc protocol update request when updating user attributes of non oauth applications.

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -1080,13 +1080,14 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
             delete submitValue.claimConfiguration.subject;
         }
         
-        const isProtocolOAuth: boolean = technology?.find((protocol: InboundProtocolListItemInterface) => 
-            protocol.type === SupportedAuthProtocolTypes.OAUTH2) !== undefined;
+        const isProtocolOAuth: boolean = !!technology?.find((protocol: InboundProtocolListItemInterface) => 
+            protocol.type === SupportedAuthProtocolTypes.OAUTH2);
         
         Promise.all([
             updateClaimConfiguration(appId, submitValue),
-            isProtocolOAuth ? updateAuthProtocolConfig<OIDCDataInterface>(appId, oidcSubmitValue, 
-                SupportedAuthProtocolTypes.OIDC) : Promise.resolve()
+            isProtocolOAuth 
+                ? updateAuthProtocolConfig<OIDCDataInterface>(appId, oidcSubmitValue, SupportedAuthProtocolTypes.OIDC) 
+                : Promise.resolve()
         ]).then(() => {
             onUpdate(appId);
             dispatch(addAlert({

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -1079,10 +1079,14 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
         if (applicationConfig.excludeSubjectClaim && onlyOIDCConfigured) {
             delete submitValue.claimConfiguration.subject;
         }
-
+        
+        const isProtocolOAuth: boolean = technology?.find((protocol: InboundProtocolListItemInterface) => 
+            protocol.type === SupportedAuthProtocolTypes.OAUTH2) !== undefined;
+        
         Promise.all([
             updateClaimConfiguration(appId, submitValue),
-            updateAuthProtocolConfig<OIDCDataInterface>(appId, oidcSubmitValue, SupportedAuthProtocolTypes.OIDC)
+            isProtocolOAuth ? updateAuthProtocolConfig<OIDCDataInterface>(appId, oidcSubmitValue, 
+                SupportedAuthProtocolTypes.OIDC) : Promise.resolve()
         ]).then(() => {
             onUpdate(appId);
             dispatch(addAlert({


### PR DESCRIPTION
### Purpose
The issues https://github.com/wso2/product-is/issues/17746 and https://github.com/wso2/product-is/issues/17748 occurs due to an OIDC protocol update request that is being sent when updating the user attributes.  For non OAuth applications, this request returns `400 - Bad Request`.

This PR modified the logic so that the OIDC protocol update request is only sent for OAuth applications.

### Related Issues
- https://github.com/wso2/product-is/issues/17748
- https://github.com/wso2/product-is/issues/17746

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
