### PR TITLE
Add support for Visual editor script window to go fullscreen

### DIFF
--- a/.changeset/afraid-bottles-sparkle.md
+++ b/.changeset/afraid-bottles-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add support for Visual editor script window to go fullscreen

--- a/apps/console/src/features/authentication-flow-builder/components/script-editor-panel/script-editor-panel.scss
+++ b/apps/console/src/features/authentication-flow-builder/components/script-editor-panel/script-editor-panel.scss
@@ -60,7 +60,7 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    width: 90%;
+    width: 95%;
     height: 90%;
     padding: 32px;
     

--- a/apps/console/src/features/authentication-flow-builder/components/script-editor-panel/script-editor-panel.scss
+++ b/apps/console/src/features/authentication-flow-builder/components/script-editor-panel/script-editor-panel.scss
@@ -20,38 +20,55 @@
     height: 100%;
     width: calc(100% - 16px);
 
-    .toolbar-container {
+    .script-editor {
+        border: 1px solid var(--oxygen-palette-divider);
+        height: 500px;
+    }
+}
 
-        .oxygen-toolbar {
+.script-editor-toolbar-container {
+    .oxygen-toolbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        align-content: center;
+        flex-wrap: nowrap;
+        flex-direction: row;
+        padding-left: 0;
+        padding-right: 0;
+
+        .actions {
             display: flex;
-            justify-content: space-between;
-            align-items: center;
-            align-content: center;
-            flex-wrap: nowrap;
             flex-direction: row;
-            padding-left: 0;
-            padding-right: 0;
+            flex-wrap: nowrap;
+            align-content: center;
+            align-items: center;
+            gap: 10px;
 
-            .actions {
-                display: flex;
-                flex-direction: row;
-                flex-wrap: nowrap;
-                align-content: center;
-                align-items: center;
-                gap: 10px;
-
-                .editor-theme-select {
-                    .MuiSelect-select {
-                        padding: 6px 15px;
-                        min-width: 150px;
-                    }
+            .editor-theme-select {
+                .MuiSelect-select {
+                    padding: 6px 15px;
+                    min-width: 150px;
                 }
             }
         }
     }
+}
 
-    .script-editor {
-        border: 1px solid var(--oxygen-palette-divider);
-        height: 500px;
+.full-screen-script-editor-container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 90%;
+    height: 90%;
+    padding: 32px;
+    
+    .script-editor-toolbar-container {
+        background-color: var(--oxygen-palette-common-white);
+        padding-left: 15px;
+        padding-right: 15px;
+        border-top-right-radius: var(--oxygen-shape-borderRadius);
+        border-top-left-radius: var(--oxygen-shape-borderRadius);
     }
 }

--- a/apps/console/src/features/authentication-flow-builder/components/script-editor-panel/script-editor-panel.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/script-editor-panel/script-editor-panel.tsx
@@ -17,8 +17,6 @@
  */
 
 import { DiffOnMount, Monaco, MonacoDiffEditor } from "@monaco-editor/react";
-import Backdrop from "@mui/material/Backdrop";
-import Fade from "@mui/material/Fade";
 import Modal from "@mui/material/Modal";
 import Box from "@oxygen-ui/react/Box";
 import CircularProgress from "@oxygen-ui/react/CircularProgress";
@@ -27,6 +25,7 @@ import IconButton from "@oxygen-ui/react/IconButton";
 import MenuItem from "@oxygen-ui/react/MenuItem";
 import Select from "@oxygen-ui/react/Select";
 import Toolbar from "@oxygen-ui/react/Toolbar";
+import Tooltip from "@oxygen-ui/react/Tooltip";
 import Typography from "@oxygen-ui/react/Typography";
 import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
@@ -274,16 +273,25 @@ const ScriptEditorPanel = (props: PropsWithChildren<ScriptEditorPanelPropsInterf
                         </>
                     ) }
                     <div className="editor-fullscreen">
-                        <IconButton
-                            size="small"
-                            onClick={ handleScriptEditorPanelSizeChange }
-                        >
-                            {
+                        <Tooltip
+                            title={
                                 scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Minimized
-                                    ? <MaximizeIcon height={ 16 } width={ 16 } />
-                                    : <MinimizeIcon height={ 16 } width={ 16 } />
+                                    ? t("common:goFullScreen")
+                                    : t("common:exitFullScreen")
                             }
-                        </IconButton>
+                            data-componentid="editor-fullscreen-toggle-tooltip"
+                        >
+                            <IconButton
+                                size="small"
+                                onClick={ handleScriptEditorPanelSizeChange }
+                            >
+                                {
+                                    scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Minimized
+                                        ? <MaximizeIcon height={ 16 } width={ 16 } />
+                                        : <MinimizeIcon height={ 16 } width={ 16 } />
+                                }
+                            </IconButton>
+                        </Tooltip>
                     </div>
                 </div>
             </Toolbar>
@@ -299,20 +307,11 @@ const ScriptEditorPanel = (props: PropsWithChildren<ScriptEditorPanelPropsInterf
                     aria-describedby="transition-modal-description"
                     open={ scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Maximized }
                     onClose={ handleScriptEditorPanelSizeChange }
-                    closeAfterTransition
-                    slots={ { backdrop: Backdrop } }
-                    slotProps={ {
-                        backdrop: {
-                            timeout: 500
-                        }
-                    } }
                 >
-                    <Fade in={ scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Maximized }>
-                        <Box className="full-screen-script-editor-container">
-                            { ScriptEditorToolbar }
-                            { ScriptEditor }
-                        </Box>
-                    </Fade>
+                    <Box className="full-screen-script-editor-container">
+                        { ScriptEditorToolbar }
+                        { ScriptEditor }
+                    </Box>
                 </Modal>
                 { ScriptEditor }
             </div>

--- a/apps/console/src/features/authentication-flow-builder/components/script-editor-panel/script-editor-panel.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/script-editor-panel/script-editor-panel.tsx
@@ -17,9 +17,13 @@
  */
 
 import { DiffOnMount, Monaco, MonacoDiffEditor } from "@monaco-editor/react";
+import Backdrop from "@mui/material/Backdrop";
+import Fade from "@mui/material/Fade";
+import Modal from "@mui/material/Modal";
 import Box from "@oxygen-ui/react/Box";
 import CircularProgress from "@oxygen-ui/react/CircularProgress";
 import FormControl from "@oxygen-ui/react/FormControl";
+import IconButton from "@oxygen-ui/react/IconButton";
 import MenuItem from "@oxygen-ui/react/MenuItem";
 import Select from "@oxygen-ui/react/Select";
 import Toolbar from "@oxygen-ui/react/Toolbar";
@@ -48,7 +52,7 @@ import { FeatureConfigInterface } from "../../../core/models";
 import { AppState } from "../../../core/store";
 import { SecretModel } from "../../../secrets/models/secret";
 import useAuthenticationFlow from "../../hooks/use-authentication-flow";
-import { SupportedEditorThemes } from "../../models/script-editor";
+import { ScriptEditorPanelSizeModes, SupportedEditorThemes } from "../../models/script-editor";
 import "./script-editor-panel.scss";
 
 /**
@@ -58,6 +62,47 @@ export type ScriptEditorPanelPropsInterface = IdentifiableComponentInterface & H
 
 const MonacoEditor: LazyExoticComponent<any> = lazy(() =>
     import("@monaco-editor/react" /* webpackChunkName: "MDMonacoEditor" */)
+);
+
+// TODO: Move this to Oxygen UI once https://github.com/wso2/oxygen-ui/issues/158 is fixed.
+const MaximizeIcon = ({ width = 16, height = 16 }: { width: number; height: number }): ReactElement => (
+    <svg
+        stroke="currentColor"
+        fill="none"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        height={ height }
+        width={ width }
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <polyline points="15 3 21 3 21 9"></polyline>
+        <polyline points="9 21 3 21 3 15"></polyline>
+        <line x1="21" y1="3" x2="14" y2="10"></line>
+        <line x1="3" y1="21" x2="10" y2="14"></line>
+    </svg>
+);
+
+// TODO: Move this to Oxygen UI once https://github.com/wso2/oxygen-ui/issues/158 is fixed.
+const MinimizeIcon = ({ width = 16, height = 16 }: { width: number; height: number }): ReactElement => (
+    <svg
+        stroke="currentColor"
+        fill="none"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        height={ height }
+        width={ width }
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+        <path d="M18 10h-4v-4"></path>
+        <path d="M20 4l-6 6"></path>
+        <path d="M6 14h4v4"></path>
+        <path d="M10 14l-6 6"></path>
+    </svg>
 );
 
 /**
@@ -77,6 +122,9 @@ const ScriptEditorPanel = (props: PropsWithChildren<ScriptEditorPanelPropsInterf
 
     const [ editorTheme, setEditorTheme ] = useState<SupportedEditorThemes>(SupportedEditorThemes.DARK);
     const [ isSecretSelectionDropdownOpen, setIsSecretSelectionDropdownOpen ] = useState<boolean>(false);
+    const [ scriptEditorPanelSizeMode, setScriptEditorPanelSizeMode ] = useState<ScriptEditorPanelSizeModes>(
+        ScriptEditorPanelSizeModes.Minimized
+    );
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
@@ -147,15 +195,46 @@ const ScriptEditorPanel = (props: PropsWithChildren<ScriptEditorPanelPropsInterf
         return authenticationSequence?.script;
     };
 
-    return (
-        <Suspense fallback={ <CircularProgress /> }>
-            <div className={ classNames("script-editor-panel", className) } data-componentid={ componentId }>
-                <Box className="toolbar-container">
-                    <Toolbar variant="dense">
-                        <Box>
-                            <Typography>{ t("console:loginFlow.scriptEditor.panelHeader") }</Typography>
-                        </Box>
-                        <div className="actions">
+    /**
+     * Function to handle the script editor panel size change.
+     */
+    const handleScriptEditorPanelSizeChange = (): void => {
+        if (scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Minimized) {
+            setScriptEditorPanelSizeMode(ScriptEditorPanelSizeModes.Maximized);
+
+            return;
+        }
+
+        setScriptEditorPanelSizeMode(ScriptEditorPanelSizeModes.Minimized);
+    };
+
+    const ScriptEditor: ReactElement = (
+        <MonacoEditor
+            loading={ null }
+            className="script-editor"
+            width="100%"
+            height="100%"
+            language="javascript"
+            theme={ editorTheme }
+            value={ getAdaptiveScript() }
+            options={ {
+                automaticLayout: true
+            } }
+            onChange={ handleScriptChange }
+            onMount={ handleEditorOnMount }
+            data-componentid={ `${componentId}-code-editor` }
+        />
+    );
+
+    const ScriptEditorToolbar: ReactElement = (
+        <Box className="script-editor-toolbar-container">
+            <Toolbar variant="dense">
+                <Box>
+                    <Typography>{ t("console:loginFlow.scriptEditor.panelHeader") }</Typography>
+                </Box>
+                <div className="actions">
+                    { scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Minimized && (
+                        <>
                             <div className="editor-theme-select">
                                 <FormControl size="small">
                                     <Select
@@ -192,24 +271,50 @@ const ScriptEditorPanel = (props: PropsWithChildren<ScriptEditorPanelPropsInterf
                                     )
                                 }
                             </div>
-                        </div>
-                    </Toolbar>
-                </Box>
-                <MonacoEditor
-                    loading={ null }
-                    className="script-editor"
-                    width="100%"
-                    height="100%"
-                    language="javascript"
-                    theme={ editorTheme }
-                    value={ getAdaptiveScript() }
-                    options={ {
-                        automaticLayout: true
+                        </>
+                    ) }
+                    <div className="editor-fullscreen">
+                        <IconButton
+                            size="small"
+                            onClick={ handleScriptEditorPanelSizeChange }
+                        >
+                            {
+                                scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Minimized
+                                    ? <MaximizeIcon height={ 16 } width={ 16 } />
+                                    : <MinimizeIcon height={ 16 } width={ 16 } />
+                            }
+                        </IconButton>
+                    </div>
+                </div>
+            </Toolbar>
+        </Box>
+    );
+
+    return (
+        <Suspense fallback={ <CircularProgress /> }>
+            <div className={ classNames("script-editor-panel", className) } data-componentid={ componentId }>
+                { ScriptEditorToolbar }
+                <Modal
+                    aria-labelledby="transition-modal-title"
+                    aria-describedby="transition-modal-description"
+                    open={ scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Maximized }
+                    onClose={ handleScriptEditorPanelSizeChange }
+                    closeAfterTransition
+                    slots={ { backdrop: Backdrop } }
+                    slotProps={ {
+                        backdrop: {
+                            timeout: 500
+                        }
                     } }
-                    onChange={ handleScriptChange }
-                    onMount={ handleEditorOnMount }
-                    data-componentid={ `${componentId}-code-editor` }
-                />
+                >
+                    <Fade in={ scriptEditorPanelSizeMode === ScriptEditorPanelSizeModes.Maximized }>
+                        <Box className="full-screen-script-editor-container">
+                            { ScriptEditorToolbar }
+                            { ScriptEditor }
+                        </Box>
+                    </Fade>
+                </Modal>
+                { ScriptEditor }
             </div>
         </Suspense>
     );

--- a/apps/console/src/features/authentication-flow-builder/models/script-editor.ts
+++ b/apps/console/src/features/authentication-flow-builder/models/script-editor.ts
@@ -17,10 +17,36 @@
  */
 
 /**
- * Supported script editor themes.
+ * Enum for supported script editor themes.
  */
 export enum SupportedEditorThemes {
+    /**
+     * Dark theme for the script editor.
+     */
     DARK = "vs-dark",
+
+    /**
+     * High contrast theme for the script editor.
+     */
     HIGH_CONTRAST = "hc-black",
+
+    /**
+     * Light theme for the script editor.
+     */
     LIGHT = "vc"
+}
+
+/**
+ * Enum for script editor panel size modes.
+ */
+export enum ScriptEditorPanelSizeModes {
+    /**
+     * Maximized mode for the script editor panel.
+     */
+    Maximized = "maximized",
+
+    /**
+     * Minimized mode for the script editor panel.
+     */
+    Minimized = "minimized",
 }


### PR DESCRIPTION
### Purpose
Add support for Visual editor script window to go fullscreen.

<img width="2054" alt="Screenshot 2024-01-28 at 15 29 11" src="https://github.com/wso2/identity-apps/assets/25959096/c89ffb2f-d984-4a5f-baa8-70e0ac2ac76b">

### Related Issues
- Address https://github.com/wso2/product-is/issues/19236

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
