### PR TITLE
Enable a single authenticator for custom connector

### DIFF
--- a/.changeset/quick-hounds-play.md
+++ b/.changeset/quick-hounds-play.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Enable a single authenticator for custom connector

--- a/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
@@ -679,7 +679,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
 
         return [
             // Checkbox which triggers the default state of authenticator.
-            availableAuthenticators.length > 1 && {
+            availableAuthenticators?.length > 1 && {
                 defaultChecked: isDefaultAuthenticator,
                 disabled: authenticator.data?.isDefault || !authenticator.data?.isEnabled,
                 label: t(isDefaultAuthenticator ?
@@ -690,7 +690,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                 type: "checkbox"
             },
             // Toggle Switch which enables/disables the authenticator state.
-            availableAuthenticators.length > 1 && {
+            availableAuthenticators?.length > 1 && {
                 defaultChecked: authenticator.data?.isEnabled,
                 disabled: isDefaultAuthenticator,
                 label: t(authenticator.data?.isEnabled ?
@@ -787,7 +787,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         return (
             <Grid>
                 {
-                    availableAuthenticators.length > 1
+                    availableAuthenticators?.length > 1
                     && (
                         <Grid.Row>
                             <Grid.Column width={ 16 } textAlign="right">
@@ -819,7 +819,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                             globalActions={ [
                                                 {
                                                     disabled:
-                                                        availableAuthenticators.length <= 1
+                                                        availableAuthenticators?.length <= 1
                                                         && isDefaultAuthenticatorPredicate(authenticator),
                                                     icon: "trash alternate",
                                                     onClick: handleAuthenticatorDeleteOnClick,
@@ -855,7 +855,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                                             />
                                                         ),
                                                         hideChevron: (
-                                                            availableAuthenticators.length <= 1
+                                                            availableAuthenticators?.length <= 1
                                                             || isEmpty(authenticator.meta?.properties)
                                                         ),
                                                         icon: {
@@ -867,7 +867,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                                 ]
                                             }
                                             accordionActiveIndexes={
-                                                availableAuthenticators.length > 1
+                                                availableAuthenticators?.length > 1
                                                     ? accordionActiveIndexes
                                                     : [ 0 ]
                                             }

--- a/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
@@ -679,7 +679,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
 
         return [
             // Checkbox which triggers the default state of authenticator.
-            {
+            availableAuthenticators.length > 1 && {
                 defaultChecked: isDefaultAuthenticator,
                 disabled: authenticator.data?.isDefault || !authenticator.data?.isEnabled,
                 label: t(isDefaultAuthenticator ?
@@ -690,7 +690,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                 type: "checkbox"
             },
             // Toggle Switch which enables/disables the authenticator state.
-            {
+            availableAuthenticators.length > 1 && {
                 defaultChecked: authenticator.data?.isEnabled,
                 disabled: isDefaultAuthenticator,
                 label: t(authenticator.data?.isEnabled ?
@@ -786,23 +786,28 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
 
         return (
             <Grid>
-                <Grid.Row>
-                    <Grid.Column width={ 16 } textAlign="right">
-                        <PrimaryButton
-                            onClick={ handleAddAuthenticator }
-                            disabled={
-                                ConnectionManagementConstants.SHOW_PREDEFINED_TEMPLATES_IN_EXPERT_MODE_SETUP
-                                    ? isEmpty(availableTemplates) && isEmpty(availableManualModeOptions)
-                                    : isEmpty(availableManualModeOptions)
-                            }
-                            loading={ isIdPTemplateFetchRequestLoading }
-                            data-testid={ `${ testId }-add-authenticator-button` }
-                        >
-                            <Icon name="add"/>
-                            { t("console:develop.features.authenticationProvider.buttons.addAuthenticator") }
-                        </PrimaryButton>
-                    </Grid.Column>
-                </Grid.Row>
+                {
+                    availableAuthenticators.length > 1
+                    && (
+                        <Grid.Row>
+                            <Grid.Column width={ 16 } textAlign="right">
+                                <PrimaryButton
+                                    onClick={ handleAddAuthenticator }
+                                    disabled={
+                                        ConnectionManagementConstants.SHOW_PREDEFINED_TEMPLATES_IN_EXPERT_MODE_SETUP
+                                            ? isEmpty(availableTemplates) && isEmpty(availableManualModeOptions)
+                                            : isEmpty(availableManualModeOptions)
+                                    }
+                                    loading={ isIdPTemplateFetchRequestLoading }
+                                    data-testid={ `${ testId }-add-authenticator-button` }
+                                >
+                                    <Icon name="add"/>
+                                    { t("console:develop.features.authenticationProvider.buttons.addAuthenticator") }
+                                </PrimaryButton>
+                            </Grid.Column>
+                        </Grid.Row>
+                    )
+                }
                 <Grid.Row>
                     <Grid.Column width={ 16 }>
                         {
@@ -813,7 +818,9 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                             key={ index }
                                             globalActions={ [
                                                 {
-                                                    disabled: isDefaultAuthenticatorPredicate(authenticator),
+                                                    disabled:
+                                                        availableAuthenticators.length <= 1
+                                                        && isDefaultAuthenticatorPredicate(authenticator),
                                                     icon: "trash alternate",
                                                     onClick: handleAuthenticatorDeleteOnClick,
                                                     popoverText: "Remove Authenticator",
@@ -847,7 +854,10 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                                                 templateId={ identityProvider.templateId }
                                                             />
                                                         ),
-                                                        hideChevron: isEmpty(authenticator.meta?.properties),
+                                                        hideChevron: (
+                                                            availableAuthenticators.length <= 1
+                                                            || isEmpty(authenticator.meta?.properties)
+                                                        ),
                                                         icon: {
                                                             icon: resolveAuthenticatorIcon(authenticator)
                                                         },
@@ -856,7 +866,11 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                                     }
                                                 ]
                                             }
-                                            accordionActiveIndexes={ accordionActiveIndexes }
+                                            accordionActiveIndexes={
+                                                availableAuthenticators.length > 1
+                                                    ? accordionActiveIndexes
+                                                    : [ 0 ]
+                                            }
                                             accordionIndex={ index }
                                             handleAccordionOnClick={ handleAccordionOnClick }
                                             data-testid={ `${ testId }-accordion` }


### PR DESCRIPTION
### Purpose
> Enable a single authenticator for custom connector

When there's a single authenticator
<img width="1438" alt="Screenshot 2024-01-10 at 14 28 11" src="https://github.com/wso2/identity-apps/assets/27746285/882d1f57-169c-40b0-a4ce-06cb3b64633b">

When there are more than one authenticator
<img width="1438" alt="Screenshot 2024-01-10 at 14 40 24" src="https://github.com/wso2/identity-apps/assets/27746285/83510b43-7a61-4acb-a9ec-9f255a3cb875">

### Related Issues
- https://github.com/wso2/product-is/issues/18651
- https://github.com/wso2/product-is/issues/18378

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
