### PR TITLE
Change application audience as default in role creation wizard

### DIFF
--- a/.changeset/short-dolphins-buy.md
+++ b/.changeset/short-dolphins-buy.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Set application audience as default in role creation

--- a/apps/console/src/features/roles/constants/role-constants.ts
+++ b/apps/console/src/features/roles/constants/role-constants.ts
@@ -71,7 +71,7 @@ export class RoleConstants {
     /**
      * Default role audience.
      */
-    public static readonly DEFAULT_ROLE_AUDIENCE: string = RoleAudienceTypes.ORGANIZATION;
+    public static readonly DEFAULT_ROLE_AUDIENCE: string = RoleAudienceTypes.APPLICATION;
 
     /**
      * Read only applications client ids.


### PR DESCRIPTION
### Purpose
Change application audience as default in role creation wizard

### Related Issues
- https://github.com/wso2/product-is/issues/17457

### Before

https://github.com/wso2/identity-apps/assets/59327626/e4af15c7-e95b-4544-91e3-88643d25b102

### After


https://github.com/wso2/identity-apps/assets/59327626/2dd3a8f9-c12b-4e68-a8bb-a05fa16727c1


