### PR TITLE
Add legacy authz runtime support for getRolesList.

### DIFF
--- a/.changeset/smart-lies-add.md
+++ b/.changeset/smart-lies-add.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add legacy authz runtime support for roles.

--- a/apps/console/src/features/roles/api/roles.ts
+++ b/apps/console/src/features/roles/api/roles.ts
@@ -21,6 +21,7 @@ import { RoleConstants } from "@wso2is/core/constants";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { HttpMethods, RoleListInterface, RolesInterface } from "@wso2is/core/models";
 import { AxiosError, AxiosResponse } from "axios";
+import isLegacyAuthzRuntime from "../../authorization/utils/get-legacy-authz-runtime";
 import { store } from "../../core";
 import useRequest, { 
     RequestConfigInterface, 
@@ -451,7 +452,8 @@ export const getRolesList = (domain: string): Promise<RoleListInterface | any> =
         params: {
             domain
         },
-        url: store.getState().config.endpoints.rolesV2
+        url: isLegacyAuthzRuntime ? 
+            store.getState().config.endpoints.roles : store.getState().config.endpoints.rolesV2
     };
 
     return httpClient(requestConfig)

--- a/apps/console/src/features/roles/api/roles.ts
+++ b/apps/console/src/features/roles/api/roles.ts
@@ -139,7 +139,8 @@ export const getRoleById = (roleId: string): Promise<any> => {
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: store.getState().config.endpoints.rolesV2 + "/" + roleId
+        url: (isLegacyAuthzRuntime ? 
+            store.getState().config.endpoints.roles : store.getState().config.endpoints.rolesV2) + "/" + roleId
     };
 
     return httpClient(requestConfig)
@@ -213,7 +214,8 @@ export const updateRoleDetails = (roleId: string, roleData: PatchRoleDataInterfa
             "Content-Type": "application/json"
         },
         method: HttpMethods.PATCH,
-        url: store.getState().config.endpoints.rolesV2 + "/" + roleId
+        url: (isLegacyAuthzRuntime ? 
+            store.getState().config.endpoints.roles : store.getState().config.endpoints.rolesV2) + "/" + roleId
     };
 
     return httpClient(requestConfig)


### PR DESCRIPTION
### Description
This will fix the role list loading issues in the administrators section mentioned in the following issues. Roles v2 support is not yet introduced to these components while running on legacy authz support.