### PR TITLE
Encode locale url parameter while retrieving the value

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -34,7 +34,7 @@
         // Set current lang value coming from cookie
         const urlParams = new URLSearchParams(window.location.search);
         const localeFromCookie = getCookie("ui_lang");
-        const localeFromUrlParams = urlParams.get('ui_locales');
+        const localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams);
 
         languageSelectionInput.val(computedLocale);

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -34,7 +34,10 @@
         // Set current lang value coming from cookie
         const urlParams = new URLSearchParams(window.location.search);
         const localeFromCookie = getCookie("ui_lang");
-        const localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
+        var localeFromUrlParams = null;
+        if (urlParams.has('ui_locales')) {
+            localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
+        }
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams);
 
         languageSelectionInput.val(computedLocale);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -35,7 +35,7 @@
         // Set current lang value coming from cookie
         const urlParams = new URLSearchParams(window.location.search);
         const localeFromCookie = getCookie("ui_lang");
-        const localeFromUrlParams = urlParams.get('ui_locales');
+        const localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams);
 
         languageSelectionInput.val(computedLocale);
@@ -179,7 +179,7 @@
             <i class="cn flag"></i>
             <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "lang.switcher.chinese")%>
         </div>
-        
+
         <div class="item"
              data-value="ja_JP"
              style="background-color: var(--language-selector-background-color) !important;

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -35,7 +35,10 @@
         // Set current lang value coming from cookie
         const urlParams = new URLSearchParams(window.location.search);
         const localeFromCookie = getCookie("ui_lang");
-        const localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
+        var localeFromUrlParams = null;
+        if (urlParams.has('ui_locales')) {
+            localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
+        }
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams);
 
         languageSelectionInput.val(computedLocale);


### PR DESCRIPTION
$subject

This change will encode the value of the `ui_locales` url parameter before its extended usage in the code base to avoid security vulnerabilities.