### PR TITLE
Adding config for API Based Authn configuration

### DIFF
--- a/.changeset/thick-apricots-bake.md
+++ b/.changeset/thick-apricots-bake.md
@@ -1,0 +1,16 @@
+---
+"@wso2is/react-components": patch
+"@wso2is/access-control": patch
+"@wso2is/dynamic-forms": patch
+"@wso2is/identity-apps-core": patch
+"@wso2is/myaccount": patch
+"@wso2is/common": patch
+"@wso2is/forms": patch
+"@wso2is/theme": patch
+"@wso2is/console": patch
+"@wso2is/core": patch
+"@wso2is/form": patch
+"@wso2is/i18n": patch
+---
+
+config for api based authn

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -200,6 +200,11 @@
         {% if console.ui.show_app_switch_button is defined %}
         "showAppSwitchButton": {{ console.ui.show_app_switch_button }},
         {% endif %}
+        {% if console.ui.show_api_based_authentication is defined %}
+        "showAPIBasedAuthentication": {{ console.ui.show_api_based_authentication }},
+        {% else %}
+        "showAPIBasedAuthentication": true,
+        {% endif %}
         "features": {
             {% if console.extensions.features is defined %}
             {% for name, feature in console.extensions.features.items() %}

--- a/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
+++ b/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
@@ -214,6 +214,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 hint={ t("console:develop.features.applications.forms.advancedConfig.fields.enableAuthorization.hint") }
             />
             {
+                UIConfig?.showAPIBasedAuthentication && 
                 (template?.id === ApplicationManagementConstants.CUSTOM_APPLICATION
                     || template?.id === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC ) &&
                 (

--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -307,6 +307,7 @@ export class Config {
             productName: window[ "AppUtils" ]?.getConfig()?.ui?.productName,
             productVersionConfig: window[ "AppUtils" ]?.getConfig()?.ui?.productVersionConfig,
             selfAppIdentifier: window[ "AppUtils" ]?.getConfig()?.ui?.selfAppIdentifier,
+            showAPIBasedAuthentication: window[ "AppUtils" ]?.getConfig()?.ui?.showAPIBasedAuthentication,
             showAppSwitchButton: window[ "AppUtils" ]?.getConfig()?.ui?.showAppSwitchButton,
             systemAppsIdentifiers: window[ "AppUtils" ]?.getConfig()?.ui?.systemAppsIdentifiers,
             theme: window[ "AppUtils" ]?.getConfig()?.ui?.theme

--- a/apps/console/src/features/core/store/reducers/config.ts
+++ b/apps/console/src/features/core/store/reducers/config.ts
@@ -253,6 +253,7 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
             productName: "",
             productVersionConfig: null,
             selfAppIdentifier: "",
+            showAPIBasedAuthentication: undefined, 
             showAppSwitchButton: undefined,
             systemAppsIdentifiers: [],
             theme: {

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -226,6 +226,7 @@
         "appFaviconPath": "/assets/images/branding/favicon.ico",
         "isGOTEnabledForSuperTenantOnly": true,
         "showAppSwitchButton": true,
+        "showAPIBasedAuthentication": true,
         "features": {
             "administrators": {
                 "disabledFeatures": [],

--- a/modules/common/src/store/reducers/config.ts
+++ b/modules/common/src/store/reducers/config.ts
@@ -147,6 +147,7 @@ export const commonConfigReducerInitialState = {
             productName: "",
             productVersionConfig: null,
             selfAppIdentifier: "",
+            showAPIBasedAuthentication: undefined, 
             showAppSwitchButton: undefined,
             systemAppsIdentifiers: [],
             theme: {

--- a/modules/core/src/models/config.ts
+++ b/modules/core/src/models/config.ts
@@ -212,6 +212,10 @@ export interface CommonUIConfigInterface<T = Record<string, unknown>> {
      * Theme configs.
      */
     theme: AppThemeConfigInterface;
+    /**
+     * Enable/Disable API Based Authenticaiton Config.
+     */
+    showAPIBasedAuthentication?: boolean;
 }
 
 /**


### PR DESCRIPTION
### Purpose
Conditionally render API_Based_Authentication, with following toml file
By default, its enabled but this can be disabled with following config
```
[console.ui]
show_api_based_authentication = false
```