### PR TITLE
Improve the content of the attribute section in connections

### DIFF
--- a/.changeset/little-ads-give.md
+++ b/.changeset/little-ads-give.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/myaccount": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Improve the messaging of the group attribute dropdown in connections

--- a/apps/console/src/features/connections/components/edit/settings/attribute-management/uri-attributes-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/attribute-management/uri-attributes-settings.tsx
@@ -149,9 +149,9 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
                                         ".uriAttributeSettings.subject.hint"
                                     }
                                 >
-                                The attribute that identifies the user at the enterprise identity provider.
+                                The attribute that identifies the user at the enterprise connection.
                                 When attributes are configured based on the authentication response of this
-                                IdP connection, you can use one of them as the subject. Otherwise, the
+                                connection, you can use one of them as the subject. Otherwise, the
                                 default <Code>saml2:Subject</Code> in the SAML response is used as the
                                 subject attribute.
                                 </Trans>
@@ -163,7 +163,7 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
                                         ".subject.hint"
                                     }
                                 >
-                                Specifies the attribute that identifies the user at the identity provider.
+                                Specifies the attribute that identifies the user at the connection.
                                 </Trans>
                             )
                         }
@@ -245,7 +245,7 @@ export const UriAttributesSettings: FunctionComponent<AdvanceAttributeSettingsPr
                                                     : ConnectionManagementConstants.CLAIM_ROLES }</strong>
                                                  attribute will be considered as the default
                                                 <strong> Group Attribute</strong> as you have not added a
-                                                custom attribute mapping for the connection roles attribute.
+                                                custom attribute.
                                             </Trans>
                                         )
                                     }

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -4598,7 +4598,7 @@ export const console: ConsoleNS = {
                             label: "Group Attribute",
                             message: "Please note that <1>{{ attribute }}</1> attribute will be considered as the default " +
                                 "<1>Group Attribute</1> as you have not added a custom attribute " +
-                                "mapping for the connection roles attribute.",
+                                "mapping.",
                             placeHolder: "Select the attribute",
                             validation: {
                                 empty: "Please select an attribute for groups"
@@ -5846,7 +5846,7 @@ export const console: ConsoleNS = {
                             },
                             attributeMapTable: {
                                 mappedAttributeColumnHeader: "Mapped Attribute",
-                                externalAttributeColumnHeader: "External IdP Attribute"
+                                externalAttributeColumnHeader: "External Connection Attribute"
                             },
                             heading: "Connection Attribute Mappings",
                             subheading: "Add and map the supported attributes from external connection.",

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -4606,9 +4606,9 @@ export const console: ConsoleNS = {
                         },
                         subject: {
                             heading: "Subject",
-                            hint: "The attribute that identifies the user at the enterprise identity provider. " +
+                            hint: "The attribute that identifies the user at the enterprise connection. " +
                                 "When attributes are configured based on the authentication response of " +
-                                "this IdP connection, you can use one of them as the subject. " +
+                                "this connection, you can use one of them as the subject. " +
                                 "Otherwise, the default <1>saml2:Subject</1> in the SAML response is used " +
                                 "as the subject attribute.",
                             label: "Subject Attribute",

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -3801,7 +3801,7 @@ export const console: ConsoleNS = {
                             label: "Attribut de groupe",
                             message: "Veuillez noter que l'attribut <1>{{attribut }}</1> sera considéré " +
                                 "comme <1>attribut de groupe</1> par défaut car vous n'avez pas ajouté de " +
-                                "mappage d'attribut personnalisé pour l'attribut des rôles de connexion.",
+                                "mappage d'attribut personnalisé.",
                             placeHolder: "Sélectionnez l'attribut",
                             validation: {
                                 empty: "Veuillez sélectionner un attribut pour les groupes"
@@ -4213,7 +4213,7 @@ export const console: ConsoleNS = {
                             },
                             attributeMapTable: {
                                 mappedAttributeColumnHeader: "Attribut mappé",
-                                externalAttributeColumnHeader: "Attribut IdP externe"
+                                externalAttributeColumnHeader: "Attribut de connexion externe"
                             },
                             heading: "Mappages d'attributs de connexion",
                             subheading: "Ajoutez et mappez les attributs pris en charge à partir du connexion externe.",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -3700,7 +3700,7 @@ export const console: ConsoleNS = {
                             heading: "සමූහය",
                             hint: "සම්බන්ධතාවයේ ඇති කණ්ඩායම් හඳුනා ගන්නා ගුණාංගය නියම කරයි.",
                             label: "කණ්ඩායම් ගුණාංගය",
-                            message: "ඔබ සම්බන්ධතා භූමිකාවන් සඳහා අභිරුචි ගුණාංග සිතියම්ගත කිරීමක් එක් කර " +
+                            message: "ඔබ අභිරුචි ගුණාංග සිතියම්ගත කිරීමක් එක් කර " +
                                 "නොමැති බැවින් <1>{{ attribute }}</1> ගුණාංගය පෙරනිමියෙන් <1>කණ්ඩායම් ගුණාංගය</1> " +
                                 "ලෙස සලකනු ඇති බව කරුණාවෙන් සලකන්න.",
                             placeHolder: "ගුණාංගය තෝරන්න",
@@ -4105,7 +4105,7 @@ export const console: ConsoleNS = {
                             },
                             attributeMapTable: {
                                 mappedAttributeColumnHeader: "සිතියම්ගත කළ ගුණාංගය",
-                                externalAttributeColumnHeader: "බාහිර IdP ගුණාංගය"
+                                externalAttributeColumnHeader: "බාහිර සම්බන්ධතා ගුණාංගය"
                             },
                             heading: "අනන්‍යතා සපයන්නාගේ ගුණාංග සිතියම්ගත කිරීම්",
                             subheading: "බාහිර අනන්‍යතා සපයන්නා වෙතින් සහාය දක්වන උපලක්ෂණ එකතු කර සිතියම්ගත කරන්න.",


### PR DESCRIPTION
### Purpose
> This PR addresses the following

- Remove the `identity provider` references
- Improve the message of the group attribute dropdown.

### Preview
![image](https://github.com/wso2/identity-apps/assets/30111554/0bb8a806-1b3a-42b2-87f9-aac077525991)

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
