### PR TITLE
Fix account lock option being hidden based on the status of "activate account immediately" option

### DIFF
--- a/.changeset/old-steaks-occur.md
+++ b/.changeset/old-steaks-occur.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix account lock option being hidden based on the status of account immediately enable option

--- a/apps/console/src/features/users/components/user-profile.tsx
+++ b/apps/console/src/features/users/components/user-profile.tsx
@@ -1153,7 +1153,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                     )
                                 }
                                 {
-                                    !allowDeleteOnly && configSettings?.accountLock === "true" && (
+                                    !allowDeleteOnly && (
                                         <DangerZone
                                             data-testid={ `${ testId }-danger-zone` }
                                             actionTitle={ t("console:manage.features.user.editUser.dangerZoneGroup." +


### PR DESCRIPTION
### Purpose

$subject

### Related Issues
- https://github.com/wso2/product-is/issues/18030

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
