### PR TITLE
Fix role update being invoked twice

### DIFF
--- a/.changeset/red-pugs-relax.md
+++ b/.changeset/red-pugs-relax.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix role update being invoked twice

--- a/apps/console/src/features/roles/components/application-roles.tsx
+++ b/apps/console/src/features/roles/components/application-roles.tsx
@@ -140,16 +140,8 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
             return;
         }
 
-        /**
-         * Ideally, the selectedRoles list should be cleared immediately when the current roleAudience is not allowed
-         * for the application. This does not happen in some cases due to the asynchronous nature of the
-         * setSelectedRoles() method. This if block prevents the roles from being updated with stale data in such cases.
-         */
-        if (roleAudience !== application?.associatedRoles?.allowedAudience && selectedRoles?.length !== 0) {
-            return;
-        }
         updateRoles();
-    }, [ shouldUpdateRoleAudience, roleAudience, selectedRoles ]);
+    }, [ shouldUpdateRoleAudience, roleAudience ]);
 
     /**
      * Set removed roles
@@ -225,13 +217,16 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
      */
     const updateRoles = (): void => {
         setIsSubmitting(true);
+        const isRoleAudienceChanged: boolean = roleAudience !== application?.associatedRoles?.allowedAudience;
         const data: AssociatedRolesPatchObjectInterface = {
             allowedAudience: roleAudience,
-            roles: selectedRoles ? selectedRoles.map((role: BasicRoleInterface) => {
-                return {
-                    id: role.id
-                };
-            }) : []
+            roles: (isRoleAudienceChanged || !selectedRoles)
+                ? []
+                : selectedRoles.map((role: BasicRoleInterface) => {
+                    return {
+                        id: role.id
+                    };
+                })
         };
 
         const updatedApplication: ApplicationInterface = {


### PR DESCRIPTION
### Purpose

When the assigned roles list is empty, and the role audience is updated there are two patch calls invoked. As a result two success messages are displayed in the UI. The cause is that the useEffect hook that is responsible for this depends on both `roleAudience` and `selectedRoles` states, so when both the values are changed, it gets executed twice.

This PR fixes this issue by removing the selectedRoles dependency from the useEffect hook.

### Related Issues
- https://github.com/wso2/product-is/issues/17995

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
