### PR TITLE
Fix the required field issue in the custom SMS provider

### DIFF
--- a/.changeset/three-carpets-switch.md
+++ b/.changeset/three-carpets-switch.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix required field issue in custom sms provider

--- a/apps/console/src/features/sms-providers/pages/custom-sms-provider.tsx
+++ b/apps/console/src/features/sms-providers/pages/custom-sms-provider.tsx
@@ -217,7 +217,7 @@ const CustomSMSProvider: FunctionComponent<CustomSMSProviderPageInterface> = (
                             } }
                             ariaLabel="contentType"
                             readOnly={ isReadOnly }
-                            required={ false }
+                            required={ true }
                             data-componentid={ `${componentId}-contentType` }
                             name="contentType"
                             type="text"
@@ -311,7 +311,7 @@ const CustomSMSProvider: FunctionComponent<CustomSMSProviderPageInterface> = (
                             } }
                             ariaLabel="payload"
                             readOnly={ isReadOnly }
-                            required={ false }
+                            required={ true }
                             data-componentid={ `${componentId}-payload` }
                             name="payload"
                             type="text"

--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -410,6 +410,16 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                     "extensions:develop.smsProviders.form.custom.validations.required"
                 );
             }
+            if (!values?.contentType) {
+                error.contentType = t(
+                    "extensions:develop.smsProviders.form.custom.validations.required"
+                );
+            }
+            if (!values?.payload) {
+                error.payload = t(
+                    "extensions:develop.smsProviders.form.custom.validations.required"
+                );
+            }
         }
 
         return error;


### PR DESCRIPTION
### Purpose
> Fix the required field issue in the custom SMS provider
<img width="1073" alt="Screenshot 2024-01-29 at 15 24 16" src="https://github.com/wso2/identity-apps/assets/27746285/5e4d38d0-04fa-4923-9533-7f4ad4c140d9">


### Related Issues
- https://github.com/wso2/product-is/issues/17494

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
