### PR TITLE
Fix "Permission assignment to role in same Tenant API and organization API can't be distinguished" issue

### DIFF
--- a/.changeset/wild-yaks-return.md
+++ b/.changeset/wild-yaks-return.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add category,identifier to role permissions

--- a/apps/console/src/features/roles/components/edit-role/edit-role-common/role-api-resources-list-item.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-common/role-api-resources-list-item.tsx
@@ -27,6 +27,7 @@ import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { Tooltip } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
+import { Label } from "semantic-ui-react";
 import { PermissionsList } from "./permissions-list";
 import { APIResourceInterface, ScopeInterface } from "../../../models/apiResources";
 
@@ -144,6 +145,31 @@ export const RoleAPIResourcesListItem: FunctionComponent<RoleAPIResourcesListIte
                         disablePadding
                     >
                         <ListItemText primary={ apiResource?.name } />
+                        <ListItemText
+                            secondary={ (
+                                <Label
+                                    // pointing="left"
+                                    size="mini"
+                                    className= "info-label"
+                                >
+                                    { apiResource?.type }
+                                </Label>
+                            ) } >
+
+                        </ListItemText>
+                        <ListItemText
+                            secondary={ (<>
+                                { apiResource?.identifier }
+                                <Label
+                                    pointing="left"
+                                    size="mini"
+                                    className= "client-id-label"
+                                >
+                                    { t("extensions:develop.apiResource.table.identifier.label") }
+                                </Label>
+                            </>
+                            ) } >
+                        </ListItemText>
                     </ListItem>
                 </AccordionSummary>
                 {

--- a/apps/console/src/features/roles/components/edit-role/edit-role-common/role-api-resources-list-item.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-common/role-api-resources-list-item.tsx
@@ -148,7 +148,6 @@ export const RoleAPIResourcesListItem: FunctionComponent<RoleAPIResourcesListIte
                         <ListItemText
                             secondary={ (
                                 <Label
-                                    // pointing="left"
                                     size="mini"
                                     className= "info-label"
                                 >

--- a/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
@@ -163,16 +163,15 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                     !selectedAPIResources.find((selectedAPIResource: APIResourceInterface) =>
                         selectedAPIResource?.id === api?.id)) {
                     // Remove this once the backend improvement is done to send the type of the API resource.
-                    let type: string = APIResourcesConstants.SYSTEM;
+                    const apiResourceType: string = api?.identifier?.startsWith("/o/")
+                        ? APIResourcesConstants.SYSTEM_ORG
+                        : APIResourcesConstants.SYSTEM;
 
-                    if (api?.identifier?.startsWith("/o/")) {
-                        type = APIResourcesConstants.SYSTEM_ORG;
-                    }
                     options.push({
                         identifier: api.identifier,
                         key: api.id,
                         text: api.displayName,
-                        type: api.type ?? type,
+                        type: api.type ?? apiResourceType,
                         value: api.id
                     });
                 }
@@ -336,12 +335,6 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                     const selectedAPIResourcesList: APIResourceInterface[] = [];
 
                     response.map((apiResource: APIResourceInterface) => {
-                        // Remove this once the backend improvement is done to send the type of the API resource.
-                        let type: string = APIResourcesConstants.SYSTEM;
-
-                        if (apiResource?.identifier?.startsWith("/o/")) {
-                            type = APIResourcesConstants.SYSTEM_ORG;
-                        }
                         const selectedAPIResource: AuthorizedAPIListItemInterface =
                             authorizedAPIListForApplication?.find(
                                 (api: AuthorizedAPIListItemInterface) => api.id === apiResource.id
@@ -353,7 +346,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                                 identifier: selectedAPIResource.identifier,
                                 name: selectedAPIResource.displayName,
                                 scopes: selectedAPIResource.authorizedScopes,
-                                type: selectedAPIResource.type ?? type
+                                type: selectedAPIResource.type
                             });
                         }
                     });
@@ -485,13 +478,17 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                 (api: AuthorizedAPIListItemInterface) => api?.id === data?.value?.toString()
             );
 
+            const apiResourceType: string = selectedAPIResource?.identifier?.startsWith("/o/")
+                ? APIResourcesConstants.SYSTEM_ORG
+                : APIResourcesConstants.SYSTEM;
+
             setSelectedAPIResources([
                 {
                     id: selectedAPIResource?.id,
                     identifier: selectedAPIResource?.identifier,
                     name: selectedAPIResource?.displayName,
                     scopes: selectedAPIResource?.authorizedScopes,
-                    type: selectedAPIResource?.type
+                    type: selectedAPIResource?.type ?? apiResourceType
                 },
                 ...selectedAPIResources
             ]);

--- a/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
@@ -162,9 +162,16 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                 if (
                     !selectedAPIResources.find((selectedAPIResource: APIResourceInterface) =>
                         selectedAPIResource?.id === api?.id)) {
+                    // Remove this once the backend improvement is done to send the type of the API resource.
+                    let type: string = APIResourcesConstants.SYSTEM;
+
+                    if (api?.identifier?.startsWith("/o/")) {
+                        type = APIResourcesConstants.SYSTEM_ORG;
+                    }
                     options.push({
                         key: api.id,
                         text: api.displayName,
+                        type: api.type ?? type,
                         value: api.id
                     });
                 }

--- a/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
@@ -169,6 +169,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                         type = APIResourcesConstants.SYSTEM_ORG;
                     }
                     options.push({
+                        identifier: api.identifier,
                         key: api.id,
                         text: api.displayName,
                         type: api.type ?? type,
@@ -191,6 +192,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                 if (!selectedAPIResources.find((selectedAPIResource: APIResourceInterface) =>
                     selectedAPIResource?.id === api?.id)) {
                     options.push({
+                        identifier: api.identifier,
                         key: api.id,
                         text: api.name,
                         type: api.type,
@@ -260,6 +262,7 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
 
                     if (isCurrentAPIResourceAlreadyAdded) {
                         filtered.push({
+                            identifier: apiResource.identifier,
                             key: apiResource.id,
                             text: apiResource.name,
                             type: apiResource.type,
@@ -333,6 +336,12 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                     const selectedAPIResourcesList: APIResourceInterface[] = [];
 
                     response.map((apiResource: APIResourceInterface) => {
+                        // Remove this once the backend improvement is done to send the type of the API resource.
+                        let type: string = APIResourcesConstants.SYSTEM;
+
+                        if (apiResource?.identifier?.startsWith("/o/")) {
+                            type = APIResourcesConstants.SYSTEM_ORG;
+                        }
                         const selectedAPIResource: AuthorizedAPIListItemInterface =
                             authorizedAPIListForApplication?.find(
                                 (api: AuthorizedAPIListItemInterface) => api.id === apiResource.id
@@ -341,8 +350,10 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                         if (selectedAPIResource) {
                             selectedAPIResourcesList.push({
                                 id: selectedAPIResource.id,
+                                identifier: selectedAPIResource.identifier,
                                 name: selectedAPIResource.displayName,
-                                scopes: selectedAPIResource.authorizedScopes
+                                scopes: selectedAPIResource.authorizedScopes,
+                                type: selectedAPIResource.type ?? type
                             });
                         }
                     });
@@ -477,8 +488,10 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
             setSelectedAPIResources([
                 {
                     id: selectedAPIResource?.id,
+                    identifier: selectedAPIResource?.identifier,
                     name: selectedAPIResource?.displayName,
-                    scopes: selectedAPIResource?.authorizedScopes
+                    scopes: selectedAPIResource?.authorizedScopes,
+                    type: selectedAPIResource?.type
                 },
                 ...selectedAPIResources
             ]);

--- a/apps/console/src/features/roles/models/apiResources.ts
+++ b/apps/console/src/features/roles/models/apiResources.ts
@@ -55,5 +55,6 @@ export interface AuthorizedAPIListItemInterface {
     identifier: string,
     displayName: string,
     policyId: string,
-    authorizedScopes: ScopeInterface[]
+    authorizedScopes: ScopeInterface[],
+    type?: string;
 }


### PR DESCRIPTION
### Purpose
Fixed mentioned issues in this [issue](https://github.com/wso2/product-is/issues/18090).

<img width="910" alt="image" src="https://github.com/wso2/identity-apps/assets/61885844/3415a1ab-dade-4370-93d8-556149cf957c">

Here in the list, the categories "SYSTEM" and "SYSTEM_ORG" are displayed, and it's important to note that these values are retrieved from the API. Modifications to these values will be handled from the backend.

<img width="859" alt="image" src="https://github.com/wso2/identity-apps/assets/61885844/ac106a0c-948c-4f94-975d-bf6098a1dd55">

### Related Issues
- https://github.com/wso2/product-is/issues/18090

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
