### PR TITLE
Improve logic to display Google private key file picker

### DIFF
--- a/.changeset/khaki-parents-march.md
+++ b/.changeset/khaki-parents-march.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Improve logic to display google private key file picker

--- a/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
@@ -67,8 +67,8 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
         dynamicValues?.properties?.map(
             (prop: CommonPluggableComponentPropertyInterface) =>
             {
-                if (prop.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY) {
-                    setPrivateKeyValue(prop.value);
+                if (prop?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY) {
+                    setPrivateKeyValue(prop?.value);
                 }
             }
         );
@@ -117,10 +117,28 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
             }
 
             if (
-                !values.has(ConnectionManagementConstants.GOOGLE_PRIVATE_KEY)
-                && !properties?.find(
-                    (item: CommonPluggableComponentMetaPropertyInterface) =>
-                        item?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY)){
+                (
+                    // Check whether the values has the google private key.
+                    !values.has(ConnectionManagementConstants.GOOGLE_PRIVATE_KEY)
+                    // Check whether the property values list does not have the google private key-value pair.
+                    && !properties?.find(
+                        (item: CommonPluggableComponentPropertyInterface) =>
+                            (item?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY))
+                    // Check whether the properties key-value pair has the value undefined.
+                    && properties?.find(
+                        (item: CommonPluggableComponentPropertyInterface) => (
+                            item?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY
+                            && item?.value !== undefined
+                        )
+                    )
+                ) || (
+                    // // Check whether the properties key-value pair has an already added google private key.
+                    !properties?.find(
+                        (item: CommonPluggableComponentPropertyInterface) =>
+                            (item?.key === ConnectionManagementConstants.GOOGLE_PRIVATE_KEY))
+                        && privateKeyValue !== undefined
+                )
+            ){
                 properties.push({
                     key: ConnectionManagementConstants.GOOGLE_PRIVATE_KEY,
                     value: privateKeyValue

--- a/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/helpers/form-fields-helper.tsx
@@ -191,7 +191,8 @@ export const getUserIdClaimRadioButtonField = (
     eachProp: CommonPluggableComponentPropertyInterface,
     propertyMetadata: CommonPluggableComponentMetaPropertyInterface,
     listen: (key: string, values: Map<string, FormValue>) => void,
-    testId?: string): ReactElement => {
+    testId?: string
+): ReactElement => {
     const options: StrictRadioChild[] = [
         {
             label: "Use NameID as the User Identifier",

--- a/apps/console/src/features/identity-providers/components/forms/helpers/form-fields-helper.tsx
+++ b/apps/console/src/features/identity-providers/components/forms/helpers/form-fields-helper.tsx
@@ -187,12 +187,21 @@ export const getRadioButtonField = (eachProp: CommonPluggableComponentPropertyIn
     );
 };
 
-// Add a radio field for user id in claims with predefined options.
+/**
+ * Radio input field for user id in claims with predefined options.
+ *
+ * @param eachProp - Property value.
+ * @param propertyMetadata - Property metadata.
+ * @param listen - Callblack.
+ * @param testId - data test id.
+ * @returns User id in claims property field.
+ */
 export const getUserIdClaimRadioButtonField = (
     eachProp: CommonPluggableComponentPropertyInterface,
     propertyMetadata: CommonPluggableComponentMetaPropertyInterface,
     listen: (key: string, values: Map<string, FormValue>) => void,
-    testId?: string): ReactElement => {
+    testId?: string
+) : ReactElement => {
     const options: StrictRadioChild[] = [
         {
             label: "Use NameID as the User Identifier",


### PR DESCRIPTION
### Purpose
> Improve logic to display Google private key file picker.

https://github.com/wso2/identity-apps/assets/27746285/ee1cb5bc-e57a-4685-93e0-957316cc6852

### Related Issues
- https://github.com/wso2/product-is/issues/19449

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
