### PR TITLE
Ignore user existing error when JIT Provisioning if JITProvisioning.AllowAssociatingToExistingUser configuration is enabled.

### DIFF
--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -41,6 +41,7 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ValidationConfigurationRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
 <%@ page import="org.wso2.carbon.utils.multitenancy.MultitenantUtils" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.Arrays" %>
 <%@ page import="java.util.List" %>
@@ -171,6 +172,18 @@
     }
 
     Integer userNameValidityStatusCode = usernameValidityResponse.getInt("code");
+
+    final String ALLOW_ASSOCIATING_TO_EXISTING_USER = "JITProvisioning.AllowAssociatingToExistingUser";
+    boolean allowAssociationToExistingUser = Boolean.parseBoolean(
+                                IdentityUtil.getProperty(ALLOW_ASSOCIATING_TO_EXISTING_USER));
+
+    if (consentPurposeGroupName == "JIT" && userNameValidityStatusCode != null && allowAssociationToExistingUser) {
+        String errorCode = String.valueOf(userNameValidityStatusCode);
+        if (SelfRegistrationStatusCodes.ERROR_CODE_USER_ALREADY_EXISTS.equalsIgnoreCase(errorCode)) {
+             userNameValidityStatusCode = Integer.valueOf(SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE);
+        }
+    }
+
     if (!SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE.equalsIgnoreCase(userNameValidityStatusCode.toString())) {
         if (allowchangeusername || !skipSignUpEnableCheck) {
             request.setAttribute("error", true);


### PR DESCRIPTION
### Purpose
In JIT provisioning, in the current implementation, if `AllowAssociatingToExistingUser` configuration is enabled the user is allowed to associate with an already existing user. However, in provisioning methods other than silent provisioning this is not allowed since the username validation response is returning status as user already existing. Then an error is thrown.
This behaviour should change to ignore this status for the JIT provisioning flow when `AllowAssociatingToExistingUser` configuration is enabled. 
This PR adds a check to the JIT provisioning flow to check if the user validation response status is equal to user already existing status and if so, then set the status to user name available.

### Related Issue
https://github.com/wso2/product-is/issues/19493
