### PR TITLE
Add regenerate button when client secret hashing is enabled

### DIFF
--- a/.changeset/clever-dogs-deny.md
+++ b/.changeset/clever-dogs-deny.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add Regenerate button when client secret is hashed.

--- a/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
+++ b/apps/console/src/features/applications/components/forms/inbound-oidc-form.tsx
@@ -3714,14 +3714,30 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             {
                                                 isClientSecretHashEnabled
                                                     ? (
-                                                        <Message
-                                                            visible
-                                                            type="info"
-                                                            content={
-                                                                t("console:develop.features.applications.forms." +
+                                                        <>
+                                                            <Message
+                                                                visible
+                                                                type="info"
+                                                                content={
+                                                                    t("console:develop.features.applications.forms." +
                                                                     "inboundOIDC.fields.clientSecret.hashedDisclaimer")
+                                                                }
+                                                            />
+                                                            {
+                                                                !readOnly && (
+                                                                    <Button
+                                                                        color="red"
+                                                                        className="oidc-action-button"
+                                                                        onClick={ handleRegenerateButton }
+                                                                        data-testid={
+                                                                            `${ testId }-oidc-regenerate-button`
+                                                                        }
+                                                                    >
+                                                                        { t("common:regenerate") }
+                                                                    </Button>
+                                                                )
                                                             }
-                                                        />
+                                                        </>
                                                     )
                                                     : (
                                                         <div className="display-flex">


### PR DESCRIPTION
### Purpose
<img width="700" alt="Screenshot 2024-02-16 at 12 53 35" src="https://github.com/wso2/identity-apps/assets/67315176/ca1ee7e4-2976-4d9c-a375-f037facdb138">

### Related Issues
- https://github.com/wso2/product-is/issues/19403

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
