### PR TITLE
[1.6.x] Apply fixes from patches to identity components

### DIFF
--- a/apps/authentication-portal/pom.xml
+++ b/apps/authentication-portal/pom.xml
@@ -267,6 +267,26 @@
             <artifactId>org.wso2.identity.apps.taglibs.layout.controller</artifactId>
             <version>1.4.34</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-transports-http</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-rs-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -15,7 +15,9 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   --%>
-
+<%@ page import="org.apache.cxf.jaxrs.client.Client" %>
+<%@ page import="org.apache.cxf.configuration.jsse.TLSClientParameters" %>
+<%@ page import="org.apache.cxf.transport.http.HTTPConduit" %>
 <%@ page import="org.apache.cxf.jaxrs.client.JAXRSClientFactory" %>
 <%@ page import="org.apache.cxf.jaxrs.provider.json.JSONProvider" %>
 <%@ page import="org.apache.cxf.jaxrs.client.WebClient" %>
@@ -47,6 +49,12 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApplicationDataRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClientException" %>
+<%@ page import="org.wso2.carbon.utils.CustomHostNameVerifier" %>
+<%@ page import="javax.net.ssl.HostnameVerifier" %>
+<%@ page import="static org.wso2.carbon.CarbonConstants.ALLOW_ALL" %>
+<%@ page import="static org.wso2.carbon.CarbonConstants.DEFAULT_AND_LOCALHOST" %>
+<%@ page import="static org.wso2.carbon.CarbonConstants.HOST_NAME_VERIFIER" %>
+<%@ page import="org.apache.http.conn.ssl.AllowAllHostnameVerifier" %>
 
 <jsp:directive.include file="includes/init-loginform-action-url.jsp"/>
 <jsp:directive.include file="plugins/basicauth-extensions.jsp"/>
@@ -222,6 +230,32 @@
 
         SelfUserRegistrationResource selfUserRegistrationResource = JAXRSClientFactory
                 .create(url, SelfUserRegistrationResource.class, providers);
+
+        Client client = WebClient.client(selfUserRegistrationResource);
+        HTTPConduit conduit = WebClient.getConfig(client).getHttpConduit();
+        TLSClientParameters tlsParams = conduit.getTlsClientParameters();
+        if (tlsParams == null) {
+            tlsParams = new TLSClientParameters();
+        }
+        HostnameVerifier allowAllHostnameVerifier = new AllowAllHostnameVerifier();
+        if (EndpointConfigManager.isHostnameVerificationEnabled()) {
+            if (DEFAULT_AND_LOCALHOST.equals(System.getProperty(HOST_NAME_VERIFIER))) {
+                /*
+                 * If hostname verifier is set to DefaultAndLocalhost, allow following domains in addition to the
+                 * hostname:
+                 *      ["::1", "127.0.0.1", "localhost", "localhost.localdomain"]
+                 */
+                tlsParams.setHostnameVerifier(new CustomHostNameVerifier());
+            } else if (ALLOW_ALL.equals(System.getProperty(HOST_NAME_VERIFIER))) {
+                // If hostname verifier is set to AllowAll, disable hostname verification.
+                tlsParams.setHostnameVerifier(allowAllHostnameVerifier);
+            }
+        } else {
+            // Disable hostname verification
+            tlsParams.setHostnameVerifier(allowAllHostnameVerifier);
+        }
+        conduit.setTlsClientParameters(tlsParams);
+
         String reCaptchaResponse = request.getParameter("g-recaptcha-response");
         WebClient.client(selfUserRegistrationResource).header("g-recaptcha-response", reCaptchaResponse);
         WebClient.client(selfUserRegistrationResource).header("Authorization", header);

--- a/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
+++ b/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
@@ -169,9 +169,10 @@
     <script type="text/javascript">
         $(document).ready(function () {
             var myaccountUrl = '<%=application.getInitParameter("MyAccountURL")%>';
+            var tenantDomain = '<%=Encode.forJavaScriptBlock(tenantDomain)%>';
 
-            if ("<%=tenantDomain%>" !== "" || "<%=tenantDomain%>" !== "null") {
-                myaccountUrl = myaccountUrl + "/t/" + "<%=tenantDomain%>";
+            if (tenantDomain !== "" && tenantDomain !== "null") {
+                myaccountUrl = myaccountUrl + "/t/" + tenantDomain;
             }
 
             $("#my-account-link").attr("href", myaccountUrl +"/myaccount");

--- a/apps/authentication-portal/src/main/webapp/org_name.jsp
+++ b/apps/authentication-portal/src/main/webapp/org_name.jsp
@@ -95,7 +95,7 @@
             <layout:component componentName="MainSection" >
                 <div class="ui segment">
                     <%-- page content --%>
-                    <h2>Sign In with <%= StringUtils.isNotBlank(idp) ? idp : "Organization Login" %></h2>
+                    <h2>Sign In with <%= StringUtils.isNotBlank(idp) ? Encode.forHtmlContent(idp) : "Organization Login" %></h2>
                     <div class="ui divider hidden"></div>
 
                     <%

--- a/apps/authentication-portal/src/main/webapp/requested-claims.jsp
+++ b/apps/authentication-portal/src/main/webapp/requested-claims.jsp
@@ -17,8 +17,10 @@
   --%>
 
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
+<%@ page import="java.util.List" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 
@@ -26,11 +28,28 @@
 <%@ include file="includes/init-url.jsp" %>
 <jsp:directive.include file="includes/layout-resolver.jsp"/>
 
+<%!
+    private static final String EXCLUDE_POLICY = "exclude";
+%>
+
 <%
     String[] missingClaimList = null;
     String appName = null;
     Boolean isFederated = false;
-    if (request.getParameter(Constants.MISSING_CLAIMS) != null) {
+    List<String> queryParams = FileBasedConfigurationBuilder.getInstance()
+        .getAuthEndpointRedirectParams();
+    String action = FileBasedConfigurationBuilder.getInstance()
+        .getAuthEndpointRedirectParamsAction();
+    boolean missingClaimFilteringEnabled =
+        StringUtils.equals(action, EXCLUDE_POLICY) && queryParams.contains(Constants.MISSING_CLAIMS);
+    if (!missingClaimFilteringEnabled) {
+        if (request.getParameter(Constants.MISSING_CLAIMS) != null) {
+            missingClaimList = request.getParameter(Constants.MISSING_CLAIMS).split(",");
+        }
+    } else {
+        if (request.getQueryString().contains(Constants.MISSING_CLAIMS)) {
+            request.getRequestDispatcher("error.do").forward(request, response);
+        }
         missingClaimList = request.getParameter(Constants.MISSING_CLAIMS).split(",");
     }
     if (request.getParameter(Constants.REQUEST_PARAM_SP) != null) {

--- a/apps/authentication-portal/src/main/webapp/requested-claims.jsp
+++ b/apps/authentication-portal/src/main/webapp/requested-claims.jsp
@@ -16,11 +16,16 @@
   ~ under the License.
   --%>
 
+<%@ page import="com.google.gson.Gson" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.framework.config.builder.FileBasedConfigurationBuilder" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityCoreConstants" %>
+<%@ page import="org.wso2.carbon.identity.core.util.IdentityUtil" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
 <%@ page import="java.util.List" %>
+<%@ page import="java.util.Map" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 
@@ -50,7 +55,24 @@
         if (request.getQueryString().contains(Constants.MISSING_CLAIMS)) {
             request.getRequestDispatcher("error.do").forward(request, response);
         }
-        missingClaimList = request.getParameter(Constants.MISSING_CLAIMS).split(",");
+        String authAPIURL = application.getInitParameter(Constants.AUTHENTICATION_REST_ENDPOINT_URL);
+        if (StringUtils.isBlank(authAPIURL)) {
+            authAPIURL = IdentityUtil.getServerURL("/api/identity/auth/v1.1/", true, true);
+        }
+        if (!authAPIURL.endsWith("/")) {
+            authAPIURL += "/";
+        }
+        authAPIURL += "context/" + request.getParameter("sessionDataKey");
+        String contextProperties = AuthContextAPIClient.getContextProperties(authAPIURL);
+        Gson gson = new Gson();
+        Map<String, Object> parameters = gson.fromJson(contextProperties, Map.class);
+        if (parameters != null) {
+            missingClaimList = ((String) parameters.get(Constants.MISSING_CLAIMS)).split(",");
+        } else {
+            String redirectURL = "error.do";
+            response.sendRedirect(redirectURL);
+            return;
+        }
     }
     if (request.getParameter(Constants.REQUEST_PARAM_SP) != null) {
         appName = request.getParameter(Constants.REQUEST_PARAM_SP);

--- a/pom.xml
+++ b/pom.xml
@@ -348,6 +348,11 @@
                 <version>${carbon.kernel.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.utils</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
                 <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
                 <version>${org.wso2.carbon.identity.outbound.auth.oidc}</version>
@@ -451,6 +456,11 @@
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-rs-client</artifactId>
+                <version>${org.apache.cxf.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-transports-http</artifactId>
                 <version>${org.apache.cxf.version}</version>
             </dependency>
             <dependency>
@@ -662,7 +672,7 @@
         <commons-logging.imp.pkg.version.range>[1.2, 2.0)</commons-logging.imp.pkg.version.range>
 
         <carbon.identity.version>5.0.7</carbon.identity.version>
-        <carbon.kernel.version>4.9.0</carbon.kernel.version>
+        <carbon.kernel.version>4.9.26-SNAPSHOT</carbon.kernel.version>
         <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
@@ -676,7 +686,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>5.25.690</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.693-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.core.service.version>1.0.0
         </identity.organization.management.core.service.version>


### PR DESCRIPTION
Sync identity apps support fixes from IS 6.1.0 and IS 6.0.0.

Note : Not adding the commit https://github.com/wso2/identity-apps/pull/5548/commits/e9a06aa8955aa4aa6f5b575f3e6591b335174ac4 (which was customized for APIM usage) to product-apim because the corresponding fix has been released as a feature for IS 7.0 onwards. Hence it will not be required to apply the fix for next APIM release.

