### PR TITLE
Fix groups search bar not showing when the no. of connected user stores are less than 3

### DIFF
--- a/.changeset/fluffy-yaks-peel.md
+++ b/.changeset/fluffy-yaks-peel.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix groups search bar not showing when the no. of connected user stores are less than 3

--- a/apps/console/src/features/groups/pages/groups.tsx
+++ b/apps/console/src/features/groups/pages/groups.tsx
@@ -338,13 +338,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                     </RootOnlyComponent>
                 ) }
                 showPagination={ paginatedGroups?.length > 0  }
-                showTopActionPanel={
-                    !isGroupsListRequestLoading
-                    && !(!searchQuery
-                        && !groupsError
-                        && userStoreOptions?.length < 3
-                        && (!paginatedGroups || paginatedGroups?.length <= 0))
-                }
+                showTopActionPanel={ !isGroupsListRequestLoading }
                 totalPages={ Math.ceil(groupList?.length / listItemLimit) }
                 totalListSize={ groupList?.length }
                 isLoading={ isGroupsListRequestLoading }


### PR DESCRIPTION
### Purpose

$subject

https://github.com/wso2/identity-apps/assets/41533942/e1aa054e-4034-420a-9040-52fc788674f3

### Related Issues
- https://github.com/wso2/product-is/issues/19203

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
