### PR TITLE
Inconsistent Password Validation Criteria During User Creation via Console

### DIFF
--- a/.changeset/large-dryers-cheer.md
+++ b/.changeset/large-dryers-cheer.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add validation based on event.default_listener.validation to password

--- a/apps/console/src/features/users/components/add-user.tsx
+++ b/apps/console/src/features/users/components/add-user.tsx
@@ -106,19 +106,17 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
         "inputs.username.validations.invalidCharacters");
 
     useEffect(() => {
-
         if (showPasswordValidation) {
             setPasswordConfig(getConfiguration(validationConfig));
         }
     }, [ validationConfig ]);
     
     /**
-         * Callback function to validate password.
-         *
-         * @param valid - validation status.
-         */
+     * Callback function to validate password.
+     *
+     * @param valid - validation status.
+     */
     const onPasswordValidate = (valid: boolean): void => {
-    
         setIsValidPassword(valid);
     };
 
@@ -339,14 +337,12 @@ export const AddUser: React.FunctionComponent<AddUserProps> = (props: AddUserPro
 
                                     let passwordRegex: string = "";
 
-                                    if (passwordConfig) {
-                                        if(!isValidPassword) {
-                                            validation.isValid = false;
-                                            validation.errorMessages.push( t(
-                                                "extensions:manage.features.user.addUser.validation." +
-                                                "error.passwordValidation"
-                                            ) );
-                                        }
+                                    if (passwordConfig && !isValidPassword) {
+                                        validation.isValid = false;
+                                        validation.errorMessages.push( t(
+                                            "extensions:manage.features.user.addUser.validation." +
+                                            "error.passwordValidation"
+                                        ) );
                                     }
 
                                     if (userStore !== UserstoreConstants.PRIMARY_USER_STORE.toLocaleLowerCase()) {

--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -956,6 +956,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                     triggerSubmit={ submitGeneralSettings }
                     initialValues={ wizardState && wizardState[ WizardStepsFormTypes.BASIC_DETAILS ] }
                     emailVerificationEnabled={ emailVerificationEnabled }
+                    validationConfig ={ validationData }
                     onSubmit={ (values: AddUserWizardStateInterface) =>
                         handleWizardFormSubmit(values, WizardStepsFormTypes.BASIC_DETAILS) }
                 />


### PR DESCRIPTION
### Purpose
> Use password validation from event.default_listener.validation to validate. This change was missing from unification effort.

<img width="1354" alt="Screenshot 2023-11-18 at 11 44 25" src="https://github.com/wso2/identity-apps/assets/38417165/f920d1d0-bf81-4b9d-a184-4bb1ba90db65">


### Related Issues
- [Inconsistent Password Validation Criteria During User Creation via Console](https://github.com/wso2/product-is/issues/17594)
