### PR TITLE
Make application role view read only in sub organizations

### DIFF
--- a/.changeset/fuzzy-pans-act.md
+++ b/.changeset/fuzzy-pans-act.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Make application role view read only in sub orgs.

--- a/apps/console/src/features/roles/components/application-roles.tsx
+++ b/apps/console/src/features/roles/components/application-roles.tsx
@@ -326,7 +326,7 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
                                         </Grid.Column>
                                         <Grid.Column width={ 6 }>
                                             {
-                                                roleAudience === RoleAudienceTypes.APPLICATION
+                                                roleAudience === RoleAudienceTypes.APPLICATION && !isReadOnly
                                                     && (
                                                         <LinkButton
                                                             fluid
@@ -388,10 +388,10 @@ export const ApplicationRoles: FunctionComponent<ApplicationRolesSettingsInterfa
                             <Autocomplete
                                 multiple
                                 disableCloseOnSelect
-                                readOnly={ isReadOnly }
                                 loading={ isLoading }
                                 options={ roleList }
                                 value={ selectedRoles ?? [] }
+                                disabled = { isReadOnly }
                                 getOptionLabel={
                                     (role: BasicRoleInterface) => role.name
                                 }


### PR DESCRIPTION
### Purpose
$subject

https://github.com/wso2/identity-apps/assets/27700915/2c6b0334-cd29-425c-aede-2eb9f38ccd0d


### Related Issues
- https://github.com/wso2/product-is/issues/18686

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
