### PR TITLE
Handle user not found error in sms otp

### DIFF
--- a/.changeset/sweet-rockets-doubt.md
+++ b/.changeset/sweet-rockets-doubt.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Handle user not found error in sms otp

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtpError.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtpError.jsp
@@ -64,6 +64,8 @@
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.mobile.not.found");
             } else if (errorMessage.equalsIgnoreCase("directly.send.otp.disable")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.not.found");
+            } else if (errorMessage.equalsIgnoreCase("error.user.not.found.smsotp")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.not.found.smsotp");
             } else if (errorMessage.equalsIgnoreCase("user.account.locked")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.account.locked");
                 String unlockTime = request.getParameter("unlockTime");


### PR DESCRIPTION
### Purpose
$subject

### Related Issues
- https://github.com/wso2/product-is/issues/17527

### Related PRs
- https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/183

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
