### PR TITLE
Enable SCIM2 schema retrieval on sub-organization switch

### DIFF
--- a/.changeset/sweet-apples-burn.md
+++ b/.changeset/sweet-apples-burn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Enable SCIM2 schema retrieval on sub-organization switch

--- a/apps/console/src/features/authentication/hooks/use-sign-in.ts
+++ b/apps/console/src/features/authentication/hooks/use-sign-in.ts
@@ -451,7 +451,8 @@ const useSignIn = (): UseSignInInterface => {
         await dispatch(
             getProfileInformation(
                 Config.getServiceResourceEndpoints().me,
-                window["AppUtils"].getConfig().clientOriginWithTenant
+                window["AppUtils"].getConfig().clientOriginWithTenant,
+                true
             )
         );
 

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -54,42 +54,38 @@ export const getProfileInformation = (
                                     (window[ "AppUtils" ].getConfig().getProfileInfoFromIDToken ?? false);
 
     const getProfileSchema = (): void => {
-        // If the schemas in the redux store is empty, fetch the SCIM schemas from the API.
-        if (isEmpty(store.getState().profile.profileSchemas)) {
-            dispatch(setProfileSchemaRequestLoadingStatus(true));
-
-            getProfileSchemas()
-                .then((response: ProfileSchemaInterface[]) => {
-                    dispatch(setSCIMSchemas<ProfileSchemaInterface[]>(response));
-                })
-                .catch((error: IdentityAppsApiException) => {
-                    if (error?.response?.data?.description) {
-                        dispatch(
-                            addAlert<AlertInterface>({
-                                description: error.response.data.description,
-                                level: AlertLevels.ERROR,
-                                message: I18n.instance.t("console:manage.notifications.getProfileSchema." +
-                                    "error.message")
-                            })
-                        );
-                    }
-
+        dispatch(setProfileSchemaRequestLoadingStatus(true));
+        getProfileSchemas()
+            .then((response: ProfileSchemaInterface[]) => {
+                dispatch(setSCIMSchemas<ProfileSchemaInterface[]>(response));
+            })
+            .catch((error: IdentityAppsApiException) => {
+                if (error?.response?.data?.description) {
                     dispatch(
                         addAlert<AlertInterface>({
-                            description: I18n.instance.t(
-                                "console:manage.notifications.getProfileSchema.genericError.description"
-                            ),
+                            description: error.response.data.description,
                             level: AlertLevels.ERROR,
-                            message: I18n.instance.t(
-                                "console:manage.notifications.getProfileSchema.genericError.message"
-                            )
+                            message: I18n.instance.t("console:manage.notifications.getProfileSchema." +
+                                "error.message")
                         })
                     );
-                })
-                .finally(() => {
-                    dispatch(setProfileSchemaRequestLoadingStatus(false));
-                });
-        }
+                }
+
+                dispatch(
+                    addAlert<AlertInterface>({
+                        description: I18n.instance.t(
+                            "console:manage.notifications.getProfileSchema.genericError.description"
+                        ),
+                        level: AlertLevels.ERROR,
+                        message: I18n.instance.t(
+                            "console:manage.notifications.getProfileSchema.genericError.message"
+                        )
+                    })
+                );
+            })
+            .finally(() => {
+                dispatch(setProfileSchemaRequestLoadingStatus(false));
+            });
     };
 
     if (getProfileInfoFromToken || isSubOrg && meEndpoint.includes("scim2/Me")) {

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -58,6 +58,7 @@ export const getProfileInformation = (
         if (!fetchProfileSchema && !isEmpty(store.getState().profile.profileSchemas)) {
             return;
         }
+
         dispatch(setProfileSchemaRequestLoadingStatus(true));
         getProfileSchemas()
             .then((response: ProfileSchemaInterface[]) => {

--- a/apps/console/src/features/authentication/store/actions/authenticate.ts
+++ b/apps/console/src/features/authentication/store/actions/authenticate.ts
@@ -43,7 +43,8 @@ import { getProfileInfo, getProfileSchemas } from "../../../users/api";
  */
 export const getProfileInformation = (
     meEndpoint: string = Config.getServiceResourceEndpoints().me,
-    clientOrigin: string = window["AppUtils"].getConfig().clientOriginWithTenant
+    clientOrigin: string = window["AppUtils"].getConfig().clientOriginWithTenant,
+    fetchProfileSchema: boolean = false
 ) => (dispatch: Dispatch): void => {
 
     dispatch(setProfileInfoRequestLoadingStatus(true));
@@ -54,6 +55,9 @@ export const getProfileInformation = (
                                     (window[ "AppUtils" ].getConfig().getProfileInfoFromIDToken ?? false);
 
     const getProfileSchema = (): void => {
+        if (!fetchProfileSchema && !isEmpty(store.getState().profile.profileSchemas)) {
+            return;
+        }
         dispatch(setProfileSchemaRequestLoadingStatus(true));
         getProfileSchemas()
             .then((response: ProfileSchemaInterface[]) => {


### PR DESCRIPTION
### Purpose
Previously, the frontend used the same SCIM2 schemas cached in the Redux store from the main tenant for rendering user profiles in sub-organizations, without requesting updated schemas after switching. This PR introduces a change where, upon switching to a sub-organization, an API call is made to the organization-specific `/o/scim2/Schemas` endpoint to accurately fetch the relevant schemas.

### Related Issues
- https://github.com/wso2/product-is/issues/19307

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
