### PR TITLE
Show userstores for JIT provisioning for tenant users

### DIFF
--- a/.changeset/small-actors-promise.md
+++ b/.changeset/small-actors-promise.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Show userstores for JIT Provisioning for tenant users.

--- a/apps/console/src/features/connections/components/edit/settings/jit-provisioning-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/jit-provisioning-settings.tsx
@@ -19,17 +19,17 @@
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmphasizedSegment } from "@wso2is/react-components";
+import { useGetCurrentOrganizationType } from "apps/console/src/features/organizations/hooks/use-get-organization-type";
+import { AxiosResponse } from "axios";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
 import { SimpleUserStoreListItemInterface } from "../../../../applications/models";
-import { store } from "../../../../core";
-import { OrganizationUtils } from "../../../../organizations/utils";
 import { getUserStoreList } from "../../../../userstores/api";
 import { updateJITProvisioningConfigs } from "../../../api/connections";
 import { JITProvisioningResponseInterface } from "../../../models/connection";
 import { JITProvisioningConfigurationsForm } from "../forms";
-import { useGetCurrentOrganizationType } from "apps/console/src/features/organizations/hooks/use-get-organization-type";
 
 /**
  * Proptypes for the identity provider general details component.
@@ -64,8 +64,8 @@ interface JITProvisioningSettingsInterface extends TestableComponentInterface {
 /**
  * Component to edit just-in time provisioning details of the identity provider.
  *
- * @param {JITProvisioningSettings} props - Props injected to the component.
- * @return {ReactElement}
+ * @param JITProvisioningSettings - Props injected to the component.
+ * @returns JITProvisioningSettings component.
  */
 export const JITProvisioningSettings: FunctionComponent<JITProvisioningSettingsInterface> = (
     props: JITProvisioningSettingsInterface): ReactElement => {
@@ -80,13 +80,11 @@ export const JITProvisioningSettings: FunctionComponent<JITProvisioningSettingsI
         [ "data-testid" ]: testId
     } = props;
 
-    const dispatch = useDispatch();
-    const { isSuperOrganization } = useGetCurrentOrganizationType();
+    const dispatch: Dispatch = useDispatch();
+    const { isSuperOrganization, isFirstLevelOrganization } = useGetCurrentOrganizationType();
     const { t } = useTranslation();
 
     const [ userStore, setUserStore ] = useState<SimpleUserStoreListItemInterface[]>([]);
-    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-
 
     /**
      * Handles the advanced config form submit action.
@@ -125,8 +123,8 @@ export const JITProvisioningSettings: FunctionComponent<JITProvisioningSettingsI
             name: "PRIMARY"
         });
 
-        if (isSuperOrganization()) {
-            getUserStoreList().then((response) => {
+        if (isSuperOrganization() || isFirstLevelOrganization()) {
+            getUserStoreList().then((response: AxiosResponse) => {
                 userstore.push(...response.data);
                 setUserStore(userstore);
             }).catch(() => {
@@ -148,7 +146,6 @@ export const JITProvisioningSettings: FunctionComponent<JITProvisioningSettingsI
                         useStoreList={ userStore }
                         data-testid={ testId }
                         isReadOnly={ isReadOnly }
-                        isSubmitting={ isSubmitting }
                     />
                 </EmphasizedSegment>
             )

--- a/apps/console/src/features/connections/components/edit/settings/jit-provisioning-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/jit-provisioning-settings.tsx
@@ -19,13 +19,13 @@
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmphasizedSegment } from "@wso2is/react-components";
-import { useGetCurrentOrganizationType } from "apps/console/src/features/organizations/hooks/use-get-organization-type";
 import { AxiosResponse } from "axios";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { SimpleUserStoreListItemInterface } from "../../../../applications/models";
+import { useGetCurrentOrganizationType } from "../../../../organizations/hooks/use-get-organization-type";
 import { getUserStoreList } from "../../../../userstores/api";
 import { updateJITProvisioningConfigs } from "../../../api/connections";
 import { JITProvisioningResponseInterface } from "../../../models/connection";


### PR DESCRIPTION
### Purpose
Show all userstores including secondary user stores for JIT Provisioning under a Connection.

<img width="650" alt="Screenshot 2024-02-26 at 15 38 14" src="https://github.com/wso2/identity-apps/assets/67315176/69479506-43d5-4c2f-9af0-9da577c7731b">

### Related Issues
- https://github.com/wso2/product-is/issues/18736

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
