### PR TITLE
Prevent a particular API resource being listed as a dropdown option when it's already being selected when creating an application role.

### DIFF
--- a/apps/console/src/features/roles/components/wizard-updated/application-role-wizard.tsx
+++ b/apps/console/src/features/roles/components/wizard-updated/application-role-wizard.tsx
@@ -118,15 +118,19 @@ export const ApplicationRoleWizard: FunctionComponent<ApplicationRoleWizardProps
         const options: DropdownProps[] = [];
 
         subscribedAPIResourcesListData?.map((apiResource: AuthorizedAPIListItemInterface) => {
-            options.push({
-                key: apiResource?.id,
-                text: apiResource?.displayName,
-                value: apiResource?.id
-            });
-        });
+            const isNotSelected: boolean = !selectedAPIResources
+                ?.find((selectedAPIResource: APIResourceInterface) => selectedAPIResource?.id === apiResource?.id);
 
+            if (isNotSelected) {
+                options.push({
+                    key: apiResource?.id,
+                    text: apiResource?.displayName,
+                    value: apiResource?.id
+                });
+            }
+        });
         setAPIResourcesListOptions(options);
-    }, [ subscribedAPIResourcesListData ]);
+    }, [ subscribedAPIResourcesListData, selectedAPIResources ]);
 
     /**
      * The following useEffect is used to handle if any error occurs while fetching API resources.
@@ -427,6 +431,7 @@ export const ApplicationRoleWizard: FunctionComponent<ApplicationRoleWizardProps
                         hint={
                             !isSubscribedAPIResourcesListLoading
                             && apiResourcesListOptions?.length === 0
+                            && selectedAPIResources?.length === 0
                             && (
                                 <Hint>
                                     <Trans


### PR DESCRIPTION
### Purpose
$subject.

https://github.com/wso2/identity-apps/assets/27700915/b615156e-0d22-4bf3-a82e-d7cdd81981e0


### Related Issues
- https://github.com/wso2/product-is/issues/18340

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
