### PR TITLE
Change role edit view primary buttons to be consistant with other primary buttons

### DIFF
--- a/.changeset/giant-lies-doubt.md
+++ b/.changeset/giant-lies-doubt.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change role edit view empty placeholder buttons to be consistant with other UI primary buttons

--- a/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-groups.tsx
@@ -24,7 +24,7 @@ import Button from "@oxygen-ui/react/Button";
 import TextField from "@oxygen-ui/react/TextField";
 import { AlertLevels, IdentifiableComponentInterface, RoleGroupsInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { EmphasizedSegment, EmptyPlaceholder, Heading } from "@wso2is/react-components";
+import { EmphasizedSegment, EmptyPlaceholder, Heading, PrimaryButton } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import debounce, { DebouncedFunc } from "lodash-es/debounce";
 import isEmpty from "lodash-es/isEmpty";
@@ -40,6 +40,7 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
+import { Icon } from "semantic-ui-react";
 import { AutoCompleteRenderOption } from "./edit-role-common/auto-complete-render-option";
 import { RenderChip } from "./edit-role-common/render-chip";
 import { updateResources } from "../../../core/api/bulk-operations";
@@ -222,10 +223,13 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
                     action={ 
                         !isReadOnly 
                             ? (
-                                <Button onClick={ () => setShowEmptyRolesListPlaceholder(false) } >
+                                <PrimaryButton
+                                    onClick={ () => setShowEmptyRolesListPlaceholder(false) }
+                                >
+                                    <Icon name="plus"/>
                                     { t("console:manage.features.roles.edit.groups.placeholders.emptyPlaceholder" + 
                                         ".action") }
-                                </Button>
+                                </PrimaryButton>
                             )
                             : null
                     }

--- a/apps/console/src/features/roles/components/edit-role/edit-role-users.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-users.tsx
@@ -24,7 +24,7 @@ import Button from "@oxygen-ui/react/Button";
 import TextField from "@oxygen-ui/react/TextField";
 import { AlertLevels, IdentifiableComponentInterface, RolesMemberInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { EmphasizedSegment, EmptyPlaceholder, Heading } from "@wso2is/react-components";
+import { EmphasizedSegment, EmptyPlaceholder, Heading, PrimaryButton } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import debounce, { DebouncedFunc } from "lodash-es/debounce";
 import isEmpty from "lodash-es/isEmpty";
@@ -40,6 +40,7 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
+import { Icon } from "semantic-ui-react";
 import { AutoCompleteRenderOption } from "./edit-role-common/auto-complete-render-option";
 import { RenderChip } from "./edit-role-common/render-chip";
 import { updateResources } from "../../../core/api/bulk-operations";
@@ -220,10 +221,13 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
                     action={ 
                         !isReadOnly 
                             ? (
-                                <Button onClick={ () => setShowEmptyRolesListPlaceholder(false) } >
+                                <PrimaryButton
+                                    onClick={ () => setShowEmptyRolesListPlaceholder(false) }
+                                >
+                                    <Icon name="plus"/>
                                     { t("console:manage.features.roles.edit.users.placeholders.emptyPlaceholder" + 
                                         ".action") }
-                                </Button>
+                                </PrimaryButton>
                             )
                             : null
                     }


### PR DESCRIPTION
### Purpose
Change `Assign Groups` and `Assign Users` buttons on empty assignments inside role edit view to be consistent with other Primary buttons

### Related Issues
- https://github.com/wso2/product-is/issues/17764

### Before

<img width="1378" alt="282422168-7a6336d1-8e7c-4aea-a3a1-19ab6d9a313c" src="https://github.com/wso2/identity-apps/assets/59327626/43d454e6-6c52-4bda-b0a7-170d6ec052cf">
<img width="1189" alt="282422176-a0ec5332-f487-40cd-8c25-1951650996c8" src="https://github.com/wso2/identity-apps/assets/59327626/fe31db9b-17a1-4c1f-8ddb-faa01062a366">


### After

<img width="1352" alt="Screenshot 2023-11-17 at 17 56 31" src="https://github.com/wso2/identity-apps/assets/59327626/c3b839fe-871e-475f-81a4-2e6f42607c18">
<img width="1352" alt="Screenshot 2023-11-17 at 17 56 39" src="https://github.com/wso2/identity-apps/assets/59327626/8e6fbef5-c2aa-44de-ba0f-5a81dcfacbea">
