### PR TITLE
Remove the duplicate `alias` field from IdP advance tab

### DIFF
--- a/.changeset/slow-elephants-march.md
+++ b/.changeset/slow-elephants-march.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove `alias` from IdP advance tab

--- a/apps/console/src/features/connections/components/edit/forms/advanced-configurations-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/advanced-configurations-form.tsx
@@ -77,7 +77,6 @@ export const AdvanceConfigurationsForm: FunctionComponent<AdvanceConfigurationsF
      */
     const updateConfiguration = (values: any): any => {
         return {
-            alias: values.get("alias"),
             homeRealmIdentifier: values.get("homeRealmIdentifier"),
             idpIssuerName: values.get("issuer"),
             isFederationHub: !!values.get("federationHub")?.includes("federationHub")
@@ -134,28 +133,6 @@ export const AdvanceConfigurationsForm: FunctionComponent<AdvanceConfigurationsF
                         <Hint>
                             { t("console:develop.features.authenticationProvider" +
                                 ".forms.advancedConfigs.homeRealmIdentifier.hint") }
-                        </Hint>
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 1 }>
-                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                        <Field
-                            name="alias"
-                            label={ t("console:develop.features.authenticationProvider" +
-                                ".forms.advancedConfigs.alias.label") }
-                            required={ false }
-                            requiredErrorMessage=""
-                            placeholder={
-                                t("console:develop.features.authenticationProvider.forms" +
-                                    ".advancedConfigs.alias.placeholder")
-                            }
-                            type="text"
-                            value={ config.alias }
-                            data-testid={ `${ testId }-alias` }
-                            readOnly={ isReadOnly }
-                        />
-                        <Hint>
-                            { t("console:develop.features.authenticationProvider.forms.advancedConfigs.alias.hint") }
                         </Hint>
                     </Grid.Column>
                 </Grid.Row>


### PR DESCRIPTION
### Purpose

`Alias` was available in the advance tab of IdPs. And `Alias` was recently added to the `General` tab as well to make it available for IdPs like `Trusted Token Issuer` that didn't have an Advance tab.

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/19008

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
