### PR TITLE
Remove permission assignment from console admin role

### DIFF
--- a/.changeset/big-trees-trade.md
+++ b/.changeset/big-trees-trade.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Remove permission assignment from console admin role

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -21,7 +21,6 @@ package org.wso2.identity.apps.common.util;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.api.resource.mgt.APIResourceMgtException;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.AssociatedRolesConfig;
@@ -31,7 +30,6 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
 import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
-import org.wso2.carbon.identity.application.common.model.Scope;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
@@ -44,7 +42,6 @@ import org.wso2.carbon.identity.oauth2.OAuth2Constants;
 import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
-import org.wso2.carbon.identity.role.v2.mgt.core.model.Permission;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
 import org.wso2.carbon.user.core.UserRealm;
@@ -374,19 +371,6 @@ public class AppPortalUtils {
         }
 
         return null;
-    }
-
-    private static List<Permission> getAllPermissions(String tenantDomain)
-        throws IdentityApplicationManagementException {
-
-        try {
-            List<Scope> scopes = AppsCommonDataHolder.getInstance().getAPIResourceManager()
-                .getSystemAPIScopes(tenantDomain);
-            return scopes.stream().map(scope -> new Permission(scope.getName())).collect(Collectors.toList());
-        } catch (APIResourceMgtException e) {
-            throw new IdentityApplicationManagementException("Error while retrieving internal scopes for tenant " +
-                "domain : " + tenantDomain, e);
-        }
     }
 
     private static void shareApplication(String tenantDomain, int tenantId, String appId, String appName,

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -432,7 +432,7 @@ public class AppPortalUtils {
         try {
             String userID = getUserId(appOwner, tenantId);
             AppsCommonDataHolder.getInstance().getRoleManagementServiceV2().addRole(ADMINISTRATOR,
-                Collections.singletonList(userID), Collections.emptyList(), getAllPermissions(tenantDomain),
+                Collections.singletonList(userID), Collections.emptyList(), Collections.emptyList(),
                 APPLICATION, appId, tenantDomain);
         } catch (IdentityRoleManagementException e) {
             throw new IdentityApplicationManagementException("Failed to add Administrator role for the " +


### PR DESCRIPTION
### Purpose
> $subject since permission assignment of the console role is handled with listeners with the https://github.com/wso2/carbon-identity-framework/pull/5479 change

### Related Issues
- https://github.com/wso2/product-is/issues/19321

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5479