### PR TITLE
Remove o path from myaccount config

### DIFF
--- a/.changeset/cuddly-actors-hope.md
+++ b/.changeset/cuddly-actors-hope.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove O path from myaccount config

--- a/apps/console/src/features/applications/configs/endpoints.ts
+++ b/apps/console/src/features/applications/configs/endpoints.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,9 +25,11 @@ import { ApplicationsResourceEndpointsInterface } from "../models";
  * @returns The resource endpoints for the Application Management feature.
  */
 export const getApplicationsResourceEndpoints = (serverHost: string): ApplicationsResourceEndpointsInterface => {
+    const serverHostWithoutOPath: string = serverHost.replace("/o", "");
+
     return {
         applications: `${ serverHost }/api/server/v1/applications`,
-        myAccountConfigMgt: `${ serverHost }/api/identity/config-mgt/v1.0/resource/myaccount`,
+        myAccountConfigMgt: `${ serverHostWithoutOPath }/api/identity/config-mgt/v1.0/resource/myaccount`,
         requestPathAuthenticators: `${ serverHost }/api/server/v1/configs/authenticators?type=REQUEST_PATH`
     };
 };


### PR DESCRIPTION
### Purpose
The current API endpoint `https://localhost:9443/t/carbon.super/o/api/identity/config-mgt/v1.0/resource/myaccount/status/enable` is found to be invalid. The issue lies in the inclusion of `/o` in the path, which leads to an incorrect endpoint address. Notably, this erroneous endpoint is being called unexpectedly following an organization switch using the useMyAccountStatus hook in SWR.

### Proposed Change
Immediate Fix: Remove the /o segment from the API path. The correct endpoint should be: https://localhost:9443/t/carbon.super/api/identity/config-mgt/v1.0/resource/myaccount/status/enable.
Underlying Issue: The useMyAccountStatus hook is triggered inadvertently upon switching organizations. While the immediate fix corrects the endpoint, it does not address the root cause of the unwanted request. We need a comprehensive solution to prevent this unexpected API call, which is tracked separately [here](https://github.com/wso2/product-is/issues/17892).

### Related Issues
- https://github.com/wso2/product-is/issues/17806
- https://github.com/wso2/product-is/issues/17892

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
