### PR TITLE
[bug-fix] Remove "name" field from Custom SMS Provider configuration form

### DIFF
--- a/.changeset/new-bees-try.md
+++ b/.changeset/new-bees-try.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix issues in Custom SMS Provider configuration UI

--- a/apps/console/src/features/sms-providers/pages/custom-sms-provider.tsx
+++ b/apps/console/src/features/sms-providers/pages/custom-sms-provider.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -56,35 +56,6 @@ const CustomSMSProvider: FunctionComponent<CustomSMSProviderPageInterface> = (
                 <Grid.Row columns={ 2 }>
                     <Grid.Column>
                         <FinalFormField
-                            key="provider"
-                            fullWidth
-                            FormControlProps={ {
-                                margin: "dense"
-                            } }
-                            ariaLabel="provider"
-                            readOnly={ isReadOnly }
-                            required={ true }
-                            data-componentid={ `${componentId}-provider` }
-                            name="provider"
-                            type="text"
-                            label={ t("extensions:develop.smsProviders.form.custom.providerName.label") }
-                            placeholder={ t("extensions:develop.smsProviders.form.custom" +
-                                ".providerName.placeholder") }
-                            helperText={ (<Hint compact>
-                                { t("extensions:develop.smsProviders.form.custom.providerName.hint") }
-                            </Hint>) }
-                            component={ TextFieldAdapter }
-                            maxLength={
-                                SMSProviderConstants.SMS_PROVIDER_CONFIG_FIELD_MAX_LENGTH
-                            }
-                            minLength={
-                                SMSProviderConstants.SMS_PROVIDER_CONFIG_FIELD_MIN_LENGTH
-                            }
-                            autoComplete="new-password"
-                        />
-                    </Grid.Column>
-                    <Grid.Column>
-                        <FinalFormField
                             key="providerURL"
                             fullWidth
                             FormControlProps={ {
@@ -114,8 +85,6 @@ const CustomSMSProvider: FunctionComponent<CustomSMSProviderPageInterface> = (
                             autoComplete="new-password"
                         />
                     </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
                     <Grid.Column>
                         <FinalFormField
                             key="contentType"
@@ -146,6 +115,8 @@ const CustomSMSProvider: FunctionComponent<CustomSMSProviderPageInterface> = (
                             required
                         />
                     </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
                     <Grid.Column>
                         <FinalFormField
                             key="httpMethod"
@@ -176,8 +147,6 @@ const CustomSMSProvider: FunctionComponent<CustomSMSProviderPageInterface> = (
                             autoComplete="new-password"
                         />
                     </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 } >
                     <Grid.Column>
                         <FinalFormField
                             key="headers"

--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -415,11 +415,6 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
         } else {
             if (!values?.providerURL) {
                 error.providerURL = t(
-                    "extensions:develop.smsProviders.form.custom.validations.required"
-                );
-            }
-            if (!values?.provider) {
-                error.provider = t(
                     "extensions:develop.smsProviders.form.custom.validations.required"
                 );
             }


### PR DESCRIPTION
### Purpose
> $subject

![image](https://github.com/wso2/identity-apps/assets/37938529/3328eee9-0083-45f7-900a-2c67f6ab458b)


https://github.com/wso2/identity-apps/assets/37938529/df3ce52d-7c39-4697-9dac-e28cf544aa3e


### Related Issues
- https://github.com/wso2/product-is/issues/19519

### Related PRs
- https://github.com/wso2/identity-apps/pull/5499

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
