### PR TITLE
Allow group assignment for invited users

### DIFF
--- a/.changeset/perfect-eels-yell.md
+++ b/.changeset/perfect-eels-yell.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Improve group assignment of invited users

--- a/apps/console/src/features/users/components/edit-user.tsx
+++ b/apps/console/src/features/users/components/edit-user.tsx
@@ -101,6 +101,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     const [ hideTermination, setHideTermination ] = useState<boolean>(false);
     const [ user, setUser ] = useState<ProfileInfoInterface>(selectedUser);
     const [ isUserManagedByParentOrg, setIsUserManagedByParentOrg ] = useState<boolean>(false);
+    const [ isUserProfileReadOnly, setIsUserProfileReadOnly ] = useState<boolean>(false);
 
     useEffect(() => {
         //Since the parent component is refreshing twice we are doing a deep equals operation on the user object to
@@ -122,7 +123,6 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
             || readOnlyUserStores?.includes(userStore?.toString())
             || !hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
             || user[ SCIMConfigs.scim.enterpriseSchema ]?.userSourceId
-            || user[ SCIMConfigs.scim.enterpriseSchema ]?.managedOrg
         ) {
             setReadOnly(true);
         }
@@ -140,6 +140,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
     useEffect(() => {
         if (user[ SCIMConfigs.scim.enterpriseSchema ]?.managedOrg) {
             setIsUserManagedByParentOrg(true);
+            setIsUserProfileReadOnly(true);
         }
     }, [ user ]);
 
@@ -209,7 +210,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                         onAlertFired={ handleAlerts }
                         user={ user }
                         handleUserUpdate={ handleUserUpdate }
-                        isReadOnly={ isReadOnly }
+                        isReadOnly={ isReadOnly || isUserProfileReadOnly }
                         connectorProperties={ connectorProperties }
                         isReadOnlyUserStoresLoading={ isReadOnlyUserStoresLoading }
                         isUserManagedByParentOrg={ isUserManagedByParentOrg }


### PR DESCRIPTION
### Purpose

In the previous implementation, if a user receives the `managedOrg` attribute, they are resolved as read only users. Ideally, only their attributes should be read only. Therefore, a new variable `isUserProfileReadOnly` is introduced to preserve the read only nature of the user profile while for other resource tabs (such as Groups) the read only property of the user is set to false.

This enables assigning groups to invited users which was previously restricted from the UI because the read only property was set to true.

### Related Issues
- https://github.com/wso2/product-is/issues/17933

### Related PRs
- https://github.com/wso2/identity-apps/pull/4631

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
