### PR TITLE
[TEMP] Temp fix to hide `ReadOnly` property in `UniqueIDReadOnlyLDAPUserStoreManager`

### DIFF
--- a/.changeset/fuzzy-plums-mix.md
+++ b/.changeset/fuzzy-plums-mix.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+[TEMP] Temp fix to hide `ReadOnly` property

--- a/apps/console/src/features/userstores/components/add-user-store.tsx
+++ b/apps/console/src/features/userstores/components/add-user-store.tsx
@@ -274,6 +274,7 @@ export const AddUserStore: FunctionComponent<AddUserStoreProps> = (props: AddUse
                     onSubmit={ onSubmitUserDetails }
                     values={ userDetailsData }
                     properties={ properties?.user?.required }
+                    type={ type?.typeName }
                     data-testid={ `${ testId }-user-details` }
                 />
             ),

--- a/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
+++ b/apps/console/src/features/userstores/components/edit/edit-user-details-userstore.tsx
@@ -74,6 +74,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
         properties,
         readOnly,
         update,
+        type,
         [ "data-testid" ]: testId
     } = props;
 
@@ -254,6 +255,12 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
                                         (attribute: PropertyAttribute) => attribute?.name === "type"
                                     )?.value === "boolean";
 
+                                    // FIXME: Temp fix to hide the `ReadOnly` property from ReadOnly Userstores.
+                                    // This should be handled in the backend and reverted from the UI.
+                                    // Tracker: https://github.com/wso2/product-is/issues/19769#issuecomment-1957415262
+                                    const isHidden: boolean = type.typeName === "UniqueIDReadOnlyLDAPUserStoreManager"
+                                        && property.name === "ReadOnly";
+
                                     return (
                                         isPassword
                                             ? (
@@ -284,6 +291,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
                                                             }
                                                         )
                                                     }
+                                                    hidden={ isHidden }
                                                     data-testid={ `${ testId }-form-password-input-${ property.name }` }
                                                 />
                                             )
@@ -316,6 +324,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
                                                                 }
                                                             )
                                                         }
+                                                        hidden={ isHidden }
                                                         data-testid={ `${ testId }-form-toggle-${ property.name }` }
                                                     />
                                                 ) :
@@ -349,6 +358,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
                                                                         }
                                                                     )
                                                                 }
+                                                                hidden={ isHidden }
                                                                 data-testid={
                                                                     `${ testId }-form-text-input-${ property.name }`
                                                                 }
@@ -382,6 +392,7 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
                                                                     }
                                                                 )
                                                             }
+                                                            hidden={ isHidden }
                                                             data-testid={
                                                                 `${ testId }-form-text-input-${ property?.name }`
                                                             }

--- a/apps/console/src/features/userstores/components/wizards/summary.tsx
+++ b/apps/console/src/features/userstores/components/wizards/summary.tsx
@@ -85,6 +85,10 @@ export const SummaryUserStores: FunctionComponent<SummaryUserStoresPropsInterfac
         description: string | number | ReactElement,
         key?: number
     ): ReactElement => {
+        if (!title) {
+            return null;
+        }
+
         return (
             <Grid.Row key={ key } className="summary-field" columns={ 2 }>
                 <Grid.Column mobile={ 16 } tablet={ 8 } computer={ 7 } textAlign="right">

--- a/apps/console/src/features/userstores/components/wizards/user-details.tsx
+++ b/apps/console/src/features/userstores/components/wizards/user-details.tsx
@@ -44,6 +44,10 @@ interface UserDetailsPropsInterface extends TestableComponentInterface {
      * The properties to be shown in this component.
      */
     properties: TypeProperty[];
+    /**
+     * The type of the userstore.
+     */
+    type: string;
 }
 
 /**
@@ -60,6 +64,7 @@ export const UserDetails: FunctionComponent<UserDetailsPropsInterface> = (
         onSubmit,
         values,
         properties,
+        type,
         [ "data-testid" ]: testId
     } = props;
 
@@ -83,6 +88,12 @@ export const UserDetails: FunctionComponent<UserDetailsPropsInterface> = (
                                         return attribute.name === "type";
                                     })?.value === "boolean";
                                 const isRequired: boolean = !isEmpty(selectedTypeDetail?.defaultValue);
+
+                                // FIXME: Temp fix to hide the `ReadOnly` property from ReadOnly Userstores.
+                                // This should be handled in the backend and reverted from the UI.
+                                // Tracker: https://github.com/wso2/product-is/issues/19769#issuecomment-1957415262
+                                const isHidden: boolean = type === "UniqueIDReadOnlyLDAPUserStoreManager"
+                                    && selectedTypeDetail.name === "ReadOnly";
 
                                 if (toggle) {
                                     return (
@@ -111,6 +122,7 @@ export const UserDetails: FunctionComponent<UserDetailsPropsInterface> = (
                                                     ?? selectedTypeDetail.defaultValue
                                             }
                                             toggle
+                                            hidden={ isHidden }
                                             data-testid={ `${ testId }-form-toggle-${
                                                 selectedTypeDetail.name }` }
                                         />
@@ -142,6 +154,7 @@ export const UserDetails: FunctionComponent<UserDetailsPropsInterface> = (
                                             values?.get(selectedTypeDetail?.name)?.toString()
                                                 ?? selectedTypeDetail.defaultValue
                                         }
+                                        hidden={ isHidden }
                                         data-testid={ `${ testId }-form-text-input-${
                                             selectedTypeDetail.name }` }
                                     />


### PR DESCRIPTION
### Purpose

Temp fix to hide `ReadOnly` property in `UniqueIDReadOnlyLDAPUserStoreManager` until userstore metadata is properly updated.

### Related Issues
- Address https://github.com/wso2/product-is/issues/19769

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
