### PR TITLE
Userstore field validation

### DIFF
--- a/.changeset/afraid-shirts-listen.md
+++ b/.changeset/afraid-shirts-listen.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add validation for user store input fields

--- a/.changeset/afraid-shirts-listen.md
+++ b/.changeset/afraid-shirts-listen.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/console": patch
+"@wso2is/myaccount": patch
 "@wso2is/i18n": patch
 ---
 

--- a/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
@@ -20,7 +20,7 @@ import { UserstoreConstants } from "@wso2is/core/constants";
 import { IdentityAppsError } from "@wso2is/core/errors";
 import { AlertInterface, AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { Field, FormValue, Forms } from "@wso2is/forms";
+import { Field, FormValue, Forms, Validation } from "@wso2is/forms";
 import { ConfirmationModal, DangerZone, EmphasizedSegment, LinkButton, PrimaryButton } from "@wso2is/react-components";
 import { DangerZoneGroup } from "@wso2is/react-components/src";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
@@ -32,7 +32,7 @@ import { SqlEditor } from "..";
 import { userstoresConfig } from "../../../../extensions";
 import { AppConstants, history } from "../../../core";
 import { deleteUserStore, patchUserStore } from "../../api";
-import { CONSUMER_USERSTORE, CONSUMER_USERSTORE_ID, DISABLED } from "../../constants";
+import { CONSUMER_USERSTORE, CONSUMER_USERSTORE_ID, DISABLED, USERSTORE_VALIDATION_REGEX_PATTERNS } from "../../constants";
 import { PatchData, PropertyAttribute, RequiredBinary, TypeProperty, UserStore } from "../../models";
 
 /**
@@ -356,6 +356,30 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
             });
     };
 
+    /**
+     * This validates and extracts the matched string with Regex.
+     *
+     * @returns validity status and the invalid string
+     */
+    const validateInputWithRegex = (input: string, regex: string): Map<string, string | boolean> => {
+        const regExpInvalidSymbols: RegExp = new RegExp(regex);
+
+        let isMatch: boolean = false;
+        let invalidStringValue: string = null;
+
+        if (regExpInvalidSymbols.test(input)) {
+            isMatch = true;
+            invalidStringValue = regExpInvalidSymbols.exec(input).toString();
+        }
+
+        const validityResultsMap: Map<string, string | boolean> = new Map<string, string | boolean>();
+
+        validityResultsMap.set("isMatch", isMatch);
+        validityResultsMap.set("invalidStringValue", invalidStringValue);
+
+        return validityResultsMap;
+    };
+
     return (
         <>
             { confirmDelete && deleteConfirmation() }
@@ -414,6 +438,24 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
                                             "description.placeholder") }
                                         value={ userStore?.description }
                                         data-testid={ `${ testId }-form-description-textarea` }
+                                        validation={ async (value: string, validation: Validation) => {
+                                            const validityResult: Map<string, string | boolean> = validateInputWithRegex(value,
+                                                USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
+                                            const isMatch: string = validityResult.get("isMatch").toString();
+
+                                            if (isMatch === "true") {
+                                                validation.isValid = false;
+                                                const invalidString: string = validityResult.get("invalidStringValue").toString();
+
+                                                validation.errorMessages.push(
+                                                    t("console:manage.features.userstores.forms.general.description"
+                                                        + ".validationErrorMessages.invalidInputErrorMessage", {
+                                                        invalidString: invalidString
+                                                    })
+                                                );
+                                            }
+                                        }
+                                        }
                                     />
                                 }
                             </Grid.Column>

--- a/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
@@ -32,8 +32,11 @@ import { SqlEditor } from "..";
 import { userstoresConfig } from "../../../../extensions";
 import { AppConstants, history } from "../../../core";
 import { deleteUserStore, patchUserStore } from "../../api";
-import { CONSUMER_USERSTORE, CONSUMER_USERSTORE_ID, DISABLED, USERSTORE_VALIDATION_REGEX_PATTERNS } from "../../constants";
+import { CONSUMER_USERSTORE, CONSUMER_USERSTORE_ID, DISABLED, USERSTORE_VALIDATION_REGEX_PATTERNS }
+    from "../../constants";
 import { PatchData, PropertyAttribute, RequiredBinary, TypeProperty, UserStore } from "../../models";
+import { validateInputWithRegex } from "../../utils/userstore-utils";
+
 
 /**
  * Prop types of `EditBasicDetailsUserStore` component
@@ -356,30 +359,6 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
             });
     };
 
-    /**
-     * This validates and extracts the matched string with Regex.
-     *
-     * @returns validity status and the invalid string
-     */
-    const validateInputWithRegex = (input: string, regex: string): Map<string, string | boolean> => {
-        const regExpInvalidSymbols: RegExp = new RegExp(regex);
-
-        let isMatch: boolean = false;
-        let invalidStringValue: string = null;
-
-        if (regExpInvalidSymbols.test(input)) {
-            isMatch = true;
-            invalidStringValue = regExpInvalidSymbols.exec(input).toString();
-        }
-
-        const validityResultsMap: Map<string, string | boolean> = new Map<string, string | boolean>();
-
-        validityResultsMap.set("isMatch", isMatch);
-        validityResultsMap.set("invalidStringValue", invalidStringValue);
-
-        return validityResultsMap;
-    };
-
     return (
         <>
             { confirmDelete && deleteConfirmation() }
@@ -439,13 +418,15 @@ export const EditBasicDetailsUserStore: FunctionComponent<EditBasicDetailsUserSt
                                         value={ userStore?.description }
                                         data-testid={ `${ testId }-form-description-textarea` }
                                         validation={ async (value: string, validation: Validation) => {
-                                            const validityResult: Map<string, string | boolean> = validateInputWithRegex(value,
-                                                USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
+                                            const validityResult: Map<string, string | boolean> =
+                                                validateInputWithRegex(value, USERSTORE_VALIDATION_REGEX_PATTERNS
+                                                    .xssEscapeRegEx);
                                             const isMatch: string = validityResult.get("isMatch").toString();
 
                                             if (isMatch === "true") {
                                                 validation.isValid = false;
-                                                const invalidString: string = validityResult.get("invalidStringValue").toString();
+                                                const invalidString: string = validityResult
+                                                    .get("invalidStringValue").toString();
 
                                                 validation.errorMessages.push(
                                                     t("console:manage.features.userstores.forms.general.description"

--- a/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-basic-details-user-store.tsx
@@ -37,7 +37,6 @@ import { CONSUMER_USERSTORE, CONSUMER_USERSTORE_ID, DISABLED, USERSTORE_VALIDATI
 import { PatchData, PropertyAttribute, RequiredBinary, TypeProperty, UserStore } from "../../models";
 import { validateInputWithRegex } from "../../utils/userstore-utils";
 
-
 /**
  * Prop types of `EditBasicDetailsUserStore` component
  */

--- a/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
@@ -170,7 +170,7 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                             placeholder={ t("console:manage.features.userstores.forms.general.name.placeholder") }
                             value={ values?.get("name")?.toString() }
                             data-testid={ `${ testId }-form-name-input` }
-                            validation={ async (value: FormValue, validation: Validation) => {
+                            validation={ async (value: string, validation: Validation) => {
                                 let userStores: UserStoreListItem[] = null;
 
                                 try {
@@ -207,6 +207,22 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                                         })
                                     );
                                 }
+
+                                const regExpInvalidSymbols: RegExp = new RegExp('\\$\\{[^}]*\\}');
+
+                                let isMatch: boolean = false;
+
+                                if (regExpInvalidSymbols.test(value)) {
+                                    isMatch = true;
+                                }
+                                if (isMatch) {
+                                    validation.isValid = false;
+                                    validation.errorMessages.push(
+                                        t("console:manage.features.userstores.forms.general.name"
+                                        + ".validationErrorMessages.invalidInputErrorMessage")
+                                    );
+                                }
+
                             }
                             }
                         />
@@ -219,7 +235,26 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                             placeholder={ t("console:manage.features.userstores.forms.general." +
                                 "description.placeholder") }
                             value={ values?.get("description")?.toString() }
-                            data-testid={ `${ testId }-form-description-textarea` }
+                            data-testid={ `${testId}-form-description-textarea` }
+                            validation={ async (value: string, validation: Validation) => {
+                                validation.isValid = true;
+                                const regExpInvalidSymbols: RegExp = new RegExp('\\$\\{[^}]*\\}');
+
+                                let isMatch: boolean = false;
+
+                                if (regExpInvalidSymbols.test(value)) {
+                                    isMatch = true;
+                                }
+                                if (isMatch) {
+                                    validation.isValid = false;
+                                    validation.errorMessages.push(
+                                        t("console:manage.features.userstores.forms.general.description"
+                                        + ".validationErrorMessages.invalidInputErrorMessage")
+                                    );
+                                }
+
+                            }
+                            }
                         />
                         {
                             basicProperties?.map(

--- a/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
@@ -212,19 +212,19 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                                     USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
 
                                 let isMatch: boolean = false;
-                                let invalidStringValue: RegExpExecArray = null;
+                                let invalidStringValue: string = null;
 
                                 if (regExpInvalidSymbols.test(value)) {
                                     isMatch = true;
-                                    invalidStringValue = regExpInvalidSymbols.exec(value)
-
+                                    invalidStringValue = regExpInvalidSymbols.exec(value).toString();
                                 }
                                 if (isMatch) {
                                     validation.isValid = false;
                                     validation.errorMessages.push(
                                         t("console:manage.features.userstores.forms.general.name"
-                                            + ".validationErrorMessages.invalidInputErrorMessage",
-                                            { invalidString: invalidStringValue })
+                                            + ".validationErrorMessages.invalidInputErrorMessage", {
+                                            invalidString: invalidStringValue
+                                        })
                                     );
                                 }
 
@@ -240,29 +240,27 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                             placeholder={ t("console:manage.features.userstores.forms.general." +
                                 "description.placeholder") }
                             value={ values?.get("description")?.toString() }
-                            data-testid={ `${testId}-form-description-textarea` }
+                            data-testid={ `${ testId }-form-description-textarea` }
                             validation={ async (value: string, validation: Validation) => {
-                                validation.isValid = true;
 
                                 const regExpInvalidSymbols: RegExp = new RegExp(
                                     USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
 
                                 let isMatch: boolean = false;
-                                let invalidStringValue: RegExpExecArray = null;
+                                let invalidStringValue: string = null;
 
                                 if (regExpInvalidSymbols.test(value)) {
                                     isMatch = true;
-                                    invalidStringValue = regExpInvalidSymbols.exec(value)
-
+                                    invalidStringValue = regExpInvalidSymbols.exec(value).toString();
                                 }
-
                                 if (isMatch) {
                                     validation.isValid = false;
                                     validation.errorMessages.push(
-                                        t("console:manage.features.userstores.forms.general.description" +
-                                            ".validationErrorMessages.invalidInputErrorMessage",
-                                            { invalidString: invalidStringValue })
-                                    )
+                                        t("console:manage.features.userstores.forms.general.description"
+                                            + ".validationErrorMessages.invalidInputErrorMessage", {
+                                            invalidString: invalidStringValue
+                                        })
+                                    );
                                 }
 
                             }

--- a/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
@@ -25,7 +25,7 @@ import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { Button, Divider, Grid, Header, Icon } from "semantic-ui-react";
 import { getUserStores, testConnection } from "../../api";
-import { DISABLED, JDBC, USERSTORE_NAME_CHARACTER_LIMIT } from "../../constants";
+import { DISABLED, JDBC, USERSTORE_NAME_CHARACTER_LIMIT, USERSTORE_VALIDATION_REGEX_PATTERNS } from "../../constants";
 import { PropertyAttribute, TestConnection, TypeProperty, UserStoreListItem, UserstoreType } from "../../models";
 
 /**
@@ -208,18 +208,23 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                                     );
                                 }
 
-                                const regExpInvalidSymbols: RegExp = new RegExp('\\$\\{[^}]*\\}');
+                                const regExpInvalidSymbols: RegExp = new RegExp(
+                                    USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
 
                                 let isMatch: boolean = false;
+                                let invalidStringValue: RegExpExecArray = null;
 
                                 if (regExpInvalidSymbols.test(value)) {
                                     isMatch = true;
+                                    invalidStringValue = regExpInvalidSymbols.exec(value)
+
                                 }
                                 if (isMatch) {
                                     validation.isValid = false;
                                     validation.errorMessages.push(
                                         t("console:manage.features.userstores.forms.general.name"
-                                        + ".validationErrorMessages.invalidInputErrorMessage")
+                                            + ".validationErrorMessages.invalidInputErrorMessage",
+                                            { invalidString: invalidStringValue })
                                     );
                                 }
 
@@ -238,19 +243,26 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                             data-testid={ `${testId}-form-description-textarea` }
                             validation={ async (value: string, validation: Validation) => {
                                 validation.isValid = true;
-                                const regExpInvalidSymbols: RegExp = new RegExp('\\$\\{[^}]*\\}');
+
+                                const regExpInvalidSymbols: RegExp = new RegExp(
+                                    USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
 
                                 let isMatch: boolean = false;
+                                let invalidStringValue: RegExpExecArray = null;
 
                                 if (regExpInvalidSymbols.test(value)) {
                                     isMatch = true;
+                                    invalidStringValue = regExpInvalidSymbols.exec(value)
+
                                 }
+
                                 if (isMatch) {
                                     validation.isValid = false;
                                     validation.errorMessages.push(
-                                        t("console:manage.features.userstores.forms.general.description"
-                                        + ".validationErrorMessages.invalidInputErrorMessage")
-                                    );
+                                        t("console:manage.features.userstores.forms.general.description" +
+                                            ".validationErrorMessages.invalidInputErrorMessage",
+                                            { invalidString: invalidStringValue })
+                                    )
                                 }
 
                             }

--- a/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
@@ -27,6 +27,7 @@ import { Button, Divider, Grid, Header, Icon } from "semantic-ui-react";
 import { getUserStores, testConnection } from "../../api";
 import { DISABLED, JDBC, USERSTORE_NAME_CHARACTER_LIMIT, USERSTORE_VALIDATION_REGEX_PATTERNS } from "../../constants";
 import { PropertyAttribute, TestConnection, TypeProperty, UserStoreListItem, UserstoreType } from "../../models";
+import { validateInputWithRegex } from "../../utils/userstore-utils";
 
 /**
  * Prop types of the `GeneralDetails` component
@@ -141,30 +142,6 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
         } else {
             return TestButtonColor.INITIAL;
         }
-    };
-
-    /**
-     * This validates and extracts the matched string with Regex.
-     *
-     * @returns validity status and the invalid string
-     */
-    const validateInputWithRegex = (input: string, regex: string): Map<string, string | boolean> => {
-        const regExpInvalidSymbols: RegExp = new RegExp(regex);
-
-        let isMatch: boolean = false;
-        let invalidStringValue: string = null;
-
-        if (regExpInvalidSymbols.test(input)) {
-            isMatch = true;
-            invalidStringValue = regExpInvalidSymbols.exec(input).toString();
-        }
-
-        const validityResultsMap: Map<string, string | boolean> = new Map<string, string | boolean>();
-
-        validityResultsMap.set("isMatch", isMatch);
-        validityResultsMap.set("invalidStringValue", invalidStringValue);
-
-        return validityResultsMap;
     };
 
     return (

--- a/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
@@ -234,9 +234,9 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
 
                                 const validityResult: Map<string, string | boolean> = validateInputWithRegex(value,
                                     USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
-                                const isMatch: boolean | string = validityResult.get("isMatch");
+                                const isMatch: string = validityResult.get("isMatch").toString();
 
-                                if (isMatch) {
+                                if (isMatch === "ture") {
                                     validation.isValid = false;
                                     const invalidString: string = validityResult.get("invalidStringValue").toString();
 
@@ -263,9 +263,9 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                             validation={ async (value: string, validation: Validation) => {
                                 const validityResult: Map<string, string | boolean> = validateInputWithRegex(value,
                                     USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
-                                const isMatch: boolean | string = validityResult.get("isMatch");
+                                const isMatch: string = validityResult.get("isMatch").toString();
 
-                                if (isMatch) {
+                                if (isMatch === "true") {
                                     validation.isValid = false;
                                     const invalidString: string = validityResult.get("invalidStringValue").toString();
 

--- a/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
@@ -213,7 +213,7 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                                     USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
                                 const isMatch: string = validityResult.get("isMatch").toString();
 
-                                if (isMatch === "ture") {
+                                if (isMatch === "true") {
                                     validation.isValid = false;
                                     const invalidString: string = validityResult.get("invalidStringValue").toString();
 

--- a/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/wizards/general-details-userstore.tsx
@@ -143,6 +143,30 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
         }
     };
 
+    /**
+     * This validates and extracts the matched string with Regex.
+     *
+     * @returns validity status and the invalid string
+     */
+    const validateInputWithRegex = (input: string, regex: string): Map<string, string | boolean> => {
+        const regExpInvalidSymbols: RegExp = new RegExp(regex);
+
+        let isMatch: boolean = false;
+        let invalidStringValue: string = null;
+
+        if (regExpInvalidSymbols.test(input)) {
+            isMatch = true;
+            invalidStringValue = regExpInvalidSymbols.exec(input).toString();
+        }
+
+        const validityResultsMap: Map<string, string | boolean> = new Map<string, string | boolean>();
+
+        validityResultsMap.set("isMatch", isMatch);
+        validityResultsMap.set("invalidStringValue", invalidStringValue);
+
+        return validityResultsMap;
+    };
+
     return (
         <Grid data-testid={ testId }>
             <Grid.Row columns={ 1 }>
@@ -208,26 +232,21 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                                     );
                                 }
 
-                                const regExpInvalidSymbols: RegExp = new RegExp(
+                                const validityResult: Map<string, string | boolean> = validateInputWithRegex(value,
                                     USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
+                                const isMatch: boolean | string = validityResult.get("isMatch");
 
-                                let isMatch: boolean = false;
-                                let invalidStringValue: string = null;
-
-                                if (regExpInvalidSymbols.test(value)) {
-                                    isMatch = true;
-                                    invalidStringValue = regExpInvalidSymbols.exec(value).toString();
-                                }
                                 if (isMatch) {
                                     validation.isValid = false;
+                                    const invalidString: string = validityResult.get("invalidStringValue").toString();
+
                                     validation.errorMessages.push(
                                         t("console:manage.features.userstores.forms.general.name"
                                             + ".validationErrorMessages.invalidInputErrorMessage", {
-                                            invalidString: invalidStringValue
+                                            invalidString: invalidString
                                         })
                                     );
                                 }
-
                             }
                             }
                         />
@@ -242,27 +261,21 @@ export const GeneralDetailsUserstore: FunctionComponent<GeneralDetailsUserstoreP
                             value={ values?.get("description")?.toString() }
                             data-testid={ `${ testId }-form-description-textarea` }
                             validation={ async (value: string, validation: Validation) => {
-
-                                const regExpInvalidSymbols: RegExp = new RegExp(
+                                const validityResult: Map<string, string | boolean> = validateInputWithRegex(value,
                                     USERSTORE_VALIDATION_REGEX_PATTERNS.xssEscapeRegEx);
+                                const isMatch: boolean | string = validityResult.get("isMatch");
 
-                                let isMatch: boolean = false;
-                                let invalidStringValue: string = null;
-
-                                if (regExpInvalidSymbols.test(value)) {
-                                    isMatch = true;
-                                    invalidStringValue = regExpInvalidSymbols.exec(value).toString();
-                                }
                                 if (isMatch) {
                                     validation.isValid = false;
+                                    const invalidString: string = validityResult.get("invalidStringValue").toString();
+
                                     validation.errorMessages.push(
                                         t("console:manage.features.userstores.forms.general.description"
                                             + ".validationErrorMessages.invalidInputErrorMessage", {
-                                            invalidString: invalidStringValue
+                                            invalidString: invalidString
                                         })
                                     );
                                 }
-
                             }
                             }
                         />

--- a/apps/console/src/features/userstores/constants/user-store-constants.ts
+++ b/apps/console/src/features/userstores/constants/user-store-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/features/userstores/constants/user-store-constants.ts
+++ b/apps/console/src/features/userstores/constants/user-store-constants.ts
@@ -166,11 +166,12 @@ export const USERSTORE_REGEX_PROPERTIES: UserStoreRegexPropertiesInterface = {
 interface UserStoreValidationRegexPatternInterface {
     xssEscapeRegEx: string;
 }
+
 /**
- * User store regEx patterns
+ * User store validation regEx patterns
  */
 export const USERSTORE_VALIDATION_REGEX_PATTERNS: UserStoreValidationRegexPatternInterface = {
-    xssEscapeRegEx: '\\$\\{[^}]*\\}'
+    xssEscapeRegEx: "\\$\\{[^}]*\\}"
 };
 
 /**

--- a/apps/console/src/features/userstores/constants/user-store-constants.ts
+++ b/apps/console/src/features/userstores/constants/user-store-constants.ts
@@ -163,6 +163,16 @@ export const USERSTORE_REGEX_PROPERTIES: UserStoreRegexPropertiesInterface = {
     UsernameRegEx: "UsernameJavaScriptRegEx"
 };
 
+interface UserStoreValidationRegexPatternInterface {
+    xssEscapeRegEx: string;
+}
+/**
+ * User store regEx patterns
+ */
+export const USERSTORE_VALIDATION_REGEX_PATTERNS: UserStoreValidationRegexPatternInterface = {
+    xssEscapeRegEx: '\\$\\{[^}]*\\}'
+};
+
 /**
  * Disabled property name.
  */

--- a/apps/console/src/features/userstores/utils/userstore-utils.ts
+++ b/apps/console/src/features/userstores/utils/userstore-utils.ts
@@ -180,3 +180,27 @@ export const reOrganizeProperties = (
         }
     };
 };
+
+/**
+ * This validates and extracts the matched string with Regex.
+ *
+ * @returns validity status and the invalid string
+ */
+export const validateInputWithRegex = (input: string, regex: string): Map<string, string | boolean> => {
+    const regExpInvalidSymbols: RegExp = new RegExp(regex);
+
+    let isMatch: boolean = false;
+    let invalidStringValue: string = null;
+
+    if (regExpInvalidSymbols.test(input)) {
+        isMatch = true;
+        invalidStringValue = regExpInvalidSymbols.exec(input).toString();
+    }
+
+    const validityResultsMap: Map<string, string | boolean> = new Map<string, string | boolean>();
+
+    validityResultsMap.set("isMatch", isMatch);
+    validityResultsMap.set("invalidStringValue", invalidStringValue);
+
+    return validityResultsMap;
+};

--- a/apps/console/src/features/userstores/utils/userstore-utils.ts
+++ b/apps/console/src/features/userstores/utils/userstore-utils.ts
@@ -1,8 +1,8 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
- * Version 2.0 (the 'License'); you may not use this file except
+ * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -10,18 +10,15 @@
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
- * 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
 
 import {
-    CategorizedProperties,
-    TypeProperty,
-    UserStoreProperty,
-    UserstorePropertiesCategories,
-    UserstoreType
+    CategorizedProperties, PropertyAttribute, TypeProperty, UserStoreProperty,
+    UserstorePropertiesCategories, UserstoreType
 } from "../models";
 
 export const reOrganizeProperties = (
@@ -29,6 +26,7 @@ export const reOrganizeProperties = (
     valueProperties?: UserStoreProperty[]
 ): CategorizedProperties => {
     const flattenedProperties: TypeProperty[] = [];
+
     flattenedProperties.push(...properties.Advanced);
     flattenedProperties.push(...properties.Mandatory);
     flattenedProperties.push(...properties.Optional);
@@ -62,15 +60,19 @@ export const reOrganizeProperties = (
     const basicOptionalSqlSelectProperties: TypeProperty[] = [];
 
     flattenedProperties.forEach((property: TypeProperty) => {
-        const category = property.attributes?.find((attribute) => attribute.name === "category")?.value;
-        const required = property.attributes?.find((attribute) => attribute.name === "required")?.value === "true";
-        const sql = property.attributes?.find((attribute) => attribute.name === "type")?.value === "sql";
-        const INSERT = property.description.toLowerCase().includes("add");
-        const DELETE = property.description.toLowerCase().includes("delete");
-        const UPDATE = property.description.toLowerCase().includes("update");
+        const category: string = property.attributes?.find((attribute: PropertyAttribute) =>
+            attribute.name === "category")?.value;
+        const required: boolean = property.attributes?.find((attribute: PropertyAttribute) =>
+            attribute.name === "required")?.value === "true";
+        const sql: boolean = property.attributes?.find((attribute: PropertyAttribute) =>
+            attribute.name === "type")?.value === "sql";
+        const INSERT: boolean = property.description.toLowerCase().includes("add");
+        const DELETE: boolean = property.description.toLowerCase().includes("delete");
+        const UPDATE: boolean = property.description.toLowerCase().includes("update");
 
         if (valueProperties) {
-            property.value = valueProperties.find((valueProperty) => valueProperty.name === property.name)?.value ?? "";
+            property.value = valueProperties.find((valueProperty: UserStoreProperty) =>
+                valueProperty.name === property.name)?.value ?? "";
         }
 
         switch (category) {
@@ -78,53 +80,57 @@ export const reOrganizeProperties = (
                 required
                     ? connectionRequiredProperties.push(property)
                     : sql
-                    ? INSERT
-                        ? connectionOptionalSqlInsertProperties.push(property)
-                        : DELETE
-                        ? connectionOptionalSqlDeleteProperties.push(property)
-                        : UPDATE
-                        ? connectionOptionalSqlUpdateProperties.push(property)
-                        : connectionOptionalSqlSelectProperties.push(property)
-                    : connectionOptionalProperties.push(property);
+                        ? INSERT
+                            ? connectionOptionalSqlInsertProperties.push(property)
+                            : DELETE
+                                ? connectionOptionalSqlDeleteProperties.push(property)
+                                : UPDATE
+                                    ? connectionOptionalSqlUpdateProperties.push(property)
+                                    : connectionOptionalSqlSelectProperties.push(property)
+                        : connectionOptionalProperties.push(property);
+
                 break;
             case UserstorePropertiesCategories.GROUP:
                 required
                     ? groupRequiredProperties.push(property)
                     : sql
-                    ? INSERT
-                        ? groupOptionalSqlInsertProperties.push(property)
-                        : DELETE
-                        ? groupOptionalSqlDeleteProperties.push(property)
-                        : UPDATE
-                        ? groupOptionalSqlUpdateProperties.push(property)
-                        : groupOptionalSqlSelectProperties.push(property)
-                    : groupOptionalProperties.push(property);
+                        ? INSERT
+                            ? groupOptionalSqlInsertProperties.push(property)
+                            : DELETE
+                                ? groupOptionalSqlDeleteProperties.push(property)
+                                : UPDATE
+                                    ? groupOptionalSqlUpdateProperties.push(property)
+                                    : groupOptionalSqlSelectProperties.push(property)
+                        : groupOptionalProperties.push(property);
+
                 break;
             case UserstorePropertiesCategories.USER:
                 required
                     ? userRequiredProperties.push(property)
                     : sql
-                    ? INSERT
-                        ? userOptionalSqlInsertProperties.push(property)
-                        : DELETE
-                        ? userOptionalSqlDeleteProperties.push(property)
-                        : UPDATE
-                        ? userOptionalSqlUpdateProperties.push(property)
-                        : userOptionalSqlSelectProperties.push(property)
-                    : userOptionalProperties.push(property);
+                        ? INSERT
+                            ? userOptionalSqlInsertProperties.push(property)
+                            : DELETE
+                                ? userOptionalSqlDeleteProperties.push(property)
+                                : UPDATE
+                                    ? userOptionalSqlUpdateProperties.push(property)
+                                    : userOptionalSqlSelectProperties.push(property)
+                        : userOptionalProperties.push(property);
+
                 break;
             case UserstorePropertiesCategories.BASIC:
                 required
                     ? basicRequiredProperties.push(property)
                     : sql
-                    ? INSERT
-                        ? basicOptionalSqlInsertProperties.push(property)
-                        : DELETE
-                        ? basicOptionalSqlDeleteProperties.push(property)
-                        : UPDATE
-                        ? basicOptionalSqlUpdateProperties.push(property)
-                        : basicOptionalSqlSelectProperties.push(property)
-                    : basicOptionalProperties.push(property);
+                        ? INSERT
+                            ? basicOptionalSqlInsertProperties.push(property)
+                            : DELETE
+                                ? basicOptionalSqlDeleteProperties.push(property)
+                                : UPDATE
+                                    ? basicOptionalSqlUpdateProperties.push(property)
+                                    : basicOptionalSqlSelectProperties.push(property)
+                        : basicOptionalProperties.push(property);
+
                 break;
         }
     });

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -12645,7 +12645,10 @@ export const console: ConsoleNS = {
                     general: {
                         description: {
                             label: "Description",
-                            placeholder: "Enter a description"
+                            placeholder: "Enter a description",
+                            validationErrorMessages: {
+                                invalidInputErrorMessage: "Description cannot contain the pattern ${***}."
+                            }
                         },
                         name: {
                             label: "Name",
@@ -12653,7 +12656,8 @@ export const console: ConsoleNS = {
                             requiredErrorMessage: "Name is a required field",
                             validationErrorMessages: {
                                 alreadyExistsErrorMessage: "A user store with this name already exists.",
-                                maxCharLimitErrorMessage: "User store name cannot exceed {{maxLength}} characters."
+                                maxCharLimitErrorMessage: "User store name cannot exceed {{maxLength}} characters.",
+                                invalidInputErrorMessage: "Description cannot contain the pattern ${***}."
                             }
                         },
                         type: {

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -12647,7 +12647,7 @@ export const console: ConsoleNS = {
                             label: "Description",
                             placeholder: "Enter a description",
                             validationErrorMessages: {
-                                invalidInputErrorMessage: "Description cannot contain the pattern ${***}."
+                                invalidInputErrorMessage: "Description cannot contain the pattern {{invalidString}}."
                             }
                         },
                         name: {
@@ -12657,7 +12657,7 @@ export const console: ConsoleNS = {
                             validationErrorMessages: {
                                 alreadyExistsErrorMessage: "A user store with this name already exists.",
                                 maxCharLimitErrorMessage: "User store name cannot exceed {{maxLength}} characters.",
-                                invalidInputErrorMessage: "Description cannot contain the pattern ${***}."
+                                invalidInputErrorMessage: "User store name cannot contain the pattern {{invalidString}}."
                             }
                         },
                         type: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -10956,7 +10956,7 @@ export const console: ConsoleNS = {
                             label: "Description",
                             placeholder: "Veuillez saisir une description",
                             validationErrorMessages: {
-                                invalidInputErrorMessage: "La description ne peut pas contenir le modèle ${***}."
+                                invalidInputErrorMessage: "La description ne peut pas contenir le modèle {{invalidString}}."
                             }
                         },
                         name: {
@@ -10964,7 +10964,8 @@ export const console: ConsoleNS = {
                             placeholder: "Veuillez saisir un nom",
                             requiredErrorMessage: "Le nom de l'annuaire est obligatoire",
                             validationErrorMessages: {
-                                invalidInputErrorMessage: "Le nom ne peut pas contenir le modèle ${***}."
+                                invalidInputErrorMessage: "Le nom du magasin d'utilisateurs ne peut pas contenir"
+                                + "le modèle {{invalidString}}."
                             }
                         },
                         type: {

--- a/modules/i18n/src/translations/fr-FR/portals/console.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/console.ts
@@ -10954,12 +10954,18 @@ export const console: ConsoleNS = {
                     general: {
                         description: {
                             label: "Description",
-                            placeholder: "Veuillez saisir une description"
+                            placeholder: "Veuillez saisir une description",
+                            validationErrorMessages: {
+                                invalidInputErrorMessage: "La description ne peut pas contenir le modèle ${***}."
+                            }
                         },
                         name: {
                             label: "Nom",
                             placeholder: "Veuillez saisir un nom",
-                            requiredErrorMessage: "Le nom de l'annuaire est obligatoire"
+                            requiredErrorMessage: "Le nom de l'annuaire est obligatoire",
+                            validationErrorMessages: {
+                                invalidInputErrorMessage: "Le nom ne peut pas contenir le modèle ${***}."
+                            }
                         },
                         type: {
                             label: "Type",

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -10695,14 +10695,18 @@ export const console: ConsoleNS = {
                     general: {
                         description: {
                             label: "විස්තර",
-                            placeholder: "විස්තරයක් ඇතුළත් කරන්න"
+                            placeholder: "විස්තරයක් ඇතුළත් කරන්න",
+                            validationErrorMessages: {
+                                invalidInputErrorMessage: "විස්තර ක්ෂේත්‍රයේ ${***} රටාව අඩංගු විය නොහැක."
+                            }
                         },
                         name: {
                             label: "නම",
                             placeholder: "නමක් ඇතුළත් කරන්න",
                             requiredErrorMessage: "නම අත්‍යවශ්‍ය ක්ෂේත්‍රයකි",
                             validationErrorMessages: {
-                                alreadyExistsErrorMessage: "මෙම නම සහිත පරිශීලක වෙළඳසැලක් දැනටමත් පවතී."
+                                alreadyExistsErrorMessage: "මෙම නම සහිත පරිශීලක වෙළඳසැලක් දැනටමත් පවතී.",
+                                invalidInputErrorMessage: "නම ක්ෂේත්‍රයේ ${***} රටාව අඩංගු විය නොහැක."
                             }
                         },
                         type: {

--- a/modules/i18n/src/translations/si-LK/portals/console.ts
+++ b/modules/i18n/src/translations/si-LK/portals/console.ts
@@ -10697,7 +10697,7 @@ export const console: ConsoleNS = {
                             label: "විස්තර",
                             placeholder: "විස්තරයක් ඇතුළත් කරන්න",
                             validationErrorMessages: {
-                                invalidInputErrorMessage: "විස්තර ක්ෂේත්‍රයේ ${***} රටාව අඩංගු විය නොහැක."
+                                invalidInputErrorMessage: "විස්තර ක්ෂේත්‍රයේ {{invalidString}} රටාව අඩංගු විය නොහැක."
                             }
                         },
                         name: {
@@ -10706,7 +10706,8 @@ export const console: ConsoleNS = {
                             requiredErrorMessage: "නම අත්‍යවශ්‍ය ක්ෂේත්‍රයකි",
                             validationErrorMessages: {
                                 alreadyExistsErrorMessage: "මෙම නම සහිත පරිශීලක වෙළඳසැලක් දැනටමත් පවතී.",
-                                invalidInputErrorMessage: "නම ක්ෂේත්‍රයේ ${***} රටාව අඩංගු විය නොහැක."
+                                invalidInputErrorMessage: "පරිශීලක වෙළඳසැලේ නම ක්ෂේත්‍රයේ {{invalidString}} රටාව"
+                                + "අඩංගු විය නොහැක."
                             }
                         },
                         type: {


### PR DESCRIPTION
### Purpose
- In the user store creation process and user store edit process, users can proceed with the restricted string in the description but receive an API error when the request is sent, which isn't ideal from a UX perspective.
- Therefore, FE validation is needed in the user store creation wizard and edit component to enforce the same behavior at the frontend level.

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/21966

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
