### PR TITLE
(fix) Change page title of `channels` to be changed based on the enabled providers.

### DIFF
--- a/.changeset/nasty-tigers-heal.md
+++ b/.changeset/nasty-tigers-heal.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/identity-apps-core": patch
+"@wso2is/i18n": patch
+---
+
+(fix) Change page title of `channels` to be changed based on the enabled providers.

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -1858,9 +1858,21 @@ export interface Extensions {
             };
         };
         notificationChannel: {
-            heading: string;
-            title: string;
-            description: string;
+            heading: {
+                heading: string;
+                onlySMSProvider: string;
+                onlyEmailProvider: string;
+            },
+            title: {
+                heading: string;
+                onlySMSProvider: string;
+                onlyEmailProvider: string;
+            },
+            description: {
+                description: string;
+                onlySMSProvider: string;
+                onlyEmailProvider: string;
+            }
         };
         smsProviders: {
             heading: string;

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -2090,9 +2090,21 @@ export const extensions: Extensions = {
             }
         },
         notificationChannel: {
-            heading: "SMS / Email Providers",
-            title: "SMS / Email Providers",
-            description: "Configure the SMS and Email providers for your organization."
+            heading: {
+                heading: "SMS / Email Providers",
+                onlySMSProvider: "SMS Provider",
+                onlyEmailProvider: "Email Provider"
+            },
+            title: {
+                heading: "SMS / Email Providers",
+                onlySMSProvider: "SMS Provider",
+                onlyEmailProvider: "Email Provider"
+            },
+            description: {
+                description: "Configure the SMS and Email providers for your organization.",
+                onlySMSProvider: "Configure the SMS provider for your organization.",
+                onlyEmailProvider: "Configure the Email provider for your organization."
+            }
         },
         smsProviders: {
             heading: "Custom SMS Provider",

--- a/apps/console/src/extensions/i18n/resources/fr-FR/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/fr-FR/extensions.ts
@@ -2124,9 +2124,21 @@ export const extensions: Extensions = {
             }
         },
         notificationChannel: {
-            heading: "Fournisseurs SMS/e-mail",
-            title: "Fournisseurs SMS/e-mail",
-            description: "Configurez les fournisseurs SMS et Email pour votre organisation."
+            heading: {
+                heading: "SMS / fournisseurs de courriels",
+                onlySMSProvider: "Fournisseur de SMS",
+                onlyEmailProvider: "Fournisseur de messagerie"
+            },
+            title: {
+                heading: "SMS / fournisseurs de courriels",
+                onlySMSProvider: "Fournisseur de SMS",
+                onlyEmailProvider: "Fournisseur de messagerie"
+            },
+            description: {
+                description: "Configurez les SMS et les fournisseurs de messagerie pour votre organisation.",
+                onlySMSProvider: "Configurez le fournisseur SMS pour votre organisation.",
+                onlyEmailProvider: "Configurez le fournisseur de messagerie pour votre organisation."
+            }
         },
         smsProviders: {
             heading: "Fournisseur de SMS personnalisé",

--- a/apps/console/src/extensions/i18n/resources/si-LK/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/si-LK/extensions.ts
@@ -2063,9 +2063,21 @@ export const extensions: Extensions = {
             }
         },
         notificationChannel: {
-            heading: "SMS / ඊමේල් සපයන්නන්",
-            title: "SMS / ඊමේල් සපයන්නන්",
-            description: "ඔබේ සංවිධානය සඳහා SMS සහ විද්‍යුත් තැපැල් සපයන්නන් වින්‍යාස කරන්න."
+            heading: {
+                heading: "කෙටි පණිවුඩ / ඊමේල් සැපයුම්කරුවන්",
+                onlySMSProvider: "කෙටි පණිවුඩ සැපයුම්කරු",
+                onlyEmailProvider: "විද්යුත් තැපැල් සැපයුම්කරු"
+            },
+            title: {
+                heading: "කෙටි පණිවුඩ / ඊමේල් සැපයුම්කරුවන්",
+                onlySMSProvider: "කෙටි පණිවුඩ සැපයුම්කරු",
+                onlyEmailProvider: "විද්යුත් තැපැල් සැපයුම්කරු"
+            },
+            description: {
+                description: "ඔබේ සංවිධානය සඳහා කෙටි පණිවුඩ සහ විද්යුත් තැපැල් සපයන්නන් වින්‍යාස කරන්න.",
+                onlySMSProvider: "ඔබේ සංවිධානය සඳහා කෙටි පණිවුඩ සැපයුම්කරු වින්‍යාස කරන්න.",
+                onlyEmailProvider: "ඔබේ සංවිධානය සඳහා විද්යුත් තැපැල් සැපයුම්කරු වින්‍යාස කරන්න."
+            }
         },
         smsProviders: {
             heading: "අභිරුචි කෙටි පණිවුඩ සපයන්නා",

--- a/apps/console/src/features/notification-channels/pages/notification-channels.tsx
+++ b/apps/console/src/features/notification-channels/pages/notification-channels.tsx
@@ -82,7 +82,7 @@ export const NotificationChannelPage: FunctionComponent<NotificationChannelPageI
         pageTitle: string;
         title: string;
     } => {
-        if (isEmailProviderEnabled === isSMSProviderEnabled) {
+        if ((isEmailProviderEnabled && isSMSProviderEnabled) || (!isEmailProviderEnabled && !isSMSProviderEnabled)) {
             return {
                 description: t("extensions:develop.notificationChannel.description.description"),
                 pageTitle: t("extensions:develop.notificationChannel.heading.heading"),

--- a/apps/console/src/features/notification-channels/pages/notification-channels.tsx
+++ b/apps/console/src/features/notification-channels/pages/notification-channels.tsx
@@ -54,14 +54,14 @@ export const NotificationChannelPage: FunctionComponent<NotificationChannelPageI
     /**
      * Check if the email provider is enabled for the tenant.
      */
-    const isEmailProviderEnabled: boolean = featureConfig.emailProviders?.enabled
+    const isEmailProviderEnabled: boolean = featureConfig?.emailProviders?.enabled
         && !(featureConfig?.emailProviders?.disabledFeatures?.includes("superTenantProvider")
         && organizationType === OrganizationType.SUPER_ORGANIZATION);
 
     /**
      * Check if the SMS provider is enabled for the tenant.
      */
-    const isSMSProviderEnabled: boolean = featureConfig.smsProviders?.enabled;
+    const isSMSProviderEnabled: boolean = featureConfig?.smsProviders?.enabled;
 
     /**
      * Handle connector advance setting selection.

--- a/apps/console/src/features/notification-channels/pages/notification-channels.tsx
+++ b/apps/console/src/features/notification-channels/pages/notification-channels.tsx
@@ -52,6 +52,18 @@ export const NotificationChannelPage: FunctionComponent<NotificationChannelPageI
     const featureConfig : FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
     /**
+     * Check if the email provider is enabled for the tenant.
+     */
+    const isEmailProviderEnabled: boolean = featureConfig.emailProviders?.enabled
+        && !(featureConfig?.emailProviders?.disabledFeatures?.includes("superTenantProvider")
+        && organizationType === OrganizationType.SUPER_ORGANIZATION);
+
+    /**
+     * Check if the SMS provider is enabled for the tenant.
+     */
+    const isSMSProviderEnabled: boolean = featureConfig.smsProviders?.enabled;
+
+    /**
      * Handle connector advance setting selection.
      */
     const handleSMSSelection = (): void => {
@@ -61,17 +73,44 @@ export const NotificationChannelPage: FunctionComponent<NotificationChannelPageI
     const handleEmailSelection = (): void => {
         history.push(AppConstants.getPaths().get("EMAIL_PROVIDER"));
     };
+    
+    /**
+     * Get the page details based on the enabled providers.
+     */
+    const getPageDetails = (): {
+        description: string;
+        pageTitle: string;
+        title: string;
+    } => {
+        if (isEmailProviderEnabled === isSMSProviderEnabled) {
+            return {
+                description: t("extensions:develop.notificationChannel.description.description"),
+                pageTitle: t("extensions:develop.notificationChannel.heading.heading"),
+                title: t("extensions:develop.notificationChannel.title.title")
+            };
+        } else if (isSMSProviderEnabled) {
+            return {
+                description: t("extensions:develop.notificationChannel.description.onlySMSProvider"),
+                pageTitle: t("extensions:develop.notificationChannel.heading.onlySMSProvider"),
+                title: t("extensions:develop.notificationChannel.title.onlySMSProvider")
+            };
+        } else if (isEmailProviderEnabled) {
+            return {
+                description: t("extensions:develop.notificationChannel.description.onlyEmailProvider"),
+                pageTitle: t("extensions:develop.notificationChannel.heading.onlyEmailProvider"),
+                title: t("extensions:develop.notificationChannel.title.onlyEmailProvider")
+            };
+        }
+    };
 
     return (
         <PageLayout
-            pageTitle={ t("extensions:develop.notificationChannel.heading") }
-            title={ t("extensions:develop.notificationChannel.title") }
-            description={ t("extensions:develop.notificationChannel.description") }
+            pageTitle={ getPageDetails().pageTitle }
+            title={ getPageDetails().title }
+            description={ getPageDetails().description }
             data-testid={ `${componentid}-page-layout` }
         >
-            { featureConfig.emailProviders?.enabled
-                && !(featureConfig?.emailProviders?.disabledFeatures?.includes("superTenantProvider")
-                && organizationType === OrganizationType.SUPER_ORGANIZATION) && (
+            { isEmailProviderEnabled && (
                 <>
                     <Grid xs={ 12 } lg={ 6 }>
                         <SettingsSection
@@ -87,7 +126,7 @@ export const NotificationChannelPage: FunctionComponent<NotificationChannelPageI
                     <Divider hidden/>
                 </>
             ) }
-            { featureConfig.smsProviders?.enabled && (
+            { isSMSProviderEnabled && (
                 <Grid xs={ 12 } lg={ 6 }>
                     <SettingsSection
                         data-componentid={ "account-login-page-section" }


### PR DESCRIPTION
### Purpose
(fix) Change page title of `channels` to be changed based on the enabled providers.

### Related Issues
- https://github.com/wso2/product-is/issues/17805

### Screenshot
<img width="1548" alt="Screenshot 2023-11-19 at 12 35 30" src="https://github.com/wso2/identity-apps/assets/46097917/7ae3d35f-786a-4efb-8e36-7c4305832b7d">

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
