### PR TITLE
Add notification alerts when authenticator creation fails

### DIFF
--- a/.changeset/odd-eggs-design.md
+++ b/.changeset/odd-eggs-design.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add alerts to create authenticator failures

--- a/apps/console/src/features/connections/components/wizards/authenticator-create-wizard.tsx
+++ b/apps/console/src/features/connections/components/wizards/authenticator-create-wizard.tsx
@@ -155,18 +155,15 @@ export const AuthenticatorCreateWizard: FunctionComponent<AddAuthenticatorWizard
     const formTopRef: MutableRefObject<HTMLDivElement> = useRef<HTMLDivElement>();
 
     /**
-     * Scrolls to the first field that throws an error.
-     *
-     * @param field - field The name of the field.
+     * Scrolls to the top of the form.
      */
-    const scrollToInValidField = (): void => {
+    const scrollToTop = (): void => {
         const options: ScrollIntoViewOptions = {
             behavior: "smooth",
             block: "center"
         };
 
         formTopRef.current.scrollIntoView(options);
-
     };
 
     /**
@@ -286,7 +283,7 @@ export const AuthenticatorCreateWizard: FunctionComponent<AddAuthenticatorWizard
                         message: t("console:develop.features.authenticationProvider.notifications." +
                             "addFederatedAuthenticator.error.message")
                     });
-                    scrollToInValidField();
+                    scrollToTop();
 
                     return;
                 }
@@ -299,7 +296,7 @@ export const AuthenticatorCreateWizard: FunctionComponent<AddAuthenticatorWizard
                         "notifications.addFederatedAuthenticator." +
                         "genericError.message")
                 });
-                scrollToInValidField();
+                scrollToTop();
             })
             .finally(() => {
                 setIsSubmitting(false);

--- a/apps/console/src/features/connections/components/wizards/authenticator-create-wizard.tsx
+++ b/apps/console/src/features/connections/components/wizards/authenticator-create-wizard.tsx
@@ -150,7 +150,7 @@ export const AuthenticatorCreateWizard: FunctionComponent<AddAuthenticatorWizard
     const [ submitTemplateSelection, setSubmitTemplateSelection ] = useTrigger();
     const [ submitAuthenticator, setSubmitAuthenticator ] = useTrigger();
 
-    const [ alert, setAlert, alertComponent ] = useWizardAlert();
+    const [ alert, alertComponent ] = useWizardAlert();
     /**
      * Navigates to the next wizard step.
      */
@@ -259,27 +259,31 @@ export const AuthenticatorCreateWizard: FunctionComponent<AddAuthenticatorWizard
             })
             .catch((error: IdentityAppsApiException) => {
                 if (error.response && error.response.data && error.response.data.description) {
-                    setAlert({
-                        description: t("console:develop.features.authenticationProvider." +
-                            "notifications.addFederatedAuthenticator." +
-                            "error.description", { description: error.response.data.description }),
-                        level: AlertLevels.ERROR,
-                        message: t("console:develop.features.authenticationProvider.notifications." +
-                            "addFederatedAuthenticator.error.message")
-                    });
+                    dispatch(
+                        addAlert({
+                            description: t("console:develop.features.authenticationProvider." +
+                                "notifications.addFederatedAuthenticator." +
+                                "error.description", { description: error.response.data.description }),
+                            level: AlertLevels.ERROR,
+                            message: t("console:develop.features.authenticationProvider.notifications." +
+                                "addFederatedAuthenticator.error.message")
+                        })
+                    );
 
                     return;
                 }
 
-                setAlert({
-                    description: t("console:develop.features.authenticationProvider." +
-                        "notifications.addFederatedAuthenticator." +
-                        "genericError.description"),
-                    level: AlertLevels.ERROR,
-                    message: t("console:develop.features.authenticationProvider." +
-                        "notifications.addFederatedAuthenticator." +
-                        "genericError.message")
-                });
+                dispatch(
+                    addAlert({
+                        description: t("console:develop.features.authenticationProvider." +
+                            "notifications.addFederatedAuthenticator." +
+                            "genericError.description"),
+                        level: AlertLevels.ERROR,
+                        message: t("console:develop.features.authenticationProvider." +
+                            "notifications.addFederatedAuthenticator." +
+                            "genericError.message")
+                    })
+                );
             })
             .finally(() => {
                 setIsSubmitting(false);


### PR DESCRIPTION
### Purpose
> Add notification alerts to create authenticator failures

https://github.com/wso2/identity-apps/assets/27746285/02cb590f-719b-4c54-9abe-e0424030f773

### Related Issues
- https://github.com/wso2/product-is/issues/18609

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
