### PR TITLE
Add missing i18n mappings for org sso page when email domain discovery is enabled

### DIFF
--- a/.changeset/lovely-knives-smoke.md
+++ b/.changeset/lovely-knives-smoke.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add missing i18n mappings for org sso page when email domain discovery is enabled

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -497,6 +497,7 @@ error.504=Fehler 504 - Timeout von Gateway
 # Organization Login
 organization.login=Organisation Login
 organization.name=Name der Organisation
+organization.email=E-Mail der Organisation
 invalid.organization.discovery.input=Die Organisation konnte nicht identifiziert werden. Bitte geben Sie den Namen der Organisation an, um fortzufahren.
 discovery.input.cannot.be.empty=E-Mail darf nicht leer sein.
 organization.name.cannot.be.empty=Der Name der Organisation darf nicht leer sein.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -497,6 +497,7 @@ error.504=Error 504 - Tiempo de espera de la puerta de enlace agotado
 # Organization Login
 organization.login=Inicio de sesión de la organización
 organization.name=Nombre de la Organizaci�n
+organization.email=Correo electrónico de la organización
 invalid.organization.discovery.input=No se puede identificar la organizaci�n. Proporcione el nombre de la organizaci�n para continuar.
 discovery.input.cannot.be.empty=El correo electr�nico no puede estar vac�o.
 organization.name.cannot.be.empty=El nombre de la organizaci�n no puede estar vac�o.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -498,6 +498,7 @@ error.504=Erreur 504 - Délai d'expiration de la passerelle
 # Organization Login
 organization.login=Connexion de l'organisation
 organization.name=Nom de l'organisation
+organization.email=E-mail de l'organisation
 invalid.organization.discovery.input=Impossible d'identifier l'organisation. Veuillez fournir le nom de l'organisation pour continuer.
 discovery.input.cannot.be.empty=L'e-mail ne peut pas �tre vide.
 organization.name.cannot.be.empty=Le nom de l'organisation ne peut pas �tre vide.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -497,6 +497,7 @@ error.504=Erro 504 - Tempo limite do gateway
 # Organization Login
 organization.login=Login da organização
 organization.name=Nome da organiza��o
+organization.email=E-mail da organização
 invalid.organization.discovery.input=N�o foi poss�vel identificar a organiza��o. Forne�a o nome da organiza��o para continuar.
 discovery.input.cannot.be.empty=O e-mail n�o pode ficar vazio.
 organization.name.cannot.be.empty=O nome da organiza��o n�o pode ficar vazio.


### PR DESCRIPTION
### Purpose

$subject

### Related Issues
- https://github.com/wso2/product-is/issues/18730

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
