### PR TITLE
Fix UI disparities between cloud offering UI and onprem UI

### DIFF
--- a/.changeset/quick-tigers-enjoy.md
+++ b/.changeset/quick-tigers-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix UI disparities between cloud offering UI and onprem UI

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -551,94 +551,6 @@
                         if ((hasLocalLoginOptions && localAuthenticatorNames.size() > 1) || (!hasLocalLoginOptions)
                                 || (hasLocalLoginOptions && idpAuthenticatorMapping != null && idpAuthenticatorMapping.size() > 1)) {
                     %>
-                    <%
-                    String clientId = request.getParameter("client_id");
-                    String urlParameters = "";
-                    if (!isSelfSignUpEnabledInTenant
-                            && StringUtils.isNotBlank(application.getInitParameter("AccountRegisterEndpointURL"))
-                            && (StringUtils.equals("CONSOLE",clientId)
-                            || (StringUtils.equals("MY_ACCOUNT",clientId)
-                            && StringUtils.equals(tenantForTheming, IdentityManagementEndpointConstants.SUPER_TENANT)))
-                            && !StringUtils.equals("true", promptAccountLinking)) {
-                            String recoveryEPAvailable = application.getInitParameter("EnableRecoveryEndpoint");
-                            String enableSelfSignUpEndpoint = application.getInitParameter("EnableSelfSignUpEndpoint");
-                            Boolean isRecoveryEPAvailable = false;
-                            Boolean isSelfSignUpEPAvailable = false;
-                            String urlEncodedURL = "";
-                            if (StringUtils.isNotBlank(recoveryEPAvailable)) {
-                                isRecoveryEPAvailable = Boolean.valueOf(recoveryEPAvailable);
-                            } else {
-                                isRecoveryEPAvailable = isRecoveryEPAvailable();
-                            }
-                            if (StringUtils.isNotBlank(enableSelfSignUpEndpoint)) {
-                                isSelfSignUpEPAvailable = Boolean.valueOf(enableSelfSignUpEndpoint);
-                            } else {
-                                isSelfSignUpEPAvailable = isSelfSignUpEPAvailable();
-                            }
-                            if (isRecoveryEPAvailable || isSelfSignUpEPAvailable) {
-                                if (StringUtils.equals("business-app", insightsAppIdentifier)) {
-                                    String scheme = request.getScheme();
-                                    String serverName = request.getServerName();
-                                    int serverPort = request.getServerPort();
-                                    String uri = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_REQUEST_URI);
-                                    String prmstr = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
-                                    String urlWithoutEncoding = scheme + "://" +serverName + ":" + serverPort + uri + "?" + prmstr;
-                                    urlEncodedURL = URLEncoder.encode(urlWithoutEncoding, UTF_8);
-                                    urlParameters = prmstr;
-                                } else {
-                                    urlParameters = "utm_source=" + insightsAppIdentifier;
-                                }
-                                if (StringUtils.isBlank(accountRegistrationEndpointContextURL)) {
-                                    accountRegistrationEndpointContextURL = identityMgtEndpointContextURL + ACCOUNT_RECOVERY_ENDPOINT_REGISTER;
-                                }
-                            }
-                        %>
-                            <div class="mt-4 mb-4">
-                                <div class="mt-3 external-link-container text-small">
-                                    <%=AuthenticationEndpointUtil.i18n(resourceBundle, "dont.have.an.account")%>
-                                    <a
-                                        onclick="handleSignupClick()"
-                                        href="<%=getRegistrationUrl(accountRegistrationEndpointContextURL, urlEncodedURL, urlParameters)%>"
-                                        target="_self"
-                                        class="clickable-link"
-                                        rel="noopener noreferrer"
-                                        data-testid="login-page-early-signup-link"
-                                        style="cursor: pointer;"
-                                    >
-                                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "register")%>
-                                    </a>
-                                </div>
-                            </div>
-                            <% }
-                            if (!StringUtils.equals("CONSOLE",clientId)
-                                    && !StringUtils.equals("MY_ACCOUNT",clientId) && !hasLocalLoginOptions && hasFederatedOptions &&
-                                    isSelfSignUpEnabledInTenant && isSelfSignUpEnabledInTenantPreferences) {
-                                    urlParameters = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
-                            %>
-                                    <div class="ui horizontal divider">
-                                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
-                                    </div>
-                                    <div class="mt-0">
-                                    <div class="buttons">
-                                        <button
-                                            type="button"
-                                            <% if(StringUtils.isNotBlank(selfSignUpOverrideURL)) { %>
-                                            onclick="window.location.href='<%=i18nLink(userLocale, selfSignUpOverrideURL)%>';"
-                                            <% } else { %>
-                                            onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(getRegistrationUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, urlParameters))%>';"
-                                            <% } %>
-                                            class="ui large fluid button secondary"
-                                            id="registerLink"
-                                            role="button"
-                                            data-testid="login-page-create-account-button"
-                                        >
-                                            Create an account
-                                        </button>
-                                    </div>
-                                </div>
-                            <%
-                            }
-                            %>
                     <% if (localAuthenticatorNames.contains(BASIC_AUTHENTICATOR) ||
                             localAuthenticatorNames.contains(IDENTIFIER_EXECUTOR)) { %>
                     <div class="ui horizontal divider">
@@ -1156,6 +1068,100 @@
                             </div>
                         </div>
                     <% } %>
+
+                    <%
+                    String clientId = request.getParameter("client_id");
+                    String urlParameters = "";
+                    if (
+                        !isSelfSignUpEnabledInTenant
+                        && StringUtils.isNotBlank(application.getInitParameter("AccountRegisterEndpointURL"))
+                        && (
+                            StringUtils.equals("CONSOLE",clientId)
+                            || (
+                                StringUtils.equals("MY_ACCOUNT",clientId)
+                                && StringUtils.equals(tenantForTheming, IdentityManagementEndpointConstants.SUPER_TENANT)
+                            )
+                        )
+                        && !StringUtils.equals("true", promptAccountLinking)) {
+                            String recoveryEPAvailable = application.getInitParameter("EnableRecoveryEndpoint");
+                            String enableSelfSignUpEndpoint = application.getInitParameter("EnableSelfSignUpEndpoint");
+                            Boolean isRecoveryEPAvailable = false;
+                            Boolean isSelfSignUpEPAvailable = false;
+                            String urlEncodedURL = "";
+                            if (StringUtils.isNotBlank(recoveryEPAvailable)) {
+                                isRecoveryEPAvailable = Boolean.valueOf(recoveryEPAvailable);
+                            } else {
+                                isRecoveryEPAvailable = isRecoveryEPAvailable();
+                            }
+                            if (StringUtils.isNotBlank(enableSelfSignUpEndpoint)) {
+                                isSelfSignUpEPAvailable = Boolean.valueOf(enableSelfSignUpEndpoint);
+                            } else {
+                                isSelfSignUpEPAvailable = isSelfSignUpEPAvailable();
+                            }
+                            if (isRecoveryEPAvailable || isSelfSignUpEPAvailable) {
+                                if (StringUtils.equals("business-app", insightsAppIdentifier)) {
+                                    String scheme = request.getScheme();
+                                    String serverName = request.getServerName();
+                                    int serverPort = request.getServerPort();
+                                    String uri = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_REQUEST_URI);
+                                    String prmstr = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
+                                    String urlWithoutEncoding = scheme + "://" +serverName + ":" + serverPort + uri + "?" + prmstr;
+                                    urlEncodedURL = URLEncoder.encode(urlWithoutEncoding, UTF_8);
+                                    urlParameters = prmstr;
+                                } else {
+                                    urlParameters = "utm_source=" + insightsAppIdentifier;
+                                }
+                                if (StringUtils.isBlank(accountRegistrationEndpointContextURL)) {
+                                    accountRegistrationEndpointContextURL = identityMgtEndpointContextURL + ACCOUNT_RECOVERY_ENDPOINT_REGISTER;
+                                }
+                            }
+                        %>
+                            <div class="mt-4 mb-4">
+                                <div class="mt-3 external-link-container text-small">
+                                    <%=AuthenticationEndpointUtil.i18n(resourceBundle, "dont.have.an.account")%>
+                                    <a
+                                        onclick="handleSignupClick()"
+                                        href="<%=getRegistrationUrl(accountRegistrationEndpointContextURL, urlEncodedURL, urlParameters)%>"
+                                        target="_self"
+                                        class="clickable-link"
+                                        rel="noopener noreferrer"
+                                        data-testid="login-page-early-signup-link"
+                                        style="cursor: pointer;"
+                                    >
+                                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "register")%>
+                                    </a>
+                                </div>
+                            </div>
+                        <% }
+                        if (
+                            !StringUtils.equals("CONSOLE",clientId)
+                            && !StringUtils.equals("MY_ACCOUNT",clientId) && !hasLocalLoginOptions && hasFederatedOptions &&
+                            isSelfSignUpEnabledInTenant && isSelfSignUpEnabledInTenantPreferences
+                        ) {
+                                urlParameters = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
+                        %>
+                                <div class="ui horizontal divider">
+                                    <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
+                                </div>
+                                <div class="mt-0">
+                                <div class="buttons">
+                                    <button
+                                        type="button"
+                                        <% if(StringUtils.isNotBlank(selfSignUpOverrideURL)) { %>
+                                        onclick="window.location.href='<%=i18nLink(userLocale, selfSignUpOverrideURL)%>';"
+                                        <% } else { %>
+                                        onclick="window.location.href='<%=StringEscapeUtils.escapeHtml4(getRegistrationUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, urlParameters))%>';"
+                                        <% } %>
+                                        class="ui large fluid button secondary"
+                                        id="registerLink"
+                                        role="button"
+                                        data-testid="login-page-create-account-button"
+                                    >
+                                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "create.an.account")%>
+                                    </button>
+                                </div>
+                            </div>
+                        <% } %>
                 </div>
             </div>
         </layout:component>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -222,7 +222,7 @@
                         %>
                         <div class="field">
                             <label class="mb-5" for="username">
-                                <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, usernameLabel)%>
+                                <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "password.reset.with.username")%>
                             </label>
                             <div class="ui fluid left icon input">
                                 <input
@@ -252,7 +252,7 @@
 
                         <div class="field">
                             <label class="mb-5" for="username">
-                                <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, usernameLabel)%>
+                                <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "password.reset.with.username")%>
                             </label>
                             <div class="ui fluid left icon input">
                                 <% if (isMultiAttributeLoginEnabledInTenant) { %>


### PR DESCRIPTION
### Purpose

This PR will,

- show the same help text shown in the password recovery page of the cloud offering to the onprem apps.
- fix the order in which the signup link and external connections are displayed in the login page.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
