### PR TITLE
[fix] The Continue button text change is affecting the Set Password section as well

### DIFF
--- a/.changeset/dry-hounds-search.md
+++ b/.changeset/dry-hounds-search.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+[fix] The Continue button text change is affecting the Set Password section as well

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset.jsp
@@ -288,9 +288,14 @@
 
                             <div class="align-right buttons">
                                 <button id="submit"
-                                        class="ui primary button"
-                                        type="submit">
-                                    <%=i18n(recoveryResourceBundle, customText, "password.reset.button")%>
+                                    class="ui primary button"
+                                    type="submit"
+                                >
+                                    <% if ("invite".equalsIgnoreCase(type)) { %>
+                                        <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Proceed")%>
+                                    <% } else { %>
+                                        <%=i18n(recoveryResourceBundle, customText, "password.reset.button")%>
+                                    <% } %>
                                 </button>
                             </div>
                         </form>


### PR DESCRIPTION
### Purpose
[fix] The Continue button text change is affecting the Set Password section as well

### Related Issues
- https://github.com/wso2/product-is/issues/19710

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
