### PR TITLE
Improve url building for tenant qualified URLs

### DIFF
--- a/.changeset/tiny-pianos-destroy.md
+++ b/.changeset/tiny-pianos-destroy.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/identity-apps-core": patch
+"@wso2is/myaccount": patch
+"@wso2is/console": patch
+---
+
+Improve url building

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -52,7 +52,7 @@
         "superTenantProxy" : "{{ console.super_tenant_proxy_name }}",
     {% endif %}
     {% if tenant_context.enable_tenant_qualified_urls is defined && tenant_context.require_super_tenant_in_urls is defined %}
-    "requireSuperTenantInUrls" : "{{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }}",
+    "requireSuperTenantInUrls" : {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }},
     {% endif %}
     {% if console.doc_site_path is defined %}
     "docSiteUrl": "{{ console.doc_site_path }}",

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -51,6 +51,9 @@
     {% if console.super_tenant_proxy_name is defined %}
         "superTenantProxy" : "{{ console.super_tenant_proxy_name }}",
     {% endif %}
+    {% if tenant_context.enable_tenant_qualified_urls is defined && tenant_context.require_super_tenant_in_urls is defined %}
+    "requireSuperTenantInUrls" : "{{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }}",
+    {% endif %}
     {% if console.doc_site_path is defined %}
     "docSiteUrl": "{{ console.doc_site_path }}",
     {% endif %}

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -451,9 +451,11 @@ export const AppUtils: any = (function() {
                 const tenantName: string = paths[tenantIndex + 1];
 
                 return (tenantName) ? tenantName : "";
-            } else {
-                return "";
             }
+
+            return (_config.requireSuperTenantInUrls)
+                ? this.getSuperTenant()
+                : "";
         },
 
         /**
@@ -538,6 +540,7 @@ export const AppUtils: any = (function() {
                 "clientOrigin": window.location.origin,
                 "contextPath": _args.contextPath,
                 "legacyAuthzRuntime": _args.legacyAuthzRuntime || false,
+                "requireSuperTenantInUrls" : _args.requireSuperTenantInUrls || false,
                 "serverOrigin": _args.serverOrigin || fallbackServerOrigin
             };
 

--- a/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
+++ b/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
@@ -90,7 +90,7 @@
         "superTenantProxy" : "{{ myaccount.super_tenant_proxy_name }}",
     {% endif %}
     {% if tenant_context.enable_tenant_qualified_urls is defined && tenant_context.require_super_tenant_in_urls is defined %}
-    "requireSuperTenantInUrls" : "{{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }}",
+    "requireSuperTenantInUrls" : {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }},
     {% endif %}
     {% if myaccount.idp_configs is defined %}
     "idpConfigs": {

--- a/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
+++ b/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
@@ -89,6 +89,9 @@
     {% if myaccount.super_tenant_proxy_name is defined %}
         "superTenantProxy" : "{{ myaccount.super_tenant_proxy_name }}",
     {% endif %}
+    {% if tenant_context.enable_tenant_qualified_urls is defined && tenant_context.require_super_tenant_in_urls is defined %}
+    "requireSuperTenantInUrls" : "{{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }}",
+    {% endif %}
     {% if myaccount.idp_configs is defined %}
     "idpConfigs": {
         {% if myaccount.idp_configs.items() is defined %}

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -280,9 +280,11 @@ export const AppUtils: AppUtilsInterface = (function() {
                 const tenantName: string = paths[tenantIndex + 1];
 
                 return (tenantName) ? tenantName : "";
-            } else {
-                return "";
             }
+
+            return (_config.requireSuperTenantInUrls)
+                ? this.getSuperTenant()
+                : "";
         },
 
         /**
@@ -335,6 +337,7 @@ export const AppUtils: AppUtilsInterface = (function() {
                 "clientOrigin": window.location.origin,
                 "consoleAppOrigin": _args.consoleAppOrigin || _args.serverOrigin || fallbackServerOrigin,
                 "contextPath": _args.contextPath,
+                "requireSuperTenantInUrls" : _args.requireSuperTenantInUrls || false,
                 "serverOrigin": _args.serverOrigin || fallbackServerOrigin
             };
 

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -127,7 +127,7 @@ export const AppUtils: AppUtilsInterface = (function() {
                 return _config.clientOrigin + (_config.appBaseName ? "/" + _config.appBaseName : "") + url;
             }
 
-            return _config.clientOrigin + this.getTenantPath() + 
+            return _config.clientOrigin + this.getTenantPath() +
                 (_config.appBaseName ? "/" + _config.appBaseName : "") + url;
         },
 
@@ -396,7 +396,7 @@ export const AppUtils: AppUtilsInterface = (function() {
             return {
                 serverOrigin: this.isSaas()
                     ? _config.serverOrigin
-                    : _config.serverOrigin + 
+                    : _config.serverOrigin +
                     (_config.legacyAuthzRuntime ? this.getTenantPath(true) : this.getTenantPath()),
                 ..._config.idpConfigs,
                 ...this.resolveURLs()
@@ -412,7 +412,7 @@ export const AppUtils: AppUtilsInterface = (function() {
          */
         resolveURLs: function() {
             const tenantPath: string = _config.legacyAuthzRuntime ? "" : this.getTenantPath();
-        
+
             return {
                 authorizeEndpointURL: _config.idpConfigs
                     && _config.idpConfigs.authorizeEndpointURL
@@ -495,7 +495,7 @@ export const AppUtils: AppUtilsInterface = (function() {
             }
 
             _config.appBaseWithTenant = "/" + this.getTenantPrefix() + "/" + tenant + "/" + _config.appBaseName;
-            
+
         }
     };
 }());

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/init-url.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/init-url.jsp
@@ -131,10 +131,7 @@
         }
     }
 
-    if (!StringUtils.equals(tenantDomain, "carbon.super")) {
-        identityServerEndpointContextParam = ServiceURLBuilder.create().setTenant(tenantDomain).build()
-                .getAbsolutePublicURL();
-    }
+    identityServerEndpointContextParam = ServiceURLBuilder.create().build().getAbsolutePublicURL();
 
     if (StringUtils.isNotBlank(identityServerEndpointContextParam)) {
 

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -119,6 +119,9 @@ public class AppPortalUtils {
                 callbackUrl = "regexp=(" + callbackUrl + "|" +
                     callbackUrl.replace(portalPath, "/t/(.*)" + portalPath) + ")";
             }
+        } else if (SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
+            callbackUrl = "regexp=(" + callbackUrl + "|" + callbackUrl.replace(portalPath, "/t/carbon.super" +
+                    portalPath) + ")";
         }
         oAuthConsumerAppDTO.setCallbackUrl(callbackUrl);
         oAuthConsumerAppDTO.setBypassClientCredentials(true);


### PR DESCRIPTION
Following improvements will done with this,
- Changes the callback URL regexp of the console and myaccount.
- Add config send `/t/carbon.super` in the requests initiated from the myaccount and console.