### PR TITLE
Show "Managed by" coloumn in administrators page only if saas is enabled

### DIFF
--- a/.changeset/sour-dragons-play.md
+++ b/.changeset/sour-dragons-play.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove "Managed by" coloumn in administrators page if saas is not enabled

--- a/apps/console/src/extensions/components/users/components/guests/onboarded-guest-user-list.tsx
+++ b/apps/console/src/extensions/components/users/components/guests/onboarded-guest-user-list.tsx
@@ -407,7 +407,7 @@ export const OnboardedGuestUsersList: React.FunctionComponent<OnboardedGuestUser
         ];
 
         if (saasFeatureStatus === FeatureStatus.ENABLED) {
-            const saasColumn: TableColumnInterface = {
+            const managedByColumn: TableColumnInterface = {
                 allowToggleVisibility: false,
                 dataIndex: "idpType",
                 id: "idpType",
@@ -446,7 +446,7 @@ export const OnboardedGuestUsersList: React.FunctionComponent<OnboardedGuestUser
                 )
             };
 
-            defaultColumns.push(saasColumn);
+            defaultColumns.push(managedByColumn);
         }
 
         defaultColumns.push({
@@ -688,7 +688,6 @@ export const OnboardedGuestUsersList: React.FunctionComponent<OnboardedGuestUser
                 } }
                 placeholders={ showPlaceholders() }
                 selectable={ selection }
-                // Show headers only if saas feature status is true
                 showHeader={ saasFeatureStatus === FeatureStatus.ENABLED }
                 transparent={ !isLoading && (showPlaceholders() !== null) }
                 data-componentid={ componentId }

--- a/apps/console/src/extensions/components/users/components/guests/onboarded-guest-user-list.tsx
+++ b/apps/console/src/extensions/components/users/components/guests/onboarded-guest-user-list.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { FeatureStatus, useCheckFeatureStatus } from "@wso2is/access-control";
 import { UserstoreConstants } from "@wso2is/core/constants";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { getUserNameWithoutDomain, hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
@@ -60,6 +61,7 @@ import {
     UserListInterface
 } from "../../../../../features/users/models";
 import { SCIMConfigs } from "../../../../configs/scim";
+import { FeatureGateConstants } from "../../../feature-gate/constants/feature-gate";
 import { deleteGuestUser } from "../../api";
 import { AdminAccountTypes, GUEST_ADMIN_ASSOCIATION_TYPE, UserAccountTypes, UsersConstants } from "../../constants";
 import { UserManagementUtils } from "../../utils";
@@ -188,6 +190,8 @@ export const OnboardedGuestUsersList: React.FunctionComponent<OnboardedGuestUser
     const authenticatedUser: string = useSelector((state: AppState) => state?.auth?.username);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const isPrivilegedUser: boolean = useSelector((state: AppState) => state.auth.isPrivilegedUser);
+
+    const saasFeatureStatus : FeatureStatus = useCheckFeatureStatus(FeatureGateConstants.SAAS_FEATURES_IDENTIFIER);
 
     /**
      * Set users list.
@@ -399,8 +403,11 @@ export const OnboardedGuestUsersList: React.FunctionComponent<OnboardedGuestUser
                     );
                 },
                 title: "User"
-            },
-            {
+            }
+        ];
+
+        if (saasFeatureStatus === FeatureStatus.ENABLED) {
+            const saasColumn: TableColumnInterface = {
                 allowToggleVisibility: false,
                 dataIndex: "idpType",
                 id: "idpType",
@@ -437,16 +444,19 @@ export const OnboardedGuestUsersList: React.FunctionComponent<OnboardedGuestUser
                         </div>
                     </>
                 )
-            },
-            {
-                allowToggleVisibility: false,
-                dataIndex: "action",
-                id: "actions",
-                key: "actions",
-                textAlign: "right",
-                title: ""
-            }
-        ];
+            };
+
+            defaultColumns.push(saasColumn);
+        }
+
+        defaultColumns.push({
+            allowToggleVisibility: false,
+            dataIndex: "action",
+            id: "actions",
+            key: "actions",
+            textAlign: "right",
+            title: ""
+        });
 
         const internalAdminColumns: TableColumnInterface[] = [
             {
@@ -678,7 +688,8 @@ export const OnboardedGuestUsersList: React.FunctionComponent<OnboardedGuestUser
                 } }
                 placeholders={ showPlaceholders() }
                 selectable={ selection }
-                showHeader={ true }
+                // Show headers only if saas feature status is true
+                showHeader={ saasFeatureStatus === FeatureStatus.ENABLED }
                 transparent={ !isLoading && (showPlaceholders() !== null) }
                 data-componentid={ componentId }
             />


### PR DESCRIPTION
### Purpose
The "Managed by" coloumn is only required in Asgardeo and should not be visible in the IS. This fix only displays that coloumn only if SaaS is enabled, to display it for Asgardeo.

### Related Issues
- https://github.com/wso2/product-is/issues/17899

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
