### PR TITLE
Support HSTS configuration updates through deployment.toml

### DIFF
--- a/.changeset/honest-bulldogs-fetch.md
+++ b/.changeset/honest-bulldogs-fetch.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Support HSTS configuration updates through deployment.toml

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -164,15 +164,27 @@
     <filter>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
         <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+        {% set ns = namespace(hstsEnabledFound=false) %}
+        {% for header_security_filter in authenticationendpoint.tomcat.header_security_filters %}
+        <init-param>
+            <param-name>{{ header_security_filter.name }}</param-name>
+            <param-value>{{ header_security_filter.value }}</param-value>
+        </init-param>
+        {% if header_security_filter.name == 'hstsEnabled' %}
+            {% set ns.hstsEnabledFound = true %}
+        {% endif %}
+        {% endfor %}
+        {% if not ns.hstsEnabledFound %}
         <init-param>
             <param-name>hstsEnabled</param-name>
             <param-value>false</param-value>
         </init-param>
+        {% endif %}
     </filter>
 
     <filter-mapping>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
-        <url-pattern>*</url-pattern>
+        <url-pattern>{{ authenticationendpoint.tomcat.header_security_filter.url_pattern | default('*') }}</url-pattern>
     </filter-mapping>
 
     <filter>

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -165,12 +165,12 @@
         <filter-name>HttpHeaderSecurityFilter</filter-name>
         <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
         {% set ns = namespace(hstsEnabledFound=false) %}
-        {% for header_security_filter in authenticationendpoint.tomcat.header_security_filters %}
+        {% for parameter in authenticationendpoint.tomcat.http_header_security_filter.parameters %}
         <init-param>
-            <param-name>{{ header_security_filter.name }}</param-name>
-            <param-value>{{ header_security_filter.value }}</param-value>
+            <param-name>{{ parameter.name }}</param-name>
+            <param-value>{{ parameter.value }}</param-value>
         </init-param>
-        {% if header_security_filter.name == 'hstsEnabled' %}
+        {% if parameter.name == 'hstsEnabled' %}
             {% set ns.hstsEnabledFound = true %}
         {% endif %}
         {% endfor %}
@@ -184,7 +184,7 @@
 
     <filter-mapping>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
-        <url-pattern>{{ authenticationendpoint.tomcat.header_security_filter.url_pattern | default('*') }}</url-pattern>
+        <url-pattern>{{ authenticationendpoint.tomcat.http_header_security_filter.url_pattern | default('*') }}</url-pattern>
     </filter-mapping>
 
     <filter>

--- a/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -94,12 +94,12 @@
         <filter-name>HttpHeaderSecurityFilter</filter-name>
         <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
         {% set ns = namespace(hstsEnabledFound=false) %}
-        {% for header_security_filter in accountrecoveryendpoint.tomcat.header_security_filters %}
+        {% for parameter in accountrecoveryendpoint.tomcat.http_header_security_filter.parameters %}
         <init-param>
-            <param-name>{{ header_security_filter.name }}</param-name>
-            <param-value>{{ header_security_filter.value }}</param-value>
+            <param-name>{{ parameter.name }}</param-name>
+            <param-value>{{ parameter.value }}</param-value>
         </init-param>
-        {% if header_security_filter.name == 'hstsEnabled' %}
+        {% if parameter.name == 'hstsEnabled' %}
             {% set ns.hstsEnabledFound = true %}
         {% endif %}
         {% endfor %}
@@ -113,7 +113,7 @@
 
     <filter-mapping>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
-        <url-pattern>{{ accountrecoveryendpoint.tomcat.header_security_filter.url_pattern | default('*') }}</url-pattern>
+        <url-pattern>{{ accountrecoveryendpoint.tomcat.http_header_security_filter.url_pattern | default('*') }}</url-pattern>
     </filter-mapping>
 
     <filter>

--- a/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -93,15 +93,27 @@
     <filter>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
         <filter-class>org.apache.catalina.filters.HttpHeaderSecurityFilter</filter-class>
+        {% set ns = namespace(hstsEnabledFound=false) %}
+        {% for header_security_filter in accountrecoveryendpoint.tomcat.header_security_filters %}
+        <init-param>
+            <param-name>{{ header_security_filter.name }}</param-name>
+            <param-value>{{ header_security_filter.value }}</param-value>
+        </init-param>
+        {% if header_security_filter.name == 'hstsEnabled' %}
+            {% set ns.hstsEnabledFound = true %}
+        {% endif %}
+        {% endfor %}
+        {% if not ns.hstsEnabledFound %}
         <init-param>
             <param-name>hstsEnabled</param-name>
             <param-value>false</param-value>
         </init-param>
+        {% endif %}
     </filter>
 
     <filter-mapping>
         <filter-name>HttpHeaderSecurityFilter</filter-name>
-        <url-pattern>*</url-pattern>
+        <url-pattern>{{ accountrecoveryendpoint.tomcat.header_security_filter.url_pattern | default('*') }}</url-pattern>
     </filter-mapping>
 
     <filter>


### PR DESCRIPTION
## Purpose

- $Subject
- Resolves https://github.com/wso2/product-is/issues/19174


To customize HTTP Header Security Filter initialization parameters and set the HSTS filter URL pattern in the `deployment.toml` for `accountrecoveryendpoint` , use the following configurations:

```
# Configuring the URL pattern for the HSTS filter
[accountrecoveryendpoint.tomcat.http_header_security_filter]
url_pattern = "url-pattern"

# Setting initialization parameters for HTTP Header Security Filter
[[accountrecoveryendpoint.tomcat.http_header_security_filter.parameters]]
name = "param-name"
value = "param-value"

```

To customize HTTP Header Security Filter initialization parameters and set the HSTS filter URL pattern in the `deployment.toml` for `authenticationendpoint` , use the following configurations:

```
# Configuring the URL pattern for the HSTS filter
[authenticationendpoint.tomcat.http_header_security_filter]
url_pattern = "url-pattern"

# Setting initialization parameters for HTTP Header Security Filter
[[authenticationendpoint.tomcat.http_header_security_filter.parameters]]
name = "param-name"
value = "param-value"

```



