### PR TITLE
Remove the user store option in the multiple users wizard

### DIFF
--- a/.changeset/gentle-kings-roll.md
+++ b/.changeset/gentle-kings-roll.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Bump my account version

--- a/.changeset/tidy-clocks-sip.md
+++ b/.changeset/tidy-clocks-sip.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Remove the userstore dropdown from multiple user creation wizard

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -5918,7 +5918,6 @@ export interface ConsoleNS {
                                 primaryButton: string;
                                 rolesLabel: string;
                                 rolesPlaceholder: string;
-                                warningMessage: string;
                             };
                             fileBased: {
                                 hint: string;
@@ -5926,7 +5925,8 @@ export interface ConsoleNS {
                             responseOperationType: {
                                 userCreation: string;
                                 roleAssignment: string;
-                            }
+                            };
+                            userstoreMessage: string;
                         };
                         buttons: {
                             import: string;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -11178,8 +11178,7 @@ export const console: ConsoleNS = {
                                 },
                                 primaryButton: "Invite",
                                 rolesLabel: "Roles",
-                                rolesPlaceholder: "Enter roles",
-                                warningMessage: "Manual invite multiple users feature can only be used when email address is configured as the username."
+                                rolesPlaceholder: "Enter roles"
                             },
                             fileBased: {
                                 hint: "Bulk invite multiple users using a CSV file."
@@ -11187,7 +11186,8 @@ export const console: ConsoleNS = {
                             responseOperationType: {
                                 userCreation: "User Creation",
                                 roleAssignment: "Role/Group Assignment"
-                            }
+                            },
+                            userstoreMessage: "The created users will be added to the <1>{{ userstore }}</1> user store."
                         },
                         buttons: {
                             import: "Import"

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -9442,8 +9442,7 @@ export const console: ConsoleNS = {
                                 },
                                 primaryButton: "Inviter",
                                 rolesLabel: "Les rôles",
-                                rolesPlaceholder: "Entrez les rôles",
-                                warningMessage: "La fonctionnalité d'invitation manuelle de plusieurs utilisateurs ne peut être utilisée que lorsque l'adresse e-mail est configurée comme nom d'utilisateur."
+                                rolesPlaceholder: "Entrez les rôles"
                             },
                             fileBased: {
                                 hint: "Invitez plusieurs utilisateurs en masse à l’aide d’un fichier CSV."
@@ -9451,7 +9450,8 @@ export const console: ConsoleNS = {
                             responseOperationType: {
                                 userCreation: "Création d'utilisateur",
                                 roleAssignment: "Affectation de rôle/groupe"
-                            }
+                            },
+                            userstoreMessage: "Les utilisateurs créés seront ajoutés au magasin d'utilisateurs <1>{{ userstore }></1>."
                         },
                         buttons: {
                             import: "Importer"

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -9226,8 +9226,7 @@ export const console: ConsoleNS = {
                                 },
                                 primaryButton: "ආරාධනා කරන්න",
                                 rolesLabel: "භූමිකාවන්",
-                                rolesPlaceholder: "භූමිකාවන් ඇතුළත් කරන්න",
-                                warningMessage: "හස්තීය ආරාධනා බහු පරිශීලක විශේෂාංගය භාවිතා කළ හැක්කේ ඊමේල් ලිපිනය පරිශීලක නාමය ලෙස වින්‍යාස කර ඇති විට පමණි."
+                                rolesPlaceholder: "භූමිකාවන් ඇතුළත් කරන්න"
                             },
                             fileBased: {
                                 hint: "CSV ගොනුවක් භාවිතයෙන් බහු පරිශීලකයින්ට තොග වශයෙන් ආරාධනා කරන්න."
@@ -9235,7 +9234,8 @@ export const console: ConsoleNS = {
                             responseOperationType: {
                                 userCreation: "පරිශීලක නිර්මාණය",
                                 roleAssignment: "භූමිකාව/කණ්ඩායම් පැවරුම"
-                            }
+                            },
+                            userstoreMessage: "සාදන ලද පරිශීලකයින් <1>{{ userstore }}</1> පරිශීලක ගබඩාවට එක් කරනු ලැබේ."
                         },
                         buttons: {
                             import: "ආනයනය කරන්න"


### PR DESCRIPTION
### Purpose
> Remove the user store option in the multiple users wizard

Manual Tab
<img width="715" alt="Screenshot 2023-11-14 at 13 58 41" src="https://github.com/wso2/identity-apps/assets/27746285/bdd66fef-989a-44e9-bbcd-1ab19cd6d124">

File Based
<img width="715" alt="Screenshot 2023-11-14 at 13 58 48" src="https://github.com/wso2/identity-apps/assets/27746285/1de1fda7-8f9e-4cf1-a777-f0e3856dd6c4">

### Related Issues
- https://github.com/wso2/product-is/issues/17681

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
