### PR TITLE
Make claim configuration update request and OIDC protocol update request sequential.

### DIFF
--- a/.changeset/rotten-radios-fix.md
+++ b/.changeset/rotten-radios-fix.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Make claim configuration update request and OIDC protocol update request sequential when updating the user attributes in a application to mitigate possible race conditions.

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -1079,16 +1079,18 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
         if (applicationConfig.excludeSubjectClaim && onlyOIDCConfigured) {
             delete submitValue.claimConfiguration.subject;
         }
-        
-        const isProtocolOAuth: boolean = !!technology?.find((protocol: InboundProtocolListItemInterface) => 
-            protocol.type === SupportedAuthProtocolTypes.OAUTH2);
-        
-        Promise.all([
-            updateClaimConfiguration(appId, submitValue),
-            isProtocolOAuth 
-                ? updateAuthProtocolConfig<OIDCDataInterface>(appId, oidcSubmitValue, SupportedAuthProtocolTypes.OIDC) 
-                : Promise.resolve()
-        ]).then(() => {
+
+        const onClaimConfigUpdateError = () => {
+            dispatch(addAlert({
+                description: t("console:develop.features.applications.notifications.updateClaimConfig" +
+                    ".genericError.description"),
+                level: AlertLevels.ERROR,
+                message: t("console:develop.features.applications.notifications.updateClaimConfig.genericError" +
+                    ".message")
+            }));
+        };
+
+        const onSuccessfulClaimConfigUpdate = () => {
             onUpdate(appId);
             dispatch(addAlert({
                 description: t("console:develop.features.applications.notifications.updateClaimConfig.success" +
@@ -1096,16 +1098,22 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                 level: AlertLevels.SUCCESS,
                 message: t("console:develop.features.applications.notifications.updateClaimConfig.success.message")
             }));
-        })
-            .catch(() => {
-                dispatch(addAlert({
-                    description: t("console:develop.features.applications.notifications.updateClaimConfig" +
-                        ".genericError.description"),
-                    level: AlertLevels.ERROR,
-                    message: t("console:develop.features.applications.notifications.updateClaimConfig.genericError" +
-                        ".message")
-                }));
-            });
+        };
+        
+        const isProtocolOAuth: boolean = !!technology?.find((protocol: InboundProtocolListItemInterface) => 
+            protocol.type === SupportedAuthProtocolTypes.OAUTH2);
+
+        updateClaimConfiguration(appId, submitValue)
+            .then(() => {
+                if (isProtocolOAuth) {
+                    updateAuthProtocolConfig<OIDCDataInterface>(appId, oidcSubmitValue, SupportedAuthProtocolTypes.OIDC)
+                        .then(onSuccessfulClaimConfigUpdate)
+                        .catch(onClaimConfigUpdateError);
+                } else {
+                    onSuccessfulClaimConfigUpdate();
+                }
+            })
+            .catch(onClaimConfigUpdateError);
     };
 
     /**

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -1080,6 +1080,10 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
             delete submitValue.claimConfiguration.subject;
         }
 
+        /**
+         * Handles the error scenario of the claim configuration update by displaying a generic claim configuration
+         * update failure alert.
+         */
         const onClaimConfigUpdateError = () => {
             dispatch(addAlert({
                 description: t("console:develop.features.applications.notifications.updateClaimConfig" +
@@ -1090,6 +1094,10 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
             }));
         };
 
+        /**
+         * Handles the successful claim configuration update scenario by executing the `onUpdate` callback and 
+         * displaying a success alert.
+         */
         const onSuccessfulClaimConfigUpdate = () => {
             onUpdate(appId);
             dispatch(addAlert({


### PR DESCRIPTION
### Purpose
Making the claim configuration update request and OIDC protocol update request sequential when updating user attributes in an application based on the [analysis](https://github.com/wso2/product-is/issues/17475#issuecomment-1808224267).

### Related Issues
- https://github.com/wso2/product-is/issues/17475


### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
