### PR TITLE
Replace `isSaaSDeployment` deployment config with extension model

### DIFF
--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1725,9 +1725,6 @@
         {% if console.ui.is_left_navigation_categorized is defined %}
         "isLeftNavigationCategorized": {{ console.ui.is_left_navigation_categorized }},
         {% endif %}
-        {% if console.ui.is_saas_deployment is defined %}
-        "isSAASDeployment": {{ console.ui.saas_deployment }},
-        {% endif %}
         {% if event.default_listener.validation.enable is defined %}
         "isPasswordInputValidationEnabled": {{ event.default_listener.validation.enable }},
         {% else %}

--- a/apps/console/src/extensions/configs/application.tsx
+++ b/apps/console/src/extensions/configs/application.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import Chip from "@oxygen-ui/react/Chip";
 import { LegacyModeInterface } from "@wso2is/core/models";
 import { I18n } from "@wso2is/i18n";
 import {
@@ -24,6 +25,7 @@ import {
     EmphasizedSegment,
     GenericIcon,
     Heading,
+    LinkButton,
     Popup,
     PrimaryButton,
     ResourceTab,
@@ -50,8 +52,10 @@ import {
     additionalSpProperty
 } from "../../features/applications/models";
 import { ClaimManagementConstants } from "../../features/claims/constants/claim-management-constants";
+import { AuthenticatorManagementConstants } from "../../features/connections";
 import { EventPublisher, FeatureConfigInterface } from "../../features/core";
 import { AppConstants } from "../../features/core/constants";
+import { GenericAuthenticatorInterface } from "../../features/identity-providers/models";
 import { ApplicationRoles } from "../../features/roles/components/application-roles";
 import MobileAppTemplate from "../application-templates/templates/mobile-application/mobile-application.json";
 import OIDCWebAppTemplate from "../application-templates/templates/oidc-web-application/oidc-web-application.json";
@@ -644,6 +648,99 @@ export const applicationConfig: ApplicationConfig = {
                 }
             }
         },
+        renderAcsUrlSelectPrompt: (
+            acsUrlFromTemplate: string,
+            onAccept:  (
+                e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+            ) => void,
+            showAcsUrlAcceptButton: boolean,
+            metadata?: any
+        ) => {
+            return (
+                <Message
+                    visible
+                    type="info"
+                    content={
+                        (<>
+                            {
+                                <Trans
+                                    i18nKey={ "console:develop.features.applications.forms." +
+                                        "inboundSAML.fields.assertionURLs.info" }
+                                    tOptions={ {
+                                        assertionURLFromTemplate:
+                                            acsUrlFromTemplate
+                                    } }
+                                >
+                                        Don’t have an app? Try out a sample app
+                                        using <strong>{ acsUrlFromTemplate }</strong>
+                                        as the assertion Response URL.
+                                        (You can download and run a sample
+                                        at a later step.)
+                                </Trans>
+                            }
+                            {
+                                showAcsUrlAcceptButton && (
+                                    <LinkButton
+                                        className={ "m-1 p-1 with-no-border orange" }
+                                        onClick={ onAccept }
+                                        data-testid={ `${metadata?.testId}-add-now-button` }
+                                    >
+                                        <span style={ { fontWeight: "bold" } }>Add Now</span>
+                                    </LinkButton>
+                                )
+                            }
+                        </>)
+                    }
+                />
+            );
+        },
+        renderCallbackUrlSelectPrompt: (
+            callbackUrlFromTemplate: string,
+            onAccept:  (
+                e: React.MouseEvent<
+                    HTMLButtonElement, MouseEvent
+                >
+            ) => void,
+            showCallbackUrlAcceptButton: boolean,
+            metadata: any
+        ) => (
+            <Message
+                type="info"
+                content={
+                    (<>
+                        {
+                            <Trans
+                                i18nKey={
+                                    "console:develop.features." +
+                                    "applications.forms.inboundOIDC.fields." +
+                                    "callBackUrls.info"
+                                }
+                                tOptions={ {
+                                    callBackURLFromTemplate: callbackUrlFromTemplate
+                                } }
+                            >
+                                Don’t have an app? Try out a sample app
+                                using <strong>{ callbackUrlFromTemplate }</strong>
+                                as the Authorized URL.
+                            </Trans>
+                        }
+                        {
+                            showCallbackUrlAcceptButton && (
+                                <LinkButton
+                                    className={ "m-1 p-1 with-no-border orange" }
+                                    onClick={ onAccept }
+                                    data-testid={ `${ metadata?.testId }-add-now-button` }
+                                >
+                                    <span style={ { fontWeight: "bold" } }>
+                                        Add Now
+                                    </span>
+                                </LinkButton>
+                            )
+                        }
+                    </>)
+                }
+            />
+        ),
         samlWeb: {
             tomcatSAMLAgent: {
                 catalog: "",
@@ -716,7 +813,31 @@ export const applicationConfig: ApplicationConfig = {
                 ),
                 secondFactorDisabledInFirstStep: null
             }
-        }
+        },
+        /**
+         * Render feature status chip.
+         *
+         * @param authenticator - Authenticator.
+         *
+         * @returns Feature status chip.
+         */
+        renderAuthenticatorFeatureStatusChip: (authenticator: GenericAuthenticatorInterface): ReactElement => {
+            if (
+                authenticator?.defaultAuthenticator?.authenticatorId === AuthenticatorManagementConstants
+                    .ACTIVE_SESSION_LIMIT_HANDLER_AUTHENTICATOR_ID
+            ) {
+                return (
+                    <Chip
+                        size="small"
+                        label={ I18n.instance.t("common:beta").toUpperCase() }
+                        className="oxygen-chip-beta"
+                    />
+                );
+            }
+
+            return null;
+        },
+        showSetupGuideButtonInAuthenticatorCards: false
     },
     templates:{
         custom: true,

--- a/apps/console/src/extensions/configs/models/application.ts
+++ b/apps/console/src/extensions/configs/models/application.ts
@@ -26,6 +26,7 @@ import {
 } from "../../../features/applications/components/settings";
 import { ApplicationInterface, ApplicationTabTypes } from "../../../features/applications/models";
 import { FeatureConfigInterface } from "../../../features/core";
+import { GenericAuthenticatorInterface } from "../../../features/identity-providers/models";
 import { OIDCSDKMeta } from "../../application-templates/templates/oidc-web-application/models";
 import { SAMLSDKMeta } from "../../application-templates/templates/saml-web-application/models";
 import { SDKMetaInterface } from "../../application-templates/templates/single-page-application/models";
@@ -147,6 +148,8 @@ export interface ApplicationConfig {
                 secondFactorDisabledInFirstStep: ReactNode;
             };
         };
+        showSetupGuideButtonInAuthenticatorCards: boolean;
+        renderAuthenticatorFeatureStatusChip: (authenticator: GenericAuthenticatorInterface) => ReactElement
     };
     templates: {
         oidc: boolean;
@@ -165,6 +168,38 @@ export interface ApplicationConfig {
     excludeSubjectClaim: boolean;
     quickstart: {
         oidcWeb: OIDCSDKMeta;
+        /**
+         *
+         * @param callbackUrlFromTemplate - callback URL/ACS URL predefined in the template
+         * @param onAccept - callback function to run on clicking the "add now" button
+         * @param showTemplateConfiguredUrlAcceptButton - whether the "add now" button should be displayed or not
+         * @param metadata - any other data required for rendering the UI widget
+         * @returns a UI widget prompting the end user to select a predefined callback URL/ACS URL
+         */
+        renderCallbackUrlSelectPrompt: (
+            callbackUrlFromTemplate: string,
+            onAccept:  (
+                e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+            ) => void,
+            showCallbackUrlAcceptButton: boolean,
+            metadata?: any
+        )  => ReactNode,
+                /**
+         *
+         * @param acsUrlFromTemplate - Assertion Consumer Service URL predefined in the template
+         * @param onAccept - callback function to run on clicking the "add now" button
+         * @param showAcsUrlAcceptButton - whether the "add now" button should be displayed or not
+         * @param metadata - any other data required for rendering the UI widget
+         * @returns a UI widget prompting the end user to select a predefined callback URL/ACS URL
+         */
+        renderAcsUrlSelectPrompt: (
+            acsUrlFromTemplate: string,
+            onAccept:  (
+                e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+            ) => void,
+            showAcsUrlAcceptButton: boolean,
+            metadata?: any
+        )  => ReactNode,
         samlWeb: SAMLSDKMeta;
         spa: SDKMetaInterface
     };

--- a/apps/console/src/extensions/configs/models/organization.ts
+++ b/apps/console/src/extensions/configs/models/organization.ts
@@ -20,4 +20,5 @@ export interface OrganizationConfigs {
     allowNavigationInDropdown: boolean;
     showSwitcherInTenants: boolean;
     showOrganizationDropdown: boolean;
+    showRootOrganizationInBreadCrumb: boolean;
 }

--- a/apps/console/src/extensions/configs/organization.tsx
+++ b/apps/console/src/extensions/configs/organization.tsx
@@ -21,5 +21,6 @@ import { OrganizationConfigs } from "./models";
 export const organizationConfigs: OrganizationConfigs = {
     allowNavigationInDropdown: false,
     showOrganizationDropdown: false,
+    showRootOrganizationInBreadCrumb: false,
     showSwitcherInTenants: false
 };

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
@@ -90,6 +90,7 @@ import {
 import { OrganizationType } from "../../../../../organizations/constants";
 import { getGeneralIcons } from "../../../../configs/ui";
 import { AuthenticationStepInterface } from "../../../../models";
+import { applicationConfig } from "apps/console/src/extensions";
 
 /**
  * Prop-types for the Add authenticator modal component.
@@ -181,8 +182,6 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
     const { getLink } = useDocumentation();
     const { hiddenAuthenticators } = useAuthenticationFlow();
     const { deploymentConfig } = useDeploymentConfig();
-
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
 
     const hiddenConnectionTemplates: string[] = useSelector(
         (state: AppState) => state.config?.ui?.hiddenConnectionTemplates
@@ -576,7 +575,11 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
 
                                             return (
                                                 <ResourceGrid.Card
-                                                    showSetupGuideButton={ !!isSAASDeployment }
+                                                    showSetupGuideButton={
+                                                        applicationConfig?.
+                                                            signInMethod?.
+                                                            showSetupGuideButtonInAuthenticatorCards
+                                                    }
                                                     navigationLink={
                                                         getLink(ConnectionsManagementUtils
                                                             .resolveConnectionDocLink(template.id))

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -119,8 +119,6 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
         "with-labels": showLabels
     });
 
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
-
     /**
      * Updates the internal selected authenticators state when the prop changes.
      */
@@ -361,31 +359,6 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
         return AuthenticatorMeta.getAuthenticatorLabels(authenticator?.defaultAuthenticator) ?? [];
     };
 
-    /**
-     * Render feature status chip.
-     *
-     * @param authenticator - Authenticator.
-     *
-     * @returns Feature status chip.
-     */
-    const renderFeatureStatusChip = (authenticator: GenericAuthenticatorInterface): ReactElement => {
-        if (
-            isSAASDeployment &&
-          authenticator?.defaultAuthenticator?.authenticatorId === AuthenticatorManagementConstants
-              .ACTIVE_SESSION_LIMIT_HANDLER_AUTHENTICATOR_ID
-        ) {
-            return (
-                <Chip
-                    size="small"
-                    label={ t("common:beta").toUpperCase() }
-                    className="oxygen-chip-beta"
-                />
-            );
-        }
-
-        return null;
-    };
-
     return (
         <Fragment data-testid={ testId }>
             { heading && <Heading as="h6">{ heading }</Heading> }
@@ -419,7 +392,11 @@ export const Authenticators: FunctionComponent<AuthenticatorsPropsInterface> = (
                                 }
                                 subHeader={ authenticator.categoryDisplayName }
                                 description={ authenticator.description }
-                                featureStatus={ renderFeatureStatusChip(authenticator) }
+                                featureStatus={
+                                    applicationConfig
+                                        ?.signInMethod
+                                        ?.renderAuthenticatorFeatureStatusChip(authenticator)
+                                }
                                 image={
                                     authenticator.idp === AuthenticatorCategories.LOCAL ||
                                     authenticator

--- a/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -19,11 +19,12 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
 import { Field, FormValue, Forms } from "@wso2is/forms";
-import { ContentLoader, Hint, LinkButton, Message, URLInput } from "@wso2is/react-components";
+import { ContentLoader, Hint, URLInput } from "@wso2is/react-components";
+import { applicationConfig } from "apps/console/src/extensions";
 import intersection from "lodash-es/intersection";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Grid } from "semantic-ui-react";
 import { AppState, ConfigReducerStateInterface } from "../../../../features/core";
@@ -124,7 +125,6 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
     } = props;
 
     const { t } = useTranslation();
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
 
     const [ callBackUrls, setCallBackUrls ] = useState("");
     const [ callBackURLFromTemplate, setCallBackURLFromTemplate ] = useState("");
@@ -588,48 +588,22 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                                         showLessContent={ t("common:showLess") }
                                         showMoreContent={ t("common:showMore") }
                                     />
-                                    { (callBackURLFromTemplate) && isSAASDeployment && (
-                                        <Message
-                                            type="info"
-                                            content={
-                                                (<>
-                                                    {
-                                                        <Trans
-                                                            i18nKey={ "console:develop.features." +
-                                                                "applications.forms.inboundOIDC.fields." +
-                                                                "callBackUrls.info" }
-                                                            tOptions={ {
-                                                                callBackURLFromTemplate: callBackURLFromTemplate
-                                                            } }
-                                                        >
-                                                                Don’t have an app? Try out a sample app
-                                                                using <strong>{ callBackURLFromTemplate }</strong>
-                                                                as the Authorized URL.
-                                                        </Trans>
-                                                    }
-                                                    {
-                                                        (callBackUrls === undefined || callBackUrls === "") && (
-                                                            <LinkButton
-                                                                className={ "m-1 p-1 with-no-border orange" }
-                                                                onClick={ (
-                                                                    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-                                                                ) => {
-                                                                    e.preventDefault();
-                                                                    const host: URL = new URL(callBackURLFromTemplate);
+                                    {
+                                        applicationConfig?.quickstart?.renderCallbackUrlSelectPrompt(
+                                            callBackURLFromTemplate,
+                                            (
+                                                e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+                                            ) => {
+                                                e.preventDefault();
+                                                const host: URL = new URL(callBackURLFromTemplate);
 
-                                                                    handleAddAllowOrigin(host.origin);
-                                                                    setCallBackUrls(callBackURLFromTemplate);
-                                                                } }
-                                                                data-testid={ `${ testId }-add-now-button` }
-                                                            >
-                                                                <span style={ { fontWeight: "bold" } }>Add Now</span>
-                                                            </LinkButton>
-                                                        )
-                                                    }
-                                                </>)
-                                            }
-                                        />
-                                    ) }
+                                                handleAddAllowOrigin(host.origin);
+                                                setCallBackUrls(callBackURLFromTemplate);
+                                            },
+                                            callBackUrls === undefined || callBackUrls === "",
+                                            { testId }
+                                        )
+                                    }
                                 </Grid.Column>
                             </Grid.Row>
                         ) }

--- a/apps/console/src/features/applications/components/wizard/saml-protocol-settings-all-option-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/saml-protocol-settings-all-option-wizard-form.tsx
@@ -23,8 +23,6 @@ import {
     ContentLoader,
     FilePicker,
     Hint,
-    LinkButton,
-    Message,
     PickerResult,
     URLInput,
     XMLFileStrategy
@@ -32,10 +30,10 @@ import {
 import { FormValidation } from "@wso2is/validation";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Button, Grid, Icon } from "semantic-ui-react";
-import { commonConfig } from "../../../../extensions";
+import { applicationConfig, commonConfig } from "../../../../extensions";
 import { AppState, ConfigReducerStateInterface, getCertificateIllustrations } from "../../../core";
 import { SAMLConfigModes } from "../../models";
 import { ApplicationManagementUtils } from "../../utils/application-management-utils";
@@ -129,7 +127,6 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
     const [ pastedMetadataContent, setPastedMetadataContent ] = useState<string>(null);
     const [ emptyFileError, setEmptyFileError ] = useState(false);
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
 
     useEffect(() => {
         setConfigureMode(SAMLConfigModes.MANUAL);
@@ -474,52 +471,19 @@ export const SAMLProtocolAllSettingsWizardForm: FunctionComponent<SAMLProtocolAl
                                     showMoreContent={ t("common:showMore") }
                                 />
                                 {
-                                    (assertionConsumerURLFromTemplate) && isSAASDeployment && (
-                                        <Message
-                                            visible
-                                            type="info"
-                                            content={
-                                                (<>
-                                                    {
-                                                        <Trans
-                                                            i18nKey={ "console:develop.features.applications.forms." +
-                                                            "inboundSAML.fields.assertionURLs.info" }
-                                                            tOptions={ {
-                                                                assertionURLFromTemplate:
-                                                                assertionConsumerURLFromTemplate
-                                                            } }
-                                                        >
-                                                            Don’t have an app? Try out a sample app
-                                                            using <strong>{ assertionConsumerURLFromTemplate }</strong>
-                                                            as the assertion Response URL.
-                                                            (You can download and run a sample
-                                                            at a later step.)
-                                                        </Trans>
-                                                    }
-                                                    {
-                                                        (assertionConsumerUrls === undefined ||
-                                                            assertionConsumerUrls === "") && (
-                                                            <LinkButton
-                                                                className={ "m-1 p-1 with-no-border orange" }
-                                                                onClick={
-                                                                    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>
-                                                                    ) => {
-                                                                        e.preventDefault();
-                                                                        setAssertionConsumerUrls(
-                                                                            assertionConsumerURLFromTemplate);
-                                                                        setIssuer(issuerFromTemplate);
-                                                                        setHasAssertionConsumerUrls(true);
-                                                                    }
-                                                                }
-                                                                data-testid={ `${testId}-add-now-button` }
-                                                            >
-                                                                <span style={ { fontWeight: "bold" } }>Add Now</span>
-                                                            </LinkButton>
-                                                        )
-                                                    }
-                                                </>)
-                                            }
-                                        />
+                                    applicationConfig?.quickstart?.renderAcsUrlSelectPrompt(
+                                        assertionConsumerURLFromTemplate,
+                                        (e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+                                        ) => {
+                                            e.preventDefault();
+                                            setAssertionConsumerUrls(
+                                                assertionConsumerURLFromTemplate);
+                                            setIssuer(issuerFromTemplate);
+                                            setHasAssertionConsumerUrls(true);
+                                        },
+                                        assertionConsumerUrls === undefined ||
+                                        assertionConsumerUrls === "",
+                                        { testId }
                                     )
                                 }
                             </Grid.Column>

--- a/apps/console/src/features/applications/pages/applications.tsx
+++ b/apps/console/src/features/applications/pages/applications.tsx
@@ -127,7 +127,6 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
     const { UIConfig } = useUIConfig();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
 
     const [ searchQuery, setSearchQuery ] = useState<string>("");
     const [ listSortingStrategy, setListSortingStrategy ] = useState<DropdownItemProps>(
@@ -422,11 +421,6 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
      * @returns My Account link.
      */
     const renderTenantedMyAccountLink = (): ReactElement => {
-        if (!applicationConfig.advancedConfigurations.showMyAccount ||
-            UIConfig?.legacyMode?.applicationListSystemApps) {
-            return null;
-        }
-
         return (
             <EmphasizedSegment
                 className="mt-0 mb-5"
@@ -573,7 +567,8 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
         >
             {
                 (
-                    isSAASDeployment
+                    applicationConfig.advancedConfigurations.showMyAccount
+                    || UIConfig?.legacyMode?.applicationListSystemApps
                     || (
                         !isMyAccountApplicationDataFetchRequestLoading
                         && myAccountApplicationData?.applications?.length !== 0

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
@@ -274,6 +274,7 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
                                                     <Typography sx={ { fontWeight: 500 } }>
                                                         { mode.label }
                                                     </Typography>
+                                                    {/* This should ideally be handled by the feature gate impl. */}
                                                     { isSAASDeployment && mode.extra }
                                                 </div>
                                             ) }

--- a/apps/console/src/features/authentication-flow-builder/components/nodes/sign-in-box-node/sign-in-box-node.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/nodes/sign-in-box-node/sign-in-box-node.tsx
@@ -302,7 +302,13 @@ export const SignInBoxNode: FunctionComponent<SignInBoxNodePropsInterface> = (
                     </IconButton>
                 </Tooltip>
                 <Button
-                    startIcon={ <img className="oxygen-sign-in-option-image" src={ authenticator.image } /> }
+                    startIcon={ (
+                        <img
+                            alt={ authenticator.displayName }
+                            className="oxygen-sign-in-option-image"
+                            src={ authenticator.image }
+                        />
+                    ) }
                     variant="contained"
                     className="oxygen-sign-in-option"
                     type="button"
@@ -542,8 +548,8 @@ export const SignInBoxNode: FunctionComponent<SignInBoxNodePropsInterface> = (
                                     }
                                 ) }
                                 {
-                                    (getBasicSignInOption() !== 
-                                        IdentityProviderManagementConstants.SESSION_EXECUTOR_AUTHENTICATOR) 
+                                    (getBasicSignInOption() !==
+                                        IdentityProviderManagementConstants.SESSION_EXECUTOR_AUTHENTICATOR)
                                     &&
                                     (<Button
                                         fullWidth

--- a/apps/console/src/features/branding/components/branding-preference-tabs.tsx
+++ b/apps/console/src/features/branding/components/branding-preference-tabs.tsx
@@ -449,6 +449,7 @@ export const BrandingPreferenceTabs: FunctionComponent<BrandingPreferenceTabsInt
             menuItem: (
                 <Menu.Item key="text">
                     { t("console:branding.tabs.text.label") }
+                    { /* This should ideally be handled by the feature gate */ }
                     { isSAASDeployment && (
                         <Chip
                             size="small"

--- a/apps/console/src/features/claims/pages/claim-dialects.tsx
+++ b/apps/console/src/features/claims/pages/claim-dialects.tsx
@@ -84,8 +84,6 @@ const ClaimDialectsPage: FunctionComponent<ClaimDialectsPageInterface> = (
         (state: AppState) => state.config.ui.listAllAttributeDialects
     );
 
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
-
     /**
      * Fetches all the dialects.
      *
@@ -328,104 +326,112 @@ const ClaimDialectsPage: FunctionComponent<ClaimDialectsPageInterface> = (
                                                 </List.Item>
                                             </List>
                                         </EmphasizedSegment>
-                                        { !isSAASDeployment &&
-                                        featureConfig?.server?.enabled &&
-                                        hasRequiredScopes(
-                                            featureConfig?.server,
-                                            featureConfig?.server?.scopes?.read,
-                                            allowedScopes
-                                        ) && (
-                                            <EmphasizedSegment
-                                                onClick={ () => {
-                                                    history.push(AppConstants.getPaths()
-                                                        .get("CLAIM_VERIFICATION_SETTINGS"));
-                                                } }
-                                                className="clickable"
-                                                data-testid={ `${ testId }-attribute-verification-settings-container` }
-                                            >
-                                                <List>
-                                                    <List.Item>
-                                                        <Grid>
-                                                            <Grid.Row columns={ 2 }>
-                                                                <Grid.Column width={ 12 }>
-                                                                    <GenericIcon
-                                                                        verticalAlign="middle"
-                                                                        fill="primary"
-                                                                        transparent
-                                                                        icon={ getSidePanelIcons().gears }
-                                                                        spaced="right"
-                                                                        size="mini"
-                                                                        floated="left"
-                                                                    />
-                                                                    <List.Header>
-                                                                        { t(
-                                                                            "console:manage.features." +
+                                        {
+                                            featureConfig?.server?.enabled &&
+                                            hasRequiredScopes(
+                                                featureConfig?.server,
+                                                featureConfig?.server?.scopes?.read,
+                                                allowedScopes
+                                            ) && (
+                                                <EmphasizedSegment
+                                                    onClick={ () => {
+                                                        history.push(AppConstants.getPaths()
+                                                            .get("CLAIM_VERIFICATION_SETTINGS"));
+                                                    } }
+                                                    className="clickable"
+                                                    data-testid={
+                                                        `${ testId }-attribute-verification-settings-container`
+                                                    }
+                                                >
+                                                    <List>
+                                                        <List.Item>
+                                                            <Grid>
+                                                                <Grid.Row columns={ 2 }>
+                                                                    <Grid.Column width={ 12 }>
+                                                                        <GenericIcon
+                                                                            verticalAlign="middle"
+                                                                            fill="primary"
+                                                                            transparent
+                                                                            icon={ getSidePanelIcons().gears }
+                                                                            spaced="right"
+                                                                            size="mini"
+                                                                            floated="left"
+                                                                        />
+                                                                        <List.Header>
+                                                                            { t(
+                                                                                "console:manage.features." +
                                                                             "governanceConnectors." +
                                                                             "connectorCategories." +
                                                                             "otherSettings.connectors." +
                                                                             "userClaimUpdate." +
                                                                             "friendlyName"
-                                                                        ) }
-                                                                    </List.Header>
-                                                                    <List.Description
-                                                                        data-testid={
-                                                                            `${ testId }-attribute-verification` +
+                                                                            ) }
+                                                                        </List.Header>
+                                                                        <List.Description
+                                                                            data-testid={
+                                                                                `${ testId }-attribute-verification` +
                                                                             "-settings"
-                                                                        }
-                                                                    >
-                                                                        { t(
-                                                                            "console:manage.features." +
+                                                                            }
+                                                                        >
+                                                                            { t(
+                                                                                "console:manage.features." +
                                                                             "governanceConnectors." +
                                                                             "connectorSubHeading",
-                                                                            { name: t(
-                                                                                "console:manage.features." +
+                                                                                { name: t(
+                                                                                    "console:manage.features." +
                                                                                 "governanceConnectors." +
                                                                                 "connectorCategories." +
                                                                                 "otherSettings.connectors." +
                                                                                 "userClaimUpdate.friendlyName"
+                                                                                ) }
                                                                             ) }
-                                                                        ) }
-                                                                    </List.Description>
-                                                                </Grid.Column>
-                                                                <Grid.Column
-                                                                    width={ 4 }
-                                                                    verticalAlign="middle"
-                                                                    textAlign="right"
-                                                                    data-testid={
-                                                                        `${ testId }-attribute-verification-` +
+                                                                        </List.Description>
+                                                                    </Grid.Column>
+                                                                    <Grid.Column
+                                                                        width={ 4 }
+                                                                        verticalAlign="middle"
+                                                                        textAlign="right"
+                                                                        data-testid={
+                                                                            `${ testId }-attribute-verification-` +
                                                                         "settings-edit-icon"
-                                                                    }
-                                                                >
-                                                                    <Popup
-                                                                        content={
-                                                                            hasRequiredScopes(
-                                                                                featureConfig?.attributeDialects,
-                                                                                featureConfig?.attributeDialects?.
-                                                                                    scopes?.create,
-                                                                                allowedScopes
-                                                                            ) ?
-                                                                                t("common:configure") :
-                                                                                t("common:view")
                                                                         }
-                                                                        trigger={
-                                                                            hasRequiredScopes(
-                                                                                featureConfig?.attributeDialects,
-                                                                                featureConfig?.attributeDialects?.
-                                                                                    scopes?.create,
-                                                                                allowedScopes
-                                                                            ) ?
-                                                                                <Icon color="grey" name="pencil" /> :
-                                                                                <Icon color="grey" name="eye" />
-                                                                        }
-                                                                        inverted
-                                                                    />
-                                                                </Grid.Column>
-                                                            </Grid.Row>
-                                                        </Grid>
-                                                    </List.Item>
-                                                </List>
-                                            </EmphasizedSegment>
-                                        ) }
+                                                                    >
+                                                                        <Popup
+                                                                            content={
+                                                                                hasRequiredScopes(
+                                                                                    featureConfig?.attributeDialects,
+                                                                                    featureConfig?.attributeDialects?.
+                                                                                        scopes?.create,
+                                                                                    allowedScopes
+                                                                                ) ?
+                                                                                    t("common:configure") :
+                                                                                    t("common:view")
+                                                                            }
+                                                                            trigger={
+                                                                                hasRequiredScopes(
+                                                                                    featureConfig?.attributeDialects,
+                                                                                    featureConfig?.attributeDialects?.
+                                                                                        scopes?.create,
+                                                                                    allowedScopes
+                                                                                ) ?
+                                                                                    (<Icon
+                                                                                        color="grey"
+                                                                                        name="pencil"
+                                                                                    />) :
+                                                                                    (<Icon
+                                                                                        color="grey"
+                                                                                        name="eye"
+                                                                                    />)
+                                                                            }
+                                                                            inverted
+                                                                        />
+                                                                    </Grid.Column>
+                                                                </Grid.Row>
+                                                            </Grid>
+                                                        </List.Item>
+                                                    </List>
+                                                </EmphasizedSegment>
+                                            ) }
                                     </>
                                 )
                         )

--- a/apps/console/src/features/organizations/components/organization-switch/organization-switch-breadcrumb.tsx
+++ b/apps/console/src/features/organizations/components/organization-switch/organization-switch-breadcrumb.tsx
@@ -76,7 +76,6 @@ export const OrganizationSwitchBreadcrumb: FunctionComponent<OrganizationSwitchD
     const isFirstLevelOrg: boolean = useSelector(
         (state: AppState) => state?.organization?.isFirstLevelOrganization
     );
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
 
     const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
@@ -363,7 +362,7 @@ export const OrganizationSwitchBreadcrumb: FunctionComponent<OrganizationSwitchD
                 <>
                     { breadcrumbList?.map(
                         (breadcrumb: BreadcrumbItem, index: number) => {
-                            if (index === 0 && !isSAASDeployment) {
+                            if (index === 0 && organizationConfigs?.showRootOrganizationInBreadCrumb) {
                                 return (
                                     <>
                                         { generateSuperBreadcrumbItem(breadcrumb) }


### PR DESCRIPTION
### Purpose

A new config called `isSaaSDeployment` was added recently to the console app, in order to conditionally render UI features that should only be available in the cloud offering deployment. However, this can cause problems because it makes the on-prem console too coupled with the cloud offering. 

Instead of using a config just for the cloud offering, we should have use the existing extensions system to handle features meant only for the cloud. So, this pull request removes `isSaaSDeployment` from the console app and uses console extensions to conditionally render cloud-only UI features instead.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
