### PR TITLE
Add ability to edit Console Role permissions

### DIFF
--- a/.changeset/spotty-jeans-cheat.md
+++ b/.changeset/spotty-jeans-cheat.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove `isAuthenticatorAllowed` method infavor of `hiddenAuthenticators`

--- a/apps/console/src/features/console-settings/components/console-roles/console-roles-edit/console-role-permissions.tsx
+++ b/apps/console/src/features/console-settings/components/console-roles/console-roles-edit/console-role-permissions.tsx
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+    AlertInterface,
+    AlertLevels,
+    IdentifiableComponentInterface,
+    LoadableComponentInterface,
+    RolePermissionInterface,
+    RolesInterface
+} from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import {
+    EmphasizedSegment,
+    Heading,
+    PrimaryButton
+} from "@wso2is/react-components";
+import isEmpty from "lodash-es/isEmpty";
+import React, { FunctionComponent, ReactElement, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
+import { updateRoleDetails } from "../../../../roles/api/roles";
+import { Schemas } from "../../../../roles/constants/role-constants";
+import { CreateRolePermissionInterface, PatchRoleDataInterface } from "../../../../roles/models/roles";
+import useGetAPIResourceCollections from "../../../api/use-get-api-resource-collections";
+import {
+    APIResourceCollectionInterface,
+    APIResourceCollectionPermissionCategoryInterface,
+    APIResourceCollectionPermissionScopeInterface
+} from "../../../models/console-roles";
+import { SelectedPermissionCategoryInterface, SelectedPermissionsInterface } from "../../../models/permissions-ui";
+import transformResourceCollectionToPermissions from "../../../utils/transform-resource-collection-to-permissions";
+import CreateConsoleRoleWizardPermissionsForm from
+    "../create-console-role-wizard/create-console-role-wizard-permissions-form";
+
+/**
+ * Props interface of {@link ConsoleRolePermissions}
+ */
+export interface ConsoleRolePermissionsProps extends LoadableComponentInterface, IdentifiableComponentInterface {
+    /**
+     * Is read only.
+     */
+    isReadOnly?: boolean;
+    /**
+     * All the details about the role.
+     */
+    role: RolesInterface;
+    /**
+     * Handle role update callback.
+     */
+    onRoleUpdate: (activeTabIndex: number) => void;
+    /**
+     * Tab index
+     */
+    tabIndex: number;
+}
+
+/**
+ * Component to render the tenant & organization permission trees.
+ *
+ * @param props - Props injected to the component.
+ * @returns ConsoleRolePermissions component.
+ */
+const ConsoleRolePermissions: FunctionComponent<ConsoleRolePermissionsProps> = (
+    props: ConsoleRolePermissionsProps
+): ReactElement => {
+    const {
+        isReadOnly,
+        role,
+        onRoleUpdate,
+        tabIndex,
+        [ "data-componentid" ]: componentId
+    } = props;
+
+    const dispatch: Dispatch = useDispatch();
+
+    const { t } = useTranslation();
+
+    const { data: tenantAPIResourceCollections } = useGetAPIResourceCollections(true, "type eq tenant", "apiResources");
+
+    const { data: organizationAPIResourceCollections } = useGetAPIResourceCollections(
+        true,
+        "type eq organization",
+        "apiResources"
+    );
+
+    const [ permissions, setPermissions ] = useState<CreateRolePermissionInterface[]>(undefined);
+
+    /**
+     * Process the collection and return the selected permissions.
+     *
+     * @param collection - API resource collection.
+     * @param selectedFeatures - Selected features.
+     * @returns Selected permissions.
+     */
+    const processCollection = (
+        collection: APIResourceCollectionInterface,
+        selectedFeatures: string[]
+    ): SelectedPermissionCategoryInterface | null => {
+        const readPermissions: string[] = collection.apiResources.read.flatMap(
+            (resource: APIResourceCollectionPermissionCategoryInterface) =>
+                resource.scopes.map((scope: APIResourceCollectionPermissionScopeInterface) => scope.name)
+        );
+
+        const writePermissions: string[] = collection.apiResources.write.flatMap(
+            (resource: APIResourceCollectionPermissionCategoryInterface) =>
+                resource.scopes.map((scope: APIResourceCollectionPermissionScopeInterface) => scope.name)
+        );
+
+        const hasReadPermissions: boolean = readPermissions.every((scope: string) =>
+            selectedFeatures.includes(scope)
+        );
+        const hasWritePermissions: boolean = writePermissions.every((scope: string) =>
+            selectedFeatures.includes(scope)
+        );
+
+        if (hasReadPermissions || hasWritePermissions) {
+            return {
+                permissions: transformResourceCollectionToPermissions(
+                    collection.apiResources[hasWritePermissions ? "write" : "read"]
+                ),
+                read: hasWritePermissions ? false : hasReadPermissions,
+                write: hasWritePermissions
+            };
+        }
+
+        return null;
+    };
+
+    /**
+     * Initial values for the permission form.
+     */
+    const permissionFormInitialValues: SelectedPermissionsInterface = useMemo(() => {
+        const selectedFeatures: string[] = (role?.permissions as RolePermissionInterface[])?.map(
+            (permission: RolePermissionInterface) => {
+                return permission.value;
+            }
+        );
+
+        const permissions: SelectedPermissionsInterface = {
+            organization: {},
+            tenant: {}
+        };
+
+        tenantAPIResourceCollections?.apiResourceCollections?.forEach((collection: APIResourceCollectionInterface) => {
+            const processedCollection: SelectedPermissionCategoryInterface = processCollection(
+                collection,
+                selectedFeatures
+            );
+
+            if (processedCollection) {
+                permissions.tenant[collection.id] = processedCollection;
+            }
+        });
+
+        organizationAPIResourceCollections?.apiResourceCollections?.forEach(
+            (collection: APIResourceCollectionInterface) => {
+                const processedCollection: SelectedPermissionCategoryInterface = processCollection(
+                    collection,
+                    selectedFeatures
+                );
+
+                if (processedCollection) {
+                    permissions.organization[collection.id] = processedCollection;
+                }
+            }
+        );
+
+        return permissions;
+    }, [ role, tenantAPIResourceCollections, organizationAPIResourceCollections ]);
+
+    /**
+     * Update the role permissions.
+     *
+     * @param permissions - Permissions to be updated.
+     */
+    const updateRolePermissions = (permissions: CreateRolePermissionInterface[]): void => {
+        const _permissions: CreateRolePermissionInterface[] | RolePermissionInterface[] =
+            permissions ?? (role?.permissions as RolePermissionInterface[]);
+
+        const roleData: PatchRoleDataInterface = {
+            Operations: [
+                {
+                    op: "replace",
+                    value: {
+                        permissions: _permissions?.map(
+                            (permission: CreateRolePermissionInterface | RolePermissionInterface) => {
+                                return {
+                                    value: permission.value
+                                };
+                            }
+                        )
+                    }
+                }
+            ],
+            schemas: [ Schemas.PATCH_OP ]
+        };
+
+        updateRoleDetails(role.id, roleData)
+            .then(() => {
+                onRoleUpdate(tabIndex);
+
+                dispatch(
+                    addAlert<AlertInterface>({
+                        description: t("console:manage.features.roles.notifications.updateRole.success.description"),
+                        level: AlertLevels.SUCCESS,
+                        message: t("console:manage.features.roles.notifications.updateRole.success.message")
+                    })
+                );
+            })
+            .catch(() => {
+                dispatch(
+                    addAlert<AlertInterface>({
+                        description: t(
+                            "console:manage.features.roles.notifications.updateRole.genericError.description"
+                        ),
+                        level: AlertLevels.ERROR,
+                        message: t("console:manage.features.roles.notifications.updateRole.genericError.message")
+                    })
+                );
+            });
+    };
+
+    return (
+        <EmphasizedSegment padded="very" className="console-role-permissions">
+            <div className="section-heading">
+                <Heading as="h4">
+                    { t("console:manage.features.roles.edit.permissions.heading") }
+                </Heading>
+                <Heading as="h6" color="grey" subHeading>
+                    {
+                        isReadOnly
+                            ? t("console:manage.features.roles.edit.permissions.readOnlySubHeading")
+                            : t("console:manage.features.roles.edit.permissions.subHeading")
+                    }
+                </Heading>
+            </div>
+            <CreateConsoleRoleWizardPermissionsForm
+                defaultExpandedIfPermissionsAreSelected
+                isReadOnly={ isReadOnly }
+                initialValues={ permissionFormInitialValues }
+                onPermissionsChange={ setPermissions }
+            />
+            {
+                !isReadOnly && (
+                    <PrimaryButton
+                        className="submit-button"
+                        variant="contained"
+                        size="small"
+                        loading={ false }
+                        disabled={ isEmpty(role?.permissions) || (permissions && isEmpty(permissions)) }
+                        onClick={ () => {
+                            updateRolePermissions(permissions);
+                        } }
+                        data-componentid={ `${ componentId }-update-button` }
+                    >
+                        { t("common:update") }
+                    </PrimaryButton>
+                )
+            }
+        </EmphasizedSegment>
+    );
+};
+
+/**
+ * Default props for {@link ConsoleRolePermissions}
+ */
+ConsoleRolePermissions.defaultProps = {
+    "data-componentid": "console-roles-table"
+};
+
+export default ConsoleRolePermissions;

--- a/apps/console/src/features/console-settings/components/console-roles/console-roles-edit/console-role-permissions.tsx
+++ b/apps/console/src/features/console-settings/components/console-roles/console-roles-edit/console-role-permissions.tsx
@@ -184,11 +184,11 @@ const ConsoleRolePermissions: FunctionComponent<ConsoleRolePermissionsProps> = (
                 resource.scopes.map((scope: APIResourceCollectionPermissionScopeInterface) => scope.name)
         );
 
-        const hasReadPermissions: boolean = readPermissions.every((scope: string) =>
-            selectedFeatures.includes(scope)
+        const hasReadPermissions: boolean = readPermissions.every((permission: string) =>
+            selectedFeatures.includes(permission)
         );
-        const hasWritePermissions: boolean = writePermissions.every((scope: string) =>
-            selectedFeatures.includes(scope)
+        const hasWritePermissions: boolean = writePermissions.every((permission: string) =>
+            selectedFeatures.includes(permission)
         );
 
         if (hasReadPermissions || hasWritePermissions) {

--- a/apps/console/src/features/console-settings/components/console-roles/console-roles-edit/console-roles-edit.scss
+++ b/apps/console/src/features/console-settings/components/console-roles/console-roles-edit/console-roles-edit.scss
@@ -1,0 +1,9 @@
+.console-role-permissions {
+    .section-heading {
+        margin-bottom: 2rem;
+    }
+
+    .submit-button {
+        margin-top: 2rem;
+    }
+}

--- a/apps/console/src/features/console-settings/components/console-roles/console-roles-edit/console-roles-edit.tsx
+++ b/apps/console/src/features/console-settings/components/console-roles/console-roles-edit/console-roles-edit.tsx
@@ -24,14 +24,15 @@ import { ResourceTab, ResourceTabPaneInterface } from "@wso2is/react-components"
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
+import ConsoleRolePermissions from "./console-role-permissions";
 import { AppState } from "../../../../core";
 import { useGetCurrentOrganizationType } from "../../../../organizations/hooks/use-get-organization-type";
 import { BasicRoleDetails } from "../../../../roles/components/edit-role/edit-role-basic";
 import { RoleConnectedApps } from "../../../../roles/components/edit-role/edit-role-connected-apps";
 import { RoleGroupsList } from "../../../../roles/components/edit-role/edit-role-groups";
-import { UpdatedRolePermissionDetails } from "../../../../roles/components/edit-role/edit-role-permission";
 import { RoleUsersList } from "../../../../roles/components/edit-role/edit-role-users";
 import { RoleAudienceTypes } from "../../../../roles/constants/role-constants";
+import "./console-roles-edit.scss";
 
 /**
  * Captures props needed for edit role component
@@ -116,8 +117,10 @@ const ConsoleRolesEdit: FunctionComponent<ConsoleRolesEditPropsInterface> = (
                 menuItem: t("console:manage.features.roles.edit.menuItems.permissions"),
                 render: () => (
                     <ResourceTab.Pane controlledSegmentation attached={ false }>
-                        <UpdatedRolePermissionDetails
-                            isReadOnly={ true }
+                        <ConsoleRolePermissions
+                            isReadOnly={
+                                !hasRequiredScopes(featureConfig, featureConfig?.scopes?.update, allowedScopes)
+                            }
                             role={ roleObject }
                             onRoleUpdate={ onRoleUpdate }
                             tabIndex={ 1 }
@@ -179,7 +182,8 @@ const ConsoleRolesEdit: FunctionComponent<ConsoleRolesEditPropsInterface> = (
         <ResourceTab
             isLoading={ isLoading }
             defaultActiveIndex={ defaultActiveIndex }
-            panes={ resolveResourcePanes() } />
+            panes={ resolveResourcePanes() }
+        />
     );
 };
 

--- a/apps/console/src/features/console-settings/components/console-roles/create-console-role-wizard/create-console-role-wizard-permissions-form.scss
+++ b/apps/console/src/features/console-settings/components/console-roles/create-console-role-wizard/create-console-role-wizard-permissions-form.scss
@@ -29,4 +29,12 @@
             }
         }
     }
+
+    .accordion-container {
+        .oxygen-accordion {
+            &.Mui-expanded:first-of-type {
+                margin-top: 10px;
+            }
+        }
+    }
 }

--- a/apps/console/src/features/console-settings/components/console-roles/create-console-role-wizard/create-console-role-wizard-permissions-form.tsx
+++ b/apps/console/src/features/console-settings/components/console-roles/create-console-role-wizard/create-console-role-wizard-permissions-form.tsx
@@ -68,7 +68,7 @@ import "./create-console-role-wizard-permissions-form.scss";
  */
 export interface CreateConsoleRoleWizardPermissionsFormProps extends IdentifiableComponentInterface {
     /**
-     * Should the accordion be expanded 
+     * Should the accordion be expanded
      */
     defaultExpandedIfPermissionsAreSelected?: boolean;
     /**

--- a/apps/console/src/features/console-settings/components/console-roles/create-console-role-wizard/create-console-role-wizard-permissions-form.tsx
+++ b/apps/console/src/features/console-settings/components/console-roles/create-console-role-wizard/create-console-role-wizard-permissions-form.tsx
@@ -494,7 +494,10 @@ const CreateConsoleRoleWizardPermissionsForm: FunctionComponent<CreateConsoleRol
                             readOnly={ isReadOnly }
                             disabled={ isReadOnly }
                             color="primary"
-                            defaultChecked={ false }
+                            checked={
+                                Object.keys(selectedPermissions.organization).length ===
+                                filteredOrganizationAPIResourceCollections?.apiResourceCollections?.length
+                            }
                             onChange={ (e: ChangeEvent<HTMLInputElement>) => {
                                 handleSelectAll(e, APIResourceCollectionTypes.ORGANIZATION);
                             } }

--- a/apps/console/src/features/console-settings/models/permissions-ui.ts
+++ b/apps/console/src/features/console-settings/models/permissions-ui.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Interface to represent permission scopes.
+ */
+export interface PermissionScopeInterface {
+    /**
+     * Name of the permission.
+     */
+    value: string;
+}
+
+
+/**
+ * Interface to represent selected permissions.
+ */
+export interface SelectedPermissionsInterface {
+    /**
+     * Set of tenant level permissions.
+     */
+    tenant: {
+        [key: string]: SelectedPermissionCategoryInterface;
+    };
+    /**
+     * Set of system level permissions.
+     */
+    organization: {
+        [key: string]: SelectedPermissionCategoryInterface;
+    };
+}
+
+/**
+ * Interface to represent selected permission category.
+ */
+export interface SelectedPermissionCategoryInterface {
+    /**
+     * Indicates if the permission is read only.
+     */
+    read: boolean;
+    /**
+     * Indicates if the permission is write only.
+     */
+    write: boolean;
+    /**
+     * Indicates if the permission is delete only.
+     */
+    permissions: PermissionScopeInterface[];
+}

--- a/apps/console/src/features/console-settings/utils/transform-resource-collection-to-permissions.ts
+++ b/apps/console/src/features/console-settings/utils/transform-resource-collection-to-permissions.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+    APIResourceCollectionPermissionCategoryInterface,
+    APIResourceCollectionPermissionScopeInterface
+} from "../models/console-roles";
+import { PermissionScopeInterface } from "../models/permissions-ui";
+
+/**
+ * Transforms the API resource collection to permission scopes.
+ *
+ * @example
+ * // returns `[{ value: "permission1" }, { value: "permission2" }]`
+ * transformResourceCollectionToPermissions(resource);
+ *
+ * @param resource - API resource collection.
+ * @returns Transformed permission scopes.
+ */
+const transformResourceCollectionToPermissions = (
+    resource: APIResourceCollectionPermissionCategoryInterface[]
+): PermissionScopeInterface[] => {
+    return resource
+        .map((resource: APIResourceCollectionPermissionCategoryInterface) =>
+            resource.scopes.map((scope: APIResourceCollectionPermissionScopeInterface) => ({ value: scope.name }))
+        )
+        .reduce(
+            (result: PermissionScopeInterface[], permissions: PermissionScopeInterface[]) => result.concat(permissions),
+            []
+        );
+};
+
+export default transformResourceCollectionToPermissions;


### PR DESCRIPTION
### Purpose

Add the ability to edit Console Role permissions from the edit view.

<img width="1669" alt="Screenshot 2024-01-27 at 22 06 24" src="https://github.com/wso2/identity-apps/assets/25959096/6a7ca5c4-e9d3-4ff3-9dbf-327c388624c1">

*Read-Only View*

<img width="1677" alt="Screenshot 2024-01-27 at 22 08 29" src="https://github.com/wso2/identity-apps/assets/25959096/dd107844-7c0b-4b5e-b8ca-f2a78a5d9b9f">

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/19040

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
