### PR TITLE
Skip username validation from UI if InputValidation.Username.Enabled is false

### DIFF
--- a/.changeset/pretty-impalas-study.md
+++ b/.changeset/pretty-impalas-study.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Skip username validation from UI.

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -39,6 +39,7 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.Claim" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.User" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
 <%@ page import="org.wso2.carbon.utils.multitenancy.MultitenantUtils" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.Arrays" %>
@@ -132,67 +133,71 @@
         user.setTenantDomain(tenantDomain);
     }
 
-    try {
-        usernameValidityResponse = selfRegistrationMgtClient.checkUsernameValidityStatus(user, skipSignUpEnableCheck);
-    } catch (SelfRegistrationMgtClientException e) {
-        request.setAttribute("error", true);
-        request.setAttribute("errorMsg", IdentityManagementEndpointUtil
-                .i18n(recoveryResourceBundle, "Something.went.wrong.while.registering.user") + Encode
-                .forHtmlContent(username) + IdentityManagementEndpointUtil
-                .i18n(recoveryResourceBundle, "Please.contact.administrator"));
-
-        if (allowchangeusername) {
-            request.getRequestDispatcher("register.do").forward(request, response);
-        } else {
-            IdentityManagementEndpointUtil.addErrorInformation(request, e);
-            if (!StringUtils.isBlank(username)) {
-                request.setAttribute("username", username);
-            }
-            request.getRequestDispatcher("error.jsp").forward(request, response);
-            return;
-        }
-        return;
-    }
-
     if (StringUtils.isBlank(callback)) {
         callback = Encode.forHtmlAttribute(IdentityManagementEndpointUtil.getUserPortalUrl(
                 application.getInitParameter(IdentityManagementEndpointConstants.ConfigConstants.USER_PORTAL_URL), tenantDomain));
     }
 
-    Integer userNameValidityStatusCode = usernameValidityResponse.getInt("code");
-    if (!SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE.equalsIgnoreCase(userNameValidityStatusCode.toString())) {
-        if (allowchangeusername || !skipSignUpEnableCheck) {
+    boolean isUsernameValidationEnabled = Boolean.parseBoolean(IdentityUtil.getProperty("InputValidation.Username.Enabled"));
+    if (isUsernameValidationEnabled) {
+        try {
+            usernameValidityResponse = selfRegistrationMgtClient.checkUsernameValidityStatus(user, skipSignUpEnableCheck);
+        } catch (SelfRegistrationMgtClientException e) {
             request.setAttribute("error", true);
-            request.setAttribute("errorCode", userNameValidityStatusCode);
-            if (usernameValidityResponse.has("message")) {
-                if (usernameValidityResponse.get("message") instanceof String) {
-                    request.setAttribute("errorMessage", usernameValidityResponse.getString("message"));
+            request.setAttribute("errorMsg", IdentityManagementEndpointUtil
+                    .i18n(recoveryResourceBundle, "Something.went.wrong.while.registering.user") + Encode
+                    .forHtmlContent(username) + IdentityManagementEndpointUtil
+                    .i18n(recoveryResourceBundle, "Please.contact.administrator"));
+
+            if (allowchangeusername) {
+                request.getRequestDispatcher("register.do").forward(request, response);
+            } else {
+                IdentityManagementEndpointUtil.addErrorInformation(request, e);
+                if (!StringUtils.isBlank(username)) {
+                    request.setAttribute("username", username);
                 }
+                request.getRequestDispatcher("error.jsp").forward(request, response);
+                return;
             }
-            request.getRequestDispatcher("register.do").forward(request, response);
-        } else {
-            String errorCode = String.valueOf(userNameValidityStatusCode);
-            if (SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT.equalsIgnoreCase(errorCode)) {
-                errorMsg = IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "invalid.tenant.domain")
-                    + " - " + user.getTenantDomain() + ".";
-            } else if (SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS.equalsIgnoreCase(errorCode)) {
-                errorMsg = IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Username")
-                    + " '" + username + "' " + IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "username.already.taken.pick.different.username");
-            } else if (SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID.equalsIgnoreCase(errorCode)) {
-                errorMsg = user.getUsername() + " " + IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "invalid.username.pick.a.valid.username");
-            } else if (SelfRegistrationStatusCodes.ERROR_CODE_INVALID_USERSTORE.equalsIgnoreCase(errorCode)) {
-                errorMsg = IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "invalid.userstore.domain") + " - " + user.getRealm();
-            }
-            request.setAttribute("errorMsg", errorMsg + " "
-                + IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "please.contact.administrator.to.fix.issue"));
-            request.setAttribute("errorCode", errorCode);
-            if (!StringUtils.isBlank(username)) {
-                request.setAttribute("username", username);
-            }
-            request.getRequestDispatcher("error.jsp").forward(request, response);
+            return;
         }
-        return;
+
+        Integer userNameValidityStatusCode = usernameValidityResponse.getInt("code");
+        if (!SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE.equalsIgnoreCase(userNameValidityStatusCode.toString())) {
+            if (allowchangeusername || !skipSignUpEnableCheck) {
+                request.setAttribute("error", true);
+                request.setAttribute("errorCode", userNameValidityStatusCode);
+                if (usernameValidityResponse.has("message")) {
+                    if (usernameValidityResponse.get("message") instanceof String) {
+                        request.setAttribute("errorMessage", usernameValidityResponse.getString("message"));
+                    }
+                }
+                request.getRequestDispatcher("register.do").forward(request, response);
+            } else {
+                String errorCode = String.valueOf(userNameValidityStatusCode);
+                if (SelfRegistrationStatusCodes.ERROR_CODE_INVALID_TENANT.equalsIgnoreCase(errorCode)) {
+                    errorMsg = IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "invalid.tenant.domain")
+                        + " - " + user.getTenantDomain() + ".";
+                } else if (SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS.equalsIgnoreCase(errorCode)) {
+                    errorMsg = IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Username")
+                        + " '" + username + "' " + IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "username.already.taken.pick.different.username");
+                } else if (SelfRegistrationStatusCodes.CODE_USER_NAME_INVALID.equalsIgnoreCase(errorCode)) {
+                    errorMsg = user.getUsername() + " " + IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "invalid.username.pick.a.valid.username");
+                } else if (SelfRegistrationStatusCodes.ERROR_CODE_INVALID_USERSTORE.equalsIgnoreCase(errorCode)) {
+                    errorMsg = IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "invalid.userstore.domain") + " - " + user.getRealm();
+                }
+                request.setAttribute("errorMsg", errorMsg + " "
+                    + IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "please.contact.administrator.to.fix.issue"));
+                request.setAttribute("errorCode", errorCode);
+                if (!StringUtils.isBlank(username)) {
+                    request.setAttribute("username", username);
+                }
+                request.getRequestDispatcher("error.jsp").forward(request, response);
+            }
+            return;
+        }
     }
+    
     String purposes = selfRegistrationMgtClient.getPurposes(user.getTenantDomain(), consentPurposeGroupName,
             consentPurposeGroupType);
     boolean hasPurposes = StringUtils.isNotEmpty(purposes);


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/17408

If the `InputValidation.Username.Enabled` config is disabled, skip the username validation against the regex from the UI. So we user is creating the username will be validate against the regex defined in the corresponding user store.