### PR TITLE
Fix groups view empty state

### DIFF
--- a/.changeset/calm-rivers-wink.md
+++ b/.changeset/calm-rivers-wink.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix groups view placeholder

--- a/apps/console/src/features/groups/components/group-list.tsx
+++ b/apps/console/src/features/groups/components/group-list.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -30,7 +30,7 @@ import {
     TableActionsInterface,
     TableColumnInterface
 } from "@wso2is/react-components";
-import moment from "moment";
+import moment, { Moment } from "moment";
 import React, { ReactElement, ReactNode, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -63,7 +63,7 @@ interface GroupListProps extends SBACInterface<FeatureConfigInterface>,
     groupList: GroupsInterface[];
     /**
      * Group delete callback.
-     * @param {GroupsInterface} group - Deleting group.
+     * @param group - Deleting group.
      */
     handleGroupDelete?: (group: GroupsInterface) => void;
     /**
@@ -103,7 +103,8 @@ interface GroupListProps extends SBACInterface<FeatureConfigInterface>,
 /**
  * List component for Group Management list
  *
- * @param props contains the role list as a prop to populate
+ * @param props - Props injected to the component.
+ * @returns Groups list component.
  */
 export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupListProps): ReactElement => {
 
@@ -132,7 +133,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
     const [ showGroupDeleteConfirmation, setShowDeleteConfirmationModal ] = useState<boolean>(false);
     const [ currentDeletedGroup, setCurrentDeletedGroup ] = useState<GroupsInterface>();
 
-    const handleGroupEdit = (groupId: string) => {
+    const handleGroupEdit = (groupId: string): void => {
         history.push(AppConstants.getPaths().get("GROUP_EDIT").replace(":id", groupId));
     };
 
@@ -176,7 +177,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
     /**
      * Shows list placeholders.
      *
-     * @return {React.ReactElement}
+     * @returns Empty placeholders.
      */
     const showPlaceholders = (): ReactElement => {
         // When the search returns empty.
@@ -204,7 +205,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
             );
         }
 
-        if (groupList?.length === 0) {
+        if (!groupList || groupList?.length === 0) {
             return (
                 <EmptyPlaceholder
                     data-testid={ `${ testId }-empty-list-empty-placeholder` }
@@ -242,7 +243,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
     /**
      * Resolves data table columns.
      *
-     * @return {TableColumnInterface[]}
+     * @returns Table Columns.
      */
     const resolveTableColumns = (): TableColumnInterface[] => {
         return [
@@ -284,8 +285,8 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
                 id: "lastModified",
                 key: "lastModified",
                 render: (group: GroupsInterface): ReactNode => {
-                    const now = moment(new Date());
-                    const receivedDate = moment(group.meta.created);
+                    const now: Moment = moment(new Date());
+                    const receivedDate: Moment = moment(group.meta.created);
 
                     return t("console:common.dateTime.humanizedDateString", {
                         date: moment.duration(now.diff(receivedDate)).humanize()
@@ -307,7 +308,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
     /**
      * Resolves data table actions.
      *
-     * @return {TableActionsInterface[]}
+     * @returns Table Actions.
      */
     const resolveTableActions = (): TableActionsInterface[] => {
         if (!showListItemActions) {
@@ -319,11 +320,11 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
                 hidden: (): boolean => !isFeatureEnabled(featureConfig?.groups,
                     GroupConstants.FEATURE_DICTIONARY.get("GROUP_READ")),
                 icon: (group: GroupsInterface): SemanticICONS => {
-                    const userStore = group?.displayName?.split("/").length > 1
+                    const userStore: string = group?.displayName?.split("/").length > 1
                         ? group?.displayName?.split("/")[0]
                         : "PRIMARY";
 
-                    return !isFeatureEnabled(featureConfig?.groups, 
+                    return !isFeatureEnabled(featureConfig?.groups,
                         GroupConstants.FEATURE_DICTIONARY.get("GROUP_UPDATE"))
                     || !hasRequiredScopes(featureConfig?.groups, featureConfig?.groups?.scopes?.update, allowedScopes)
                     || readOnlyUserStores?.includes(userStore.toString())
@@ -333,7 +334,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
                 onClick: (e: SyntheticEvent, group: GroupsInterface): void =>
                     handleGroupEdit(group.id),
                 popupText: (group: GroupsInterface): string => {
-                    const userStore = group?.displayName?.split("/").length > 1
+                    const userStore: string = group?.displayName?.split("/").length > 1
                         ? group?.displayName?.split("/")[0]
                         : "PRIMARY";
 
@@ -350,7 +351,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
 
         actions.push({
             hidden: (group: GroupsInterface): boolean => {
-                const userStore = group?.displayName?.split("/").length > 1
+                const userStore: string = group?.displayName?.split("/").length > 1
                     ? group?.displayName?.split("/")[0]
                     : "PRIMARY";
 

--- a/apps/console/src/features/groups/components/wizard/create-group-wizard-updated.tsx
+++ b/apps/console/src/features/groups/components/wizard/create-group-wizard-updated.tsx
@@ -60,10 +60,25 @@ import {
  * Interface which captures create group props.
  */
 interface CreateGroupProps extends IdentifiableComponentInterface {
+    /**
+     * Callback for the wizard close event.
+     */
     closeWizard: () => void;
-    updateList: () => void;
+    /**
+     * Callback for the group create event.
+     */
+    onCreate: () => void;
+    /**
+     * Initial step of the wizard.
+     */
     initStep?: number;
+    /**
+     * Required steps for the wizard.
+     */
     requiredSteps?: WizardStepsFormTypes[] | string[];
+    /**
+     * Should the wizard show the steps.
+     */
     showStepper?: boolean;
 }
 
@@ -80,6 +95,7 @@ export const CreateGroupWizardUpdated: FunctionComponent<CreateGroupProps> =
         initStep,
         showStepper,
         requiredSteps,
+        onCreate,
         [ "data-componentid" ]: componentId
     } = props;
 
@@ -316,6 +332,8 @@ export const CreateGroupWizardUpdated: FunctionComponent<CreateGroupProps> =
                     });
                 }
             }
+
+            onCreate();
         }).catch((error: AxiosError)  => {
             if (!error.response || error.response.status === 401) {
                 dispatch(

--- a/apps/console/src/features/groups/pages/groups.tsx
+++ b/apps/console/src/features/groups/pages/groups.tsx
@@ -100,7 +100,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
         data,
         error: groupsError,
         isLoading: isGroupsListRequestLoading,
-        mutate
+        mutate: mutateGroupsFetchRequest
     } = useGroupList(userStore, "members,roles", searchQuery, true);
 
     useEffect(() => {
@@ -256,7 +256,8 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                     "console:manage.features.groups.notifications.deleteGroup.success.message"
                 )
             });
-            mutate();
+
+            mutateGroupsFetchRequest();
         }).catch(() => {
             handleAlerts({
                 description: t(
@@ -273,7 +274,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     return (
         <PageLayout
             action={
-                (isGroupsListRequestLoading || !(!searchQuery && paginatedGroups?.length <= 0))
+                (!isGroupsListRequestLoading && paginatedGroups?.length > 0)
                 && (
                     <Show when={ AccessControlConstants.GROUP_WRITE }>
                         <PrimaryButton
@@ -337,11 +338,13 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                     </RootOnlyComponent>
                 ) }
                 showPagination={ paginatedGroups?.length > 0  }
-                showTopActionPanel={ isGroupsListRequestLoading
-                    || !(!searchQuery
+                showTopActionPanel={
+                    !isGroupsListRequestLoading
+                    && !(!searchQuery
                         && !groupsError
                         && userStoreOptions?.length < 3
-                        && paginatedGroups?.length <= 0) }
+                        && (!paginatedGroups || paginatedGroups?.length <= 0))
+                }
                 totalPages={ Math.ceil(groupList?.length / listItemLimit) }
                 totalListSize={ groupList?.length }
                 isLoading={ isGroupsListRequestLoading }
@@ -399,7 +402,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                     <CreateGroupWizardUpdated
                         data-testid="group-mgt-create-group-wizard"
                         closeWizard={ () => setShowWizard(false) }
-                        updateList={ () => mutate() }
+                        onCreate={ () => mutateGroupsFetchRequest() }
                         requiredSteps={ [
                             WizardStepsFormTypes.BASIC_DETAILS,
                             WizardStepsFormTypes.ROLE_LIST


### PR DESCRIPTION
### Purpose

The groups view doesn't properly handle the empty state.

<img width="1407" alt="Screenshot 2023-12-01 at 22 13 38" src="https://github.com/wso2/identity-apps/assets/25959096/a1d2db8c-ac5c-460c-9631-c1f9e924992e">

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/18257

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
