### PR TITLE
Fix My Account logout issues in legacy mode

### DIFF
--- a/.changeset/stale-fans-swim.md
+++ b/.changeset/stale-fans-swim.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Fix my account logout issues

--- a/apps/myaccount/src/hooks/use-sign-in.ts
+++ b/apps/myaccount/src/hooks/use-sign-in.ts
@@ -275,52 +275,48 @@ const useSignIn = (): UseSignInInterface => {
         ContextUtils.setRuntimeConfig(Config.getDeploymentConfig());
 
         // Update post_logout_redirect_uri of logout_url with tenant qualified url
-        if (legacyAuthzRuntime) {
-            if (sessionStorage.getItem(LOGOUT_URL)) {
-                logoutUrl = sessionStorage.getItem(LOGOUT_URL);
+        if (sessionStorage.getItem(LOGOUT_URL)) {
+            logoutUrl = sessionStorage.getItem(LOGOUT_URL);
 
-                // If there is a base name, replace the `post_logout_redirect_uri` with the tenanted base name.
-                if (window["AppUtils"].getConfig().appBase) {
-                    logoutUrl = logoutUrl.replace(
+            // If there is a base name, replace the `post_logout_redirect_uri` with the tenanted base name.
+            if (window["AppUtils"].getConfig().appBase) {
+                logoutUrl = logoutUrl.replace(
+                    window["AppUtils"].getAppBase(),
+                    window["AppUtils"].getAppBaseWithTenant()
+                );
+                logoutRedirectUrl = window["AppUtils"]
+                    .getConfig()
+                    .logoutCallbackURL.replace(
                         window["AppUtils"].getAppBase(),
                         window["AppUtils"].getAppBaseWithTenant()
                     );
-                    logoutRedirectUrl = window["AppUtils"]
-                        .getConfig()
-                        .logoutCallbackURL.replace(
-                            window["AppUtils"].getAppBase(),
-                            window["AppUtils"].getAppBaseWithTenant()
-                        );
-                } else {
-                    logoutUrl = logoutUrl.replace(
-                        window["AppUtils"].getConfig().logoutCallbackURL,
-                        window["AppUtils"].getConfig().clientOrigin + window["AppUtils"].getConfig().routes.login
-                    );
-                    logoutRedirectUrl =
-                        window["AppUtils"].getConfig().clientOrigin + window["AppUtils"].getConfig().routes.login;
-                }
-
-                // If an override URL is defined in config, use that instead.
-                if (window["AppUtils"].getConfig().idpConfigs?.logoutEndpointURL) {
-                    logoutUrl = resolveIdpURLSAfterTenantResolves(
-                        logoutUrl,
-                        window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL
-                    );
-                }
-
-                // If super tenant proxy is configured, logout url is updated with the
-                // configured super tenant proxy.
-                if (window["AppUtils"].getConfig().superTenantProxy) {
-                    logoutUrl = logoutUrl.replace(
-                        window["AppUtils"].getConfig().superTenant,
-                        window["AppUtils"].getConfig().superTenantProxy
-                    );
-                }
-
-                sessionStorage.setItem(LOGOUT_URL, logoutUrl);
+            } else {
+                logoutUrl = logoutUrl.replace(
+                    window["AppUtils"].getConfig().logoutCallbackURL,
+                    window["AppUtils"].getConfig().clientOrigin + window["AppUtils"].getConfig().routes.login
+                );
+                logoutRedirectUrl =
+                    window["AppUtils"].getConfig().clientOrigin + window["AppUtils"].getConfig().routes.login;
             }
-        } else {
-            logoutUrl = window["AppUtils"].getConfig().idpConfigs?.logoutEndpointURL;
+
+            // If an override URL is defined in config, use that instead.
+            if (window["AppUtils"].getConfig().idpConfigs?.logoutEndpointURL) {
+                logoutUrl = resolveIdpURLSAfterTenantResolves(
+                    logoutUrl,
+                    window["AppUtils"].getConfig().idpConfigs.logoutEndpointURL
+                );
+            }
+
+            // If super tenant proxy is configured, logout url is updated with the
+            // configured super tenant proxy.
+            if (window["AppUtils"].getConfig().superTenantProxy) {
+                logoutUrl = logoutUrl.replace(
+                    window["AppUtils"].getConfig().superTenant,
+                    window["AppUtils"].getConfig().superTenantProxy
+                );
+            }
+
+            sessionStorage.setItem(LOGOUT_URL, logoutUrl);
         }
 
         getDecodedIDToken()

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -241,6 +241,7 @@ export const AppUtils: AppUtilsInterface = (function() {
                 extensions: _config.extensions,
                 idpConfigs: this.resolveIdpConfigs(),
                 isSaas: this.isSaas(),
+                legacyAuthzRuntime: _config.legacyAuthzRuntime,
                 loginCallbackURL: this.constructRedirectURLs(_config.loginCallbackPath),
                 logoutCallbackURL: this.constructRedirectURLs(_config.logoutCallbackPath),
                 organizationPrefix: this.getOrganizationPrefix(),


### PR DESCRIPTION
### Purpose

`legacyAuthzRuntime` was missing in My Account causing the execution of the legacy sign in hook to be bypassed.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
