### PR TITLE
Fix issue with show icon of the password type fields

### DIFF
--- a/.changeset/hot-mayflies-cough.md
+++ b/.changeset/hot-mayflies-cough.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/dynamic-forms": patch
+"@wso2is/console": patch
+---
+
+Fix issue with show icon of the password type fields

--- a/modules/dynamic-forms/src/components/utils.tsx
+++ b/modules/dynamic-forms/src/components/utils.tsx
@@ -93,6 +93,16 @@ export const renderFormFields = (fields: Record<string, any>): ReactElement => {
                         { ...omit(fieldProps, "type") }
                     />
                 );
+            case "password":
+                return (
+                    <DynamicField.Input
+                        key={ fieldProps.name }
+                        name={ fieldProps.name }
+                        label={ fieldProps.label }
+                        inputType={ fieldProps.inputType ?? "password" }
+                        { ...omit(fieldProps, "type") }
+                    />
+                );
             default:
                 return (
                     <DynamicField.Input
@@ -100,7 +110,7 @@ export const renderFormFields = (fields: Record<string, any>): ReactElement => {
                         name={ fieldProps.name }
                         label={ fieldProps.label }
                         inputType={ fieldProps.inputType }
-                        { ...fieldProps }
+                        { ...omit(fieldProps, "type") }
                     />
                 );
         }});


### PR DESCRIPTION
### Purpose
> This PR fixes the issue with password type fields not showing the value when show icon is clicked.

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
