### PR TITLE
Fix unwanted PATCH request in Application Protocol Update

### DIFF
--- a/.changeset/healthy-turkeys-double.md
+++ b/.changeset/healthy-turkeys-double.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix unwanted PATCH request

--- a/apps/console/src/features/applications/api/application.ts
+++ b/apps/console/src/features/applications/api/application.ts
@@ -129,8 +129,10 @@ export const deleteApplication = (id: string): Promise<any> => {
  *
  * @returns A promise containing the response.
  */
-export const updateApplicationDetails = (app: ApplicationInterface, skipEmptyPayloads?: boolean): Promise<any> => {
-
+export const updateApplicationDetails = (
+    app: ApplicationInterface,
+    skipEmptyPayloads?: boolean
+): Promise<ApplicationBasicInterface | void> => {
     const { id, ...rest } = app;
 
     if (skipEmptyPayloads && isEmpty(rest)) {

--- a/apps/console/src/features/applications/api/application.ts
+++ b/apps/console/src/features/applications/api/application.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -20,6 +20,7 @@ import { AsgardeoSPAClient, HttpClientInstance, HttpRequestConfig } from "@asgar
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { HttpMethods } from "@wso2is/core/models";
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import isEmpty from "lodash-es/isEmpty";
 import useRequest, {
     RequestConfigInterface,
     RequestErrorInterface,
@@ -124,12 +125,17 @@ export const deleteApplication = (id: string): Promise<any> => {
  * Updates the application with basic details.
  *
  * @param app - Basic info about the application.
+ * @param skipEmptyPayloads - Skip empty payloads.
  *
  * @returns A promise containing the response.
  */
-export const updateApplicationDetails = (app: ApplicationInterface): Promise<any> => {
+export const updateApplicationDetails = (app: ApplicationInterface, skipEmptyPayloads?: boolean): Promise<any> => {
 
     const { id, ...rest } = app;
+
+    if (skipEmptyPayloads && isEmpty(rest)) {
+        return Promise.resolve();
+    }
 
     const requestConfig: AxiosRequestConfig = {
         data: rest,

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -379,6 +379,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
      * Handles form submit.
      *
      * @param values - Form values.
+     * @param protocol - The protocol to be updated.
      */
     const handleSubmit = (
         values: {

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -382,7 +382,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
      */
     const handleSubmit = (values: any, protocol: string): void => {
         setIsLoading(true);
-        updateApplicationDetails({ id: appId, ...values.general })
+        updateApplicationDetails({ id: appId, ...values.general }, true)
             .then(async () => {
                 await handleInboundConfigFormSubmit(values.inbound, protocol);
 

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -179,6 +179,20 @@ interface AccessConfigurationPropsInterface extends SBACInterface<FeatureConfigI
 }
 
 /**
+ * Interface for the form values when updating an application.
+ */
+interface ApplicationUpdateFormValuesInterface {
+    /**
+     * Inbound protocol configuration values.
+    * */
+    inbound: Record<string, FormValue>;
+    /**
+     * General application configuration values.
+    */
+    general: ApplicationInterface;
+}
+
+/**
  *  Inbound protocols and advance settings component.
  *
  * @param props - Props injected to the component.
@@ -382,10 +396,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
      * @param protocol - The protocol to be updated.
      */
     const handleSubmit = (
-        values: {
-            inbound: Record<string, unknown>;
-            general: ApplicationInterface;
-        },
+        values: ApplicationUpdateFormValuesInterface,
         protocol: string
     ): void => {
         setIsLoading(true);
@@ -765,7 +776,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                                                                     : undefined
                                                             }
                                                             onSubmit={
-                                                                (values: Record<string, FormValue>) =>
+                                                                (values: ApplicationUpdateFormValuesInterface) =>
                                                                     handleSubmit(values, protocol)
                                                             }
                                                             type={ protocol as SupportedAuthProtocolTypes }
@@ -845,7 +856,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                                                     ]
                                                     : undefined
                                             }
-                                            onSubmit={ (values: Record<string, FormValue>) =>
+                                            onSubmit={ (values: ApplicationUpdateFormValuesInterface) =>
                                                 handleSubmit(values, protocol) }
                                             type={ SupportedAuthProtocolTypes.CUSTOM }
                                             readOnly={
@@ -907,7 +918,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                                                     : undefined
                                             }
                                             onSubmit={
-                                                (values: Record<string, FormValue>) =>
+                                                (values: ApplicationUpdateFormValuesInterface) =>
                                                     handleSubmit(values, inboundProtocolList[0])
                                             }
                                             type={ inboundProtocolList[0] as SupportedAuthProtocolTypes }
@@ -972,7 +983,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                                                     : undefined
                                             }
                                             onSubmit={
-                                                (values: Record<string, FormValue>) =>
+                                                (values: ApplicationUpdateFormValuesInterface) =>
                                                     handleSubmit(values, inboundProtocolList[0])
                                             }
                                             type={ SupportedAuthProtocolTypes.CUSTOM }

--- a/apps/console/src/features/applications/components/settings/access-configuration.tsx
+++ b/apps/console/src/features/applications/components/settings/access-configuration.tsx
@@ -380,8 +380,15 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
      *
      * @param values - Form values.
      */
-    const handleSubmit = (values: any, protocol: string): void => {
+    const handleSubmit = (
+        values: {
+            inbound: Record<string, unknown>;
+            general: ApplicationInterface;
+        },
+        protocol: string
+    ): void => {
         setIsLoading(true);
+
         updateApplicationDetails({ id: appId, ...values.general }, true)
             .then(async () => {
                 await handleInboundConfigFormSubmit(values.inbound, protocol);


### PR DESCRIPTION
### Purpose

An empty payload is sent as a PATCH when the certificates section is not there in the protocol section.

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/17694

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
