### PR TITLE
Remove console scope check for legacy mode

### DIFF
--- a/.changeset/great-coats-complain.md
+++ b/.changeset/great-coats-complain.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove console scope check in legazy runtime

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1747,7 +1747,8 @@
             "rolesV1": true,
             "roleMapping": true,
             "secretsManagement": true,
-            "saasApplications": true
+            "saasApplications": true,
+            "consoleFeatureScopeCheck": true
             {% else %}
             {% if console.ui.legacy_mode.items() is defined %}
             {% for key, value in console.ui.legacy_mode.items() %}

--- a/apps/console/src/features/core/hooks/use-routes.tsx
+++ b/apps/console/src/features/core/hooks/use-routes.tsx
@@ -156,6 +156,7 @@ const useRoutes = (): useRoutesInterface => {
                 && AppConstants.ORGANIZATION_ENABLED_ROUTES;
         }
 
+        // Console feature scope check is disabled when the consoleFeatureScopeCheck flag is explicitly set to false.
         const checkConsoleScopes: boolean = !(legacyModeConfigs?.consoleFeatureScopeCheck === false);
 
         const [

--- a/apps/console/src/features/core/hooks/use-routes.tsx
+++ b/apps/console/src/features/core/hooks/use-routes.tsx
@@ -17,7 +17,7 @@
  */
 
 import { AccessControlUtils } from "@wso2is/access-control";
-import { RouteInterface } from "@wso2is/core/models";
+import { LegacyModeInterface, RouteInterface } from "@wso2is/core/models";
 import { RouteUtils as CommonRouteUtils } from "@wso2is/core/utils";
 import isEmpty from "lodash-es/isEmpty";
 import { useDispatch, useSelector } from "react-redux";
@@ -54,6 +54,7 @@ const useRoutes = (): useRoutesInterface => {
     const { isSuperOrganization } = useGetCurrentOrganizationType();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const legacyModeConfigs: LegacyModeInterface = useSelector((state: AppState) => state.config.ui.legacyMode);
     const loggedUserName: string = useSelector((state: AppState) => state.profile.profileInfo.userName);
     const superAdmin: string = useSelector((state: AppState) => state.organization.superAdmin);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
@@ -155,6 +156,8 @@ const useRoutes = (): useRoutesInterface => {
                 && AppConstants.ORGANIZATION_ENABLED_ROUTES;
         }
 
+        const checkConsoleScopes: boolean = !(legacyModeConfigs?.consoleFeatureScopeCheck === false);
+
         const [
             appRoutes,
             sanitizedAppRoutes
@@ -162,7 +165,7 @@ const useRoutes = (): useRoutesInterface => {
             getAppViewRoutes(commonConfig.useExtendedRoutes),
             featureConfig,
             allowedScopes,
-            !legacyAuthzRuntime,
+            checkConsoleScopes,
             resolveHiddenRoutes(),
             allowedRoutes
         );

--- a/apps/console/src/features/core/hooks/use-routes.tsx
+++ b/apps/console/src/features/core/hooks/use-routes.tsx
@@ -162,7 +162,7 @@ const useRoutes = (): useRoutesInterface => {
             getAppViewRoutes(commonConfig.useExtendedRoutes),
             featureConfig,
             allowedScopes,
-            true,
+            !legacyAuthzRuntime,
             resolveHiddenRoutes(),
             allowedRoutes
         );

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -1154,7 +1154,8 @@
             "rolesV1": false,
             "roleMapping": false,
             "secretsManagement": false,
-            "saasApplications": false
+            "saasApplications": false,
+            "consoleFeatureScopeCheck": true
         },
         "theme": {
             "name": "wso2is"

--- a/modules/core/src/models/core.ts
+++ b/modules/core/src/models/core.ts
@@ -224,4 +224,5 @@ export interface LegacyModeInterface {
     roleMapping: boolean;
     secretsManagement: boolean;
     saasApplications: boolean;
+    consoleFeatureScopeCheck: boolean;
 }


### PR DESCRIPTION
### Purpose
The removal of the console scope check from the legacy mode is based on observations in versions 6.0 and 6.1. In these versions, it was noted that console: scopes were not issued in the token. Consequently, since the scope check was not previously enforced in the console, users were able to access the console without encountering any issues. However, with the introduction of checks for 'features' and 'read' scopes in the current version's console, users in legacy mode faced login difficulties. To resolve this and maintain consistency with the behavior observed in versions 6.0 and 6.1, the 'features' scope check in the console has now been removed in legazy mode.

### Related Issues
- https://github.com/wso2/product-is/issues/19167

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
