### PR TITLE
(improvement) add APIAuth label to the authenticators in the application sign in method connections

### DIFF
--- a/.changeset/calm-insects-suffer.md
+++ b/.changeset/calm-insects-suffer.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+(improvement) add `APIAuth` label to the authenticators in the application sign in method connections

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -35,7 +35,6 @@ import {
 import { AuthenticatorMeta } from "../../../../../identity-providers/meta/authenticator-meta";
 import {
     AuthenticatorCategories,
-    FederatedAuthenticatorInterface,
     GenericAuthenticatorInterface
 } from "../../../../../identity-providers/models/identity-provider";
 import { ApplicationManagementConstants } from "../../../../constants/application-management";
@@ -302,7 +301,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                     { InfoLabel }
                     <Text>
                         {
-                            (authenticationSteps[currentStep]?.options?.length !== 0) 
+                            (authenticationSteps[currentStep]?.options?.length !== 0)
                                 ? t(
                                     "console:develop.features.applications.edit.sections" +
                                     ".signOnMethod.sections.authenticationFlow.sections.stepBased" +
@@ -354,12 +353,12 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
      *
      * @returns Authenticator labels.
      */
-    const resolveAuthenticatorLabels = (authenticator: FederatedAuthenticatorInterface): string[] => {
+    const resolveAuthenticatorLabels = (authenticator: GenericAuthenticatorInterface): string[] => {
         if (!authenticator) {
             return [];
         }
 
-        return AuthenticatorMeta.getAuthenticatorLabels(authenticator.authenticatorId) ?? [];
+        return AuthenticatorMeta.getAuthenticatorLabels(authenticator) ?? [];
     };
 
     /**
@@ -383,7 +382,7 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                 />
             );
         }
-    
+
         return null;
     };
 
@@ -421,16 +420,16 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                                 subHeader={ authenticator.categoryDisplayName }
                                 description={ authenticator.description }
                                 featureStatus={ renderFeatureStatusChip(authenticator) }
-                                image={ 
-                                    authenticator.idp === AuthenticatorCategories.LOCAL || 
+                                image={
+                                    authenticator.idp === AuthenticatorCategories.LOCAL ||
                                     authenticator
                                         .defaultAuthenticator?.authenticatorId === AuthenticatorManagementConstants
                                         .ORGANIZATION_ENTERPRISE_AUTHENTICATOR_ID
-                                        ? authenticator.image 
+                                        ? authenticator.image
                                         : ConnectionsManagementUtils
                                             .resolveConnectionResourcePath(connectionResourcesUrl, authenticator.image)
                                 }
-                                tags={ showLabels && resolveAuthenticatorLabels(authenticator?.defaultAuthenticator) }
+                                tags={ showLabels && resolveAuthenticatorLabels(authenticator) }
                                 onClick={ () => {
                                     isFactorEnabled(authenticator) && handleAuthenticatorSelect(authenticator);
                                 } }

--- a/apps/console/src/features/identity-providers/meta/authenticator-meta.ts
+++ b/apps/console/src/features/identity-providers/meta/authenticator-meta.ts
@@ -21,7 +21,7 @@ import { ReactNode } from "react";
 import { identityProviderConfig } from "../../../extensions";
 import { getAuthenticatorIcons } from "../configs/ui";
 import { IdentityProviderManagementConstants } from "../constants";
-import { AuthenticatorCategories, AuthenticatorLabels } from "../models";
+import { AuthenticatorCategories, AuthenticatorLabels, GenericAuthenticatorInterface } from "../models";
 
 export class AuthenticatorMeta {
 
@@ -86,9 +86,11 @@ export class AuthenticatorMeta {
      *
      * @returns Authenticator labels.
      */
-    public static getAuthenticatorLabels(authenticatorId: string): string[] {
+    public static getAuthenticatorLabels(authenticator: GenericAuthenticatorInterface): string[] {
 
-        return get({
+        const authenticatorId: string = authenticator?.defaultAuthenticator?.authenticatorId;
+
+        const authenticatorLabels: string[] = get({
             [ IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR_ID ]: [ AuthenticatorLabels.HANDLERS ],
             [ IdentityProviderManagementConstants.FIDO_AUTHENTICATOR_ID ]: identityProviderConfig.fidoTags,
             [ IdentityProviderManagementConstants.TOTP_AUTHENTICATOR_ID ]: [
@@ -131,6 +133,16 @@ export class AuthenticatorMeta {
                 AuthenticatorLabels.HANDLERS
             ]
         }, authenticatorId);
+
+        if ( authenticator?.tags?.includes(AuthenticatorLabels.API_AUTHENTICATION) ) {
+            if ( authenticatorLabels ) {
+                return [ ...authenticatorLabels, AuthenticatorLabels.API_AUTHENTICATION ];
+            } else {
+                return [ AuthenticatorLabels.API_AUTHENTICATION ];
+            }
+        }
+
+        return authenticatorLabels;
     }
 
     /**

--- a/apps/console/src/features/identity-providers/models/identity-provider.ts
+++ b/apps/console/src/features/identity-providers/models/identity-provider.ts
@@ -56,6 +56,7 @@ export interface StrictIdentityProviderInterface {
     self?: string;
     federatedAuthenticators?: FederatedAuthenticatorListResponseInterface;
     templateId?: string;
+    tags?: string[];
 }
 
 export interface IdentityProviderInterface extends StrictIdentityProviderInterface {
@@ -588,6 +589,10 @@ export interface LocalAuthenticatorInterface extends CommonPluggableComponentInt
      * Details endpoint.
      */
     self?: string;
+    /**
+     * The list of tags that the authenticator can be categorized under.
+     */
+    tags?: string[];
 }
 
 /**
@@ -804,7 +809,8 @@ export enum AuthenticatorLabels {
     PASSWORDLESS = "Passwordless",
     HANDLERS = "Handlers",
     USERNAMELESS = "Usernameless",
-    PASSKEY = "Passkey"
+    PASSKEY = "Passkey",
+    API_AUTHENTICATION = "APIAuth"
 }
 
 /**


### PR DESCRIPTION
### Purpose
(improvement) add APIAuth label to the authenticators in the application sign in method connections

### Related Issues
- https://github.com/wso2/product-is/issues/18274

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
