### PR TITLE
Change role edit button popup

### DIFF
--- a/.changeset/itchy-scissors-rescue.md
+++ b/.changeset/itchy-scissors-rescue.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change the role edit popup text in role list view to match other edit texts

--- a/apps/console/src/features/roles/components/role-list.tsx
+++ b/apps/console/src/features/roles/components/role-list.tsx
@@ -265,8 +265,7 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
                         && handleRoleEdit(role?.id),
                 popupText: (): string =>
                     hasRequiredScopes(featureConfig?.roles, featureConfig?.roles?.scopes?.update, allowedScopes)
-                        ? t("console:manage.features.roles.list.popups.edit",
-                            { type: "Role" })
+                        ? t("common:edit")
                         : t("common:view"),
                 renderer: "semantic-icon"
             },


### PR DESCRIPTION
### Purpose
- Change role edit button popup text to be consistent with other edit button popups.

### Related Issue
- https://github.com/wso2/product-is/issues/17763

### Before

<img width="1409" alt="282420263-1ad979fc-6a88-4b9e-bdf8-d6bc47bfed61" src="https://github.com/wso2/identity-apps/assets/59327626/789ad4c3-a6cf-4343-b3a6-a3a966c245fb">


### After

<img width="1352" alt="Screenshot 2023-11-16 at 17 39 25" src="https://github.com/wso2/identity-apps/assets/59327626/07a21672-df04-45e5-9497-c2ffda0aad5f">
