### PR TITLE
Change the federated authenticator details view (in  custom connector) to change dynamically

### DIFF
--- a/.changeset/hot-crabs-jam.md
+++ b/.changeset/hot-crabs-jam.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Update the custom connector details view to change dynamically

--- a/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
@@ -114,7 +114,7 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
 
             if (
                 !values.has(ConnectionManagementConstants.GOOGLE_PRIVATE_KEY)
-                && !properties.find(
+                && !properties?.find(
                     (item: CommonPluggableComponentMetaPropertyInterface) =>
                         item?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY)){
                 properties.push({

--- a/apps/console/src/features/connections/components/edit/forms/factories/authenticator-form-factory.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/factories/authenticator-form-factory.tsx
@@ -151,6 +151,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
         return OverriddenForm;
     }
 
+    // Render the form dynamically for federated authenticators in custom connector.
     if (templateId === ConnectionManagementConstants.EXPERT_MODE_TEMPLATE_ID) {
         return (
             <CommonAuthenticatorForm

--- a/apps/console/src/features/connections/components/edit/forms/factories/authenticator-form-factory.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/factories/authenticator-form-factory.tsx
@@ -30,7 +30,7 @@ import {
     FederatedAuthenticatorWithMetaInterface
 } from "../../../../models/connection";
 import { AuthenticatorSettingsForm } from "../authenticator-settings-form";
-import { 
+import {
     AppleAuthenticatorForm,
     CommonAuthenticatorForm,
     EmailOTPAuthenticatorForm,
@@ -149,6 +149,23 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
 
     if (OverriddenForm) {
         return OverriddenForm;
+    }
+
+    if (templateId === ConnectionManagementConstants.EXPERT_MODE_TEMPLATE_ID){
+        return (
+            <CommonAuthenticatorForm
+                mode={ mode }
+                initialValues={ initialValues }
+                metadata={ metadata }
+                onSubmit={ onSubmit }
+                triggerSubmit={ triggerSubmit }
+                enableSubmitButton={ enableSubmitButton }
+                data-testid={ testId }
+                showCustomProperties={ showCustomProperties }
+                readOnly={ isReadOnly }
+                isSubmitting={ isSubmitting }
+            />
+        );
     }
 
     switch (type) {
@@ -322,7 +339,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
                     isSubmitting={ isSubmitting }
                 />
             );
-            
+
         default:
             return (
                 <AuthenticatorSettingsForm

--- a/apps/console/src/features/connections/components/edit/forms/factories/authenticator-form-factory.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/factories/authenticator-form-factory.tsx
@@ -151,7 +151,7 @@ export const AuthenticatorFormFactory: FunctionComponent<AuthenticatorFormFactor
         return OverriddenForm;
     }
 
-    if (templateId === ConnectionManagementConstants.EXPERT_MODE_TEMPLATE_ID){
+    if (templateId === ConnectionManagementConstants.EXPERT_MODE_TEMPLATE_ID) {
         return (
             <CommonAuthenticatorForm
                 mode={ mode }


### PR DESCRIPTION
### Purpose
> Currently, when we add a federated authenticator, the details will be listed using a predefined form. This PR allows changing the federated authenticator details view dynamically.

**Google Federated Authenticator** (change dynamically along with metadata)
<img width="1082" alt="Screenshot 2024-01-29 at 11 35 32" src="https://github.com/wso2/identity-apps/assets/27746285/8ba5f052-c3ef-4375-b19c-37f21c7a40f0">

**Dedicated Google Authenticator**
<img width="1082" alt="Screenshot 2024-01-29 at 11 59 38" src="https://github.com/wso2/identity-apps/assets/27746285/0a4997a6-11b7-464f-83dd-b4ac40f4786a">

### Related Issues
- https://github.com/wso2/product-is/issues/19245

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
