### PR TITLE
Remove invited user update option in suborganization

### DIFF
--- a/.changeset/fuzzy-spoons-destroy.md
+++ b/.changeset/fuzzy-spoons-destroy.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Remove invited user update option in suborganization

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -104,6 +104,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     const currentOrganization: GenericOrganization = useSelector((state: AppState) => state.organization.organization);
     const isRootOrganization: boolean = useMemo(() =>
         OrganizationUtils.isRootOrganization(currentOrganization), [ currentOrganization ]);
+    const [ isUserManagedByParentOrg, setIsUserManagedByParentOrg ] = useState<boolean>(false);
 
     useEffect(() => {
         //Since the parent component is refreshing twice we are doing a deep equals operation on the user object to
@@ -125,6 +126,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
             || readOnlyUserStores?.includes(userStore?.toString())
             || !hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
             || user[ SCIMConfigs.scim.enterpriseSchema ]?.userSourceId
+            || user[ SCIMConfigs.scim.enterpriseSchema ]?.managedOrg 
         ) {
             setReadOnly(true);
         }
@@ -137,6 +139,12 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
         }
 
         checkIsSuperAdmin();
+    }, [ user ]);
+
+    useEffect(() => {
+        if (user[ SCIMConfigs.scim.enterpriseSchema ]?.managedOrg) {
+            setIsUserManagedByParentOrg(true);
+        }
     }, [ user ]);
 
     const handleAlerts = (alert: AlertInterface) => {
@@ -208,6 +216,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                         isReadOnly={ isReadOnly }
                         connectorProperties={ connectorProperties }
                         isReadOnlyUserStoresLoading={ isReadOnlyUserStoresLoading }
+                        isUserManagedByParentOrg={ isUserManagedByParentOrg }
                     />
                 </ResourceTab.Pane>
             )

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -100,11 +100,11 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     ] = useState<boolean>(false);
     const [ hideTermination, setHideTermination ] = useState<boolean>(false);
     const [ user, setUser ] = useState<ProfileInfoInterface>(selectedUser);
+    const [ isUserManagedByParentOrg, setIsUserManagedByParentOrg ] = useState<boolean>(false);
 
     const currentOrganization: GenericOrganization = useSelector((state: AppState) => state.organization.organization);
     const isRootOrganization: boolean = useMemo(() =>
         OrganizationUtils.isRootOrganization(currentOrganization), [ currentOrganization ]);
-    const [ isUserManagedByParentOrg, setIsUserManagedByParentOrg ] = useState<boolean>(false);
 
     useEffect(() => {
         //Since the parent component is refreshing twice we are doing a deep equals operation on the user object to
@@ -126,7 +126,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
             || readOnlyUserStores?.includes(userStore?.toString())
             || !hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
             || user[ SCIMConfigs.scim.enterpriseSchema ]?.userSourceId
-            || user[ SCIMConfigs.scim.enterpriseSchema ]?.managedOrg 
+            || user[ SCIMConfigs.scim.enterpriseSchema ]?.managedOrg
         ) {
             setReadOnly(true);
         }

--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -1093,7 +1093,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                                     "passwordResetZone.subheader") }
                                                 onActionClick={ () => setOpenChangePasswordModal(true) }
                                             />
-                                        </Show> 
+                                        </Show>
                                     )
                                 }
                                 {

--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -116,6 +116,10 @@ interface UserProfilePropsInterface extends TestableComponentInterface, SBACInte
      * Admin user type
      */
     adminUserType?: string;
+    /**
+     * Is user managed by parent organization.
+     */
+    isUserManagedByParentOrg?: boolean;
 }
 
 /**
@@ -141,6 +145,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         tenantAdmin,
         editUserDisclaimerMessage,
         adminUserType,
+        isUserManagedByParentOrg,
         [ "data-testid" ]: testId
     } = props;
 
@@ -1064,7 +1069,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         return (
             <>
                 {
-                    ((!isReadOnly || allowDeleteOnly)
+                    ((!isReadOnly || allowDeleteOnly || isUserManagedByParentOrg)
                     && ((adminUserType === AdminAccountTypes.INTERNAL && !isPrivilegedUser)
                         || (!(resolveUsernameOrDefaultEmail(user, false) === tenantAdmin ||
                                     resolveUsernameOrDefaultEmail(user, false) === "admin")
@@ -1075,18 +1080,22 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                             <DangerZoneGroup
                                 sectionHeader={ t("console:manage.features.user.editUser.dangerZoneGroup.header") }
                             >
-                                <Show when={ AccessControlConstants.USER_EDIT }>
-                                    <DangerZone
-                                        data-testid={ `${ testId }-revoke-admin-privilege-danger-zone` }
-                                        actionTitle={ t("console:manage.features.user.editUser.dangerZoneGroup." +
-                                            "passwordResetZone.actionTitle") }
-                                        header={ t("console:manage.features.user.editUser.dangerZoneGroup." +
-                                            "passwordResetZone.header") }
-                                        subheader={ t("console:manage.features.user.editUser.dangerZoneGroup." +
-                                            "passwordResetZone.subheader") }
-                                        onActionClick={ () => setOpenChangePasswordModal(true) }
-                                    />
-                                </Show> 
+                                {
+                                    !isUserManagedByParentOrg && (
+                                        <Show when={ AccessControlConstants.USER_EDIT }>
+                                            <DangerZone
+                                                data-testid={ `${ testId }-revoke-admin-privilege-danger-zone` }
+                                                actionTitle={ t("console:manage.features.user.editUser." +
+                                                    "dangerZoneGroup.passwordResetZone.actionTitle") }
+                                                header={ t("console:manage.features.user.editUser.dangerZoneGroup." +
+                                                    "passwordResetZone.header") }
+                                                subheader={ t("console:manage.features.user.editUser.dangerZoneGroup." +
+                                                    "passwordResetZone.subheader") }
+                                                onActionClick={ () => setOpenChangePasswordModal(true) }
+                                            />
+                                        </Show> 
+                                    )
+                                }
                                 {
                                     !allowDeleteOnly && configSettings?.accountDisable === "true" && (
                                         <DangerZone

--- a/apps/console/src/features/users/components/users-list.tsx
+++ b/apps/console/src/features/users/components/users-list.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -41,7 +41,7 @@ import React, { ReactElement, ReactNode, SyntheticEvent, useState } from "react"
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
-import { Header, ListItemProps, SemanticICONS } from "semantic-ui-react";
+import { Header, Label, ListItemProps, SemanticICONS } from "semantic-ui-react";
 import { SCIMConfigs } from "../../../extensions/configs/scim";
 import {
     AppConstants,
@@ -259,7 +259,17 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
                                 spaced="right"
                             />
                             <Header.Content>
-                                <div>{ header as ReactNode }</div>
+                                <div>
+                                    { header as ReactNode }
+                                    {
+                                        user[SCIMConfigs.scim.enterpriseSchema]?.managedOrg && (
+                                            <Label size="mini" className="client-id-label">
+                                                { t("console:manage.features.parentOrgInvitations." +
+                                                "invitedUserLabel") }
+                                            </Label>
+                                        )
+                                    }
+                                </div>
                                 {
                                     (!isNameAvailable) &&
                                     (
@@ -351,6 +361,7 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
                     || !isFeatureEnabled(featureConfig?.users,
                         UserManagementConstants.FEATURE_DICTIONARY.get("USER_UPDATE"))
                     || readOnlyUserStores?.includes(userStore.toString())
+                    || user[SCIMConfigs.scim.enterpriseSchema]?.managedOrg
                         ? "eye"
                         : "pencil alternate";
                 },

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -6339,6 +6339,7 @@ export interface ConsoleNS {
                     noInvitations: string;
                     noCollaboratorUserInvitations: string;
                 };
+                invitedUserLabel: string;
             };
             onboarded?: {
                 notifications?: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -9210,7 +9210,8 @@ export const console: ConsoleNS = {
                     noExpiredInvitations: "There are expired invitations at the moment.",
                     noInvitations: "There are no invitations at the moment.",
                     noCollaboratorUserInvitations: "There are no collaborator users with expired invitations at the moment."
-                }
+                },
+                invitedUserLabel: "Managed by parent organization"
             },
             oidcScopes: {
                 viewAttributes: "View Attributes",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -7457,7 +7457,8 @@ export const console: ConsoleNS = {
                     noExpiredInvitations: "Il y a des invitations expirées pour le moment.",
                     noInvitations: "Il n'y a aucune invitation pour le moment.",
                     noCollaboratorUserInvitations: "Il n’y a actuellement aucun utilisateur collaborateur dont les invitations ont expiré."
-                }
+                },
+                invitedUserLabel: "Géré par l'organisation mère"
             },
             oidcScopes: {
                 viewAttributes: "Afficher les attributs",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -7288,7 +7288,8 @@ export const console: ConsoleNS = {
                     noExpiredInvitations: "මේ මොහොතේ කල් ඉකුත් වූ ආරාධනා ඇත.",
                     noInvitations: "දැනට ආරාධනා නැහැ.",
                     noCollaboratorUserInvitations: "මේ මොහොතේ කල් ඉකුත් වූ ආරාධනා සහිත සහකාරක පරිශීලකයන් නොමැත."
-                }
+                },
+                invitedUserLabel: "මව් සංවිධානය විසින් කළමනාකරණය කරනු ලැබේ"
             },
             oidcScopes: {
                 viewAttributes: "ගුණාංග පෙන්වන්න",


### PR DESCRIPTION
### Purpose

This PR adds the following changes.
- User profile of users who are managed by the parent organization will be shown as read only.
- Password reset option is removed for users who are managed by the parent organization.
- Added label in the user list view for users who are managed by the parent organization.

Screenshots

<img width="1000" alt="Screenshot 2023-11-16 at 12 27 41" src="https://github.com/wso2/identity-apps/assets/28347418/28afec12-48b5-40b1-ad3c-3098653b0d4f">
<img width="1000" alt="Screenshot 2023-11-16 at 12 32 34" src="https://github.com/wso2/identity-apps/assets/28347418/6960ca2c-417c-4632-b0fe-71f0d1cad475">

### Related Issues
- https://github.com/wso2/product-is/issues/17492
- https://github.com/wso2/product-is/issues/17402

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
