### PR TITLE
[fix] Locale not setting properly when the language cookie is not set

### DIFF
--- a/.changeset/thick-tools-nail.md
+++ b/.changeset/thick-tools-nail.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+[fix] locale not setting properly when the language cookie is not set

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -55,6 +55,18 @@
         String localeFromCookie = null;
         // Check cookie for the user selected language first
         Cookie[] cookies = request.getCookies();
+
+        // Map to store default supported language codes.
+        List<String> languageSupportedCountries = new ArrayList<>();
+        languageSupportedCountries.add("US");
+        languageSupportedCountries.add("FR");
+        languageSupportedCountries.add("ES");
+        languageSupportedCountries.add("PT");
+        languageSupportedCountries.add("DE");
+        languageSupportedCountries.add("CN");
+        languageSupportedCountries.add("JP");
+        languageSupportedCountries.add("BR");
+
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if (cookie.getName().equals(COOKIE_NAME)) {
@@ -94,7 +106,7 @@
                     langStr = lang.split("-")[0];
                     langLocale = lang.split("-")[1];
                 }
-                
+
                 Locale tempLocale = new Locale(langStr, langLocale);
                 // Trying to find out whether we have a resource bundle for the given locale
                 try {
@@ -116,6 +128,15 @@
                 } catch (Exception e) {
                     userLocale = browserLocale;
                 }
+            }
+        } else {
+            // `browserLocale` is coming as `en` instead of `en_US` for the first render before switching the language from the dropdown.
+            String countryCode = browserLocale.getCountry();
+
+            if (StringUtils.isNotBlank(countryCode) && languageSupportedCountries.contains(countryCode)) {
+                userLocale = new Locale(browserLocale.getLanguage(), countryCode);
+            } else {
+                userLocale = new Locale("en","US");
             }
         }
         return userLocale;

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -55,6 +55,18 @@
         String localeFromCookie = null;
         // Check cookie for the user selected language first
         Cookie[] cookies = request.getCookies();
+
+        // Map to store default supported language codes.
+        List<String> languageSupportedCountries = new ArrayList<>();
+        languageSupportedCountries.add("US");
+        languageSupportedCountries.add("FR");
+        languageSupportedCountries.add("ES");
+        languageSupportedCountries.add("PT");
+        languageSupportedCountries.add("DE");
+        languageSupportedCountries.add("CN");
+        languageSupportedCountries.add("JP");
+        languageSupportedCountries.add("BR");
+
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if (cookie.getName().equals(COOKIE_NAME)) {
@@ -116,6 +128,15 @@
                 } catch (Exception e) {
                     userLocale = browserLocale;
                 }
+            }
+        } else {
+            // `browserLocale` is coming as `en` instead of `en_US` for the first render before switching the language from the dropdown.
+            String countryCode = browserLocale.getCountry();
+
+            if (StringUtils.isNotBlank(countryCode) && languageSupportedCountries.contains(countryCode)) {
+                userLocale = new Locale(browserLocale.getLanguage(), countryCode);
+            } else {
+                userLocale = new Locale("en","US");
             }
         }
         return userLocale;


### PR DESCRIPTION
### Purpose
Locale not setting properly when the language cookie is not set.

### Related Issues
- https://github.com/wso2/product-is/issues/18859

### Screen record
https://github.com/wso2/identity-apps/assets/46097917/7c096d0b-b169-44bc-b59e-e0625913a1a4

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
