### PR TITLE
Add branding text preference resolve API call

### DIFF
--- a/apps/console/src/features/branding/api/use-get-custom-text-preference-resolve.ts
+++ b/apps/console/src/features/branding/api/use-get-custom-text-preference-resolve.ts
@@ -42,7 +42,7 @@ import {
  * @param type - Resource Type.
  * @returns SWR response object containing the data, error, isValidating, mutate.
  */
-const useGetCustomTextPreference = <
+const useGetCustomTextPreferenceResolve = <
     Data = CustomTextPreferenceAPIResponseInterface,
     Error = RequestErrorInterface>(
         shouldFetch: boolean,
@@ -70,8 +70,8 @@ const useGetCustomTextPreference = <
             type
         },
         url: organizationType === OrganizationType.SUBORGANIZATION
-            ? store.getState().config.endpoints.brandingTextPreferenceSubOrg
-            : store.getState().config.endpoints.brandingTextPreference
+            ? `${store.getState().config.endpoints.brandingTextPreferenceSubOrg}/resolve`
+            : `${store.getState().config.endpoints.brandingTextPreference}/resolve`
     };
 
     const { data, error, isValidating, mutate } = useRequest<Data, Error>(shouldFetch? requestConfig : null, {
@@ -98,4 +98,4 @@ const useGetCustomTextPreference = <
     };
 };
 
-export default useGetCustomTextPreference;
+export default useGetCustomTextPreferenceResolve;

--- a/apps/console/src/features/branding/constants/branding-preferences-constants.ts
+++ b/apps/console/src/features/branding/constants/branding-preferences-constants.ts
@@ -36,6 +36,7 @@ export class BrandingPreferencesConstants {
     public static readonly DEFAULT_LAYOUT: PredefinedLayouts = PredefinedLayouts.CENTERED;
     public static readonly DEFAULT_FONT_FROM_THEME: string = "Gilmer";
     public static readonly BRANDING_NOT_CONFIGURED_ERROR_CODE: string = "BPM-60002";
+    public static readonly CUSTOM_TEXT_PREFERENCE_NOT_CONFIGURED_ERROR_CODE: string = "BPM-60006";
     public static readonly BRANDING_PREFERENCE_FETCH_INVALID_STATUS_CODE_ERROR_CODE: string = "ASG-CON-BPM-60001";
     public static readonly BRANDING_PREFERENCE_FETCH_ERROR_CODE: string = "ASG-CON-BPM-60002";
     public static readonly BRANDING_PREFERENCE_UPDATE_INVALID_STATUS_CODE_ERROR_CODE: string = "ASG-CON-BPM-60005";

--- a/apps/console/src/features/branding/providers/branding-preference-provider.tsx
+++ b/apps/console/src/features/branding/providers/branding-preference-provider.tsx
@@ -17,6 +17,7 @@
  */
 
 import { OrganizationType } from "@wso2is/common";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertInterface, AlertLevels } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { FormState } from "@wso2is/form";
@@ -36,9 +37,9 @@ import { OrganizationResponseInterface } from "../../organizations/models/organi
 import deleteCustomTextPreference from "../api/delete-custom-text-preference";
 import updateCustomTextPreference from "../api/update-custom-text-preference";
 import useGetBrandingPreferenceResolve from "../api/use-get-branding-preference-resolve";
-import useGetCustomTextPreference from "../api/use-get-custom-text-preference";
 import useGetCustomTextPreferenceFallbacks from "../api/use-get-custom-text-preference-fallbacks";
 import useGetCustomTextPreferenceMeta from "../api/use-get-custom-text-preference-meta";
+import useGetCustomTextPreferenceResolve from "../api/use-get-custom-text-preference-resolve";
 import { BrandingPreferencesConstants } from "../constants/branding-preferences-constants";
 import { CustomTextPreferenceConstants } from "../constants/custom-text-preference-constants";
 import AuthenticationFlowContext from "../context/branding-preference-context";
@@ -99,19 +100,26 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
         CustomTextConfigurationModes
     >(CustomTextConfigurationModes.TEXT_FIELDS);
 
+    const [ isCustomTextPreferenceConfigured, setIsCustomTextPreferenceConfigured ] = useState<boolean>(true);
+
+
     const {
         data: brandingPreference
     } = useGetBrandingPreferenceResolve(tenantDomain);
 
     const {
         data: customTextCommons
-    } = useGetCustomTextPreference(!!selectedLocale, tenantDomain, "common", selectedLocale);
+    } = useGetCustomTextPreferenceResolve(!!selectedLocale, tenantDomain, "common", selectedLocale);
 
     const {
         data: customText,
         error: customTextPreferenceFetchRequestError,
         mutate: mutateCustomTextPreferenceFetchRequest
-    } = useGetCustomTextPreference(!!selectedScreen && !!selectedLocale, tenantDomain, selectedScreen, selectedLocale);
+    } = useGetCustomTextPreferenceResolve(
+        !!selectedScreen && !!selectedLocale,
+        tenantDomain,
+        selectedScreen,
+        selectedLocale);
 
     const {
         data: customTextFallbackCommons
@@ -173,22 +181,36 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
     }, [ customTextPreferenceFetchRequestError ]);
 
     /**
-     * Updates the custom text preference.
-     *
-     * @param values - Values to be updated.
-     * @returns Promise containing the API response.
+     * Moderates the Custom Text Preference response.
      */
-    const _updateCustomTextPreference = (values: CustomTextPreferenceInterface): Promise<void> => {
-        let isAlreadyConfigured: boolean = !!customText;
-
+    useEffect(() => {
+        if (!customText) {
+            return;
+        }
         if (organizationType === OrganizationType.SUBORGANIZATION
             && customText?.name !== currentOrganization?.id) {
             // This means the sub-org has no custom text preference configured.
             // It gets the custom text preference from the parent org.
-            isAlreadyConfigured = false;
+            setIsCustomTextPreferenceConfigured(false);
+        } else {
+            setIsCustomTextPreferenceConfigured(true);
         }
+    }, [ customText ]);
 
-        return updateCustomTextPreference(isAlreadyConfigured, values, tenantDomain, selectedScreen, selectedLocale)
+    /**
+     * Updates the custom text preference.
+     *
+     * @param values - Values to be updated.
+     * @param _isCustomTextPreferenceConfigured - Flag to check if the custom text preference is configured.
+     * @returns Promise containing the API response.
+     */
+    const _updateCustomTextPreference = (
+        values: CustomTextPreferenceInterface,
+        _isCustomTextPreferenceConfigured: boolean
+    ): Promise<void> => {
+
+        return updateCustomTextPreference(_isCustomTextPreferenceConfigured, values, tenantDomain, selectedScreen,
+            selectedLocale)
             .then(
                 () => {
                     dispatch(
@@ -205,7 +227,13 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
                     mutateCustomTextPreferenceFetchRequest();
                 }
             )
-            .catch(() => {
+            .catch((error: IdentityAppsApiException) => {
+                // Edge Case.Try again with POST, if custom text preference has been removed due to concurrent sessions.
+                if (error.code === BrandingPreferencesConstants.CUSTOM_TEXT_PREFERENCE_NOT_CONFIGURED_ERROR_CODE) {
+                    _updateCustomTextPreference(values, false);
+
+                    return;
+                }
                 addAlert<AlertInterface>({
                     description: t("console:brandingCustomText.notifications.updateError.description", {
                         locale: selectedLocale,
@@ -299,7 +327,7 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
         };
 
         // Update the value in the API.
-        _updateCustomTextPreference(updatedValues).then(() => {
+        _updateCustomTextPreference(updatedValues, isCustomTextPreferenceConfigured).then(() => {
             // Update the value in the form state.
             setCustomTextFormSubscription({
                 ...customTextFormSubscription,
@@ -391,7 +419,7 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
                     _updateCustomTextPreference({
                         ...resolvedCustomText?.preference,
                         text: customTextFormSubscription?.values
-                    });
+                    }, isCustomTextPreferenceConfigured);
                 }
             } }
         >


### PR DESCRIPTION
### Purpose
Add branding text preference resolve api

### Related Issues
- https://github.com/wso2/product-is/issues/19187

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
