### PR TITLE
Fix user store list not populating in the users page

### DIFF
--- a/.changeset/orange-stingrays-grab.md
+++ b/.changeset/orange-stingrays-grab.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix user store list not populating in the users page

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -156,7 +156,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
     const [ showMultipleInviteConfirmationModal, setShowMultipleInviteConfirmationModal ] = useState<boolean>(false);
     const [ connectorConfigLoading, setConnecterConfigLoading ] = useState<boolean>(false);
 
-    const { isSuperOrganization, isFirstLevelOrganization } = useGetCurrentOrganizationType();
+    const { isSubOrganization, isSuperOrganization, isFirstLevelOrganization } = useGetCurrentOrganizationType();
 
     const username: string = useSelector((state: AppState) => state.auth.username);
     const tenantName: string = store.getState().config.deployment.tenant;
@@ -187,7 +187,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
      * Fetch the list of available userstores.
      */
     useEffect(() => {
-        if (!isSuperOrganization() || !isFirstLevelOrganization()) {
+        if (isSubOrganization()) {
             return;
         }
 
@@ -699,15 +699,14 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 data-testid="user-mgt-user-list-layout"
                 onPageChange={ handlePaginationChange }
                 rightActionPanel={
-                    (
-                        <Dropdown
+                    isFirstLevelOrganization() || isSuperOrganization()  
+                        ? (<Dropdown
                             data-testid="user-mgt-user-list-userstore-dropdown"
                             selection
                             options={ userStoreOptions && userStoreOptions }
                             onChange={ handleDomainChange }
                             defaultValue={ PRIMARY_USERSTORE.toLocaleLowerCase() }
-                        />
-                    )
+                        />) : null  
                 }
                 showPagination={ true }
                 showTopActionPanel={ isUserListRequestLoading


### PR DESCRIPTION
### Purpose

$subject

Root cause: The logic to prevent fetching userstores if the logged in org is a sub org was incorrect.

This PR also fixes the issue of showing the userstore dropdown for sub organizations.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
