### PR TITLE
Make the appearance of audience column in the roles page consistent with the appearance of audience column in other places

### DIFF
--- a/.changeset/stupid-ducks-fetch.md
+++ b/.changeset/stupid-ducks-fetch.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Make the appearance of audience column in the roles page consistent with other places.

--- a/apps/console/src/features/roles/components/role-list.tsx
+++ b/apps/console/src/features/roles/components/role-list.tsx
@@ -232,23 +232,16 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
                 id: "audience",
                 key: "audience",
                 render: (role: RolesInterface) => (
-                    <Header as="h6" data-componentid={ `${ componentId }-col-2-item-heading` }>
-                        <Header.Content>
-                            <Header.Subheader data-componentid={ `${ componentId }-col-2-item-sub-heading` }>
-                                { role?.audience?.type.charAt(0).toUpperCase() + role?.audience?.type.slice(1) }
-                                {
-                                    RoleAudienceTypes.APPLICATION === role?.audience?.type.toUpperCase() && (
-                                        <Label
-                                            size="mini"
-                                            className="client-id-label"
-                                        >
-                                            { role?.audience?.display }
-                                        </Label>
-                                    )
-                                }
-                            </Header.Subheader>
-                        </Header.Content>
-                    </Header>
+                    role?.audience && (
+                        <Label size="mini">
+                            { role.audience.type }
+                            {
+                                role.audience.type.toUpperCase() === RoleAudienceTypes.APPLICATION
+                                    ? ` | ${role.audience.display} `
+                                    : ""
+                            }
+                        </Label>
+                    )
                 ),
                 title: (
                     <div className="pl-3">


### PR DESCRIPTION
### Purpose
This PR ensures that the audience column's appearance on the Roles page aligns consistently with the presentation of audience columns on the Roles tab within the Edit User and Edit Group pages.

https://github.com/wso2/identity-apps/assets/27700915/73d0ae68-8f6a-4c17-a6b5-ee4f44265ee1

### Related Issues
- https://github.com/wso2/product-is/issues/18480


### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
