### PR TITLE
Make the roles tab on Edit Users and Edit Groups sections a consistent list view.

### DIFF
--- a/.changeset/fair-humans-sort.md
+++ b/.changeset/fair-humans-sort.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Make the roles tab on Edit Users and Edit Groups sections a consistent list view.

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.scss
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.scss
@@ -1,3 +1,21 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 .list-group-roles-section {
     .ui.table thead th {
         background: transparent;

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.scss
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.scss
@@ -1,0 +1,5 @@
+.list-group-roles-section {
+    .ui.table thead th {
+        background: transparent;
+    }
+}

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
@@ -16,27 +16,19 @@
  * under the License.
  */
 
-import Autocomplete, {  
-    AutocompleteRenderGetTagProps, 
-    AutocompleteRenderInputParams 
-} from "@oxygen-ui/react/Autocomplete";
-import TextField from "@oxygen-ui/react/TextField";
 import { IdentifiableComponentInterface, RolesMemberInterface } from "@wso2is/core/models";
-import { EmphasizedSegment, EmptyPlaceholder, Heading } from "@wso2is/react-components";
+import { EmptyPlaceholder, Heading } from "@wso2is/react-components";
 import React, {
     FunctionComponent,
-    HTMLAttributes,
     ReactElement,
     useEffect,
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
-import { getEmptyPlaceholderIllustrations } from "../../../core/configs/ui";
-import { GroupsInterface } from "../../models/groups";
-import { AutoCompleteRenderOption } from "../group-common-components/auto-complete-render-option";
-import { RenderChipRolesInGroups } from "../group-common-components/render-chip";
-import { ReadOnlyRoleList } from "../../../roles/components/readonly-role-list";
 import { Divider } from "semantic-ui-react";
+import { getEmptyPlaceholderIllustrations } from "../../../core";
+import { ReadOnlyRoleList } from "../../../roles/components/readonly-role-list";
+import { GroupsInterface } from "../../models";
 
 interface EditGroupRolesPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -54,7 +46,6 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
     const { t } = useTranslation();
 
     const [ initialSelectedRolesOptions, setInitialSelectedRolesOptions ] = useState<RolesMemberInterface[]>([]);
-    const [ activeOption, setActiveOption ] = useState<RolesMemberInterface>(undefined);
 
     /**
      * Set initial selected roles options
@@ -66,14 +57,14 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
     }, [ group ]);
 
     /**
-     * Get the place holder components.
-     * 
+     * Get the placeholder components.
+     *
      * @returns place holder components
      */
     const getPlaceholders = () => {
         return (
             <EmptyPlaceholder
-                subtitle={ 
+                subtitle={
                     [ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.subtitles") ]
                 }
                 title={ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.title") }

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
@@ -36,6 +36,7 @@ import { GroupsInterface } from "../../models/groups";
 import { AutoCompleteRenderOption } from "../group-common-components/auto-complete-render-option";
 import { RenderChipRolesInGroups } from "../group-common-components/render-chip";
 import { ReadOnlyRoleList } from "../../../roles/components/readonly-role-list";
+import { Divider } from "semantic-ui-react";
 
 interface EditGroupRolesPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -83,10 +84,19 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
     };
 
     return (
-        <ReadOnlyRoleList
-            totalRoleList={ initialSelectedRolesOptions }
-            emptyRolesListPlaceholder={ getPlaceholders() }
-        />
+        <>
+            <Heading as="h4">
+                { t("console:manage.features.groups.edit.roles.heading") }
+            </Heading>
+            <Heading subHeading ellipsis as="h6">
+                { t("console:manage.features.groups.edit.roles.subHeading") }
+            </Heading>
+            <Divider hidden/>
+            <ReadOnlyRoleList
+                totalRoleList={ initialSelectedRolesOptions }
+                emptyRolesListPlaceholder={ getPlaceholders() }
+            />
+        </>
     );
 };
 

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
@@ -16,9 +16,9 @@
  * under the License.
  */
 
-import Autocomplete, {
-    AutocompleteRenderGetTagProps,
-    AutocompleteRenderInputParams
+import Autocomplete, {  
+    AutocompleteRenderGetTagProps, 
+    AutocompleteRenderInputParams 
 } from "@oxygen-ui/react/Autocomplete";
 import TextField from "@oxygen-ui/react/TextField";
 import { IdentifiableComponentInterface, RolesMemberInterface } from "@wso2is/core/models";
@@ -35,6 +35,7 @@ import { getEmptyPlaceholderIllustrations } from "../../../core/configs/ui";
 import { GroupsInterface } from "../../models/groups";
 import { AutoCompleteRenderOption } from "../group-common-components/auto-complete-render-option";
 import { RenderChipRolesInGroups } from "../group-common-components/render-chip";
+import { ReadOnlyRoleList } from "../../../roles/components/readonly-role-list";
 
 interface EditGroupRolesPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -53,7 +54,6 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
 
     const [ initialSelectedRolesOptions, setInitialSelectedRolesOptions ] = useState<RolesMemberInterface[]>([]);
     const [ activeOption, setActiveOption ] = useState<RolesMemberInterface>(undefined);
-    const [ showEmptyRolesListPlaceholder, setShowEmptyRolesListPlaceholder ] = useState<boolean>(false);
 
     /**
      * Set initial selected roles options
@@ -61,85 +61,32 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
     useEffect(() => {
         if ( group?.roles?.length > 0 ) {
             setInitialSelectedRolesOptions(group.roles);
-        } else {
-            setShowEmptyRolesListPlaceholder(true);
         }
     }, [ group ]);
 
     /**
      * Get the place holder components.
-     *
+     * 
      * @returns place holder components
      */
     const getPlaceholders = () => {
-        if (showEmptyRolesListPlaceholder) {
-            return (
-                <EmptyPlaceholder
-                    subtitle={
-                        [ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.subtitles") ]
-                    }
-                    title={ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.title") }
-                    image={ getEmptyPlaceholderIllustrations().emptyList }
-                    imageSize="tiny"
-                />
-            );
-        }
+        return (
+            <EmptyPlaceholder
+                subtitle={ 
+                    [ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.subtitles") ]
+                }
+                title={ t("console:manage.features.groups.edit.roles.placeHolders.emptyListPlaceholder.title") }
+                image={ getEmptyPlaceholderIllustrations().emptyList }
+                imageSize="tiny"
+            />
+        );
     };
 
     return (
-        <EmphasizedSegment padded="very">
-            <Heading as="h4">
-                { t("console:manage.features.groups.edit.roles.heading") }
-            </Heading>
-            <Heading subHeading ellipsis as="h6">
-                { t("console:manage.features.groups.edit.roles.subHeading") }
-            </Heading>
-            {
-                showEmptyRolesListPlaceholder
-                    ? getPlaceholders()
-                    : (
-                        <Autocomplete
-                            multiple
-                            disableCloseOnSelect
-                            options={ initialSelectedRolesOptions }
-                            value={ initialSelectedRolesOptions }
-                            getOptionLabel={ (role: RolesMemberInterface) => role.display }
-                            renderInput={ (params: AutocompleteRenderInputParams) => (
-                                <TextField
-                                    { ...params }
-                                    placeholder= { t("console:manage.features.transferList.searchPlaceholder",
-                                        { type: "Roles" }) }
-                                />
-                            ) }
-                            renderTags={ (
-                                value: RolesMemberInterface[],
-                                getTagProps: AutocompleteRenderGetTagProps
-                            ) => value.map((option: RolesMemberInterface, index: number) => (
-                                <RenderChipRolesInGroups
-                                    { ...getTagProps({ index }) }
-                                    key={ index }
-                                    displayName={ option?.display }
-                                    audienceType={ option?.audienceType }
-                                    audienceDisplay={ option?.audienceDisplay }
-                                    option={ option }
-                                    activeOption={ activeOption }
-                                    setActiveOption={ setActiveOption }
-                                    onDelete={ null }
-                                />
-                            )) }
-                            renderOption={ (
-                                props: HTMLAttributes<HTMLLIElement>,
-                                option: RolesMemberInterface
-                            ) => (
-                                <AutoCompleteRenderOption
-                                    displayName={ option.display }
-                                    renderOptionProps={ props }
-                                />
-                            ) }
-                        />
-                    )
-            }
-        </EmphasizedSegment>
+        <ReadOnlyRoleList
+            totalRoleList={ initialSelectedRolesOptions }
+            emptyRolesListPlaceholder={ getPlaceholders() }
+        />
     );
 };
 

--- a/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
+++ b/apps/console/src/features/groups/components/edit-group/edit-group-roles.tsx
@@ -17,7 +17,7 @@
  */
 
 import { IdentifiableComponentInterface, RolesMemberInterface } from "@wso2is/core/models";
-import { EmptyPlaceholder, Heading } from "@wso2is/react-components";
+import { EmphasizedSegment, EmptyPlaceholder, Heading } from "@wso2is/react-components";
 import React, {
     FunctionComponent,
     ReactElement,
@@ -29,6 +29,7 @@ import { Divider } from "semantic-ui-react";
 import { getEmptyPlaceholderIllustrations } from "../../../core";
 import { ReadOnlyRoleList } from "../../../roles/components/readonly-role-list";
 import { GroupsInterface } from "../../models";
+import "./edit-group-roles.scss";
 
 interface EditGroupRolesPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -75,7 +76,7 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
     };
 
     return (
-        <>
+        <EmphasizedSegment padded="very" className="list-group-roles-section">
             <Heading as="h4">
                 { t("console:manage.features.groups.edit.roles.heading") }
             </Heading>
@@ -87,7 +88,7 @@ export const EditGroupRoles: FunctionComponent<EditGroupRolesPropsInterface> = (
                 totalRoleList={ initialSelectedRolesOptions }
                 emptyRolesListPlaceholder={ getPlaceholders() }
             />
-        </>
+        </EmphasizedSegment>
     );
 };
 

--- a/apps/console/src/features/roles/components/readonly-role-list.tsx
+++ b/apps/console/src/features/roles/components/readonly-role-list.tsx
@@ -46,9 +46,10 @@ interface ReadOnlyRoleListProps extends LoadableComponentInterface, Identifiable
 }
 
 /**
- * List component for Role Management list
+ * A read only component to display a list of roles. Supports pagination, searching by role name and filtering by
+ * role audience.
  *
- * @param props - contains the role list as a prop to populate
+ * @returns ReadOnlyRoleList component.
  */
 export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = (
     props: ReadOnlyRoleListProps
@@ -69,7 +70,6 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
     const [ listOffset, setListOffset ] = useState<number>(0);
     const [ roleNameSearchQuery, setRoleNameSearchQuery ] = useState<string>(undefined);
     const [ roleAudienceFilter, setRoleAudienceFilter ] = useState<string>(undefined);
-    const [ triggerClearQuery, setTriggerClearQuery ] = useState<boolean>(false);
 
     /**
      * Filter options for the roles list.
@@ -127,11 +127,21 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
         setFinalRoleList(getPaginatedRoleList(filteredRoleList));
     }, [ listOffset, listItemLimit, filteredRoleList ]);
 
+    /**
+     * Handles the dropdown change event of the items per page dropdown.
+     * @param event - Mouse event.
+     * @param data - Data from the selected dropdown option.
+     */
     const handleItemsPerPageDropdownChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
 
         setListItemLimit(data.value as number);
     };
 
+    /**
+     * Handles the pagination change event.
+     * @param event - Mouse event.
+     * @param data - Data from the selected dropdown option.
+     */
     const handlePaginationChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
 
         const activePage: number = data?.activePage as number ?? 1;
@@ -139,12 +149,20 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
         setListOffset((activePage - 1) * listItemLimit);
     };
 
+    /**
+     * Takes a list of roles and returns a paginated list according to the list offset and the list item limit.
+     * @param roleListToPaginate - List of roles to paginate.
+     * @returns Paginated list of roles.
+     */
     const getPaginatedRoleList = (roleListToPaginate: RolesMemberInterface[]): RolesMemberInterface[] => {
 
         return roleListToPaginate?.length >= 0 ? roleListToPaginate.slice(listOffset, listOffset + listItemLimit) : [];
     };
 
-
+    /**
+     * Handles the search role by name event.
+     * @param query - Search query.
+     */
     const handleSearchByRoleName = (query: string) => {
 
         setListOffset(0);
@@ -152,6 +170,11 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
         setRoleNameSearchQuery(query);
     };
 
+    /**
+     * Handles the filter by role audience event.
+     * @param event - Mouse event.
+     * @param data - Data from the selected dropdown option.
+     */
     const handleFilterByRoleAudience = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
 
         setListOffset(0);
@@ -160,10 +183,11 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
     };
 
     /**
-     * Shows list placeholders.
+     * Shows the placeholders when the role list is empty or when there are no matching results for the specified role
+     * name and the role audience combination.
      */
     const showPlaceholders = (): ReactElement => {
-        // When the search returns empty.
+
         if ((roleNameSearchQuery || roleAudienceFilter) && finalRoleList?.length === 0) {
             return (
                 <EmptyPlaceholder
@@ -336,5 +360,5 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
  * Default props for the component.
  */
 ReadOnlyRoleList.defaultProps = {
-    "data-componentid": "role-mgt-roles-list"
+    "data-componentid": "read-only-roles-list"
 };

--- a/apps/console/src/features/roles/components/readonly-role-list.tsx
+++ b/apps/console/src/features/roles/components/readonly-role-list.tsx
@@ -63,6 +63,7 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
     const { t } = useTranslation();
     const [ listItemLimit, setListItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);
     const [ isLoading, setIsLoading ] = useState<boolean>(true);
+    const [ resetPagination, setResetPagination ] = useState<boolean>(false);
     const [ finalRoleList, setFinalRoleList ] = useState<RolesMemberInterface[]>(undefined);
     const [ filteredRoleList, setFilteredRoleList ] = useState<RolesMemberInterface[]>(undefined);
     const [ listOffset, setListOffset ] = useState<number>(0);
@@ -146,12 +147,14 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
     const handleSearchByRoleName = (query: string) => {
 
         setListOffset(0);
+        setResetPagination(true);
         setRoleNameSearchQuery(query);
     };
 
     const handleFilterByRoleAudience = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
 
         setListOffset(0);
+        setResetPagination(true);
         setRoleAudienceFilter(data.value as string);
     };
 
@@ -316,6 +319,7 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
             totalPages={ Math.ceil(filteredRoleList?.length / listItemLimit) }
             totalListSize={ filteredRoleList?.length }
             isLoading={ isLoading }
+            resetPagination={ resetPagination }
         >
             <DataTable<RolesMemberInterface>
                 loadingStateOptions={ { imageType: "square" } }

--- a/apps/console/src/features/roles/components/readonly-role-list.tsx
+++ b/apps/console/src/features/roles/components/readonly-role-list.tsx
@@ -22,13 +22,13 @@ import {
     AppAvatar,
     DataTable,
     EmptyPlaceholder,
-    LinkButton,
     ListLayout,
+    TableActionsInterface,
     TableColumnInterface
 } from "@wso2is/react-components";
 import React, { ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Dropdown, DropdownItemProps, DropdownProps, Header, Label } from "semantic-ui-react";
+import { Dropdown, DropdownItemProps, DropdownProps, Header, Label, SemanticICONS } from "semantic-ui-react";
 import { AdvancedSearchWithBasicFilters, UIConstants, getEmptyPlaceholderIllustrations } from "../../core";
 import { RoleAudienceTypes } from "../constants";
 
@@ -159,12 +159,6 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
         setRoleAudienceFilter(data.value as string);
     };
 
-    const handleSearchQueryClear = () => {
-
-        setTriggerClearQuery(true);
-        setRoleNameSearchQuery(null);
-    };
-
     /**
      * Shows list placeholders.
      */
@@ -260,6 +254,18 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
         ];
     };
 
+    /**
+     * Resolves data table actions.
+     */
+    const resolveTableActions = (): TableActionsInterface[] => {
+        return [
+            {
+                icon: (): SemanticICONS => "eye",
+                onClick: (): void => { return;},
+                popupText: (): string => t("common:view"),
+                renderer: "semantic-icon"
+            } ];
+    };
 
     return (
         <ListLayout
@@ -316,6 +322,7 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
             <DataTable<RolesMemberInterface>
                 loadingStateOptions={ { imageType: "square" } }
                 columns={ resolveTableColumns() }
+                actions={ resolveTableActions() }
                 data={ finalRoleList }
                 onRowClick={ () => { return; } }
                 placeholders={ showPlaceholders() }

--- a/apps/console/src/features/roles/components/readonly-role-list.tsx
+++ b/apps/console/src/features/roles/components/readonly-role-list.tsx
@@ -100,7 +100,7 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
 
         setFilteredRoleList(totalRoleList);
         setIsLoading(false);
-    }, [ totalRoleList, triggerClearQuery ]);
+    }, [ totalRoleList ]);
 
     useEffect(() => {
 
@@ -128,14 +128,15 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
     }, [ listOffset, listItemLimit, filteredRoleList ]);
 
     const handleItemsPerPageDropdownChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
+
         setListItemLimit(data.value as number);
     };
 
     const handlePaginationChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
+
         const activePage: number = data?.activePage as number ?? 1;
 
         setListOffset((activePage - 1) * listItemLimit);
-
     };
 
     const getPaginatedRoleList = (roleListToPaginate: RolesMemberInterface[]): RolesMemberInterface[] => {
@@ -159,6 +160,7 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
     };
 
     const handleSearchQueryClear = () => {
+
         setTriggerClearQuery(true);
         setRoleNameSearchQuery(null);
     };
@@ -297,7 +299,6 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
                     placeholder={ t("console:manage.features.roles.advancedSearch.placeholder") }
                     defaultSearchAttribute="displayName"
                     defaultSearchOperator= { DEFAULT_SEARCH_OPERATOR }
-                    triggerClearQuery={ triggerClearQuery }
                 />
             ) }
             listItemLimit={ listItemLimit }

--- a/apps/console/src/features/roles/components/readonly-role-list.tsx
+++ b/apps/console/src/features/roles/components/readonly-role-list.tsx
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AccessControlConstants, Show } from "@wso2is/access-control";
+import {
+    IdentifiableComponentInterface,
+    LoadableComponentInterface,
+    RolesInterface
+} from "@wso2is/core/models";
+import { RolesMemberInterface } from "@wso2is/core/models";
+import {
+    AnimatedAvatar,
+    AppAvatar,
+    DataTable,
+    EmptyPlaceholder,
+    LinkButton, ListLayout,
+    PrimaryButton,
+    TableActionsInterface,
+    TableColumnInterface
+} from "@wso2is/react-components";
+import React, { ReactElement, ReactNode, SyntheticEvent, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { DropdownProps, Header, Icon, Label, SemanticICONS } from "semantic-ui-react";
+import { UIConstants } from "../../core";
+import { AdvancedSearchWithBasicFilters } from "../../core/components/advanced-search-with-basic-filters";
+import { getEmptyPlaceholderIllustrations } from "../../core/configs/ui";
+import { RoleAudienceTypes } from "../constants/role-constants";
+
+interface ReadOnlyRoleListProps extends LoadableComponentInterface, IdentifiableComponentInterface {
+    /**
+     * Roles list.
+     */
+    totalRoleList: RolesMemberInterface[];
+    /**
+     * Callback for the search query clear action.
+     */
+    onSearchQueryClear?: () => void;
+    /**
+     * Search query for the list.
+     */
+    searchQuery?: string;
+    /**
+     * Is the current org a sub org.
+     */
+    isSubOrg?: boolean;
+}
+
+/**
+ * List component for Role Management list
+ *
+ * @param props - contains the role list as a prop to populate
+ */
+export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = (
+    props: ReadOnlyRoleListProps
+): ReactElement => {
+
+    const {
+        isSubOrg,
+        onSearchQueryClear,
+        totalRoleList,
+        searchQuery,
+        [ "data-componentid" ]: componentId
+    } = props;
+
+    const { t } = useTranslation();
+    const [ listItemLimit, setListItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);
+    const [ isLoading, setIsLoading ] = useState<boolean>(true);
+    const [ roleList, setRoleList ] = useState<RolesMemberInterface[]>(undefined);
+    const [ listOffset, setListOffset ] = useState<number>(0);
+
+    useEffect(() => {
+        if (totalRoleList.length === 0) {
+            return;
+        }
+
+        setRoleList(getPaginatedRoleList());
+        setIsLoading(false);
+    }, [ totalRoleList ]);
+
+
+    useEffect(() => {
+        setRoleList(getPaginatedRoleList());
+    }, [ listOffset, listItemLimit ]);
+
+
+    const handleItemsPerPageDropdownChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
+        setListItemLimit(data.value as number);
+    };
+
+    const handlePaginationChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
+        const activePage: number = data?.activePage as number ?? 1;
+
+        // setCurrentPage(activePage);
+        setListOffset((activePage - 1) * listItemLimit);
+
+    };
+
+    const getPaginatedRoleList = (): RolesMemberInterface[] => {
+        // return totalRoleList.slice((currentPage - 1) * listItemLimit, currentPage * listItemLimit);
+        return totalRoleList.slice(listOffset, listOffset + listItemLimit);
+    };
+
+    /**
+     * Shows list placeholders.
+     */
+    const showPlaceholders = (): ReactElement => {
+        // When the search returns empty.
+        if (searchQuery && totalRoleList?.length === 0) {
+            return (
+                <EmptyPlaceholder
+                    data-componentid={ `${ componentId }-search-empty-placeholder` }
+                    action={ (
+                        <LinkButton
+                            data-componentid={ `${ componentId }-search-empty-placeholder-clear-button` }
+                            onClick={ onSearchQueryClear }
+                        >
+                            { t("console:manage.features.roles.list.emptyPlaceholders.search.action") }
+                        </LinkButton>
+                    ) }
+                    image={ getEmptyPlaceholderIllustrations().emptySearch }
+                    imageSize="tiny"
+                    title={ t("console:manage.features.roles.list.emptyPlaceholders.search.title") }
+                    subtitle={ [
+                        t("console:manage.features.roles.list.emptyPlaceholders.search.subtitles.0",
+                            { searchQuery: searchQuery }),
+                        t("console:manage.features.roles.list.emptyPlaceholders.search.subtitles.1")
+                    ] }
+                />
+            );
+        }
+
+        if (totalRoleList?.length === 0) {
+            return (
+                <EmptyPlaceholder
+                    data-componentid={ `${ componentId }-empty-list-empty-placeholder` }
+                    action={ !isSubOrg && (
+                        <Show when={ AccessControlConstants.ROLE_WRITE }>
+                        </Show>
+                    ) }
+                    image={ getEmptyPlaceholderIllustrations().newList }
+                    imageSize="tiny"
+                    title={ !isSubOrg && t("console:manage.features.roles.list.emptyPlaceholders.emptyRoleList.title",
+                        { type: "role" }) }
+                    subtitle={ isSubOrg
+                        ? [
+                            t("console:manage.features.roles.list.emptyPlaceholders.emptyRoleList.subtitles.0",
+                                { type: "roles" })
+                        ]
+                        : [
+                            t("console:manage.features.roles.list.emptyPlaceholders.emptyRoleList.subtitles.0",
+                                { type: "roles" }),
+                            t("console:manage.features.roles.list.emptyPlaceholders.emptyRoleList.subtitles.1",
+                                { type: "role" }),
+                            t("console:manage.features.roles.list.emptyPlaceholders.emptyRoleList.subtitles.2",
+                                { type: "role" })
+                        ]
+                    }
+                />
+            );
+        }
+
+        return null;
+    };
+
+    /**
+     * Resolves data table columns.
+     */
+    const resolveTableColumns = (): TableColumnInterface[] => {
+        return [
+            {
+                allowToggleVisibility: false,
+                dataIndex: "name",
+                id: "name",
+                key: "name",
+                render: (role: RolesMemberInterface): ReactNode => (
+                    <Header
+                        image
+                        as="h6"
+                        className="header-with-icon"
+                        data-componentid={ `${ componentId }-item-heading` }
+                    >
+                        <AppAvatar
+                            image={ (
+                                <AnimatedAvatar
+                                    name={ role.display }
+                                    size="mini"
+                                    data-componentid={ `${ componentId }-item-image-inner` }
+                                />
+                            ) }
+                            size="mini"
+                            spaced="right"
+                            data-componentid={ `${ componentId }-item-image` }
+                        />
+                        <Header.Content>
+                            { role?.display }
+                        </Header.Content>
+                    </Header>
+                ),
+                title: t("console:manage.features.roles.list.columns.name")
+            },
+            {
+                allowToggleVisibility: false,
+                dataIndex: "audience",
+                id: "audience",
+                key: "audience",
+                render: (role: RolesMemberInterface) => (
+                    <Label size="mini">
+                        { role.audienceType }
+                        {
+                            role.audienceType.toUpperCase() === RoleAudienceTypes.APPLICATION
+                                ? ` | ${role.audienceDisplay} `
+                                : ""
+                        }
+                    </Label>
+                ),
+                title: (
+                    <div className="pl-3">
+                        { t("console:manage.features.roles.list.columns.audience") }
+                    </div>
+                )
+            },
+            {
+                allowToggleVisibility: false,
+                dataIndex: "action",
+                id: "actions",
+                key: "actions",
+                textAlign: "right",
+                title: null
+            }
+        ];
+    };
+
+
+    return (
+        <ListLayout
+            advancedSearch={ (
+                <AdvancedSearchWithBasicFilters
+                    data-componentid={ `${componentId}-list-advanced-search` }
+                    onFilter={ () => {console.log("filter");}  }
+                    filterAttributeOptions={ [
+                        {
+                            key: 0,
+                            text: t("console:manage.features.roles.list.filterAttirbutes.name"),
+                            value: "displayName"
+                        },
+                        {
+                            key: 1,
+                            text: t("console:manage.features.roles.list.filterAttirbutes.audience"),
+                            value: "audience.type"
+                        }
+                    ] }
+                    filterAttributePlaceholder={
+                        t("console:manage.features.roles.advancedSearch.form.inputs.filterAttribute." +
+                            "placeholder")
+                    }
+                    filterConditionsPlaceholder={
+                        t("console:manage.features.roles.advancedSearch.form.inputs.filterCondition" +
+                            ".placeholder")
+                    }
+                    filterValuePlaceholder={
+                        t("console:manage.features.roles.advancedSearch.form.inputs.filterValue" +
+                            ".placeholder")
+                    }
+                    placeholder={ t("console:manage.features.roles.advancedSearch.placeholder") }
+                    defaultSearchAttribute="displayName"
+                    defaultSearchOperator="co"
+                    // triggerClearQuery={ () => {console.log("clear query");} }
+                />
+            ) }
+            currentListSize={ roleList?.length }
+            listItemLimit={ listItemLimit }
+            onItemsPerPageDropdownChange={ handleItemsPerPageDropdownChange }
+            onPageChange={ handlePaginationChange }
+            // showTopActionPanel={ (rolesList?.totalResults > 0 || filterBy?.length !== 0) }
+            showPagination={ totalRoleList?.length > 0 }
+            totalPages={ Math.ceil(totalRoleList?.length / listItemLimit) }
+            totalListSize={ totalRoleList?.length }
+            isLoading={ isLoading }
+        >
+            <DataTable<RolesMemberInterface>
+                loadingStateOptions={ { imageType: "square" } }
+                columns={ resolveTableColumns() }
+                data={ roleList }
+                onRowClick={ () => { return; } }
+                placeholders={ showPlaceholders() }
+                data-componentid={ componentId }
+            />
+        </ListLayout>
+    );
+};
+
+/**
+ * Default props for the component.
+ */
+ReadOnlyRoleList.defaultProps = {
+    "data-componentid": "role-mgt-roles-list"
+};

--- a/apps/console/src/features/roles/components/readonly-role-list.tsx
+++ b/apps/console/src/features/roles/components/readonly-role-list.tsx
@@ -170,25 +170,16 @@ export const ReadOnlyRoleList: React.FunctionComponent<ReadOnlyRoleListProps> = 
      */
     const showPlaceholders = (): ReactElement => {
         // When the search returns empty.
-        if (roleNameSearchQuery && finalRoleList?.length === 0) {
+        if ((roleNameSearchQuery || roleAudienceFilter) && finalRoleList?.length === 0) {
             return (
                 <EmptyPlaceholder
                     data-componentid={ `${ componentId }-search-empty-placeholder` }
-                    action={ (
-                        <LinkButton
-                            data-componentid={ `${ componentId }-search-empty-placeholder-clear-button` }
-                            onClick={ handleSearchQueryClear }
-                        >
-                            { t("console:manage.features.roles.list.emptyPlaceholders.search.action") }
-                        </LinkButton>
-                    ) }
                     image={ getEmptyPlaceholderIllustrations().emptySearch }
                     imageSize="tiny"
-                    title={ t("console:manage.features.roles.list.emptyPlaceholders.search.title") }
+                    title={ t("console:manage.features.roles.readOnlyList.emptyPlaceholders.searchAndFilter.title") }
                     subtitle={ [
-                        t("console:manage.features.roles.list.emptyPlaceholders.search.subtitles.0",
-                            { searchQuery: roleNameSearchQuery }),
-                        t("console:manage.features.roles.list.emptyPlaceholders.search.subtitles.1")
+                        t("console:manage.features.roles.readOnlyList.emptyPlaceholders.searchAndFilter.subtitles.0"),
+                        t("console:manage.features.roles.readOnlyList.emptyPlaceholders.searchAndFilter.subtitles.1")
                     ] }
                 />
             );

--- a/apps/console/src/features/users/components/user-roles-list.scss
+++ b/apps/console/src/features/users/components/user-roles-list.scss
@@ -1,0 +1,5 @@
+.list-user-roles-section {
+    .ui.table thead th {
+        background: transparent;
+    }
+}

--- a/apps/console/src/features/users/components/user-roles-list.scss
+++ b/apps/console/src/features/users/components/user-roles-list.scss
@@ -1,3 +1,21 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 .list-user-roles-section {
     .ui.table thead th {
         background: transparent;

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -41,7 +41,11 @@ import { AutoCompleteRenderOption } from "./user-common-components/auto-complete
 import { RenderChip } from "./user-common-components/render-chip";
 import { AppState } from "../../core";
 import { getEmptyPlaceholderIllustrations } from "../../core/configs/ui";
-import { APPLICATION_DOMAIN, DOMAIN_SEPARATOR, INTERNAL_DOMAIN } from "../../roles/constants";
+import { APPLICATION_DOMAIN, DOMAIN_SEPARATOR, INTERNAL_DOMAIN, RoleAudienceTypes } from "../../roles/constants";
+import { Grid, Label, Table } from "semantic-ui-react";
+import RolesList from "../../application-roles/components/roles-list";
+import { RoleList } from "../../roles/components/role-list";
+import { ReadOnlyRoleList } from "../../roles/components/readonly-role-list";
 
 interface UserRoleEditPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -60,7 +64,6 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
 
     const [ initialSelectedRolesOptions, setInitialSelectedRolesOptions ] = useState<RolesMemberInterface[]>([]);
     const [ activeOption, setActiveOption ] = useState<RolesMemberInterface>(undefined);
-    const [ showEmptyRolesListPlaceholder, setShowEmptyRolesListPlaceholder ] = useState<boolean>(false);
 
     const isGroupAndRoleSeparationEnabled: boolean = useSelector((state: AppState) => 
         state?.config?.ui?.isGroupAndRoleSeparationEnabled);
@@ -79,8 +82,6 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
 
         if (userRoles?.length > 0) {
             setInitialSelectedRolesOptions(userRoles);
-        } else {
-            setShowEmptyRolesListPlaceholder(true);
         }
     }, [ user ]);
 
@@ -118,74 +119,25 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
      * @returns place holder components
      */
     const getPlaceholders = () => {
-        if (showEmptyRolesListPlaceholder) {
-            return (
-                <EmptyPlaceholder
-                    subtitle={ 
-                        [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
-                            ".subtitles") ]
-                    }
-                    title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
-                        ".title") }
-                    image={ getEmptyPlaceholderIllustrations().emptyList }
-                    imageSize="tiny"
-                />
-            );
-        }
+        return (
+            <EmptyPlaceholder
+                subtitle={ 
+                    [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
+                        ".subtitles") ]
+                }
+                title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
+                    ".title") }
+                image={ getEmptyPlaceholderIllustrations().emptyList }
+                imageSize="tiny"
+            />
+        );
     };
 
     return (
-        <EmphasizedSegment padded="very">
-            <Heading as="h4">
-                { t("console:manage.features.user.updateUser.roles.editRoles.heading") }
-            </Heading>
-            <Heading subHeading ellipsis as="h6">
-                { t("console:manage.features.user.updateUser.roles.editRoles.subHeading") }
-            </Heading>
-            {
-                showEmptyRolesListPlaceholder
-                    ? getPlaceholders()
-                    : (
-                        <Autocomplete
-                            multiple
-                            disableCloseOnSelect
-                            options={ initialSelectedRolesOptions }
-                            value={ initialSelectedRolesOptions }
-                            getOptionLabel={ (role: RolesMemberInterface) => role.display }
-                            renderInput={ (params: AutocompleteRenderInputParams) => (
-                                <TextField
-                                    { ...params }
-                                    placeholder= { t("console:manage.features.user.updateUser.roles.editRoles" + 
-                                        ".searchPlaceholder") }
-                                />
-                            ) }
-                            renderTags={ (
-                                value: RolesMemberInterface[], 
-                                getTagProps: AutocompleteRenderGetTagProps
-                            ) => value.map((option: RolesMemberInterface, index: number) => (
-                                <RenderChip 
-                                    { ...getTagProps({ index }) }
-                                    key={ index }
-                                    primaryText={ option.display }
-                                    option={ option }
-                                    activeOption={ activeOption }
-                                    setActiveOption={ setActiveOption }
-                                    onDelete={ null }
-                                />
-                            )) }
-                            renderOption={ (
-                                props: HTMLAttributes<HTMLLIElement>, 
-                                option: RolesMemberInterface
-                            ) => (
-                                <AutoCompleteRenderOption
-                                    displayName={ option.display }
-                                    renderOptionProps={ props }
-                                />
-                            ) }
-                        />
-                    )
-            }
-        </EmphasizedSegment>
+        <ReadOnlyRoleList
+            totalRoleList={ initialSelectedRolesOptions }
+            emptyRolesListPlaceholder={ getPlaceholders() }
+        />
     );
 };
 

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -16,36 +16,25 @@
  * under the License.
  */
 
-import Autocomplete, {  
-    AutocompleteRenderGetTagProps, 
-    AutocompleteRenderInputParams 
-} from "@oxygen-ui/react/Autocomplete";
-import TextField from "@oxygen-ui/react/TextField";
-import { 
-    IdentifiableComponentInterface, 
-    ProfileInfoInterface, 
-    RoleGroupsInterface, 
-    RolesMemberInterface 
+import {
+    IdentifiableComponentInterface,
+    ProfileInfoInterface,
+    RoleGroupsInterface,
+    RolesMemberInterface
 } from "@wso2is/core/models";
-import { EmphasizedSegment, EmptyPlaceholder, Heading } from "@wso2is/react-components";
+import { EmptyPlaceholder, Heading } from "@wso2is/react-components";
 import React, {
     FunctionComponent,
-    HTMLAttributes,
     ReactElement,
     useEffect,
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { AutoCompleteRenderOption } from "./user-common-components/auto-complete-render-option";
-import { RenderChip } from "./user-common-components/render-chip";
-import { AppState } from "../../core";
-import { getEmptyPlaceholderIllustrations } from "../../core/configs/ui";
-import { APPLICATION_DOMAIN, DOMAIN_SEPARATOR, INTERNAL_DOMAIN, RoleAudienceTypes } from "../../roles/constants";
-import { Divider, Grid, Label, Table } from "semantic-ui-react";
-import RolesList from "../../application-roles/components/roles-list";
-import { RoleList } from "../../roles/components/role-list";
+import { Divider } from "semantic-ui-react";
+import { AppState, getEmptyPlaceholderIllustrations } from "../../core";
 import { ReadOnlyRoleList } from "../../roles/components/readonly-role-list";
+import { APPLICATION_DOMAIN, DOMAIN_SEPARATOR, INTERNAL_DOMAIN } from "../../roles/constants";
 
 interface UserRoleEditPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -63,9 +52,7 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
     const { t } = useTranslation();
 
     const [ initialSelectedRolesOptions, setInitialSelectedRolesOptions ] = useState<RolesMemberInterface[]>([]);
-    const [ activeOption, setActiveOption ] = useState<RolesMemberInterface>(undefined);
-
-    const isGroupAndRoleSeparationEnabled: boolean = useSelector((state: AppState) => 
+    const isGroupAndRoleSeparationEnabled: boolean = useSelector((state: AppState) =>
         state?.config?.ui?.isGroupAndRoleSeparationEnabled);
 
     /**
@@ -73,7 +60,7 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
      */
     useEffect(() => {
         let userRoles: RolesMemberInterface[];
-        
+
         if (isGroupAndRoleSeparationEnabled && user?.roles?.length > 0) {
             userRoles = user.roles;
         } else {
@@ -88,17 +75,17 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
     /**
      * When Group and Role Separation is enabled, the groups section of the user will contain both roles and groups.
      * This method can be used to extract roles from the groups section.
-     * 
+     *
      * @param groups - Groups of the user
      * @returns Roles of the user
      */
     const extractUserRolesFromGroups = (groups: RoleGroupsInterface[]): RolesMemberInterface[] => {
 
         const userRoles: RolesMemberInterface[] = [];
-        
+
         groups?.forEach((group: RoleGroupsInterface) => {
             const [ domain, displayName ]: string[] = group?.display?.split(DOMAIN_SEPARATOR);
-            
+
             if (domain && displayName && [ APPLICATION_DOMAIN, INTERNAL_DOMAIN ].includes(domain)) {
                 userRoles.push({
                     $ref: group.$ref,
@@ -109,23 +96,23 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
                 });
             }
         });
-        
+
         return userRoles;
     };
 
     /**
-     * Get the place holder components.
-     * 
+     * Get the placeholder components.
+     *
      * @returns place holder components
      */
     const getPlaceholders = () => {
         return (
             <EmptyPlaceholder
-                subtitle={ 
-                    [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
+                subtitle={
+                    [ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" +
                         ".subtitles") ]
                 }
-                title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" + 
+                title={ t("console:manage.features.user.updateUser.roles.editRoles.placeholders.emptyPlaceholder" +
                     ".title") }
                 image={ getEmptyPlaceholderIllustrations().emptyList }
                 imageSize="tiny"

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -42,7 +42,7 @@ import { RenderChip } from "./user-common-components/render-chip";
 import { AppState } from "../../core";
 import { getEmptyPlaceholderIllustrations } from "../../core/configs/ui";
 import { APPLICATION_DOMAIN, DOMAIN_SEPARATOR, INTERNAL_DOMAIN, RoleAudienceTypes } from "../../roles/constants";
-import { Grid, Label, Table } from "semantic-ui-react";
+import { Divider, Grid, Label, Table } from "semantic-ui-react";
 import RolesList from "../../application-roles/components/roles-list";
 import { RoleList } from "../../roles/components/role-list";
 import { ReadOnlyRoleList } from "../../roles/components/readonly-role-list";
@@ -134,10 +134,20 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
     };
 
     return (
-        <ReadOnlyRoleList
-            totalRoleList={ initialSelectedRolesOptions }
-            emptyRolesListPlaceholder={ getPlaceholders() }
-        />
+
+        <>
+            <Heading as="h4">
+                { t("console:manage.features.user.updateUser.roles.editRoles.heading") }
+            </Heading>
+            <Heading subHeading ellipsis as="h6">
+                { t("console:manage.features.user.updateUser.roles.editRoles.subHeading") }
+            </Heading>
+            <Divider hidden/>
+            <ReadOnlyRoleList
+                totalRoleList={ initialSelectedRolesOptions }
+                emptyRolesListPlaceholder={ getPlaceholders() }
+            />
+        </>
     );
 };
 

--- a/apps/console/src/features/users/components/user-roles-list.tsx
+++ b/apps/console/src/features/users/components/user-roles-list.tsx
@@ -22,7 +22,7 @@ import {
     RoleGroupsInterface,
     RolesMemberInterface
 } from "@wso2is/core/models";
-import { EmptyPlaceholder, Heading } from "@wso2is/react-components";
+import { EmphasizedSegment, EmptyPlaceholder, Heading } from "@wso2is/react-components";
 import React, {
     FunctionComponent,
     ReactElement,
@@ -35,6 +35,7 @@ import { Divider } from "semantic-ui-react";
 import { AppState, getEmptyPlaceholderIllustrations } from "../../core";
 import { ReadOnlyRoleList } from "../../roles/components/readonly-role-list";
 import { APPLICATION_DOMAIN, DOMAIN_SEPARATOR, INTERNAL_DOMAIN } from "../../roles/constants";
+import "./user-roles-list.scss";
 
 interface UserRoleEditPropsInterface extends IdentifiableComponentInterface {
     /**
@@ -121,8 +122,7 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
     };
 
     return (
-
-        <>
+        <EmphasizedSegment padded="very" className="list-user-roles-section">
             <Heading as="h4">
                 { t("console:manage.features.user.updateUser.roles.editRoles.heading") }
             </Heading>
@@ -134,7 +134,7 @@ export const UserRolesList: FunctionComponent<UserRoleEditPropsInterface> = (
                 totalRoleList={ initialSelectedRolesOptions }
                 emptyRolesListPlaceholder={ getPlaceholders() }
             />
-        </>
+        </EmphasizedSegment>
     );
 };
 

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -5736,6 +5736,11 @@ export interface ConsoleNS {
                         audience: string;
                     };
                 };
+                readOnlyList: {
+                    emptyPlaceholders: {
+                        searchAndFilter: Placeholder;
+                    }
+                }
                 notifications: {
                     deleteRole: Notification;
                     fetchRoles: Notification;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -10851,6 +10851,17 @@ export const console: ConsoleNS = {
                         audience: "Role Audience"
                     }
                 },
+                readOnlyList: {
+                    emptyPlaceholders: {
+                        searchAndFilter: {
+                            subtitles: {
+                                0: "We couldn't find any results for the specified role name and audience combination.",
+                                1: "Please try a different combination."
+                            },
+                            title: "No results found"
+                        }
+                    }
+                },
                 notifications: {
                     createPermission: {
                         error: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -9083,6 +9083,17 @@ export const console: ConsoleNS = {
                         audience: "Rôle public"
                     }
                 },
+                readOnlyList: {
+                    emptyPlaceholders: {
+                        searchAndFilter: {
+                            subtitles: {
+                                0: "Nous n'avons trouvé aucun résultat pour la combinaison de nom de rôle et d'audience spécifiée.",
+                                1: "Veuillez essayer une combinaison différente."
+                            },
+                            title: "Aucun résultat trouvé"
+                        }
+                    }
+                },
                 notifications: {
                     createPermission: {
                         error: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -8890,6 +8890,17 @@ export const console: ConsoleNS = {
                         audience: "භූමිකාව ප්රේක්ෂකයින්"
                     }
                 },
+                readOnlyList: {
+                    emptyPlaceholders: {
+                        searchAndFilter: {
+                            subtitles: {
+                                0: "අපට වත්මන් භූමිකාවේ නම සහ ප්‍රේක්ෂක සංයෝජනය සඳහා ප්‍රතිඵල කිසිවක් සොයාගත නොහැකි විය.",
+                                1: "කරුණාකර වෙනස් සංයෝජනයක් උත්සාහ කරන්න."
+                            },
+                            title: "ප්‍රතිඵල හමු නොවීය"
+                        }
+                    }
+                },
                 notifications: {
                     createPermission: {
                         error: {


### PR DESCRIPTION
### Purpose
This PR:

- Adds a new `ReadOnlyRoleList` component that can be used to render a read only list of roles and have support for pagination, search by role name and filter by role audience.
- Use the above mentioned `ReadOnlyRoleList` component in the roles tabs of  **Edit Users** and **Edit Groups** sections to make them consistent.

#### Edit Groups > Roles
<img width="1504" alt="image" src="https://github.com/wso2/identity-apps/assets/27700915/7c0f8197-cc27-4196-8571-999563e21d21">

#### Edit Users > Roles
<img width="1490" alt="image" src="https://github.com/wso2/identity-apps/assets/27700915/0696164c-ddb7-4069-839e-d811fc582bbc">

### Demo
https://github.com/wso2/identity-apps/assets/27700915/dd44331d-9720-421b-9e8b-aab5fa853bfe

### Related Issues
- https://github.com/wso2/product-is/issues/18153

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
