### PR TITLE
[bug-fix][legacy] Avoid rendering `OrganizationSwitchBreadcrumb` when the organizations are disabled

### DIFF
--- a/.changeset/eighty-garlics-prove.md
+++ b/.changeset/eighty-garlics-prove.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Avoid rendering `OrganizationSwitchBreadcrumb` when the organizations are disabled

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -28,14 +28,15 @@ import Menu from "@oxygen-ui/react/Menu";
 import MenuItem from "@oxygen-ui/react/MenuItem";
 import { FeatureStatus, Show, useCheckFeatureStatus } from "@wso2is/access-control";
 import { OrganizationType } from "@wso2is/common";
+import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import { hasRequiredScopes, resolveAppLogoFilePath } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface, ProfileInfoInterface } from "@wso2is/core/models";
 import { LocalStorageUtils, StringUtils } from "@wso2is/core/utils";
 import { I18n } from "@wso2is/i18n";
 import { GenericIcon, useDocumentation } from "@wso2is/react-components";
-import { 
-    TenantTier, 
-    TenantTierRequestResponse 
+import {
+    TenantTier,
+    TenantTierRequestResponse
 } from "apps/console/src/extensions/components/subscription/models/subscription";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
@@ -127,6 +128,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
     const userOrganizationID: string = useSelector((state: AppState) =>
         state?.organization?.userOrganizationId);
 
+    const { UIConfig } = useUIConfig();
     const saasFeatureStatus : FeatureStatus = useCheckFeatureStatus(FeatureGateConstants.SAAS_FEATURES_IDENTIFIER);
     const { tierName }: TenantTierRequestResponse = useContext(SubscriptionContext);
 
@@ -178,6 +180,11 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
      *  - the user is logged in to a non-super-tenant account
      */
     const isOrgSwitcherEnabled: boolean = useMemo(() => {
+        // If the organizations feature is disabled, do not show the org switcher.
+        if (!UIConfig?.legacyMode?.organizations) {
+            return false;
+        }
+
         if (legacyAuthzRuntime) {
             return (
                 isOrganizationManagementEnabled &&
@@ -361,9 +368,9 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             window[ "AppUtils" ].getConfig().extensions
                 .upgradeButtonEnabled && (
                 <Show when={ [] } featureId={ FeatureGateConstants.SAAS_FEATURES_IDENTIFIER }>
-                    <a 
-                        href={ upgradeButtonURL } 
-                        target="_blank" 
+                    <a
+                        href={ upgradeButtonURL }
+                        target="_blank"
                         rel="noreferrer"
                         data-componentid="upgrade-button-link"
                     >
@@ -394,7 +401,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             return (!userOrganizationID
                 || userOrganizationID === window[ "AppUtils" ].getConfig().organizationName);
         }
-        
+
         return true;
     };
 
@@ -497,7 +504,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                     </Box>
                 ],
                 menuItems: [
-                    billingPortalURL && window[ "AppUtils" ].getConfig().extensions.billingPortalUrl && 
+                    billingPortalURL && window[ "AppUtils" ].getConfig().extensions.billingPortalUrl &&
                     !isPrivilegedUser && (
                         <Show when={ [] } featureId={ FeatureGateConstants.SAAS_FEATURES_IDENTIFIER }>
                             <MenuItem
@@ -518,7 +525,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                             </MenuItem>
                         </Show>
                     ),
-                    isShowAppSwitchButton() 
+                    isShowAppSwitchButton()
                         ? (
                             <MenuItem
                                 color="inherit"

--- a/apps/console/src/features/core/components/header.tsx
+++ b/apps/console/src/features/core/components/header.tsx
@@ -174,6 +174,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
 
     /**
      * Show the organization switching dropdown only if
+     *  - the organizations feature is enabled
      *  - the extensions config enables this
      *  - the requires scopes are there
      *  - the organization management feature is enabled by the backend


### PR DESCRIPTION
### Purpose
> $subject

### Related Issues
- https://github.com/wso2/product-is/issues/18352

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
