### PR TITLE
[bug-fix] Onboard the organization-wise JWT Token re-use config

### DIFF
--- a/.changeset/rare-llamas-vanish.md
+++ b/.changeset/rare-llamas-vanish.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Onboard the organization-wise JWT Token re-use config

--- a/apps/console/src/extensions/configs/server-configuration.tsx
+++ b/apps/console/src/extensions/configs/server-configuration.tsx
@@ -72,7 +72,6 @@ export const serverConfigurationConfig: ServerConfigurationConfig = {
     },
     connectorsToHide: [
         ServerConfigurationsConstants.ALTERNATIVE_LOGIN_IDENTIFIER,
-        ServerConfigurationsConstants.PRIVATE_KEY_JWT_CLIENT_AUTH,
         ServerConfigurationsConstants.USERNAME_VALIDATION,
         ServerConfigurationsConstants.CONSENT_INFO_CONNECTOR_ID,
         ServerConfigurationsConstants.WSO2_ANALYTICS_ENGINE_CONNECTOR_CATEGORY_ID,

--- a/apps/console/src/features/core/utils/route-utils.ts
+++ b/apps/console/src/features/core/utils/route-utils.ts
@@ -318,7 +318,8 @@ export class RouteUtils {
             AppConstants.getPaths().get("MULTI_ATTRIBUTE_LOGIN"),
             AppConstants.getPaths().get("VALIDATION_CONFIG_EDIT"),
             AppConstants.getPaths().get("ORGANIZATION_DISCOVERY_DOMAINS"),
-            AppConstants.getPaths().get("OUTBOUND_PROVISIONING_SETTINGS")
+            AppConstants.getPaths().get("OUTBOUND_PROVISIONING_SETTINGS"),
+            AppConstants.getPaths().get("PRIVATE_KEY_JWT_CONFIG_EDIT")
         ];
 
         const CategoryMappedRoutes: Omit<RouteInterface, "showOnSidePanel">[] = [


### PR DESCRIPTION
### Purpose
> "Private Key JWT Client Authentication for OIDC" has been removed from IS 7.0. This will be enabled with this PR.

![image](https://github.com/wso2/identity-apps/assets/37938529/99ff5781-ec2e-49b7-aba6-f9e96025a1f5)

![image](https://github.com/wso2/identity-apps/assets/37938529/ee609164-c11a-4102-8d4c-a362f2af4e44)


### Related Issues
- https://github.com/wso2/product-is/issues/19502

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
