### PR TITLE
Make `DisplayName` property optional in JDBC userstore creation

### DIFF
--- a/.changeset/selfish-gorillas-poke.md
+++ b/.changeset/selfish-gorillas-poke.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Make `DisplayName` optional in JDBC

--- a/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
@@ -329,7 +329,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
                                                                 value={ property.value ?? property.defaultValue }
                                                                 type="text"
                                                                 key={ index }
-                                                                required={ true }
+                                                                required={ false }
                                                                 label={ userStorePropertyName }
                                                                 requiredErrorMessage={
                                                                     t(

--- a/apps/console/src/features/userstores/components/wizards/user-details.tsx
+++ b/apps/console/src/features/userstores/components/wizards/user-details.tsx
@@ -1,30 +1,31 @@
 /**
-* Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
-*
-* WSO2 LLC. licenses this file to you under the Apache License,
-* Version 2.0 (the 'License'); you may not use this file except
-* in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied. See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms } from "@wso2is/forms";
+import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { Grid } from "semantic-ui-react";
-import { TypeProperty } from "../../models";
+import { PropertyAttribute, TypeProperty } from "../../models";
 
 /**
- * Prop types of the `UserDetails` component 
+ * Props interface of {@link UserDetails}
  */
 interface UserDetailsPropsInterface extends TestableComponentInterface {
     /**
@@ -48,14 +49,12 @@ interface UserDetailsPropsInterface extends TestableComponentInterface {
 /**
  * This component renders the User Details step of the wizard.
  *
- * @param {UserDetailsPropsInterface} props - Props injected to the component.
- *
- * @returns {React.ReactElement}
+ * @param props - Props injected to the component.
+ * @returns User Details wizard form component.
  */
 export const UserDetails: FunctionComponent<UserDetailsPropsInterface> = (
     props: UserDetailsPropsInterface
 ): ReactElement => {
-
     const {
         submitState,
         onSubmit,
@@ -77,75 +76,77 @@ export const UserDetails: FunctionComponent<UserDetailsPropsInterface> = (
                         submitState={ submitState }
                     >
                         {
-                            properties.map(
-                                (selectedTypeDetail: TypeProperty, index: number) => {
-                                    const name = selectedTypeDetail.description.split("#")[ 0 ];
-                                    const toggle = selectedTypeDetail.attributes
-                                        .find(attribute => attribute.name === "type")?.value === "boolean";
-                                    return (
-                                        toggle
-                                            ? (
-                                                <Field
-                                                    key={ index }
-                                                    label={ name }
-                                                    name={ selectedTypeDetail.name }
-                                                    type="toggle"
-                                                    required={ false }
-                                                    requiredErrorMessage={
-                                                        t("console:manage.features.userstores.forms." +
-                                                            "custom.requiredErrorMessage",
-                                                            {
-                                                                name: name
-                                                            })
-                                                    }
-                                                    placeholder={
-                                                        t("console:manage.features.userstores.forms." +
-                                                            "custom.placeholder",
-                                                            {
-                                                                name: name
-                                                            })
-                                                    }
-                                                    value={
-                                                        values?.get(selectedTypeDetail?.name)?.toString()
-                                                        ?? selectedTypeDetail.defaultValue
-                                                    }
-                                                    toggle
-                                                    data-testid={ `${ testId }-form-toggle-${
-                                                        selectedTypeDetail.name }` }
-                                                />
-                                            )
-                                            : (
-                                                <Field
-                                                    key={ index }
-                                                    label={ name }
-                                                    name={ selectedTypeDetail.name }
-                                                    type="text"
-                                                    required={ true }
-                                                    requiredErrorMessage={
-                                                        t("console:manage.features.userstores.forms." +
-                                                            "custom.requiredErrorMessage",
-                                                            {
-                                                                name: name
-                                                            })
-                                                    }
-                                                    placeholder={
-                                                        t("console:manage.features.userstores.forms." +
-                                                            "custom.placeholder",
-                                                            {
-                                                                name: name
-                                                            })
-                                                    }
-                                                    value={
-                                                        values?.get(selectedTypeDetail?.name)?.toString()
-                                                        ?? selectedTypeDetail.defaultValue
-                                                    }
-                                                    data-testid={ `${ testId }-form-text-input-${
-                                                        selectedTypeDetail.name }` }
-                                                />
+                            properties.map((selectedTypeDetail: TypeProperty, index: number) => {
+                                const name: string = selectedTypeDetail.description.split("#")[ 0 ];
+                                const toggle: boolean = selectedTypeDetail.attributes
+                                    .find((attribute: PropertyAttribute) => {
+                                        return attribute.name === "type";
+                                    })?.value === "boolean";
+                                const isRequired: boolean = !isEmpty(selectedTypeDetail?.defaultValue);
 
-                                            )
+                                if (toggle) {
+                                    return (
+                                        <Field
+                                            key={ index }
+                                            label={ name }
+                                            name={ selectedTypeDetail.name }
+                                            type="toggle"
+                                            required={ false }
+                                            requiredErrorMessage={
+                                                t("console:manage.features.userstores.forms." +
+                                                        "custom.requiredErrorMessage",
+                                                {
+                                                    name: name
+                                                })
+                                            }
+                                            placeholder={
+                                                t("console:manage.features.userstores.forms." +
+                                                        "custom.placeholder",
+                                                {
+                                                    name: name
+                                                })
+                                            }
+                                            value={
+                                                values?.get(selectedTypeDetail?.name)?.toString()
+                                                    ?? selectedTypeDetail.defaultValue
+                                            }
+                                            toggle
+                                            data-testid={ `${ testId }-form-toggle-${
+                                                selectedTypeDetail.name }` }
+                                        />
                                     );
-                                })
+                                }
+
+                                return (
+                                    <Field
+                                        key={ index }
+                                        label={ name }
+                                        name={ selectedTypeDetail.name }
+                                        type="text"
+                                        required={ isRequired }
+                                        requiredErrorMessage={
+                                            t("console:manage.features.userstores.forms." +
+                                                    "custom.requiredErrorMessage",
+                                            {
+                                                name: name
+                                            })
+                                        }
+                                        placeholder={
+                                            t("console:manage.features.userstores.forms." +
+                                                    "custom.placeholder",
+                                            {
+                                                name: name
+                                            })
+                                        }
+                                        value={
+                                            values?.get(selectedTypeDetail?.name)?.toString()
+                                                ?? selectedTypeDetail.defaultValue
+                                        }
+                                        data-testid={ `${ testId }-form-text-input-${
+                                            selectedTypeDetail.name }` }
+                                    />
+                                );
+                            })
                         }
                     </Forms>
                 </Grid.Column>


### PR DESCRIPTION
### Purpose

*DisplayName* property is set to mandatory in JDBC userstore creation and improve the placeholder.

**After**

<img width="431" alt="Screenshot 2024-01-20 at 14 42 02" src="https://github.com/wso2/identity-apps/assets/25959096/0df70d9c-9a1a-4cba-84f3-560f0129b23c">

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/19010

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
