### PR TITLE
Fix issue with adding multiple scopes in the api resource edit section

### DIFF
--- a/.changeset/hungry-bats-kneel.md
+++ b/.changeset/hungry-bats-kneel.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix issue with adding multiple scopes in the edit section

--- a/apps/console/src/features/api-resources/pages/api-resource-edit.tsx
+++ b/apps/console/src/features/api-resources/pages/api-resource-edit.tsx
@@ -73,11 +73,16 @@ const APIResourcesEditPage: FunctionComponent<APIResourcesEditPageInterface> = (
     useEffect(() => {
         setAPIResourceIdFromPath();
     }, []);
-    
+
     /**
      * The following useEffect is used to handle if the user has the required scopes to update the API resource
      */
     useEffect(() => {
+
+        if (!apiResourceData) {
+            return;
+        }
+
         const updateForbidden: boolean = !APIResourceUtils.isAPIResourceUpdateAllowed(featureConfig, allowedScopes);
         const isSytemAPIResource: boolean = APIResourceUtils.isSystemAPI(apiResourceData?.type);
 
@@ -123,6 +128,8 @@ const APIResourcesEditPage: FunctionComponent<APIResourcesEditPageInterface> = (
         }
     };
 
+    console.log("readonly", isReadOnly);
+
     return (
         (!isAPIResourceDatatLoading && !apiResourceData) || apiResourceDataFetchRequestError
             ? (<EmptyPlaceholder
@@ -145,7 +152,7 @@ const APIResourcesEditPage: FunctionComponent<APIResourcesEditPageInterface> = (
                     onClick: handleBackButtonClick,
                     text: categoryId === APIResourceType.MANAGEMENT
                         ? t("console:manage.pages.rolesEdit.backButton", { type: "Management APIs" })
-                        : categoryId === APIResourceType.ORGANIZATION 
+                        : categoryId === APIResourceType.ORGANIZATION
                             ? t("console:manage.pages.rolesEdit.backButton", { type: "Organization APIs" })
                             : t("console:manage.pages.rolesEdit.backButton", { type: "APIs" })
                 } }
@@ -153,12 +160,12 @@ const APIResourcesEditPage: FunctionComponent<APIResourcesEditPageInterface> = (
                 bottomMargin={ false }
                 pageHeaderMaxWidth={ true }
             >
-                <EditAPIResource 
-                    apiResourceData={ apiResourceData } 
-                    isAPIResourceDataLoading={ isAPIResourceDatatLoading }   
+                <EditAPIResource
+                    apiResourceData={ apiResourceData }
+                    isAPIResourceDataLoading={ isAPIResourceDatatLoading }
                     featureConfig={ featureConfig }
                     isReadOnly={ isReadOnly }
-                    mutateAPIResource={ updateAPIResource }           
+                    mutateAPIResource={ updateAPIResource }
                 />
             </TabPageLayout>)
     );

--- a/apps/console/src/features/api-resources/pages/api-resource-edit.tsx
+++ b/apps/console/src/features/api-resources/pages/api-resource-edit.tsx
@@ -78,7 +78,6 @@ const APIResourcesEditPage: FunctionComponent<APIResourcesEditPageInterface> = (
      * The following useEffect is used to handle if the user has the required scopes to update the API resource
      */
     useEffect(() => {
-
         if (!apiResourceData) {
             return;
         }
@@ -127,8 +126,6 @@ const APIResourcesEditPage: FunctionComponent<APIResourcesEditPageInterface> = (
             history.push(APIResourcesConstants.getPaths().get("API_RESOURCES"));
         }
     };
-
-    console.log("readonly", isReadOnly);
 
     return (
         (!isAPIResourceDatatLoading && !apiResourceData) || apiResourceDataFetchRequestError


### PR DESCRIPTION
### Purpose
> Fix issue with adding multiple scopes in the API resource edit section.

### Preview
![image](https://github.com/wso2/identity-apps/assets/30111554/459ec5df-a89b-4ddf-90f5-c903641b45bb)

### Related Issues
- https://github.com/wso2/product-is/issues/19180

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
