### PR TITLE
Improve validation logic and UX of Create Application Role wizard.

### DIFF
--- a/.changeset/kind-bats-dream.md
+++ b/.changeset/kind-bats-dream.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Improve validation logic and UX of Create Application Role wizard.

--- a/apps/console/src/features/roles/components/edit-role/edit-role-common/permissions-list.scss
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-common/permissions-list.scss
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.permissions-label .MuiInputLabel-asterisk {
+    color: #e53535;
+}

--- a/apps/console/src/features/roles/components/edit-role/edit-role-common/permissions-list.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-common/permissions-list.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from "react-i18next";
 import { AutoCompleteRenderOption } from "./auto-complete-render-option";
 import { RenderChip } from "./render-chip";
 import { APIResourceInterface, ScopeInterface } from "../../../models/apiResources";
+import "./permissions-list.scss";
 
 interface PermissionsListPropsInterface extends  IdentifiableComponentInterface {
     /**
@@ -101,6 +102,12 @@ export const PermissionsList: FunctionComponent<PermissionsListPropsInterface> =
                                 "permissions.placeholder") }
                             error={ isTouched && hasError }
                             helperText={ isTouched && hasError && errorMessage }
+                            label={ t("console:manage.features.roles.addRoleWizard.forms.rolePermission.permissions" +
+                                ".permissionsLabel") }
+                            InputLabelProps={ {
+                                required: true,
+                                className: "permissions-label"
+                            } }
                         />
                     ) }
                     onChange={ (event: SyntheticEvent, scopes: ScopeInterface[]) => handleScopeSelection(scopes) }

--- a/apps/console/src/features/roles/components/edit-role/edit-role-common/permissions-list.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-common/permissions-list.tsx
@@ -105,8 +105,8 @@ export const PermissionsList: FunctionComponent<PermissionsListPropsInterface> =
                             label={ t("console:manage.features.roles.addRoleWizard.forms.rolePermission.permissions" +
                                 ".permissionsLabel") }
                             InputLabelProps={ {
-                                required: true,
-                                className: "permissions-label"
+                                className: "permissions-label",
+                                required: true
                             } }
                         />
                     ) }

--- a/apps/console/src/features/roles/components/edit-role/edit-role-common/permissions-list.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-common/permissions-list.tsx
@@ -71,6 +71,7 @@ export const PermissionsList: FunctionComponent<PermissionsListPropsInterface> =
         const { t } = useTranslation();
 
         const [ activeOption, setActiveOption ] = useState<ScopeInterface>(undefined);
+        const [ isTouched, setIsTouched ] = useState<boolean>(false);
 
         /**
          * Handles the select scope action.
@@ -98,11 +99,12 @@ export const PermissionsList: FunctionComponent<PermissionsListPropsInterface> =
                             data-componentid={ `${componentId}-textfield` }
                             placeholder= { t("console:manage.features.roles.addRoleWizard.forms.rolePermission." +
                                 "permissions.placeholder") }
-                            error={ hasError }
-                            helperText={ hasError && errorMessage }
+                            error={ isTouched && hasError }
+                            helperText={ isTouched && hasError && errorMessage }
                         />
                     ) }
                     onChange={ (event: SyntheticEvent, scopes: ScopeInterface[]) => handleScopeSelection(scopes) }
+                    onClose={ () => setIsTouched(true) }
                     renderTags={ (
                         value: ScopeInterface[],
                         getTagProps: AutocompleteRenderGetTagProps

--- a/apps/console/src/features/roles/components/edit-role/edit-role-common/role-api-resources-list-item.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-common/role-api-resources-list-item.tsx
@@ -161,19 +161,7 @@ export const RoleAPIResourcesListItem: FunctionComponent<RoleAPIResourcesListIte
                                     ) } >
                                 </ListItemText>
                             ) }
-                        <ListItemText
-                            secondary={ (<>
-                                { apiResource?.identifier }
-                                <Label
-                                    pointing="left"
-                                    size="mini"
-                                    className= "client-id-label"
-                                >
-                                    { t("extensions:develop.apiResource.table.identifier.label") }
-                                </Label>
-                            </>
-                            ) } >
-                        </ListItemText>
+                        <ListItemText secondary={ apiResource?.identifier } />
                     </ListItem>
                 </AccordionSummary>
                 {

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -5531,6 +5531,7 @@ export interface ConsoleNS {
                                 validation: {
                                     empty: string;
                                 };
+                                permissionsLabel: string;
                             };
                             notes: {
                                 applicationRoles: string;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -10537,7 +10537,8 @@ export const console: ConsoleNS = {
                                 },
                                 validation: {
                                     empty: "Permissions(scopes) list cannot be empty. Select at least one permission(scope)."
-                                }
+                                },
+                                permissionsLabel: "Permissions (scopes)"
                             },
                             notes: {
                                 applicationRoles: "Only the APIs and the permissions(scopes) that are authorized in the selected application(<1>{{applicationName}}</1>) will be listed to select."

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -8763,7 +8763,8 @@ export const console: ConsoleNS = {
                                 },
                                 validation: {
                                     empty: "La liste des autorisations(lunettes) ne peut pas être vide. Sélectionnez au moins une autorisation(lunettes)."
-                                }
+                                },
+                                permissionsLabel: "Autorisations (étendues)"
                             },
                             notes: {
                                 applicationRoles: "Seules les API et les autorisations (lunettes) autorisées dans l'application sélectionnée(<1>{{applicationName}}</1>) seront répertoriées pour être sélectionnées."

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -8580,7 +8580,8 @@ export const console: ConsoleNS = {
                                 },
                                 validation: {
                                     empty: "අවසර(විෂය පද) ලැයිස්තුව හිස් විය නොහැක. අවම වශයෙන් එක් අවසරයක්වත්(විෂය පථය) තෝරන්න."
-                                }
+                                },
+                                permissionsLabel: "අවසර (විෂය පද)"
                             },
                             notes: {
                                 applicationRoles: "තෝරාගත් අයදුම්පතේ(<1>{{applicationName}}</1>) තෝරා ගැනීමට ලැයිස්තුගත කර ඇති APIs සහ විෂය පථයන් පමණක් තෝරා ගැනීමට ලැයිස්තුගත කර ඇත."


### PR DESCRIPTION
### Purpose
This PR:

- Removes the unnecessary "Identifier" label from the Create Application Role wizard.
- Adds a "Permissions(scopes)" label to the scopes dropdown to indicate its required status.
- Adds validation logic to the wizard:
    - When there are added API resources, the "Create" button will on be enabled when there is at least one scope for every API resource (Provided the other validation conditions are met).
    -  Validation error message will be displayed on the scopes dropdown if the user touches the dropdown, but doesn't set a value.

#### Demo:

https://github.com/wso2/identity-apps/assets/27700915/b739fddc-ff03-4d8c-89cf-dddd77b9d94b

### Related Issues
- https://github.com/wso2/product-is/issues/18523

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
