### PR TITLE
Fix issue with cursor change on create connections page

### DIFF
--- a/.changeset/fifty-pots-study.md
+++ b/.changeset/fifty-pots-study.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix hover issue with the new connection cards.

--- a/apps/console/src/features/connections/pages/connection-templates.tsx
+++ b/apps/console/src/features/connections/pages/connection-templates.tsx
@@ -519,6 +519,7 @@ const ConnectionTemplatesPage: FC<ConnectionTemplatePagePropsInterface> = (
                                                                 .resolveConnectionResourcePath("", template.image)
                                                         }
                                                         tags={ template.tags }
+                                                        showActions={ true }
                                                         onClick={ (e: SyntheticEvent) => {
                                                             handleTemplateSelection(e, template.id);
                                                             setShowWizard(true);


### PR DESCRIPTION
### Purpose
Fix cursor change on hovering over a new connection card which gives the feel of a clickable item.