### PR TITLE
Disable user store attribute mapping step when there are no user stores

### DIFF
--- a/.changeset/hungry-laws-juggle.md
+++ b/.changeset/hungry-laws-juggle.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Disable userstore attribute mapping step when there are no userstores

--- a/apps/console/src/features/claims/components/add/add-local-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-local-claim.tsx
@@ -132,7 +132,7 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
 
                 setShowMapAttributes(state.length > 0 && userStoresEnabled);
             });
-        } else if (userStoreList?.length>0) {
+        } else if (userStoreList?.length > 0) {
             setShowMapAttributes(true);
         } else {
             setShowMapAttributes(false);

--- a/apps/console/src/features/claims/components/add/add-local-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-local-claim.tsx
@@ -35,6 +35,7 @@ import { AppConstants } from "../../../core/constants";
 import { history } from "../../../core/helpers";
 import { getProfileSchemas } from "../../../users/api";
 import { WizardStepInterface } from "../../../users/models";
+import { useUserStores } from "../../../userstores/api";
 import { UserStoreListItem } from "../../../userstores/models";
 import { addDialect, addExternalClaim, addLocalClaim } from "../../api";
 import { getAddLocalClaimWizardStepIcons } from "../../configs";
@@ -108,6 +109,10 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
+    const {
+        data: userStoreList
+    } = useUserStores(null);
+
     /**
      * Conditionally disable map attribute step
      * if there are no secondary user stores and
@@ -127,10 +132,12 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
 
                 setShowMapAttributes(state.length > 0 && userStoresEnabled);
             });
-        } else {
+        } else if (userStoreList?.length>0) {
             setShowMapAttributes(true);
+        } else {
+            setShowMapAttributes(false);
         }
-    }, [ hiddenUserStores ]);
+    }, [ hiddenUserStores, userStoreList ]);
 
     /**
      * Navigate to the claim edit page after adding a claim.


### PR DESCRIPTION
### Purpose
> Disable user store attribute mapping step when there are no user stores
<img width="1440" alt="Screenshot 2023-12-12 at 15 30 13" src="https://github.com/wso2/identity-apps/assets/27746285/b8f1fdb2-4cf5-45b4-9eb6-f26ecd6c8ad8">

### Related Issues
- https://github.com/wso2/product-is/issues/18186

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
