### PR TITLE
Handle application names with multiple words

### DIFF
--- a/.changeset/rude-lamps-taste.md
+++ b/.changeset/rude-lamps-taste.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Handle application names with multiple words.

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -825,7 +825,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
             let filter: string = "name eq ";
 
             if (value.toString().includes(" ")) {
-                filter += "\"" + value.toString() + "\"";
+                filter += `"${value.toString()}"`;
             } else {
                 filter += value.toString();
             }

--- a/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/minimal-application-create-wizard.tsx
@@ -822,7 +822,15 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         let response: ApplicationListInterface = null;
 
         try {
-            response = await getApplicationList(null, null, "name eq " + value.toString());
+            let filter: string = "name eq ";
+
+            if (value.toString().includes(" ")) {
+                filter += "\"" + value.toString() + "\"";
+            } else {
+                filter += value.toString();
+            }
+
+            response = await getApplicationList(null, null, filter);
             if (response?.applications?.length > 0) {
                 validation.isValid = false;
                 validation.errorMessages.push(

--- a/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
+++ b/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -187,11 +187,25 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
             + " "
             + values.get(FILTER_CONDITION_FIELD_IDENTIFIER)
             + " "
-            + values.get(FILTER_VALUES_FIELD_IDENTIFIER);
+            + getFilterValue(values.get(FILTER_VALUES_FIELD_IDENTIFIER)[0]);
 
         setExternalSearchQuery(query);
         onFilter(query);
         setIsFormSubmitted(true);
+    };
+
+    /**
+     * Handle filter values with multiple words (enclose in double quotes).
+     *
+     * @param value - Input filter value.
+     * @returns Formatted filter value.
+     */
+    const getFilterValue = (value: string): string => {
+        if (value.includes(" ")) {
+            return "\"" + value + "\"";
+        }
+
+        return value;
     };
 
     /**

--- a/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
+++ b/apps/console/src/features/core/components/advanced-search-with-basic-filters.tsx
@@ -202,7 +202,7 @@ export const AdvancedSearchWithBasicFilters: FunctionComponent<AdvancedSearchWit
      */
     const getFilterValue = (value: string): string => {
         if (value.includes(" ")) {
-            return "\"" + value + "\"";
+            return `"${value}"`;
         }
 
         return value;


### PR DESCRIPTION
### Purpose
Enclose application names in double quotes when name has more than one word to avoid filtering issues when calling the applications API.

### Related Issues
- wso2/product-is#18921

### Related PRs
- None.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
