### PR TITLE
Add info message to the SMS OTP Connection

### DIFF
--- a/.changeset/flat-cats-move.md
+++ b/.changeset/flat-cats-move.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+"@wso2is/myaccount": patch
+---
+
+Add info message to the SMS Provider

--- a/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,13 +18,17 @@
 
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Form } from "@wso2is/form";
-import { Code } from "@wso2is/react-components";
+import { Code, Link } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import isBoolean from "lodash-es/isBoolean";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { Label } from "semantic-ui-react";
+import { Icon, Label, Message } from "semantic-ui-react";
+import {
+    AppConstants,
+    history
+} from "../../../../core";
 import { IdentityProviderManagementConstants } from "../../../constants";
 import {
     CommonAuthenticatorFormFieldInterface,
@@ -349,6 +353,27 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
             initialValues={ initialValues }
             validate={ validateForm }
         >
+            <Message info>
+                <Icon name="info circle" />
+                <Trans
+                    i18nKey={
+                        "console:develop.features.authenticationProvider.forms.authenticatorSettings" +
+                        ".smsOTP.hint"
+                    }
+                >
+                    Ensure that an
+                    <Link
+                        external={ false }
+                        onClick={ () => {
+                            history.push(
+                                AppConstants.getPaths().get("SMS_PROVIDER")
+                            );
+                        } }
+                    > SMS Provider
+                    </Link>
+                    &nbsp;is configured for the OTP feature to work properly.
+                </Trans>
+            </Message>
             <Field.Input
                 ariaLabel="SMS OTP expiry time"
                 inputType="number"

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -1819,6 +1819,7 @@ export interface ConsoleNS {
                             };
                         };
                         smsOTP: {
+                            hint: string;
                             expiryTime: {
                                 hint: string;
                                 label: string;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -4001,6 +4001,7 @@ export const console: ConsoleNS = {
                             }
                         },
                         smsOTP: {
+                            hint: "Ensure that an <1>SMS Provider</1> is configured for the OTP feature to work properly.",
                             expiryTime: {
                                 hint: "Please pick a value between <1>1 minute</1> & <3> 1440 minutes (1 day)</3>.",
                                 label: "SMS OTP expiry time",


### PR DESCRIPTION
### Purpose
> Add info message to the SMS OTP Connection

<img width="713" alt="Screenshot 2024-02-09 at 13 59 17" src="https://github.com/wso2/identity-apps/assets/27746285/e87c2bf1-df63-4cb8-a046-f2cd438dd59b">

### Related Issues
- https://github.com/wso2/product-is/issues/18650

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
