### PR TITLE
Define payload as a required field in custom sms provider config form

### DIFF
--- a/.changeset/dull-oranges-dream.md
+++ b/.changeset/dull-oranges-dream.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Define payload as a required field in custom sms provider config form

--- a/apps/console/src/features/sms-providers/pages/custom-sms-provider.tsx
+++ b/apps/console/src/features/sms-providers/pages/custom-sms-provider.tsx
@@ -311,7 +311,7 @@ const CustomSMSProvider: FunctionComponent<CustomSMSProviderPageInterface> = (
                             } }
                             ariaLabel="payload"
                             readOnly={ isReadOnly }
-                            required={ false }
+                            required
                             data-componentid={ `${componentId}-payload` }
                             name="payload"
                             type="text"

--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -410,6 +410,11 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                     "extensions:develop.smsProviders.form.custom.validations.required"
                 );
             }
+            if (!values?.payload) {
+                error.payload = t(
+                    "extensions:develop.smsProviders.form.custom.validations.required"
+                );
+            }
         }
 
         return error;


### PR DESCRIPTION
### Purpose
> $subject

### Related Issues
- https://github.com/wso2/product-is/issues/19231

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
