### PR TITLE
Change message text for 'no-results-found' on application shared access page

### DIFF
--- a/.changeset/breezy-olives-sparkle.md
+++ b/.changeset/breezy-olives-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change message text for no-results-found on application shared access page.

--- a/apps/console/src/features/applications/components/forms/share-application-form.tsx
+++ b/apps/console/src/features/applications/components/forms/share-application-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -114,17 +114,11 @@ export const ApplicationShareForm: FunctionComponent<ApplicationShareFormPropsIn
 
     const [ subOrganizationList, setSubOrganizationList ] = useState<Array<OrganizationInterface>>([]);
     const [ sharedOrganizationList, setSharedOrganizationList ] = useState<Array<OrganizationInterface>>([]);
-    const [ tempOrganizationList, setTempOrganizationList ] = useState<
-        OrganizationInterface[]
-    >([]);
-    const [
-        checkedUnassignedListItems,
-        setCheckedUnassignedListItems
-    ] = useState<OrganizationInterface[]>([]);
-    const [ shareType, setShareType ] = useState<ShareType>(
-        ShareType.UNSHARE
-    );
+    const [ tempOrganizationList, setTempOrganizationList ] = useState<OrganizationInterface[]>([]);
+    const [ checkedUnassignedListItems, setCheckedUnassignedListItems ] = useState<OrganizationInterface[]>([]);
+    const [ shareType, setShareType ] = useState<ShareType>(ShareType.UNSHARE);
     const [ sharedWithAll, setSharedWithAll ] = useState<boolean>(false);
+    const [ filter, setFilter ] = useState<string>();
 
     useEffect(() => setTempOrganizationList(subOrganizationList || []),
         [ subOrganizationList ]
@@ -471,6 +465,7 @@ export const ApplicationShareForm: FunctionComponent<ApplicationShareFormPropsIn
         const filteredOrganizationList: OrganizationInterface[] = [];
 
         if (!isEmpty(value)) {
+            setFilter(value);
             const re: RegExp = new RegExp(escapeRegExp(value), "i");
 
             subOrganizationList &&
@@ -587,11 +582,11 @@ export const ApplicationShareForm: FunctionComponent<ApplicationShareFormPropsIn
                                         ),
                                         ""
                                     ] }
-                                    emptyPlaceholderContent={ t(
-                                        "console:manage.features.transferList.list.emptyPlaceholders." +
-                                            "groups.unselected",
-                                        { type: "organizations" }
-                                    ) }
+                                    emptyPlaceholderContent={
+                                        t("console:develop.placeholders.emptySearchResult.subtitles.0",
+                                            { query: filter }) + ". " +
+                                            t("console:develop.placeholders.emptySearchResult.subtitles.1")
+                                    }
                                     data-testid="application-share-modal-organization-transfer-component-all-items"
                                     emptyPlaceholderDefaultContent={ t(
                                         "console:manage.features.transferList.list." +

--- a/apps/console/src/features/applications/components/modals/application-share-modal.tsx
+++ b/apps/console/src/features/applications/components/modals/application-share-modal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2022-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -111,18 +111,12 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
         (state: AppState) => state.organization.organization
     );
 
-    const [ tempOrganizationList, setTempOrganizationList ] = useState<
-        OrganizationInterface[]
-    >([]);
-    const [
-        checkedUnassignedListItems,
-        setCheckedUnassignedListItems
-    ] = useState<OrganizationInterface[]>([]);
-    const [ shareType, setShareType ] = useState<ShareType>( 
-        ShareType.SHARE_ALL
-    );
+    const [ tempOrganizationList, setTempOrganizationList ] = useState<OrganizationInterface[]>([]);
+    const [ checkedUnassignedListItems, setCheckedUnassignedListItems ] = useState<OrganizationInterface[]>([]);
+    const [ shareType, setShareType ] = useState<ShareType>(ShareType.SHARE_ALL);
     const [ subOrganizationList, setSubOrganizationList ] = useState<Array<OrganizationInterface>>([]);
     const [ sharedOrganizationList, setSharedOrganizationList ] = useState<Array<OrganizationInterface>>([]);
+    const [ filter, setFilter ] = useState<string>();
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
@@ -445,6 +439,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
         const filteredOrganizationList: OrganizationInterface[] = [];
 
         if (!isEmpty(value)) {
+            setFilter(value);
             const re: RegExp = new RegExp(escapeRegExp(value), "i");
 
             subOrganizationList &&
@@ -572,11 +567,11 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                                     ),
                                     ""
                                 ] }
-                                emptyPlaceholderContent={ t(
-                                    "console:manage.features.transferList.list.emptyPlaceholders." +
-                                        "groups.unselected",
-                                    { type: "organizations" }
-                                ) }
+                                emptyPlaceholderContent={
+                                    t("console:develop.placeholders.emptySearchResult.subtitles.0",
+                                        { query: filter }) + ". " +
+                                        t("console:develop.placeholders.emptySearchResult.subtitles.1")
+                                }
                                 data-testid="application-share-modal-organization-transfer-component-all-items"
                                 emptyPlaceholderDefaultContent={ t(
                                     "console:manage.features.transferList.list." +

--- a/apps/console/src/features/applications/components/modals/application-share-modal.tsx
+++ b/apps/console/src/features/applications/components/modals/application-share-modal.tsx
@@ -94,7 +94,7 @@ export interface ApplicationShareModalPropsInterface
 
 export const ApplicationShareModal: FunctionComponent<ApplicationShareModalPropsInterface> = (
     props: ApplicationShareModalPropsInterface
-) => { 
+) => {
     const {
         applicationId,
         clientId,
@@ -528,9 +528,9 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                         checked={ shareType === ShareType.SHARE_SELECTED }
                         data-componentid={ `${ componentId }-share-with-all-checkbox` }
                     />
-                    <Transition 
-                        visible={ shareType === ShareType.SHARE_SELECTED } 
-                        animation="slide down" 
+                    <Transition
+                        visible={ shareType === ShareType.SHARE_SELECTED }
+                        animation="slide down"
                         duration={ 1000 }
                     >
                         <TransferComponent
@@ -587,7 +587,7 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                                                     (org: OrganizationInterface) =>
                                                         org.id === organization.id
                                                 ) !== -1;
-    
+
                                         return (
                                             <TransferListItem
                                                 disabled={
@@ -612,21 +612,21 @@ export const ApplicationShareModal: FunctionComponent<ApplicationShareModalProps
                                     }
                                 ) }
                             </TransferList>
-                        </TransferComponent> 
+                        </TransferComponent>
                     </Transition>
                 </Segment>
             </Modal.Content>
             <Modal.Actions>
-                <LinkButton 
+                <LinkButton
                     data-testid={ `${ componentId }-cancel-button` }
                     onClick={ () => onApplicationSharingCompleted() }
                 >
                     { t("common:cancel") }
                 </LinkButton>
                 <PrimaryButton
-                    disabled={ 
+                    disabled={
                         shareType === ShareType.SHARE_SELECTED &&
-                        (checkedUnassignedListItems?.length == 0 || !subOrganizationList) 
+                        (checkedUnassignedListItems?.length == 0 || !subOrganizationList)
                     }
                     onClick={ () => {
                         handleShareApplication();


### PR DESCRIPTION
### Purpose
When a user enters an unavailable sub organisation name under the "Share with only selected sub-organizations" option search, the user is displayed with a message "There are no organizations available to assign to this group". This PR changes the message to "We couldn't find any results for "xxxx". Please try a different search term." as returned on other pages.

### Related Issues
- None.

### Related PRs
- None.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
