### PR TITLE
[improvement] Update password validation field min limit

### DIFF
--- a/.changeset/afraid-feet-buy.md
+++ b/.changeset/afraid-feet-buy.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Update password validation min length field limit

--- a/apps/console/src/features/validation/constants/validation-config-constants.ts
+++ b/apps/console/src/features/validation/constants/validation-config-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2022-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -38,7 +38,7 @@ export class ValidationConfigConstants {
         PASSWORD_MAX_LENGTH: 2,
         PASSWORD_MAX_VALUE: 30,
         PASSWORD_MIN_LENGTH: 1,
-        PASSWORD_MIN_VALUE: 8
+        PASSWORD_MIN_VALUE: 5
     };
 
 }


### PR DESCRIPTION
### Purpose
> Password validation field min limit is reduced to 5 from 8.

### Related Issues
- https://github.com/wso2/product-is/issues/19062

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
