### PR TITLE
Remove client credential grant warning from M2M applications

### DIFF
--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -806,14 +806,16 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 <>
                     <label>
                         { label }
-                        <GenericIcon
-                            icon={ getGeneralIcons().warning }
-                            defaultIcon
-                            colored
-                            transparent
-                            spaced="left"
-                            floated="right"
-                        />
+                        { !isM2MApplication && (
+                            <GenericIcon
+                                icon={ getGeneralIcons().warning }
+                                defaultIcon
+                                colored
+                                transparent
+                                spaced="left"
+                                floated="right"
+                            />)
+                        }
                     </label>
                 </>
             );
@@ -902,7 +904,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                  */
                 const description: string = getGrantTypeHintDescription(name);
 
-                if (description) {
+                if (description && !isM2MApplication) {
                     grant.hint = {
                         content: description,
                         header: ""


### PR DESCRIPTION
### Purpose
Remove client credential grant warning from M2M applications in the Protocol tab.

### Related Issues
- https://github.com/wso2/product-is/issues/17515

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
