### PR TITLE
Replace direct use of window object usage in getting org prefix

### DIFF
--- a/.changeset/shiny-brooms-prove.md
+++ b/.changeset/shiny-brooms-prove.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Replace direct use of window object usage in getting org prefix

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -165,7 +165,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                     ?? window.location.pathname;
                 const pathChunks: string[] = path.split("/");
 
-                const orgPrefixIndex: number = pathChunks.indexOf(window["AppUtils"].getConfig().organizationPrefix);
+                const orgPrefixIndex: number = pathChunks.indexOf(Config.getDeploymentConfig().organizationPrefix);
 
                 if (orgPrefixIndex !== -1) {
                     return pathChunks[ orgPrefixIndex + 1 ];


### PR DESCRIPTION
### Purpose

Switching to sub organization fails intermittently in the test suite. Even if the correct URL is there in the address bar, in the middle of loading the page, the URL is changed back to tenant specific URL.

Observing the code, I suspect that the direct use of window object in retrieving the organization prefix may cause this intermittent failure. Therefore, in this PR, I have updated the logic to get the organization prefix from already loaded config object.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
