### PR TITLE
Fix width issue in attribute mapping search of custom connector

### DIFF
--- a/.changeset/wicked-singers-wait.md
+++ b/.changeset/wicked-singers-wait.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix width issue in attribute mapping search of custom connector

--- a/apps/console/src/features/connections/components/edit/settings/attribute-management/attribute-selection-v2.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/attribute-management/attribute-selection-v2.tsx
@@ -24,9 +24,9 @@ import { useTranslation } from "react-i18next";
 import { Grid, Icon, Segment, Table } from "semantic-ui-react";
 import { AddAttributeSelectionModal } from "./attribute-selection-modal";
 import { AttributeMappingList } from "./attributes-mapping-list";
-import { 
+import {
     ConnectionClaimInterface,
-    ConnectionCommonClaimMappingInterface 
+    ConnectionCommonClaimMappingInterface
 } from "../../../../models/connection";
 
 /**
@@ -184,7 +184,7 @@ export const AttributesSelectionV2: FunctionComponent<AttributesSelectionV2Props
                                 >
                                     <Table.Body>
                                         <Table.Row>
-                                            <Table.Cell collapsing width="6">
+                                            <Table.Cell collapsing width="10">
                                                 <Form
                                                     id={ FORM_ID }
                                                     // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
### Purpose
> Fix width issue in attribute mapping search of custom connector


Before
<img width="859" alt="Screenshot 2024-01-10 at 13 38 09" src="https://github.com/wso2/identity-apps/assets/27746285/ac3bd8a1-4e56-4e27-9592-b65ec807c8d8">


After
<img width="839" alt="Screenshot 2024-01-10 at 14 49 46" src="https://github.com/wso2/identity-apps/assets/27746285/f23d6d0c-ff8b-4ab7-a39a-a2a4184cbeb8">

### Related Issues
- https://github.com/wso2/product-is/issues/18869

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
