### PR TITLE
Hide the `Enable rules` option in App outbound provisioning

### DIFF
--- a/.changeset/odd-rivers-obey.md
+++ b/.changeset/odd-rivers-obey.md
@@ -1,0 +1,12 @@
+---
+"@wso2is/common": patch
+"@wso2is/console": patch
+"@wso2is/core": patch
+"@wso2is/myaccount": patch
+"@wso2is/identity-apps-core": patch
+"@wso2is/access-control": patch
+"@wso2is/dynamic-forms": patch
+"@wso2is/form": patch
+---
+
+Hide Xacml feature with config

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1696,7 +1696,9 @@
                 {% endfor %}
             {% endif %}
         ],
-        "isXacmlConnectorEnabled": "{{ console.ui.isXacmlConnectorEnabled }}",
+        {% if console.ui.isXacmlConnectorEnabled is defined %}
+        "isXacmlConnectorEnabled": {{ console.ui.isXacmlConnectorEnabled }},
+        {% endif %}
         "legacyMode": {
             {% if legacy_mode.enable == true %}
             "apiResources": false,

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1696,6 +1696,7 @@
                 {% endfor %}
             {% endif %}
         ],
+        "isXacmlConnectorEnabled": "{{ console.ui.isXacmlConnectorEnabled }}",
         "legacyMode": {
             {% if legacy_mode.enable == true %}
             "apiResources": false,
@@ -1703,7 +1704,6 @@
             "applicationOIDCSubjectIdentifier": true,
             "applicationRequestPathAuthentication": true,
             "applicationSystemAppsSettings": true,
-            "applicationXacmlAuthorization": true,
             "approvals": true,
             "certificates": true,
             "loginAndRegistrationEmailDomainDiscovery": false,

--- a/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
+++ b/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
@@ -26,7 +26,6 @@ import {
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
 import { GenericIcon, Heading } from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
-import useUIConfig from "modules/common/src/hooks/use-ui-configs";
 import React, {
     FunctionComponent,
     MutableRefObject,
@@ -95,8 +94,6 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
     } = props;
 
     const { t } = useTranslation();
-
-    const { UIConfig } = useUIConfig();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
     const isApplicationNativeAuthenticationEnabled: boolean = isFeatureEnabled(featureConfig?.applications,
@@ -306,7 +303,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 data-componentid={ `${ testId }-enable-authorization-checkbox` }
                 hidden={
                     !applicationConfig.advancedConfigurations.showEnableAuthorization
-                    || !UIConfig?.legacyMode?.applicationXacmlAuthorization }
+                    || !window[ "AppUtils" ].getConfig().ui.isXacmlConnectorEnabled }
                 hint={ t("console:develop.features.applications.forms.advancedConfig.fields.enableAuthorization.hint") }
             />
             {

--- a/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
+++ b/apps/console/src/features/applications/components/forms/advanced-configurations-form.tsx
@@ -17,6 +17,7 @@
  */
 
 import Alert from "@oxygen-ui/react/Alert";
+import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import { isFeatureEnabled } from "@wso2is/core/helpers";
 import {
     AlertInterface,
@@ -94,6 +95,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
     } = props;
 
     const { t } = useTranslation();
+    const { UIConfig } = useUIConfig();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
     const isApplicationNativeAuthenticationEnabled: boolean = isFeatureEnabled(featureConfig?.applications,
@@ -303,7 +305,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 data-componentid={ `${ testId }-enable-authorization-checkbox` }
                 hidden={
                     !applicationConfig.advancedConfigurations.showEnableAuthorization
-                    || !window[ "AppUtils" ].getConfig().ui.isXacmlConnectorEnabled }
+                    || !UIConfig?.isXacmlConnectorEnabled }
                 hint={ t("console:develop.features.applications.forms.advancedConfig.fields.enableAuthorization.hint") }
             />
             {

--- a/apps/console/src/features/applications/components/wizard/outbound-provisioining-idp-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/outbound-provisioining-idp-wizard-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -83,7 +83,6 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
     const [ isJITChecked, setIsJITChecked ] = useState<boolean>(initialValues?.jit);
     const [ isRulesChecked, setIsRulesChecked ] = useState<boolean>(initialValues?.rules);
     const [ connector, setConnector ] = useState<string>(initialValues?.connector);
-
 
     useEffect(() => {
         if (!idpList) {
@@ -259,34 +258,39 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
                         ) }
                     </Grid.Column>
                 </Grid.Row>
-                <Grid.Row columns={ 1 }>
-                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
-                        <Field
-                            name="rules"
-                            required={ false }
-                            requiredErrorMessage=""
-                            type="checkbox"
-                            children={ [
-                                {
-                                    label: t("console:develop.features.applications.forms.outboundProvisioning" +
-                                        ".fields.rules.label"),
-                                    value: "rules"
-                                }
-                            ] }
-                            value={ initialValues?.rules ? [ "rules" ] : [] }
-                            listen={
-                                (values: Map<string, FormValue>) => {
-                                    setIsRulesChecked(values.get("rules").includes("rules"));
-                                }
-                            }
-                            readOnly={ readOnly }
-                            data-testid={ `${ testId }-rules-checkbox` }
-                        />
-                        <Hint>
-                            { t("console:develop.features.applications.forms.outboundProvisioning.fields.rules.hint") }
-                        </Hint>
-                    </Grid.Column>
-                </Grid.Row>
+                {
+                    window[ "AppUtils" ].getConfig().ui.isXacmlConnectorEnabled && (
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
+                                <Field
+                                    name="rules"
+                                    required={ false }
+                                    requiredErrorMessage=""
+                                    type="checkbox"
+                                    children={ [
+                                        {
+                                            label: t("console:develop.features.applications.forms." +
+                                            "outboundProvisioning.fields.rules.label"),
+                                            value: "rules"
+                                        }
+                                    ] }
+                                    value={ initialValues?.rules ? [ "rules" ] : [] }
+                                    listen={
+                                        (values: Map<string, FormValue>) => {
+                                            setIsRulesChecked(values.get("rules").includes("rules"));
+                                        }
+                                    }
+                                    readOnly={ readOnly }
+                                    data-testid={ `${ testId }-rules-checkbox` }
+                                />
+                                <Hint>
+                                    { t("console:develop.features.applications.forms.outboundProvisioning." +
+                                    "fields.rules.hint") }
+                                </Hint>
+                            </Grid.Column>
+                        </Grid.Row>
+                    )
+                }
                 <Grid.Row columns={ 1 }>
                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
                         <Field

--- a/apps/console/src/features/applications/components/wizard/outbound-provisioining-idp-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/outbound-provisioining-idp-wizard-form.tsx
@@ -15,6 +15,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms } from "@wso2is/forms";
 import { Hint, PrimaryButton } from "@wso2is/react-components";
@@ -83,6 +85,8 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
     const [ isJITChecked, setIsJITChecked ] = useState<boolean>(initialValues?.jit);
     const [ isRulesChecked, setIsRulesChecked ] = useState<boolean>(initialValues?.rules);
     const [ connector, setConnector ] = useState<string>(initialValues?.connector);
+
+    const { UIConfig } = useUIConfig();
 
     useEffect(() => {
         if (!idpList) {
@@ -259,7 +263,7 @@ export const OutboundProvisioningWizardIdpForm: FunctionComponent<OutboundProvis
                     </Grid.Column>
                 </Grid.Row>
                 {
-                    window[ "AppUtils" ].getConfig().ui.isXacmlConnectorEnabled && (
+                    UIConfig?.isXacmlConnectorEnabled && (
                         <Grid.Row columns={ 1 }>
                             <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 10 }>
                                 <Field

--- a/apps/console/src/features/core/configs/app.ts
+++ b/apps/console/src/features/core/configs/app.ts
@@ -302,6 +302,7 @@ export class Config {
             isSAASDeployment: window[ "AppUtils" ]?.getConfig()?.ui?.isSAASDeployment,
             isSignatureValidationCertificateAliasEnabled:
                 window[ "AppUtils" ]?.getConfig()?.ui?.isSignatureValidationCertificateAliasEnabled,
+            isXacmlConnectorEnabled: window[ "AppUtils" ]?.getConfig()?.ui?.isXacmlConnectorEnabled,
             legacyMode: window[ "AppUtils" ]?.getConfig()?.ui?.legacyMode,
             listAllAttributeDialects: window[ "AppUtils" ]?.getConfig()?.ui?.listAllAttributeDialects,
             privacyPolicyConfigs: window[ "AppUtils" ]?.getConfig()?.ui?.privacyPolicyConfigs,

--- a/apps/console/src/features/core/models/config.ts
+++ b/apps/console/src/features/core/models/config.ts
@@ -370,6 +370,10 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
         defaultLogoUrl: string;
         defaultWhiteLogoUrl: string;
     };
+    /**
+     * is XACML connector enabled.
+     */
+    isXacmlConnectorEnabled?: boolean;
 }
 
 /**

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -1051,13 +1051,13 @@
             "Console",
             "My Account"
         ],
+        "isXacmlConnectorEnabled": false,
         "legacyMode": {
             "apiResources": true,
             "applicationListSystemApps": false,
             "applicationOIDCSubjectIdentifier": false,
             "applicationRequestPathAuthentication": false,
             "applicationSystemAppsSettings": false,
-            "applicationXacmlAuthorization": false,
             "approvals": false,
             "certificates": false,
             "loginAndRegistrationEmailDomainDiscovery": true,

--- a/modules/common/src/models/config.ts
+++ b/modules/common/src/models/config.ts
@@ -261,6 +261,10 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      * Hidden userstores
      */
     hiddenUserStores: string[];
+    /**
+     * is XACML connector enabled.
+     */
+    isXacmlConnectorEnabled?: boolean;
 }
 
 /**

--- a/modules/core/src/models/core.ts
+++ b/modules/core/src/models/core.ts
@@ -216,7 +216,6 @@ export interface LegacyModeInterface {
     applicationOIDCSubjectIdentifier: boolean;
     applicationRequestPathAuthentication: boolean;
     applicationSystemAppsSettings: boolean;
-    applicationXacmlAuthorization: boolean;
     approvals: boolean;
     certificates: boolean;
     loginAndRegistrationEmailDomainDiscovery: boolean;


### PR DESCRIPTION
### Purpose
Hide the `Enable rules` option in App outbound provisioning as the XACML connector is deprecated. A user can add the connector and enable this via the deployment file.

<img width="500" alt="Screenshot 2023-12-13 at 11 35 44" src="https://github.com/wso2/identity-apps/assets/67315176/14a98b7f-ff6d-4870-a670-fdf78b1322ae">

### Related Issues
- https://github.com/wso2/product-is/issues/18445

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
