### PR TITLE
Set domain cookie upon language switch in myaccount

### DIFF
--- a/.changeset/gentle-pianos-greet.md
+++ b/.changeset/gentle-pianos-greet.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Set domain cookie upon language switch in myaccount

--- a/apps/myaccount/src/components/shared/header.tsx
+++ b/apps/myaccount/src/components/shared/header.tsx
@@ -179,6 +179,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
 
     /**
      * Handles language switch action.
+
      * @param language - Selected language.
      */
     const handleLanguageSwitch = (language: string): void => {


### PR DESCRIPTION
### Purpose
This is to fix an issue where the language setting in my account is not persisting upon refresh and logout.

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/20346

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
