### PR TITLE
Allow federated authenticator deletion when there is only one authenticator

### DIFF
--- a/.changeset/giant-comics-invite.md
+++ b/.changeset/giant-comics-invite.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Allow federated authenticator deletion when there is only one authenticator

--- a/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
@@ -518,7 +518,10 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
 
         const data: { authenticators: FederatedAuthenticatorInterface[], defaultAuthenticatorId: string } = {
             authenticators: authenticatorsList,
-            defaultAuthenticatorId: identityProvider.federatedAuthenticators.defaultAuthenticatorId
+            defaultAuthenticatorId:
+                authenticatorsList?.length !== 0
+                    ? identityProvider.federatedAuthenticators.defaultAuthenticatorId
+                    : ""
         };
 
         updateFederatedAuthenticators(data, identityProvider.id)
@@ -571,20 +574,6 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
      */
     const handleAuthenticatorDeleteOnClick = (e: MouseEvent<HTMLDivElement>, id: string): void => {
         if (!id) {
-            return;
-        }
-
-        if (id == identityProvider.federatedAuthenticators.defaultAuthenticatorId) {
-            dispatch(addAlert({
-                description: t("console:develop.features.authenticationProvider" +
-                    ".notifications.deleteDefaultAuthenticator" +
-                    ".error.description"),
-                level: AlertLevels.WARNING,
-                message: t("console:develop.features.authenticationProvider.notifications." +
-                    "deleteDefaultAuthenticator" +
-                    ".error.message")
-            }));
-
             return;
         }
 
@@ -819,7 +808,7 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                                             globalActions={ [
                                                 {
                                                     disabled:
-                                                        availableAuthenticators?.length <= 1
+                                                        availableAuthenticators?.length > 1
                                                         && isDefaultAuthenticatorPredicate(authenticator),
                                                     icon: "trash alternate",
                                                     onClick: handleAuthenticatorDeleteOnClick,


### PR DESCRIPTION
### Purpose
> Allow federated authenticator deletion when there is only one authenticator.

https://github.com/wso2/identity-apps/assets/27746285/b7d8b510-e1af-406e-aeba-53080ffcf52a

### Related Issues
- https://github.com/wso2/product-is/issues/18845

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
