### PR TITLE
Avoid making an organization switch call for users who directly SSO to the console.

### DIFF
--- a/.changeset/itchy-monkeys-cheat.md
+++ b/.changeset/itchy-monkeys-cheat.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Avoid making an organization switch call for users who directly SSO to the console.

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -175,7 +175,8 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
             };
 
             try {
-                if (getOrganizationName()) {
+                // The organization switch is not needed for organization users who directly SSO to the organization.
+                if (getOrganizationName() && signInResponse.userOrg != signInResponse.orgId) {
                     response = await switchOrganization(getOrganizationName());
                 } else {
                     response = { ...signInResponse };


### PR DESCRIPTION

### Purpose
- Avoid making an organization switch call for users who directly SSO to the console.

### Related Issues
- https://github.com/wso2/product-is/issues/19175#issuecomment-1935495115

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
