### PR TITLE
Fix RBAC issue in group create button

### DIFF
--- a/.changeset/light-snakes-sing.md
+++ b/.changeset/light-snakes-sing.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix RBAC bug in Group Create button

--- a/apps/console/src/features/connections/components/edit/settings/identity-provider-groups/identity-provider-groups-list.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/identity-provider-groups/identity-provider-groups-list.tsx
@@ -365,7 +365,7 @@ export const IdentityProviderGroupsList: FunctionComponent<IdentityProviderGroup
                             transparent
                         />
                         {
-                            (<Show when={ AccessControlConstants.SCOPE_WRITE }>
+                            (<Show when={ AccessControlConstants.GROUP_WRITE }>
                                 <PrimaryButton
                                     data-testid="user-mgt-roles-list-update-button"
                                     size="medium"

--- a/apps/console/src/features/identity-providers/components/settings/identity-provider-groups/identity-provider-groups-list.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/identity-provider-groups/identity-provider-groups-list.tsx
@@ -371,7 +371,7 @@ export const IdentityProviderGroupsList: FunctionComponent<IdentityProviderGroup
                             transparent
                         />
                         {
-                            (<Show when={ AccessControlConstants.SCOPE_WRITE }>
+                            (<Show when={ AccessControlConstants.GROUP_WRITE }>
                                 <PrimaryButton
                                     data-testid="user-mgt-roles-list-update-button"
                                     size="medium"


### PR DESCRIPTION
### Purpose

RBAC for Group Create button was handled with an incorrect scope group.

### Related Issues
- Fixes https://github.com/wso2/product-is/issues/19831

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
