### PR TITLE
Remove preview label from myaccount for SaaS deployment

### DIFF
--- a/.changeset/warm-chicken-double.md
+++ b/.changeset/warm-chicken-double.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove preview label from myaccount for SaaS deployment

--- a/apps/console/src/extensions/components/my-account/pages/my-account-edit.tsx
+++ b/apps/console/src/extensions/components/my-account/pages/my-account-edit.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -45,7 +45,7 @@ import React, {
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
-import { Checkbox, CheckboxProps, Grid, Icon, Label, List, Ref } from "semantic-ui-react";
+import { Checkbox, CheckboxProps, Grid, Icon, List, Ref } from "semantic-ui-react";
 import { ApplicationManagementConstants } from "../../../../features/applications/constants";
 import { AppConstants, AppState, history } from "../../../../features/core";
 import { useSMSNotificationSenders } from "../../identity-providers/api";
@@ -322,7 +322,7 @@ export const MyAccountSettingsEditPage: FunctionComponent<MyAccountSettingsEditP
     useEffect(() => {
         if (!isTOTPChecked) {
             setCheckTotpEnrollment(false);
-        } 
+        }
     }, [ isTOTPChecked ]);
 
     const getMyAccountStatus = (attributeName: string): boolean => {
@@ -640,14 +640,7 @@ export const MyAccountSettingsEditPage: FunctionComponent<MyAccountSettingsEditP
     return !isMyAccountDataValidating ?  (
         <PageLayout
             pageTitle={ t("extensions:manage.myAccount.editPage.pageTitle") }
-            title={ (
-                <>
-                    { t("extensions:manage.myAccount.editPage.pageTitle") }
-                    <Label size="medium" className="preview-label ml-2">
-                        { t("common:preview") }
-                    </Label>
-                </>
-            ) }
+            title={ t("extensions:manage.myAccount.editPage.pageTitle") }
             description={ (
                 <>
                     { t("extensions:manage.myAccount.editPage.description") }
@@ -715,7 +708,7 @@ export const MyAccountSettingsEditPage: FunctionComponent<MyAccountSettingsEditP
                                             <Field.Checkbox
                                                 ariaLabel="totpEnrollmentEnabled"
                                                 name="totpEnrollmentEnabled"
-                                                label={ 
+                                                label={
                                                     t("extensions:manage.myAccount.editPage.EnableTotpEnrollment") }
                                                 required={ false }
                                                 disabled={ !isMyAccountEnabled || !isTOTPChecked }
@@ -784,7 +777,7 @@ export const MyAccountSettingsEditPage: FunctionComponent<MyAccountSettingsEditP
                                                 name="backupCodeEnabled"
                                                 label={ t("extensions:manage.myAccount.editPage.enableBackupCodes") }
                                                 required={ false }
-                                                disabled={ !isMyAccountEnabled || !isOtpEnabled } 
+                                                disabled={ !isMyAccountEnabled || !isOtpEnabled }
                                                 width={ 16 }
                                                 data-testid={ `${ componentId }-backup-code-toggle` }
                                                 listen={ (value: boolean) => setCheckBackupCodeAuthenticator(value) }
@@ -793,7 +786,7 @@ export const MyAccountSettingsEditPage: FunctionComponent<MyAccountSettingsEditP
                                         </div>
                                         { !isOtpEnabled && (
                                             <div className="mt-0 mb-0">
-                                                <Message 
+                                                <Message
                                                     content={ t("extensions:manage.myAccount.editPage.backupCodeInfo") }
                                                     type="warning"
                                                 />

--- a/apps/console/src/extensions/components/my-account/pages/my-account.tsx
+++ b/apps/console/src/extensions/components/my-account/pages/my-account.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import Chip from "@oxygen-ui/react/Chip";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { GridLayout, PageLayout, Section } from "@wso2is/react-components";
@@ -159,12 +158,7 @@ export const MyAccountSettingsPage: FunctionComponent<MyAccountSettingsPageInter
     return (
         <PageLayout
             pageTitle={ t("extensions:manage.myAccount.pageTitle") }
-            title={ (
-                <>
-                    { t("extensions:manage.myAccount.pageTitle") }
-                    <Chip label={ t("common:preview") } className="oxygen-chip-beta ml-2" />
-                </>
-            ) }
+            title={ t("extensions:manage.myAccount.pageTitle") }
             description={ t("extensions:manage.myAccount.description") }
             data-componentid={ `${ componentId }-page-layout` }
         >

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -456,14 +456,6 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                     className="my-account-title mb-1"
                                 >
                                     { t("console:develop.features.applications.myaccount.title") }
-                                    {
-                                        isSAASDeployment && (
-                                            <Chip
-                                                label={ t("common:preview") }
-                                                className="oxygen-chip-beta ml-2"
-                                            />
-                                        )
-                                    }
                                     <Icon
                                         color={ isMyAccountEnabled ? "green":"grey" }
                                         name={ isMyAccountEnabled ? "check circle" : "minus circle" }

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import Chip from "@oxygen-ui/react/Chip";
+
 import { AccessControlConstants, Show } from "@wso2is/access-control";
 import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";


### PR DESCRIPTION
### Purpose

Removing the preview label from myaccount list item in the applications page for SaaS deployment, since My Account is no longer considered a preview feature.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
