### PR TITLE
Implement legacy group and role separation behavior into the roles section in user settings page

### DIFF
--- a/.changeset/khaki-apricots-talk.md
+++ b/.changeset/khaki-apricots-talk.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Implement legacy group and role separation behavior into the roles section in user settings page.

--- a/apps/console/src/features/roles/constants/role-constants.ts
+++ b/apps/console/src/features/roles/constants/role-constants.ts
@@ -20,6 +20,7 @@ export const APPLICATION_DOMAIN: string = "Application/";
 export const INTERNAL_DOMAIN: string = "Internal";
 export const PRIMARY_DOMAIN: string = "Primary";
 export const ROLE_VIEW_PATH: string = "/roles/";
+export const DOMAIN_SEPARATOR: string = "/";
 
 /**
  * Role audience interface.

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -96,12 +96,12 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
         const userRoles: RolesMemberInterface[] = [];
         
         groups?.forEach((group: RoleGroupsInterface) => {
-            const splitDisplayName: string[] = group?.display?.split(DOMAIN_SEPARATOR);
+            const [ domain, displayName ]: string[] = group?.display?.split(DOMAIN_SEPARATOR);
             
-            if (splitDisplayName?.length > 1 && [ APPLICATION_DOMAIN, INTERNAL_DOMAIN ].includes(splitDisplayName[0])) {
+            if (domain && displayName && [ APPLICATION_DOMAIN, INTERNAL_DOMAIN ].includes(domain)) {
                 userRoles.push({
                     $ref: group.$ref,
-                    display: splitDisplayName[1],
+                    display: displayName,
                     orgId: undefined,
                     orgName: undefined,
                     value: group.value

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -77,12 +77,11 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
             userRoles = extractUserRolesFromGroups(user?.groups);
         }
 
-        if ( userRoles?.length > 0 ) {
+        if (userRoles?.length > 0) {
             setInitialSelectedRolesOptions(userRoles);
         } else {
             setShowEmptyRolesListPlaceholder(true);
         }
-        
     }, [ user ]);
 
     /**
@@ -97,12 +96,12 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
         const userRoles: RolesMemberInterface[] = [];
         
         groups?.forEach((group: RoleGroupsInterface) => {
-            const displayName: string[] = group?.display?.split(DOMAIN_SEPARATOR);
+            const splitDisplayName: string[] = group?.display?.split(DOMAIN_SEPARATOR);
             
-            if (displayName?.length > 1 && [ APPLICATION_DOMAIN, INTERNAL_DOMAIN ].includes(displayName[0])) {
+            if (splitDisplayName?.length > 1 && [ APPLICATION_DOMAIN, INTERNAL_DOMAIN ].includes(splitDisplayName[0])) {
                 userRoles.push({
                     $ref: group.$ref,
-                    display: displayName[1],
+                    display: splitDisplayName[1],
                     orgId: undefined,
                     orgName: undefined,
                     value: group.value


### PR DESCRIPTION
### Purpose
Fixes https://github.com/wso2/product-is/issues/18002 by extracting roles from the groups section in SCIM user response when the legacy group and role separation behavior is enabled.

### Related Issues
- https://github.com/wso2/product-is/issues/18002

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
