### PR TITLE
Fix form autofill preventing form submission

### DIFF
--- a/.changeset/fast-stingrays-roll.md
+++ b/.changeset/fast-stingrays-roll.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/forms": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/common": patch
+---
+
+Fix form autofill preventing form submission


### PR DESCRIPTION
### Purpose

The current implementation of the forms module does not allow an autofilled form to be submitted. This issue arises because the input validation logic is linked to the onBlur event, and autofilling the form does not trigger the onBlur event. As a result, the form is prevented from submission, as the validation process is not completed.

This PR relocates the input validation logic just before the onSubmit method is called. Consequently, even if the form is autofilled, the form inputs are validated, enabling the submission of the form.

### Related Issues
- https://github.com/wso2/product-is/issues/18956

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
