### PR TITLE
Fix inconsistency issue in `choose other option button` in sms otp and email otp pages

### DIFF
--- a/.changeset/lucky-apes-burn.md
+++ b/.changeset/lucky-apes-burn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix inconsistency issue in choose other option button in sms otp and email otp pages

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
@@ -249,9 +249,12 @@
                                         String multiOptionURI = request.getParameter("multiOptionURI");
                                         if (isMultiAuthAvailable(multiOptionURI)) {
                                     %>
-                                        <a class="ui fluid large button secondary mt-2" 
-                                        id="goBackLink"
-                                        href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'>
+                                        <div class="ui divider hidden"></div>
+                                        <a
+                                            class="ui fluid primary basic button link-button" 
+                                            id="goBackLink"
+                                            href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'
+                                        >
                                             <%=AuthenticationEndpointUtil.i18n(resourceBundle, "choose.other.option")%>
                                         </a>
                                     <% } %>


### PR DESCRIPTION
### Purpose
> Fix inconsistency issue in `choose other option button` in sms otp and email otp pages
<img width="719" alt="Screenshot 2023-11-17 at 14 22 32" src="https://github.com/wso2/identity-apps/assets/27746285/0fad651b-4812-4fdc-b3a5-9f038e2b361e">

### Related Issues
- https://github.com/wso2/product-is/issues/17673

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
