### PR TITLE
Add missing arguments in getStrongAuthenticationFlowTabIndex

### DIFF
--- a/.changeset/quick-chicken-smile.md
+++ b/.changeset/quick-chicken-smile.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add missing arguement in application.ts

--- a/apps/console/src/extensions/configs/models/application.ts
+++ b/apps/console/src/extensions/configs/models/application.ts
@@ -97,7 +97,9 @@ export interface ApplicationConfig {
         showApplicationShare: boolean;
         getStrongAuthenticationFlowTabIndex: (
             clientId: string,
-            tenantDomain: string
+            tenantDomain: string,
+            _templateId: string,
+            _customApplicationTemplateId: string
         ) => number
     };
     inboundOIDCForm: {

--- a/apps/console/src/extensions/configs/models/application.ts
+++ b/apps/console/src/extensions/configs/models/application.ts
@@ -98,8 +98,8 @@ export interface ApplicationConfig {
         getStrongAuthenticationFlowTabIndex: (
             clientId: string,
             tenantDomain: string,
-            _templateId: string,
-            _customApplicationTemplateId: string
+            templateId?: string,
+            customApplicationTemplateId?: string
         ) => number
     };
     inboundOIDCForm: {


### PR DESCRIPTION
### Purpose
> Add missing arguments in getStrongAuthenticationFlowTabIndex  for extensions