### PR TITLE
Add support to upload a pkcs12 file

### DIFF
--- a/.changeset/orange-peaches-repair.md
+++ b/.changeset/orange-peaches-repair.md
@@ -1,0 +1,9 @@
+---
+"@wso2is/react-components": patch
+"@wso2is/forms": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/common": patch
+---
+
+Add support to upload a pkcs12 file

--- a/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
@@ -22,6 +22,7 @@ import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, Grid } from "semantic-ui-react";
+import { ConnectionManagementConstants } from "../../../../constants/connection-constants";
 import { AuthenticatorSettingsFormModes } from "../../../../models/authenticators";
 import {
     CommonPluggableComponentFormPropsInterface,
@@ -66,7 +67,7 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
         dynamicValues?.properties?.map(
             (prop: CommonPluggableComponentPropertyInterface) =>
             {
-                if (prop.key === "google_prov_private_key") {
+                if (prop.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY) {
                     setPrivateKeyValue(prop.value);
                 }
             }
@@ -113,12 +114,12 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
             }
 
             if (
-                !values.has("google_prov_private_key")
+                !values.has(ConnectionManagementConstants.GOOGLE_PRIVATE_KEY)
                 && !properties.find(
                     (item: CommonPluggableComponentMetaPropertyInterface) =>
-                        item?.key === "google_prov_private_key")){
+                        item?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY)){
                 properties.push({
-                    key: "google_prov_private_key",
+                    key: ConnectionManagementConstants.GOOGLE_PRIVATE_KEY,
                     value: privateKeyValue
                 });
             }
@@ -220,7 +221,7 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                     </Grid.Column>
                 </Grid.Row>
             );
-        } else if (eachPropertyMeta?.key === "google_prov_private_key") {
+        } else if (eachPropertyMeta?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY) {
             return (
                 (<Grid.Row key={ eachPropertyMeta?.displayOrder }>
                     <Grid.Column computer={ 16 }>

--- a/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
@@ -72,7 +72,6 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                 }
             }
         );
-
     },[ dynamicValues ]);
 
     const interpretValueByType = (value: FormValue, key: string, type: string) => {

--- a/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
@@ -36,7 +36,7 @@ import { CommonConstants, FieldType, getFieldType, getPropertyField } from "../h
  * Common pluggable connector configurations form.
  *
  * @param props - CommonPluggableComponentFormPropsInterface
- * @returns ReactElement 
+ * @returns ReactElement
  */
 export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComponentFormPropsInterface> = (
     props: CommonPluggableComponentFormPropsInterface
@@ -65,13 +65,13 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
     useEffect(() => {
         dynamicValues?.properties?.map(
             (prop: CommonPluggableComponentPropertyInterface) =>
-                 {
-                    if (prop.key === "google_prov_private_key") {
-                        setPrivateKeyValue(prop.value);
-                    }
-        }
+            {
+                if (prop.key === "google_prov_private_key") {
+                    setPrivateKeyValue(prop.value);
+                }
+            }
         );
-        
+
     },[ dynamicValues ]);
 
     const interpretValueByType = (value: FormValue, key: string, type: string) => {
@@ -112,11 +112,15 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                 });
             }
 
-            if (!values.has("google_prov_private_key") && !properties.find(item => item?.key === "google_prov_private_key")){
-                    properties.push({
-                        key: "google_prov_private_key",
-                        value: privateKeyValue
-                    });
+            if (
+                !values.has("google_prov_private_key")
+                && !properties.find(
+                    (item: CommonPluggableComponentMetaPropertyInterface) =>
+                        item?.key === "google_prov_private_key")){
+                properties.push({
+                    key: "google_prov_private_key",
+                    value: privateKeyValue
+                });
             }
 
         });
@@ -236,7 +240,7 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                     </Grid.Column>
                 </Grid.Row>
                 )
-            )
+            );
         } else {
             return (
                 <Grid.Row columns={ 1 } key={ eachPropertyMeta?.displayOrder }>
@@ -276,7 +280,7 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                 let field: ReactElement;
 
                 if (!isCheckboxWithSubProperties(metaProperty)) {
-                    if (metaProperty?.key === CommonConstants.FIELD_COMPONENT_SCOPES 
+                    if (metaProperty?.key === CommonConstants.FIELD_COMPONENT_SCOPES
                         && !isScopesDefined() && isScopesEmpty()) {
                         const updatedProperty: CommonPluggableComponentPropertyInterface = {
                             key: CommonConstants.FIELD_COMPONENT_SCOPES,
@@ -286,8 +290,9 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                         field = getField(updatedProperty, metaProperty, isSub,
                             `${ testId }-form`, handleParentPropertyChange);
                     } else {
-                        field = getField(property, metaProperty, isSub, `${ testId }-form`, handleParentPropertyChange, onCertificateChange);
-                    }                  
+                        field = getField(property, metaProperty, isSub, `${ testId }-form`,
+                            handleParentPropertyChange, onCertificateChange);
+                    }
                 } else if (isRadioButtonWithSubProperties(metaProperty)) {
                     field =
                         (<React.Fragment key={ metaProperty?.key }>
@@ -432,7 +437,6 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
     };
 
     useEffect(() => {
-        console.log("jj");
 
         setDynamicValues(initialValues);
 

--- a/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
@@ -60,6 +60,19 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
     // Used for field elements which needs to listen for any onChange events in the form.
     const [ dynamicValues, setDynamicValues ] = useState<CommonPluggableComponentInterface>(undefined);
     const [ customProperties, setCustomProperties ] = useState<string>(undefined);
+    const [ privateKeyValue, setPrivateKeyValue ] = useState<string>(undefined);
+
+    useEffect(() => {
+        dynamicValues?.properties?.map(
+            (prop: CommonPluggableComponentPropertyInterface) =>
+                 {
+                    if (prop.key === "google_prov_private_key") {
+                        setPrivateKeyValue(prop.value);
+                    }
+        }
+        );
+        
+    },[ dynamicValues ]);
 
     const interpretValueByType = (value: FormValue, key: string, type: string) => {
         switch (type?.toUpperCase()) {
@@ -97,6 +110,13 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                     key: key,
                     value: interpretValueByType(value, key, propertyMetadata?.type)
                 });
+            }
+
+            if (!values.has("google_prov_private_key") && !properties.find(item => item?.key === "google_prov_private_key")){
+                    properties.push({
+                        key: "google_prov_private_key",
+                        value: privateKeyValue
+                    });
             }
 
         });
@@ -171,7 +191,8 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
         eachPropertyMeta: CommonPluggableComponentMetaPropertyInterface,
         isSub?: boolean,
         testId?: string,
-        listen?: (key: string, values: Map<string, FormValue>) => void):
+        listen?: (key: string, values: Map<string, FormValue>) => void,
+        onCertificateChange?: ( newFile: string) => void):
         ReactElement => {
 
         if (isSub) {
@@ -195,6 +216,27 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                     </Grid.Column>
                 </Grid.Row>
             );
+        } else if (eachPropertyMeta?.key === "google_prov_private_key") {
+            return (
+                (<Grid.Row key={ eachPropertyMeta?.displayOrder }>
+                    <Grid.Column computer={ 16 }>
+                        {
+                            getPropertyField(
+                                property,
+                                {
+                                    ...eachPropertyMeta,
+                                    readOnly: mode === AuthenticatorSettingsFormModes.CREATE ? false : readOnly
+                                },
+                                mode,
+                                listen,
+                                testId,
+                                onCertificateChange
+                            )
+                        }
+                    </Grid.Column>
+                </Grid.Row>
+                )
+            )
         } else {
             return (
                 <Grid.Row columns={ 1 } key={ eachPropertyMeta?.displayOrder }>
@@ -244,7 +286,7 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                         field = getField(updatedProperty, metaProperty, isSub,
                             `${ testId }-form`, handleParentPropertyChange);
                     } else {
-                        field = getField(property, metaProperty, isSub, `${ testId }-form`, handleParentPropertyChange);
+                        field = getField(property, metaProperty, isSub, `${ testId }-form`, handleParentPropertyChange, onCertificateChange);
                     }                  
                 } else if (isRadioButtonWithSubProperties(metaProperty)) {
                     field =
@@ -363,6 +405,10 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
         });
     };
 
+    const onCertificateChange = (certificateContent: string) => {
+        setPrivateKeyValue(certificateContent);
+    };
+
     const getSubmitButton = (content: string) => {
         return (
             <Grid.Row columns={ 1 }>
@@ -386,6 +432,7 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
     };
 
     useEffect(() => {
+        console.log("jj");
 
         setDynamicValues(initialValues);
 

--- a/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
@@ -24,10 +24,11 @@ import {
     Validation
 } from "@wso2is/forms";
 import { I18n } from "@wso2is/i18n";
-import { CopyInputField, GenericIcon, Hint } from "@wso2is/react-components";
+import { CopyInputField, GenericIcon, Hint, P12FileStrategy } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 import { Grid } from "semantic-ui-react";
+import { Pkcs12FileField } from "./pkcs12-file-field";
 import { commonConfig } from "../../../../../../extensions";
 import {
     AuthenticatorSettingsFormModes
@@ -38,6 +39,7 @@ import {
 } from "../../../../models/connection";
 
 const AUTHORIZATION_REDIRECT_URL: string = "callbackUrl";
+const P12_FILE_STRATEGY: P12FileStrategy = new P12FileStrategy();
 
 export const getConfidentialField = (eachProp: CommonPluggableComponentPropertyInterface,
     propertyMetadata: CommonPluggableComponentMetaPropertyInterface,
@@ -156,12 +158,13 @@ export const getRadioButtonField = (eachProp: CommonPluggableComponentPropertyIn
                 requiredErrorMessage={ I18n.instance.t("console:develop.features.authenticationProvider.forms.common." +
                     "requiredErrorMessage") }
                 children={
-                    propertyMetadata?.subProperties?.map(function(val): StrictRadioChild {
-                        return {
-                            label: val.displayName,
-                            value: val.defaultValue
-                        };
-                    })
+                    propertyMetadata?.subProperties?.map(
+                        function(val: CommonPluggableComponentMetaPropertyInterface): StrictRadioChild {
+                            return {
+                                label: val.displayName,
+                                value: val.defaultValue
+                            };
+                        })
                 }
                 disabled={ propertyMetadata?.isDisabled }
                 readOnly={ propertyMetadata?.readOnly }
@@ -191,12 +194,14 @@ export const getRadioButtonFieldWithListener = (eachProp: CommonPluggableCompone
                 requiredErrorMessage={ I18n.instance.t("console:develop.features.authenticationProvider.forms.common." +
                     "requiredErrorMessage") }
                 children={
-                    propertyMetadata?.subProperties?.map(function(val): StrictRadioChild {
-                        return {
-                            label: val.displayName,
-                            value: val.defaultValue
-                        };
-                    })
+                    propertyMetadata?.subProperties?.map(
+                        function(val: CommonPluggableComponentMetaPropertyInterface): StrictRadioChild {
+                            return {
+                                label: val.displayName,
+                                value: val.defaultValue
+                            };
+                        }
+                    )
                 }
                 listen={ (values: Map<string, FormValue>) => {
                     listen(propertyMetadata?.key, values);
@@ -264,7 +269,7 @@ export const getURLField = (eachProp: CommonPluggableComponentPropertyInterface,
                 requiredErrorMessage={ I18n.instance.t("console:develop.features.authenticationProvider.forms." +
                     "common.requiredErrorMessage") }
                 placeholder={ propertyMetadata?.defaultValue }
-                validation={ (value, validation) => {
+                validation={ (value: string, validation: Validation) => {
                     if (!FormValidation.url(value)) {
                         validation.isValid = false;
                         validation.errorMessages.push(
@@ -369,7 +374,7 @@ export const getQueryParamsField = (eachProp: CommonPluggableComponentPropertyIn
                 required={ propertyMetadata?.isMandatory }
                 requiredErrorMessage={ I18n.instance.t("console:develop.features.authenticationProvider.forms.common." +
                     "requiredErrorMessage") }
-                validation={ (value, validation) => {
+                validation={ (value: string, validation: Validation) => {
                     if (!FormValidation.url("https://www.sample.com?" + value)) {
                         validation.isValid = false;
                         validation.errorMessages.push(
@@ -433,7 +438,7 @@ export const getTableField = (eachProp: CommonPluggableComponentPropertyInterfac
                 } }
             />
             <Grid>
-                { eachProp?.value.split(" ").map((scope,index) => (
+                { eachProp?.value.split(" ").map((scope: string,index: number) => (
                     <Grid.Row columns={ 3 } key={ index }>
                         <Grid.Column mobile={ 1 } tablet={ 1 } computer={ 1 }>
                             <GenericIcon
@@ -493,9 +498,79 @@ export const getDropDownField = (eachProp: CommonPluggableComponentPropertyInter
         </>
     );
 };
+/* eslint-disable react-hooks/rules-of-hooks */
+export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterface,
+    propertyMetadata: CommonPluggableComponentMetaPropertyInterface,
+    testId?: string,
+    onCertificateChange?: ( newFile: string) => void): ReactElement => {
+
+    const [data, setData] = useState<string>(eachProp?.value);
+
+    useEffect(() => {
+        // setData(eachProp?.value);
+        console.log(propertyMetadata);
+        console.log(eachProp?.value?.length);
+    },[ data, eachProp ]);
+
+    return (
+        <>
+            { (( data === "" || data?.length === 0 || eachProp?.value === undefined )) ? (
+                <>
+                    <Field
+                        name={ eachProp?.key || propertyMetadata?.key }
+                        label={ propertyMetadata?.displayName }
+                        required={ propertyMetadata?.isMandatory }
+                        requiredErrorMessage={ I18n.instance.t("console:develop.features.authenticationProvider." +
+                        "forms.common.requiredErrorMessage") }
+                        validation={ (value: string, validation: Validation) => {
+                            if (!FormValidation.url("https://www.sample.com?" + value)) {
+                                validation.isValid = false;
+                                validation.errorMessages.push(
+                                    I18n.instance.t("console:develop.features.authenticationProvider.forms.common." +
+                            "invalidQueryParamErrorMessage"));
+                            }
+                        } }
+                        type="filePicker"
+                        value={ data }
+                        key={ propertyMetadata?.key }
+                        disabled={ propertyMetadata?.isDisabled }
+                        readOnly={ propertyMetadata?.readOnly }
+                        data-testid={ `${ testId }-${ propertyMetadata?.key }` }
+                        fileStrategy={ P12_FILE_STRATEGY }
+                        uploadButtonText="Upload certificate File"
+                        dropzoneText="Drag and drop a certificate file here."
+                    />
+                    { propertyMetadata?.description
+            && (
+                <Hint disabled={ propertyMetadata?.isDisabled }>{ propertyMetadata?.description }</Hint>
+            ) }
+                </>
+            ) : (
+                <>
+                    <label>{ propertyMetadata?.displayName }</label>
+                    <Pkcs12FileField
+                        eachProp={ eachProp }
+                        propertyMetadata={ propertyMetadata }
+                        onCertificateChange={(newData) => 
+                            {
+                                setData(newData);
+                                onCertificateChange(data);
+                            }}
+                    />
+                    { propertyMetadata?.description
+                    && (
+                        <Hint disabled={ propertyMetadata?.isDisabled }>{ propertyMetadata?.description }</Hint>
+                    )
+                    }
+                </>
+            )
+            }
+        </>);
+
+};
 
 const getDropDownChildren = (key: string, options: string[]) => {
-    return options.map((option) => {
+    return options.map((option: string) => {
         return ({
             key: key,
             text: key === "RequestMethod" ? mapSAMLProtocolBindingToProperDisplayNames(option) : option,
@@ -530,7 +605,8 @@ export enum FieldType {
     QUERY_PARAMS = "QueryParameters",
     DROP_DOWN = "DropDown",
     RADIO = "Radio",
-    COPY_INPUT = "CopyInput"
+    COPY_INPUT = "CopyInput",
+    FILE_PICKER = "FilePicker"
 }
 
 /**
@@ -578,6 +654,8 @@ export const getFieldType = (
         return FieldType.DROP_DOWN;
     } else if (propertyMetadata.type?.toUpperCase() === CommonConstants.RADIO) {
         return FieldType.RADIO;
+    } else if (propertyMetadata?.key === "google_prov_private_key") {
+        return FieldType.FILE_PICKER;
     }
 
     return FieldType.TEXT;
@@ -597,7 +675,8 @@ export const getPropertyField = (
     propertyMetadata: CommonPluggableComponentMetaPropertyInterface,
     mode: AuthenticatorSettingsFormModes,
     listen?: (key: string, values: Map<string, FormValue>) => void,
-    testId?: string
+    testId?: string,
+    onCertificateChange?: ( newFile: string) => void
 ): ReactElement => {
 
     switch (getFieldType(propertyMetadata, mode)) {
@@ -635,6 +714,9 @@ export const getPropertyField = (
         }
         case FieldType.TABLE:{
             return getTableField(property, propertyMetadata, testId);
+        }
+        case FieldType.FILE_PICKER:{
+            return getFilePicker(property, propertyMetadata, testId, onCertificateChange);
         }
         default: {
             return getTextField(property, propertyMetadata, testId);

--- a/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
@@ -30,6 +30,7 @@ import React, { ReactElement, useState } from "react";
 import { Grid } from "semantic-ui-react";
 import { Pkcs12FileField } from "./pkcs12-file-field";
 import { commonConfig } from "../../../../../../extensions";
+import { ConnectionManagementConstants } from "../../../../constants/connection-constants";
 import {
     AuthenticatorSettingsFormModes
 } from "../../../../models/authenticators";
@@ -639,7 +640,7 @@ export const getFieldType = (
         return FieldType.DROP_DOWN;
     } else if (propertyMetadata.type?.toUpperCase() === CommonConstants.RADIO) {
         return FieldType.RADIO;
-    } else if (propertyMetadata?.key === "google_prov_private_key") {
+    } else if (propertyMetadata?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY) {
         return FieldType.FILE_PICKER;
     }
 

--- a/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
@@ -26,7 +26,7 @@ import {
 import { I18n } from "@wso2is/i18n";
 import { CopyInputField, GenericIcon, Hint, P12FileStrategy } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import React, { ReactElement, useEffect, useState } from "react";
+import React, { ReactElement, useState } from "react";
 import { Grid } from "semantic-ui-react";
 import { Pkcs12FileField } from "./pkcs12-file-field";
 import { commonConfig } from "../../../../../../extensions";
@@ -504,13 +504,8 @@ export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterfac
     testId?: string,
     onCertificateChange?: ( newFile: string) => void): ReactElement => {
 
-    const [data, setData] = useState<string>(eachProp?.value);
+    const [ data, setData ] = useState<string>(eachProp?.value);
 
-    useEffect(() => {
-        // setData(eachProp?.value);
-        console.log(propertyMetadata);
-        console.log(eachProp?.value?.length);
-    },[ data, eachProp ]);
 
     return (
         <>
@@ -551,11 +546,11 @@ export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterfac
                     <Pkcs12FileField
                         eachProp={ eachProp }
                         propertyMetadata={ propertyMetadata }
-                        onCertificateChange={(newData) => 
-                            {
-                                setData(newData);
-                                onCertificateChange(data);
-                            }}
+                        onCertificateChange={ (newData: string) =>
+                        {
+                            setData(newData);
+                            onCertificateChange(data);
+                        } }
                     />
                     { propertyMetadata?.description
                     && (

--- a/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
@@ -498,6 +498,7 @@ export const getDropDownField = (eachProp: CommonPluggableComponentPropertyInter
         </>
     );
 };
+
 /* eslint-disable react-hooks/rules-of-hooks */
 export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterface,
     propertyMetadata: CommonPluggableComponentMetaPropertyInterface,
@@ -505,7 +506,6 @@ export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterfac
     onCertificateChange?: ( newFile: string) => void): ReactElement => {
 
     const [ data, setData ] = useState<string>(eachProp?.value);
-
 
     return (
         <>
@@ -517,14 +517,6 @@ export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterfac
                         required={ propertyMetadata?.isMandatory }
                         requiredErrorMessage={ I18n.instance.t("console:develop.features.authenticationProvider." +
                         "forms.common.requiredErrorMessage") }
-                        validation={ (value: string, validation: Validation) => {
-                            if (!FormValidation.url("https://www.sample.com?" + value)) {
-                                validation.isValid = false;
-                                validation.errorMessages.push(
-                                    I18n.instance.t("console:develop.features.authenticationProvider.forms.common." +
-                            "invalidQueryParamErrorMessage"));
-                            }
-                        } }
                         type="filePicker"
                         value={ data }
                         key={ propertyMetadata?.key }
@@ -544,8 +536,6 @@ export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterfac
                 <>
                     <label>{ propertyMetadata?.displayName }</label>
                     <Pkcs12FileField
-                        eachProp={ eachProp }
-                        propertyMetadata={ propertyMetadata }
                         onCertificateChange={ (newData: string) =>
                         {
                             setData(newData);

--- a/apps/console/src/features/connections/components/edit/forms/helpers/pkcs12-file-field.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/helpers/pkcs12-file-field.tsx
@@ -19,13 +19,13 @@
 import {
     IdentifiableComponentInterface
 } from "@wso2is/core/models";
-import React, { FC, PropsWithChildren, ReactElement, useState } from "react";
+import { ResourceList, ResourceListActionInterface, ResourceListItem } from "@wso2is/react-components";
+import React, { FC, PropsWithChildren, ReactElement } from "react";
+import { Grid, Icon } from "semantic-ui-react";
 import {
     CommonPluggableComponentMetaPropertyInterface,
     CommonPluggableComponentPropertyInterface
 } from "../../../../models/connection";
-import { Grid, Icon } from "semantic-ui-react";
-import { ResourceList, ResourceListActionInterface, ResourceListItem } from "@wso2is/react-components";
 
 
 /**
@@ -52,22 +52,8 @@ export const Pkcs12FileField: FC<Pkcs12FileFieldProps> = (
 
     const {
         [ "data-componentid" ]: testId,
-        eachProp,
         onCertificateChange
     } = props;
-
-    const [ deletingCertificateIndex, setDeletingCertificateIndex ] = useState<number>(null);
-    const [data, setData] = useState<string>(eachProp?.value);
-
-    /**
-     * Handles the deletion of a certificate.
-     *
-     * @param certificateIndex - Index of the certificate to be deleted.
-     */
-    const updateData = newData => {
-        setData(newData);
-        onCertificateChange(newData);
-    };
 
     /**
      * Creates the certificate actions.
@@ -109,7 +95,7 @@ export const Pkcs12FileField: FC<Pkcs12FileFieldProps> = (
 
     return (
         <>
-            <Grid columns={2}>
+            <Grid columns={ 2 }>
                 <Grid.Row>
                     <Grid.Column>
                         <ResourceList

--- a/apps/console/src/features/connections/components/edit/forms/helpers/pkcs12-file-field.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/helpers/pkcs12-file-field.tsx
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+    IdentifiableComponentInterface
+} from "@wso2is/core/models";
+import React, { FC, PropsWithChildren, ReactElement, useState } from "react";
+import {
+    CommonPluggableComponentMetaPropertyInterface,
+    CommonPluggableComponentPropertyInterface
+} from "../../../../models/connection";
+import { Grid, Icon } from "semantic-ui-react";
+import { ResourceList, ResourceListActionInterface, ResourceListItem } from "@wso2is/react-components";
+
+
+/**
+ * Props interface of {@link IdpCertificatesList}
+ */
+export interface Pkcs12FileFieldProps extends IdentifiableComponentInterface {
+    /**
+     * Type of the template.
+     */
+    eachProp?: CommonPluggableComponentPropertyInterface;
+    propertyMetadata?: CommonPluggableComponentMetaPropertyInterface;
+    onCertificateChange?: ( newFile: string) => void;
+}
+
+/**
+ * List of added certificates.
+ *
+ * @param props - Props injected to the component.
+ * @returns Functional component.
+ */
+export const Pkcs12FileField: FC<Pkcs12FileFieldProps> = (
+    props: PropsWithChildren<Pkcs12FileFieldProps>
+): ReactElement => {
+
+    const {
+        [ "data-componentid" ]: testId,
+        eachProp,
+        onCertificateChange
+    } = props;
+
+    const [ deletingCertificateIndex, setDeletingCertificateIndex ] = useState<number>(null);
+    const [data, setData] = useState<string>(eachProp?.value);
+
+    /**
+     * Handles the deletion of a certificate.
+     *
+     * @param certificateIndex - Index of the certificate to be deleted.
+     */
+    const updateData = newData => {
+        setData(newData);
+        onCertificateChange(newData);
+    };
+
+    /**
+     * Creates the certificate actions.
+     *
+     * @param certificate - Certificate.
+     * @param index - Cert index.
+     */
+    const createCertificateActions = (index: number) => {
+        return [
+            {
+                "data-componentid": `${ testId }-delete-cert-${ index }-button`,
+                icon: "trash alternate",
+                onClick: () => handleDelete(),
+                popupText: "Delete",
+                type: "button"
+            }
+        ] as (ResourceListActionInterface & IdentifiableComponentInterface)[];
+    };
+
+    /**
+     * Creates what to show as the resource list item avatar.
+     *
+     * @param certificate - Certificate.
+     */
+    const createCertificateResourceAvatar = (): ReactElement => {
+        return (
+            <Icon name="key" size="large" className="mr-3"/>
+        );
+    };
+
+    /**
+     * Handles the deletion of a certificate.
+     *
+     * @param certificateIndex - Index of the certificate to be deleted.
+     */
+    const handleDelete = () => {
+        onCertificateChange("");
+    };
+
+    return (
+        <>
+            <Grid columns={2}>
+                <Grid.Row>
+                    <Grid.Column>
+                        <ResourceList
+                            fill
+                            relaxed={ false }
+                            className="application-list"
+                            loadingStateOptions={ {
+                                count: 2,
+                                imageType: "circular"
+                            } }
+                            readOnly={ true }>
+                            <ResourceListItem
+                                key={ 1 }
+                                actionsColumnWidth={ 3 }
+                                descriptionColumnWidth={ 9 }
+                                actions={ createCertificateActions(1) }
+                                actionsFloated="right"
+                                avatar={ createCertificateResourceAvatar() }
+                                itemHeader={
+                                    "Private Key"
+                                }
+                                itemDescription={
+                                    "PKCS12 private key file"
+                                }
+                            />
+
+                        </ResourceList>
+                    </Grid.Column>
+                </Grid.Row>
+            </Grid>
+        </>
+    );
+};
+
+/**
+ * Default properties of Pkcs12FileField.
+ */
+Pkcs12FileField.defaultProps = {
+    "data-componentid": "idp-certificates-list"
+};

--- a/apps/console/src/features/connections/components/edit/forms/helpers/pkcs12-file-field.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/helpers/pkcs12-file-field.tsx
@@ -22,26 +22,16 @@ import {
 import { ResourceList, ResourceListActionInterface, ResourceListItem } from "@wso2is/react-components";
 import React, { FC, PropsWithChildren, ReactElement } from "react";
 import { Grid, Icon } from "semantic-ui-react";
-import {
-    CommonPluggableComponentMetaPropertyInterface,
-    CommonPluggableComponentPropertyInterface
-} from "../../../../models/connection";
-
 
 /**
- * Props interface of {@link IdpCertificatesList}
+ * Props interface of {@link Pkcs12FileField}
  */
 export interface Pkcs12FileFieldProps extends IdentifiableComponentInterface {
-    /**
-     * Type of the template.
-     */
-    eachProp?: CommonPluggableComponentPropertyInterface;
-    propertyMetadata?: CommonPluggableComponentMetaPropertyInterface;
     onCertificateChange?: ( newFile: string) => void;
 }
 
 /**
- * List of added certificates.
+ * PKCS file field.
  *
  * @param props - Props injected to the component.
  * @returns Functional component.
@@ -57,14 +47,11 @@ export const Pkcs12FileField: FC<Pkcs12FileFieldProps> = (
 
     /**
      * Creates the certificate actions.
-     *
-     * @param certificate - Certificate.
-     * @param index - Cert index.
      */
-    const createCertificateActions = (index: number) => {
+    const createCertificateActions = () => {
         return [
             {
-                "data-componentid": `${ testId }-delete-cert-${ index }-button`,
+                "data-componentid": `${ testId }-delete-cert-button`,
                 icon: "trash alternate",
                 onClick: () => handleDelete(),
                 popupText: "Delete",
@@ -74,9 +61,7 @@ export const Pkcs12FileField: FC<Pkcs12FileFieldProps> = (
     };
 
     /**
-     * Creates what to show as the resource list item avatar.
-     *
-     * @param certificate - Certificate.
+     * Creates certificate item avatar.
      */
     const createCertificateResourceAvatar = (): ReactElement => {
         return (
@@ -86,47 +71,42 @@ export const Pkcs12FileField: FC<Pkcs12FileFieldProps> = (
 
     /**
      * Handles the deletion of a certificate.
-     *
-     * @param certificateIndex - Index of the certificate to be deleted.
      */
     const handleDelete = () => {
         onCertificateChange("");
     };
 
     return (
-        <>
-            <Grid columns={ 2 }>
-                <Grid.Row>
-                    <Grid.Column>
-                        <ResourceList
-                            fill
-                            relaxed={ false }
-                            className="application-list"
-                            loadingStateOptions={ {
-                                count: 2,
-                                imageType: "circular"
-                            } }
-                            readOnly={ true }>
-                            <ResourceListItem
-                                key={ 1 }
-                                actionsColumnWidth={ 3 }
-                                descriptionColumnWidth={ 9 }
-                                actions={ createCertificateActions(1) }
-                                actionsFloated="right"
-                                avatar={ createCertificateResourceAvatar() }
-                                itemHeader={
-                                    "Private Key"
-                                }
-                                itemDescription={
-                                    "PKCS12 private key file"
-                                }
-                            />
-
-                        </ResourceList>
-                    </Grid.Column>
-                </Grid.Row>
-            </Grid>
-        </>
+        <Grid columns={ 2 }>
+            <Grid.Row>
+                <Grid.Column>
+                    <ResourceList
+                        fill
+                        relaxed={ false }
+                        className="certificate"
+                        loadingStateOptions={ {
+                            count: 2,
+                            imageType: "circular"
+                        } }
+                        readOnly={ true }>
+                        <ResourceListItem
+                            key={ 1 }
+                            actionsColumnWidth={ 3 }
+                            descriptionColumnWidth={ 9 }
+                            actions={ createCertificateActions() }
+                            actionsFloated="right"
+                            avatar={ createCertificateResourceAvatar() }
+                            itemHeader={
+                                "Private Key"
+                            }
+                            itemDescription={
+                                "PKCS12 private key file"
+                            }
+                        />
+                    </ResourceList>
+                </Grid.Column>
+            </Grid.Row>
+        </Grid>
     );
 };
 
@@ -134,5 +114,5 @@ export const Pkcs12FileField: FC<Pkcs12FileFieldProps> = (
  * Default properties of Pkcs12FileField.
  */
 Pkcs12FileField.defaultProps = {
-    "data-componentid": "idp-certificates-list"
+    "data-componentid": "google-private-key-file"
 };

--- a/apps/console/src/features/connections/constants/connection-constants.ts
+++ b/apps/console/src/features/connections/constants/connection-constants.ts
@@ -182,6 +182,8 @@ export class ConnectionManagementConstants {
 
     public static readonly SHOW_PREDEFINED_TEMPLATES_IN_EXPERT_MODE_SETUP: boolean = false;
 
+    public static readonly GOOGLE_PRIVATE_KEY: string = "google_prov_private_key";
+
     /**
      * Google Scope mappings.
      */

--- a/apps/console/src/features/identity-providers/components/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/helpers/form-fields-helper.tsx
@@ -587,14 +587,6 @@ export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterfac
                 required={ propertyMetadata?.isMandatory }
                 requiredErrorMessage={ I18n.instance.t("console:develop.features.authenticationProvider.forms.common." +
                 "requiredErrorMessage") }
-                validation={ (value: string, validation: Validation) => {
-                    if (!FormValidation.url("https://www.sample.com?" + value)) {
-                        validation.isValid = false;
-                        validation.errorMessages.push(
-                            I18n.instance.t("console:develop.features.authenticationProvider.forms.common." +
-                            "invalidQueryParamErrorMessage"));
-                    }
-                } }
                 type="filePicker"
                 value={ eachProp?.value }
                 key={ propertyMetadata?.key }

--- a/apps/console/src/features/identity-providers/components/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/helpers/form-fields-helper.tsx
@@ -24,7 +24,7 @@ import {
     Validation
 } from "@wso2is/forms";
 import { I18n } from "@wso2is/i18n";
-import { CopyInputField, GenericIcon, Hint } from "@wso2is/react-components";
+import { CopyInputField, GenericIcon, Hint, XMLFileStrategy } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import React, { ReactElement } from "react";
 import { Grid } from "semantic-ui-react";
@@ -36,6 +36,7 @@ import {
 } from "../../../models";
 
 const AUTHORIZATION_REDIRECT_URL: string = "callbackUrl";
+const XML_FILE_PROCESSING_STRATEGY: XMLFileStrategy = new XMLFileStrategy();
 
 export const getConfidentialField = (eachProp: CommonPluggableComponentPropertyInterface,
     propertyMetadata: CommonPluggableComponentMetaPropertyInterface,
@@ -600,6 +601,9 @@ export const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterfac
                 disabled={ propertyMetadata?.isDisabled }
                 readOnly={ propertyMetadata?.readOnly }
                 data-testid={ `${ testId }-${ propertyMetadata?.key }` }
+                fileStrategy={ XML_FILE_PROCESSING_STRATEGY }
+                uploadButtonText="Upload Metadata File"
+                dropzoneText="Drag and drop a XML file here."
             />) }
             { showField
             && propertyMetadata?.description

--- a/modules/forms/src/components/field.tsx
+++ b/modules/forms/src/components/field.tsx
@@ -444,13 +444,16 @@ export const InnerField = React.forwardRef((props: InnerFieldPropsInterface, ref
                     <label>
                         { inputField.label }
                         {
-                            inputField.label
+                            inputField.label && inputField.required
                                 ? <span className="ui text color red">*</span>
                                 : null
                         }
                     </label>
                     <MetaFilePicker
+                        fileStrategy={ inputField.fileStrategy }
                         value={ inputField.value }
+                        uploadButtonText={ inputField.uploadButtonText }
+                        dropzoneText={ inputField.dropzoneText }
                         onChange={ (event: React.ChangeEvent<HTMLInputElement>) => {
                             handleChange(event.target.value, inputField.name);
                         } }

--- a/modules/forms/src/components/meta-file-picker.tsx
+++ b/modules/forms/src/components/meta-file-picker.tsx
@@ -16,13 +16,16 @@
  * under the License.
  */
 
-import { FilePicker, PickerResult, XMLFileStrategy } from "@wso2is/react-components";
+import { FilePicker, PickerResult, PickerStrategy } from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { Form, InputOnChangeData } from "semantic-ui-react";
 
 interface MetaFilePickerPropsInterface {
     value: string;
+    fileStrategy: PickerStrategy<any>;
+    uploadButtonText: string;
+    dropzoneText: string;
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
@@ -35,6 +38,9 @@ export const MetaFilePicker: FunctionComponent<MetaFilePickerPropsInterface> = (
 
     const {
         value,
+        fileStrategy,
+        uploadButtonText,
+        dropzoneText,
         onChange
     } = props;
 
@@ -42,8 +48,6 @@ export const MetaFilePicker: FunctionComponent<MetaFilePickerPropsInterface> = (
 
     const [ metaFilePickerValue, setMetaFilePickerValue ] = useState<string>(null);
     const [ filePicker, setFilePicker ] = useState<FilePickerInterface[]>();
-
-    const XML_FILE_PROCESSING_STRATEGY: XMLFileStrategy = new XMLFileStrategy();
 
     /**
      * Build query parameter object from the given string form.
@@ -166,14 +170,14 @@ export const MetaFilePicker: FunctionComponent<MetaFilePickerPropsInterface> = (
                 {
                     (<div style={ { display: "block" } }>
                         <FilePicker
-                            fileStrategy={ XML_FILE_PROCESSING_STRATEGY }
+                            fileStrategy={ fileStrategy }
                             normalizeStateOnRemoveOperations={ true }
                             onChange={ (result: PickerResult<File>) => {
                                 setMetaFilePickerValue(result.serialized as string);
                                 handleQueryParameterAdd();
                             } }
-                            uploadButtonText="Upload Metadata File"
-                            dropzoneText="Drag and drop a XML file here."
+                            uploadButtonText={ uploadButtonText }
+                            dropzoneText={ dropzoneText }
                             hidePasteOption
                             pasteAreaPlaceholderText="Paste metadata file in xml format."
                             icon={ null }

--- a/modules/forms/src/models/forms.ts
+++ b/modules/forms/src/models/forms.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { PickerStrategy } from "@wso2is/react-components";
 import * as React from "react";
 import { FlagProps, SemanticSIZES, SemanticShorthandItem, SemanticWIDTHS } from "semantic-ui-react";
 
@@ -195,6 +196,9 @@ export interface QueryParamsField extends FormRequiredFieldModel {
 export interface FilePickerField extends FormRequiredFieldModel {
     type: "filePicker";
     value?: string;
+    uploadButtonText?: string;
+    dropzoneText?: string;
+    fileStrategy?: PickerStrategy<any>;
     validation?: (value: string, validation: Validation, allValues?: Map<string, FormValue>) => void;
 }
 

--- a/modules/react-components/src/components/file-picker/file-picker.tsx
+++ b/modules/react-components/src/components/file-picker/file-picker.tsx
@@ -584,7 +584,7 @@ export const FilePicker: FC<FilePickerProps> = (props: FilePickerPropsAlias): Re
                     <Icon name="file"/>
                     { errorMessage }
                 </Message>)
-                
+
             }
         </React.Fragment>
     );
@@ -667,6 +667,52 @@ export class DefaultFileStrategy implements PickerStrategy<string> {
 
     async serialize(): Promise<string> {
         return Promise.resolve("");
+    }
+
+    async validate(): Promise<ValidationResult> {
+        return Promise.resolve({ valid: true });
+    }
+
+}
+
+
+export class P12FileStrategy implements PickerStrategy<string> {
+
+    mimeTypes: string[];
+
+    constructor() {
+        this.mimeTypes = [ ".p12" ];
+    }
+
+    async serialize(data: File | string): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+            if (!data) {
+                reject({ valid: false });
+
+                return;
+            }
+
+            if (data instanceof File) {
+                const reader = new FileReader();
+
+                reader.readAsArrayBuffer(data);
+
+                reader.onload = (e) => {
+                    const binaryData: string | ArrayBuffer | null = e.target.result;
+                    const base64String = btoa(
+                        new Uint8Array(binaryData as ArrayBufferLike)
+                            .reduce((acc, byte) => acc + String.fromCharCode(byte), ""));
+
+                    resolve(base64String);
+                };
+
+            } else {
+                reject({
+                    errorMessage: "The file is invalid",
+                    valid: false
+                });
+            }
+        });
     }
 
     async validate(): Promise<ValidationResult> {
@@ -989,19 +1035,19 @@ export class CSVFileStrategy implements PickerStrategy<CSVResult> {
         return new Promise<CSVResult>((resolve, reject) => {
             if (!data) {
                 reject({ valid: false });
-                
+
                 return;
             }
 
             const processCSV = (csvContent: string) => {
                 const delimiter: string = ",";
                 const lines: string[] = csvContent.split(/\r?\n/).filter(line => line.trim() !== "");
-                
+
                 const data: string[][] = lines.map(line => {
                     const cells = [];
                     let cell: string = "";
                     let insideQuotes: boolean = false;
-                    
+
                     for (const c of line) {
                         if (c === delimiter && !insideQuotes) {
                             cells.push(cell.trim());
@@ -1013,10 +1059,10 @@ export class CSVFileStrategy implements PickerStrategy<CSVResult> {
                             cell += c;
                         }
                     }
-            
+
                     // Add the last cell.
                     cells.push(cell.trim());
-                    
+
                     // Remove quotes and handle double quotes inside quoted fields.
                     return cells.map(cell => {
                         if (cell.startsWith("\"") && cell.endsWith("\"")) {
@@ -1026,9 +1072,9 @@ export class CSVFileStrategy implements PickerStrategy<CSVResult> {
                         return cell;
                     });
                 });
-            
+
                 const headers = data.shift();
-                
+
                 resolve({ headers, items: data });
             };
 
@@ -1057,7 +1103,7 @@ export class CSVFileStrategy implements PickerStrategy<CSVResult> {
 
                     return;
                 }
-    
+
                 // Check file size.
                 if (data.size > this.maxSize) {
                     reject({
@@ -1067,7 +1113,7 @@ export class CSVFileStrategy implements PickerStrategy<CSVResult> {
 
                     return;
                 }
-    
+
                 const reader = new FileReader();
 
                 reader.readAsText(data, CSVFileStrategy.ENCODING);
@@ -1083,7 +1129,7 @@ export class CSVFileStrategy implements PickerStrategy<CSVResult> {
 
                             return acc;
                         }, { lines: [], rowCount: 0 });
-                        const actualRowCount: number = rowCount - 1; 
+                        const actualRowCount: number = rowCount - 1;
 
                         if (actualRowCount > this.maxRowCount) {
                             reject({
@@ -1122,5 +1168,5 @@ export class CSVFileStrategy implements PickerStrategy<CSVResult> {
                 }
             }
         });
-    } 
+    }
 }

--- a/modules/react-components/src/components/file-picker/file-picker.tsx
+++ b/modules/react-components/src/components/file-picker/file-picker.tsx
@@ -675,7 +675,6 @@ export class DefaultFileStrategy implements PickerStrategy<string> {
 
 }
 
-
 export class P12FileStrategy implements PickerStrategy<string> {
 
     mimeTypes: string[];
@@ -696,9 +695,9 @@ export class P12FileStrategy implements PickerStrategy<string> {
                 const reader = new FileReader();
 
                 reader.readAsArrayBuffer(data);
-
                 reader.onload = (e) => {
                     const binaryData: string | ArrayBuffer | null = e.target.result;
+                    // Transform the binary data to base64 encoded string.
                     const base64String = btoa(
                         new Uint8Array(binaryData as ArrayBufferLike)
                             .reduce((acc, byte) => acc + String.fromCharCode(byte), ""));


### PR DESCRIPTION
### Purpose
> Currently, our file uploader does not support uploading pkcs12 files. This PR adds support to upload a pkcs12 file to the private key of the google outbound provision connector.

Empty File Uploader 
<img width="717" alt="Screenshot 2024-01-24 at 15 13 42" src="https://github.com/wso2/identity-apps/assets/27746285/daf3a96c-7d14-42ec-9556-954d9f62d8d6">

Uploaded File
<img width="524" alt="Screenshot 2024-01-24 at 15 14 29" src="https://github.com/wso2/identity-apps/assets/27746285/86605c44-6952-4d22-b257-66ec32adeb1f">

### Related Issues
- https://github.com/wso2/product-is/issues/18993

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
