### PR TITLE
Change the ParentOrgUserResultStatus values along with the backend improvement.

### DIFF
--- a/.changeset/metal-buckets-divide.md
+++ b/.changeset/metal-buckets-divide.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change the ParentOrgUserResultStatus values along with the backend improvement.

--- a/apps/console/src/features/users/components/guests/models/invite.ts
+++ b/apps/console/src/features/users/components/guests/models/invite.ts
@@ -68,8 +68,8 @@ export interface ParentOrgUserInvitationResult {
  * Enum for the result status of a parent org user invite.
  */
 export enum ParentOrgUserInviteResultStatus {
-    SUCCESS = "Success",
-    FAIL = "Fail"
+    SUCCESS = "Successful",
+    FAIL = "Failed"
 }
 
 /**


### PR DESCRIPTION
### Purpose
The status values sent by the backend for `/guests/invite` endpoint were changed from:

- `Success` -> `Successful`
- `Fail` -> `Failed`

This PR makes frontend compatible with the backend changes.

### Related Issues
- https://github.com/wso2/product-is/issues/18255

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
