### PR TITLE
Only show `Outbound Provisioning` section in Application configurations for migrating users

### DIFF
--- a/.changeset/gentle-beers-collect.md
+++ b/.changeset/gentle-beers-collect.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Only show `Outbound Provisioning` section in Application configurations for migrating users

--- a/apps/console/src/features/applications/components/settings/provisioning/provisioning-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/provisioning/provisioning-settings.tsx
@@ -18,7 +18,8 @@
 
 import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
-import React, { FunctionComponent, ReactElement } from "react";
+import { EmphasizedSegment } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement, useMemo } from "react";
 import { useSelector } from "react-redux";
 import { Grid } from "semantic-ui-react";
 import { InboundProvisioningConfigurations } from "./inbound-provisioning-configuration";
@@ -72,41 +73,49 @@ export const ProvisioningSettings: FunctionComponent<ProvisioningSettingsPropsIn
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
 
+    const shouldShowOutboundProvisioningConfigurations: boolean = useMemo(() => {
+        return application?.provisioningConfigurations?.outboundProvisioningIdps?.length > 0;
+    }, [ application ]);
+
     return (
-        <Grid>
-            <Grid.Row columns={ 1 }>
-                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 12 }>
-                    <InboundProvisioningConfigurations
-                        appId={ application.id }
-                        provisioningConfigurations={ provisioningConfigurations }
-                        onUpdate={ onUpdate }
-                        readOnly={
-                            readOnly
-                            || !hasRequiredScopes(featureConfig?.applications,
-                                featureConfig?.applications?.scopes?.update,
-                                allowedScopes)
-                        }
-                        data-testid={ `${ componentId }-inbound-configuration` }
-                    />
-                </Grid.Column>
-            </Grid.Row>
-            <Grid.Row>
-                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 12 }>
-                    <OutboundProvisioningConfiguration
-                        application={ application }
-                        provisioningConfigurations={ provisioningConfigurations }
-                        onUpdate={ onUpdate }
-                        readOnly={
-                            readOnly
-                            || !hasRequiredScopes(featureConfig?.applications,
-                                featureConfig?.applications?.scopes?.update,
-                                allowedScopes)
-                        }
-                        data-testid={ `${ componentId }-outbound-configuration` }
-                    />
-                </Grid.Column>
-            </Grid.Row>
-        </Grid>
+        <EmphasizedSegment padded="very">
+            <Grid>
+                <Grid.Row columns={ 1 }>
+                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 12 }>
+                        <InboundProvisioningConfigurations
+                            appId={ application.id }
+                            provisioningConfigurations={ provisioningConfigurations }
+                            onUpdate={ onUpdate }
+                            readOnly={
+                                readOnly
+                                || !hasRequiredScopes(featureConfig?.applications,
+                                    featureConfig?.applications?.scopes?.update,
+                                    allowedScopes)
+                            }
+                            data-testid={ `${ componentId }-inbound-configuration` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                { shouldShowOutboundProvisioningConfigurations &&  (
+                    <Grid.Row>
+                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 12 }>
+                            <OutboundProvisioningConfiguration
+                                application={ application }
+                                provisioningConfigurations={ provisioningConfigurations }
+                                onUpdate={ onUpdate }
+                                readOnly={
+                                    readOnly
+                                    || !hasRequiredScopes(featureConfig?.applications,
+                                        featureConfig?.applications?.scopes?.update,
+                                        allowedScopes)
+                                }
+                                data-testid={ `${ componentId }-outbound-configuration` }
+                            />
+                        </Grid.Column>
+                    </Grid.Row>
+                ) }
+            </Grid>
+        </EmphasizedSegment>
     );
 };
 


### PR DESCRIPTION
### Purpose

Only show `Outbound Provisioning` section in Application configurations for migrating users since there are feature gaps.

#### New Apps
<img width="1692" alt="Screenshot 2024-02-09 at 19 41 43" src="https://github.com/wso2/identity-apps/assets/25959096/79cbde97-7f08-42b0-b395-755268193211">

####  Migrating Apps with Outbound Configs
<img width="1699" alt="Screenshot 2024-02-09 at 19 42 17" src="https://github.com/wso2/identity-apps/assets/25959096/72d7fc97-3919-419a-9a68-9be8707d8723">

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/19473

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
