### PR TITLE
Use default token validity values from the OIDC meta endpoint.

### DIFF
--- a/.changeset/lemon-moose-relate.md
+++ b/.changeset/lemon-moose-relate.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix globa token validity update issue

--- a/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -342,12 +342,12 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
         }
 
         config.inboundProtocolConfiguration.oidc[ "refreshToken" ] = {
-            expiryInSeconds: Number(OIDCMeta?.defaultRefreshTokenExpiryTime)
+            expiryInSeconds: parseInt(OIDCMeta?.defaultRefreshTokenExpiryTime, 10)
         };
 
         if (showRefreshToken || (!fields || fields.includes("RefreshToken"))) {
             config.inboundProtocolConfiguration.oidc[ "refreshToken" ] = {
-                expiryInSeconds: Number(OIDCMeta?.defaultRefreshTokenExpiryTime),
+                expiryInSeconds: parseInt(OIDCMeta?.defaultRefreshTokenExpiryTime, 10),
                 renewRefreshToken: values.get("RefreshToken").includes("refreshToken")
             };
         }
@@ -366,8 +366,8 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
         if (selectedTemplate?.templateId === ApplicationTemplateIdTypes.SPA && OIDCMeta) {
             config.inboundProtocolConfiguration.oidc["accessToken"] =
            {
-               applicationAccessTokenExpiryInSeconds: Number(OIDCMeta?.defaultApplicationAccessTokenExpiryTime),
-               userAccessTokenExpiryInSeconds: Number(OIDCMeta?.defaultUserAccessTokenExpiryTime)
+               applicationAccessTokenExpiryInSeconds: parseInt(OIDCMeta?.defaultApplicationAccessTokenExpiryTime, 10),
+               userAccessTokenExpiryInSeconds: parseInt(OIDCMeta?.defaultUserAccessTokenExpiryTime, 10)
            };
         }
 

--- a/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -32,6 +32,7 @@ import { ApplicationManagementConstants } from "../../constants";
 import SinglePageApplicationTemplate
     from "../../data/application-templates/templates/single-page-application/single-page-application.json";
 import {
+    ApplicationTemplateIdTypes,
     ApplicationTemplateListItemInterface,
     DefaultProtocolTemplate,
     GrantTypeInterface,
@@ -340,8 +341,13 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                 = values.get("publicClients").includes("supportPublicClients");
         }
 
+        config.inboundProtocolConfiguration.oidc[ "refreshToken" ] = {
+            expiryInSeconds: Number(OIDCMeta?.defaultRefreshTokenExpiryTime)
+        };
+
         if (showRefreshToken || (!fields || fields.includes("RefreshToken"))) {
             config.inboundProtocolConfiguration.oidc[ "refreshToken" ] = {
+                expiryInSeconds: Number(OIDCMeta?.defaultRefreshTokenExpiryTime),
                 renewRefreshToken: values.get("RefreshToken").includes("refreshToken")
             };
         }
@@ -355,6 +361,14 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
             config.inboundProtocolConfiguration.oidc[ "grantTypes" ] = selectedGrantTypes;
             config.inboundProtocolConfiguration.oidc[ "allowedOrigins" ] = resolveAllowedOrigins( urls ? urls
                 : callBackUrls);
+        }
+
+        if (selectedTemplate?.templateId === ApplicationTemplateIdTypes.SPA && OIDCMeta) {
+            config.inboundProtocolConfiguration.oidc["accessToken"] =
+           {
+               applicationAccessTokenExpiryInSeconds: Number(OIDCMeta?.defaultApplicationAccessTokenExpiryTime),
+               userAccessTokenExpiryInSeconds: Number(OIDCMeta?.defaultUserAccessTokenExpiryTime)
+           };
         }
 
         return config;


### PR DESCRIPTION
### Purpose
Fix global token expiration time update issue in SP and Traditional web apps

### Related Issues
- https://github.com/wso2/product-is/issues/18766

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
