### PR TITLE
Add custom servlet mapping configuration support in deployment.toml for account recovery endpoint 

### DIFF
--- a/.changeset/blue-colts-explain.md
+++ b/.changeset/blue-colts-explain.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add custom servlet mapping configuration support in deployment.toml for account recovery endpoint

--- a/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -232,7 +232,7 @@
         <jsp-file>/accept-invitation.jsp</jsp-file>
     </servlet>
 
-    {% for custom_servlet in account_recovery.endpoint.servlet %}
+    {% for custom_servlet in accountrecoveryendpoint.servlet %}
     <servlet>
         <servlet-name>{{custom_servlet.name}}</servlet-name>
         <jsp-file>{{custom_servlet.jsp}}</jsp-file>

--- a/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -232,6 +232,17 @@
         <jsp-file>/accept-invitation.jsp</jsp-file>
     </servlet>
 
+    {% for custom_servlet in account_recovery.endpoint.servlet %}
+    <servlet>
+        <servlet-name>{{custom_servlet.name}}</servlet-name>
+        <jsp-file>{{custom_servlet.jsp}}</jsp-file>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>{{custom_servlet.name}}</servlet-name>
+        <url-pattern>{{custom_servlet.url}}</url-pattern>
+    </servlet-mapping>
+    {% endfor %}
+
     <servlet-mapping>
         <servlet-name>recoveraccountrouter.do</servlet-name>
         <url-pattern>/recoveraccountrouter.do</url-pattern>


### PR DESCRIPTION
## Purpose

- $Subject
- Resolves https://github.com/wso2/product-is/issues/19185

With this fix servlet mappings can be configured using deployment.toml as follows:
```
[[accountrecoveryendpoint.servlet]]
name = "<servlet-name>"
url = "<url-pattern>"
jsp = "<jsp-file>"
```