### PR TITLE
Hide `Console Settings` page when group and role separation is disabled.

### DIFF
--- a/.changeset/wild-flowers-arrive.md
+++ b/.changeset/wild-flowers-arrive.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Implement hiding console settings page when group and role separation is disabled.

--- a/apps/console/src/features/core/constants/app-constants.ts
+++ b/apps/console/src/features/core/constants/app-constants.ts
@@ -497,6 +497,11 @@ export class AppConstants {
     ]
 
     /**
+     * Route id of the console settings page.
+     */
+    public static readonly CONSOLE_SETTINGS_ROUTE: string = "consoleSettings";
+
+    /**
      * Name of the root node
      */
     public static readonly PERMISSIONS_ROOT_NODE: string = "All Permissions";

--- a/apps/console/src/features/core/hooks/use-routes.tsx
+++ b/apps/console/src/features/core/hooks/use-routes.tsx
@@ -16,32 +16,22 @@
  * under the License.
  */
 
-import { GearIcon } from "@oxygen-ui/react-icons";
 import { AccessControlUtils } from "@wso2is/access-control";
-import { ChildRouteInterface, RouteInterface } from "@wso2is/core/models";
+import { RouteInterface } from "@wso2is/core/models";
 import { RouteUtils as CommonRouteUtils } from "@wso2is/core/utils";
 import isEmpty from "lodash-es/isEmpty";
-import React, { lazy } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { commonConfig } from "../../../extensions/configs/common";
-import { serverConfigurationConfig } from "../../../extensions/configs/server-configuration";
 import useAuthorization from "../../authorization/hooks/use-authorization";
 import { OrganizationManagementConstants } from "../../organizations/constants/organization-constants";
-import { OrganizationUtils } from "../../organizations/utils/organization";
-import { useGovernanceConnectorCategories } from "../../server-configurations/api/governance-connectors";
-import {
-    GovernanceCategoryForOrgsInterface,
-    GovernanceConnectorForOrgsInterface
-} from "../../server-configurations/models/governance-connectors";
+import { useGetCurrentOrganizationType } from "../../organizations/hooks/use-get-organization-type";
 import { getAppViewRoutes } from "../configs/routes";
-import { getSidePanelIcons } from "../configs/ui";
 import { AppConstants } from "../constants/app-constants";
 import { history } from "../helpers/history";
 import { FeatureConfigInterface } from "../models/config";
 import { AppState, setDeveloperVisibility, setFilteredDevelopRoutes, setSanitizedDevelopRoutes } from "../store";
 import { AppUtils } from "../utils/app-utils";
-import { useGetCurrentOrganizationType } from "../../organizations/hooks/use-get-organization-type";
 
 /**
  * Props interface of {@link useOrganizations}
@@ -67,17 +57,11 @@ const useRoutes = (): useRoutesInterface => {
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const loggedUserName: string = useSelector((state: AppState) => state.profile.profileInfo.userName);
     const isSuperAdmin: string = useSelector((state: AppState) => state.organization.superAdmin);
-    const isFirstLevelOrg: boolean = useSelector((state: AppState) => state.organization.isFirstLevelOrganization);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const isPrivilegedUser: boolean = useSelector((state: AppState) => state?.auth?.isPrivilegedUser);
     const tenantDomain: string = useSelector((state: AppState) => state.auth.tenantDomain);
     const isGroupAndRoleSeparationEnabled: boolean = useSelector((state: AppState) => 
         state?.config?.ui?.isGroupAndRoleSeparationEnabled);
-
-    const {
-        data: governanceConnectors
-    } = useGovernanceConnectorCategories(featureConfig?.residentIdp?.enabled && isFirstLevelOrg);
-
     /**
      * Filter the routes based on the user roles and permissions.
      *

--- a/apps/console/src/features/core/hooks/use-routes.tsx
+++ b/apps/console/src/features/core/hooks/use-routes.tsx
@@ -71,6 +71,8 @@ const useRoutes = (): useRoutesInterface => {
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const isPrivilegedUser: boolean = useSelector((state: AppState) => state?.auth?.isPrivilegedUser);
     const tenantDomain: string = useSelector((state: AppState) => state.auth.tenantDomain);
+    const isGroupAndRoleSeparationEnabled: boolean = useSelector((state: AppState) => 
+        state?.config?.ui?.isGroupAndRoleSeparationEnabled);
 
     const {
         data: governanceConnectors
@@ -154,6 +156,10 @@ const useRoutes = (): useRoutesInterface => {
             }
 
             const additionalRoutes: string[] = getAdditionalRoutes();
+            
+            if (!isGroupAndRoleSeparationEnabled) {
+                additionalRoutes.push(AppConstants.CONSOLE_SETTINGS_ROUTE);
+            }
 
             return [ ...additionalRoutes ];
         };


### PR DESCRIPTION
### Purpose
The new `Console Settings` page relies on `/scim2/v2/Roles` endpoint for fetching roles intended for the console audience and `/scim2/Users` endpoint for fetching users. Since this will not work properly when group and role separation disabled, it was decided to hide the `Console Settings` page from the console UI when group and role separation disabled.

### Related Issues
- https://github.com/wso2/product-is/issues/17923


### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
