### PR TITLE
(fix) Fix empty placeholder text in Roles section in the edit user.

### DIFF
--- a/.changeset/lazy-plants-report.md
+++ b/.changeset/lazy-plants-report.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+(fix) Fix empty placeholder text in `Roles` section in the edit user.

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -73,12 +73,13 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
     const getPlaceholders = () => {
         if (showEmptyRolesListPlaceholder) {
             return (
-                // TODO: Need to replace the i18N with the correct one.
                 <EmptyPlaceholder
                     subtitle={ 
-                        [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.subtitles") ]
+                        [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
+                            ".subtitles") ]
                     }
-                    title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.title") }
+                    title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
+                        ".title") }
                     image={ getEmptyPlaceholderIllustrations().emptyList }
                     imageSize="tiny"
                 />


### PR DESCRIPTION
### Purpose
(fix) Fix empty placeholder text in Roles section in the edit user.

### Screenshot
<img width="1512" alt="Screenshot 2023-11-19 at 10 57 18" src="https://github.com/wso2/identity-apps/assets/46097917/20647be8-3c1d-4ae2-a1fc-20327baee2a0">

### Related Issues
- https://github.com/wso2/product-is/issues/17924

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
