### PR TITLE
[improvement] add text customization to the password-reset-success interface

### DIFF
--- a/.changeset/smart-news-cry.md
+++ b/.changeset/smart-news-cry.md
@@ -1,0 +1,10 @@
+---
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/identity-apps-core": patch
+"@wso2is/form": patch
+"@wso2is/i18n": patch
+"@wso2is/theme": patch
+---
+
+[improvement] add text customization to the password-reset-success interface

--- a/apps/console/src/features/branding/api/use-get-custom-text-preference-screen-meta.ts
+++ b/apps/console/src/features/branding/api/use-get-custom-text-preference-screen-meta.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -26,7 +26,7 @@ import useRequest, {
 import { CustomTextPreferenceScreenMetaInterface } from "../models/custom-text-preference";
 
 /**
- * Hook to get the platform default branding preference text customizations from the distribution.
+ * Hook to get the custom text preference screen meta.
  *
  * @param shouldFetch - Should fetch the data.
  * @param screen - Resource Screen.

--- a/apps/console/src/features/branding/api/use-get-custom-text-preference-screen-meta.ts
+++ b/apps/console/src/features/branding/api/use-get-custom-text-preference-screen-meta.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HttpMethods } from "@wso2is/core/models";
+import { AppConstants } from "../../core/constants/app-constants";
+import useRequest, {
+    RequestConfigInterface,
+    RequestErrorInterface,
+    RequestResultInterface
+} from "../../core/hooks/use-request";
+import { CustomTextPreferenceScreenMetaInterface } from "../models/custom-text-preference";
+
+/**
+ * Hook to get the platform default branding preference text customizations from the distribution.
+ *
+ * @param shouldFetch - Should fetch the data.
+ * @param screen - Resource Screen.
+ * @returns SWR response object containing the data, error, isValidating, mutate.
+ */
+const useGetCustomTextPreferenceScreenMeta = <
+    Data = CustomTextPreferenceScreenMetaInterface,
+    Error = RequestErrorInterface
+>(
+        shouldFetch: boolean,
+        screen: string
+    ): RequestResultInterface<Data, Error> => {
+    const basename: string = AppConstants.getAppBasename() ? `/${AppConstants.getAppBasename()}` : "";
+    const url: string = `https://${
+        window.location.host
+    }${basename}/resources/branding/i18n/screens/${screen}/meta.json`;
+
+    const requestConfig: RequestConfigInterface = {
+        headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        url
+    };
+
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(shouldFetch ? requestConfig : null, {
+        attachToken: false,
+        shouldRetryOnError: false
+    });
+
+    return {
+        data,
+        error,
+        isLoading: !error && !data,
+        isValidating,
+        mutate
+    };
+};
+
+export default useGetCustomTextPreferenceScreenMeta;

--- a/apps/console/src/features/branding/components/custom-text/custom-text-fields.tsx
+++ b/apps/console/src/features/branding/components/custom-text/custom-text-fields.tsx
@@ -86,6 +86,7 @@ const CustomTextFields: FunctionComponent<CustomTextFieldsProps> = (props: Custo
 
     const {
         customTextDefaults,
+        customTextScreenMeta,
         updateCustomTextFormSubscription,
         selectedScreen,
         selectedLocale,
@@ -208,9 +209,11 @@ const CustomTextFields: FunctionComponent<CustomTextFieldsProps> = (props: Custo
                                                 i18n.exists(hintKey) && (
                                                     <Hint>{ t(hintKey, { productName }) }</Hint>
                                                 )
-
                                             ) }
                                             component={ TextFieldAdapter }
+                                            multiline={ customTextScreenMeta &&
+                                                customTextScreenMeta[fieldName.replaceAll("_", ".")].MULTI_LINE }
+                                            size="small"
                                             maxLength={
                                                 CustomTextPreferenceConstants.FORM_FIELD_CONSTRAINTS.MAX_LENGTH
                                             }

--- a/apps/console/src/features/branding/components/preview/product-footer.tsx
+++ b/apps/console/src/features/branding/components/preview/product-footer.tsx
@@ -66,7 +66,7 @@ export const ProductFooter: FunctionComponent<ProductFooterInterface> = (
             <div className="ui container fluid">
                 <div className="ui text menu">
                     <div className="left menu">
-                        <a className="item no-hover" id="copyright">
+                        <a className="item no-hover copyright-text new-line-support" id="copyright">
                             { !isEmpty(i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.COPYRIGHT, "")) && (
                                 <>
                                     <span>{ i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.COPYRIGHT, "") }</span>

--- a/apps/console/src/features/branding/components/preview/product-footer.tsx
+++ b/apps/console/src/features/branding/components/preview/product-footer.tsx
@@ -66,7 +66,7 @@ export const ProductFooter: FunctionComponent<ProductFooterInterface> = (
             <div className="ui container fluid">
                 <div className="ui text menu">
                     <div className="left menu">
-                        <a className="item no-hover copyright-text new-line-support" id="copyright">
+                        <a className="item no-hover copyright-text line-break" id="copyright">
                             { !isEmpty(i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.COPYRIGHT, "")) && (
                                 <>
                                     <span>{ i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.COPYRIGHT, "") }</span>

--- a/apps/console/src/features/branding/components/preview/sign-in-box/fragments/password-recovery-fragment.tsx
+++ b/apps/console/src/features/branding/components/preview/sign-in-box/fragments/password-recovery-fragment.tsx
@@ -46,7 +46,7 @@ const PasswordRecoveryFragment: FunctionComponent<PasswordRecoveryFragmentInterf
             </h2>
             <div className="segment-form">
                 <form method="post" id="totpForm" className="ui large form otp-form">
-                    <p className="text-center" id="instruction">
+                    <p className="new-line-support text-center" id="instruction" >
                         { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.PASSWORD_RECOVERY.BODY,
                             "Don't worry, it happens. We will send you an email to reset your password.") }
                     </p>

--- a/apps/console/src/features/branding/components/preview/sign-in-box/fragments/password-recovery-fragment.tsx
+++ b/apps/console/src/features/branding/components/preview/sign-in-box/fragments/password-recovery-fragment.tsx
@@ -46,7 +46,7 @@ const PasswordRecoveryFragment: FunctionComponent<PasswordRecoveryFragmentInterf
             </h2>
             <div className="segment-form">
                 <form method="post" id="totpForm" className="ui large form otp-form">
-                    <p className="new-line-support text-center" id="instruction" >
+                    <p className="line-break text-center" id="instruction" >
                         { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.PASSWORD_RECOVERY.BODY,
                             "Don't worry, it happens. We will send you an email to reset your password.") }
                     </p>

--- a/apps/console/src/features/branding/components/preview/sign-in-box/fragments/password-reset-success-fragment.tsx
+++ b/apps/console/src/features/branding/components/preview/sign-in-box/fragments/password-reset-success-fragment.tsx
@@ -47,13 +47,12 @@ const PasswordResetSuccessFragment: FunctionComponent<PasswordResetSuccessFragme
             </h2>
             <div className="segment-form">
                 <form method="post" id="totpForm" className="ui large form otp-form">
-                    <p className="text-center" id="instruction">
-                        An email with a password reset link and instructions has been sent to your email.
-                    </p>
-                    <p className="text-center" id="instruction">
-                        Didn&apos;t receive an email yet? Your email address is not registered on
-                        or you have signed up using a social account with the provided email.
-                        Create an account or use a different login option.
+                    <p className="text-center new-line-support" id="instruction">
+                        { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.PASSWORD_RESET_SUCCESS.BODY,
+                            "An email with a password reset link and instructions has been sent to your email.\n\n" +
+                            "Didn't receive an email yet? Your email address might not be registered or you have" +
+                            "signed up using a social account with the provided email. Create an account or use a" +
+                            "different login option.") }
                     </p>
                     <div className="ui divider hidden"></div>
                     <div className="ui divider hidden"></div>

--- a/apps/console/src/features/branding/components/preview/sign-in-box/fragments/password-reset-success-fragment.tsx
+++ b/apps/console/src/features/branding/components/preview/sign-in-box/fragments/password-reset-success-fragment.tsx
@@ -47,7 +47,7 @@ const PasswordResetSuccessFragment: FunctionComponent<PasswordResetSuccessFragme
             </h2>
             <div className="segment-form">
                 <form method="post" id="totpForm" className="ui large form otp-form">
-                    <p className="text-center new-line-support" id="instruction">
+                    <p className="text-center line-break" id="instruction">
                         { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.PASSWORD_RESET_SUCCESS.BODY,
                             "An email with a password reset link and instructions has been sent to your email.\n\n" +
                             "Didn't receive an email yet? Your email address might not be registered or you have" +

--- a/apps/console/src/features/branding/components/preview/sign-in-box/fragments/sms-otp-fragment.tsx
+++ b/apps/console/src/features/branding/components/preview/sign-in-box/fragments/sms-otp-fragment.tsx
@@ -38,14 +38,14 @@ const SMSOTP: FunctionComponent<SMSOTPInterface> = (props: SMSOTPInterface): Rea
     const { i18n } = useBrandingPreference();
 
     return (
-        <div data-componentid={ componentId }>
+        <div className="sms-otp-portal-layout" data-componentid={ componentId }>
             <h2>{ i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.SMS_OTP.HEADING, "OTP Verification") }</h2>
             <div className="ui divider hidden" />
             <div className="segment-form">
                 <form className="ui large form" id="codeForm" name="codeForm" method="POST">
                     <div className="field">
                         <label htmlFor="password">Enter the code sent to your mobile phone (******3830)</label>
-                        <div className="equal width fields">
+                        <div className="sms-otp-fields equal width fields">
                             <div className="field mt-5">
                                 <input
                                     className="text-center p-3"

--- a/apps/console/src/features/branding/constants/custom-text-preference-constants.ts
+++ b/apps/console/src/features/branding/constants/custom-text-preference-constants.ts
@@ -120,6 +120,7 @@ export class CustomTextPreferenceConstants {
         PASSWORD_RESET_SUCCESS: {
             HEADING: string;
             ACTION: string;
+            BODY: string;
         },
         PRIVACY_POLICY: string;
         REGISTER_TEXT: {
@@ -157,6 +158,7 @@ export class CustomTextPreferenceConstants {
         },
         PASSWORD_RESET_SUCCESS: {
             ACTION: "password.reset.success.action",
+            BODY: "password.reset.success.body",
             HEADING: "password.reset.success.heading"
         },
         PRIVACY_POLICY: "privacy.policy",

--- a/apps/console/src/features/branding/context/branding-preference-context.tsx
+++ b/apps/console/src/features/branding/context/branding-preference-context.tsx
@@ -24,7 +24,11 @@ import {
     BrandingSubFeatures,
     PreviewScreenType
 } from "../models/branding-preferences";
-import { CustomTextConfigurationModes, CustomTextInterface, CustomTextPreferenceScreenMetaInterface } from "../models/custom-text-preference";
+import {
+    CustomTextConfigurationModes,
+    CustomTextInterface,
+    CustomTextPreferenceScreenMetaInterface
+} from "../models/custom-text-preference";
 
 /**
  * Props interface for BrandingPreferenceContext.

--- a/apps/console/src/features/branding/context/branding-preference-context.tsx
+++ b/apps/console/src/features/branding/context/branding-preference-context.tsx
@@ -24,7 +24,7 @@ import {
     BrandingSubFeatures,
     PreviewScreenType
 } from "../models/branding-preferences";
-import { CustomTextConfigurationModes, CustomTextInterface } from "../models/custom-text-preference";
+import { CustomTextConfigurationModes, CustomTextInterface, CustomTextPreferenceScreenMetaInterface } from "../models/custom-text-preference";
 
 /**
  * Props interface for BrandingPreferenceContext.
@@ -60,6 +60,10 @@ export interface BrandingPreferenceContextProps {
      * Default text customization preference from the in-app resource bundle.
      */
     customTextDefaults: CustomTextInterface;
+    /**
+     * Meta data for the custom text preference screen.
+     */
+    customTextScreenMeta: CustomTextPreferenceScreenMetaInterface
     /**
      * Updates the custom text preference.
      * @param values - Values to be updated.

--- a/apps/console/src/features/branding/models/custom-text-preference.ts
+++ b/apps/console/src/features/branding/models/custom-text-preference.ts
@@ -86,3 +86,23 @@ export enum CustomTextConfigurationModes {
      */
     TEXT_FIELDS = "TEXT_FIELDS"
 }
+
+/**
+ * Interface for the custom text preference screen meta.
+ */
+export interface CustomTextPreferenceScreenMetaInterface {
+    [key: string]: {
+        /**
+         * Is the text preference editable.
+         */
+        EDITABLE: boolean;
+        /**
+         * Screen name of the text preference.
+         */
+        SCREEN: string;
+        /**
+         * Is the text preference multi-line.
+         */
+        MULTI_LINE: boolean;
+    };
+}

--- a/apps/console/src/features/branding/providers/branding-preference-provider.tsx
+++ b/apps/console/src/features/branding/providers/branding-preference-provider.tsx
@@ -40,6 +40,7 @@ import useGetBrandingPreferenceResolve from "../api/use-get-branding-preference-
 import useGetCustomTextPreferenceFallbacks from "../api/use-get-custom-text-preference-fallbacks";
 import useGetCustomTextPreferenceMeta from "../api/use-get-custom-text-preference-meta";
 import useGetCustomTextPreferenceResolve from "../api/use-get-custom-text-preference-resolve";
+import useGetCustomTextPreferenceScreenMeta from "../api/use-get-custom-text-preference-screen-meta";
 import { BrandingPreferencesConstants } from "../constants/branding-preferences-constants";
 import { CustomTextPreferenceConstants } from "../constants/custom-text-preference-constants";
 import AuthenticationFlowContext from "../context/branding-preference-context";
@@ -52,7 +53,6 @@ import {
 } from "../models/custom-text-preference";
 import BrandingPreferenceMigrationClient from "../utils/branding-preference-migration-client";
 import processCustomTextTemplateLiterals from "../utils/process-custom-text-template-literals";
-import useGetCustomTextPreferenceScreenMeta from "../api/use-get-custom-text-preference-screen-meta";
 
 /**
  * Props interface for the Branding preference provider.

--- a/apps/console/src/features/branding/providers/branding-preference-provider.tsx
+++ b/apps/console/src/features/branding/providers/branding-preference-provider.tsx
@@ -52,6 +52,7 @@ import {
 } from "../models/custom-text-preference";
 import BrandingPreferenceMigrationClient from "../utils/branding-preference-migration-client";
 import processCustomTextTemplateLiterals from "../utils/process-custom-text-template-literals";
+import useGetCustomTextPreferenceScreenMeta from "../api/use-get-custom-text-preference-screen-meta";
 
 /**
  * Props interface for the Branding preference provider.
@@ -137,6 +138,13 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
     const {
         data: customTextMeta
     } = useGetCustomTextPreferenceMeta();
+
+    const {
+        data: customTextScreenMeta
+    } = useGetCustomTextPreferenceScreenMeta(
+        !!selectedScreen,
+        selectedScreen
+    );
 
     /**
      * Merge the custom text preference with the fallbacks.
@@ -349,6 +357,7 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
                 customTextFormSubscription: customTextFormSubscription ?? {
                     values: resolvedCustomText?.preference?.text
                 },
+                customTextScreenMeta,
                 getLocales: (requestingView: BrandingSubFeatures): SupportedLanguagesMeta => {
                     if (requestingView === BrandingSubFeatures.CUSTOM_TEXT) {
                         return pick(supportedI18nLanguages, customTextMeta?.locales);

--- a/apps/console/src/features/branding/utils/process-custom-text-template-literals.ts
+++ b/apps/console/src/features/branding/utils/process-custom-text-template-literals.ts
@@ -31,6 +31,8 @@
 const processCustomTextTemplateLiterals = (original: string): string => {
     const currentYear: number = new Date().getFullYear();
 
+    original = original.replace(/\\n/g, "\n");
+
     return original.replace("{{currentYear}}", currentYear.toString());
 };
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -55,7 +55,7 @@
                         String copyright = i18n(resourceBundle, customText, "copyright", __DEPRECATED__copyrightText);
                         if (StringUtils.isNotBlank(copyright)) {
                     %>
-                        <span class="copyright-text new-line-support"><%= copyright %></span>
+                        <span class="copyright-text line-break"><%= copyright %></span>
                     <% } %>
                     <%
                         if (StringUtils.isNotBlank(copyright) && !shouldRemoveDefaultBranding) {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -55,7 +55,7 @@
                         String copyright = i18n(resourceBundle, customText, "copyright", __DEPRECATED__copyrightText);
                         if (StringUtils.isNotBlank(copyright)) {
                     %>
-                        <span class="copyright-text"><%= copyright %></span>
+                        <span class="copyright-text new-line-support"><%= copyright %></span>
                     <% } %>
                     <%
                         if (StringUtils.isNotBlank(copyright) && !shouldRemoveDefaultBranding) {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
@@ -170,7 +170,7 @@
                                 <% } %>
 
                                 <% if (authenticators.equals(LOCAL_SMS_OTP_AUTHENTICATOR_ID) && otpLength <= 6) { %>
-                                    <div class="equal width fields">
+                                    <div class="sms-otp-fields equal width fields">
                                         <input
                                             hidden
                                             type="text"

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -18,45 +18,47 @@
 #If making new key entries, replace '=' with '_' for base64 encoded key values.
 
 # <!-- Start of Common Translations -->
-# EDITABLE=true,SCREEN="common"
+# EDITABLE=true,SCREEN="common",MULTI_LINE=true
 copyright=© {{currentYear}} WSO2 LLC.
-# EDITABLE=true,SCREEN="common"
+# EDITABLE=true,SCREEN="common",MULTI_LINE=false
 site.title=WSO2 Identity Server
-# EDITABLE=false,SCREEN="common"
+# EDITABLE=false,SCREEN="common",MULTI_LINE=false
 powered.by=Powered by
-# EDITABLE=true,SCREEN="common"
+# EDITABLE=true,SCREEN="common",MULTI_LINE=false
 privacy.policy=Privacy Policy
-# EDITABLE=true,SCREEN="common"
+# EDITABLE=true,SCREEN="common",MULTI_LINE=false
 terms.of.service=Terms of Service
 # <!-- End of Common Translations -->
 
 # <!-- Start of Sign Up Screen Translations -->
-# EDITABLE=true,SCREEN="sign-up"
+# EDITABLE=true,SCREEN="sign-up",MULTI_LINE=false
 sign.up.heading=Sign Up
-# EDITABLE=true,SCREEN="sign-up"
+# EDITABLE=true,SCREEN="sign-up",MULTI_LINE=false
 sign.up.button=Sign Up
 # <!-- End of Sign Up Screen Translations -->
 
 # <!-- Start of Password Recovery Translations -->
-# EDITABLE=true,SCREEN="password-recovery"
+# EDITABLE=true,SCREEN="password-recovery",MULTI_LINE=false
 password.recovery.heading=Forgot Password?
-# EDITABLE=true,SCREEN="password-recovery"
+# EDITABLE=true,SCREEN="password-recovery",MULTI_LINE=true
 password.recovery.body=Don't worry, it happens. We will send you an email to reset your password.
-# EDITABLE=true,SCREEN="password-recovery"
+# EDITABLE=true,SCREEN="password-recovery",MULTI_LINE=false
 password.recovery.button=Send Reset Link
 # <!-- End of Password Recovery Translations -->
 
 # <!-- Start of Password Reset Translations -->
-# EDITABLE=true,SCREEN="password-reset"
+# EDITABLE=true,SCREEN="password-reset",MULTI_LINE=false
 password.reset.heading=Reset Password
-# EDITABLE=true,SCREEN="password-reset"
+# EDITABLE=true,SCREEN="password-reset",MULTI_LINE=false
 password.reset.button=Proceed
 # <!-- End of Password Reset Translations -->
 
 # <!-- Start of Password Reset Success Translations -->
-# EDITABLE=true,SCREEN="password-reset-success"
+# EDITABLE=true,SCREEN="password-reset-success",MULTI_LINE=false
 password.reset.success.heading=Check Your Email
-# EDITABLE=true,SCREEN="password-reset-success"
+# EDITABLE=true,SCREEN="password-reset-success",MULTI_LINE=true
+password.reset.success.body=An email with a password reset link and instructions has been sent to your email.\n\nDidn't receive an email yet? Your email address might not be registered or you have signed up using a social account with the provided email. Create an account or use a different login option.
+# EDITABLE=true,SCREEN="password-reset-success",MULTI_LINE=false
 password.reset.success.action=Back to application
 # <!-- End of Password Reset Success Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
@@ -43,6 +43,7 @@ password.reset.button=Weiter
 
 # <!-- Start of Password Reset Success Translations -->
 password.reset.success.heading=Überprüfen Sie Ihre E-Mail
+password.reset.success.body=Ein Link zum Zurücksetzen des Passworts wurde an Ihre E-Mail-Adresse gesendet.\n\nNoch keine E-Mail erhalten? Ihre E-Mail-Adresse ist möglicherweise nicht registriert Oder haben Sie sich mit einem sozialen Konto mit der angegebenen E -Mail angemeldet? Erstellen Sie ein Konto oder verwenden Sie eine andere Anmeldeoption.
 password.reset.success.action=Zurück zur Registrierung
 # <!-- End of Password Reset Success Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_es_ES.properties
@@ -43,6 +43,7 @@ password.reset.button=Proceder
 
 # <!-- Start of Password Reset Success Translations -->
 password.reset.success.heading=Consultar su correo electrónico
+password.reset.success.body=Se ha enviado un correo electrónico con un enlace e instrucciones de restablecimiento de contraseña a su correo electrónico.\n\n¿No recibió un correo electrónico todavía? Su dirección de correo electrónico no está registrada O se ha registrado utilizando una cuenta social con el correo electrónico proporcionado. Cree una cuenta o use una opción de inicio de sesión diferente.
 password.reset.success.action=Volver a la aplicación
 # <!-- End of Password Reset Success Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
@@ -43,6 +43,7 @@ password.reset.button=procéder
 
 # <!-- Start of Password Reset Success Translations -->
 password.reset.success.heading=Vérifiez votre e-mail
+password.reset.success.body=Un e-mail avec un lien de réinitialisation de mot de passe et des instructions a été envoyé à votre e-mail.\n\nVous n'avez pas encore reçu d'e-mail?Votre adresse e-mail n'est pas enregistrée Ou vous vous êtes inscrit à l'aide d'un compte social avec l'e-mail fourni. Créez un compte ou utilisez une option de connexion différente.
 password.reset.success.action=Retour à la candidature
 # <!-- End of Password Reset Success Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_ja_JP.properties
@@ -43,6 +43,7 @@ password.reset.button=続行
 
 # <!-- Start of Password Reset Success Translations -->
 password.reset.success.heading=メールのチェック
+password.reset.success.body=パスワードリセットのリンクと手順が記載されたメールがお客様のメールアドレスに送信されました。\n\nまだメールが届きませんでしたか？メールアドレスが登録されていない場合があります または、提供されたメールアドレスを使ったソーシャルアカウントを使用してサインアップしています。アカウントを作成するか、別のログインオプションを使用してください。
 password.reset.success.action=アプリケーションに戻る
 # <!-- End of Password Reset Success Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_BR.properties
@@ -43,6 +43,7 @@ password.reset.button=Continuar
 
 # <!-- Start of Password Reset Success Translations -->
 password.reset.success.heading=Verifique seu e-mail
+password.reset.success.body=Um email com um link de redefinição de senha e instruções foi enviado para o seu email.\n\nAinda não recebeu um e-mail? Seu endereço de e-mail pode não estar registrado ou você se inscreveu usando uma conta social com o e-mail fornecido. Crie uma conta ou use uma opção de login diferente.
 password.reset.success.action=Voltar ao aplicativo
 # <!-- End of Password Reset Success Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_PT.properties
@@ -43,6 +43,7 @@ password.reset.button=Continuar
 
 # <!-- Start of Password Reset Success Translations -->
 password.reset.success.heading=Verifique seu e-mail
+password.reset.success.body=Um email com um link de redefinição de senha e instruções foi enviado para o seu email.\n\nAinda não recebeu um e-mail? Seu endereço de e-mail não está registrado Ou você se inscreveu usando uma conta social com o e-mail fornecido. Crie uma conta ou use uma opção de login diferente.
 password.reset.success.action=De volta ao aplicativo
 # <!-- End of Password Reset Success Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_zh_CN.properties
@@ -43,6 +43,7 @@ password.reset.button=继续
 
 # <!-- Start of Password Reset Success Translations -->
 password.reset.success.heading=查看你的邮件
+password.reset.success.body=带有密码重置链接的电子邮件已发送到您的电子邮件中。\n\n还没有收到电子邮件吗？您的电子邮件地址可能未注册 或者，您已经使用提供的电子邮件使用社交帐户注册。创建帐户或使用其他登录选项。
 password.reset.success.action=返回应用程序
 # <!-- End of Password Reset Success Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
@@ -54,7 +54,7 @@
                         String copyright = i18n(recoveryResourceBundle, customText, "copyright", __DEPRECATED__copyrightText);
                         if (StringUtils.isNotBlank(copyright)) {
                     %>
-                        <span class="copyright-text new-line-support"><%= copyright %></span>
+                        <span class="copyright-text line-break"><%= copyright %></span>
                     <% } %>
                     <%
                         if (StringUtils.isNotBlank(copyright) && !shouldRemoveDefaultBranding) {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
@@ -54,7 +54,7 @@
                         String copyright = i18n(recoveryResourceBundle, customText, "copyright", __DEPRECATED__copyrightText);
                         if (StringUtils.isNotBlank(copyright)) {
                     %>
-                        <span class="copyright-text"><%= copyright %></span>
+                        <span class="copyright-text new-line-support"><%= copyright %></span>
                     <% } %>
                     <%
                         if (StringUtils.isNotBlank(copyright) && !shouldRemoveDefaultBranding) {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -228,7 +228,7 @@
                                                     && !isQuestionBasedPasswordRecoveryEnabledByTenant) {
 
                             %>
-                            <label class="mb-5" for="username">
+                            <label class="mb-5 new-line-support" for="username">
                                 <%=i18n(recoveryResourceBundle, customText, "password.recovery.body")%>
                             </label>
                             <% }  %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -228,7 +228,7 @@
                                                     && !isQuestionBasedPasswordRecoveryEnabledByTenant) {
 
                             %>
-                            <label class="mb-5 new-line-support" for="username">
+                            <label class="mb-5 line-break" for="username">
                                 <%=i18n(recoveryResourceBundle, customText, "password.recovery.body")%>
                             </label>
                             <% }  %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-success.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-success.jsp
@@ -78,7 +78,7 @@
                     <%=i18n(recoveryResourceBundle, customText, "password.reset.success.heading")%>
                 </h3>
                 <p class="portal-tagline-description">
-                    <span class="new-line-support">
+                    <span class="line-break">
                         <%=i18n(recoveryResourceBundle, customText, "password.reset.success.heading")%>
                     </span>
                     <%

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-success.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-success.jsp
@@ -78,11 +78,9 @@
                     <%=i18n(recoveryResourceBundle, customText, "password.reset.success.heading")%>
                 </h3>
                 <p class="portal-tagline-description">
-                    <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "follow.reset.password.email.instructions")%>
-                    <br><br>
-                    <%= IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "didnt.receive.email.not.registered.alt") + " "
-                        + IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "signed.up.using.social.account.create.account.or.use.different.login")
-                    %>
+                    <span class="new-line-support">
+                        <%=i18n(recoveryResourceBundle, customText, "password.reset.success.heading")%>
+                    </span>
                     <%
                         if(StringUtils.isNotBlank(accessUrl)) {
                     %>

--- a/modules/form/src/components/adapters/text-field-adapter.scss
+++ b/modules/form/src/components/adapters/text-field-adapter.scss
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.text-field-adapter {
+    .MuiInputBase-root {
+        padding: 0;
+    }
+}

--- a/modules/form/src/components/adapters/text-field-adapter.tsx
+++ b/modules/form/src/components/adapters/text-field-adapter.tsx
@@ -21,6 +21,7 @@ import FormHelperText from "@oxygen-ui/react/FormHelperText";
 import TextField from "@oxygen-ui/react/TextField";
 import React, { FunctionComponent, ReactElement } from "react";
 import { FieldRenderProps } from "react-final-form";
+import "./text-field-adapter.scss";
 
 /**
  * Props for the TextFieldAdapter component.
@@ -66,6 +67,7 @@ const TextFieldAdapter: FunctionComponent<TextFieldAdapterPropsInterface> = (
     return (
         <>
             <TextField
+                className="text-field-adapter"
                 fullWidth={ fullWidth }
                 variant="outlined"
                 error={ isError }

--- a/modules/form/src/components/adapters/url-field-adapter.scss
+++ b/modules/form/src/components/adapters/url-field-adapter.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/form/src/components/adapters/url-field-adapter.scss
+++ b/modules/form/src/components/adapters/url-field-adapter.scss
@@ -1,3 +1,21 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 .url-field-adapter {
     .oxygen-input-label {
         color: var(--oxygen-palette-text-secondary);
@@ -14,7 +32,7 @@
         text-overflow: ellipsis;
         max-width: 100%;
     }
-    
+
     .oxygen-url-field {
         margin-top: 8px;
         margin-bottom: 3px;

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -503,6 +503,9 @@ export interface ConsoleNS {
                 "password.reset.success.action": {
                     hint: string;
                 };
+                "password.reset.success.body": {
+                    hint: string;
+                };
                 "password.reset.success.heading": {
                     hint: string;
                 };

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -687,6 +687,9 @@ export const console: ConsoleNS = {
                 "password.reset.success.action": {
                     hint: "The text that appears on the main action link of the password reset success box. If not set, {{productName}} defaults are used."
                 },
+                "password.reset.success.body": {
+                    hint: "The body text of the password reset success box. If not set, {{productName}} defaults are used."
+                },
                 "password.reset.success.heading": {
                     hint: "The heading of the password reset success box. If not set, {{productName}} defaults are used."
                 }

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -685,6 +685,9 @@ export const console: ConsoleNS = {
                 "password.reset.success.action": {
                     hint: "Le texte qui apparaît sur le lien d'action principal de la boîte de réussite de réinitialisation du mot de passe.Si ce n'est pas défini, {{productName}} Les défauts sont utilisés."
                 },
+                "password.reset.success.body": {
+                    hint: "Le texte du corps de la boîte de réussite de réinitialisation du mot de passe.Si ce n'est pas défini, {{productName}} Les défauts sont utilisés."
+                },
                 "password.reset.success.heading": {
                     hint: "L'en-tête de la boîte de réussite de réinitialisation du mot de passe.Si ce n'est pas défini, {{productName}} Les défauts sont utilisés."
                 }

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -693,6 +693,9 @@ export const console: ConsoleNS = {
                 "password.reset.success.action": {
                     hint: "මුරපදයේ මූලික කේතයේ ප්රධාන ක්රියාකාරී සබැඳියේ දිස්වන පෙළ.සකසා නොමැති නම්, {{productName}} පෙරනිමි භාවිතා වේ."
                 },
+                "password.reset.success.body": {
+                    hint: "මුරපදයේ ශරීර පෙළ නැවත සකස් කිරීමේ කොටුව.සකසා නොමැති නම්, {{productName}} පෙරනිමි භාවිතා වේ."
+                },
                 "password.reset.success.heading": {
                     hint: "මුරපදයේ ශීර්ෂය RESURD BOOTEX යළි පිහිටුවීම.සකසා නොමැති නම්, {{productName}} පෙරනිමි භාවිතා වේ."
                 }

--- a/modules/theme/src/theme-core/definitions/apps/login-portal.less
+++ b/modules/theme/src/theme-core/definitions/apps/login-portal.less
@@ -247,6 +247,15 @@
             }
         }
 
+        /* SMS OTP interface */
+        .sms-otp-portal-layout {
+            .sms-otp-fields {
+                @media screen and (min-width: 500px) {
+                    flex-wrap: nowrap;
+                }
+            }
+        }
+
         .cookie-policy-message {
             font-size: 14px;
         }
@@ -298,8 +307,8 @@
 ------------------------------*/
 
 a.session-refresh {
-    float: right; 
-    margin-bottom: 5px; 
+    float: right;
+    margin-bottom: 5px;
 }
 
 .active-sessions-table tr {

--- a/modules/theme/src/theme-core/definitions/globals/product.less
+++ b/modules/theme/src/theme-core/definitions/globals/product.less
@@ -454,6 +454,11 @@ body {
     }
 }
 
+/** Helper class to support new line */
+.line-break {
+    white-space: pre-line;
+}
+
 /*****************************************
                 Layout
 *****************************************/

--- a/modules/theme/src/themes/wso2is/apps/login-portal.overrides
+++ b/modules/theme/src/themes/wso2is/apps/login-portal.overrides
@@ -165,20 +165,6 @@
             }
         }
 
-        /** Helper class to support new line */
-        .line-break {
-            white-space: pre-line;
-        }
-
-        /* SMS OTP interface */
-        .sms-otp-portal-layout {
-            .sms-otp-fields {
-                @media screen and (min-width: 500px) {
-                    flex-wrap: nowrap;
-                }
-            }
-        }
-
         input[type="password"]::-ms-reveal,
         input[type="password"]::-ms-clear {
             display: none;

--- a/modules/theme/src/themes/wso2is/apps/login-portal.overrides
+++ b/modules/theme/src/themes/wso2is/apps/login-portal.overrides
@@ -165,6 +165,19 @@
             }
         }
 
+        .new-line-support {
+            white-space: pre-line;
+        }
+
+        /* SMS OTP interface */
+        .sms-otp-portal-layout {
+            .sms-otp-fields {
+                @media screen and (min-width: 500px) {
+                    flex-wrap: nowrap;
+                }
+            }
+        }
+
         input[type="password"]::-ms-reveal,
         input[type="password"]::-ms-clear {
             display: none;
@@ -565,7 +578,6 @@
             }
 
             .copyright-text {
-                white-space: pre-line;
                 text-align: center;
             }
 

--- a/modules/theme/src/themes/wso2is/apps/login-portal.overrides
+++ b/modules/theme/src/themes/wso2is/apps/login-portal.overrides
@@ -165,6 +165,7 @@
             }
         }
 
+        /** Helper class to support new line */
         .new-line-support {
             white-space: pre-line;
         }

--- a/modules/theme/src/themes/wso2is/apps/login-portal.overrides
+++ b/modules/theme/src/themes/wso2is/apps/login-portal.overrides
@@ -166,7 +166,7 @@
         }
 
         /** Helper class to support new line */
-        .new-line-support {
+        .line-break {
             white-space: pre-line;
         }
 


### PR DESCRIPTION
### Purpose
Add text customization to the password-reset-success interface

### Related Issues
- https://github.com/wso2/product-is/issues/19155

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
