### PR TITLE
Append tenant domain before resolving the username

### DIFF
--- a/.changeset/weak-vans-double.md
+++ b/.changeset/weak-vans-double.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Append tenant to the username before validation and JIT consent flow password validation logic refactor.

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -105,6 +105,13 @@
         tenantDomain = srtenantDomain;
     }
 
+    String tenantQualifiedUsername = username;
+    if (username.contains(IdentityManagementEndpointConstants.TENANT_DOMAIN_SEPARATOR) && tenantDomain != null) {
+        if (username.split(IdentityManagementEndpointConstants.TENANT_DOMAIN_SEPARATOR).length == 2) {
+            tenantQualifiedUsername = username + IdentityManagementEndpointConstants.TENANT_DOMAIN_SEPARATOR + tenantDomain;
+        }
+    }
+
     User user = IdentityManagementServiceUtil.getInstance().resolveUser(username, tenantDomain, isSaaSApp);
 
     if (skipSignUpEnableCheck) {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -1515,6 +1515,10 @@
         }
 
         function validatePasswordFields() {
+            var isPasswordProvisionEnabled = <%=isPasswordProvisionEnabled%>;
+            if (!isPasswordProvisionEnabled) {
+                return true;
+            }
             var passwordInput = document.getElementById("password");
             var confirmPasswordInput = document.getElementById("password2");
 


### PR DESCRIPTION
### Purpose
> When resolving user using `IdentityManagementServiceUtil.getInstance().resolveUser` method, if the username is an email, as the method uses `getTenantAwareUsername` util method, the email domain part will be assumed to be the tenant domain and it removes the email domain from the username. To fix this, the tenant domain will be added prior to the user resolving.

This is important when the associated local user of the federated user is getting resolved.

Resolves https://github.com/wso2/product-is/issues/18129