### PR TITLE
Keep last selected tab active upon refresh when editing groups

### DIFF
--- a/.changeset/khaki-mugs-hammer.md
+++ b/.changeset/khaki-mugs-hammer.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Keep last selected tab active upon refresh when editing groups.

--- a/apps/console/src/extensions/components/groups/edit-group/edit-group.tsx
+++ b/apps/console/src/extensions/components/groups/edit-group/edit-group.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,12 +25,14 @@ import { useTranslation } from "react-i18next";
 // TODO: Move to shared components.
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
+import { TabProps } from "semantic-ui-react";
 import { BasicGroupDetails } from "./edit-group-basic";
 import { GroupRolesList } from "./edit-group-roles";
 import { GroupUsersList } from "./edit-group-users";
 import { AppState, FeatureConfigInterface } from "../../../../features/core";
 import { GroupsInterface } from "../../../../features/groups";
 import { GroupConstants } from "../../../../features/groups/constants";
+import useGroupManagement from "../../../../features/groups/hooks/use-group-management";
 import { ExtendedFeatureConfigInterface } from "../../../configs/models";
 import { UserStoreUtils } from "../../../utils/user-store-utils";
 import { CONSUMER_USERSTORE } from "../../users/constants";
@@ -79,7 +81,7 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const extendedFeatureConfig: ExtendedFeatureConfigInterface = useSelector(
         (state: AppState) => state.config.ui.features);
-    
+
     const isSubOrg: boolean = window[ "AppUtils" ].getConfig().organizationName;
 
     const [ isReadOnly, setReadOnly ] = useState<boolean>(false);
@@ -89,6 +91,7 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
     const [ isRolesTabEnabled, setRolesTabEnabled ] = useState<boolean>(false);
     const [ isResourcePanesLoading, setIsResourcePanesLoading ] = useState<boolean>(true);
 
+    const { activeTab, updateActiveTab } = useGroupManagement();
     const dispatch: Dispatch = useDispatch();
 
     useEffect(() => {
@@ -100,7 +103,7 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
             })
             .catch(() => {
                 dispatch(addAlert({
-                    description: t("console:manage.features.groups.notifications.fetchGroups.genericError" + 
+                    description: t("console:manage.features.groups.notifications.fetchGroups.genericError" +
                         ".description"),
                     level: AlertLevels.ERROR,
                     message: t("console:manage.features.groups.notifications.fetchGroups.genericError.message")
@@ -136,11 +139,11 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
     const checkRolesTabEnabled = () => {
 
         const userHasRequiredScopes: boolean = hasRequiredScopes(
-            extendedFeatureConfig?.apiResources, 
-            [ ...extendedFeatureConfig?.apiResources?.scopes?.create, 
+            extendedFeatureConfig?.apiResources,
+            [ ...extendedFeatureConfig?.apiResources?.scopes?.create,
                 ...extendedFeatureConfig?.apiResources?.scopes?.delete,
-                ...extendedFeatureConfig?.apiResources?.scopes?.read, 
-                ...extendedFeatureConfig?.apiResources?.scopes?.update ], 
+                ...extendedFeatureConfig?.apiResources?.scopes?.read,
+                ...extendedFeatureConfig?.apiResources?.scopes?.update ],
             allowedScopes
         );
 
@@ -213,7 +216,7 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
         if (isRolesTabEnabled) {
             panes.push(
                 {
-                    menuItem: isSubOrg 
+                    menuItem: isSubOrg
                         ? t("extensions:console.applicationRoles.heading")
                         : t("extensions:manage.groups.edit.roles.title"),
                     render: () => (
@@ -237,7 +240,11 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
 
     return (
         <ResourceTab
+            activeIndex={ activeTab }
             isLoading={ isResourcePanesLoading }
+            onTabChange={ (event: React.MouseEvent<HTMLDivElement>, data: TabProps) => {
+                updateActiveTab(data.activeIndex as number);
+            } }
             panes={ resolveResourcePanes() }
         />
     );

--- a/apps/console/src/extensions/components/groups/pages/groups-edit.tsx
+++ b/apps/console/src/extensions/components/groups/pages/groups-edit.tsx
@@ -85,11 +85,7 @@ const GroupEditPage: FunctionComponent<any> = (): ReactElement => {
         <GroupManagementProvider>
             <TabPageLayout
                 isLoading={ isGroupDetailsRequestLoading }
-                title={
-                    group && group?.displayName ?
-                        group?.displayName?.split("/")[1] :
-                        t("console:manage.pages.rolesEdit.title")
-                }
+                title={ group?.displayName?.split("/")[1] ?? t("console:manage.pages.rolesEdit.title") }
                 backButton={ {
                     onClick: handleBackButtonClick,
                     text: t("console:manage.pages.rolesEdit.backButton", { type: "Groups" })

--- a/apps/console/src/extensions/components/groups/pages/groups-edit.tsx
+++ b/apps/console/src/extensions/components/groups/pages/groups-edit.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -31,6 +31,7 @@ import {
 } from "../../../../features/core";
 import { getGroupById } from "../../../../features/groups/api";
 import { GroupsInterface } from "../../../../features/groups/models";
+import GroupManagementProvider from "../../../../features/groups/providers/group-management-provider";
 import { EditGroup } from "../edit-group";
 
 const GroupEditPage: FunctionComponent<any> = (): ReactElement => {
@@ -81,48 +82,50 @@ const GroupEditPage: FunctionComponent<any> = (): ReactElement => {
     };
 
     return (
-        <TabPageLayout
-            isLoading={ isGroupDetailsRequestLoading }
-            title={
-                group && group?.displayName ?
-                    group?.displayName?.split("/")[1] :
-                    t("console:manage.pages.rolesEdit.title")
-            }
-            backButton={ {
-                onClick: handleBackButtonClick,
-                text: t("console:manage.pages.rolesEdit.backButton", { type: "Groups" })
-            } }
-            titleTextAlign="left"
-            bottomMargin={ false }
-            description={ (
-                <div>
-                    {
-                        <Label className="group-source-label">
-                            <GenericIcon
-                                className="mt-1 mb-0"
-                                square
-                                inline
-                                size="default"
-                                transparent
-                                icon={ getSidePanelIcons().userStore }
-                                verticalAlign="middle"
-                            />
-                            <Label.Detail className="mt-1 ml-0 mb-1">
-                                { group?.displayName?.split("/")[0] }
-                            </Label.Detail>
-                        </Label>  
-                    }
-                </div>
-            ) }
-        >
-            <EditGroup
-                isGroupDetailsRequestLoading={ isGroupDetailsRequestLoading }
-                group={ group }
-                groupId={ roleId }
-                onGroupUpdate={ onGroupUpdate }
-                featureConfig={ featureConfig }
-            />
-        </TabPageLayout>
+        <GroupManagementProvider>
+            <TabPageLayout
+                isLoading={ isGroupDetailsRequestLoading }
+                title={
+                    group && group?.displayName ?
+                        group?.displayName?.split("/")[1] :
+                        t("console:manage.pages.rolesEdit.title")
+                }
+                backButton={ {
+                    onClick: handleBackButtonClick,
+                    text: t("console:manage.pages.rolesEdit.backButton", { type: "Groups" })
+                } }
+                titleTextAlign="left"
+                bottomMargin={ false }
+                description={ (
+                    <div>
+                        {
+                            <Label className="group-source-label">
+                                <GenericIcon
+                                    className="mt-1 mb-0"
+                                    square
+                                    inline
+                                    size="default"
+                                    transparent
+                                    icon={ getSidePanelIcons().userStore }
+                                    verticalAlign="middle"
+                                />
+                                <Label.Detail className="mt-1 ml-0 mb-1">
+                                    { group?.displayName?.split("/")[0] }
+                                </Label.Detail>
+                            </Label>
+                        }
+                    </div>
+                ) }
+            >
+                <EditGroup
+                    isGroupDetailsRequestLoading={ isGroupDetailsRequestLoading }
+                    group={ group }
+                    groupId={ roleId }
+                    onGroupUpdate={ onGroupUpdate }
+                    featureConfig={ featureConfig }
+                />
+            </TabPageLayout>
+        </GroupManagementProvider>
     );
 };
 


### PR DESCRIPTION
### Purpose
After merging https://github.com/wso2/identity-apps/pull/4402 the issue was still reproducible. This resolves the issue.

### Related Issues
- https://github.com/wso2/product-is/issues/17318

### Related PRs
- https://github.com/wso2/identity-apps/pull/4402

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
