### PR TITLE
Preserve Application `Sign In Method` configuration mode as a user preference

### DIFF
--- a/.changeset/plenty-days-argue.md
+++ b/.changeset/plenty-days-argue.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add support to store preferences in storage

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
@@ -79,7 +79,9 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
         isAuthenticationSequenceDefault,
         isVisualEditorEnabled,
         isLegacyEditorEnabled,
-        refetchApplication
+        refetchApplication,
+        preferredAuthenticationFlowBuilderMode,
+        setPreferredAuthenticationFlowBuilderMode
     } = useAuthenticationFlow();
 
     const FlowModes: AuthenticationFlowBuilderModesInterface[] = readOnly ? [
@@ -126,6 +128,21 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
             setActiveFlowMode(FlowModes[0]);
         }
     }, [ isVisualEditorEnabled, isLegacyEditorEnabled ]);
+
+    /**
+     * Set the active flow mode to the preferred flow mode when the user preference is updated.
+     */
+    useEffect(() => {
+        if (!preferredAuthenticationFlowBuilderMode) {
+            return;
+        }
+
+        const activeMode: AuthenticationFlowBuilderModesInterface = FlowModes.find(
+            (mode: AuthenticationFlowBuilderModesInterface) => mode.mode === preferredAuthenticationFlowBuilderMode
+        );
+
+        setActiveFlowMode(activeMode);
+    }, [ preferredAuthenticationFlowBuilderMode ]);
 
     /**
      * Handles the flow mode switch.
@@ -210,6 +227,7 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
                             setFlowModeToSwitch(null);
                             setShowAuthenticationFlowModeSwitchDisclaimerModal(false);
                             refetchApplication();
+                            setPreferredAuthenticationFlowBuilderMode(flowModeToSwitch?.mode);
                         } }
                         onClose={ () => {
                             setFlowModeToSwitch(null);

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
@@ -35,7 +35,7 @@ import ScriptBasedFlowSwitch from "./script-editor-panel/script-based-flow-switc
 import SidePanelDrawer from "./side-panel-drawer";
 import { AppState } from "../../core/store";
 import useAuthenticationFlow from "../hooks/use-authentication-flow";
-import { AuthenticationFlowBuilderModesInterface } from "../models/flow-builder";
+import { AuthenticationFlowBuilderModes, AuthenticationFlowBuilderModesInterface } from "../models/flow-builder";
 import "./sign-in-methods.scss";
 
 /**
@@ -85,17 +85,20 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
     const FlowModes: AuthenticationFlowBuilderModesInterface[] = readOnly ? [
         {
             id: 0,
-            label: t("console:loginFlow.modes.legacy.label")
+            label: t("console:loginFlow.modes.legacy.label"),
+            mode: AuthenticationFlowBuilderModes.Classic
         }
     ] : [
         {
             id: 0,
-            label: t("console:loginFlow.modes.legacy.label")
+            label: t("console:loginFlow.modes.legacy.label"),
+            mode: AuthenticationFlowBuilderModes.Classic
         },
         {
             extra: <Chip size="small" label="Beta" className="oxygen-chip-beta" />,
             id: 1,
-            label: t("console:loginFlow.modes.visual.label")
+            label: t("console:loginFlow.modes.visual.label"),
+            mode: AuthenticationFlowBuilderModes.Visual
         }
     ];
 

--- a/apps/console/src/features/authentication-flow-builder/hooks/use-authentication-flow.ts
+++ b/apps/console/src/features/authentication-flow-builder/hooks/use-authentication-flow.ts
@@ -18,11 +18,24 @@
 
 import { useContext } from "react";
 import AuthenticationFlowContext, { AuthenticationFlowContextProps } from "./../context/authentication-flow-context";
+import useUserPreferences from "../../core/hooks/use-user-preferences";
+import { UserPreferencesInterface } from "../../core/models/user-preferences";
+import { AuthenticationFlowBuilderModes } from "../models/flow-builder";
 
 /**
  * Interface for the return type of the UseAuthenticationFlow hook.
  */
-export type UseAuthenticationFlowInterface = AuthenticationFlowContextProps;
+export interface UseAuthenticationFlowInterface extends AuthenticationFlowContextProps {
+    /**
+     * The preferred authentication flow builder mode.
+     */
+    preferredAuthenticationFlowBuilderMode: AuthenticationFlowBuilderModes;
+    /**
+     * Sets the preferred authentication flow builder mode.
+     * @param mode - The preferred mode.
+     */
+    setPreferredAuthenticationFlowBuilderMode: (mode: AuthenticationFlowBuilderModes) => void;
+}
 
 /**
  * Hook that provides access to the branding preference context.
@@ -31,11 +44,35 @@ export type UseAuthenticationFlowInterface = AuthenticationFlowContextProps;
 const useAuthenticationFlow = (): UseAuthenticationFlowInterface => {
     const context: AuthenticationFlowContextProps = useContext(AuthenticationFlowContext);
 
+    const { setPreferences, preferredAuthenticationFlowBuilderMode } = useUserPreferences<UserPreferencesInterface>();
+
     if (context === undefined) {
         throw new Error("UseAuthenticationFlow must be used within a AuthenticationFlowProvider");
     }
 
-    return context;
+    /**
+     * Get the preferred authentication flow builder mode.
+     */
+    const getPreferredAuthenticationFlowBuilderMode = (): AuthenticationFlowBuilderModes => {
+        return preferredAuthenticationFlowBuilderMode as AuthenticationFlowBuilderModes;
+    };
+
+    /**
+     * Sets the preferred authentication flow builder mode.
+     *
+     * @param mode - The preferred mode.
+     */
+    const setPreferredAuthenticationFlowBuilderMode = (mode: AuthenticationFlowBuilderModes): void => {
+        setPreferences({
+            preferredAuthenticationFlowBuilderMode: mode
+        });
+    };
+
+    return {
+        preferredAuthenticationFlowBuilderMode: getPreferredAuthenticationFlowBuilderMode(),
+        setPreferredAuthenticationFlowBuilderMode,
+        ...context
+    };
 };
 
 export default useAuthenticationFlow;

--- a/apps/console/src/features/authentication-flow-builder/models/flow-builder.ts
+++ b/apps/console/src/features/authentication-flow-builder/models/flow-builder.ts
@@ -34,4 +34,23 @@ export interface AuthenticationFlowBuilderModesInterface {
      * Extra content for the mode.
      */
     extra?: ReactNode;
+    /**
+     * Mode of the flow.
+     */
+    mode?: AuthenticationFlowBuilderModes;
+}
+
+/**
+ * Enum for authentication flow builder modes.
+ */
+export enum AuthenticationFlowBuilderModes {
+    /**
+     * Classic mode for the authentication flow builder.
+     */
+    Classic = "classic",
+
+    /**
+     * Visual mode for the authentication flow builder.
+     */
+    Visual = "visual",
 }

--- a/apps/console/src/features/core/context/user-preferences-context.tsx
+++ b/apps/console/src/features/core/context/user-preferences-context.tsx
@@ -21,25 +21,21 @@ import { Context, createContext } from "react";
 /**
  * Props interface of {@link UserPreferenceContext}
  */
-export interface UserPreferencesContextProps<T> {
-    /**
-     * User preferences.
-     */
-    preferences: T;
+export type UserPreferencesContextProps<T> = {
     /**
      * Function to retrieve a user preference.
      * @param key - The key of the preference to retrieve.
-     * @param orgId - Optional organization ID. If provided, the preference for this organization will be retrieved.
+     * @param userId - Optional user Id. If provided, the preferences for the passed in user-id will be updated.
      * @returns The preference value.
      */
-    getPreferences: (key: string, orgId?: string) => unknown;
+    getPreferences: (key: string, userId?: string) => unknown;
     /**
      * Function to update user preferences.
      * @param preferencesToUpdate - The new preferences to update.
-     * @param orgId - Optional organization ID. If provided, the preferences for this organization will be updated.
+     * @param userId - Optional user Id. If provided, the preferences for the passed in user-id will be updated.
      */
-    setPreferences: (preferencesToUpdate: T, orgId?: string) => void;
-}
+    setPreferences: (preferencesToUpdate: T, userId?: string) => void;
+} & T;
 
 /**
  * Context object for managing the User's preferences.

--- a/apps/console/src/features/core/context/user-preferences-context.tsx
+++ b/apps/console/src/features/core/context/user-preferences-context.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Context, createContext } from "react";
+
+/**
+ * Props interface of {@link UserPreferenceContext}
+ */
+export interface UserPreferencesContextProps<T> {
+    /**
+     * User preferences.
+     */
+    preferences: T;
+    /**
+     * Function to retrieve a user preference.
+     * @param key - The key of the preference to retrieve.
+     * @param orgId - Optional organization ID. If provided, the preference for this organization will be retrieved.
+     * @returns The preference value.
+     */
+    getPreferences: (key: string, orgId?: string) => unknown;
+    /**
+     * Function to update user preferences.
+     * @param preferencesToUpdate - The new preferences to update.
+     * @param orgId - Optional organization ID. If provided, the preferences for this organization will be updated.
+     */
+    setPreferences: (preferencesToUpdate: T, orgId?: string) => void;
+}
+
+/**
+ * Context object for managing the User's preferences.
+ */
+const UserPreferencesContext: Context<UserPreferencesContextProps<any>> =
+    createContext<null | UserPreferencesContextProps<any>>(null);
+
+/**
+ * Display name for the UserPreferencesContext.
+ */
+UserPreferencesContext.displayName = "UserPreferencesContext";
+
+export default UserPreferencesContext;

--- a/apps/console/src/features/core/hooks/use-user-preferences.ts
+++ b/apps/console/src/features/core/hooks/use-user-preferences.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useContext } from "react";
+import UserPreferenceContext, { UserPreferencesContextProps } from "../context/user-preferences-context";
+
+/**
+ * Hook that provides access to the user's preference context.
+ * @returns An object containing the context values of {@link UserPreferenceContext}.
+ */
+const useUserPreferences = <T, >(): UserPreferencesContextProps<T> => {
+    const context: UserPreferencesContextProps<T> = useContext(UserPreferenceContext);
+
+    if (context === undefined) {
+        throw new Error("useUserPreferences must be used within a UserPreferencesProvider");
+    }
+
+    return context;
+};
+
+export default useUserPreferences;

--- a/apps/console/src/features/core/models/user-preferences.ts
+++ b/apps/console/src/features/core/models/user-preferences.ts
@@ -19,4 +19,9 @@
 /**
  * Interface for user preferences.
  */
-export interface UserPreferencesInterface {}
+export interface UserPreferencesInterface {
+    /**
+     * The preferred strategy for login flow configuration
+     */
+    preferredAuthenticationFlowBuilderMode: string;
+}

--- a/apps/console/src/features/core/models/user-preferences.ts
+++ b/apps/console/src/features/core/models/user-preferences.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Interface for user preferences.
+ */
+export interface UserPreferencesInterface {}

--- a/apps/console/src/features/core/providers/user-preferences-provider.tsx
+++ b/apps/console/src/features/core/providers/user-preferences-provider.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import get from "lodash-es/get";
+import merge from "lodash-es/merge";
+import React, { PropsWithChildren, ReactElement, useState } from "react";
+import { useSelector } from "react-redux";
+import UserPreferencesContext from "../context/user-preferences-context";
+import { AppState } from "../store";
+
+/**
+ * Props interface of {@link UserPreferenceProvider}
+ */
+export interface UserPreferenceProviderProps<T> {
+    /**
+     * Initial preferences.
+     */
+    initialPreferences?: T;
+}
+
+/**
+ * Provider for the Application local settings.
+ * This is a generic provider which can be used to store any type of settings.
+ * The type of the preferences should be passed as a generic type.
+ *
+ * @example
+ * `<UserPreferenceProvider<Preference> initialPreferences={ { "orgId": { "key": "value" } } }>`
+ *
+ * @param props - Props for the client.
+ * @returns App settings provider.
+ */
+const UserPreferenceProvider = <T, >(props: PropsWithChildren<UserPreferenceProviderProps<T>>): ReactElement => {
+    const { children } = props;
+
+    const organizationId: string = useSelector((state: AppState) => {
+        return state?.organization?.organization?.id;
+    });
+
+    const [ preferencesInContext, setPreferencesInContext ] = useState<T>(null);
+
+    /**
+     * Set the preferences in storage.
+     *
+     * @example
+     * `setPreferences({ "key": "value" }, "orgId")`
+     *
+     * @param preferencesToUpdate - The new preferences to update.
+     * @param orgId - Optional organization ID. If provided, the preferences for this organization will be updated.
+     */
+    const setPreferences = (preferencesToUpdate: T, orgId?: string) => {
+        const _orgId: string = orgId ?? organizationId;
+
+        const updatedPreferences: T = merge({}, preferencesInContext, {
+            [_orgId]: {
+                ...preferencesToUpdate
+            }
+        });
+
+        setPreferencesInContext(updatedPreferences);
+    };
+
+    /**
+     * Get the preferences from storage.
+     *
+     * @example
+     * `getPreferences("key.nested", "orgId")`
+     *
+     * @param key - The key of the preference to retrieve.
+     * @param orgId - Optional organization ID. If provided, the preference for this organization will be retrieved.
+     */
+    const getPreferences = (key: string, orgId?: string): unknown => {
+        const _orgId: string = orgId ?? organizationId;
+
+        return get(preferencesInContext, `${_orgId}.${key}`, null);
+    };
+
+    return (
+        <UserPreferencesContext.Provider
+            value={ {
+                getPreferences,
+                preferences: preferencesInContext,
+                setPreferences
+            } }
+        >
+            { children }
+        </UserPreferencesContext.Provider>
+    );
+};
+
+export default UserPreferenceProvider;

--- a/apps/console/src/index.tsx
+++ b/apps/console/src/index.tsx
@@ -29,7 +29,9 @@ import { BrowserRouter } from "react-router-dom";
 import { AsgardeoTheme } from "./branding/theme";
 import { AuthenticateUtils } from "./features/authentication";
 import { Config, PreLoader, store } from "./features/core";
+import { UserPreferencesInterface } from "./features/core/models/user-preferences";
 import AppSettingsProvider from "./features/core/providers/app-settings-provider";
+import UserPreferencesProvider from "./features/core/providers/user-preferences-provider";
 import OrganizationsProvider from "./features/organizations/providers/organizations-provider";
 import { ProtectedApp } from "./protected-app";
 
@@ -83,19 +85,21 @@ const RootWithConfig = (): ReactElement => {
         <AppSettingsProvider>
             <ThemeProvider theme={ AsgardeoTheme } defaultMode="light" modeStorageKey="console-oxygen-mode">
                 <Provider store={ store }>
-                    <BrowserRouter>
-                        <AuthProvider
-                            config={ AuthenticateUtils.getInitializeConfig() }
-                            fallback={ <PreLoader /> }
-                            getAuthParams={ getAuthParams }
-                        >
-                            <AppConfigProvider>
-                                <OrganizationsProvider>
-                                    <ProtectedApp />
-                                </OrganizationsProvider>
-                            </AppConfigProvider>
-                        </AuthProvider>
-                    </BrowserRouter>
+                    <UserPreferencesProvider<UserPreferencesInterface>>
+                        <BrowserRouter>
+                            <AuthProvider
+                                config={ AuthenticateUtils.getInitializeConfig() }
+                                fallback={ <PreLoader /> }
+                                getAuthParams={ getAuthParams }
+                            >
+                                <AppConfigProvider>
+                                    <OrganizationsProvider>
+                                        <ProtectedApp />
+                                    </OrganizationsProvider>
+                                </AppConfigProvider>
+                            </AuthProvider>
+                        </BrowserRouter>
+                    </UserPreferencesProvider>
                 </Provider>
             </ThemeProvider>
         </AppSettingsProvider>


### PR DESCRIPTION
### Purpose

ATM, when `Sign In Method` configuration mode as a user preference i.e Classic Editor & Visual Editor toggle state is not stored as a user preference. This might come across as a UX issue since it'll be a hassle to always switch for users who prefer the visual editor.

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/17489

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
