### PR TITLE
Fix label for back button on administrator user page

### DIFF
--- a/.changeset/olive-tools-raise.md
+++ b/.changeset/olive-tools-raise.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+"@wso2is/myaccount": patch
+"@wso2is/identity-apps-core": patch
+---
+
+Fix label for back button on administrator user page

--- a/apps/console/src/extensions/components/users/pages/consumer-user-edit.tsx
+++ b/apps/console/src/extensions/components/users/pages/consumer-user-edit.tsx
@@ -556,7 +556,7 @@ const ConsumerUserEditPage = (): ReactElement => {
                 backButton={ {
                     "data-testid": "user-mgt-edit-user-back-button",
                     onClick: handleBackButtonClick,
-                    text: t("console:manage.pages.usersEdit.backButton")
+                    text: t("console:manage.pages.usersEdit.backButton", { type: "Users" })
                 } }
                 titleTextAlign="left"
                 bottomMargin={ false }

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -152,6 +152,14 @@ const UserEditPage = (): ReactElement => {
         }
     };
 
+    const getBackButtonText = (): string => {
+        if (window.location.href.includes(AppConstants.getPaths().get("ADMINISTRATORS"))) {
+            return t("console:manage.pages.usersEdit.backButton", { type: "Administrators" });
+        } else {
+            return t("console:manage.pages.usersEdit.backButton", { type: "Users" });
+        }
+    };
+
     /**
      * Handles edit avatar modal submit action.
      *
@@ -316,7 +324,7 @@ const UserEditPage = (): ReactElement => {
             backButton={ {
                 "data-testid": "user-mgt-edit-user-back-button",
                 onClick: handleBackButtonClick,
-                text: t("console:manage.pages.usersEdit.backButton")
+                text: getBackButtonText()
             } }
             titleTextAlign="left"
             bottomMargin={ false }

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -12571,7 +12571,7 @@ export const console: ConsoleNS = {
                 title: "Users"
             },
             usersEdit: {
-                backButton: "Go back to Users",
+                backButton: "Go back to {{type}}",
                 subTitle: "{{name}}",
                 title: "{{email}}"
             }

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -10862,7 +10862,7 @@ export const console: ConsoleNS = {
                 title: "Utilisateurs"
             },
             usersEdit: {
-                backButton: "Revenir aux Utilisateurs",
+                backButton: "Revenir aux {{type}}",
                 subTitle: "{{name}}",
                 title: "{{email}}"
             }

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -10613,7 +10613,7 @@ export const console: ConsoleNS = {
                 title: "පරිශීලකයින්"
             },
             usersEdit: {
-                backButton: "නැවත පරිශීලකයින් වෙත යන්න",
+                backButton: "{{type}} වෙත ආපසු යන්න",
                 subTitle: "{{name}}",
                 title: "{{email}}"
             }


### PR DESCRIPTION
### Purpose
Fix label for back button on administrator user page. Currently, the back button displays as "Go back to Users" even when it redirects to the Administrators page.

### Related Issues
- https://github.com/wso2/product-is/issues/17878

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
