### PR TITLE
Add Error Page for Duo

### DIFF
--- a/.changeset/brown-ads-argue.md
+++ b/.changeset/brown-ads-argue.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add error page for Duo

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -584,3 +584,11 @@ RmFpbGVkIEJhY2t1cCBDb2RlIEF0dGVtcHRz=Failed Backup Code Attempts
 # SAAS Product taglines
 saas.tagline=Create seamless login experiences for your applications in minutes
 saas.slogan={{productName}} is an IDaaS empowering developers to implement secure and frictionless access.
+
+# Duo Authenticator
+error.failed.with.duo=Failed Authentication with Duo
+error.user.not.registered=Couldn't get the user information. User may not be registered in Duo.
+error.duo.user.not.found=Couldn't get the verified user name.
+error.mobile.not.found=User may not have a mobile number in user's profile for Duo Authentication. Please update it.
+error.mobile.not.found.duo=Unable to get the registered phone number from Duo. Authentication failed.
+error.number.mismatch.duo=Authentication failed due to mismatch in mobile numbers. Please update the correct registered duo mobile number in user profile.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -579,3 +579,11 @@ RmFpbGVkIEJhY2t1cCBDb2RlIEF0dGVtcHRz=Fehlgeschlagene Sicherungscodeversuche
 # SAAS product tagline
 saas.tagline=Erstellen Sie in wenigen Minuten nahtlose Anmeldeerlebnisse fÃ¼r Ihre Anwendungen
 saas.slogan={{productName}} ist eine IDAAS, die Entwickler befÃ¤higt, einen sicheren und reibungslosen Zugang zu implementieren.
+
+# Duo Authenticator
+error.failed.with.duo=Authentifizierung mit Duo fehlgeschlagen
+error.user.not.registered=Die Benutzerinformationen konnten nicht abgerufen werden. Der Benutzer ist möglicherweise nicht in Duo registriert.
+error.duo.user.not.found=Der verifizierte Benutzername konnte nicht abgerufen werden.
+error.mobile.not.found=Der Benutzer hat möglicherweise keine Mobiltelefonnummer im Benutzerprofil für die Duo-Authentifizierung. Bitte aktualisieren Sie es.
+error.mobile.not.found.duo=Die registrierte Telefonnummer kann nicht von Duo abgerufen werden. Authentifizierung fehlgeschlagen.
+error.number.mismatch.duo=Die Authentifizierung ist aufgrund einer Nichtübereinstimmung der Mobiltelefonnummern fehlgeschlagen. Bitte aktualisieren Sie die korrekte registrierte Duo-Mobiltelefonnummer im Benutzerprofil.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -579,3 +579,11 @@ RmFpbGVkIEJhY2t1cCBDb2RlIEF0dGVtcHRz=Intentos de cÃ³digo de copia de seguridad f
 # SAAS Product taglines
 saas.tagline=Cree experiencias de inicio de sesiÃ³n sin problemas para sus aplicaciones en minutos
 saas.slogan={{productName}} es un IDAAS que empodera a los desarrolladores para implementar un acceso seguro y sin fricciÃ³n.
+
+# Duo Authenticator
+error.failed.with.duo=Autenticación fallida con Duo
+error.user.not.registered=No se pudo obtener la información del usuario. El usuario no puede estar registrado en Duo.
+error.duo.user.not.found=No se pudo obtener el nombre de usuario verificado.
+error.mobile.not.found=Es posible que el usuario no tenga un número de teléfono móvil en su perfil para la autenticación Duo. Por favor actualícelo.
+error.mobile.not.found.duo=No se puede obtener el número de teléfono registrado de Duo. La autenticación falló.
+error.number.mismatch.duo=La autenticación falló debido a una discrepancia en los números de móvil. Actualice el número de móvil dúo registrado correcto en el perfil de usuario.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -580,3 +580,11 @@ RmFpbGVkIEJhY2t1cCBDb2RlIEF0dGVtcHRz=Ã‰chec des tentatives de code de sauvegarde
 # SAAS Product taglines
 saas.tagline=CrÃ©ez des expÃ©riences de connexion transparentes pour vos applications en quelques minutes
 saas.slogan={{productName}} est un IDaaS permettant aux dÃ©veloppeurs de mettre en? uvre un accÃ¨s sÃ©curisÃ© et fluide.
+
+# Duo Authenticator
+error.failed.with.duo=Échec de l'authentification avec Duo
+error.user.not.registered=Impossible d'obtenir les informations utilisateur. L'utilisateur n'est peut-être pas enregistré dans Duo.
+error.duo.user.not.found=Impossible d'obtenir le nom d'utilisateur vérifié.
+error.mobile.not.found=L'utilisateur peut ne pas avoir de numéro de mobile dans son profil d'utilisateur pour l'authentification Duo. Veuillez le mettre à jour.
+error.mobile.not.found.duo=Impossible d'obtenir le numéro de téléphone enregistré auprès de Duo. Authentification échouée.
+error.number.mismatch.duo=L'authentification a échoué en raison d'une incohérence entre les numéros de mobile. Veuillez mettre à jour le numéro de mobile du duo enregistré correct dans le profil utilisateur.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -578,3 +578,11 @@ RmFpbGVkIEJhY2t1cCBDb2RlIEF0dGVtcHRz=バックアップコードの失敗
 # SAAS Product taglines
 saas.tagline=アプリケーションのシームレスなログイン体験を数分で作成
 saas.slogan={{productName}}は、開発者が安全でスムーズなアクセスを実装できるようにするIDaaSです。
+
+# Duo Authenticator
+error.failed.with.duo=Duo での認証の失敗
+error.user.not.registered=ユーザー情報を取得できませんでした。ユーザーがDuoに登録されていない可能性があります。
+error.duo.user.not.found=認証されたユーザー名を取得できませんでした。
+error.mobile.not.found=ユーザーのプロフィールに Duo 認証用の携帯電話番号が含まれていない可能性があります。更新してください。
+error.mobile.not.found.duo=Duo から登録された電話番号を取得できません。認証に失敗しました。
+error.number.mismatch.duo=携帯電話番号の不一致により認証に失敗しました。ユーザープロフィールに登録されている正しいデュオ携帯電話番号を更新してください。

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -396,8 +396,8 @@ cannot.access.smsotp=NÃ£o pode acessar o dispositivo?
 fido.failed.instruction=Clique em continuar e siga as instruÃ§Ãµes fornecidas pelo seu navegador para se autenticar usando uma chave de seguranÃ§a ou biometria no seu dispositivo.
 fido.error=Login com chave de seguranÃ§a/biometria interrompida!
 fido.registration.info=Ainda nÃ£o registrou sua chave de seguranÃ§a? Registre em
-fido.registration.option.info=Inscreva-se via 
-fido.learn.more.part.one=Preciso de ajuda? Contacte-nos em 
+fido.registration.option.info=Inscreva-se via
+fido.learn.more.part.one=Preciso de ajuda? Contacte-nos em
 fido.title.login=FaÃ§a login com senha
 fido.title.registration.instruction=Crie sua chave de acesso
 fido.info.registration.instruction=Siga as instruÃ§Ãµes do navegador para criar uma chave de acesso.
@@ -575,3 +575,11 @@ RmFpbGVkIEJhY2t1cCBDb2RlIEF0dGVtcHRz=Tentativas de cÃ³digo de backup com falha
 # SAAS Product taglines
 saas.tagline=Crie experiÃªncias de login integradas para seus aplicativos em minutos
 saas.slogan={{productName}} Ã© um IDaaS habilitando desenvolvedores a implementar acesso seguro e sem atrito.
+
+# Duo Authenticator
+error.failed.with.duo=Falha na autenticação com Duo
+error.user.not.registered=Não foi possível obter as informações do usuário. O usuário pode não estar cadastrado no Duo.
+error.duo.user.not.found=Não foi possível obter o nome de usuário verificado.
+error.mobile.not.found=O usuário não pode ter um número de celular no perfil do usuário para Autenticação Duo. Por favor atualize-o.
+error.mobile.not.found.duo=Não foi possível obter o número de telefone registrado do Duo. Falha na autenticação.
+error.number.mismatch.duo=A autenticação falhou devido a incompatibilidade nos números de celular. Atualize o número de celular duo registrado correto no perfil do usuário.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -579,3 +579,11 @@ RmFpbGVkIEJhY2t1cCBDb2RlIEF0dGVtcHRz=Tentativas de cÃ³digo de backup com falha
 # SAAS Product taglines
 saas.tagline=Crie experiÃªncias de login sem costura para seus aplicativos em minutos
 saas.slogan={{productName}} Ã© um IDaaS capacitando os desenvolvedores a implementar acesso seguro e sem atrito.
+
+# Duo Authenticator
+error.failed.with.duo=Falha na autenticação com Duo
+error.user.not.registered=Não foi possível obter as informações do usuário. O usuário pode não estar cadastrado no Duo.
+error.duo.user.not.found=Não foi possível obter o nome de usuário verificado.
+error.mobile.not.found=O usuário não pode ter um número de celular no perfil do usuário para Autenticação Duo. Por favor atualize-o.
+error.mobile.not.found.duo=Não foi possível obter o número de telefone registrado do Duo. Falha na autenticação.
+error.number.mismatch.duo=A autenticação falhou devido a incompatibilidade nos números de celular. Atualize o número de celular duo registrado correto no perfil do usuário.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -578,3 +578,11 @@ RmFpbGVkIEJhY2t1cCBDb2RlIEF0dGVtcHRz=备份代码尝试失败
 # SAAS Product taglines
 saas.tagline=在几分钟内为您的应用程序创建无缝的登录体验
 saas.slogan={{productName}}是IDAAS，授权开发人员实施安全和无摩擦的访问。
+
+# Duo Authenticator
+error.failed.with.duo=Duo 身份验证失败
+error.user.not.registered=无法获取用户信息。用户可能未在 Duo 中注册。
+error.duo.user.not.found=无法获取经过验证的用户名。
+error.mobile.not.found=用户的个人资料中可能没有用于双重身份验证的手机号码。请更新它。
+error.mobile.not.found.duo=无法从 Duo 获取注册的电话号码。认证失败。
+error.number.mismatch.duo=由于手机号码不匹配，身份验证失败。请在用户个人资料中更新正确的注册双人手机号码。

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/WEB-INF/web.xml
@@ -357,6 +357,11 @@
         <jsp-file>/magic_link_notification.jsp</jsp-file>
     </servlet>
 
+    <servlet>
+        <servlet-name>duo_error.do</servlet-name>
+        <jsp-file>/duoError.jsp</jsp-file>
+    </servlet>
+
     <servlet-mapping>
         <servlet-name>magic_link_notification.do</servlet-name>
         <url-pattern>/magic_link_notification.do</url-pattern>
@@ -585,6 +590,11 @@
     <servlet-mapping>
         <servlet-name>error.do</servlet-name>
         <url-pattern>/error.do</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>duo_error.do</servlet-name>
+        <url-pattern>/duo_error.do</url-pattern>
     </servlet-mapping>
 
     <error-page>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/duoError.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/duoError.jsp
@@ -1,0 +1,138 @@
+<%--
+  ~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+--%>
+
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
+<%@ include file="includes/localize.jsp" %>
+
+<%-- Include tenant context --%>
+<jsp:directive.include file="includes/init-url.jsp"/>
+
+<%-- Branding Preferences --%>
+<jsp:directive.include file="includes/branding-preferences.jsp"/>
+
+<%
+    request.getSession().invalidate();
+    String queryString = request.getQueryString();
+    Map<String, String> idpAuthenticatorMapping = null;
+    if (request.getAttribute(Constants.IDP_AUTHENTICATOR_MAP) != null) {
+        idpAuthenticatorMapping = (Map<String, String>) request.getAttribute(Constants.IDP_AUTHENTICATOR_MAP);
+    }
+
+    String error = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.error");
+    String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "something.went.wrong.during.authentication");
+    String authenticationFailed = "false";
+
+    if (Boolean.parseBoolean(request.getParameter(Constants.AUTH_FAILURE))) {
+        authenticationFailed = "true";
+
+        if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
+            errorMessage = request.getParameter(Constants.AUTH_FAILURE_MSG);
+
+            if (errorMessage.equalsIgnoreCase("user.not.registered")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.user.not.registered");
+            } else if (errorMessage.equalsIgnoreCase("user.not.found")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.duo.user.not.found");
+            } else if (errorMessage.equalsIgnoreCase("unable.to.get.duo.mobileNumber")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.mobile.not.found.duo");
+            } else if (errorMessage.equalsIgnoreCase("unable.to.find.number")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.mobile.not.found");
+            } else if (errorMessage.equalsIgnoreCase("number.mismatch")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.number.mismatch.duo");
+            }
+        }
+    }
+%>
+
+<%-- Data for the layout from the page --%>
+<%
+    layoutData.put("containerSize", "medium");
+%>
+
+<html lang="en-US">
+    <head>
+        <%-- header --%>
+        <%
+            File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
+            if (headerFile.exists()) {
+        %>
+        <jsp:include page="extensions/header.jsp"/>
+        <% } else { %>
+        <jsp:include page="includes/header.jsp"/>
+        <% } %>
+
+        <!--[if lt IE 9]>
+        <script src="js/html5shiv.min.js"></script>
+        <script src="js/respond.min.js"></script>
+        <![endif]-->
+    </head>
+
+    <body class="login-portal layout email-otp-portal-layout">
+        <layout:main layoutName="<%= layout %>" layoutFileRelativePath="<%= layoutFileRelativePath %>" data="<%= layoutData %>" >
+            <layout:component componentName="ProductHeader">
+                <%-- product-title --%>
+                <%
+                    File productTitleFile = new File(getServletContext().getRealPath("extensions/product-title.jsp"));
+                    if (productTitleFile.exists()) {
+                %>
+                <jsp:include page="extensions/product-title.jsp"/>
+                <% } else { %>
+                <jsp:include page="includes/product-title.jsp"/>
+                <% } %>
+            </layout:component>
+            <layout:component componentName="MainSection">
+                <div class="ui segment">
+                    <%-- page content --%>
+                    <h2><%=error%></h2>
+                    <div class="ui divider hidden"></div>
+                    <%
+                        if ("true".equals(authenticationFailed)) {
+                    %>
+                    <div class="ui negative message" id="failed-msg"><%=errorMessage%></div>
+                    <% } %>
+                </div>
+            </layout:component>
+            <layout:component componentName="ProductFooter">
+                <%-- product-footer --%>
+                <%
+                    File productFooterFile = new File(getServletContext().getRealPath("extensions/product-footer.jsp"));
+                    if (productFooterFile.exists()) {
+                %>
+                <jsp:include page="extensions/product-footer.jsp"/>
+                <% } else { %>
+                <jsp:include page="includes/product-footer.jsp"/>
+                <% } %>
+            </layout:component>
+            <layout:dynamicComponent filePathStoringVariableName="pathOfDynamicComponent">
+                <jsp:include page="${pathOfDynamicComponent}" />
+            </layout:dynamicComponent>
+        </layout:main>
+
+    <%-- footer --%>
+    <%
+        File footerFile = new File(getServletContext().getRealPath("extensions/footer.jsp"));
+        if (footerFile.exists()) {
+    %>
+    <jsp:include page="extensions/footer.jsp"/>
+    <% } else { %>
+    <jsp:include page="includes/footer.jsp"/>
+    <% } %>
+    </body>
+</html>

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -435,6 +435,11 @@
         <jsp-file>/smsOtpError.jsp</jsp-file>
     </servlet>
 
+    <servlet>
+        <servlet-name>duo_error.do</servlet-name>
+        <jsp-file>/duoError.jsp</jsp-file>
+    </servlet>
+
     {% for custom_servlet in servlet %}
     <servlet>
         <servlet-name>{{custom_servlet.name}}</servlet-name>
@@ -679,6 +684,11 @@
     <servlet-mapping>
         <servlet-name>error.do</servlet-name>
         <url-pattern>/error.do</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>duo_error.do</servlet-name>
+        <url-pattern>/duo_error.do</url-pattern>
     </servlet-mapping>
 
     <error-page>


### PR DESCRIPTION
### Purpose

The purpose of this PR is to add an error page for Duo MFA.

The error strings used here are the same used in the current Duo connector. Since we will be upgrading the Duo connector to support Universal Prompt, there is no need to have a separate webapp for it. Therefore, the error page is moved to the authentication portal by the changes in this PR.

Screenshot of the error page

<img width="1512" alt="Screenshot 2024-01-17 at 11 03 50" src="https://github.com/wso2/identity-apps/assets/28347418/8014539c-4a38-422e-b6a3-89a449f6388b">

### Related Issues
- https://github.com/wso2/product-is/issues/14951

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
