### PR TITLE
Remove `isAuthenticatorAllowed` method infavor of `hiddenAuthenticators`

### DIFF
--- a/apps/console/src/extensions/configs/identity-provider.tsx
+++ b/apps/console/src/extensions/configs/identity-provider.tsx
@@ -349,13 +349,6 @@ export const identityProviderConfig: IdentityProviderConfig = {
         hideLogoInputFieldInIdPGeneralSettingsForm(): boolean {
             return true;
         },
-        isAuthenticatorAllowed: (name: string): boolean => {
-            return [
-                IdentityProviderManagementConstants.BASIC_AUTH_REQUEST_PATH_AUTHENTICATOR,
-                IdentityProviderManagementConstants.OAUTH_REQUEST_PATH_AUTHENTICATOR,
-                IdentityProviderManagementConstants.X509_AUTHENTICATOR
-            ].includes(name);
-        },
         isProvisioningAttributesEnabled(authenticatorId: string): boolean {
             const excludedAuthenticators: Set<string> = new Set([
                 IdentityProviderManagementConstants.SAML_AUTHENTICATOR_ID

--- a/apps/console/src/extensions/configs/models/identity-providers.ts
+++ b/apps/console/src/extensions/configs/models/identity-providers.ts
@@ -120,7 +120,6 @@ export interface IdentityProviderConfig {
         showCertificate: boolean;
     };
     utils: {
-        isAuthenticatorAllowed: (name: string) => boolean;
         isProvisioningAttributesEnabled: (authenticatorId: string) => boolean;
         hideIdentityClaimAttributes?: (authenticatorId: string) => boolean;
         /**

--- a/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
+++ b/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
@@ -24,7 +24,6 @@ import { I18n } from "@wso2is/i18n";
 import axios, { AxiosError } from "axios";
 import camelCase from "lodash-es/camelCase";
 import isEmpty from "lodash-es/isEmpty";
-import { identityProviderConfig } from "../../../extensions/configs/identity-provider";
 import { DocPanelUICardInterface, store } from "../../core";
 import { Config } from "../../core/configs";
 import { getFederatedAuthenticatorsList, getIdentityProviderList, getLocalAuthenticators } from "../api";

--- a/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
+++ b/apps/console/src/features/identity-providers/utils/identity-provider-management-utils.ts
@@ -187,10 +187,6 @@ export class IdentityProviderManagementUtils {
                         return;
                     }
 
-                    if (identityProviderConfig.utils.isAuthenticatorAllowed(authenticator.name)) {
-                        return;
-                    }
-
                     localAuthenticators.push({
                         authenticators: [
                             {

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -1094,7 +1094,10 @@
         "gravatarConfig": {
             "fallback": "404"
         },
-        "hiddenAuthenticators": [],
+        "hiddenAuthenticators": [
+            "BasicAuthRequestPathAuthenticator",
+            "OAuthRequestPathAuthenticator"
+        ],
         "hiddenConnectionTemplates": [
             "hypr-idp",
             "swe-idp"


### PR DESCRIPTION
### Purpose

Remove `isAuthenticatorAllowed` method infavor of `hiddenAuthenticators` deployment level config since the code level function restrictions were causing issues when custom local authenticators are being added.

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/19173

### Related PRs
- Framework: https://github.com/wso2/carbon-identity-framework/pull/5465

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
