### PR TITLE
Remove logic to hide delete option for system roles

### DIFF
--- a/apps/console/src/features/roles/components/role-list.tsx
+++ b/apps/console/src/features/roles/components/role-list.tsx
@@ -270,12 +270,7 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
                 renderer: "semantic-icon"
             },
             {
-                hidden: (role: RolesInterface) => isSubOrg
-                    || (role?.displayName === RoleConstants.ADMIN_ROLE
-                    || role?.displayName === RoleConstants.ADMIN_GROUP)
-                    || (role?.displayName === RoleConstants.EVERYONE_ROLE
-                    || role?.displayName === RoleConstants.EVERYONE_GROUP)
-                    || (role?.audience?.display + "/" + role?.displayName === RoleConstants.CONSOLE_ADMIN_ROLE)
+                hidden: () => isSubOrg
                     || !hasRequiredScopes(featureConfig?.roles, featureConfig?.roles?.scopes?.delete, allowedScopes),
                 icon: (): SemanticICONS => "trash alternate",
                 onClick: (e: SyntheticEvent, role: RolesInterface): void => {


### PR DESCRIPTION
### Purpose
Remove logic used to hide delete options to avoid deleting system roles

### Related Issues
- https://github.com/wso2/product-is/issues/18045