### PR TITLE
Fix broken branding preference import paths

### DIFF
--- a/.changeset/three-deers-drum.md
+++ b/.changeset/three-deers-drum.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix broken branding preference import paths

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/finishAccountLink.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/finishAccountLink.jsp
@@ -17,9 +17,6 @@
 <%-- Localization --%>
 <jsp:directive.include file="../includes/localize.jsp" />
 
-<%-- Branding Preferences --%>
-<jsp:directive.include file="includes/branding-preferences.jsp"/>
-
 <head>
     <script src="../js/scripts.js"></script>
 </head>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/startAccountLink.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/startAccountLink.jsp
@@ -23,9 +23,6 @@
 <%-- Localization --%>
 <jsp:directive.include file="../includes/localize.jsp" />
 
-<%-- Branding Preferences --%>
-<jsp:directive.include file="includes/branding-preferences.jsp"/>
-
 <%
     String applicationAccessURLWithoutEncoding = null;
     try {


### PR DESCRIPTION
### Purpose

This PR removes the redundant branding preference imports in dynamic templates, since branding preferences are already imported in dynamic_prompt.jsp.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
