### PR TITLE
Fix the missing connection name issue in the warning alert

### DIFF
--- a/.changeset/six-parents-rhyme.md
+++ b/.changeset/six-parents-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix the missing connection name issue in the warning alert

--- a/apps/console/src/features/authentication-flow-builder/components/predefined-flows-side-panel/duplicate-social-authenticator-selection-modal.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/predefined-flows-side-panel/duplicate-social-authenticator-selection-modal.tsx
@@ -120,7 +120,7 @@ const DuplicateSocialAuthenticatorSelectionModal: FunctionComponent<
                         }
                         tOptions={ { authenticator: authenticatorCategoryDisplayName } }
                     >
-                        You have multiple Social Connections configured with{ " " }
+                        You have multiple Social Connections configured with &nbsp;
                         <Code>
                             { authenticatorCategoryDisplayName }
                             Authenticator


### PR DESCRIPTION
### Purpose
> Fix the missing connection name issue in the warning alert
<img width="429" alt="Screenshot 2024-02-13 at 15 14 56" src="https://github.com/wso2/identity-apps/assets/27746285/bac16794-2bdf-4615-bb14-ed74f3a74a92">

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
