### PR TITLE
Enable filtering administrators based on the userstore in console settings page

### DIFF
--- a/.changeset/warm-dingos-poke.md
+++ b/.changeset/warm-dingos-poke.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Enable filtering administrators based on the userstore in console settings page

--- a/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
@@ -355,7 +355,7 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
             { adminUserListFetchError
                 ? (<EmptyPlaceholder
                     subtitle={ [ t("console:manage.features.users.placeholders.userstoreError.subtitles.0"),
-                        t("console:manage.features.users.placeholders.userstoreError.subtitles.1")     ] }
+                        t("console:manage.features.users.placeholders.userstoreError.subtitles.1") ] }
                     title={ t("console:manage.features.users.placeholders.userstoreError.title") }
                     image={ getEmptyPlaceholderIllustrations().genericError }
                     imageSize="tiny"

--- a/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
@@ -340,11 +340,11 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
                 isFirstLevelOrganization() || isSuperOrganization()
                     ? (
                         <Dropdown
-                          data-testid="user-mgt-user-list-userstore-dropdown"
-                          selection
-                          options={ availableUserStores }
-                          onChange={ handleSelectedUserStoreChange }
-                          defaultValue={ PRIMARY_USERSTORE.toLocaleLowerCase() }
+                            data-testid="user-mgt-user-list-userstore-dropdown"
+                            selection
+                            options={ availableUserStores }
+                            onChange={ handleSelectedUserStoreChange }
+                            defaultValue={ PRIMARY_USERSTORE.toLocaleLowerCase() }
                         />
                     ) : null
             }
@@ -357,29 +357,29 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
             { adminUserListFetchError
                 ? (
                     <EmptyPlaceholder
-                      subtitle={ [ t("console:manage.features.users.placeholders.userstoreError.subtitles.0"),
-                        t("console:manage.features.users.placeholders.userstoreError.subtitles.1") ] }
-                      title={ t("console:manage.features.users.placeholders.userstoreError.title") }
-                      image={ getEmptyPlaceholderIllustrations().genericError }
-                      imageSize="tiny"
+                        subtitle={ [ t("console:manage.features.users.placeholders.userstoreError.subtitles.0"),
+                            t("console:manage.features.users.placeholders.userstoreError.subtitles.1") ] }
+                        title={ t("console:manage.features.users.placeholders.userstoreError.title") }
+                        image={ getEmptyPlaceholderIllustrations().genericError }
+                        imageSize="tiny"
                     />
                 ): (
                     <AdministratorsTable
-                      defaultListItemLimit={ defaultListItemLimit }
-                      administrators={ administrators }
-                      onUserEdit={ handleUserEdit }
-                      onUserDelete={ handleUserDelete }
-                      isLoading={ loading }
-                      readOnlyUserStores={ readOnlyUserStores }
-                      onSearchQueryClear={ handleSearchQueryClear }
-                      searchQuery={ searchQuery }
-                      triggerClearQuery={ triggerClearQuery }
-                      onEmptyListPlaceholderActionClick={ () => null }
-                      onIsLoading={ setLoading }
-                      selection={ selection }
-                      showListItemActions={ showListItemActions }
-                      showMetaContent={ showMetaContent }
-                      data-componentid={ `${componentId}-table` }
+                        defaultListItemLimit={ defaultListItemLimit }
+                        administrators={ administrators }
+                        onUserEdit={ handleUserEdit }
+                        onUserDelete={ handleUserDelete }
+                        isLoading={ loading }
+                        readOnlyUserStores={ readOnlyUserStores }
+                        onSearchQueryClear={ handleSearchQueryClear }
+                        searchQuery={ searchQuery }
+                        triggerClearQuery={ triggerClearQuery }
+                        onEmptyListPlaceholderActionClick={ () => null }
+                        onIsLoading={ setLoading }
+                        selection={ selection }
+                        showListItemActions={ showListItemActions }
+                        showMetaContent={ showMetaContent }
+                        data-componentid={ `${componentId}-table` }
                     />
                 )
             }

--- a/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
@@ -23,8 +23,9 @@ import {
     IdentifiableComponentInterface
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ListLayout, PrimaryButton } from "@wso2is/react-components";
+import { EmptyPlaceholder, ListLayout, PrimaryButton } from "@wso2is/react-components";
 import { UsersConstants } from "apps/console/src/extensions/components/users/constants/users";
+import { UserStoreDropdownItem } from "apps/console/src/features/userstores/models";
 import React, { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -38,9 +39,11 @@ import {
     UIConstants,
     UserBasicInterface,
     UserRoleInterface,
+    getEmptyPlaceholderIllustrations,
     history
 } from "../../../../core";
 import { useGetCurrentOrganizationType } from "../../../../organizations/hooks/use-get-organization-type";
+import { PRIMARY_USERSTORE } from "../../../../userstores/constants";
 import useAdministrators from "../../../hooks/use-administrators";
 import useBulkAssignAdministratorRoles from "../../../hooks/use-bulk-assign-user-roles";
 import AddExistingUserWizard from "../add-existing-user-wizard/add-existing-user-wizard";
@@ -70,6 +73,10 @@ interface AdministratorsListProps extends IdentifiableComponentInterface {
      * List of readOnly user stores.
      */
     readOnlyUserStores?: string[];
+    /**
+     * List of available user stores
+     */
+    availableUserStores: UserStoreDropdownItem[]
 }
 
 /**
@@ -101,6 +108,7 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
         readOnlyUserStores,
         selection,
         showListItemActions,
+        availableUserStores,
         ["data-componentid"]: componentId
     } = props;
 
@@ -108,7 +116,7 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
 
     const dispatch: Dispatch = useDispatch();
 
-    const { isSubOrganization } = useGetCurrentOrganizationType();
+    const { isSubOrganization, isFirstLevelOrganization, isSuperOrganization } = useGetCurrentOrganizationType();
 
     const { unassignAdministratorRoles } = useBulkAssignAdministratorRoles();
 
@@ -118,18 +126,20 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
     const [ searchQuery, setSearchQuery ] = useState<string>("");
     const [ showAddExistingUserWizard, setShowAddExistingUserWizard ] = useState<boolean>(false);
     const [ showInviteNewAdministratorModal, setShowInviteNewAdministratorModal ] = useState<boolean>(false);
+    const [ selectedUserStore, setSelectedUserStore ] = useState<string>(PRIMARY_USERSTORE.toLocaleLowerCase());
 
     const {
         administrators,
         isNextPageAvailable,
         isAdministratorsListFetchRequestLoading,
-        mutateAdministratorsListFetchRequest
+        mutateAdministratorsListFetchRequest,
+        adminUserListFetchError
     } = useAdministrators(
         listItemLimit,
         listOffset,
         searchQuery,
         null,
-        null,
+        selectedUserStore,
         UsersConstants.GROUPS_ATTRIBUTE
     );
 
@@ -169,6 +179,10 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
                 );
             }
         );
+    };
+
+    const handleSelectedUserStoreChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
+        setSelectedUserStore(data.value as string);
     };
 
     const handleListFilter = (query: string): void => {
@@ -322,30 +336,48 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
             paginationOptions={ {
                 disableNextButton: !isNextPageAvailable
             } }
-            disableRightActionPanel={ true }
+            rightActionPanel={
+                isFirstLevelOrganization() || isSuperOrganization()
+                    ? (<Dropdown
+                        data-testid="user-mgt-user-list-userstore-dropdown"
+                        selection
+                        options={ availableUserStores }
+                        onChange={ handleSelectedUserStoreChange }
+                        defaultValue={ PRIMARY_USERSTORE.toLocaleLowerCase() }
+                    />) : null
+            }
             topActionPanelExtension={ (
                 <Show when={ [ AccessControlConstants.USER_WRITE, AccessControlConstants.ROLE_EDIT ] }>
                     { renderAdministratorAddOptions() }
                 </Show>
             ) }
         >
-            <AdministratorsTable
-                defaultListItemLimit={ defaultListItemLimit }
-                administrators={ administrators }
-                onUserEdit={ handleUserEdit }
-                onUserDelete={ handleUserDelete }
-                isLoading={ loading }
-                readOnlyUserStores={ readOnlyUserStores }
-                onSearchQueryClear={ handleSearchQueryClear }
-                searchQuery={ searchQuery }
-                triggerClearQuery={ triggerClearQuery }
-                onEmptyListPlaceholderActionClick={ () => null }
-                onIsLoading={ setLoading }
-                selection={ selection }
-                showListItemActions={ showListItemActions }
-                showMetaContent={ showMetaContent }
-                data-componentid={ `${componentId}-table` }
-            />
+            { adminUserListFetchError
+                ? (<EmptyPlaceholder
+                    subtitle={ [ t("console:manage.features.users.placeholders.userstoreError.subtitles.0"),
+                        t("console:manage.features.users.placeholders.userstoreError.subtitles.1")     ] }
+                    title={ t("console:manage.features.users.placeholders.userstoreError.title") }
+                    image={ getEmptyPlaceholderIllustrations().genericError }
+                    imageSize="tiny"
+                />)
+                : (<AdministratorsTable
+                    defaultListItemLimit={ defaultListItemLimit }
+                    administrators={ administrators }
+                    onUserEdit={ handleUserEdit }
+                    onUserDelete={ handleUserDelete }
+                    isLoading={ loading }
+                    readOnlyUserStores={ readOnlyUserStores }
+                    onSearchQueryClear={ handleSearchQueryClear }
+                    searchQuery={ searchQuery }
+                    triggerClearQuery={ triggerClearQuery }
+                    onEmptyListPlaceholderActionClick={ () => null }
+                    onIsLoading={ setLoading }
+                    selection={ selection }
+                    showListItemActions={ showListItemActions }
+                    showMetaContent={ showMetaContent }
+                    data-componentid={ `${componentId}-table` }
+                />)
+            }
             { showAddExistingUserWizard && (
                 <AddExistingUserWizard
                     onSuccess={ () => mutateAdministratorsListFetchRequest() }

--- a/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
@@ -338,13 +338,15 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
             } }
             rightActionPanel={
                 isFirstLevelOrganization() || isSuperOrganization()
-                    ? (<Dropdown
-                        data-testid="user-mgt-user-list-userstore-dropdown"
-                        selection
-                        options={ availableUserStores }
-                        onChange={ handleSelectedUserStoreChange }
-                        defaultValue={ PRIMARY_USERSTORE.toLocaleLowerCase() }
-                    />) : null
+                    ? (
+                        <Dropdown
+                          data-testid="user-mgt-user-list-userstore-dropdown"
+                          selection
+                          options={ availableUserStores }
+                          onChange={ handleSelectedUserStoreChange }
+                          defaultValue={ PRIMARY_USERSTORE.toLocaleLowerCase() }
+                        />
+                    ) : null
             }
             topActionPanelExtension={ (
                 <Show when={ [ AccessControlConstants.USER_WRITE, AccessControlConstants.ROLE_EDIT ] }>
@@ -353,30 +355,33 @@ const AdministratorsList: React.FunctionComponent<AdministratorsListProps> = (
             ) }
         >
             { adminUserListFetchError
-                ? (<EmptyPlaceholder
-                    subtitle={ [ t("console:manage.features.users.placeholders.userstoreError.subtitles.0"),
+                ? (
+                    <EmptyPlaceholder
+                      subtitle={ [ t("console:manage.features.users.placeholders.userstoreError.subtitles.0"),
                         t("console:manage.features.users.placeholders.userstoreError.subtitles.1") ] }
-                    title={ t("console:manage.features.users.placeholders.userstoreError.title") }
-                    image={ getEmptyPlaceholderIllustrations().genericError }
-                    imageSize="tiny"
-                />)
-                : (<AdministratorsTable
-                    defaultListItemLimit={ defaultListItemLimit }
-                    administrators={ administrators }
-                    onUserEdit={ handleUserEdit }
-                    onUserDelete={ handleUserDelete }
-                    isLoading={ loading }
-                    readOnlyUserStores={ readOnlyUserStores }
-                    onSearchQueryClear={ handleSearchQueryClear }
-                    searchQuery={ searchQuery }
-                    triggerClearQuery={ triggerClearQuery }
-                    onEmptyListPlaceholderActionClick={ () => null }
-                    onIsLoading={ setLoading }
-                    selection={ selection }
-                    showListItemActions={ showListItemActions }
-                    showMetaContent={ showMetaContent }
-                    data-componentid={ `${componentId}-table` }
-                />)
+                      title={ t("console:manage.features.users.placeholders.userstoreError.title") }
+                      image={ getEmptyPlaceholderIllustrations().genericError }
+                      imageSize="tiny"
+                    />
+                ): (
+                    <AdministratorsTable
+                      defaultListItemLimit={ defaultListItemLimit }
+                      administrators={ administrators }
+                      onUserEdit={ handleUserEdit }
+                      onUserDelete={ handleUserDelete }
+                      isLoading={ loading }
+                      readOnlyUserStores={ readOnlyUserStores }
+                      onSearchQueryClear={ handleSearchQueryClear }
+                      searchQuery={ searchQuery }
+                      triggerClearQuery={ triggerClearQuery }
+                      onEmptyListPlaceholderActionClick={ () => null }
+                      onIsLoading={ setLoading }
+                      selection={ selection }
+                      showListItemActions={ showListItemActions }
+                      showMetaContent={ showMetaContent }
+                      data-componentid={ `${componentId}-table` }
+                    />
+                )
             }
             { showAddExistingUserWizard && (
                 <AddExistingUserWizard

--- a/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
@@ -24,12 +24,17 @@ import React, {
     ChangeEvent,
     FunctionComponent,
     ReactElement,
+    useEffect,
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
 import AdministratorsList from "./administrators-list/administrators-list";
 import InvitedAdministratorsList from "./invited-administrators/invited-administrators-list";
+import { UserStoreProperty, getAUserStore } from "../../../core";
 import { useGetCurrentOrganizationType } from "../../../organizations/hooks/use-get-organization-type";
+import { useUserStores } from "../../../userstores/api";
+import { CONSUMER_USERSTORE } from "../../../userstores/constants";
+import { UserStoreDropdownItem, UserStoreListItem, UserStorePostData } from "../../../userstores/models";
 
 /**
  * Props interface of {@link ConsoleAdministrators}
@@ -50,15 +55,63 @@ const ConsoleAdministrators: FunctionComponent<ConsoleAdministratorsInterface> =
     const { isSubOrganization } = useGetCurrentOrganizationType();
 
     const [ activeAdministratorGroup, setActiveAdministratorGroup ] = useState("activeUsers");
+    const [ availableUserStores, setAvailableUserStores ] = useState<UserStoreDropdownItem[]>([]);
 
     const { t } = useTranslation();
+
+    const {
+        data: userStoreList,
+        isLoading: isUserStoreListFetchRequestLoading
+    } = useUserStores(null);
+
+    useEffect(() => {
+        if ( userStoreList && !isUserStoreListFetchRequestLoading) {
+            const storeOptions: UserStoreDropdownItem[] = [
+                {
+                    key: -1,
+                    text: t("console:manage.features.users.userstores.userstoreOptions.primary"),
+                    value: "primary"
+                }
+            ];
+
+            let storeOption: UserStoreDropdownItem = {
+                key: null,
+                text: "",
+                value: ""
+            };
+
+            userStoreList?.forEach((store: UserStoreListItem, index: number) => {
+                if (store.name !== CONSUMER_USERSTORE) {
+                    getAUserStore(store.id).then((response: UserStorePostData) => {
+                        const isDisabled: boolean = response.properties.find(
+                            (property: UserStoreProperty) => property.name === "Disabled")?.value === "true";
+
+                        if (!isDisabled) {
+                            storeOption = {
+                                key: index,
+                                text: store.name,
+                                value: store.name
+                            };
+                            storeOptions.push(storeOption);
+                        }
+                    });
+                }
+            });
+
+            setAvailableUserStores(storeOptions);
+        }
+    }, [ userStoreList, isUserStoreListFetchRequestLoading ]);
 
     const renderSelectedAdministratorGroup = (): ReactElement => {
         switch (activeAdministratorGroup) {
             case "activeUsers":
-                return <AdministratorsList />;
+                return (<AdministratorsList
+                    availableUserStores={ availableUserStores }
+                />);
             case "pendingInvitations":
-                return <InvitedAdministratorsList />;
+                return (<InvitedAdministratorsList
+                    availableUserStores={ availableUserStores }
+                />);
             default:
                 return null;
         }
@@ -86,7 +139,7 @@ const ConsoleAdministrators: FunctionComponent<ConsoleAdministratorsInterface> =
     };
 
     return (
-        <div className="console-administrators">
+        <div className="console-administrators" data-componentid={ componentId }>
             { renderActiveAdministratorGroups() }
             { renderSelectedAdministratorGroup() }
         </div>

--- a/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
@@ -105,7 +105,8 @@ const ConsoleAdministrators: FunctionComponent<ConsoleAdministratorsInterface> =
     const renderSelectedAdministratorGroup = (): ReactElement => {
         switch (activeAdministratorGroup) {
             case "activeUsers":
-                return (<AdministratorsList
+                return (
+                  <AdministratorsList
                     availableUserStores={ availableUserStores }
                 />);
             case "pendingInvitations":

--- a/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
@@ -108,11 +108,14 @@ const ConsoleAdministrators: FunctionComponent<ConsoleAdministratorsInterface> =
                 return (
                   <AdministratorsList
                     availableUserStores={ availableUserStores }
-                />);
+                  />
+                );
             case "pendingInvitations":
-                return (<InvitedAdministratorsList
-                    availableUserStores={ availableUserStores }
-                />);
+                return (
+                    <InvitedAdministratorsList
+                      availableUserStores={ availableUserStores }
+                    />
+                );
             default:
                 return null;
         }

--- a/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
@@ -65,7 +65,7 @@ const ConsoleAdministrators: FunctionComponent<ConsoleAdministratorsInterface> =
     } = useUserStores(null);
 
     useEffect(() => {
-        if ( userStoreList && !isUserStoreListFetchRequestLoading) {
+        if (userStoreList && !isUserStoreListFetchRequestLoading) {
             const storeOptions: UserStoreDropdownItem[] = [
                 {
                     key: -1,

--- a/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/console-administrators.tsx
@@ -106,14 +106,14 @@ const ConsoleAdministrators: FunctionComponent<ConsoleAdministratorsInterface> =
         switch (activeAdministratorGroup) {
             case "activeUsers":
                 return (
-                  <AdministratorsList
-                    availableUserStores={ availableUserStores }
-                  />
+                    <AdministratorsList
+                        availableUserStores={ availableUserStores }
+                    />
                 );
             case "pendingInvitations":
                 return (
                     <InvitedAdministratorsList
-                      availableUserStores={ availableUserStores }
+                        availableUserStores={ availableUserStores }
                     />
                 );
             default:

--- a/apps/console/src/features/console-settings/components/console-administrators/invited-administrators/invited-administrators-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/invited-administrators/invited-administrators-list.tsx
@@ -263,7 +263,7 @@ const InvitedAdministratorsList: React.FunctionComponent<InvitedAdministratorsLi
             { adminUserListFetchError
                 ? (<EmptyPlaceholder
                     subtitle={ [ t("console:manage.features.users.placeholders.userstoreError.subtitles.0"),
-                        t("console:manage.features.users.placeholders.userstoreError.subtitles.1")     ] }
+                        t("console:manage.features.users.placeholders.userstoreError.subtitles.1") ] }
                     title={ t("console:manage.features.users.placeholders.userstoreError.title") }
                     image={ getEmptyPlaceholderIllustrations().genericError }
                     imageSize="tiny"

--- a/apps/console/src/features/console-settings/components/console-administrators/invited-administrators/invited-administrators-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/invited-administrators/invited-administrators-list.tsx
@@ -22,19 +22,22 @@ import {
     IdentifiableComponentInterface
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { ListLayout, PrimaryButton } from "@wso2is/react-components";
-import { UsersConstants } from "apps/console/src/extensions/components/users/constants/users";
-import { UserInviteInterface } from "apps/console/src/extensions/components/users/models/invite";
+import { EmptyPlaceholder, ListLayout, PrimaryButton } from "@wso2is/react-components";
+import { PRIMARY_USERSTORE, UsersConstants } from "apps/console/src/extensions/components/users/constants/users";
 import React, { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
-import { DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
+import { Dropdown, DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
 import InvitedAdministratorsTable from "./invited-administrators-table";
+import { UserInviteInterface } from "../../../../../extensions/components/users/models/invite";
+import { useGetCurrentOrganizationType } from "../../../../../features/organizations/hooks/use-get-organization-type";
+import { UserStoreDropdownItem } from "../../../../../features/userstores/models";
 import { AccessControlConstants } from "../../../../access-control/constants/access-control";
 import {
     AdvancedSearchWithBasicFilters,
-    UIConstants
+    UIConstants,
+    getEmptyPlaceholderIllustrations
 } from "../../../../core";
 import { deleteParentOrgInvite } from "../../../../users/components/guests/api/invite";
 import useAdministrators from "../../../hooks/use-administrators";
@@ -64,6 +67,10 @@ interface InvitedAdministratorsListProps extends IdentifiableComponentInterface 
      * List of readOnly user stores.
      */
     readOnlyUserStores?: string[];
+    /**
+     * List of available user stores.
+     */
+    availableUserStores: UserStoreDropdownItem[]
 }
 
 /**
@@ -81,6 +88,7 @@ const InvitedAdministratorsList: React.FunctionComponent<InvitedAdministratorsLi
         readOnlyUserStores,
         selection,
         showListItemActions,
+        availableUserStores,
         ["data-componentid"]: componentId
     } = props;
 
@@ -93,9 +101,12 @@ const InvitedAdministratorsList: React.FunctionComponent<InvitedAdministratorsLi
     const [ triggerClearQuery, setTriggerClearQuery ] = useState<boolean>(false);
     const [ searchQuery, setSearchQuery ] = useState<string>("");
     const [ showInviteNewAdministratorModal, setShowInviteNewAdministratorModal ] = useState<boolean>(false);
+    const [ loading, setLoading ] = useState(false);
+    const [ selectedUserStore, setSelectedUserStore ] = useState<string>(PRIMARY_USERSTORE.toLocaleLowerCase());
 
     const {
         invitedAdministrators,
+        adminUserListFetchError,
         isNextPageAvailable,
         isAdministratorsListFetchRequestLoading,
         mutateInvitedAdministratorsListFetchRequest
@@ -104,11 +115,11 @@ const InvitedAdministratorsList: React.FunctionComponent<InvitedAdministratorsLi
         listOffset,
         searchQuery,
         null,
-        null,
+        selectedUserStore,
         UsersConstants.GROUPS_ATTRIBUTE
     );
 
-    const [ loading, setLoading ] = useState(false);
+    const { isFirstLevelOrganization, isSuperOrganization } = useGetCurrentOrganizationType();
 
     const handleUserDelete = (user: UserInviteInterface, onComplete: () => void): Promise<void> => {
         return deleteParentOrgInvite(user.id)
@@ -150,6 +161,10 @@ const InvitedAdministratorsList: React.FunctionComponent<InvitedAdministratorsLi
         data: DropdownProps
     ): void => {
         setListItemLimit(data.value as number);
+    };
+
+    const handleSelectedUserStoreChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
+        setSelectedUserStore(data.value as string);
     };
 
     /**
@@ -223,7 +238,16 @@ const InvitedAdministratorsList: React.FunctionComponent<InvitedAdministratorsLi
             paginationOptions={ {
                 disableNextButton: !isNextPageAvailable
             } }
-            disableRightActionPanel={ true }
+            rightActionPanel={
+                isFirstLevelOrganization() || isSuperOrganization()
+                    ? (<Dropdown
+                        data-testid="user-mgt-user-list-userstore-dropdown"
+                        selection
+                        options={ availableUserStores }
+                        onChange={ handleSelectedUserStoreChange }
+                        defaultValue={ PRIMARY_USERSTORE.toLocaleLowerCase() }
+                    />) : null
+            }
             topActionPanelExtension={ (
                 <Show when={ AccessControlConstants.USER_WRITE }>
                     <PrimaryButton
@@ -236,22 +260,32 @@ const InvitedAdministratorsList: React.FunctionComponent<InvitedAdministratorsLi
                 </Show>
             ) }
         >
-            <InvitedAdministratorsTable
-                defaultListItemLimit={ defaultListItemLimit }
-                administrators={ invitedAdministrators?.invitations }
-                onUserDelete={ handleUserDelete }
-                isLoading={ loading }
-                readOnlyUserStores={ readOnlyUserStores }
-                onSearchQueryClear={ handleSearchQueryClear }
-                searchQuery={ searchQuery }
-                triggerClearQuery={ triggerClearQuery }
-                onEmptyListPlaceholderActionClick={ () => null }
-                onIsLoading={ setLoading }
-                selection={ selection }
-                showListItemActions={ showListItemActions }
-                showMetaContent={ showMetaContent }
-                data-componentid={ `${componentId}-table` }
-            />
+            { adminUserListFetchError
+                ? (<EmptyPlaceholder
+                    subtitle={ [ t("console:manage.features.users.placeholders.userstoreError.subtitles.0"),
+                        t("console:manage.features.users.placeholders.userstoreError.subtitles.1")     ] }
+                    title={ t("console:manage.features.users.placeholders.userstoreError.title") }
+                    image={ getEmptyPlaceholderIllustrations().genericError }
+                    imageSize="tiny"
+                />)
+                : (<InvitedAdministratorsTable
+                    defaultListItemLimit={ defaultListItemLimit }
+                    administrators={ invitedAdministrators?.invitations }
+                    onUserDelete={ handleUserDelete }
+                    isLoading={ loading }
+                    readOnlyUserStores={ readOnlyUserStores }
+                    onSearchQueryClear={ handleSearchQueryClear }
+                    searchQuery={ searchQuery }
+                    triggerClearQuery={ triggerClearQuery }
+                    onEmptyListPlaceholderActionClick={ () => null }
+                    onIsLoading={ setLoading }
+                    selection={ selection }
+                    showListItemActions={ showListItemActions }
+                    showMetaContent={ showMetaContent }
+                    data-componentid={ `${componentId}-table` }
+                />)
+            }
+
             { showInviteNewAdministratorModal && (
                 <InviteNewAdministratorWizard
                     onClose={ () => setShowInviteNewAdministratorModal(false) }

--- a/apps/console/src/features/console-settings/hooks/use-administrators.ts
+++ b/apps/console/src/features/console-settings/hooks/use-administrators.ts
@@ -17,6 +17,7 @@
  */
 
 import { MultiValueAttributeInterface, RolesInterface } from "@wso2is/core/models";
+import { AxiosError } from "axios";
 import cloneDeep from "lodash-es/cloneDeep";
 import isEmpty from "lodash-es/isEmpty";
 import { useMemo, useState } from "react";
@@ -35,6 +36,10 @@ import { UserManagementUtils } from "../../users/utils/user-management-utils";
  * Props interface of {@link UseAdministrators}
  */
 export interface UseAdministratorsInterface {
+    /**
+     * Error occurred while fetching admin users list.
+     */
+    adminUserListFetchError: AxiosError;
     /**
      * Administrators list.
      */
@@ -96,6 +101,7 @@ const useAdministrators = (
 
     const {
         data: originalAdminUserList,
+        error: adminUserListFetchError,
         isLoading: isAdministratorsListFetchRequestLoading,
         mutate: mutateAdministratorsListFetchRequest
     } = useUsersList(
@@ -232,6 +238,7 @@ const useAdministrators = (
     }, [ originalAdminUserList, consoleRoles ]);
 
     return {
+        adminUserListFetchError,
         administrators,
         invitedAdministrators,
         isAdministratorsListFetchRequestLoading,

--- a/apps/console/src/features/userstores/models/user-stores.ts
+++ b/apps/console/src/features/userstores/models/user-stores.ts
@@ -38,6 +38,15 @@ export interface UserStoreListItem {
 }
 
 /**
+ * Type of userstore list item passed as options to dropdown fields.
+ */
+export interface UserStoreDropdownItem {
+    key: number;
+    text: string;
+    value: string;
+}
+
+/**
  * Type of a userstore property
  */
 export interface UserStoreProperty {


### PR DESCRIPTION
### Purpose

$subject

https://github.com/wso2/identity-apps/assets/41533942/6d739590-9efe-4ffd-985f-25b4e7a436ef

### Related Issues
- https://github.com/wso2/product-is/issues/19043

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
