### PR TITLE
Fix tenanted myaccount logout issue in legacy auth runtime

### DIFF
--- a/.changeset/rich-apricots-sing.md
+++ b/.changeset/rich-apricots-sing.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Fix logout issue in tenanted myaccount

--- a/apps/myaccount/src/hooks/use-sign-in.ts
+++ b/apps/myaccount/src/hooks/use-sign-in.ts
@@ -351,6 +351,10 @@ const useSignIn = (): UseSignInInterface => {
             }
 
             sessionStorage.setItem(LOGOUT_URL, logoutUrl);
+        } else {
+            logoutUrl = window["AppUtils"].getConfig().idpConfigs?.logoutEndpointURL;
+            logoutRedirectUrl =
+                window["AppUtils"].getConfig().clientOrigin + window["AppUtils"].getConfig().routes.login;
         }
 
         getDecodedIDToken()
@@ -410,7 +414,7 @@ const useSignIn = (): UseSignInInterface => {
                     endpoints: {
                         authorizationEndpoint: authorizationEndpoint,
                         checkSessionIframe: oidcSessionIframeEndpoint,
-                        endSessionEndpoint: logoutUrl.split("?")[0],
+                        endSessionEndpoint: logoutUrl?.split("?")[0],
                         tokenEndpoint: tokenEndpoint
                     },
                     signOutRedirectURL: logoutRedirectUrl


### PR DESCRIPTION
### Purpose
> Currently, the logout from tenanted my account redirects to the admin myaccount in the legacy authz runtime. This PR will redirect the user to tenanted myaccount.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
