### PR TITLE
Remove custom layout validation

### DIFF
--- a/.changeset/good-hairs-tap.md
+++ b/.changeset/good-hairs-tap.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove custom layout validation

--- a/apps/console/src/extensions/configs/common.tsx
+++ b/apps/console/src/extensions/configs/common.tsx
@@ -23,6 +23,7 @@ export const commonConfig: CommonConfig = {
         enableQuerySearch: false
     },
     blockLoopBackCalls: false,
+    checkCustomLayoutExistanceBeforeEnabling: false,
     checkForUIResourceScopes: false,
     enableDefaultBrandingPreviewSection: true,
     enableDefaultPreLoader: true,

--- a/apps/console/src/extensions/configs/models/common.ts
+++ b/apps/console/src/extensions/configs/models/common.ts
@@ -24,6 +24,7 @@ export interface CommonConfig {
         enableQuerySearch: boolean;
     };
     blockLoopBackCalls: boolean;
+    checkCustomLayoutExistanceBeforeEnabling: boolean;
     checkForUIResourceScopes: boolean;
     enableDefaultBrandingPreviewSection: boolean;
     enableDefaultPreLoader: boolean;

--- a/apps/console/src/features/branding/api/layout.ts
+++ b/apps/console/src/features/branding/api/layout.ts
@@ -65,7 +65,7 @@ export const useLayout = <Data = Blob, Error = RequestErrorInterface>(
         error,
         isValidating,
         mutate
-    } = useRequest<Data, Error>(shouldFetch? requestConfig : null, { attachToken: false });
+    } = useRequest<Data, Error>(shouldFetch ? requestConfig : null, { attachToken: false });
 
     return {
         data,

--- a/apps/console/src/features/branding/api/layout.ts
+++ b/apps/console/src/features/branding/api/layout.ts
@@ -31,11 +31,13 @@ import { PredefinedLayouts } from "../meta";
  *
  * @param layout - Layout name.
  * @param tenantDomain - Tenant name.
+ * @param shouldFetch - Should fetch the data.
  * @returns Layouts.
  */
 export const useLayout = <Data = Blob, Error = RequestErrorInterface>(
     layout: PredefinedLayouts,
-    tenantDomain: string
+    tenantDomain: string,
+    shouldFetch: boolean = true
 ): RequestResultInterface<Data, Error> => {
     const basename: string = AppConstants.getAppBasename()
         ? `/${AppConstants.getAppBasename()}`
@@ -63,7 +65,7 @@ export const useLayout = <Data = Blob, Error = RequestErrorInterface>(
         error,
         isValidating,
         mutate
-    } = useRequest<Data, Error>(requestConfig, { attachToken: false });
+    } = useRequest<Data, Error>(shouldFetch? requestConfig : null, { attachToken: false });
 
     return {
         data,

--- a/apps/console/src/features/branding/components/design/design-form.tsx
+++ b/apps/console/src/features/branding/components/design/design-form.tsx
@@ -335,8 +335,8 @@ export const DesignForm: FunctionComponent<DesignFormPropsInterface> = forwardRe
         }
 
         // Avoid activating the custom layout when there is no deployed custom layout.
-        if (commonConfig.checkCustomLayoutExistanceBeforeEnabling
-                && _values.layout.activeLayout === PredefinedLayouts.CUSTOM) {
+        if (commonConfig?.checkCustomLayoutExistanceBeforeEnabling
+                && _values?.layout?.activeLayout === PredefinedLayouts.CUSTOM) {
             while (customLayoutLoading) {
                 // Wait until finished the loading of custom layout.
             }

--- a/apps/console/src/features/branding/components/design/design-form.tsx
+++ b/apps/console/src/features/branding/components/design/design-form.tsx
@@ -192,7 +192,7 @@ export const DesignForm: FunctionComponent<DesignFormPropsInterface> = forwardRe
     const {
         data: customLayoutBlob,
         isLoading: customLayoutLoading
-    } = useLayout(PredefinedLayouts.CUSTOM, tenantDomain);
+    } = useLayout(PredefinedLayouts.CUSTOM, tenantDomain, commonConfig.checkCustomLayoutExistanceBeforeEnabling);
 
     /**
      * Set the internal initial theme state.
@@ -335,7 +335,8 @@ export const DesignForm: FunctionComponent<DesignFormPropsInterface> = forwardRe
         }
 
         // Avoid activating the custom layout when there is no deployed custom layout.
-        if (_values.layout.activeLayout === PredefinedLayouts.CUSTOM) {
+        if (commonConfig.checkCustomLayoutExistanceBeforeEnabling
+                && _values.layout.activeLayout === PredefinedLayouts.CUSTOM) {
             while (customLayoutLoading) {
                 // Wait until finished the loading of custom layout.
             }

--- a/apps/console/src/features/branding/components/design/design-form.tsx
+++ b/apps/console/src/features/branding/components/design/design-form.tsx
@@ -192,7 +192,7 @@ export const DesignForm: FunctionComponent<DesignFormPropsInterface> = forwardRe
     const {
         data: customLayoutBlob,
         isLoading: customLayoutLoading
-    } = useLayout(PredefinedLayouts.CUSTOM, tenantDomain, commonConfig.checkCustomLayoutExistanceBeforeEnabling);
+    } = useLayout(PredefinedLayouts.CUSTOM, tenantDomain, commonConfig?.checkCustomLayoutExistanceBeforeEnabling);
 
     /**
      * Set the internal initial theme state.


### PR DESCRIPTION
### Purpose

When activating a custom layout from the branding design section, the system currently checks for the existence of a custom layout within the current tenant. However, to perform this validation accurately, a centralized location for delivering these layouts is necessary. Currently, these layouts are stored in the authentication portal and recovery portal, inaccessible to the console due to cross-app restrictions. Consequently, validation will be disabled. There is an ongoing issue being tracked to implement centralized support for resources (https://github.com/wso2/product-is/issues/16706). This requirement can be taken into account as part of the solution for that issue.

### Issues

- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
