### PR TITLE
Remove view permissions button from user/groups creation wizard

### DIFF
--- a/.changeset/thin-books-help.md
+++ b/.changeset/thin-books-help.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove view permissions button from user/group create wizard

--- a/apps/console/src/features/core/components/roles/assign-roles.tsx
+++ b/apps/console/src/features/core/components/roles/assign-roles.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -41,7 +41,7 @@ interface AssignRoleProps {
 /**
  * Assign Role component.
  *
- * @return {JSX.Element}
+ * @returns Assign Roles component.
  */
 export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRoleProps): ReactElement => {
 
@@ -93,14 +93,17 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
         setIsSelectAssignedAllRolesChecked(!isSelectAssignedAllRolesChecked);
     };
 
-    const handleUnselectedListSearch = (e, { value }) => {
-        let isMatch = false;
-        const filteredRoleList = [];
+    const handleUnselectedListSearch = (
+        e: React.FormEvent<HTMLInputElement>,
+        { value }: { value: string;}
+    ) => {
+        let isMatch: boolean = false;
+        const filteredRoleList: RolesInterface[] = [];
 
         if (!isEmpty(value)) {
-            const re = new RegExp(escapeRegExp(value), "i");
+            const re: RegExp = new RegExp(escapeRegExp(value), "i");
 
-            initialValues.roleList && initialValues.roleList.map((role) => {
+            initialValues.roleList && initialValues.roleList.map((role: RolesInterface) => {
                 isMatch = re.test(role.displayName);
                 if (isMatch) {
                     filteredRoleList.push(role);
@@ -112,14 +115,17 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
         }
     };
 
-    const handleSelectedListSearch = (e, { value }) => {
-        let isMatch = false;
-        const filteredRoleList = [];
+    const handleSelectedListSearch = (
+        e: React.FormEvent<HTMLInputElement>,
+        { value }: { value: string;}
+    ) => {
+        let isMatch: boolean = false;
+        const filteredRoleList: RolesInterface[] = [];
 
         if (!isEmpty(value)) {
-            const re = new RegExp(escapeRegExp(value), "i");
+            const re: RegExp = new RegExp(escapeRegExp(value), "i");
 
-            initialValues.tempRoleList && initialValues.tempRoleList.map((role) => {
+            initialValues.tempRoleList && initialValues.tempRoleList.map((role: RolesInterface) => {
                 isMatch = re.test(role.displayName);
                 if (isMatch) {
                     filteredRoleList.push(role);
@@ -132,10 +138,10 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
     };
 
     const addRoles = () => {
-        const addedRoles = [ ...initialValues.tempRoleList ];
+        const addedRoles: RolesInterface[] = [ ...initialValues.tempRoleList ];
 
         if (checkedUnassignedListItems?.length > 0) {
-            checkedUnassignedListItems.map((role) => {
+            checkedUnassignedListItems.map((role: RolesInterface) => {
                 if (!(initialValues?.tempRoleList?.includes(role))) {
                     addedRoles.push(role);
                 }
@@ -143,16 +149,16 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
         }
         handleTempListChange(addedRoles);
         handleInitialTempListChange(addedRoles);
-        handleRoleListChange(initialValues?.roleList.filter(x => !addedRoles?.includes(x)));
-        handleInitialRoleListChange(initialValues?.roleList.filter(x => !addedRoles?.includes(x)));
+        handleRoleListChange(initialValues?.roleList.filter((x: RolesInterface) => !addedRoles?.includes(x)));
+        handleInitialRoleListChange(initialValues?.roleList.filter((x: RolesInterface) => !addedRoles?.includes(x)));
         setIsSelectUnassignedAllRolesChecked(false);
     };
 
     const removeRoles = () => {
-        const removedRoles = [ ...initialValues?.roleList ];
+        const removedRoles: RolesInterface[] = [ ...initialValues?.roleList ];
 
         if (checkedAssignedListItems?.length > 0) {
-            checkedAssignedListItems.map((role) => {
+            checkedAssignedListItems.map((role: RolesInterface) => {
                 if (!(initialValues?.roleList?.includes(role))) {
                     removedRoles.push(role);
                 }
@@ -160,14 +166,15 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
         }
         handleRoleListChange(removedRoles);
         handleInitialRoleListChange(removedRoles);
-        handleTempListChange(initialValues?.tempRoleList?.filter(x => !removedRoles?.includes(x)));
-        handleInitialTempListChange(initialValues?.tempRoleList?.filter(x => !removedRoles?.includes(x)));
+        handleTempListChange(initialValues?.tempRoleList?.filter((x: RolesInterface) => !removedRoles?.includes(x)));
+        handleInitialTempListChange(initialValues?.tempRoleList?.filter((
+            x: RolesInterface) => !removedRoles?.includes(x)));
         setCheckedUnassignedListItems([]);
         setIsSelectAssignedAllRolesChecked(false);
     };
 
-    const handleUnassignedItemCheckboxChange = (role) => {
-        const checkedRoles = [ ...checkedUnassignedListItems ];
+    const handleUnassignedItemCheckboxChange = (role: RolesInterface) => {
+        const checkedRoles: RolesInterface[] = [ ...checkedUnassignedListItems ];
 
         if (checkedRoles.includes(role)) {
             checkedRoles.splice(checkedRoles.indexOf(role), 1);
@@ -178,8 +185,8 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
         }
     };
 
-    const handleAssignedItemCheckboxChange = (role) => {
-        const checkedRoles = [ ...checkedAssignedListItems ];
+    const handleAssignedItemCheckboxChange = (role: RolesInterface) => {
+        const checkedRoles: RolesInterface[] = [ ...checkedAssignedListItems ];
 
         if (checkedRoles.includes(role)) {
             checkedRoles.splice(checkedRoles.indexOf(role), 1);
@@ -193,10 +200,10 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
     /**
      * The following method handles creating a label for the list item.
      *
-     * @param roleName: string
+     * @param roleName - string
      */
     const createItemLabel = (roleName: string) => {
-        const role = roleName.split("/");
+        const role: string[] = roleName.split("/");
 
         if (role.length > 0) {
             if (role[0] == "Application") {
@@ -240,8 +247,8 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
                             + "emptyPlaceholders.default") }
                     >
                         {
-                            initialValues?.roleList?.map((role, index)=> {
-                                const roleName = role?.displayName?.split("/");
+                            initialValues?.roleList?.map((role: RolesInterface, index: number)=> {
+                                const roleName: string[] = role?.displayName?.split("/");
 
                                 return (
                                     <TransferListItem
@@ -252,7 +259,7 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
                                         listItemIndex={ index }
                                         listItemTypeLabel={ createItemLabel(role?.displayName) }
                                         isItemChecked={ checkedUnassignedListItems.includes(role) }
-                                        showSecondaryActions={ true }
+                                        showSecondaryActions={ false }
                                         handleOpenPermissionModal={ () => handleSetRoleId(role.id) }
                                         data-testid="user-mgt-add-user-wizard-modal-unselected-roles"
                                     />
@@ -276,8 +283,8 @@ export const AssignRoles: FunctionComponent<AssignRoleProps> = (props: AssignRol
                             + "emptyPlaceholders.default") }
                     >
                         {
-                            initialValues?.tempRoleList?.map((role, index)=> {
-                                const roleName = role.displayName.split("/");
+                            initialValues?.tempRoleList?.map((role: RolesInterface, index: number)=> {
+                                const roleName: string[] = role.displayName.split("/");
 
                                 return (
                                     <TransferListItem

--- a/apps/console/src/features/users/components/add-user-role.tsx
+++ b/apps/console/src/features/users/components/add-user-role.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -41,7 +41,7 @@ interface AddUserRoleProps {
 /**
  * User role component.
  *
- * @return {JSX.Element}
+ * @returns Add User Role component.
  */
 export const AddUserRole: FunctionComponent<AddUserRoleProps> = (props: AddUserRoleProps): ReactElement => {
 
@@ -77,14 +77,17 @@ export const AddUserRole: FunctionComponent<AddUserRoleProps> = (props: AddUserR
         setIsSelectUnassignedAllRolesChecked(!isSelectUnassignedRolesAllRolesChecked);
     };
 
-    const handleUnselectedListSearch = (e, { value }) => {
-        let isMatch = false;
-        const filteredRoleList = [];
+    const handleUnselectedListSearch = (
+        e: React.FormEvent<HTMLInputElement>,
+        { value }: { value: string;}
+    ) => {
+        let isMatch: boolean = false;
+        const filteredRoleList: RolesInterface[] = [];
 
         if (!isEmpty(value)) {
-            const re = new RegExp(escapeRegExp(value), "i");
+            const re: RegExp= new RegExp(escapeRegExp(value), "i");
 
-            initialValues.initialRoleList && initialValues.initialRoleList.map((role) => {
+            initialValues.initialRoleList && initialValues.initialRoleList.map((role: RolesInterface) => {
                 isMatch = re.test(role.displayName);
                 if (isMatch) {
                     filteredRoleList.push(role);
@@ -96,8 +99,8 @@ export const AddUserRole: FunctionComponent<AddUserRoleProps> = (props: AddUserR
         }
     };
 
-    const handleUnassignedItemCheckboxChange = (role) => {
-        const checkedRoles = [ ...checkedUnassignedListItems ];
+    const handleUnassignedItemCheckboxChange = (role: RolesInterface) => {
+        const checkedRoles: RolesInterface[] = [ ...checkedUnassignedListItems ];
 
         if (checkedRoles.includes(role)) {
             checkedRoles.splice(checkedRoles.indexOf(role), 1);
@@ -112,10 +115,10 @@ export const AddUserRole: FunctionComponent<AddUserRoleProps> = (props: AddUserR
     /**
      * The following method handles creating a label for the list item.
      *
-     * @param roleName: string
+     * @param roleName - string
      */
     const createItemLabel = (roleName: string) => {
-        const role = roleName.split("/");
+        const role: string[] = roleName.split("/");
 
         if (role.length > 0) {
             if (role[0] == "Application") {
@@ -158,8 +161,8 @@ export const AddUserRole: FunctionComponent<AddUserRoleProps> = (props: AddUserR
                             + "emptyPlaceholders.default") }
                     >
                         {
-                            initialValues?.roleList?.map((role, index)=> {
-                                const roleName = role?.displayName?.split("/");
+                            initialValues?.roleList?.map((role: RolesInterface, index: number)=> {
+                                const roleName: string[] = role?.displayName?.split("/");
 
                                 return (
                                     <TransferListItem
@@ -170,7 +173,7 @@ export const AddUserRole: FunctionComponent<AddUserRoleProps> = (props: AddUserR
                                         listItemIndex={ index }
                                         listItemTypeLabel={ createItemLabel(role?.displayName) }
                                         isItemChecked={ checkedUnassignedListItems.includes(role) }
-                                        showSecondaryActions={ true }
+                                        showSecondaryActions={ false }
                                         handleOpenPermissionModal={ () => handleSetRoleId(role.id) }
                                         data-testid="user-mgt-add-user-wizard-modal-unselected-roles"
                                     />


### PR DESCRIPTION
### Purpose
> Remove the view permissions button from the user/groups creation wizard

Group Creation Wizard
<img width="719" alt="Screenshot 2023-11-17 at 11 27 57" src="https://github.com/wso2/identity-apps/assets/27746285/83038eb3-62ea-46e9-9e4b-164352d01f34">

User Creation Wizard
<img width="719" alt="Screenshot 2023-11-17 at 11 28 54" src="https://github.com/wso2/identity-apps/assets/27746285/7e62ebb7-feff-447a-826f-028b07253967">

### Related Issues
- https://github.com/wso2/product-is/issues/17836
- https://github.com/wso2/product-is/issues/17649
- https://github.com/wso2/product-is/issues/17647

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
