### PR TITLE
Fix issue with viewing permissions of a role for the first time

### DIFF
--- a/.changeset/six-fireants-pull.md
+++ b/.changeset/six-fireants-pull.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix selected API resources in Role view Permissions tab

--- a/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
@@ -225,7 +225,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
 
     useEffect(() => {
         getAPIResourceById(initialAPIResourceIds);
-    }, [ initialAPIResourceIds ]);
+    }, [ initialAPIResourceIds, authorizedAPIListForApplication ]);
 
     /**
      * Assign all the API resources to the dropdown options if the after value is not null. 
@@ -326,15 +326,17 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
 
                     response.map((apiResource: APIResourceInterface) => {
                         const selectedAPIResource: AuthorizedAPIListItemInterface =
-                            authorizedAPIListForApplication.find(
+                            authorizedAPIListForApplication?.find(
                                 (api: AuthorizedAPIListItemInterface) => api.id === apiResource.id
                             );
 
-                        selectedAPIResourcesList.push({
-                            id: selectedAPIResource.id,
-                            name: selectedAPIResource.displayName,
-                            scopes: selectedAPIResource.authorizedScopes
-                        });
+                        if (selectedAPIResource) {
+                            selectedAPIResourcesList.push({
+                                id: selectedAPIResource.id,
+                                name: selectedAPIResource.displayName,
+                                scopes: selectedAPIResource.authorizedScopes
+                            });
+                        }
                     });
                     setSelectedAPIResources(selectedAPIResourcesList);
                 }


### PR DESCRIPTION
### Purpose

The PR handles the error message pop up when navigating to the the permissions tab of a role and fixes the permission listing for that role.

### Related Issues
- https://github.com/wso2/product-is/issues/18039

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
