### PR TITLE
Add a text field for the ACS URL in SAML custom connector

### DIFF
--- a/.changeset/strange-knives-run.md
+++ b/.changeset/strange-knives-run.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add a text field for the ACS Url

--- a/apps/console/src/features/connections/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -215,8 +215,6 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
         { key: 25, text: "Custom Authentication Context Class", value: "Custom Authentication Context Class" }
     ];
 
-    const authorizedRedirectURL: string = config?.deployment?.customServerHost + "/commonauth";
-
     /**
      * ISAuthnReqSigned, IsLogoutReqSigned these two fields states will be used by other
      * fields states. Basically, algorithms fields enable and disable states will be

--- a/apps/console/src/features/connections/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -431,6 +431,10 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                     productName: config.ui.productName
                 }) }
                 readOnly={ readOnly }
+                validate={ composeValidators(
+                    isUrl,
+                    hasLength(IDENTITY_PROVIDER_AUTHORIZED_REDIRECT_URL_LENGTH)
+                ) }
             />
 
             <Field.Input

--- a/apps/console/src/features/connections/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -237,7 +237,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
 
         return {
             ArtifactResolveUrl: findPropVal<string>({ defaultValue: "", key: "ArtifactResolveUrl" }),
-            AuthRedirectUrl: findPropVal<string>({ defaultValue: authorizedRedirectURL, key: "AuthRedirectUrl" }),
+            AuthRedirectUrl: findPropVal<string>({ defaultValue: "", key: "AuthRedirectUrl" }),
             AuthnContextClassRef: findPropVal<string>({ defaultValue: "", key: "AuthnContextClassRef" }),
             AuthnContextComparisonLevel: findPropVal<string>({ defaultValue: "", key: "AuthnContextComparisonLevel" }),
             DigestAlgorithm: findPropVal<string>({ defaultValue: "SHA256", key: "DigestAlgorithm" }),
@@ -418,7 +418,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
             <Field.Input
                 name="AuthRedirectUrl"
                 value={ formValues?.AuthRedirectUrl }
-                inputType="copy_input"
+                inputType="default"
                 placeholder={ t(`${ I18N_TARGET_KEY }.AuthRedirectUrl.placeholder`) }
                 ariaLabel={ t(`${ I18N_TARGET_KEY }.AuthRedirectUrl.ariaLabel`) }
                 data-testid={ `${ testId }-authorized-redirect-url` }


### PR DESCRIPTION
### Purpose
> Add a text field for the ACS URL in the SAML custom connector.
<img width="634" alt="Screenshot 2024-01-11 at 14 49 42" src="https://github.com/wso2/identity-apps/assets/27746285/a91991d3-2780-47ed-af42-d45f2ad48281">

### Related Issues
- https://github.com/wso2/product-is/issues/18652

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
