### PR TITLE
Show email in profile for users with custom username

### DIFF
--- a/.changeset/tasty-starfishes-hide.md
+++ b/.changeset/tasty-starfishes-hide.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Show email in profile for users with custom username.

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -150,7 +150,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
     useEffect(() => {
         if (!isEmpty(profileInfo)) {
             if ((commonConfig.userProfilePage.showEmail && usernameConfig?.enableValidator === "true")
-                    || getUserNameWithoutDomain(profileInfo.get("userName")) != profileInfo.get("emails")) {
+                    || getUserNameWithoutDomain(profileInfo.get("userName")) !== profileInfo.get("emails")) {
                 setShowEmail(true);
             } else {
                 setShowEmail(false);

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -1206,13 +1206,13 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                                         content: (
                                             <Trans
                                                 i18nKey={
-                                                    "myAccount:modals.editAvatarModal.content.gravatar.errors." + 
+                                                    "myAccount:modals.editAvatarModal.content.gravatar.errors." +
                                                     "noAssociation.content"
                                                 }
                                             >
                                                 It seems like the selected email is not registered on Gravatar.
-                                                Sign up for a Gravatar account by visiting 
-                                                <a href="https://www.gravatar.com"> Gravatar Official Website</a> 
+                                                Sign up for a Gravatar account by visiting
+                                                <a href="https://www.gravatar.com"> Gravatar Official Website</a>
                                                 or use one of the following.
                                             </Trans>
                                         ),

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -115,6 +115,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
     const [ countryList, setCountryList ] = useState<DropdownItemProps[]>([]);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ usernameConfig, setUsernameConfig ] = useState<ValidationFormInterface>(undefined);
+    const [ showEmail, setShowEmail ] = useState<boolean>(false);
 
     const allowedScopes: string = useSelector((state: AppState) => state?.authenticationInformation?.scope);
 
@@ -142,6 +143,20 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
             dispatch(getProfileInformation());
         }
     }, []);
+
+    /**
+     * Check if email address is displayed as a separated attribute.
+     */
+    useEffect(() => {
+        if (!isEmpty(profileInfo)) {
+            if ((commonConfig.userProfilePage.showEmail && usernameConfig?.enableValidator === "true")
+                    || getUserNameWithoutDomain(profileInfo.get("userName")) != profileInfo.get("emails")) {
+                setShowEmail(true);
+            } else {
+                setShowEmail(false);
+            }
+        }
+    }, [ profileInfo, usernameConfig ]);
 
     /**
      * Get the configurations.
@@ -937,11 +952,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                         < Grid.Column mobile={ 6 } tablet={ 6 } computer={ 4 } className="first-column">
                             <List.Content>
                                 {
-                                    (
-                                        !commonConfig.userProfilePage.showEmail
-                                        ||  usernameConfig?.enableValidator === "false"
-                                    )
-                                    &&  fieldName.toLowerCase() === "username"
+                                    !showEmail && fieldName.toLowerCase() === "username"
                                         ? fieldName + " (Email)"
                                         : fieldName
                                 }
@@ -1319,11 +1330,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("RESROUCE_TYPE")
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("EXTERNAL_ID")
                             || schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("META_DATA")
-                            || ((
-                                !commonConfig.userProfilePage.showEmail
-                                || usernameConfig?.enableValidator === "false"
-                            )
-                                && schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("EMAILS"))
+                            || (!showEmail && schema.name === ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("EMAILS"))
                         )) {
                             return (
                                 <>


### PR DESCRIPTION
### Purpose
For users created with a custom username, when the username validation option is changed to `Email`, the profile info section of MyAccount does not show the email address of the user. This PR resolves that issue.

### Related Issues
- None.

### Related PRs
- None.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
