### PR TITLE
Change button type of application role wizard

### DIFF
--- a/.changeset/sixty-rings-raise.md
+++ b/.changeset/sixty-rings-raise.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change button type

--- a/apps/console/src/features/roles/components/wizard-updated/application-role-wizard.tsx
+++ b/apps/console/src/features/roles/components/wizard-updated/application-role-wizard.tsx
@@ -499,6 +499,7 @@ export const ApplicationRoleWizard: FunctionComponent<ApplicationRoleWizardProps
                                 loading={ isSubmitting }
                                 disabled={ isFormError || isSubmitting || invalidAPIResourceFields?.length > 0 }
                                 form={ FORM_ID }
+                                type="button"
                                 onClick={ () => {
                                     formRef?.current?.triggerSubmit();
                                 } }


### PR DESCRIPTION
### Purpose
$subject
Firefox automatically follows the submit standard function after an event has occured when using a submit button. In PrimaryButton default type is "submit", so from this PR that type is changed to "button".

### Related Issues
- https://github.com/wso2/product-is/issues/18722

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
