### PR TITLE
Implement functionality to navigate back to the login page from Sign In with SSO page.

### DIFF
--- a/.changeset/fuzzy-jobs-cheat.md
+++ b/.changeset/fuzzy-jobs-cheat.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Implement functionality to navigate back to the login page from Sign In with SSO pages.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -122,6 +122,11 @@
                     <input type="submit" id="submitButton" onclick="submitDiscovery(); return false;"
                         value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "submit")%>"
                         class="ui primary large fluid button" />
+                   <div class="mt-1 align-center">
+                       <a href="javascript:navigateBackToLoginPage()" class="ui button secondary large fluid">
+                           <%=AuthenticationEndpointUtil.i18n(resourceBundle, "cancel")%>
+                       </a>
+                   </div>
                     <div class="ui horizontal divider">
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
                     </div>
@@ -166,6 +171,11 @@
          function enterOrgName() {
             document.getElementById("orgDiscovery").disabled = true;
             document.getElementById("org_form").submit();
+         }
+
+         function navigateBackToLoginPage() {
+             // login page is always 2 steps back from the current page.
+             window.history.go(-2);
          }
 
          function submitDiscovery() {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -131,7 +131,7 @@
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
                     </div>
                     <div class="social-login blurring social-dimmer">
-                        <input type="submit" id="orgNameButton" onclick="enterOrgName();" class="ui fluid button"
+                        <input type="submit" id="orgNameButton" onclick="enterOrgName();" class="ui primary basic button link-button"
                             value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "provide.organization.name")%>">
                     </div>
                </form>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -147,7 +147,7 @@
                         <% if (isOrgDiscoveryEnabled) { %>
                             <div class="ui horizontal divider"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%></div>
                             <div class="social-login blurring social-dimmer">
-                                <input type="submit" id="discoveryButton" onclick="promptDiscovery();" class="ui fluid button"
+                                <input type="submit" id="discoveryButton" onclick="promptDiscovery();" class="ui primary basic button link-button"
                                     value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "provide.email.address")%>">
                             </div>
                         <% } %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -139,6 +139,11 @@
                         <input type="submit" id="submitButton" onclick="submitOrgName(); return false;"
                             value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "submit")%>"
                             class="ui primary large fluid button" />
+                        <div class="mt-1 align-center">
+                            <a href="javascript:goBack()" class="ui button secondary large fluid">
+                                <%=AuthenticationEndpointUtil.i18n(resourceBundle, "cancel")%>
+                            </a>
+                        </div>
                         <% if (isOrgDiscoveryEnabled) { %>
                             <div class="ui horizontal divider"><%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%></div>
                             <div class="social-login blurring social-dimmer">
@@ -184,6 +189,11 @@
             }
         %>
         <script type="text/javascript">
+
+            function goBack() {
+                window.history.back();
+            }
+            
             function promptDiscovery() {
                 document.getElementById("ORG_NAME").disabled = true;
                 document.getElementById("pin_form").submit();


### PR DESCRIPTION
### Purpose
Add "Cancel" buttons to both Sign In with SSO pages (email and org name).


https://github.com/wso2/identity-apps/assets/27700915/8a889d5b-d649-40fc-a3b4-20b7fb25df7b



### Related Issues
- https://github.com/wso2/product-is/issues/17758


### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
