### PR TITLE
Add an option to switch to a particular sub organization from its edit page

### DIFF
--- a/.changeset/rotten-crabs-doubt.md
+++ b/.changeset/rotten-crabs-doubt.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add option to switch to a particular sub organization from its settings page.

--- a/.changeset/rotten-crabs-doubt.md
+++ b/.changeset/rotten-crabs-doubt.md
@@ -1,4 +1,5 @@
 ---
+"@wso2is/myaccount": patch
 "@wso2is/console": patch
 "@wso2is/i18n": patch
 ---

--- a/apps/console/src/features/organizations/components/organization-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-list.tsx
@@ -60,7 +60,6 @@ import { OrganizationIcon } from "../configs";
 import { OrganizationManagementConstants } from "../constants";
 import useOrganizationSwitch from "../hooks/use-organization-switch";
 import { GenericOrganization, OrganizationInterface, OrganizationListInterface } from "../models";
-import { OrganizationUtils } from "../utils";
 
 /**
  *
@@ -162,7 +161,7 @@ export const OrganizationList: FunctionComponent<OrganizationListPropsInterface>
 
     const { onSignIn } = useSignIn();
 
-    const { switchOrganization } = useOrganizationSwitch();
+    const { switchOrganization, switchOrganizationInLegacyMode } = useOrganizationSwitch();
 
     const { legacyAuthzRuntime }  = useAuthorization();
 
@@ -290,7 +289,7 @@ export const OrganizationList: FunctionComponent<OrganizationListPropsInterface>
         organization: GenericOrganization
     ): Promise<void> => {
         if (legacyAuthzRuntime) {
-            OrganizationUtils.handleLegacyOrganizationSwitch(breadcrumbList, organization);
+            switchOrganizationInLegacyMode(breadcrumbList, organization);
         }
 
         let response: BasicUserInfo = null;

--- a/apps/console/src/features/organizations/components/organization-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-list.tsx
@@ -291,38 +291,7 @@ export const OrganizationList: FunctionComponent<OrganizationListPropsInterface>
         organization: GenericOrganization
     ): Promise<void> => {
         if (legacyAuthzRuntime) {
-            let newOrgPath: string = "";
-
-            if (
-                breadcrumbList && breadcrumbList.length > 0 &&
-                OrganizationUtils.isSuperOrganization(breadcrumbList[ 0 ]) &&
-                breadcrumbList[ 1 ]?.id === organization.id &&
-                organizationConfigs.showSwitcherInTenants
-            ) {
-                newOrgPath =
-                    "/t/" +
-                    organization.name +
-                    "/" +
-                    window[ "AppUtils" ].getConfig().appBase;
-            } else if (OrganizationUtils.isSuperOrganization(organization)) {
-                newOrgPath = `/${ window[ "AppUtils" ].getConfig().appBase }`;
-            } else {
-                newOrgPath =
-                    "/o/" +
-                    organization.id +
-                    "/" +
-                    window[ "AppUtils" ].getConfig().appBase;
-            }
-
-            // Clear the callback url of the previous organization.
-            SessionStorageUtils.clearItemFromSessionStorage(
-                "auth_callback_url_console"
-            );
-
-            // Redirect the user to the newly selected organization path.
-            window.location.replace(newOrgPath);
-
-            return;
+            OrganizationUtils.handleLegacyOrganizationSwitch(breadcrumbList, organization);
         }
 
         let response: BasicUserInfo = null;

--- a/apps/console/src/features/organizations/components/organization-list.tsx
+++ b/apps/console/src/features/organizations/components/organization-list.tsx
@@ -25,7 +25,6 @@ import {
     LoadableComponentInterface
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { SessionStorageUtils } from "@wso2is/core/utils";
 import {
     ConfirmationModal,
     DataTable,

--- a/apps/console/src/features/organizations/hooks/use-organization-switch.ts
+++ b/apps/console/src/features/organizations/hooks/use-organization-switch.ts
@@ -18,7 +18,11 @@
 
 import { BasicUserInfo, useAuthContext } from "@asgardeo/auth-react";
 import { TokenConstants } from "@wso2is/core/constants";
+import { SessionStorageUtils } from "@wso2is/core/utils";
 import useOrganizations from "./use-organizations";
+import { organizationConfigs } from "../../../extensions";
+import { BreadcrumbList, GenericOrganization } from "../models";
+import { OrganizationUtils } from "../utils";
 
 /**
  * Interface for the return type of the `useOrganizationSwitch` hook.
@@ -34,6 +38,12 @@ export interface UseOrganizationSwitchInterface {
      * @returns A promise containing the basic user info.
      */
     switchOrganization: (orgId: string) => Promise<BasicUserInfo>;
+    /**
+     * Handles the organization switch in the legacy mode.
+     * @param breadcrumbList - Breadcrumb list
+     * @param organization - Organization to switch to.
+     */
+    switchOrganizationInLegacyMode: (breadcrumbList: BreadcrumbList, organization: GenericOrganization) => void;
 }
 
 /**
@@ -79,9 +89,36 @@ const useOrganizationSwitch = (): UseOrganizationSwitchInterface => {
         return response;
     };
 
+    /**
+     * Handles the organization switch in the legacy mode.
+     * @param breadcrumbList - Breadcrumb list
+     * @param org - Organization to switch to.
+     */
+    const switchOrganizationInLegacyMode = (breadcrumbList: BreadcrumbList, org: GenericOrganization): void => {
+
+        let newOrgPath: string = "";
+
+        if (breadcrumbList && breadcrumbList.length > 0 && OrganizationUtils.isSuperOrganization(breadcrumbList[0])
+            && breadcrumbList[ 1 ]?.id === org.id && organizationConfigs.showSwitcherInTenants) {
+            newOrgPath = "/t/" + org.name + "/" + window[ "AppUtils" ].getConfig().appBase;
+        } else if (OrganizationUtils.isSuperOrganization(org)) {
+            newOrgPath = `/${ window[ "AppUtils" ].getConfig().appBase }`;
+        } else {
+            newOrgPath = "/o/" + org.id + "/" + window[ "AppUtils" ].getConfig().appBase;
+        }
+
+        // Clear the callback url of the previous organization.
+        SessionStorageUtils.clearItemFromSessionStorage("auth_callback_url_console");
+
+        // Redirect the user to the newly selected organization path.
+        window.location.replace(newOrgPath);
+    };
+
+
     return {
         isOrganizationSwitchRequestLoading,
-        switchOrganization
+        switchOrganization,
+        switchOrganizationInLegacyMode
     };
 };
 

--- a/apps/console/src/features/organizations/hooks/use-organization-switch.ts
+++ b/apps/console/src/features/organizations/hooks/use-organization-switch.ts
@@ -98,8 +98,12 @@ const useOrganizationSwitch = (): UseOrganizationSwitchInterface => {
 
         let newOrgPath: string = "";
 
-        if (breadcrumbList && breadcrumbList.length > 0 && OrganizationUtils.isSuperOrganization(breadcrumbList[0])
-            && breadcrumbList[ 1 ]?.id === org.id && organizationConfigs.showSwitcherInTenants) {
+        if (
+            breadcrumbList && breadcrumbList.length > 0
+            && OrganizationUtils.isSuperOrganization(breadcrumbList[0])
+            && breadcrumbList[ 1 ]?.id === org.id
+            && organizationConfigs.showSwitcherInTenants
+        ) {
             newOrgPath = "/t/" + org.name + "/" + window[ "AppUtils" ].getConfig().appBase;
         } else if (OrganizationUtils.isSuperOrganization(org)) {
             newOrgPath = `/${ window[ "AppUtils" ].getConfig().appBase }`;
@@ -113,7 +117,6 @@ const useOrganizationSwitch = (): UseOrganizationSwitchInterface => {
         // Redirect the user to the newly selected organization path.
         window.location.replace(newOrgPath);
     };
-
 
     return {
         isOrganizationSwitchRequestLoading,

--- a/apps/console/src/features/organizations/pages/organization-edit.tsx
+++ b/apps/console/src/features/organizations/pages/organization-edit.tsx
@@ -246,7 +246,7 @@ const OrganizationEditPage: FunctionComponent<OrganizationEditPagePropsInterface
                 <Button
                     basic
                     primary
-                    data-testid="org-mgt-edit-org-switch-button"
+                    data-componentid="org-mgt-edit-org-switch-button"
                     type="button"
                     onClick={ handleOrganizationSwitch }
                 >

--- a/apps/console/src/features/organizations/pages/organization-edit.tsx
+++ b/apps/console/src/features/organizations/pages/organization-edit.tsx
@@ -19,12 +19,13 @@
 import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertLevels, SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { GenericIcon, PageLayout } from "@wso2is/react-components";
+import { Button, GenericIcon, PageLayout } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { RouteChildrenProps } from "react-router-dom";
 import { Dispatch } from "redux";
+import { Icon } from "semantic-ui-react";
 import { AppConstants, FeatureConfigInterface, history } from "../../core";
 import { getOrganization, useAuthorizedOrganizationsList } from "../api";
 import { EditOrganization } from "../components/edit-organization/edit-organization";
@@ -183,6 +184,18 @@ const OrganizationEditPage: FunctionComponent<OrganizationEditPagePropsInterface
             } }
             titleTextAlign="left"
             bottomMargin={ false }
+            action={ !isReadOnly && (
+                <Button
+                    basic
+                    primary
+                    data-testid="org-mgt-edit-org-switch-button"
+                    type="button"
+                    onClick={ () => { null;} }
+                >
+                    <Icon name="exchange" />
+                    { t("console:manage.features.organizations.switching.switchButton") }
+                </Button>
+            ) }
         >
             <EditOrganization
                 organization={ organization }

--- a/apps/console/src/features/organizations/pages/organization-edit.tsx
+++ b/apps/console/src/features/organizations/pages/organization-edit.tsx
@@ -36,7 +36,6 @@ import { OrganizationIcon } from "../configs";
 import { OrganizationManagementConstants } from "../constants";
 import useOrganizationSwitch from "../hooks/use-organization-switch";
 import { OrganizationInterface, OrganizationResponseInterface } from "../models";
-import { OrganizationUtils } from "../utils";
 
 interface OrganizationEditPagePropsInterface extends SBACInterface<FeatureConfigInterface>,
     TestableComponentInterface, RouteChildrenProps{
@@ -59,7 +58,7 @@ const OrganizationEditPage: FunctionComponent<OrganizationEditPagePropsInterface
     const [ isAuthorizedOrganization, setIsAuthorizedOrganization ] = useState(false);
     const [ filterQuery, setFilterQuery ] = useState<string>("");
 
-    const { switchOrganization } = useOrganizationSwitch();
+    const { switchOrganization, switchOrganizationInLegacyMode } = useOrganizationSwitch();
     const { legacyAuthzRuntime }  = useAuthorization();
     const { onSignIn } = useSignIn();
 
@@ -192,7 +191,7 @@ const OrganizationEditPage: FunctionComponent<OrganizationEditPagePropsInterface
      */
     const handleOrganizationSwitch = async (): Promise<void> => {
         if (legacyAuthzRuntime) {
-            OrganizationUtils.handleLegacyOrganizationSwitch(breadcrumbList, organization);
+            switchOrganizationInLegacyMode(breadcrumbList, organization);
         }
 
         let response: BasicUserInfo = null;

--- a/apps/console/src/features/organizations/pages/organization-edit.tsx
+++ b/apps/console/src/features/organizations/pages/organization-edit.tsx
@@ -23,17 +23,18 @@ import { addAlert } from "@wso2is/core/store";
 import { Button, GenericIcon, PageLayout } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { RouteChildrenProps } from "react-router-dom";
 import { Dispatch } from "redux";
 import { Icon } from "semantic-ui-react";
 import useSignIn from "../../authentication/hooks/use-sign-in";
 import useAuthorization from "../../authorization/hooks/use-authorization";
-import { AppConstants, AppState, FeatureConfigInterface, history } from "../../core";
+import { AppConstants, FeatureConfigInterface, history } from "../../core";
 import { getOrganization, useAuthorizedOrganizationsList, useGetOrganizationBreadCrumb } from "../api";
 import { EditOrganization } from "../components/edit-organization/edit-organization";
 import { OrganizationIcon } from "../configs";
 import { OrganizationManagementConstants } from "../constants";
+import { useGetCurrentOrganizationType } from "../hooks/use-get-organization-type";
 import useOrganizationSwitch from "../hooks/use-organization-switch";
 import { OrganizationInterface, OrganizationResponseInterface } from "../models";
 
@@ -61,17 +62,13 @@ const OrganizationEditPage: FunctionComponent<OrganizationEditPagePropsInterface
     const { switchOrganization, switchOrganizationInLegacyMode } = useOrganizationSwitch();
     const { legacyAuthzRuntime }  = useAuthorization();
     const { onSignIn } = useSignIn();
-
-    const isFirstLevelOrg: boolean = useSelector((state: AppState) => state?.organization?.isFirstLevelOrganization);
-    const tenantDomain: string = useSelector((state: AppState) => state?.auth?.tenantDomain);
+    const { isFirstLevelOrganization, isSuperOrganization } = useGetCurrentOrganizationType();
 
     const shouldSendRequest: boolean = useMemo(() => {
         return (
-            isFirstLevelOrg ||
-            window[ "AppUtils" ].getConfig().organizationName ||
-            tenantDomain === AppConstants.getSuperTenant()
+            isFirstLevelOrganization() || isSuperOrganization() || window[ "AppUtils" ].getConfig().organizationName
         );
-    }, [ isFirstLevelOrg, tenantDomain ]);
+    }, [ isFirstLevelOrganization, isSuperOrganization ]);
 
     const { data: breadcrumbList, mutate: mutateOrganizationBreadCrumbFetchRequest } = useGetOrganizationBreadCrumb(
         shouldSendRequest

--- a/apps/console/src/features/organizations/utils/organization.ts
+++ b/apps/console/src/features/organizations/utils/organization.ts
@@ -45,5 +45,4 @@ export class OrganizationUtils {
     public static getOrganizationType(): OrganizationType{
         return store.getState().organization?.organizationType;
     }
-
 }

--- a/apps/console/src/features/organizations/utils/organization.ts
+++ b/apps/console/src/features/organizations/utils/organization.ts
@@ -16,9 +16,11 @@
  * under the License.
  */
 
+import { SessionStorageUtils } from "@wso2is/core/utils";
+import { organizationConfigs } from "../../../extensions";
 import { store } from "../../core/store";
 import { OrganizationManagementConstants, OrganizationType } from "../constants";
-import { GenericOrganization } from "../models";
+import { BreadcrumbList, GenericOrganization } from "../models";
 
 export class OrganizationUtils {
     /**
@@ -44,5 +46,37 @@ export class OrganizationUtils {
      */
     public static getOrganizationType(): OrganizationType{
         return store.getState().organization?.organizationType;
+    }
+
+    /**
+     * Handles the organization switch in the legacy mode.
+     * @param breadcrumbList - Breadcrumb list
+     * @param organization - Organization to switch to.
+     */
+    public static handleLegacyOrganizationSwitch(
+        breadcrumbList: BreadcrumbList,
+        organization: GenericOrganization
+    ): void {
+
+        let newOrgPath: string = "";
+
+        if (
+            breadcrumbList && breadcrumbList.length > 0 &&
+            OrganizationUtils.isSuperOrganization(breadcrumbList[ 0 ]) &&
+            breadcrumbList[ 1 ]?.id === organization.id &&
+            organizationConfigs.showSwitcherInTenants
+        ) {
+            newOrgPath = "/t/" + organization.name + "/" + window[ "AppUtils" ].getConfig().appBase;
+        } else if (OrganizationUtils.isSuperOrganization(organization)) {
+            newOrgPath = `/${ window[ "AppUtils" ].getConfig().appBase }`;
+        } else {
+            newOrgPath = "/o/" + organization.id + "/" + window[ "AppUtils" ].getConfig().appBase;
+        }
+
+        // Clear the callback url of the previous organization.
+        SessionStorageUtils.clearItemFromSessionStorage("auth_callback_url_console");
+
+        // Redirect the user to the newly selected organization path.
+        window.location.replace(newOrgPath);
     }
 }

--- a/apps/console/src/features/organizations/utils/organization.ts
+++ b/apps/console/src/features/organizations/utils/organization.ts
@@ -16,11 +16,9 @@
  * under the License.
  */
 
-import { SessionStorageUtils } from "@wso2is/core/utils";
-import { organizationConfigs } from "../../../extensions";
 import { store } from "../../core/store";
 import { OrganizationManagementConstants, OrganizationType } from "../constants";
-import { BreadcrumbList, GenericOrganization } from "../models";
+import { GenericOrganization } from "../models";
 
 export class OrganizationUtils {
     /**
@@ -48,35 +46,4 @@ export class OrganizationUtils {
         return store.getState().organization?.organizationType;
     }
 
-    /**
-     * Handles the organization switch in the legacy mode.
-     * @param breadcrumbList - Breadcrumb list
-     * @param organization - Organization to switch to.
-     */
-    public static handleLegacyOrganizationSwitch(
-        breadcrumbList: BreadcrumbList,
-        organization: GenericOrganization
-    ): void {
-
-        let newOrgPath: string = "";
-
-        if (
-            breadcrumbList && breadcrumbList.length > 0 &&
-            OrganizationUtils.isSuperOrganization(breadcrumbList[ 0 ]) &&
-            breadcrumbList[ 1 ]?.id === organization.id &&
-            organizationConfigs.showSwitcherInTenants
-        ) {
-            newOrgPath = "/t/" + organization.name + "/" + window[ "AppUtils" ].getConfig().appBase;
-        } else if (OrganizationUtils.isSuperOrganization(organization)) {
-            newOrgPath = `/${ window[ "AppUtils" ].getConfig().appBase }`;
-        } else {
-            newOrgPath = "/o/" + organization.id + "/" + window[ "AppUtils" ].getConfig().appBase;
-        }
-
-        // Clear the callback url of the previous organization.
-        SessionStorageUtils.clearItemFromSessionStorage("auth_callback_url_console");
-
-        // Redirect the user to the newly selected organization path.
-        window.location.replace(newOrgPath);
-    }
 }

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -3761,6 +3761,9 @@ export interface ConsoleNS {
                     goBack: string;
                     switchLabel: string;
                     switchButton: string;
+                    notifications: {
+                        switchOrganization: Notification;
+                    }
                 }
             };
             users: {

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -3760,6 +3760,7 @@ export interface ConsoleNS {
                     subOrganizations: string;
                     goBack: string;
                     switchLabel: string;
+                    switchButton: string;
                 }
             };
             users: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -10207,7 +10207,8 @@ export const console: ConsoleNS = {
                         placeholder: "Search by Name"
                     },
                     subOrganizations: "Organizations",
-                    switchLabel: "Organization"
+                    switchLabel: "Organization",
+                    switchButton: "Switch to Organization"
                 },
                 title: "Organizations"
             },

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -10208,7 +10208,15 @@ export const console: ConsoleNS = {
                     },
                     subOrganizations: "Organizations",
                     switchLabel: "Organization",
-                    switchButton: "Switch to Organization"
+                    switchButton: "Switch to Organization",
+                    notifications: {
+                        switchOrganization: {
+                            genericError: {
+                                description: "Couldn't switch to the selected organization.",
+                                message: "Something went wrong"
+                            }
+                        }
+                    }
                 },
                 title: "Organizations"
             },

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -8426,7 +8426,15 @@ export const console: ConsoleNS = {
                     goBack: "Retourner",
                     subOrganizations: "Organisations",
                     switchLabel: "Organisation",
-                    switchButton: "Passer à l'organisation"
+                    switchButton: "Passer à l'organisation",
+                    notifications: {
+                        switchOrganization: {
+                            genericError: {
+                                description: "Impossible de basculer vers l'organisation sélectionnée.",
+                                message: "Quelque chose s'est mal passé"
+                            }
+                        }
+                    }
                 },
                 title: "Organisations"
             },

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -8425,7 +8425,8 @@ export const console: ConsoleNS = {
                     },
                     goBack: "Retourner",
                     subOrganizations: "Organisations",
-                    switchLabel: "Organisation"
+                    switchLabel: "Organisation",
+                    switchButton: "Passer à l'organisation"
                 },
                 title: "Organisations"
             },

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -8250,7 +8250,15 @@ export const console: ConsoleNS = {
                     goBack: "ආපසු යන්න",
                     subOrganizations: "සංවිධාන",
                     switchLabel: "සංවිධානය",
-                    switchButton: "සංවිධානය වෙත මාරු වන්න"
+                    switchButton: "සංවිධානය වෙත මාරු වන්න",
+                    notifications: {
+                        switchOrganization: {
+                            genericError: {
+                                description: "ආයතනය වෙත මාරු කිරීමේදී දෝෂයක් ඇතිවිය",
+                                message: "යම්කිසි වරදක් සිදුවී ඇත."
+                            }
+                        }
+                    }
                 },
                 title: "සංවිධාන"
             },

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -8249,7 +8249,8 @@ export const console: ConsoleNS = {
                     },
                     goBack: "ආපසු යන්න",
                     subOrganizations: "සංවිධාන",
-                    switchLabel: "සංවිධානය"
+                    switchLabel: "සංවිධානය",
+                    switchButton: "සංවිධානය වෙත මාරු වන්න"
                 },
                 title: "සංවිධාන"
             },


### PR DESCRIPTION
### Purpose
This PR adds an option to switch to a particular sub organization from it's edit page in order to provide a better UX.

https://github.com/wso2/identity-apps/assets/27700915/c4cdcade-81f5-4f83-b609-587f1bc0225a

### Related Issues
- https://github.com/wso2/product-is/issues/18565

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
