### PR TITLE
Update SMS OTP authenticator heading

### DIFF
--- a/apps/myaccount/src/public/deployment.config.json
+++ b/apps/myaccount/src/public/deployment.config.json
@@ -32,16 +32,16 @@
         "enableOIDCSessionManagement": false
     },
     "session": {
-        "userIdleWarningTimeOut": 1740,
-        "sessionRefreshTimeOut": 28800,
-        "userIdleTimeOut": 1800,
-        "checkSessionInterval": 5
+        "userIdleWarningTimeOut": 580.0,
+        "sessionRefreshTimeOut": 300.0,
+        "userIdleTimeOut": 600.0,
+        "checkSessionInterval": 3.0
     },
     "legacyAuthzRuntime": false,
     "ui": {
         "announcements": [],
         "appCopyright": "${copyright} ${year} WSO2 LLC.",
-        "appTitle": "IS Account",
+        "appTitle": "My Account | WSO2 Identity Server",
         "appName": "My Account",
         "appLogoPath": "/assets/images/branding/logo.svg",
         "appWhiteLogoPath": "/assets/images/branding/logo-white.svg",
@@ -85,8 +85,7 @@
             },
             "personalInfo": {
                 "disabledFeatures": [
-                    "profileInfo.mobileVerification",
-                    "profileInfo.linkedAccounts"
+                    "profileInfo.mobileVerification"
                 ],
                 "enabled": true,
                 "scopes": {
@@ -97,7 +96,7 @@
                 }
             },
             "security": {
-                "disabledFeatures": ["security.mfa.sms", "security.loginVerifyData.typingDNA"],
+                "disabledFeatures": ["security.loginVerifyData.typingDNA"],
                 "enabled": true,
                 "scopes": {
                     "create": [],
@@ -110,7 +109,7 @@
         "isCookieConsentBannerEnabled": true,
         "isPasswordInputValidationEnabled": true,
         "cookiePolicyUrl": "/authenticationendpoint/cookie_policy.do",
-        "isHeaderAvatarLabelAllowed": false,
+        "isHeaderAvatarLabelAllowed": true,
         "i18nConfigs": {
             "showLanguageSwitcher": true,
             "langAutoDetectEnabled": true
@@ -119,8 +118,7 @@
         "isProfileUsernameReadonly": true,
         "productName": "WSO2 Identity Server",
         "productVersionConfig": {
-            "versionOverride": "",
-            "productVersion": "PREVIEW"
+            "versionOverride": ""
         },
         "theme": {
             "name": "wso2is"

--- a/modules/i18n/src/translations/de-DE/portals/myaccount.ts
+++ b/modules/i18n/src/translations/de-DE/portals/myaccount.ts
@@ -873,7 +873,7 @@ export const myAccount: MyAccountNS = {
                 "descriptions": {
                     "hint": "Sie erhalten eine SMS mit einem einmaligen Bestätigungscode"
                 },
-                "heading": "SMS-Nummer",
+                "heading": "Handynummer",
                 "notifications": {
                     "updateMobile": {
                         "error": {

--- a/modules/i18n/src/translations/en-US/portals/myaccount.ts
+++ b/modules/i18n/src/translations/en-US/portals/myaccount.ts
@@ -901,7 +901,7 @@ export const myAccount: MyAccountNS = {
                 descriptions: {
                     hint: "You'll receive a text message containing an one-time verification code"
                 },
-                heading: "SMS Number",
+                heading: "Mobile number",
                 notifications: {
                     updateMobile: {
                         error: {

--- a/modules/i18n/src/translations/es-ES/portals/myaccount.ts
+++ b/modules/i18n/src/translations/es-ES/portals/myaccount.ts
@@ -873,7 +873,7 @@ export const myAccount: MyAccountNS = {
                 "descriptions": {
                     "hint": "Recibirás un mensaje de texto que contiene un código de verificación único"
                 },
-                "heading": "Número SMS",
+                "heading": "Número de teléfono móvil",
                 "notifications": {
                     "updateMobile": {
                         "error": {

--- a/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/myaccount.ts
@@ -928,7 +928,7 @@ export const myAccount: MyAccountNS = {
                 descriptions: {
                     hint: "Vous recevrez un SMS contenant un code de vérification à usage unique"
                 },
-                heading: "à l'aide d'un SMS",
+                heading: "Mobile number",
                 notifications: {
                     updateMobile: {
                         error: {

--- a/modules/i18n/src/translations/ja-JP/portals/myaccount.ts
+++ b/modules/i18n/src/translations/ja-JP/portals/myaccount.ts
@@ -872,7 +872,7 @@ export const myAccount: MyAccountNS = {
                 "descriptions": {
                     "hint": "1回限りの検証コードを含むテキストメッセージが届きます"
                 },
-                "heading": "SMS番号",
+                "heading": "Mobile number",
                 "notifications": {
                     "updateMobile": {
                         "error": {

--- a/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/myaccount.ts
@@ -902,7 +902,7 @@ export const myAccount: MyAccountNS = {
                 descriptions: {
                     hint: "Você receberá uma mensagem de texto contendo o código de verificação"
                 },
-                heading: "SMS OTP",
+                heading: "Número de telemóvel",
                 notifications: {
                     updateMobile: {
                         error: {

--- a/modules/i18n/src/translations/si-LK/portals/myaccount.ts
+++ b/modules/i18n/src/translations/si-LK/portals/myaccount.ts
@@ -900,7 +900,7 @@ export const myAccount: MyAccountNS = {
                 descriptions: {
                     hint: "සත්\u200Dයාපන කේතය අඩංගු කෙටි පණිවිඩයක් ඔබට ලැබෙනු ඇත"
                 },
-                heading: "කෙටි පණිවුඩ OTP",
+                heading: "Mobile number",
                 notifications: {
                     updateMobile: {
                         error: {

--- a/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/myaccount.ts
@@ -914,7 +914,7 @@ export const myAccount: MyAccountNS = {
                 descriptions: {
                     hint: "நீங்கள் உறுதிப்படுத்தும் குறியீட்டினை குறுஞ் செய்தியினூடாக பெறுவீர்கள்"
                 },
-                heading: "ஒரு முறை கடவுச்சொல்(OTP) குறுஞ் செய்தி",
+                heading: "Mobile number",
                 notifications: {
                     updateMobile: {
                         error: {

--- a/modules/i18n/src/translations/zh-CN/portals/myaccount.ts
+++ b/modules/i18n/src/translations/zh-CN/portals/myaccount.ts
@@ -872,7 +872,7 @@ export const myAccount: MyAccountNS = {
                 "descriptions": {
                     "hint": "您将收到包含一次性验证代码的短信"
                 },
-                "heading": "短信号码",
+                "heading": "手机号码",
                 "notifications": {
                     "updateMobile": {
                         "error": {


### PR DESCRIPTION
### Purpose
Update SMS OTP authenticator heading from `SMS Number` to `Mobile number` to make it consistent with the label.

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/18144

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
