### PR TITLE
(fix) enable custom user store managers

### DIFF
--- a/.changeset/early-singers-build.md
+++ b/.changeset/early-singers-build.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/identity-apps-core": patch
+"@wso2is/theme": patch
+---
+
+(fix) enable custom user store managers

--- a/apps/console/src/features/userstores/models/user-stores.ts
+++ b/apps/console/src/features/userstores/models/user-stores.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020-2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -103,11 +103,12 @@ export interface TypeProperty {
  * The type of object returned by the type meta endpoint
  */
 export interface UserstoreType {
-    name: string;
+    name?: string;
     typeName: string;
     typeId: string;
+    isLocal?: boolean;
     className: string;
-    description: string;
+    description?: string;
     properties: {
         Mandatory: TypeProperty[];
         Optional: TypeProperty[];

--- a/apps/console/src/features/userstores/pages/userstores-templates.tsx
+++ b/apps/console/src/features/userstores/pages/userstores-templates.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020-2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,6 +19,7 @@
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmptyPlaceholder, PageLayout, TemplateGrid } from "@wso2is/react-components";
+import { AxiosError } from "axios";
 import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -91,14 +92,13 @@ const UserstoresTemplates: FunctionComponent<UserstoresTemplatesPageInterface> =
     useEffect(() => {
         getUserstoreTypes().then(async (response: TypeResponse[]) => {
             setIsLoading(true);
-            const typeRequests: Promise<any>[] = response.map((type: TypeResponse) => {
+            const typeRequests: Promise<UserstoreType>[] = response.map((type: TypeResponse) => {
                 return getAType(type.typeId, null);
             });
-            const results: UserstoreType[] = await Promise.all(
-                typeRequests.map(response => response.catch(error => {
+            const results: (void | UserstoreType)[] = await Promise.all(
+                typeRequests.map((response: Promise<UserstoreType>) => response.catch((error: AxiosError) => {
                     dispatch(addAlert({
-                        description: error?.description
-                            || t("console:manage.features.userstores.notifications." +
+                        description: t("console:manage.features.userstores.notifications." +
                                 "fetchUserstoreTemplates.genericError.description"),
                         level: AlertLevels.ERROR,
                         message: error?.message
@@ -140,9 +140,9 @@ const UserstoresTemplates: FunctionComponent<UserstoresTemplatesPageInterface> =
             });
             setUserstoreTypes(uniqueUserstoreTypes.concat(userstoreTypes));
             setRawUserstoreTypes(rawUserstoreTypes);
-        }).catch(error => {
+        }).catch((error: AxiosError) => {
             dispatch(addAlert({
-                description: error?.description || t("console:manage.features.userstores.notifications." +
+                description: t("console:manage.features.userstores.notifications." +
                     "fetchUserstoreTypes.genericError.description"),
                 level: AlertLevels.ERROR,
                 message: error?.message || t("console:manage.features.userstores.notifications." +
@@ -193,7 +193,8 @@ const UserstoresTemplates: FunctionComponent<UserstoresTemplatesPageInterface> =
                                 type="userstore"
                                 templates={ userstoreTypes }
                                 onTemplateSelect={ (e: SyntheticEvent, { id }: { id: string }) => {
-                                    setSelectedType(rawUserstoreTypes.find((type) => type.typeId === id));
+                                    setSelectedType(rawUserstoreTypes.find(
+                                        (type: UserstoreType) => type.typeId === id));
                                 } }
                                 templateIcons={ getUserstoreTemplateIllustrations() as any }
                                 templateIconOptions={ {
@@ -201,7 +202,7 @@ const UserstoresTemplates: FunctionComponent<UserstoresTemplatesPageInterface> =
                                 } }
                                 templateIconSize="tiny"
                                 paginate={ true }
-                                paginationLimit={ 4 }
+                                paginationLimit={ userstoreTypes?.length ? userstoreTypes.length : 0 }
                                 paginationOptions={ {
                                     showLessButtonLabel: t("common:showLess"),
                                     showMoreButtonLabel: t("common:showMore")

--- a/modules/theme/src/themes/default/assets/images/illustrations/ad-illustration.svg
+++ b/modules/theme/src/themes/default/assets/images/illustrations/ad-illustration.svg
@@ -18,7 +18,7 @@
  * under the License.
 -->
 
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg class="icon" width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
         d="M73.0735 52.3483L54.2653 26M73.0735 52.3483L63.4273 78M73.0735 52.3483L81 77.8183M26.5963 52.3483L45.4037 26M26.5963 52.3483L19 77.8183M26.5963 52.3483L36.2425 78"
         stroke="#67777E" />

--- a/modules/theme/src/themes/default/assets/images/illustrations/jdbc-illustration.svg
+++ b/modules/theme/src/themes/default/assets/images/illustrations/jdbc-illustration.svg
@@ -18,7 +18,7 @@
  * under the License.
 -->
 
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg class="icon" width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path
         d="M12 72.9589C12 77.9522 25.8792 84 43 84C52.9632 84 61.8287 82.1832 67.5 79.7567L67 79L66 77.5L64.5 73.3151L63.5 68.3836L68 62.2192L73.3339 60.9863L74 49.4795V24C74 25.2329 67.5 32.2192 41.5 32.2192C15 32.2192 12 24 12 24V72.9589Z"
         fill="#ECECEC" />

--- a/modules/theme/src/themes/default/assets/images/illustrations/ldap-illustration.svg
+++ b/modules/theme/src/themes/default/assets/images/illustrations/ldap-illustration.svg
@@ -18,7 +18,7 @@
  * under the License.
 -->
 
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg class="icon" width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M17 55.5V79.5C17 81.7091 18.7909 83.5 21 83.5H25.5" stroke="#67777E" />
     <path d="M81 55.5V79.5C81 81.7091 79.2091 83.5 77 83.5H72.5" stroke="#67777E" />
     <path d="M49 33.5V66.5" stroke="#67777E" />

--- a/modules/theme/src/themes/default/assets/images/illustrations/ldap-readonly-illustration.svg
+++ b/modules/theme/src/themes/default/assets/images/illustrations/ldap-readonly-illustration.svg
@@ -18,7 +18,7 @@
  * under the License.
 -->
 
-<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg class="icon" width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M18 55.5V79.5C18 81.7091 19.7909 83.5 22 83.5H26.5" stroke="#67777E" />
     <path d="M82 55.5V79.5C82 81.7091 80.2091 83.5 78 83.5H73.5" stroke="#67777E" />
     <path d="M50 33.5V66.5" stroke="#67777E" />


### PR DESCRIPTION
### Purpose
(fix) enable custom user store managers.

### Screenshot
<img width="1800" alt="Screenshot 2023-11-15 at 19 01 07" src="https://github.com/wso2/identity-apps/assets/46097917/e12be5cd-ade2-48b8-92ec-f9d3112f2b21">

### Related Issues
- https://github.com/wso2/product-is/issues/17729

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
