### PR TITLE
Change scim template to scim2 in outbound provisioning

### DIFF
--- a/.changeset/ninety-bears-watch.md
+++ b/.changeset/ninety-bears-watch.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change scim template to scim2

--- a/apps/console/src/features/connections/components/edit/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/outbound-provisioning-settings.tsx
@@ -410,7 +410,9 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                                                     // Filter the scim1 connector since it is deprecated.
                                                     .filter((
                                                         connector: OutboundProvisioningConnectorWithMetaInterface
-                                                    ) => connector.id !== AuthenticatorManagementConstants.scimId)
+                                                    ) => connector.id !==
+                                                        AuthenticatorManagementConstants
+                                                            .DEPRECATED_SCIM1_PROVISIONING_CONNECTOR_ID)
                                                     .map((
                                                         connector: OutboundProvisioningConnectorWithMetaInterface,
                                                         index: number

--- a/apps/console/src/features/connections/components/edit/settings/outbound-provisioning-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/outbound-provisioning-settings.tsx
@@ -43,6 +43,7 @@ import {
     updateOutboundProvisioningConnector,
     updateOutboundProvisioningConnectors
 } from "../../../api/connections";
+import { AuthenticatorManagementConstants } from "../../../constants/autheticator-constants";
 import { AuthenticatorSettingsFormModes } from "../../../models/authenticators";
 import {
     ConnectionInterface,
@@ -405,25 +406,29 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                                     <Grid.Row>
                                         <Grid.Column>
                                             {
-                                                availableConnectors.map((
-                                                    connector: OutboundProvisioningConnectorWithMetaInterface,
-                                                    index: number
-                                                ) => {
-                                                    return (
-                                                        <AuthenticatorAccordion
-                                                            key={ index }
-                                                            globalActions = {
-                                                                [
-                                                                    {
-                                                                        disabled: connector.data?.isEnabled,
-                                                                        icon: "trash alternate",
-                                                                        onClick: handleAuthenticatorDeleteOnClick,
-                                                                        type: "icon"
-                                                                    }
-                                                                ]
-                                                            }
-                                                            authenticators={
-                                                                [
+                                                availableConnectors
+                                                    // Filter the scim1 connector since it is deprecated.
+                                                    .filter((
+                                                        connector: OutboundProvisioningConnectorWithMetaInterface
+                                                    ) => connector.id !== AuthenticatorManagementConstants.scimId)
+                                                    .map((
+                                                        connector: OutboundProvisioningConnectorWithMetaInterface,
+                                                        index: number
+                                                    ) => {
+                                                        return (
+                                                            <AuthenticatorAccordion
+                                                                key={ index }
+                                                                globalActions = {
+                                                                    [
+                                                                        {
+                                                                            disabled: connector.data?.isEnabled,
+                                                                            icon: "trash alternate",
+                                                                            onClick: handleAuthenticatorDeleteOnClick,
+                                                                            type: "icon"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                                authenticators={ [
                                                                     {
                                                                         actions: createAccordionActions(connector),
                                                                         content: (
@@ -452,15 +457,14 @@ export const OutboundProvisioningSettings: FunctionComponent<ProvisioningSetting
                                                                             flex: true
                                                                         }
                                                                     }
-                                                                ]
-                                                            }
-                                                            data-testid={ `${ testId }-accordion` }
-                                                            accordionActiveIndexes = { accordionActiveIndexes }
-                                                            accordionIndex = { index }
-                                                            handleAccordionOnClick = { handleAccordionOnClick }
-                                                        />
-                                                    );
-                                                })
+                                                                ] }
+                                                                data-testid={ `${ testId }-accordion` }
+                                                                accordionActiveIndexes = { accordionActiveIndexes }
+                                                                accordionIndex = { index }
+                                                                handleAccordionOnClick = { handleAccordionOnClick }
+                                                            />
+                                                        );
+                                                    })
                                             }
                                         </Grid.Column>
                                     </Grid.Row>

--- a/apps/console/src/features/connections/components/meta/connectors.ts
+++ b/apps/console/src/features/connections/components/meta/connectors.ts
@@ -37,11 +37,11 @@ export const OutboundConnectors: OutboundProvisioningConnectorMetaDataInterface[
         self: "/t/carbon.super/api/server/v1/identity-providers/meta/outbound-provisioning-connectors/c2FsZXNmb3JjZQ"
     },
     {
-        connectorId: "c2NpbQ",
-        description: "Provision users to SCIM 1.1 or SCIM 2.0 applications.",
-        displayName: "SCIM",
+        connectorId: "U0NJTTI",
+        description: "Provision users to SCIM 2.0 applications.",
+        displayName: "SCIM2",
         icon: getConnectorIcons().scim,
         name: "scim",
-        self: "/t/carbon.super/api/server/v1/identity-providers/meta/outbound-provisioning-connectors/c2NpbQ"
+        self: "/t/carbon.super/api/server/v1/identity-providers/meta/outbound-provisioning-connectors/U0NJTTI"
     }
 ];

--- a/apps/console/src/features/connections/constants/autheticator-constants.ts
+++ b/apps/console/src/features/connections/constants/autheticator-constants.ts
@@ -350,7 +350,7 @@ export class AuthenticatorManagementConstants {
     public static readonly ERROR_IN_DELETING_SMS_NOTIFICATION_SENDER: string = "An error occurred while deleting " +
         "SMS Notification Sender";
 
-    public static readonly ERROR_IN_FETCHING_FEDERATED_AUTHENTICATOR_META_DATA: string = "Failed to get " + 
+    public static readonly ERROR_IN_FETCHING_FEDERATED_AUTHENTICATOR_META_DATA: string = "Failed to get " +
         "federated authenticator meta details";
 
     public static ErrorMessages: {

--- a/apps/console/src/features/connections/constants/autheticator-constants.ts
+++ b/apps/console/src/features/connections/constants/autheticator-constants.ts
@@ -367,5 +367,5 @@ export class AuthenticatorManagementConstants {
         )
     }
 
-    public static readonly scimId: string = "c2NpbQ";
+    public static readonly DEPRECATED_SCIM1_PROVISIONING_CONNECTOR_ID: string = "c2NpbQ";
 }

--- a/apps/console/src/features/connections/constants/autheticator-constants.ts
+++ b/apps/console/src/features/connections/constants/autheticator-constants.ts
@@ -366,4 +366,6 @@ export class AuthenticatorManagementConstants {
             "There are applications using this connection."
         )
     }
+
+    public static readonly scimId: string = "c2NpbQ";
 }


### PR DESCRIPTION
### Purpose
> Currently, we have a common template to add both scim and scim2 outbound provisioning connectors. But this connector doesn't function dynamically for scim1 and scim2. Hence we only allow to create scim2 connector for outbound provisioning since scim1 is already deprecated in identity server 6.1 console.

Create authenticator
<img width="716" alt="Screenshot 2024-01-17 at 14 53 18" src="https://github.com/wso2/identity-apps/assets/27746285/7958ab20-7ae8-46ad-820f-18955bae0338">

Edit authenticator
<img width="1111" alt="Screenshot 2024-01-17 at 14 53 52" src="https://github.com/wso2/identity-apps/assets/27746285/101cf697-f613-4159-b346-688e34e25312">

<img width="1154" alt="Screenshot 2024-01-18 at 12 25 06" src="https://github.com/wso2/identity-apps/assets/27746285/1869523b-70a5-47b6-9acb-359ce118239a">


Application section
<img width="575" alt="Screenshot 2024-01-17 at 14 52 48" src="https://github.com/wso2/identity-apps/assets/27746285/11a65333-9c42-40be-83df-45c5ac8d9db6">


### Related Issues
- https://github.com/wso2/product-is/issues/18840

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
