### PR TITLE
Fix fields displaying issue when a new connector jar is added

### DIFF
--- a/.changeset/tasty-camels-judge.md
+++ b/.changeset/tasty-camels-judge.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix fields displaying issue when a new connector jar is added

--- a/apps/console/src/features/connections/components/edit/forms/authenticator-settings-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/authenticator-settings-form.tsx
@@ -213,7 +213,7 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
                 return connectorScope?.displayName === scope;
             }
         );
-    
+
         if (foundScope) {
             return {
                 description: foundScope?.description,
@@ -280,13 +280,13 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
 
     /**
      * Resolve the form field values.
-     * 
+     *
      * @returns Form fields.
      */
     const renderFormFields = () => {
         if (settings) {
             return (
-                settings?.edit?.tabs?.settings?.fields?.map(
+                settings?.edit?.tabs?.settings?.map(
                     (connectorField: FieldInputPropsInterface) => {
                         return (
                             <DynamicField.Input
@@ -298,10 +298,10 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
                             />
                         );
                     })
-            );  
+            );
         } else if (formFields) {
             const fields: DynamicInputElementsInterface[] = [];
-            
+
             for (const key in formFields) {
                 if (key === "AdditionalQueryParameters") {
                     continue;
@@ -329,7 +329,7 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
             }
 
             const sortedFields: DynamicInputElementsInterface[] = fields.sort(
-                (firstValue: DynamicInputElementsInterface, secondValue: DynamicInputElementsInterface) => 
+                (firstValue: DynamicInputElementsInterface, secondValue: DynamicInputElementsInterface) =>
                     firstValue.displayOrder - secondValue.displayOrder
             );
 
@@ -367,7 +367,7 @@ export const AuthenticatorSettingsForm: FC<AuthenticatorSettingsFormPropsInterfa
                 <DynamicForm
                     uncontrolledForm={ false }
                     id={ `${FORM_ID}-${originalInitialValues?.authenticatorId}` }
-                    onSubmit={ (values: Record<string, any>) => onSubmit(getUpdatedConfigurations(values)) } 
+                    onSubmit={ (values: Record<string, any>) => onSubmit(getUpdatedConfigurations(values)) }
                     initialValues={ initialValues }
                     data-testid={ `${ testId }-dynamic-form` }
                 >


### PR DESCRIPTION
### Purpose
> Currently, when we add a new connector jar is added to the identity server, the settings page will be not loaded as expected. This PR will fix that issue.

**Before**
<img width="674" alt="Screenshot 2024-01-30 at 17 59 21" src="https://github.com/wso2/identity-apps/assets/27746285/d7eb95ce-83bb-436a-9c91-71b4517a1f9f">

**After**
<img width="674" alt="Screenshot 2024-01-30 at 18 01 00" src="https://github.com/wso2/identity-apps/assets/27746285/4ff37946-3944-4d60-b5ea-66f82cd13c12">

### Related Issues
- https://github.com/wso2/product-is/issues/19304

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
