### PR TITLE
Implement grouping of dynamic connectors to existing groups if present

### DIFF
--- a/.changeset/dull-falcons-cheat.md
+++ b/.changeset/dull-falcons-cheat.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+"@wso2is/myaccount": patch
+"@wso2is/common": patch
+---
+
+Fix grouping in dynamic governance connectors

--- a/apps/console/src/features/server-configurations/components/governance-connector-grid.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connector-grid.tsx
@@ -87,7 +87,7 @@ const GovernanceConnectorCategoriesGrid: FunctionComponent<GovernanceConnectorCa
             ...connectorCategories
         ];
 
-        // Add the dynamic connectors to the combined list according to the title.
+        // Add the dynamic connectors to the combined list grouped by title.
         serverConfigurationConfig.dynamicConnectors && dynamicConnectors?.length > 0 && dynamicConnectors.forEach(
             (dynamicConnector: GovernanceConnectorCategoryInterface) => {
                 const index: number = combined.findIndex((category: GovernanceConnectorCategoryInterface) =>

--- a/apps/console/src/features/server-configurations/components/governance-connector-grid.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connector-grid.tsx
@@ -88,7 +88,7 @@ const GovernanceConnectorCategoriesGrid: FunctionComponent<GovernanceConnectorCa
         ];
 
         // Add the dynamic connectors to the combined list according to the title.
-        serverConfigurationConfig.dynamicConnectors && dynamicConnectors?.length < 0 && dynamicConnectors?.forEach(
+        serverConfigurationConfig.dynamicConnectors && dynamicConnectors?.length > 0 && dynamicConnectors.forEach(
             (dynamicConnector: GovernanceConnectorCategoryInterface) => {
                 const index: number = combined.findIndex((category: GovernanceConnectorCategoryInterface) =>
                     category?.title === dynamicConnector?.title);

--- a/apps/console/src/features/server-configurations/models/governance-connectors.ts
+++ b/apps/console/src/features/server-configurations/models/governance-connectors.ts
@@ -47,11 +47,16 @@ export interface GovernanceConnectorInterface {
 	subCategory: string;
 	properties: ConnectorPropertyInterface[];
 	displayName: string;
+    header?: string;
+    isCustom?: boolean;
+    route?: string;
+    testId?: string;
 }
 
 export interface GovernanceConnectorCategoryInterface {
 	id?: string;
 	name?: string;
+    title?: string;
 	description?: string;
 	connectors?: GovernanceConnectorInterface[];
 	route?: string;

--- a/apps/console/src/features/server-configurations/pages/connector-listing-page.tsx
+++ b/apps/console/src/features/server-configurations/pages/connector-listing-page.tsx
@@ -176,6 +176,11 @@ export const ConnectorListingPage: FunctionComponent<ConnectorListingPageInterfa
         resolveDynamicCategories(dynamicConnectorCategories);
     }, [ dynamicConnectorCategories ]);
 
+    /**
+     * This will get the information from dynamic categories and will be combined with the existing categories
+     *
+     * @param categories - Dynamic categories to get information from
+     */
     const resolveDynamicCategories = async (categories: GovernanceConnectorCategoryInterface[]): Promise<void> => {
         const dynamicConnectorCategoryArray: GovernanceConnectorCategoryInterface[] = [];
 
@@ -198,6 +203,11 @@ export const ConnectorListingPage: FunctionComponent<ConnectorListingPageInterfa
         ]);
     };
 
+    /**
+     * This will get the information from a given category
+     *
+     * @param categoryId - ID of the category
+     */
     const loadCategoryConnectors = (categoryId: string): Promise<GovernanceConnectorCategoryInterface | null> => {
         return getConnectorCategory(categoryId)
             .then((response: GovernanceConnectorCategoryInterface) => {

--- a/apps/console/src/features/server-configurations/pages/connector-listing-page.tsx
+++ b/apps/console/src/features/server-configurations/pages/connector-listing-page.tsx
@@ -185,10 +185,10 @@ export const ConnectorListingPage: FunctionComponent<ConnectorListingPageInterfa
 
         for (const category of categories) {
             if (!serverConfigurationConfig.predefinedConnectorCategories.includes(category.id)) {
-                const connectorCategory: GovernanceConnectorCategoryInterface =
+                const connectorCategory: GovernanceConnectorCategoryInterface | null =
                     await loadCategoryConnectors(category.id);
 
-                dynamicConnectorCategoryArray.push(connectorCategory);
+                connectorCategory && dynamicConnectorCategoryArray.push(connectorCategory);
             }
         }
 

--- a/apps/console/src/features/validation/pages/validation-config-edit.tsx
+++ b/apps/console/src/features/validation/pages/validation-config-edit.tsx
@@ -356,14 +356,7 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
      * Handle back button click.
      */
     const handleBackButtonClick = () => {
-        history.push(
-            AppConstants.getPaths()
-                .get("GOVERNANCE_CONNECTOR")
-                .replace(
-                    ":id",
-                    ServerConfigurationsConstants.LOGIN_ATTEMPT_SECURITY_CONNECTOR_CATEGORY_ID
-                )
-        );
+        history.push(AppConstants.getPaths().get("LOGIN_AND_REGISTRATION"));
     };
 
     const validateForm = (values: ValidationFormInterface): boolean => {

--- a/modules/i18n/src/models/namespaces/console-ns.ts
+++ b/modules/i18n/src/models/namespaces/console-ns.ts
@@ -4757,6 +4757,7 @@ export interface ConsoleNS {
                 categories: string;
                 pageSubHeading: string;
                 connectorSubHeading: string;
+                genericDescription?: string;
                 connectorCategories: {
                     passwordPolicies : {
                         name: string;

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -9261,6 +9261,7 @@ export const console: ConsoleNS = {
                         positiveIntegers: "The number should not be less than 0."
                     }
                 },
+                genericDescription: "Configure settings related to {{ name }} connector.",
                 notifications: {
                     getConnector: {
                         error: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -7642,6 +7642,7 @@ export const console: ConsoleNS = {
                         positiveIntegers: "Le nombre ne doit pas être inférieur à 0."
                     }
                 },
+                genericDescription: "Configurer les paramètres liés au connecteur {{nom}}.",
                 notifications: {
                     getConnector: {
                         error: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -7474,6 +7474,7 @@ export const console: ConsoleNS = {
                         positiveIntegers: "අංකය 0 ට නොඅඩු විය යුතුය."
                     }
                 },
+                genericDescription: "{{Name}} සම්බන්ධකයට අදාළ සැකසුම් වින්යාස කරන්න.",
                 notifications: {
                     getConnector: {
                         error: {


### PR DESCRIPTION
### Purpose
$subject
Now custom connectors will appear under existing categories (if any) instead of repeating the category. If it belong to a new category, it will create a new category and will appear under it.

**Before**
![image](https://github.com/wso2/identity-apps/assets/42619922/8a503f98-00a4-466c-8cbd-b01c00c72557)


**After**
![Screenshot 2024-02-12 at 15 00 20](https://github.com/wso2/identity-apps/assets/42619922/6d0eba80-d4b3-424c-aa64-6612f6d41139)



### Related Issues
- https://github.com/wso2/product-is/issues/19125

### Related PRs
- https://github.com/wso2/identity-apps/pull/5468

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
