### PR TITLE
Fix state update issues in sms provider page

### DIFF
--- a/.changeset/friendly-plums-peel.md
+++ b/.changeset/friendly-plums-peel.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix state update issues in sms provider page

--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -319,7 +319,6 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
             setIsSubmitting(false);
             handleUpdateSuccess();
             setExistingSMSProviders([ provider + "SMSProvider" ]);
-            
         })
             .catch(() => {
                 handleUpdateError();

--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -318,6 +318,8 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
             setSmsProviderSettings({ ...smsProviderSettings, providerParams: updatedParams });
             setIsSubmitting(false);
             handleUpdateSuccess();
+            setExistingSMSProviders([ provider + "SMSProvider" ]);
+            
         })
             .catch(() => {
                 handleUpdateError();
@@ -671,6 +673,7 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                                 handleConfigurationDelete().finally(() => {
                                     setIsSubmitting(false);
                                     setOpenRevertConfigModal(false);
+                                    setExistingSMSProviders([]);
                                 });
 
                             } }


### PR DESCRIPTION
### Purpose

There are couple of issues with updating the sms providers.

1. When an sms provider is created and attempted to update immediately after creating, the page sends a POST request instead of a PUT request.

2. When the SMS provider configs are reverted and the user attempts to create a SMS provider, app sends a PUT request instead of a POST request.

Both issues happen due to the state variable `existingSMSProviders` not being synced properly.

This PR fixes that issue.

### Related Issues
- https://github.com/wso2/product-is/issues/17814

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
