### PR TITLE
Fix suborgs menu item being not visible in the side panel inside a suborg in legacy authz runtime

### DIFF
--- a/.changeset/hungry-ties-drive.md
+++ b/.changeset/hungry-ties-drive.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix suborgs menu item being not visible in the side panel inside a suborg in legacy authz runtime

--- a/apps/console/src/features/core/hooks/use-routes.tsx
+++ b/apps/console/src/features/core/hooks/use-routes.tsx
@@ -24,7 +24,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { commonConfig } from "../../../extensions/configs/common";
 import useAuthorization from "../../authorization/hooks/use-authorization";
-import { OrganizationManagementConstants } from "../../organizations/constants/organization-constants";
 import { useGetCurrentOrganizationType } from "../../organizations/hooks/use-get-organization-type";
 import { getAppViewRoutes } from "../configs/routes";
 import { AppConstants } from "../constants/app-constants";
@@ -114,8 +113,7 @@ const useRoutes = (): useRoutesInterface => {
                     } else {
                         if (window["AppUtils"].getConfig().organizationName) {
                             return [
-                                ...AppUtils.getHiddenRoutes(),
-                                ...OrganizationManagementConstants.ORGANIZATION_ROUTES
+                                ...AppUtils.getHiddenRoutes()
                             ];
                         } else {
                             return [ ...AppUtils.getHiddenRoutes(), ...AppConstants.ORGANIZATION_ROUTES ];


### PR DESCRIPTION
### Purpose

$subject

https://github.com/wso2/identity-apps/assets/41533942/b315a13c-f8ca-4c69-9072-fc29d858b97e

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
