### PR TITLE
Fix `Custom` username type validation visibility issue

### DIFF
--- a/.changeset/orange-bears-wash.md
+++ b/.changeset/orange-bears-wash.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix Custom username type validation visibility issue.

--- a/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
+++ b/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
@@ -100,14 +100,14 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
     }, [ validationData, isValidationLoading ]);
 
     useEffect(() => {
-        if (initialFormValues !== undefined) {
+        if (initialFormValues) {
             setCurrentValues({ ...initialFormValues });
         }
 
     }, [ initialFormValues ]);
 
     useEffect(() => {
-        if (currentValues !== undefined) {
+        if (currentValues) {
             setTimeout(setPageLoaded, 200, true);
         }
 

--- a/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
+++ b/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
@@ -75,9 +75,8 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
     const [ isSubmitting, setSubmitting ] = useState<boolean>(false);
     const [ initialFormValues, setInitialFormValues ] = useState<ValidationFormInterface>(undefined);
     const [ isApplicationRedirect, setApplicationRedirect ] = useState<boolean>(false);
-    const [ currentValues, setCurrentValues ] = useState<ValidationFormInterface>(
-        initialFormValues
-    );
+    const [ currentValues, setCurrentValues ] = useState<ValidationFormInterface>(initialFormValues);
+    const [ pageLoaded, setPageLoaded ] = useState<boolean>(false);
 
     const {
         data: validationData,
@@ -98,10 +97,7 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
         }
 
         initializeForm();
-    }, [
-        validationData,
-        isValidationLoading
-    ]);
+    }, [ validationData, isValidationLoading ]);
 
     useEffect(() => {
         if (initialFormValues !== undefined) {
@@ -109,6 +105,13 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
         }
 
     }, [ initialFormValues ]);
+
+    useEffect(() => {
+        if (currentValues !== undefined) {
+            setTimeout(setPageLoaded, 200, true);
+        }
+
+    }, [ currentValues ]);
 
     useEffect(() => {
         const locationState: unknown = history.location.state;
@@ -285,7 +288,7 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
         return null;
     };
 
-    const handleUpdateUserameValidationData = (values: ValidationFormInterface): void => {
+    const handleUpdateUsernameValidationData = (values: ValidationFormInterface): void => {
 
         if (!validateForm(values)) {
             return;
@@ -358,7 +361,7 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
                     <Grid.Row columns={ 1 }>
                         <Grid.Column width={ 16 }>
                             <EmphasizedSegment className="form-wrapper" padded={ "very" }>
-                                { !isValidationLoading
+                                { pageLoaded
                                     ? (
                                         <div className="validation-configurations password-validation-configurations">
                                             <Form
@@ -368,7 +371,7 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
                                                 validate={ null }
                                                 onSubmit={
                                                     (values: ValidationFormInterface) =>
-                                                        handleUpdateUserameValidationData(values)
+                                                        handleUpdateUsernameValidationData(values)
                                                 }
                                             >
                                                 <div>

--- a/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
+++ b/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
@@ -75,8 +75,7 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
     const [ isSubmitting, setSubmitting ] = useState<boolean>(false);
     const [ initialFormValues, setInitialFormValues ] = useState<ValidationFormInterface>(undefined);
     const [ isApplicationRedirect, setApplicationRedirect ] = useState<boolean>(false);
-    const [ currentValues, setCurrentValues ] = useState<ValidationFormInterface>(initialFormValues);
-    const [ pageLoaded, setPageLoaded ] = useState<boolean>(false);
+    const [ currentValues, setCurrentValues ] = useState<ValidationFormInterface>(undefined);
 
     const {
         data: validationData,
@@ -96,22 +95,10 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
             return;
         }
 
-        initializeForm();
-    }, [ validationData, isValidationLoading ]);
-
-    useEffect(() => {
-        if (initialFormValues) {
-            setCurrentValues({ ...initialFormValues });
+        if (validationData) {
+            initializeForm();
         }
-
-    }, [ initialFormValues ]);
-
-    useEffect(() => {
-        if (currentValues) {
-            setTimeout(setPageLoaded, 200, true);
-        }
-
-    }, [ currentValues ]);
+    }, [ isValidationLoading ]);
 
     useEffect(() => {
         const locationState: unknown = history.location.state;
@@ -241,10 +228,9 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
         }
 
         const config: ValidationDataInterface = usernameConf[0];
-
         const rules: ValidationConfInterface[] = config.rules;
 
-        setInitialFormValues({
+        const values: ValidationFormInterface = {
             enableValidator:
                 (getValidationConfig(rules, "AlphanumericValidator", "enable.validator")=="true"
                 || !(getValidationConfig(rules, "EmailFormatValidator", "enable.validator")=="true"))
@@ -262,7 +248,10 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
                     ? getValidationConfig(rules, "LengthValidator", "min.length")
                     : UsernameValidationConstants.VALIDATION_DEFAULT_CONSTANTS.USERNAME_MIN,
             type: "rules"
-        });
+        };
+
+        setInitialFormValues(values);
+        setCurrentValues(values);
     };
 
     /**
@@ -361,7 +350,7 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
                     <Grid.Row columns={ 1 }>
                         <Grid.Column width={ 16 }>
                             <EmphasizedSegment className="form-wrapper" padded={ "very" }>
-                                { pageLoaded
+                                { initialFormValues && currentValues
                                     ? (
                                         <div className="validation-configurations password-validation-configurations">
                                             <Form


### PR DESCRIPTION
### Purpose
With this update the configuration section of the username validation option won't be hidden when clicking the `Custom` radio button immediately after the page load.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
