### PR TITLE
Make `APPLICATION` default audience for App Templates

### DIFF
--- a/.changeset/forty-ducks-sort.md
+++ b/.changeset/forty-ducks-sort.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Make `APPLICATION` default audience for App Templates

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -73,6 +73,7 @@ import {
 import { TierLimitReachErrorModal } from "../../../core/components/tier-limit-reach-error-modal";
 import { OrganizationType } from "../../../organizations/constants";
 import { useGetCurrentOrganizationType } from "../../../organizations/hooks/use-get-organization-type";
+import { RoleAudienceTypes, RoleConstants } from "../../../roles/constants/role-constants";
 import { createApplication, getApplicationList, getApplicationTemplateData } from "../../api";
 import { getInboundProtocolLogos } from "../../configs/ui";
 import { ApplicationManagementConstants } from "../../constants";
@@ -93,7 +94,6 @@ import {
 } from "../../models";
 import { ApplicationManagementUtils } from "../../utils/application-management-utils";
 import { ApplicationShareModal } from "../modals/application-share-modal";
-import { RoleAudienceTypes, RoleConstants } from "../../../roles/constants/role-constants";
 
 /**
  * Prop types of the `MinimalAppCreateWizard` component.

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -93,6 +93,7 @@ import {
 } from "../../models";
 import { ApplicationManagementUtils } from "../../utils/application-management-utils";
 import { ApplicationShareModal } from "../modals/application-share-modal";
+import { RoleAudienceTypes, RoleConstants } from "../../../roles/constants/role-constants";
 
 /**
  * Prop types of the `MinimalAppCreateWizard` component.
@@ -327,11 +328,22 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         application.templateId = selectedTemplate.id;
         // If the application is a OIDC standard-based application
         if (legacyAuthzRuntime && customApplicationProtocol === SupportedAuthProtocolTypes.OAUTH2_OIDC
-            && (selectedTemplate?.templateId === "custom-application" 
+            && (selectedTemplate?.templateId === "custom-application"
                 || selectedTemplate?.templateId === ApplicationTemplateIdTypes.M2M_APPLICATION)) {
             application.isManagementApp = generalFormValues.get("isManagementApp").length >= 2
                 ? true
                 : false;
+        }
+
+        // Adding `APPLICATION` as the default audience for the associated roles,
+        // if a value is not set from the template.
+        if (!legacyAuthzRuntime) {
+            if (isEmpty(application.associatedRoles)) {
+                application.associatedRoles = {
+                    allowedAudience: RoleConstants.DEFAULT_ROLE_AUDIENCE as RoleAudienceTypes,
+                    roles: []
+                };
+            }
         }
 
         // If the selected template is Custom, assign the proper `template ids`.
@@ -348,7 +360,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                     }
                 };
             } else if (customApplicationProtocol === SupportedAuthProtocolTypes.SAML) {
-                
+
                 application.templateId = ApplicationManagementConstants.CUSTOM_APPLICATION_SAML;
 
                 if (samlConfigureMode === SAMLConfigModes.MANUAL) {
@@ -721,12 +733,12 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
              *
              * @example
              * SAMLProtocolSettingsWizardForm
-             *     fields= [ "issuer", "assertionConsumerURLs" ] 
-             *     hideFieldHints= true 
-             *     triggerSubmit= submitProtocolForm 
-             *     templateValues= templateSettings?.application 
-             *     onSubmit= (values): void = setProtocolFormValues(values) 
-             *     data-testid= `${ testId }-saml-protocol-settings-form` 
+             *     fields= [ "issuer", "assertionConsumerURLs" ]
+             *     hideFieldHints= true
+             *     triggerSubmit= submitProtocolForm
+             *     templateValues= templateSettings?.application
+             *     onSubmit= (values): void = setProtocolFormValues(values)
+             *     data-testid= `${ testId }-saml-protocol-settings-form`
              * /
              */
             return (
@@ -1077,8 +1089,8 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                     </Grid.Row>
                     {
                         // The Management App checkbox is only present in OIDC Standard-Based apps
-                        (legacyAuthzRuntime && customApplicationProtocol === SupportedAuthProtocolTypes.OAUTH2_OIDC && 
-                            (selectedTemplate?.templateId === "custom-application" || 
+                        (legacyAuthzRuntime && customApplicationProtocol === SupportedAuthProtocolTypes.OAUTH2_OIDC &&
+                            (selectedTemplate?.templateId === "custom-application" ||
                             selectedTemplate?.templateId === ApplicationTemplateIdTypes.M2M_APPLICATION)
                         ) && (
                             <div className="pt-0 mt-0">
@@ -1145,9 +1157,9 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                                 <Grid.Row columns={ 1 }>
                                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 14 }>
                                         <div className="pt-0 mt-0">
-                                            <Checkbox 
+                                            <Checkbox
                                                 onChange={ (
-                                                    event: React.FormEvent<HTMLInputElement>, 
+                                                    event: React.FormEvent<HTMLInputElement>,
                                                     data: CheckboxProps
                                                 ) => {
                                                     setIsAppSharingEnabled(data.checked);


### PR DESCRIPTION
### Purpose

Make APPLICATION default audience for App Template so that it's selected in the edit view.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
