### PR TITLE
Make the assigned roles view on Edit Users and Edit Groups sections consistent.

### DIFF
--- a/.changeset/witty-mayflies-collect.md
+++ b/.changeset/witty-mayflies-collect.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Make the assigned roles view on Edit Users and Edit Groups sections consistent.

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import Autocomplete, {  
-    AutocompleteRenderGetTagProps, 
-    AutocompleteRenderInputParams 
+import Autocomplete, {
+    AutocompleteRenderGetTagProps,
+    AutocompleteRenderInputParams
 } from "@oxygen-ui/react/Autocomplete";
 import TextField from "@oxygen-ui/react/TextField";
 import { IdentifiableComponentInterface, RolesMemberInterface } from "@wso2is/core/models";
@@ -32,9 +32,9 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { getEmptyPlaceholderIllustrations } from "../../../core/configs/ui";
+import { RenderRoleChip } from "../../../roles/components/common-role-components/render-chip";
 import { GroupsInterface } from "../../models/groups";
 import { AutoCompleteRenderOption } from "../group-common-components/auto-complete-render-option";
-import { RenderRoleChip } from "../../../roles/components/common-role-components/render-chip";
 
 interface EditGroupRolesPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -68,14 +68,14 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
 
     /**
      * Get the place holder components.
-     * 
+     *
      * @returns place holder components
      */
     const getPlaceholders = () => {
         if (showEmptyRolesListPlaceholder) {
             return (
                 <EmptyPlaceholder
-                    subtitle={ 
+                    subtitle={
                         [ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.subtitles") ]
                     }
                     title={ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.title") }
@@ -112,7 +112,7 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
                                 />
                             ) }
                             renderTags={ (
-                                value: RolesMemberInterface[], 
+                                value: RolesMemberInterface[],
                                 getTagProps: AutocompleteRenderGetTagProps
                             ) => value.map((option: RolesMemberInterface, index: number) => (
                                 <RenderRoleChip
@@ -128,7 +128,7 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
                                 />
                             )) }
                             renderOption={ (
-                                props: HTMLAttributes<HTMLLIElement>, 
+                                props: HTMLAttributes<HTMLLIElement>,
                                 option: RolesMemberInterface
                             ) => (
                                 <AutoCompleteRenderOption

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
@@ -34,7 +34,7 @@ import { useTranslation } from "react-i18next";
 import { getEmptyPlaceholderIllustrations } from "../../../core/configs/ui";
 import { GroupsInterface } from "../../models/groups";
 import { AutoCompleteRenderOption } from "../group-common-components/auto-complete-render-option";
-import { RenderChipRolesInGroups } from "../group-common-components/render-chip";
+import { RenderRoleChip } from "../../../roles/components/common-role-components/render-chip";
 
 interface EditGroupRolesPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -115,7 +115,7 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
                                 value: RolesMemberInterface[], 
                                 getTagProps: AutocompleteRenderGetTagProps
                             ) => value.map((option: RolesMemberInterface, index: number) => (
-                                <RenderChipRolesInGroups 
+                                <RenderRoleChip
                                     { ...getTagProps({ index }) }
                                     key={ index }
                                     displayName={ option.display }

--- a/apps/console/src/features/roles/components/common-role-components/render-chip.tsx
+++ b/apps/console/src/features/roles/components/common-role-components/render-chip.tsx
@@ -47,7 +47,7 @@ interface RenderChipInterface extends IdentifiableComponentInterface, ChipProps 
     option: RolesMemberInterface;
 }
 
-export const RenderChipRolesInGroups: FunctionComponent<RenderChipInterface> = (
+export const RenderRoleChip: FunctionComponent<RenderChipInterface> = (
     props: RenderChipInterface
 ): ReactElement => {
 
@@ -63,7 +63,7 @@ export const RenderChipRolesInGroups: FunctionComponent<RenderChipInterface> = (
 
     /**
      * Handles the mouse enter event of the chip.
-     * 
+     *
      * @param event - Mouse event
      * @param option - Group or user object
      */
@@ -71,7 +71,7 @@ export const RenderChipRolesInGroups: FunctionComponent<RenderChipInterface> = (
         event.stopPropagation();
         setActiveOption(option);
     };
-    
+
     /**
      * Handles the mouse leave event of the chip.
      */
@@ -84,9 +84,9 @@ export const RenderChipRolesInGroups: FunctionComponent<RenderChipInterface> = (
             <Chip
                 { ...props }
                 key={ key }
-                label={ 
+                label={
                     (<>
-                        <i> { audienceType } </i> 
+                        <i> { audienceType } </i>
                         <i> { audienceType === "application" && ( " : " + audienceDisplay ) } </i>
                         { " | " }
                         <strong> { displayName } </strong>

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -16,16 +16,16 @@
  * under the License.
  */
 
-import Autocomplete, {  
-    AutocompleteRenderGetTagProps, 
-    AutocompleteRenderInputParams 
+import Autocomplete, {
+    AutocompleteRenderGetTagProps,
+    AutocompleteRenderInputParams
 } from "@oxygen-ui/react/Autocomplete";
 import TextField from "@oxygen-ui/react/TextField";
-import { 
-    IdentifiableComponentInterface, 
-    ProfileInfoInterface, 
-    RoleGroupsInterface, 
-    RolesMemberInterface 
+import {
+    IdentifiableComponentInterface,
+    ProfileInfoInterface,
+    RoleGroupsInterface,
+    RolesMemberInterface
 } from "@wso2is/core/models";
 import { EmphasizedSegment, EmptyPlaceholder, Heading } from "@wso2is/react-components";
 import React, {
@@ -62,7 +62,7 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
     const [ activeOption, setActiveOption ] = useState<RolesMemberInterface>(undefined);
     const [ showEmptyRolesListPlaceholder, setShowEmptyRolesListPlaceholder ] = useState<boolean>(false);
 
-    const isGroupAndRoleSeparationEnabled: boolean = useSelector((state: AppState) => 
+    const isGroupAndRoleSeparationEnabled: boolean = useSelector((state: AppState) =>
         state?.config?.ui?.isGroupAndRoleSeparationEnabled);
 
     /**
@@ -70,7 +70,7 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
      */
     useEffect(() => {
         let userRoles: RolesMemberInterface[];
-        
+
         if (isGroupAndRoleSeparationEnabled && user?.roles?.length > 0) {
             userRoles = user.roles;
         } else {
@@ -87,17 +87,17 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
     /**
      * When Group and Role Separation is enabled, the groups section of the user will contain both roles and groups.
      * This method can be used to extract roles from the groups section.
-     * 
+     *
      * @param groups - Groups of the user
      * @returns Roles of the user
      */
     const extractUserRolesFromGroups = (groups: RoleGroupsInterface[]): RolesMemberInterface[] => {
 
         const userRoles: RolesMemberInterface[] = [];
-        
+
         groups?.forEach((group: RoleGroupsInterface) => {
             const [ domain, displayName ]: string[] = group?.display?.split(DOMAIN_SEPARATOR);
-            
+
             if (domain && displayName && [ APPLICATION_DOMAIN, INTERNAL_DOMAIN ].includes(domain)) {
                 userRoles.push({
                     $ref: group.$ref,
@@ -108,24 +108,24 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
                 });
             }
         });
-        
+
         return userRoles;
     };
 
     /**
      * Get the place holder components.
-     * 
+     *
      * @returns place holder components
      */
     const getPlaceholders = () => {
         if (showEmptyRolesListPlaceholder) {
             return (
                 <EmptyPlaceholder
-                    subtitle={ 
-                        [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
+                    subtitle={
+                        [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" +
                             ".subtitles") ]
                     }
-                    title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
+                    title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" +
                         ".title") }
                     image={ getEmptyPlaceholderIllustrations().emptyList }
                     imageSize="tiny"
@@ -155,12 +155,12 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
                             renderInput={ (params: AutocompleteRenderInputParams) => (
                                 <TextField
                                     { ...params }
-                                    placeholder= { t("console:manage.features.user.updateUser.roles.editRoles" + 
+                                    placeholder= { t("console:manage.features.user.updateUser.roles.editRoles" +
                                         ".searchPlaceholder") }
                                 />
                             ) }
                             renderTags={ (
-                                value: RolesMemberInterface[], 
+                                value: RolesMemberInterface[],
                                 getTagProps: AutocompleteRenderGetTagProps
                             ) => value.map((option: RolesMemberInterface, index: number) => (
                                 <RenderRoleChip
@@ -176,7 +176,7 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
                                 />
                             )) }
                             renderOption={ (
-                                props: HTMLAttributes<HTMLLIElement>, 
+                                props: HTMLAttributes<HTMLLIElement>,
                                 option: RolesMemberInterface
                             ) => (
                                 <AutoCompleteRenderOption

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -38,9 +38,9 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { AutoCompleteRenderOption } from "./user-common-components/auto-complete-render-option";
-import { RenderChip } from "./user-common-components/render-chip";
 import { AppState } from "../../core";
 import { getEmptyPlaceholderIllustrations } from "../../core/configs/ui";
+import { RenderRoleChip } from "../../roles/components/common-role-components/render-chip";
 import { APPLICATION_DOMAIN, DOMAIN_SEPARATOR, INTERNAL_DOMAIN } from "../../roles/constants";
 
 interface UserRoleEditPropsInterface extends IdentifiableComponentInterface {
@@ -163,10 +163,12 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
                                 value: RolesMemberInterface[], 
                                 getTagProps: AutocompleteRenderGetTagProps
                             ) => value.map((option: RolesMemberInterface, index: number) => (
-                                <RenderChip 
+                                <RenderRoleChip
                                     { ...getTagProps({ index }) }
                                     key={ index }
-                                    primaryText={ option.display }
+                                    displayName={ option.display }
+                                    audienceType={ option.audienceType }
+                                    audienceDisplay={ option.audienceDisplay }
                                     option={ option }
                                     activeOption={ activeOption }
                                     setActiveOption={ setActiveOption }


### PR DESCRIPTION
### Purpose
This PR
- Moves the `RenderChipRolesInGroups` component from `groups` feature into `roles` feature under the new name `RenderRoleChip` to be more reusable.
- Makes the assigned roles view on **Edit Users** and **Edit Groups** sections consistent by using `RenderRoleChip` in both places (Earlier it was used only on **Edit Groups** section).

#### Edit Users
<img width="1512" alt="image" src="https://github.com/wso2/identity-apps/assets/27700915/82a9b7a6-b486-4114-8989-b41575284cce">

#### Edit Groups
<img width="1511" alt="image" src="https://github.com/wso2/identity-apps/assets/27700915/0323fcd5-4241-47b6-a54c-bedfa985b687">

### Related Issues
- https://github.com/wso2/product-is/issues/18153

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
