### PR TITLE
Allow assignment of only RBAC-authorized APIs to application roles

### DIFF
--- a/.changeset/two-ducks-sort.md
+++ b/.changeset/two-ducks-sort.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Allow assignment of only RBAC-authorized APIs to application roles

--- a/apps/console/src/features/roles/components/wizard-updated/application-role-wizard.tsx
+++ b/apps/console/src/features/roles/components/wizard-updated/application-role-wizard.tsx
@@ -49,6 +49,7 @@ import {
     SelectedPermissionsInterface
 } from "../../models/roles";
 import { RoleAPIResourcesListItem } from "../edit-role/edit-role-common/role-api-resources-list-item";
+import {Policy} from "../../../../extensions/components/application/constants";
 
 interface ApplicationRoleWizardPropsInterface extends IdentifiableComponentInterface {
     application: ApplicationInterface;
@@ -121,7 +122,7 @@ export const ApplicationRoleWizard: FunctionComponent<ApplicationRoleWizardProps
             const isNotSelected: boolean = !selectedAPIResources
                 ?.find((selectedAPIResource: APIResourceInterface) => selectedAPIResource?.id === apiResource?.id);
 
-            if (isNotSelected) {
+            if (isNotSelected && apiResource.policyId == Policy.ROLE) {
                 options.push({
                     key: apiResource?.id,
                     text: apiResource?.displayName,

--- a/apps/console/src/features/roles/components/wizard-updated/application-role-wizard.tsx
+++ b/apps/console/src/features/roles/components/wizard-updated/application-role-wizard.tsx
@@ -34,6 +34,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { DropdownItemProps, DropdownProps, Grid, Modal } from "semantic-ui-react";
+import { Policy } from "../../../../extensions/components/application/constants";
 import { AppConstants, history } from "../../../../features/core";
 import { APIResourceInterface } from "../../../api-resources/models";
 import useSubscribedAPIResources from "../../../applications/api/use-subscribed-api-resources";
@@ -49,7 +50,6 @@ import {
     SelectedPermissionsInterface
 } from "../../models/roles";
 import { RoleAPIResourcesListItem } from "../edit-role/edit-role-common/role-api-resources-list-item";
-import {Policy} from "../../../../extensions/components/application/constants";
 
 interface ApplicationRoleWizardPropsInterface extends IdentifiableComponentInterface {
     application: ApplicationInterface;

--- a/apps/console/src/features/roles/components/wizard-updated/role-permissions/role-permissions.tsx
+++ b/apps/console/src/features/roles/components/wizard-updated/role-permissions/role-permissions.tsx
@@ -38,11 +38,11 @@ import { RoleAPIResourcesListItem } from "./components/role-api-resources-list-i
 import { useAPIResources } from "../../../../api-resources/api";
 import { APIResourceCategories, APIResourcesConstants } from "../../../../api-resources/constants";
 import { APIResourceUtils } from "../../../../api-resources/utils/api-resource-utils";
+import { Policy } from "../../../../applications/constants/api-authorization";
 import { useAPIResourceDetails, useGetAuthorizedAPIList } from "../../../api";
 import { RoleAudienceTypes } from "../../../constants/role-constants";
 import { APIResourceInterface, AuthorizedAPIListItemInterface, ScopeInterface } from "../../../models/apiResources";
 import { SelectedPermissionsInterface } from "../../../models/roles";
-import {Policy} from "../../../../applications/constants/api-authorization";
 
 /**
  * Interface to capture permission list props

--- a/apps/console/src/features/roles/components/wizard-updated/role-permissions/role-permissions.tsx
+++ b/apps/console/src/features/roles/components/wizard-updated/role-permissions/role-permissions.tsx
@@ -42,6 +42,7 @@ import { useAPIResourceDetails, useGetAuthorizedAPIList } from "../../../api";
 import { RoleAudienceTypes } from "../../../constants/role-constants";
 import { APIResourceInterface, AuthorizedAPIListItemInterface, ScopeInterface } from "../../../models/apiResources";
 import { SelectedPermissionsInterface } from "../../../models/roles";
+import {Policy} from "../../../../applications/constants/api-authorization";
 
 /**
  * Interface to capture permission list props
@@ -159,7 +160,7 @@ export const RolePermissionsList: FunctionComponent<RolePermissionsListProp> =
                 // API resources list options when role audience is "application".
                 authorizedAPIListForApplication?.map((api: AuthorizedAPIListItemInterface) => {
                     if (!selectedAPIResources.find((selectedAPIResource: APIResourceInterface) =>
-                        selectedAPIResource?.id === api?.id)) {
+                        selectedAPIResource?.id === api?.id) && api.policyId == Policy.ROLE) {
                         options.push({
                             key: api.id,
                             text: api.displayName,


### PR DESCRIPTION
### Purpose
- [Allow assignment of only RBAC-authorized APIs to application roles](https://github.com/wso2/identity-apps/commit/1420ca02d3bd82d291702b0088d309d04e54d5d1)

### Related Issues
- https://github.com/wso2/product-is/issues/18689

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
