### PR TITLE
Only show subject type configs for OIDC

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -429,45 +429,45 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                         }
                     />
                     <Divider />
-
-                    <div>
-                        <Text>
+                    { onlyOIDCConfigured && (
+                        <div>
+                            <Text>
+                                {
+                                    t("console:develop.features.applications.forms.advancedAttributeSettings" +
+                                        ".sections.subject.fields.subjectType.label")
+                                }
+                            </Text>
                             {
-                                t("console:develop.features.applications.forms.advancedAttributeSettings" +
-                                    ".sections.subject.fields.subjectType.label")
+                                Object.keys(SubjectTypes)
+                                    .map((subjectTypeKey: SubjectTypes, index: number) => {
+                                        const subjectType: SubjectTypes
+                                            = SubjectTypes[subjectTypeKey];
+
+                                        return (
+                                            <>
+                                                <Field.Radio
+                                                    key={ index }
+                                                    ariaLabel={ `Subject type ${subjectType}` }
+                                                    name={ "subjectType" }
+                                                    value={ subjectType }
+                                                    label={ t("console:develop.features.applications.forms" +
+                                                        ".advancedAttributeSettings.sections.subject.fields" +
+                                                        ".subjectType." + subjectType + ".label") }
+                                                    hint={ subjectType === SubjectTypes.PAIRWISE &&
+                                                            t("console:develop.features.applications.forms" +
+                                                        ".advancedAttributeSettings.sections.subject.fields" +
+                                                        ".subjectType." + subjectType + ".hint") }
+                                                    checked={ selectedSubjectType === subjectType }
+                                                    listen={ () => {
+                                                        setSelectedSubjectType(subjectType);
+                                                    } }
+                                                />
+                                            </>
+                                        );
+                                    })
                             }
-                        </Text>
-                        {
-                            Object.keys(SubjectTypes)
-                                .map((subjectTypeKey: SubjectTypes, index: number) => {
-                                    const subjectType: SubjectTypes
-                                        = SubjectTypes[subjectTypeKey];
-
-                                    return (
-                                        <>
-                                            <Field.Radio
-                                                key={ index }
-                                                ariaLabel={ `Subject type ${subjectType}` }
-                                                name={ "subjectType" }
-                                                value={ subjectType }
-                                                label={ t("console:develop.features.applications.forms" +
-                                                     ".advancedAttributeSettings.sections.subject.fields" +
-                                                     ".subjectType." + subjectType + ".label") }
-                                                hint={ subjectType === SubjectTypes.PAIRWISE &&
-                                                        t("console:develop.features.applications.forms" +
-                                                       ".advancedAttributeSettings.sections.subject.fields" +
-                                                       ".subjectType." + subjectType + ".hint") }
-                                                checked={ selectedSubjectType === subjectType }
-                                                listen={ () => {
-                                                    setSelectedSubjectType(subjectType);
-                                                } }
-                                            />
-                                        </>
-                                    );
-                                })
-                        }
-                    </div>
-
+                        </div>
+                    ) }
                     { selectedSubjectType === SubjectTypes.PAIRWISE && (
                         <Field.Input
                             ariaLabel="Sector Identifier URI"


### PR DESCRIPTION
### Purpose
Subject type was added with FAPI related changes and it's not needed for apps using SAML protocol.

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/18246

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
