### PR TITLE
Fix `something went wrong` when assigning email domains when there are no created sub organizations

### DIFF
--- a/.changeset/gentle-olives-jog.md
+++ b/.changeset/gentle-olives-jog.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix a NPE that occurs when assigning email domains in the absence of any created sub organizations.

--- a/apps/console/src/features/organization-discovery/components/add-organization-discovery-domains.tsx
+++ b/apps/console/src/features/organization-discovery/components/add-organization-discovery-domains.tsx
@@ -122,7 +122,7 @@ const AddOrganizationDiscoveryDomains: FunctionComponent<AddOrganizationDiscover
                     return discoverableOrganization.organizationId === organization.id;
                 }
             );
-        });
+        }) ?? [];
     }, [ discoverableOrganizations, organizations ]);
 
     const optionsArray: string[] = [];


### PR DESCRIPTION
### Purpose
Fix `something went wrong` when assigning email domains when there are no created sub organizations by adding a fallback value to `filteredDiscoverableOrganizations` for cases where it's becoming null or undefined.

https://github.com/wso2/identity-apps/assets/27700915/727794e7-e64f-41e7-985f-cebe52038759


### Related Issues
- https://github.com/wso2/product-is/issues/18602

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
