### PR TITLE
(fix) admin username not getting displaying properly in myaccount.

### DIFF
--- a/.changeset/warm-dingos-battle.md
+++ b/.changeset/warm-dingos-battle.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+(fix) admin username not getting displaying properly in myaccount.

--- a/apps/myaccount/src/components/shared/header.tsx
+++ b/apps/myaccount/src/components/shared/header.tsx
@@ -267,7 +267,14 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
         }
 
         if (profileInfo?.userName) {
-            return profileInfo.userName.split("/")[ 1 ];
+            const userName: string = profileInfo.userName.split("/")[ 1 ];
+
+            // If the username is in TENANT/USERNAME format, return the USERNAME.
+            if (userName) {
+                return userName;
+            }
+
+            return profileInfo.userName;
         }
 
         return "";


### PR DESCRIPTION
### Purpose
(fix) admin username not getting displaying properly in myaccount.

### Related Issues
- https://github.com/wso2/product-is/issues/17463

### Screenshot
<img width="1269" alt="Screenshot 2023-11-15 at 12 17 56" src="https://github.com/wso2/identity-apps/assets/46097917/f57841cb-03ba-499c-9804-359cadf51d09">

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
