### PR TITLE
(fix) Fix content of roles tabs in users and groups to convey that this tab is read only

### DIFF
--- a/.changeset/kind-ducks-wink.md
+++ b/.changeset/kind-ducks-wink.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+"@wso2is/myaccount": patch
+"@wso2is/identity-apps-core": patch
+---
+
+(fix) Fix content of roles tabs in users and groups to convey that this tab is read only

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
@@ -76,9 +76,9 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
             return (
                 <EmptyPlaceholder
                     subtitle={ 
-                        [ t("console:manage.features.roles.edit.groups.placeholders.emptyPlaceholder.subtitles.0") ]
+                        [ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.subtitles") ]
                     }
-                    title={ t("console:manage.features.roles.edit.groups.placeholders.emptyPlaceholder.title") }
+                    title={ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.title") }
                     image={ getEmptyPlaceholderIllustrations().emptyList }
                     imageSize="tiny"
                 />
@@ -89,10 +89,9 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
     return (
         <EmphasizedSegment padded="very">
             <Heading as="h4">
-                { t("console:manage.features.user.updateUser.roles.editRoles.heading") }
+                { t("console:manage.features.groups.edit.roles.heading") }
             </Heading>
             <Heading subHeading ellipsis as="h6">
-                { /* TODO: Need to replace this with "View assigned roles for the group." */ }
                 { t("console:manage.features.groups.edit.roles.subHeading") }
             </Heading>
             {

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -76,9 +76,9 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
                 // TODO: Need to replace the i18N with the correct one.
                 <EmptyPlaceholder
                     subtitle={ 
-                        [ t("console:manage.features.roles.edit.groups.placeholders.emptyPlaceholder.subtitles.0") ]
+                        [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.subtitles") ]
                     }
-                    title={ t("console:manage.features.roles.edit.groups.placeholders.emptyPlaceholder.title") }
+                    title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.title") }
                     image={ getEmptyPlaceholderIllustrations().emptyList }
                     imageSize="tiny"
                 />
@@ -92,7 +92,6 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
                 { t("console:manage.features.user.updateUser.roles.editRoles.heading") }
             </Heading>
             <Heading subHeading ellipsis as="h6">
-                { /* TODO: Need to replace this with "View assigned roles for the user." */ }
                 { t("console:manage.features.user.updateUser.roles.editRoles.subHeading") }
             </Heading>
             {

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -4407,7 +4407,11 @@ export interface ConsoleNS {
                             heading: string;
                             subHeading: string;
                         };
+                        heading: string;
                         subHeading: string;
+                        placeHolders: {
+                            emptyListPlaceholder: Placeholder;
+                        };
                     };
                 };
                 list: {
@@ -6104,6 +6108,9 @@ export interface ConsoleNS {
                                     0: string;
                                     1: string;
                                 };
+                            };
+                            placeholders: {
+                                emptyPlaceholder: Placeholder;
                             };
                             heading: string;
                             popups: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -8937,12 +8937,18 @@ export const console: ConsoleNS = {
                         }
                     },
                     roles: {
+                        placeHolders: {
+                            emptyListPlaceholder: {
+                                subtitles: "There are no roles assigned to this group at the moment.",
+                                title: "No Roles Assigned"
+                            }
+                        },
+                        heading: "Assigned Roles",
                         addRolesModal: {
                             heading: "Update Group Roles",
                             subHeading: "Add new roles or remove existing roles assigned to the group."
                         },
-                        subHeading: "Add or remove the roles this group is assigned with and note that this " +
-                            "will affect performing certain tasks."
+                        subHeading: "View assigned roles for the group."
                     }
                 },
                 list: {
@@ -11541,6 +11547,12 @@ export const console: ConsoleNS = {
                                 header: "Are you sure?",
                                 message: "This action will modify the role of this user."
                             },
+                            placeholders: {
+                                emptyPlaceholder: {
+                                    title: "No roles assigned",
+                                    subtitles: "There are no roles assigned to the user at the moment."
+                                }
+                            },
                             heading: "Assigned Roles",
                             popups: {
                                 viewPermissions: "View Permissions"
@@ -11560,8 +11572,7 @@ export const console: ConsoleNS = {
                                 }
                             },
                             searchPlaceholder: "Search Roles",
-                            subHeading: "Add or remove the roles this user is assigned with and note that this " +
-                                "will affect performing certain tasks."
+                            subHeading: "View assigned roles for the user."
                         },
                         notifications: {
                             addUserRoles: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -7315,13 +7315,19 @@ export const console: ConsoleNS = {
                         }
                     },
                     roles: {
+                        placeHolders: {
+                            emptyListPlaceholder: {
+                                subtitles: "Il n'y a aucun rôle attribué à ce groupe pour le moment.",
+                                title: "Aucun rôle attribué"
+                            }
+                        },
+                        heading: "Rôles attribués",
                         addRolesModal: {
                             heading: "Mettre à jour les rôles de groupe",
                             subHeading: "Ajoutez de nouveaux rôles ou supprimez les rôles existants attribués " +
                                 "au groupe."
                         },
-                        subHeading: "Ajoutez ou supprimez les rôles auxquels ce groupe est affecté et " +
-                            "notez que cela affectera l'exécution de certaines tâches."
+                        subHeading: "Afficher les rôles attribués pour le groupe."
                     }
                 },
                 list: {
@@ -9829,6 +9835,12 @@ export const console: ConsoleNS = {
                                 header: "Êtes-vous sûr?",
                                 message: "Cette action modifiera le rôle de cet utilisateur."
                             },
+                            placeholders: {
+                                emptyPlaceholder: {
+                                    title: "Aucun rôle attribué",
+                                    subtitles: "Il n'y a aucun rôle attribué à l'utilisateur pour le moment."
+                                }
+                            },
                             heading: "Rôles assignés",
                             popups: {
                                 viewPermissions: "Voir les permissions"
@@ -9848,8 +9860,7 @@ export const console: ConsoleNS = {
                                 }
                             },
                             searchPlaceholder: "Rechercher des rôles",
-                            subHeading: "Ajouter ou supprimer le rôle auquel l'utilisateur est affecté. Notez que " +
-                                "cela affectera également l'exécution de certaines tâches."
+                            subHeading: "Afficher les rôles attribués pour l'utilisateur."
                         },
                         notifications: {
                             addUserRoles: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -7149,12 +7149,18 @@ export const console: ConsoleNS = {
                         }
                     },
                     roles: {
+                        placeHolders: {
+                            emptyListPlaceholder: {
+                                subtitles: "මේ මොහොතේ මෙම කණ්ඩායමට කිසිදු භූමිකාවන් පවරා නොමැත.",
+                                title: "කිසිදු භූමිකාවක් පවරා නොමැත"
+                            }
+                        },
+                        heading: "පවරා ඇති භූමිකාවන්",
                         addRolesModal: {
                             heading: "කණ්ඩායම් භූමිකාවන් යාවත්කාලීන කරන්න",
                             subHeading: "නව භූමිකාවන් එක් කරන්න හෝ කණ්ඩායමට පවරා ඇති භූමිකාවන් ඉවත් කරන්න."
                         },
-                        subHeading: "මෙම කණ්ඩායම විසින් පවරා ඇති භූමිකාවන් එකතු කිරීම හෝ ඉවත් කිරීම සහ " +
-                            "මෙය ඇතැම් කාර්යයන් ඉටු කිරීමට බලපානු ඇති බව සලකන්න."
+                        subHeading: "කණ්ඩායම සඳහා පවරා ඇති භූමිකාවන් බලන්න."
                     }
                 },
                 list: {
@@ -9592,6 +9598,12 @@ export const console: ConsoleNS = {
                                 header: "ඔබට විශ්වාසද?",
                                 message: "මෙම ක්‍රියාව මෙම පරිශීලකයාගේ භූමිකාව වෙනස් කරයි."
                             },
+                            placeholders: {
+                                emptyPlaceholder: {
+                                    title: "කිසිදු භූමිකාවක් පවරා නොමැත",
+                                    subtitles: "මේ මොහොතේ පරිශීලකයාට කිසිදු භූමිකාවන් නොමැත."
+                                }
+                            },
                             heading: "පවරා ඇති භූමිකාවන්",
                             popups: {
                                 viewPermissions: "අවසර බලන්න"
@@ -9611,8 +9623,7 @@ export const console: ConsoleNS = {
                                 }
                             },
                             searchPlaceholder: "සෙවුම් භූමිකාවන්",
-                            subHeading: "මෙම පරිශීලකයාට පවරා ඇති භූමිකාවන් එකතු කිරීම හෝ ඉවත් කිරීම සහ " +
-                                "මෙය ඇතැම් කාර්යයන් ඉටු කිරීමට බලපානු ඇති බව සලකන්න."
+                            subHeading: "පරිශීලකයා සඳහා පවරා ඇති භූමිකාවන් බලන්න."
                         },
                         notifications: {
                             addUserRoles: {


### PR DESCRIPTION
### Purpose
(fix) Fix content of roles tabs in users and groups to convey that this tab is read only.

### Screenshots
<img width="1800" alt="Screenshot 2023-11-14 at 13 42 00" src="https://github.com/wso2/identity-apps/assets/46097917/7e94e450-7663-4869-bc94-ebf76f1e7f03">
<img width="1800" alt="Screenshot 2023-11-14 at 13 42 14" src="https://github.com/wso2/identity-apps/assets/46097917/d9ac9ce4-53a5-4428-b45b-5e97e70f015f">

### Related Issues
- https://github.com/wso2/product-is/issues/17636

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
