### PR TITLE
Remove the repetitive authenticators from the custom connector authenticator templates

### DIFF
--- a/.changeset/honest-boxes-exist.md
+++ b/.changeset/honest-boxes-exist.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove the repetitive authenticators from the custom connector authenticator templates

--- a/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
@@ -111,6 +111,20 @@ const URL_MAX_LENGTH: number = 2048;
 const AUTHORIZED_REDIRECT_URLS: string[] = [ "callbackUrl", "callBackUrl" ];
 
 /**
+ * The set of authenticator templates in the Create New Connection Wizard.
+ */
+const commonAuthenticators: string[] = [
+    ConnectionManagementConstants.GOOGLE_OIDC_AUTHENTICATOR_ID,
+    ConnectionManagementConstants.MICROSOFT_AUTHENTICATOR_ID,
+    ConnectionManagementConstants.FACEBOOK_AUTHENTICATOR_ID,
+    ConnectionManagementConstants.GITHUB_AUTHENTICATOR_ID,
+    ConnectionManagementConstants.APPLE_AUTHENTICATOR_ID,
+    ConnectionManagementConstants.TRUSTED_TOKEN_TEMPLATE_ID,
+    ConnectionManagementConstants.SAML_AUTHENTICATOR_ID,
+    ConnectionManagementConstants.OIDC_AUTHENTICATOR_ID
+];
+
+/**
  *  Identity Provider and advance settings component.
  *
  * @param props - Props injected to the component.
@@ -621,6 +635,10 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
         let moderatedManualModeOptions: FederatedAuthenticatorMetaDataInterface[] = cloneDeep(
             availableFederatedAuthenticators as FederatedAuthenticatorMetaDataInterface[]
         );
+
+        moderatedManualModeOptions = moderatedManualModeOptions?.filter(
+            (moderatedManualModeOption: FederatedAuthenticatorMetaDataInterface) =>
+                !commonAuthenticators.includes(moderatedManualModeOption.authenticatorId));
 
         moderatedManualModeOptions = moderatedManualModeOptions?.map(
             (option: FederatedAuthenticatorMetaDataInterface) => {


### PR DESCRIPTION
### Purpose
> Remove the authenticators (in the create new connection wizard) from the custom connector authenticator templates.

<img width="720" alt="Screenshot 2024-01-18 at 16 57 54" src="https://github.com/wso2/identity-apps/assets/27746285/0a4e2ad4-b6ec-4c24-ae77-8de50fbb5c94">

### Related Issues
- https://github.com/wso2/product-is/issues/18929

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
