### PR TITLE
Fix 404 response for IDP filtering with tags

### DIFF
--- a/.changeset/fresh-hornets-fly.md
+++ b/.changeset/fresh-hornets-fly.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Prevent API call with filter attribute tags for the IDP list endpoint

--- a/apps/console/src/features/connections/api/connections.ts
+++ b/apps/console/src/features/connections/api/connections.ts
@@ -93,6 +93,8 @@ export const createConnection = (
  * @param offset - Offset for get to start.
  * @param filter - Search filter.
  * @param requiredAttributes - Extra attribute to be included in the list response. ex:`isFederationHub`
+ * @param shouldFetch - Should fetch from the network. If false, will return results from cache.
+ * @param expectEmpty - If true, will allow returning empty results.
  *
  * @returns Requested connections.
  */
@@ -101,7 +103,8 @@ export const useGetConnections = <Data = ConnectionListResponseInterface, Error 
     offset?: number,
     filter?: string,
     requiredAttributes?: string,
-    shouldFetch: boolean = true
+    shouldFetch: boolean = true,
+    expectEmpty: boolean = false
 ): RequestResultInterface<Data, Error> => {
     
     const { resourceEndpoints } = useResourceEndpoints();
@@ -126,7 +129,7 @@ export const useGetConnections = <Data = ConnectionListResponseInterface, Error 
     return {
         data,
         error: error,
-        isLoading: !error && !data,
+        isLoading: !expectEmpty && !error && !data,
         isValidating,
         mutate
     };

--- a/apps/console/src/features/connections/pages/connections.tsx
+++ b/apps/console/src/features/connections/pages/connections.tsx
@@ -389,12 +389,7 @@ const ConnectionsPage: FC<ConnectionsPropsInterface> = (props: ConnectionsPropsI
 
         setSelectedFilterTags(filterTags);
         setFilter(ConnectionsManagementUtils.buildAuthenticatorsFilterQuery(query, filterTags));
-
-        if (filterTags && filterTags.length > 0) {
-            setFilterAuthenticatorsOnly(true);
-        } else {
-            setFilterAuthenticatorsOnly(false);
-        }
+        setFilterAuthenticatorsOnly(filterTags && filterTags.length > 0);
 
         if (isEmpty(query) && isEmpty(filterTags)) {
             setShowFilteredList(false);

--- a/apps/console/src/features/connections/pages/connections.tsx
+++ b/apps/console/src/features/connections/pages/connections.tsx
@@ -107,6 +107,7 @@ const ConnectionsPage: FC<ConnectionsPropsInterface> = (props: ConnectionsPropsI
     const [ localAuthenticatorList, setLocalAuthenticatorList ] = useState<AuthenticatorInterface[]>([]);
     const [ filteredAuthenticatorList, setFilteredAuthenticatorList ] = useState<AuthenticatorInterface[]>([]);
     const [ filter, setFilter ] = useState<string>(null);
+    const [ filterAuthenticatorsOnly, setFilterAuthenticatorsOnly ] = useState<boolean>(false);
     const [ appendConnections, setAppendConnections ] = useState<boolean>(false);
     const isPaginating: boolean = false;
 
@@ -122,7 +123,14 @@ const ConnectionsPage: FC<ConnectionsPropsInterface> = (props: ConnectionsPropsI
         isLoading: isConnectionsFetchRequestLoading,
         error: connectionsFetchRequestError,
         mutate: mutateConnectionsFetchRequest
-    } = useGetConnections(listItemLimit, listOffset, filter, "federatedAuthenticators");
+    } = useGetConnections(
+        listItemLimit, 
+        listOffset, 
+        filter, 
+        "federatedAuthenticators", 
+        !filterAuthenticatorsOnly, 
+        filterAuthenticatorsOnly
+    );
 
     const {
         data: authenticatorTags,
@@ -381,6 +389,12 @@ const ConnectionsPage: FC<ConnectionsPropsInterface> = (props: ConnectionsPropsI
 
         setSelectedFilterTags(filterTags);
         setFilter(ConnectionsManagementUtils.buildAuthenticatorsFilterQuery(query, filterTags));
+
+        if (filterTags && filterTags.length > 0) {
+            setFilterAuthenticatorsOnly(true);
+        } else {
+            setFilterAuthenticatorsOnly(false);
+        }
 
         if (isEmpty(query) && isEmpty(filterTags)) {
             setShowFilteredList(false);


### PR DESCRIPTION
### Purpose
> Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. Remove this placeholder when you're editing.

Fixes https://github.com/wso2/product-is/issues/17418.

Currently tags are only applicable for authenticators and not identity-providers. Hence when filtering by tags, the additional frontend call for identity-providers should be prevented.

Have introduced an additional parameter `expectEmpty` into the `useGetConnections` hook to allow returning empty result without keeping the model loading. Otherwise if we are not fetching the IDPs and the list turns out to be empty, the IDP list model will keep showing as loading.
If this behavior is altered to work only with `shouldFetch` parameter without adding new param, then the model won't display the loading UI when the results are fetching from cache.

### Related Issues
- https://github.com/wso2/product-is/issues/17418

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
