### PR TITLE
Fix issues with sign up confirmation configuration value not being sent

### DIFF
--- a/.changeset/many-hornets-serve.md
+++ b/.changeset/many-hornets-serve.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix issues with sign up confirmation configuration value not being sent

--- a/apps/console/src/features/server-configurations/forms/self-registration-form.tsx
+++ b/apps/console/src/features/server-configurations/forms/self-registration-form.tsx
@@ -303,12 +303,6 @@ export const SelfRegistrationForm: FunctionComponent<SelfRegistrationFormPropsIn
             };
         }
 
-        // Temporarily make SelfRegistration.NotifyAccountConfirmation false.
-        data = {
-            ...data,
-            "SelfRegistration.NotifyAccountConfirmation": false
-        };
-
         if (serverConfigurationConfig.dynamicConnectors) {
 
             const keysToOmit: string[] = [


### PR DESCRIPTION
### Purpose

`Send sign up confirmation email` property has been intentionally set to `false` in https://github.com/wso2-enterprise/asgardeo-app-extensions/pull/877. This PR removes that logic and enables end users to enable/disable the configuration as they prefer.

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/21217

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
