### PR TITLE
Hide role delete option in the roles list in console settings page of a sub organization

### DIFF
--- a/.changeset/neat-pumpkins-rescue.md
+++ b/.changeset/neat-pumpkins-rescue.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Replace hardcoded isSubOrg prop with proper implementation

--- a/apps/console/src/features/console-settings/components/console-roles/console-roles-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-roles/console-roles-list.tsx
@@ -16,22 +16,17 @@
  * under the License.
  */
 
-import { AlertLevels, IdentifiableComponentInterface, RoleListInterface, RolesInterface } from "@wso2is/core/models";
+import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import ConsoleRolesListLayout from "./console-roles-list-layout";
-import { AppConstants } from "../../../core/constants/app-constants";
-import { UIConstants } from "../../../core/constants/ui-constants";
-import { history } from "../../../core/helpers";
-import { useRolesList } from "../../../roles/api/roles";
-import useConsoleSettings from "../../hooks/use-console-settings";
-import { AssociatedRolesPatchObjectInterface, BasicRoleInterface } from "../../../roles/models/roles";
 import CreateConsoleRoleWizard from "./create-console-role-wizard/create-console-role-wizard";
-import useConsoleRoles from "../../hooks/use-console-roles";
+import { UIConstants } from "../../../core/constants/ui-constants";
 import { useGetCurrentOrganizationType } from "../../../organizations/hooks/use-get-organization-type";
+import useConsoleRoles from "../../hooks/use-console-roles";
 
 /**
  * Props interface of {@link ConsoleRolesList}

--- a/apps/console/src/features/console-settings/components/console-roles/console-roles-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-roles/console-roles-list.tsx
@@ -31,6 +31,7 @@ import useConsoleSettings from "../../hooks/use-console-settings";
 import { AssociatedRolesPatchObjectInterface, BasicRoleInterface } from "../../../roles/models/roles";
 import CreateConsoleRoleWizard from "./create-console-role-wizard/create-console-role-wizard";
 import useConsoleRoles from "../../hooks/use-console-roles";
+import { useGetCurrentOrganizationType } from "../../../organizations/hooks/use-get-organization-type";
 
 /**
  * Props interface of {@link ConsoleRolesList}
@@ -64,6 +65,8 @@ const ConsoleRolesList: FunctionComponent<ConsoleRolesListInterface> = (
         isConsoleRolesFetchRequestLoading
     } = useConsoleRoles(true, listItemLimit, listOffset, searchQuery);
 
+    const { isSubOrganization } = useGetCurrentOrganizationType();
+
     /**
      * The following useEffect is used to handle if any error occurs while fetching the roles list.
      */
@@ -87,7 +90,7 @@ const ConsoleRolesList: FunctionComponent<ConsoleRolesListInterface> = (
         <>
             <ConsoleRolesListLayout
                 data-componentid={ `${ componentId }-layout` }
-                isSubOrg={ false }
+                isSubOrg={ isSubOrganization() }
                 rolesList={ consoleRoles }
                 onMutateRolesList={ mutateConsoleRolesFetchRequest }
                 isRolesListLoading={ isConsoleRolesFetchRequestLoading }


### PR DESCRIPTION
### Purpose
This PR hides the role delete option in the roles list in console settings page of a sub organization by replace hardcoded isSubOrg prop with proper implementation.

https://github.com/wso2/identity-apps/assets/27700915/759e4c99-018d-4b3c-b589-85cdd41c5cb0

### Related Issues
- https://github.com/wso2/product-is/issues/18722

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
