### PR TITLE
[improvement] Unmask OTP in Email OTP & SMS OTP UI by default

### DIFF
--- a/.changeset/odd-news-repair.md
+++ b/.changeset/odd-news-repair.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+[improvement] Unmask OTP in Email OTP UI by default

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -209,12 +209,12 @@
                             <span id="OTPDescription" style="display: none;">Enter your OTP</span>
                             <div class="ui fluid icon input addon-wrapper">
                                 <input
-                                    type="password"
+                                    type="text"
                                     id='OTPCode'
                                     name="OTPCode"
                                     c size='30'
                                     aria-describedby="OTPDescription"/>
-                                <i id="password-eye" class="eye icon right-align password-toggle" onclick="showOTPCode()"></i>
+                                <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
                             </div>
                                 <% } else { %>
                             <div class="field">
@@ -222,12 +222,12 @@
                                     :</label>
                                 <div class="ui fluid icon input addon-wrapper">
                                     <input
-                                        type="password"
+                                        type="text"
                                         id='OTPCode'
                                         name="OTPCode"
                                         size='30'
                                         aria-describedby="OTPDescription"/>
-                                    <i id="password-eye" class="eye icon right-align password-toggle" onclick="showOTPCode()"></i>
+                                    <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
                                 </div>
                                 <% } %>
                             </div>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
@@ -160,7 +160,7 @@
                                             class="form-control"
                                             placeholder="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "verification.code")%>"
                                         >
-                                        <% for (int index = 1; index <= otpLength;) { 
+                                        <% for (int index = 1; index <= otpLength;) {
                                             String previousStringIndex = null;
                                             if (index != 1) {
                                                 previousStringIndex = "pincode-" + (index - 1);
@@ -170,17 +170,17 @@
                                             String nextStringIndex = null;
                                             if (index != (otpLength + 1)) {
                                                 nextStringIndex = "pincode-" + index;
-                                            } 
+                                            }
                                         %>
                                             <div class="field mt-5">
                                                 <input
-                                                    class="text-center p-3" 
-                                                    id=<%= currentStringIndex %> 
+                                                    class="text-center p-3"
+                                                    id=<%= currentStringIndex %>
                                                     name=<%= currentStringIndex %>
                                                     onkeyup="movetoNext(this, '<%= nextStringIndex %>', '<%= previousStringIndex %>')"
-                                                    tabindex="1" 
-                                                    placeholder="·" 
-                                                    autofocus 
+                                                    tabindex="1"
+                                                    placeholder="·"
+                                                    autofocus
                                                     maxlength="1"
                                                 >
                                             </div>
@@ -188,8 +188,8 @@
                                     </div>
                                 <% } else { %>
                                     <div class="ui fluid icon input addon-wrapper">
-                                        <input type="password" id='OTPCode' name="OTPcode" size='30'/>
-                                        <i id="password-eye" class="eye icon right-align password-toggle" onclick="showOTPCode()"></i>
+                                        <input type="text" id='OTPCode' name="OTPcode" size='30'/>
+                                        <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
                                     </div>
                                 <% } %>
                             </div>
@@ -225,22 +225,22 @@
                                 <div class="buttons">
                                     <% if (otpLength <= 6) { %>
                                         <div>
-                                            <input type="button" 
-                                                id="subButton" 
+                                            <input type="button"
+                                                id="subButton"
                                                 onclick="sub(); return false;"
                                                 value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "authenticate")%>"
                                                 class="ui primary fluid large button" />
                                         </div>
                                     <% } else { %>
-                                        <input type="submit" 
-                                            name="authenticate" 
+                                        <input type="submit"
+                                            name="authenticate"
                                             id="authenticate"
                                             value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "authenticate")%>"
                                             class="ui primary fluid large button"/>
                                     <% } %>
 
-                                    <button type="button" 
-                                            class="ui fluid large button secondary mt-2" 
+                                    <button type="button"
+                                            class="ui fluid large button secondary mt-2"
                                             id="resend">
                                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "resend.code")%>
                                     </button>
@@ -251,7 +251,7 @@
                                     %>
                                         <div class="ui divider hidden"></div>
                                         <a
-                                            class="ui fluid primary basic button link-button" 
+                                            class="ui fluid primary basic button link-button"
                                             id="goBackLink"
                                             href='<%=Encode.forHtmlAttribute(multiOptionURI)%>'
                                         >


### PR DESCRIPTION
### Purpose
[improvement] Unmask OTP in Email OTP UI by default

### Screenrecording
#### SMS OTP
https://github.com/wso2/identity-apps/assets/46097917/acfba49d-bdc6-48bd-8c0c-002337b97211

#### Email OTP
https://github.com/wso2/identity-apps/assets/46097917/7da8a0f5-15cd-4732-ba35-cfbd9f0090ac

### Related Issues
- https://github.com/wso2/product-is/issues/18789

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
