### PR TITLE
Add password fields and validations for jit provisioned users

### DIFF
--- a/.changeset/sixty-icons-tan.md
+++ b/.changeset/sixty-icons-tan.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add password feilds for jit provisioned users

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -406,13 +406,34 @@
                                            value="<%=Encode.forHtmlAttribute(username)%>"
                                            class="form-control required usrName usrNameLength">
                                 </div>
-                                <div class="field">
-                                    <input id="password" name="password" type="hidden"
-                                        value="<%=Encode.forHtmlAttribute(password)%>"
-                                        class="form-control required usrName usrNameLength">
+                                <div class="two fields">
+                                    <div id="passwordField" class="required field">
+                                        <label for="password" class="control-label">
+                                            <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Password")%>
+                                        </label>
+                                        <input id="password" name="password" type="password"
+                                            class="form-control" required>
+                                        <div class="mt-1" id="password-error-msg" hidden="hidden">
+                                            <i class="red exclamation circle fitted icon"></i>
+                                            <span class="validation-error-message" id="password-error-msg-text"></span>
+                                        </div>
+                                    </div>
+                                    <div id="confirmPasswordField" class="required field">
+                                        <label for="password2" class="control-label">
+                                            <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Confirm.password")%>
+                                        </label>
+                                        <input id="password2" name="password2" type="password" class="form-control"
+                                            data-match="reg-password" required>
+                                        <div class="mt-1" id="confirm-password-error-msg" hidden="hidden">
+                                            <i class="red exclamation circle fitted icon"></i>
+                                            <span class="validation-error-message" id="confirm-password-error-msg-text"></span>
+                                        </div>
+                                    </div>
                                 </div>
-
-
+                                <div class="mb-2" id="password-mismatch-error-msg" hidden="hidden">
+                                    <i class="red exclamation circle fitted icon"></i>
+                                    <span class="validation-error-message" id="password-mismatch-error-msg-text"></span>
+                                </div>
                                 <% Claim emailNamePII =
                                         uniquePIIs.get(IdentityManagementEndpointConstants.ClaimURIs.EMAIL_CLAIM);
                                     if (emailNamePII != null) {
@@ -807,6 +828,16 @@
         // Fires when lastname field lose focus.
         $('#lastNameUserInput').bind('blur keyup', function () {
             showLastNameValidationStatus();
+        });
+
+        // Fires when password field lose focus.
+        $('#password').bind('blur keyup', function () {
+            showPasswordValidationStatus();
+        });
+
+        // Fires when confirm password field lose focus.
+        $('#password2').bind('blur keyup', function () {
+            showConfirmPasswordValidationStatus();
         });
 
         function goBack() {
@@ -1409,6 +1440,58 @@
             }
         }
 
+        function showPasswordValidationStatus() {
+            var passwordInput = document.getElementById("password");
+            var password_error_msg = $("#password-error-msg");
+            var password_error_msg_text = $("#password-error-msg-text");
+            var password_field= $("#passwordField");
+
+            if ( passwordInput.value.trim() === "" )  {
+                password_error_msg_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "required")%>");
+                password_error_msg.show();
+                $("html, body").animate({scrollTop: password_error_msg.offset().top}, 'slow');
+                password_field.addClass("error");
+            } else {
+                // When password is accepted.
+                password_error_msg.hide();
+                password_field.removeClass("error");
+            }
+        }
+
+        function showConfirmPasswordValidationStatus() {
+            var passwordInput = document.getElementById("password");
+            var confirmPasswordInput = document.getElementById("password2");
+            var confirm_password_error_msg = $("#confirm-password-error-msg");
+            var confirm_password_error_msg_text = $("#confirm-password-error-msg-text");
+            var password_mismatch_error_msg = $("#password-mismatch-error-msg");
+            var password_mismatch_error_msg_text = $("#password-mismatch-error-msg-text");
+            var confirm_password_field= $("#confirmPasswordField");
+
+            if ( confirmPasswordInput.value.trim() === "" )  {
+                confirm_password_error_msg_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "required")%>");
+                confirm_password_error_msg.show();
+                $("html, body").animate({scrollTop: confirm_password_error_msg.offset().top}, 'slow');
+                confirm_password_field.addClass("error");
+            } else {
+                // When confirm password is accepted.
+                confirm_password_error_msg.hide();
+                confirm_password_field.removeClass("error");
+            }
+
+            if ( confirmPasswordInput.value.trim() !== passwordInput.value.trim() )  {
+                password_mismatch_error_msg_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Passwords.did.not.match.please.try.again")%>");
+                password_mismatch_error_msg.show();
+                $("html, body").animate({scrollTop: confirm_password_error_msg.offset().top}, 'slow');
+                password_field.addClass("error");
+                confirm_password_field.addClass("error");
+            } else {
+                // When passwords match.
+                password_mismatch_error_msg.hide();
+                confirm_password_field.removeClass("error");
+                password_field.removeClass("error");
+            }
+        }
+
         function validateNameFields() {
             var firstNameUserInput = document.getElementById("firstNameUserInput");
             var lastNameUserInput = document.getElementById("lastNameUserInput");
@@ -1421,13 +1504,25 @@
             return true;
         }
 
+        function validatePasswordFields() {
+            var passwordInput = document.getElementById("password");
+            var confirmPasswordInput = document.getElementById("password2");
+
+            if ( (!!passwordInput &&  passwordInput.value.trim() === "")
+                || ( !!confirmPasswordInput && confirmPasswordInput.value.trim() === ""))  {
+                return false;
+            }
+
+            return true;
+        }
+
         function changeSubmitButtonStatus() {
             var agreementChk = $("#termsCheckbox");
             var registrationBtn = $("#registrationSubmit");
             var termsCheckboxField = $("#termsCheckboxField");
 
             // Checking for empty name fields.
-            if (validateNameFields()) {
+            if (validateNameFields() && validatePasswordFields()) {
                 // Checking for consent checkbox status.
                 if (agreementChk.is(":checked")) {
                     registrationBtn.prop("disabled", false).removeClass("disabled");

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -972,6 +972,16 @@
                     }
                 }
 
+                var password = $("#password").val();
+                var password2 = $("#password2").val();
+
+                if (password !== password2) {
+                    error_msg.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
+                        "Passwords.did.not.match.please.try.again")%>");
+                    error_msg.show();
+                    $("html, body").animate({scrollTop: error_msg.offset().top}, 'slow');
+                    return false;
+                }
                 if (invalidInput) {
                     return false;
                 }
@@ -1478,7 +1488,7 @@
                 confirm_password_field.removeClass("error");
             }
 
-            if ( confirmPasswordInput.value.trim() !== passwordInput.value.trim() )  {
+            if ( confirmPasswordInput.value.trim() !== "" && confirmPasswordInput.value.trim() !== passwordInput.value.trim() )  {
                 password_mismatch_error_msg_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Passwords.did.not.match.please.try.again")%>");
                 password_mismatch_error_msg.show();
                 $("html, body").animate({scrollTop: confirm_password_error_msg.offset().top}, 'slow');
@@ -1490,6 +1500,7 @@
                 confirm_password_field.removeClass("error");
                 password_field.removeClass("error");
             }
+
         }
 
         function validateNameFields() {
@@ -1509,7 +1520,8 @@
             var confirmPasswordInput = document.getElementById("password2");
 
             if ( (!!passwordInput &&  passwordInput.value.trim() === "")
-                || ( !!confirmPasswordInput && confirmPasswordInput.value.trim() === ""))  {
+                || (!!confirmPasswordInput && confirmPasswordInput.value.trim() === "")
+                || (confirmPasswordInput.value.trim() !== passwordInput.value.trim()))  {
                 return false;
             }
 


### PR DESCRIPTION
### Purpose
> Add password fields and validations for jit-provisioned users.
<img width="1096" alt="Screenshot 2023-12-06 at 17 20 17" src="https://github.com/wso2/identity-apps/assets/27746285/0e78d10f-3c1e-4960-90d6-9f89a36eae70">

### Related Issues
- https://github.com/wso2/product-is/issues/18331

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
