### PR TITLE
Add authType hidden input to hyprlogin

### DIFF
--- a/.changeset/sixty-bobcats-hope.md
+++ b/.changeset/sixty-bobcats-hope.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+add hidden input to hyprelogin

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/hyprlogin.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/hyprlogin.jsp
@@ -83,6 +83,7 @@
                         </div>
                         <input id="sessionDataKeyLoginForm" type="hidden" name="sessionDataKey"
                             value='<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>' />
+                        <input id="authType" name="authType" type="hidden" value="hypr">
                         <div class="ui divider hidden"></div>
                         <div class="align-center buttons">
                             <button type="button" class="ui primary large button" tabindex="4" role="button"
@@ -101,6 +102,7 @@
                     <form id="completeAuthenticationForm" action="<%=commonauthURL%>" method="POST">
                         <input id="sessionDataKeyAuthenticationForm" type="hidden" name="sessionDataKey"
                         value='<%=Encode.forHtmlAttribute(request.getParameter("sessionDataKey"))%>' />
+                        <input id="authType" name="authType" type="hidden" value="hypr">
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
### Purpose
> This adds a hidden input called `authType` when submitting the username so that it can be used to distinguish the HYPR authenticator in the canHandle method of the BE.

### Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/21750

### Related PRs
- Related PR https://github.com/wso2-extensions/identity-outbound-auth-hypr/pull/18

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
