### PR TITLE
Fix issue next button state of the user creation wizard

### DIFF
--- a/.changeset/sour-cobras-jog.md
+++ b/.changeset/sour-cobras-jog.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix issue with user creation wizard

--- a/apps/console/src/features/users/components/wizard/steps/add-user-basic.tsx
+++ b/apps/console/src/features/users/components/wizard/steps/add-user-basic.tsx
@@ -98,8 +98,8 @@ export const AddUserUpdated: React.FunctionComponent<AddUserProps> = (
     } = props;
 
     const [ passwordOption, setPasswordOption ] = useState<PasswordOptionTypes>(PasswordOptionTypes.CREATE_PASSWORD);
-    const [ askPasswordOption, setAskPasswordOption ] = useState<string>(AskPasswordOptionTypes.OFFLINE);
-    const [ password, setPassword ] = useState<string>("");
+    const [ askPasswordOption ] = useState<string>("email");
+    const [ password, setPassword ] = useState<string>(initialValues?.newPassword ?? "");
     const [ userStoreRegex, setUserStoreRegex ] = useState<string>("");
     const [ passwordConfig, setPasswordConfig ] = useState<ValidationFormInterface>(undefined);
     const [ usernameConfig, setUsernameConfig ] = useState<ValidationFormInterface>(undefined);

--- a/apps/console/src/features/users/components/wizard/steps/add-user-basic.tsx
+++ b/apps/console/src/features/users/components/wizard/steps/add-user-basic.tsx
@@ -98,7 +98,7 @@ export const AddUserUpdated: React.FunctionComponent<AddUserProps> = (
     } = props;
 
     const [ passwordOption, setPasswordOption ] = useState<PasswordOptionTypes>(PasswordOptionTypes.CREATE_PASSWORD);
-    const [ askPasswordOption ] = useState<string>("email");
+    const [ askPasswordOption, setAskPasswordOption ] = useState<string>(AskPasswordOptionTypes.OFFLINE);
     const [ password, setPassword ] = useState<string>(initialValues?.newPassword ?? "");
     const [ userStoreRegex, setUserStoreRegex ] = useState<string>("");
     const [ passwordConfig, setPasswordConfig ] = useState<ValidationFormInterface>(undefined);


### PR DESCRIPTION
### Purpose
> This PR fixes the state issue with the next button in the user creation wizard.

### Related Issues
- https://github.com/wso2/product-is/issues/18799

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
