### PR TITLE
Fix the org name display issue in the user creation wizard of the sub-organization

### DIFF
--- a/.changeset/dirty-flies-confess.md
+++ b/.changeset/dirty-flies-confess.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix org name display issue in user creation wizard of sub organization

--- a/apps/console/src/features/users/components/wizard/user-wizard-summary.tsx
+++ b/apps/console/src/features/users/components/wizard/user-wizard-summary.tsx
@@ -28,6 +28,7 @@ import { Dispatch } from "redux";
 import { Button, Divider, Grid, Icon } from "semantic-ui-react";
 import { AppState } from "../../../core/store";
 import { OrganizationType } from "../../../organizations/constants";
+import { OrganizationResponseInterface } from "../../../organizations/models";
 import { generateInviteLink } from "../../api";
 
 interface AddUserWizardSummaryProps extends IdentifiableComponentInterface {
@@ -60,16 +61,16 @@ export const AddUserWizardSummary: FunctionComponent<AddUserWizardSummaryProps> 
     const dispatch: Dispatch = useDispatch();
 
     const tenantDomain: string = useSelector((state: AppState) => state.auth.tenantDomain);
-    const currentOrganization: string
-        = useSelector((state: AppState) => state?.organization?.currentOrganization);
     const orgType: OrganizationType = useSelector((state: AppState) => state?.organization?.organizationType);
+    const currentOrganization: OrganizationResponseInterface = useSelector(
+        (state: AppState) => state?.organization?.organization);
 
     const [ inviteLink, setInviteLink ] = useState<string>("");
     const [ isSummaryLoading, setIsSummaryLoading ] = useState<boolean>(true);
 
     const tenantname: string = useMemo(() => {
         if (orgType === OrganizationType.SUBORGANIZATION) {
-            return currentOrganization;
+            return currentOrganization?.name;
         }
 
         return tenantDomain;


### PR DESCRIPTION
### Purpose
> Fix the org name display issue in the user creation wizard of the sub-organization.
<img width="968" alt="Screenshot 2023-12-13 at 14 33 37" src="https://github.com/wso2/identity-apps/assets/27746285/007d3f67-564c-4b18-ad6c-7455bb8a85c6">

### Related Issues
- https://github.com/wso2/product-is/issues/18511

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
