### PR TITLE
Add public client option for token exchange grant

### DIFF
--- a/.changeset/cool-geckos-beam.md
+++ b/.changeset/cool-geckos-beam.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add public client option for token exchange grant

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -1463,6 +1463,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 && (
                     selectedGrantTypes?.includes(ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT)
                     || selectedGrantTypes?.includes(ApplicationManagementConstants.DEVICE_GRANT)
+                    || selectedGrantTypes?.includes(ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE)
                 ) && (
                     <>
                         <Grid.Row columns={ 1 }>


### PR DESCRIPTION
### Purpose
The public client option is currently available only when the "code" grant type is selected. It should be available when the token exchange grant type is selected as well, and this fix addresses that issue.

### Related Issues
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/1001

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
