### PR TITLE
Fix organization switch issue in legacy authz runtime

### DIFF
--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -297,6 +297,7 @@ export const AppUtils: any = (function() {
                 getProfileInfoFromIDToken: _config.getProfileInfoFromIDToken,
                 idpConfigs: this.resolveIdpConfigs(),
                 isSaas: this.isSaas(),
+                legacyAuthzRuntime: _config.legacyAuthzRuntime,
                 loginCallbackURL: this.constructRedirectURLs(_config.loginCallbackPath),
                 logoutCallbackURL: this.constructRedirectURLs(_config.logoutCallbackPath),
                 organizationName: this.getOrganizationName(),

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -225,7 +225,12 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                     ? idToken?.amr[ 0 ] === "EnterpriseIDPAuthenticator"
                     : false;
 
-            if (has(idToken, "associated_tenants") || isPrivilegedUser) {
+            let isOrgSwitch: boolean = false;
+
+            if (has(idToken, "org_id") && has(idToken, "user_org")) {
+                isOrgSwitch = (idToken?.org_id !== idToken?.user_org);
+            }
+            if (has(idToken, "associated_tenants") || isPrivilegedUser || isOrgSwitch) {
                 // If there is an association, the user should be redirected to console landing page.
                 const location: string =
                     !AuthenticationCallbackUrl ||


### PR DESCRIPTION
### Purpose
When switching to an organization, console redirects to /t/{tenantDomain} path. This is due to getting the legacyAuthzRuntime config as undefined due to not setting legacyAuthzRuntime in app-utils.

When redirecting to /o/{orgId} path, still there is an issue since we are not sending two token calls in which one id token has associated tenants. So, the logic is updated to handle the org switch with org switch token call's id token.

