### PR TITLE
(fix) Permission name is not centered in the label

### DIFF
--- a/.changeset/ninety-coats-rush.md
+++ b/.changeset/ninety-coats-rush.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+(fix) Permission name is not centered in the label

--- a/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
+++ b/apps/console/src/features/roles/components/edit-role/edit-role-permission.tsx
@@ -661,7 +661,6 @@ export const UpdatedRolePermissionDetails: FunctionComponent<RolePermissionDetai
                 <RenderChip
                     { ...getTagProps({ index }) }
                     key={ index }
-                    className="pt-5 m-1"
                     primaryText={ option.display }
                     secondaryText={ option.value }
                     option={ option }


### PR DESCRIPTION
### Purpose
Fix permission name is not centered in the label in the Console settings -> Roles section.

### Screenshot
<img width="1800" alt="Screenshot 2023-12-13 at 13 42 07" src="https://github.com/wso2/identity-apps/assets/46097917/a0080b1d-e557-44a2-a94f-dea82b9351c5">

### Related Issues
- https://github.com/wso2/product-is/issues/18555

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
