### PR TITLE
Fix view permissions issue in user creation wizard

### DIFF
--- a/.changeset/nice-houses-remain.md
+++ b/.changeset/nice-houses-remain.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix view permissions issue in create user wizard

--- a/apps/console/src/features/roles/components/wizard/role-permission.tsx
+++ b/apps/console/src/features/roles/components/wizard/role-permission.tsx
@@ -265,7 +265,7 @@ export const PermissionList: FunctionComponent<PermissionListProp> = (props: Per
                                     className={ "customIcon" }
                                     data-testid={ `${ testId }-tree` }
                                     disabled={ isReadOnly }
-                                    checkedKeys={ checkedPermission.map( (permission: TreeNode) => permission.key ) }
+                                    checkedKeys={ checkedPermission?.map( (permission: TreeNode) => permission?.key ) }
                                     defaultExpandedKeys={ defaultExpandedKeys }
                                     showLine
                                     showIcon={ false }


### PR DESCRIPTION
### Purpose
> Fix the `view permissions` issue in the user creation wizard.

### Related Issues
- https://github.com/wso2/product-is/issues/17836

https://github.com/wso2/identity-apps/assets/27746285/7b411213-eab5-4a73-9930-8be3d6073bce

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
