### PR TITLE
Fix resend confirmation mail failure issue in self registration flow

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/init-url.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/init-url.jsp
@@ -14,11 +14,11 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
 <%
-    String TENANT_DOMAIN = "tenantDomain";
+    String TENANT_DOMAIN_KEY = "tenantDomain";
     String TENANT_DOMAIN_SHORT = "t";
     String USER_TENANT_DOMAIN_SHORT = "ut";
     String SERVICE_PROVIDER_NAME_SHORT = "sp";
-    
+
     String identityServerEndpointContextParam = application.getInitParameter("IdentityServerEndpointContextURL");
     String samlssoURL = "../samlsso";
     String commonauthURL = "../commonauth";
@@ -27,7 +27,7 @@
     String openidServerURL = "../openidserver";
     String logincontextURL = "../logincontext";
     String longwaitstatusURL = "/longwaitstatus";
-    
+
     String tenantDomain;
     String userTenantDomain;
     String tenantForTheming;
@@ -75,9 +75,9 @@
             }
         }
     } else {
-        tenantDomain = request.getParameter(TENANT_DOMAIN);
-        if (StringUtils.isBlank(tenantDomain) && StringUtils.isNotBlank((String) request.getAttribute(TENANT_DOMAIN))) {
-            tenantDomain = (String) request.getAttribute(TENANT_DOMAIN);
+        tenantDomain = request.getParameter(TENANT_DOMAIN_KEY);
+        if (StringUtils.isBlank(tenantDomain) && StringUtils.isNotBlank((String) request.getAttribute(TENANT_DOMAIN_KEY))) {
+            tenantDomain = (String) request.getAttribute(TENANT_DOMAIN_KEY);
         }
 
         String tenantDomainFromURL = request.getParameter(TENANT_DOMAIN_SHORT);
@@ -135,7 +135,7 @@
         identityServerEndpointContextParam = application.getInitParameter("IdentityServerEndpointContextURL");
     } else {
         identityServerEndpointContextParam = ServiceURLBuilder.create().setTenant(tenantDomain).build().getAbsolutePublicURL();
-    }    
+    }
 
     if (StringUtils.isNotBlank(identityServerEndpointContextParam)) {
 


### PR DESCRIPTION
### Purpose
- Fix resend confirmation mail failure issue in self registration flow.


### Solution Summary
"We have defined the same variable name `TENANT_DOMAIN` in basicauth.jsp[1] and init-url.jsp[2]. We have included these two JSPs in the login.jsp file, which leads to a variable conflict."

So with this fix, changed the newly introduced variable with this PR[3] in init-url.jsp to a Unique Variable Name to fix above mentioned issue.


[1] https://github.com/wso2/identity-apps/blob/dd123d67327fc4056fcd3530ceb019c1449bbc75/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp#L229
[2] https://github.com/wso2/identity-apps/blob/dd123d67327fc4056fcd3530ceb019c1449bbc75/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/init-url.jsp#L17
[3] https://github.com/wso2/identity-apps/pull/4128


### Related Issues
- https://github.com/wso2/product-is/issues/18443


