### PR TITLE
(fix) Revert the fix the user avatar default shape to square

### DIFF
--- a/.changeset/giant-kids-pay.md
+++ b/.changeset/giant-kids-pay.md
@@ -1,0 +1,16 @@
+---
+"@wso2is/react-components": patch
+"@wso2is/access-control": patch
+"@wso2is/dynamic-forms": patch
+"@wso2is/identity-apps-core": patch
+"@wso2is/myaccount": patch
+"@wso2is/common": patch
+"@wso2is/forms": patch
+"@wso2is/theme": patch
+"@wso2is/console": patch
+"@wso2is/core": patch
+"@wso2is/form": patch
+"@wso2is/i18n": patch
+---
+
+(fix) Revert the fix the user avatar default shape to square

--- a/modules/react-components/src/components/avatar/user-avatar.tsx
+++ b/modules/react-components/src/components/avatar/user-avatar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/react-components/src/components/avatar/user-avatar.tsx
+++ b/modules/react-components/src/components/avatar/user-avatar.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -26,10 +26,7 @@ import {
 } from "@wso2is/core/models";
 import classNames from "classnames";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { SemanticSIZES } from "semantic-ui-react";
-import { AnimatedAvatar } from "./animated-avatar";
-import { AppAvatar } from "./app-avatar";
-import { AvatarPropsInterface } from "./avatar";
+import { Avatar, AvatarPropsInterface } from "./avatar";
 import GravatarLogo from "../../assets/images/gravatar-logo.png";
 import DummyUser from "../../assets/images/user.png";
 import { Popup } from "../popup";
@@ -87,10 +84,6 @@ export const UserAvatar: FunctionComponent<UserAvatarPropsInterface> = (
 
     const [ userImage, setUserImage ] = useState(null);
     const [ showPopup, setShowPopup ] = useState(false);
-
-    // To check if the size is a valid Semantic UI size.
-    const validSizesAnimatedAppAvatar: SemanticSIZES[] = 
-        [ "mini", "tiny", "small", "medium", "large", "big", "huge", "massive" ];
 
     // Check if the image is a promise, and resolve.
     useEffect(() => {
@@ -176,22 +169,14 @@ export const UserAvatar: FunctionComponent<UserAvatarPropsInterface> = (
             hoverable
             open={ showPopup }
             trigger={ (
-                <AppAvatar
+                <Avatar
+                    avatar
+                    shape="circular"
+                    bordered={ false }
                     className={ classes }
-                    image={ 
-                        resolveAvatarImage() 
-                        ?? (
-                            <AnimatedAvatar
-                                name={ profileInfo ? resolveUserDisplayName(profileInfo, authState) : name || "" }
-                                size={ 
-                                    validSizesAnimatedAppAvatar.includes(rest.size as SemanticSIZES)
-                                        ? rest.size as SemanticSIZES 
-                                        : "mini" 
-                                }
-                                data-testid={ `${componentId}-item-display-name-avatar` }
-                            />
-                        ) }
+                    image={ resolveAvatarImage() }
                     label={ showGravatarLabel ? resolveTopLabel() : null }
+                    name={ profileInfo ? resolveUserDisplayName(profileInfo, authState) : name || "" }
                     onMouseOver={ handleOnMouseOver }
                     onMouseOut={ handleOnMouseOut }
                     data-componentid={ componentId }
@@ -199,7 +184,7 @@ export const UserAvatar: FunctionComponent<UserAvatarPropsInterface> = (
                     { ...rest }
                 >
                     { children }
-                </AppAvatar>
+                </Avatar>
             ) }
             data-componentid={ `${ componentId }-gravatar-disclaimer-popup` }
             data-testid={ `${ testId }-gravatar-disclaimer-popup` }


### PR DESCRIPTION
### Purpose
(fix) Revert the fix the user avatar default shape to square"

### Related Issues
- https://github.com/wso2/product-is/issues/17804

### Screenshot
<img width="1800" alt="Screenshot 2023-11-22 at 10 12 23" src="https://github.com/wso2/identity-apps/assets/46097917/1171beb7-5c32-4334-be91-03a562e71a03">

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
