### PR TITLE
update value for getProfileInfoFromIDToken config

### DIFF
--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -208,7 +208,7 @@
         "checkSessionInterval": 5,
         "userIdleTimeOut": 1800
     },
-    "getProfileInfoFromIDToken": true,
+    "getProfileInfoFromIDToken": false,
     "superTenantProxy": "",
     "legacyAuthzRuntime": false,
     "legacyMode": false,


### PR DESCRIPTION
### Purpose
Make the default value of the `getProfileInfoFromIDToken` config false to trigger a `/Me` call to get the profile information.

### Related Issues
- https://github.com/wso2/product-is/issues/18582

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5323

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
