### PR TITLE
Make FE compatible with the new request and response format of `/guests/invite` endpoint

### DIFF
--- a/.changeset/tiny-monkeys-fold.md
+++ b/.changeset/tiny-monkeys-fold.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/react-components": patch
+"@wso2is/console": patch
+---
+
+Make FE compatible with the new request and response formats of /guests/invite endpoint, which allows multiple parent org user invites at once.

--- a/apps/console/src/features/console-settings/components/console-administrators/invite-new-administrator-wizard/invite-new-administrator-wizard.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/invite-new-administrator-wizard/invite-new-administrator-wizard.tsx
@@ -120,15 +120,14 @@ const InviteNewAdministratorWizard: FunctionComponent<InviteNewAdministratorWiza
                 const responseData: ParentOrgUserInvitationResult = response.data[0];
 
                 if (responseData.result.status !== ParentOrgUserInviteResultStatus.SUCCESS) {
-
-                    dispatch(addAlert({
+                    setAlert({
                         description: t(
                             "console:manage.features.invite.notifications.sendInvite.error.description",
                             { description: responseData.result.errorDescription }
                         ),
                         level: AlertLevels.ERROR,
                         message: t("console:manage.features.invite.notifications.sendInvite.error.message")
-                    }));
+                    });
 
                     return;
                 }
@@ -143,6 +142,7 @@ const InviteNewAdministratorWizard: FunctionComponent<InviteNewAdministratorWiza
                     )
                 }));
 
+                onClose(null, null);
             })
             .catch((error: AxiosError) => {
                 /**
@@ -193,9 +193,6 @@ const InviteNewAdministratorWizard: FunctionComponent<InviteNewAdministratorWiza
                         )
                     });
                 }
-            })
-            .finally(() => {
-                onClose(null, null);
             });
     };
 

--- a/apps/console/src/features/console-settings/components/console-administrators/invite-new-administrator-wizard/invite-new-administrator-wizard.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/invite-new-administrator-wizard/invite-new-administrator-wizard.tsx
@@ -112,7 +112,7 @@ const InviteNewAdministratorWizard: FunctionComponent<InviteNewAdministratorWiza
             roles: values.roles.map((role: InviteNewAdministratorWizardFormValuesRoleInterface) => role.role.id),
             usernames: [ values.username ]
         };
-        
+
         sendParentOrgUserInvite(invite)
             .then((response: AxiosResponse) => {
                 // TODO: Handle errors for each user if needed when revamping invite parent org user UI to facilitate

--- a/apps/console/src/features/console-settings/components/console-administrators/invite-new-administrator-wizard/invite-new-administrator-wizard.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/invite-new-administrator-wizard/invite-new-administrator-wizard.tsx
@@ -34,7 +34,7 @@ import { Grid, Modal, ModalProps } from "semantic-ui-react";
 import { UsersConstants } from "../../../../../extensions/components/users/constants/users";
 import { AppState } from "../../../../core/store";
 import { sendParentOrgUserInvite } from "../../../../users/components/guests/api/invite";
-import { UserInviteInterface } from "../../../../users/components/guests/models/invite";
+import { ParentOrgUserInviteInterface } from "../../../../users/components/guests/models/invite";
 import { ConsoleAdministratorOnboardingConstants } from "../../../constants/console-administrator-onboarding-constants";
 import useConsoleRoles from "../../../hooks/use-console-roles";
 import "./invite-new-administrator-wizard.scss";
@@ -104,9 +104,9 @@ const InviteNewAdministratorWizard: FunctionComponent<InviteNewAdministratorWiza
      * Handles the API resource creation.
      */
     const handleInviteNewAdministratorFormSubmit = (values: InviteNewAdministratorWizardFormValuesInterface): void => {
-        const invite: UserInviteInterface = {
+        const invite: ParentOrgUserInviteInterface = {
             roles: values.roles.map((role: InviteNewAdministratorWizardFormValuesRoleInterface) => role.role.id),
-            username: values.username
+            usernames: [ values.username ]
         };
 
         sendParentOrgUserInvite(invite)

--- a/apps/console/src/features/console-settings/components/console-administrators/invite-new-administrator-wizard/invite-new-administrator-wizard.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/invite-new-administrator-wizard/invite-new-administrator-wizard.tsx
@@ -205,7 +205,9 @@ const InviteNewAdministratorWizard: FunctionComponent<InviteNewAdministratorWiza
             <Modal.Header className="wizard-header">
                 <Typography variant="inherit">Invite Administrator</Typography>
                 <Heading as="h6">
-                    <Typography variant="inherit">Invite an existing user from your root organization as an administrator</Typography>
+                    <Typography variant="inherit">
+                        Invite an existing user from your root organization as an administrator
+                    </Typography>
                 </Heading>
             </Modal.Header>
             <Modal.Content className="content-container" scrolling>
@@ -304,9 +306,11 @@ const InviteNewAdministratorWizard: FunctionComponent<InviteNewAdministratorWiza
                                 tabIndex={ 6 }
                                 data-componentid={ `${componentId}-cancel-button` }
                                 floated="left"
-                                onClick={ (e) => onClose(e, null) }
+                                onClick={ (e: React.MouseEvent<HTMLElement>) => onClose(e, null) }
                             >
-                                <Typography variant="inherit">{ t("extensions:develop.apiResource.wizard.addApiResource.cancelButton") }</Typography>
+                                <Typography variant="inherit">
+                                    { t("extensions:develop.apiResource.wizard.addApiResource.cancelButton") }
+                                </Typography>
                             </LinkButton>
                         </Grid.Column>
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 8 }>

--- a/apps/console/src/features/users/components/guests/api/invite.ts
+++ b/apps/console/src/features/users/components/guests/api/invite.ts
@@ -20,7 +20,7 @@ import { AsgardeoSPAClient, HttpClientInstance } from "@asgardeo/auth-react";
 import { HttpMethods } from "@wso2is/core/models";
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { store } from "../../../../core/store";
-import { UserInviteInterface } from "../models/invite";
+import { ParentOrgUserInviteInterface } from "../models/invite";
 
 /**
  * Initialize an axios Http client.
@@ -28,7 +28,7 @@ import { UserInviteInterface } from "../models/invite";
 const httpClient: HttpClientInstance = AsgardeoSPAClient.getInstance().httpRequest.bind(
     AsgardeoSPAClient.getInstance());
 
-export const sendParentOrgUserInvite = (userInvite: UserInviteInterface): Promise<any> => {
+export const sendParentOrgUserInvite = (userInvite: ParentOrgUserInviteInterface): Promise<any> => {
     const requestConfig: AxiosRequestConfig = {
         data: userInvite,
         headers: {
@@ -36,7 +36,7 @@ export const sendParentOrgUserInvite = (userInvite: UserInviteInterface): Promis
             "Content-Type": "application/json"
         },
         method: HttpMethods.POST,
-        url: store.getState().config.endpoints.guests  
+        url: store.getState().config.endpoints.guests
     };
 
     return httpClient(requestConfig).then((response: AxiosResponse) => {

--- a/apps/console/src/features/users/components/guests/models/invite.ts
+++ b/apps/console/src/features/users/components/guests/models/invite.ts
@@ -40,6 +40,18 @@ export interface UserInviteInterface {
 }
 
 /**
+ * Interface to represent invite for parent org user.
+ */
+export interface ParentOrgUserInviteInterface {
+    id?: string;
+    roles?: string[];
+    email?: string;
+    status?: InviteUserStatus;
+    expiredAt?: string;
+    usernames?: string[];
+}
+
+/**
  * Interface to store invitations list.
  */
 export interface InvitationsInterface {

--- a/apps/console/src/features/users/components/guests/models/invite.ts
+++ b/apps/console/src/features/users/components/guests/models/invite.ts
@@ -52,6 +52,27 @@ export interface ParentOrgUserInviteInterface {
 }
 
 /**
+ * Interface to represent the result of an invitation for a parent org user.
+ */
+export interface ParentOrgUserInvitationResult {
+    username: string;
+    result: {
+        status: ParentOrgUserInviteResultStatus
+        errorCode?: string;
+        errorMessage?: string;
+        errorDescription?: string;
+    }
+}
+
+/**
+ * Enum for the result status of a parent org user invite.
+ */
+export enum ParentOrgUserInviteResultStatus {
+    SUCCESS = "Success",
+    FAIL = "Fail"
+}
+
+/**
  * Interface to store invitations list.
  */
 export interface InvitationsInterface {

--- a/apps/console/src/features/users/components/guests/pages/invite-parent-org-user.tsx
+++ b/apps/console/src/features/users/components/guests/pages/invite-parent-org-user.tsx
@@ -16,8 +16,9 @@
  * under the License.
  */
 
-import { Chip, Typography } from "@oxygen-ui/react";
 import { AutocompleteRenderGetTagProps } from "@oxygen-ui/react/Autocomplete";
+import Chip from "@oxygen-ui/react/Chip";
+import Typography from "@oxygen-ui/react/Typography";
 import { AlertLevels, IdentifiableComponentInterface, RolesInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { AutocompleteFieldAdapter, FinalForm, FinalFormField, TextFieldAdapter } from "@wso2is/form";

--- a/apps/console/src/features/users/components/guests/pages/invite-parent-org-user.tsx
+++ b/apps/console/src/features/users/components/guests/pages/invite-parent-org-user.tsx
@@ -33,7 +33,7 @@ import { UsersConstants } from "../../../../../extensions/components/users/const
 import { useRolesList } from "../../../../roles/api";
 import { UserManagementConstants } from "../../../constants";
 import { sendParentOrgUserInvite } from "../api/invite";
-import { UserInviteInterface } from "../models/invite";
+import { ParentOrgUserInviteInterface } from "../models/invite";
 
 interface RolesAutoCompleteOption {
     key: string;
@@ -158,9 +158,9 @@ export const InviteParentOrgUser: FunctionComponent<InviteParentOrgUserPropsInte
      */
     const inviteParentOrgUser = (values: InviteParentOrgUserFormValuesInterface) => {
 
-        const invite: UserInviteInterface = {
+        const invite: ParentOrgUserInviteInterface = {
             roles: values?.roles?.map((role: RolesAutoCompleteOption) => role.role.id),
-            username: values?.username
+            usernames: [ values?.username ]
         };
 
         setIsSubmitting(true);

--- a/apps/console/src/features/users/components/guests/pages/invite-parent-org-user.tsx
+++ b/apps/console/src/features/users/components/guests/pages/invite-parent-org-user.tsx
@@ -22,7 +22,7 @@ import Typography from "@oxygen-ui/react/Typography";
 import { AlertLevels, IdentifiableComponentInterface, RolesInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { AutocompleteFieldAdapter, FinalForm, FinalFormField, TextFieldAdapter } from "@wso2is/form";
-import { Hint, Message } from "@wso2is/react-components";
+import { Hint, Message, WizardAlert } from "@wso2is/react-components";
 import { AxiosError, AxiosResponse } from "axios";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, ReactNode, useMemo } from "react";
@@ -72,6 +72,11 @@ interface InviteParentOrgUserPropsInterface extends IdentifiableComponentInterfa
      * The Callback method for when the user invite is successful.
      */
     onUserInviteSuccess: () => void;
+    /**
+     * The callback method for setting the alert.
+     * @param alert - The alert object.
+     */
+    setAlert: (alert: WizardAlert) => void;
 }
 
 /**
@@ -87,6 +92,7 @@ export const InviteParentOrgUser: FunctionComponent<InviteParentOrgUserPropsInte
         closeWizard,
         setIsSubmitting,
         onUserInviteSuccess,
+        setAlert,
         [ "data-componentid"]: componentId
     } = props;
 
@@ -124,36 +130,36 @@ export const InviteParentOrgUser: FunctionComponent<InviteParentOrgUserPropsInte
          * is available has been used.
          */
         if (!error.response || error.response.status === 401) {
-            dispatch(addAlert({
+            setAlert({
                 description: t("console:manage.features.invite.notifications.sendInvite.error.description"),
                 level: AlertLevels.ERROR,
                 message: t("console:manage.features.invite.notifications.sendInvite.error.message")
-            }));
+            });
         } else if (error.response.status === 403 &&
             error?.response?.data?.code === UsersConstants.ERROR_COLLABORATOR_USER_LIMIT_REACHED) {
-            dispatch(addAlert({
+            setAlert({
                 description: t("extensions:manage.invite.notifications.sendInvite.limitReachError.description"),
                 level: AlertLevels.ERROR,
                 message: t("extensions:manage.invite.notifications.sendInvite.limitReachError.message")
-            }));
+            });
         } else if (error?.response?.data?.description) {
-            dispatch(addAlert({
+            setAlert({
                 description: t(
                     "console:manage.features.invite.notifications.sendInvite.error.description",
                     { description: error.response.data.description }
                 ),
                 level: AlertLevels.ERROR,
                 message: t("console:manage.features.invite.notifications.sendInvite.error.message")
-            }));
+            });
         } else {
             // Generic error message
-            dispatch(addAlert({
+            setAlert({
                 description: t(
                     "console:manage.features.invite.notifications.sendInvite.genericError.description"
                 ),
                 level: AlertLevels.ERROR,
                 message: t("console:manage.features.invite.notifications.sendInvite.genericError.message")
-            }));
+            });
         }
     };
 
@@ -178,15 +184,14 @@ export const InviteParentOrgUser: FunctionComponent<InviteParentOrgUserPropsInte
                 const responseData: ParentOrgUserInvitationResult = response.data[0];
 
                 if (responseData.result.status !== ParentOrgUserInviteResultStatus.SUCCESS) {
-
-                    dispatch(addAlert({
+                    setAlert({
                         description: t(
                             "console:manage.features.invite.notifications.sendInvite.error.description",
                             { description: responseData.result.errorDescription }
                         ),
                         level: AlertLevels.ERROR,
                         message: t("console:manage.features.invite.notifications.sendInvite.error.message")
-                    }));
+                    });
 
                     return;
                 }
@@ -207,7 +212,6 @@ export const InviteParentOrgUser: FunctionComponent<InviteParentOrgUserPropsInte
                 handleParentOrgUserInviteError(error);
             })
             .finally(() => {
-                closeWizard();
                 setIsSubmitting(false);
             });
     };

--- a/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
+++ b/apps/console/src/features/users/components/wizard/add-user-wizard.tsx
@@ -988,6 +988,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
                                 closeWizard={ closeWizard }
                                 setIsSubmitting={ setIsSubmitting }
                                 onUserInviteSuccess={ onUserInviteSuccess }
+                                setAlert={ setAlert }
                             />
                         )
                     }

--- a/modules/react-components/src/components/alert/wizard-alert.tsx
+++ b/modules/react-components/src/components/alert/wizard-alert.tsx
@@ -23,7 +23,7 @@ import { Message } from "semantic-ui-react";
 /**
  * The model of the `alert` state.
  */
-interface WizardAlert {
+export interface WizardAlert {
     message: string;
     description: string;
     code?: string | number;


### PR DESCRIPTION
### Purpose
With the PR https://github.com/wso2/identity-api-server/pull/551, the payload of `/guests/invite` is changed to allow multiple user invite at once to parent org users. This PR makes the FE compatible with the new payload.

https://github.com/wso2/identity-apps/assets/27700915/885c282d-eb53-4e87-862a-76b2d7d4faaf

### Related Issues
- https://github.com/wso2/product-is/issues/18255

### Related PRs
- https://github.com/wso2/identity-api-server/pull/551

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
