### PR TITLE
Update Password Validation connector ID

### DIFF
--- a/.changeset/tiny-bugs-refuse.md
+++ b/.changeset/tiny-bugs-refuse.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Update Password Validation connector ID

--- a/apps/console/src/features/server-configurations/constants/server-configurations-constants.ts
+++ b/apps/console/src/features/server-configurations/constants/server-configurations-constants.ts
@@ -132,7 +132,7 @@ export class ServerConfigurationsConstants {
 	/**
 	 * UUID of the identity governance password expiry connector.
 	 */
-	public static readonly PASSWORD_EXPIRY_CONNECTOR_ID: string = "cGFzc3dvcmRFeHBpcnlWMg";
+	public static readonly PASSWORD_EXPIRY_CONNECTOR_ID: string = "cGFzc3dvcmRFeHBpcnk";
 
 	/**
 	 * UUID of the identity governance captcha for sso login connector.

--- a/apps/console/src/features/server/constants/server.ts
+++ b/apps/console/src/features/server/constants/server.ts
@@ -235,7 +235,7 @@ export class ServerConstants {
 
 	public static readonly ACCOUNT_LOCKING_NOTIFICATIONS_INTERNALLY_MANAGED: string =
 		"account.lock.handler.notification.manageInternally";
-	
+
 	public static readonly ACCOUNT_DISABLING_NOTIFICATIONS_INTERNALLY_MANAGED: string =
 		"account.disable.handler.notification.manageInternally";
 
@@ -342,8 +342,8 @@ export class ServerConstants {
 	public static readonly ANALYTICS_HOST: string = "adaptive_authentication.elastic.receiver";
 	public static readonly ANALYTICS_BASIC_AUTH_ENABLE: string = "adaptive_authentication.elastic.basicAuth.enabled";
 	public static readonly ANALYTICS_BASIC_AUTH_USERNAME: string = "adaptive_authentication.elastic.basicAuth.username";
-	public static readonly ANALYTICS_BASIC_AUTH_PASSWORD: string = 
-		"__secret__adaptive_authentication.elastic.basicAuth.password";
+	public static readonly ANALYTICS_BASIC_AUTH_PASSWORD: string =
+	"__secret__adaptive_authentication.elastic.basicAuth.password";
 
 	public static readonly ANALYTICS_HTTP_CONNECTION_TIMEOUT: string =
 		"adaptive_authentication.elastic.HTTPConnectionTimeout";

--- a/apps/console/src/features/server/constants/server.ts
+++ b/apps/console/src/features/server/constants/server.ts
@@ -343,7 +343,7 @@ export class ServerConstants {
 	public static readonly ANALYTICS_BASIC_AUTH_ENABLE: string = "adaptive_authentication.elastic.basicAuth.enabled";
 	public static readonly ANALYTICS_BASIC_AUTH_USERNAME: string = "adaptive_authentication.elastic.basicAuth.username";
 	public static readonly ANALYTICS_BASIC_AUTH_PASSWORD: string =
-	"__secret__adaptive_authentication.elastic.basicAuth.password";
+		"__secret__adaptive_authentication.elastic.basicAuth.password";
 
 	public static readonly ANALYTICS_HTTP_CONNECTION_TIMEOUT: string =
 		"adaptive_authentication.elastic.HTTPConnectionTimeout";

--- a/apps/console/src/features/server/constants/server.ts
+++ b/apps/console/src/features/server/constants/server.ts
@@ -132,7 +132,7 @@ export class ServerConstants {
 	/**
 	 * UUID of the identity governance password expiry connector.
 	 */
-	public static readonly PASSWORD_EXPIRY_CONNECTOR_ID: string = "cGFzc3dvcmRFeHBpcnlWMg";
+	public static readonly PASSWORD_EXPIRY_CONNECTOR_ID: string = "cGFzc3dvcmRFeHBpcnk";
 
 	/**
 	 * UUID of the identity governance captcha for sso login connector.


### PR DESCRIPTION
### Purpose
Update the Password Validation connector ID corresponding to the connector renaming from `Password Expiry V2 --> Password Expiry`

Fixes : https://github.com/wso2/product-is/issues/18216

### Related Issues
- https://github.com/wso2/product-is/issues/17735