### PR TITLE
 [improvement] change the text "Password reset success" to "Password Reset Link Sent"

### DIFF
--- a/.changeset/beige-mangos-tell.md
+++ b/.changeset/beige-mangos-tell.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/i18n": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+---
+
+[improvement] change the text "Password reset success" to "Email Confirmation Sent"

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -618,7 +618,7 @@ export const console: ConsoleNS = {
             myaccount: "My Account",
             "password-recovery": "Password Recovery",
             "password-reset": "Password Reset",
-            "password-reset-success": "Email Confirmation Sent"
+            "password-reset-success": "Password Reset Link Sent"
         }
     },
     brandingCustomText: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -618,7 +618,7 @@ export const console: ConsoleNS = {
             myaccount: "My Account",
             "password-recovery": "Password Recovery",
             "password-reset": "Password Reset",
-            "password-reset-success": "Password Reset Success"
+            "password-reset-success": "Email Confirmation Sent"
         }
     },
     brandingCustomText: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -616,7 +616,7 @@ export const console: ConsoleNS = {
             myaccount: "Mon compte",
             "password-recovery": "Récupération de mot de passe",
             "password-reset": "Réinitialisation du mot de passe",
-            "password-reset-success": "Confirmation par e-mail envoyée"
+            "password-reset-success": "Lien de réinitialisation du mot de passe envoyé"
         }
     },
     brandingCustomText: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -616,7 +616,7 @@ export const console: ConsoleNS = {
             myaccount: "Mon compte",
             "password-recovery": "Récupération de mot de passe",
             "password-reset": "Réinitialisation du mot de passe",
-            "password-reset-success": "Réinitialisation du mot de passe Succès"
+            "password-reset-success": "Confirmation par e-mail envoyée"
         }
     },
     brandingCustomText: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -624,7 +624,7 @@ export const console: ConsoleNS = {
             myaccount: "මගේ ගිණුම",
             "password-recovery": "මුරපද ප්රතිසාධනය",
             "password-reset": "මුරපද යළි පිහිටුවීම",
-            "password-reset-success": "විද්යුත් තැපැල් තහවුරු කිරීම යවන ලදි"
+            "password-reset-success": "මුරපදය යළි පිහිටුවීමේ සබැඳිය යවන ලදි"
         }
     },
     brandingCustomText: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -624,7 +624,7 @@ export const console: ConsoleNS = {
             myaccount: "මගේ ගිණුම",
             "password-recovery": "මුරපද ප්රතිසාධනය",
             "password-reset": "මුරපද යළි පිහිටුවීම",
-            "password-reset-success": "මුරපදය නැවත සකස් කිරීම සාර්ථකත්වය"
+            "password-reset-success": "විද්යුත් තැපැල් තහවුරු කිරීම යවන ලදි"
         }
     },
     brandingCustomText: {


### PR DESCRIPTION
### Purpose
[improvement] change the text "Password reset success" to "Password Reset Link Sent"

### Related Issues
- https://github.com/wso2/product-is/issues/19155

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
