### PR TITLE
(fix) Add missing localization text in the account recovery panel in my account

### DIFF
--- a/.changeset/little-bugs-shake.md
+++ b/.changeset/little-bugs-shake.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/myaccount": patch
+"@wso2is/i18n": patch
+"@wso2is/console": patch
+---
+
+(fix) add missing localization text in the account recovery panel in my account

--- a/apps/myaccount/src/components/account-recovery/account-recovery.tsx
+++ b/apps/myaccount/src/components/account-recovery/account-recovery.tsx
@@ -154,7 +154,7 @@ export const AccountRecoveryComponent: FunctionComponent<AccountRecoveryProps> =
             placeholder={
                 !isAccountRecoveryDetailsLoading &&
                 !(isQsRecoveryEnabled || isNotificationRecoveryEnabled || isUsernameRecoveryEnabled)
-                    ? "No Account Recovery options available"
+                    ? t("myAccount:sections.accountRecovery.emptyPlaceholderText")
                     : null
             }
         >

--- a/modules/i18n/src/models/namespaces/myaccount-ns.ts
+++ b/modules/i18n/src/models/namespaces/myaccount-ns.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -1026,6 +1026,7 @@ export interface MyAccountNS {
     sections: {
         accountRecovery: {
             description: string;
+            emptyPlaceholderText: string;
             heading: string;
         };
         changePassword: {

--- a/modules/i18n/src/translations/de-DE/portals/myaccount.ts
+++ b/modules/i18n/src/translations/de-DE/portals/myaccount.ts
@@ -1587,6 +1587,7 @@ export const myAccount: MyAccountNS = {
     "sections": {
         "accountRecovery": {
             "description": "Verwalten Sie Wiederherstellungsinformationen, mit denen Sie Ihr Passwort wiederherstellen können",
+            "emptyPlaceholderText": "Keine Optionen zur Wiederherstellung von Kontos zur Verfügung stehen",
             "heading": "Konto-Wiederherstellung"
         },
         "changePassword": {

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -1720,8 +1720,8 @@ export const myAccount: MyAccountNS = {
     },
     sections: {
         accountRecovery: {
-            description:
-            "Manage recovery information that we can use to help you recover your password",
+            description: "Manage recovery information that we can use to help you recover your password",
+            emptyPlaceholderText: "No Account Recovery options available",
             heading: "Account Recovery"
         },
         changePassword: {

--- a/modules/i18n/src/translations/es-ES/portals/myaccount.ts
+++ b/modules/i18n/src/translations/es-ES/portals/myaccount.ts
@@ -1587,6 +1587,7 @@ export const myAccount: MyAccountNS = {
     "sections": {
         "accountRecovery": {
             "description": "Administre la información de recuperación que podemos usar para ayudarlo a recuperar su contraseña",
+            "emptyPlaceholderText": "No hay opciones de recuperación de cuenta disponibles",
             "heading": "Recuperación de Cuenta"
         },
         "changePassword": {

--- a/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
@@ -1765,6 +1765,7 @@ export const myAccount: MyAccountNS = {
     sections: {
         accountRecovery: {
             description: "Gérer les informations de récupération que nous pouvons utiliser pour vous aider à récupérer votre mot de passe",
+            emptyPlaceholderText: "Aucune option de récupération de compte disponible",
             heading: "Récupération de votre compte"
         },
         changePassword: {

--- a/modules/i18n/src/translations/ja-JP/portals/myaccount.ts
+++ b/modules/i18n/src/translations/ja-JP/portals/myaccount.ts
@@ -1586,6 +1586,7 @@ export const myAccount: MyAccountNS = {
     "sections": {
         "accountRecovery": {
             "description": "パスワードの回復に役立つリカバリ情報を管理する",
+            "emptyPlaceholderText": "アカウントの回復オプションはありません",
             "heading": "アカウント復旧"
         },
         "changePassword": {

--- a/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
@@ -1708,6 +1708,7 @@ export const myAccount: MyAccountNS = {
     sections: {
         accountRecovery: {
             description: "Gerenciar informações de recuperação que podemos usar para ajudá -lo a recuperar sua senha",
+            emptyPlaceholderText: "Sem opções de recuperação de conta disponíveis",
             heading: "Recuperação de Conta"
         },
         changePassword: {

--- a/modules/i18n/src/translations/si-LK/portals/myaccount.ts
+++ b/modules/i18n/src/translations/si-LK/portals/myaccount.ts
@@ -1715,9 +1715,9 @@ export const myAccount: MyAccountNS = {
     },
     sections: {
         accountRecovery: {
-            description:
-                "ඔබගේ පරිශීලක මුරපදය නැවත ලබා ගැනීමට ඔබට උදව් කිරීමට අපට භාවිතා කළ හැකි ප්‍රතිසාධන තොරතුරු " +
+            description: "ඔබගේ පරිශීලක මුරපදය නැවත ලබා ගැනීමට ඔබට උදව් කිරීමට අපට භාවිතා කළ හැකි ප්‍රතිසාධන තොරතුරු " +
                 "කළමනාකරණය කරන්න",
+            emptyPlaceholderText: "ගිණුම් ප්රතිසාධන විකල්ප නොමැත",
             heading: "ගිණුම් ප්‍රතිසාධනය"
         },
         changePassword: {

--- a/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
@@ -1765,6 +1765,7 @@ export const myAccount: MyAccountNS = {
     sections: {
         accountRecovery: {
             description: "உங்கள் கடவுச்சொல்லை மீட்டெடுக்க உதவ நாங்கள் பயன்படுத்தக்கூடிய மீட்பு தகவல்களை நிர்வகிக்கவும்",
+            emptyPlaceholderText: "கணக்கு மீட்பு விருப்பங்கள் எதுவும் கிடைக்கவில்லை",
             heading: "கணக்கு மீட்பு"
         },
         changePassword: {

--- a/modules/i18n/src/translations/zh-CN/portals/myaccount.ts
+++ b/modules/i18n/src/translations/zh-CN/portals/myaccount.ts
@@ -1586,6 +1586,7 @@ export const myAccount: MyAccountNS = {
     "sections": {
         "accountRecovery": {
             "description": "管理我们可以用来帮助您恢复密码的恢复信息",
+            "emptyPlaceholderText": "没有帐户恢复选项",
             "heading": "帐户恢复"
         },
         "changePassword": {


### PR DESCRIPTION
### Purpose
(fix) add missing localization text in the account recovery panel in my account

### Screen record

https://github.com/wso2/identity-apps/assets/46097917/749afb3b-5068-4428-b8f4-c0f2aa70f1ef

### Related Issues
- https://github.com/wso2/product-is/issues/17411

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
