### PR TITLE
Logout wreply url should not be mandatory in passive sts

### DIFF
--- a/.changeset/nine-lamps-dream.md
+++ b/.changeset/nine-lamps-dream.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Logout wreply url should not be mandatory in passive sts

--- a/.changeset/rotten-kangaroos-refuse.md
+++ b/.changeset/rotten-kangaroos-refuse.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Logout wreply url should not be mandatory in passive sts

--- a/apps/console/src/features/applications/components/forms/inbound-passive-sts-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-passive-sts-form.tsx
@@ -200,11 +200,6 @@ export const InboundPassiveStsForm: FunctionComponent<InboundPassiveStsFormProps
                             label={ 
                                 t("console:develop.features.applications.forms.inboundSTS.fields.replyToLogout.label") 
                             }
-                            required
-                            requiredErrorMessage={
-                                t("console:develop.features.applications.forms.inboundSTS.fields.replyToLogout" +
-                                    ".validations.empty")
-                            }
                             placeholder={
                                 t("console:develop.features.applications.forms.inboundSTS.fields.replyToLogout" +
                                     ".placeholder")

--- a/apps/console/src/features/applications/components/forms/inbound-passive-sts-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-passive-sts-form.tsx
@@ -24,12 +24,12 @@ import isEmpty from "lodash-es/isEmpty";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState  } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Grid } from "semantic-ui-react";
-import { 
-    ApplicationInterface, 
-    CertificateInterface, 
-    CertificateTypeInterface, 
-    PassiveStsConfigurationInterface, 
-    SupportedAuthProtocolTypes 
+import {
+    ApplicationInterface,
+    CertificateInterface,
+    CertificateTypeInterface,
+    PassiveStsConfigurationInterface,
+    SupportedAuthProtocolTypes
 } from "../../models";
 import { CertificateFormFieldModal } from "../modals";
 import { ApplicationCertificateWrapper } from "../settings/certificate";
@@ -128,8 +128,8 @@ export const InboundPassiveStsForm: FunctionComponent<InboundPassiveStsFormProps
      */
     const handleFormSubmit = (values: Map<string, FormValue>): void => {
         setTriggerCertSubmit();
-        onSubmit(updateConfiguration(values));           
-    };        
+        onSubmit(updateConfiguration(values));
+    };
 
     return (
         <Forms
@@ -197,8 +197,8 @@ export const InboundPassiveStsForm: FunctionComponent<InboundPassiveStsFormProps
                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                         <Field
                             name="replyToLogout"
-                            label={ 
-                                t("console:develop.features.applications.forms.inboundSTS.fields.replyToLogout.label") 
+                            label={
+                                t("console:develop.features.applications.forms.inboundSTS.fields.replyToLogout.label")
                             }
                             placeholder={
                                 t("console:develop.features.applications.forms.inboundSTS.fields.replyToLogout" +
@@ -225,7 +225,6 @@ export const InboundPassiveStsForm: FunctionComponent<InboundPassiveStsFormProps
                 </Grid.Row>
                 { /* Certificates */ }
                 <Grid.Row columns={ 1 }>
-                    
                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                         <ApplicationCertificateWrapper
                             protocol={ SupportedAuthProtocolTypes.WS_FEDERATION }

--- a/apps/console/src/features/applications/components/wizard/passive-sts-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/passive-sts-protocol-settings-wizard-form.tsx
@@ -150,10 +150,6 @@ export const PassiveStsProtocolSettingsWizardForm: FunctionComponent<PassiveStsS
                                         t("console:develop.features.applications.forms.inboundSTS.fields." +
                                           "replyToLogout.label")
                                     }
-                                    requiredErrorMessage={
-                                        t("console:develop.features.applications.forms.inboundSTS.fields." +
-                                          "replyToLogout.validations.empty")
-                                    }
                                     placeholder={
                                         t("console:develop.features.applications.forms.inboundSTS.fields." +
                                           "replyToLogout.placeholder")
@@ -170,7 +166,6 @@ export const PassiveStsProtocolSettingsWizardForm: FunctionComponent<PassiveStsS
                                     type="text"
                                     value={ initialValues?.replyToLogout ?? templateValues?.replyToLogout }
                                     data-testid={ `${ testId }-reply-to-logout-url-input` }
-                                    required
                                 />
                                 <Hint>
                                     { t("console:develop.features.applications.forms.inboundSTS.fields." +

--- a/apps/console/src/features/applications/components/wizard/passive-sts-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/passive-sts-protocol-settings-wizard-form.tsx
@@ -66,8 +66,7 @@ export const PassiveStsProtocolSettingsWizardForm: FunctionComponent<PassiveStsS
             inboundProtocolConfiguration: {
                 passiveSts: {
                     realm: values.get("realm"),
-                    replyTo: values.get("replyTo"),
-                    replyToLogout: values.get("replyToLogout")
+                    replyTo: values.get("replyTo")
                 }
             }
         };
@@ -139,37 +138,6 @@ export const PassiveStsProtocolSettingsWizardForm: FunctionComponent<PassiveStsS
                                 />
                                 <Hint>
                                     { t("console:develop.features.applications.forms.inboundSTS.fields.replyTo.hint") }
-                                </Hint>
-                            </Grid.Column>
-                        </Grid.Row>
-                        <Grid.Row>
-                            <Grid.Column mobile={ 16 }>
-                                <Field
-                                    name="replyToLogout"
-                                    label={
-                                        t("console:develop.features.applications.forms.inboundSTS.fields." +
-                                          "replyToLogout.label")
-                                    }
-                                    placeholder={
-                                        t("console:develop.features.applications.forms.inboundSTS.fields." +
-                                          "replyToLogout.placeholder")
-                                    }
-                                    validation={ (value: string, validation: Validation) => {
-                                        if (!FormValidation.url(value)) {
-                                            validation.isValid = false;
-                                            validation.errorMessages.push(
-                                                t("console:develop.features.applications.forms" +
-                                                  ".inboundSTS.fields.replyToLogout.validations.invalid")
-                                            );
-                                        }
-                                    } }
-                                    type="text"
-                                    value={ initialValues?.replyToLogout ?? templateValues?.replyToLogout }
-                                    data-testid={ `${ testId }-reply-to-logout-url-input` }
-                                />
-                                <Hint>
-                                    { t("console:develop.features.applications.forms.inboundSTS.fields." +
-                                        "replyToLogout.hint") }
                                 </Hint>
                             </Grid.Column>
                         </Grid.Row>


### PR DESCRIPTION
### Purpose
The logout wreply url configuration in passive sts applications should not be mandatory as the validation will fallback to the wreply url if the logout url is not specified.

### Related Issues
- https://github.com/wso2/product-is/issues/18388

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
