### PR TITLE
Add special character username support for console

### DIFF
--- a/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
+++ b/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
@@ -242,6 +242,8 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
         const rules: ValidationConfInterface[] = config.rules;
 
         setInitialFormValues({
+            enableSpecialChars: getValidationConfig(
+                rules, "AlphanumericValidator", "enable.special.characters")=="true",
             enableValidator:
                 (getValidationConfig(rules, "AlphanumericValidator", "enable.validator")=="true"
                 || !(getValidationConfig(rules, "EmailFormatValidator", "enable.validator")=="true"))
@@ -566,6 +568,18 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
                                                                 data-testid={ `${componentId}-max-length` }
                                                             />
                                                         </div>
+                                                        <Field.Checkbox
+                                                            ariaLabel="enableSpecialChars"
+                                                            name="enableSpecialChars"
+                                                            label={ t("extensions:manage.accountLogin.editPage." + 
+                                                                "usernameSpecialChars") }
+                                                            tabIndex={ 3 }
+                                                            hint={ t("extensions:manage.accountLogin.editPage." + 
+                                                                "usernameSpecialCharsHint") }
+                                                            width={ 16 }
+                                                            defaultValue={ initialFormValues }           
+                                                            data-componentid={ `${componentId}-enable-special-chars` }
+                                                        />
                                                     </div>
                                                 ) }
                                                 <Field.Button

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -2761,6 +2761,8 @@ export interface Extensions {
                 usernameLength: string;
                 usernameLengthMin: string;
                 usernameLengthMax: string;
+                usernameSpecialChars: string;
+                usernameSpecialCharsHint: string;
             };
             alternativeLoginIdentifierPage: {
                 pageTitle: string;
@@ -3073,8 +3075,10 @@ export interface Extensions {
                             passwordValidation: string;
                         };
                         usernameHint: string;
+                        usernameSpecialCharHint: string;
                         usernameLength: string;
                         usernameSymbols: string;
+                        usernameSpecialCharSymbols: string;
                     };
                     summary: {
                         invitation: string;

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -3066,7 +3066,9 @@ export const extensions: Extensions = {
                 alphanumericType: "Alphanumeric (a-z, A-Z, 0-9)",
                 usernameLength: "Set username length",
                 usernameLengthMin: "Min",
-                usernameLengthMax: "Max"
+                usernameLengthMax: "Max",
+                usernameSpecialChars: "Allow special characters in username.",
+                usernameSpecialCharsHint: "Usage of forward slash (\"/\") is restricted."
             },
             alternativeLoginIdentifierPage: {
                 pageTitle: "Alternative Login Identifiers",
@@ -3308,8 +3310,11 @@ export const extensions: Extensions = {
                         },
                         usernameHint: "Must be an alphanumeric (a-z, A-Z, 0-9) string between {{minLength}} to " +
                             "{{maxLength}} characters including at least one letter.",
+                        usernameSpecialCharHint: "Must be a unique string between {{minLength}} to " +
+                            "{{maxLength}} characters including at least one letter.",
                         usernameLength: "The username length should be between {{minLength}} and {{maxLength}}.",
-                        usernameSymbols: "The username should consist of alphanumeric characters (a-z, A-Z, 0-9) and must include at least one letter."
+                        usernameSymbols: "The username should consist of alphanumeric characters (a-z, A-Z, 0-9) and must include at least one letter.",
+                        usernameSpecialCharSymbols: "The username must include at least one letter and should not consist of invalid special characters."
                     }
                 }
             },

--- a/apps/console/src/extensions/i18n/resources/fr-FR/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/fr-FR/extensions.ts
@@ -3141,7 +3141,9 @@ export const extensions: Extensions = {
                 alphanumericType: "Alphanumérique (a-z, A-Z, 0-9)",
                 usernameLength: "Définir la longueur du nom d'utilisateur",
                 usernameLengthMin: "Min",
-                usernameLengthMax: "Max"
+                usernameLengthMax: "Max",
+                usernameSpecialChars: "Autoriser les caractères spéciaux dans le nom d'utilisateur.",
+                usernameSpecialCharsHint: "L'utilisation de la barre oblique (\"/\") est restreinte."
             },
             alternativeLoginIdentifierPage: {
                 pageTitle: "Identifiants de connexion alternatifs",
@@ -3392,9 +3394,13 @@ export const extensions: Extensions = {
                         },
                         usernameHint: "Doit être une chaîne alphanumérique (a-z, A-Z, 0-9) entre {{minLength}} et {{maxLength}} caractères comprenant " +
                             "au moins une lettre.",
+                        usernameSpecialCharHint: "Doit être une chaîne unique comprise entre {{minLength}} et" + 
+                            "{{maxLength}} caractères comprenant au moins une lettre.",
                         usernameLength: "La longueur du nom d'utilisateur doit être comprise " +
                             "entre {{minLength}} et {{maxLength}}.",
-                        usernameSymbols: "Le nom d'utilisateur doit être composé de caractères alphanumériques (a-z, A-Z, 0-9) et doit inclure au moins une lettre."
+                        usernameSymbols: "Le nom d'utilisateur doit être composé de caractères alphanumériques (a-z, A-Z, 0-9) et doit inclure au moins une lettre.",
+                        usernameSpecialCharSymbols: "Le nom d'utilisateur doit inclure au moins une lettre et ne doit pas contenir de caractères spéciaux invalides."
+
                     }
                 }
             },

--- a/apps/console/src/extensions/i18n/resources/si-LK/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/si-LK/extensions.ts
@@ -3034,7 +3034,9 @@ export const extensions: Extensions = {
                 alphanumericType: "අක්ෂරාංක (a-z, A-Z, 0-9)",
                 usernameLength: "පරිශීලක නාමය දිග සකසන්න",
                 usernameLengthMin: "අවම",
-                usernameLengthMax: "උපරිම"
+                usernameLengthMax: "උපරිම",
+                usernameSpecialChars: "පරිශීලක නාමයේ විශේෂ අක්ෂරවලට ඉඩ දෙන්න.",
+                usernameSpecialCharsHint: "ඉදිරි ස්ලැෂ් (\"/\") භාවිතය සීමා කර ඇත."
             },
             alternativeLoginIdentifierPage: {
                 pageTitle: "විකල්ප පිවිසුම් හඳුනාගැනීම්",
@@ -3272,8 +3274,10 @@ export const extensions: Extensions = {
                             passwordValidation: "මුරපදය පහත සීමාවන් සපුරාලිය යුතුය."
                         },
                         usernameHint: "අවම වශයෙන් එක් අකුරක් ඇතුළුව අක්ෂර {{minLength}} සිට {{maxLength}} දක්වා අක්ෂරාංක (a-z, A-Z, 0-9) තන්තුවක් විය යුතුය.",
+                        usernameSpecialCharHint: "අවම වශයෙන් එක් අකුරක් ඇතුළුව අනුලකුණු {{minLength}} සිට {{maxLength}} දක්වා අද්විතීය තන්තුවක් විය යුතුය.",
                         usernameLength: "පරිශීලක නාමයේ දිග {{minLength}} සහ {{maxLength}} අතර විය යුතුය.",
-                        usernameSymbols: "පරිශීලක නාමය අක්ෂරාංක අක්ෂරවලින් (a-z, A-Z, 0-9) සමන්විත විය යුතු අතර අවම වශයෙන් එක් අකුරක් ඇතුළත් විය යුතුය."
+                        usernameSymbols: "පරිශීලක නාමය අක්ෂරාංක අක්ෂරවලින් (a-z, A-Z, 0-9) සමන්විත විය යුතු අතර අවම වශයෙන් එක් අකුරක් ඇතුළත් විය යුතුය.",
+                        usernameSpecialCharSymbols: "පරිශීලක නාමයේ අවම වශයෙන් එක් අකුරක්වත් අඩංගු විය යුතු අතර වලංගු නොවන විශේෂ අක්ෂර වලින් සමන්විත නොවිය යුතුය."
                     }
                 }
             },

--- a/apps/console/src/features/users/utils/user-management-utils.ts
+++ b/apps/console/src/features/users/utils/user-management-utils.ts
@@ -92,6 +92,7 @@ export const getUsernameConfiguration = (configs: ValidationDataInterface[]): Va
     }
 
     return {
+        enableSpecialChars: getValidationConfig(rules, "AlphanumericValidator", "enable.special.characters") === "true",
         enableValidator: 
                 (getValidationConfig(rules, "AlphanumericValidator", "enable.validator") === "true"
                 || !(getValidationConfig(rules, "EmailFormatValidator", "enable.validator") === "true"))

--- a/apps/console/src/features/validation/models/validation-config.ts
+++ b/apps/console/src/features/validation/models/validation-config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -54,4 +54,5 @@ export interface ValidationFormInterface {
     minUniqueCharacters?: string;
     maxConsecutiveCharacters?: string;
     enableValidator?: string;
+    enableSpecialChars?: boolean;
 }


### PR DESCRIPTION
Support for alphanumeric usernames with the following special characters in the regex,
```
^(?=.*[a-zA-Z])[a-zA-Z0-9!@#$%&'*+/=?^_`.{|}~-]+$
```

