### PR TITLE
Remove validation for carbon.super which is not required

### DIFF
--- a/.changeset/warm-seals-applaud.md
+++ b/.changeset/warm-seals-applaud.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove not required validation when loding readonly userstores

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -32,14 +32,13 @@ import { Dispatch } from "redux";
 import { Icon } from "semantic-ui-react";
 import { getProfileInformation } from "../../authentication/store";
 import { AppConstants, AppState, FeatureConfigInterface, SharedUserStoreUtils, history } from "../../core";
-import { OrganizationUtils } from "../../organizations/utils";
+import { useGetCurrentOrganizationType } from "../../organizations/hooks/use-get-organization-type";
 import { getGovernanceConnectors } from "../../server-configurations/api";
 import { ServerConfigurationsConstants } from "../../server-configurations/constants";
 import { ConnectorPropertyInterface, GovernanceConnectorInterface } from "../../server-configurations/models";
 import { getUserDetails, updateUserInfo } from "../api";
 import { EditUser } from "../components/edit-user";
 import { UserManagementUtils } from "../utils";
-import { useGetCurrentOrganizationType } from "../../organizations/hooks/use-get-organization-type";
 
 /**
  * User Edit page.

--- a/apps/console/src/features/users/pages/user-edit.tsx
+++ b/apps/console/src/features/users/pages/user-edit.tsx
@@ -110,9 +110,6 @@ const UserEditPage = (): ReactElement => {
     }, []);
 
     useEffect(() => {
-        if (!isSuperOrganization) {
-            return;
-        }
 
         setReadOnlyUserStoresLoading(true);
         SharedUserStoreUtils.getReadOnlyUserStores()


### PR DESCRIPTION
### Purpose
The validation that was removed does not let the readOnly user stores to be added to the list of readOnly user stores. 

### Related Issues
https://github.com/wso2/product-is/issues/17659


After changes, the readonly userStore users will be shown in read only view. 

<img width="1211" alt="Screenshot 2023-11-18 at 13 02 59" src="https://github.com/wso2/identity-apps/assets/50905371/7a419171-276f-4d01-936a-434c7a0ea4f4">


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
