### PR TITLE
Handle null parameter value

### DIFF
--- a/.changeset/nice-hounds-smoke.md
+++ b/.changeset/nice-hounds-smoke.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+handle null pointer exception

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/username-resolver.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/username-resolver.jsp
@@ -26,7 +26,7 @@
 
 <%
     String username = Encode.forJava(request.getParameter("username"));
-    String userTenantHint = Encode.forJava(request.getParameter("t"));
+    String userTenantHint = (request.getParameter("t") != null) ? Encode.forJava(request.getParameter("t")) : null;
     if (StringUtils.isNotBlank(userTenantHint)) {
         username = MultitenantUtils.getTenantAwareUsername(username);
         username = UserCoreUtil.addTenantDomainToEntry(username, userTenantHint);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/username-resolver.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/username-resolver.jsp
@@ -26,7 +26,7 @@
 
 <%
     String username = Encode.forJava(request.getParameter("username"));
-    String userTenantHint = (request.getParameter("t") != null) ? Encode.forJava(request.getParameter("t")) : null;
+    String userTenantHint = (Encode.forJava(request.getParameter("t")) != "null") ? Encode.forJava(request.getParameter("t")) : null;
     if (StringUtils.isNotBlank(userTenantHint)) {
         username = MultitenantUtils.getTenantAwareUsername(username);
         username = UserCoreUtil.addTenantDomainToEntry(username, userTenantHint);


### PR DESCRIPTION
### Purpose
> $subject

If the request parameter value is null, currently we're assigning null as a string to `userTenantHint`, instead we should assign null value. 

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
