### PR TITLE
Implement updating the role audience by just selecting the particular audience without having to click on the update button.

### DIFF
--- a/.changeset/polite-hounds-rule.md
+++ b/.changeset/polite-hounds-rule.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Improve the UX of the role creation flow.

--- a/apps/console/src/features/roles/components/application-roles.tsx
+++ b/apps/console/src/features/roles/components/application-roles.tsx
@@ -139,8 +139,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
     useEffect(() => {
 
         /**
-         * This if block prevents the roles being updated unless shouldUpdateRoleAudience is specifically set to true.
-         * It prevents the roles from being updated in unwanted scenarios such as in the initial render of the
+         * This prevents the roles from being updated in unwanted scenarios such as in the initial render of the
          * component.
          */
         if (!shouldUpdateRoleAudience) {
@@ -148,9 +147,9 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
         }
 
         /**
-         * When the roleAudience is not allowed for the application, the selectedRoles list should be cleared.
-         * However, due to the asynchronous nature of setSelectedRoles(), the selectedRoles list is not cleared
-         * immediately. This if block prevents the roles from being updated with stale data in such cases.
+         * Ideally, the selectedRoles list should be cleared immediately when the current roleAudience is not allowed 
+         * for the application. This does not happen in some cases due to the asynchronous nature of the 
+         * setSelectedRoles() method. This if block prevents the roles from being updated with stale data in such cases.
          */
         if (roleAudience !== application?.associatedRoles?.allowedAudience && selectedRoles?.length !== 0) {
             return;

--- a/apps/console/src/features/roles/components/application-roles.tsx
+++ b/apps/console/src/features/roles/components/application-roles.tsx
@@ -101,6 +101,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
 
     const [ isLoading, setIsLoading ] = useState<boolean>(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ shouldUpdateRoleAudience, setShouldUpdateRoleAudience ] = useState<boolean>(false);
     const [ showSwitchAudienceWarning, setShowSwitchAudienceWarning ] = useState<boolean>(false);
     const [ roleAudience, setRoleAudience ] =
         useState<RoleAudienceTypes>(application?.associatedRoles?.allowedAudience ?? RoleAudienceTypes.ORGANIZATION);
@@ -131,6 +132,31 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
             setInitialSelectedRoles([]);
         }
     }, [ roleAudience ]);
+
+    /**
+     * Send a request to update roles when one of the role audience radio buttons is selected. 
+     */
+    useEffect(() => {
+
+        /**
+         * This if block prevents the roles being updated unless shouldUpdateRoleAudience is specifically set to true.
+         * It prevents the roles from being updated in unwanted scenarios such as in the initial render of the
+         * component.
+         */
+        if (!shouldUpdateRoleAudience) {
+            return;
+        }
+
+        /**
+         * When the roleAudience is not allowed for the application, the selectedRoles list should be cleared.
+         * However, due to the asynchronous nature of setSelectedRoles(), the selectedRoles list is not cleared
+         * immediately. This if block prevents the roles from being updated with stale data in such cases.
+         */
+        if (roleAudience !== application?.associatedRoles?.allowedAudience && selectedRoles?.length !== 0) {
+            return;
+        }
+        updateRoles();
+    }, [ shouldUpdateRoleAudience, roleAudience, selectedRoles ]);
 
     /**
      * Set removed roles
@@ -250,6 +276,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
             })
             .finally(() => {
                 setIsSubmitting(false);
+                setShouldUpdateRoleAudience(false);
             });
     };
 
@@ -517,6 +544,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
                 } }
                 onPrimaryActionClick={ (): void => {
                     setRoleAudience(tempRoleAudience);
+                    setShouldUpdateRoleAudience(true);
                     setShowSwitchAudienceWarning(false);
                 } }
                 data-componentid={ `${ componentId }-switch-role-audience-confirmation-modal` }

--- a/apps/console/src/features/roles/components/application-roles.tsx
+++ b/apps/console/src/features/roles/components/application-roles.tsx
@@ -138,10 +138,6 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
      */
     useEffect(() => {
 
-        /**
-         * This prevents the roles from being updated in unwanted scenarios such as in the initial render of the
-         * component.
-         */
         if (!shouldUpdateRoleAudience) {
             return;
         }


### PR DESCRIPTION
### Purpose
Previously, the users first had to select `Application` role audience and click on the update button before creating a role. This PR improves the UX of role creation flow by allowing the users to just select the role audience and create the role without having to click on the update button in the middle of the flow.

https://github.com/wso2/identity-apps/assets/27700915/4cf53280-474a-4a1c-851f-60af6df9d548

### Related Issues
- https://github.com/wso2/product-is/issues/17654

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
