### PR TITLE
Disable linked accounts heading based on config

### DIFF
--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -521,13 +521,17 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                         />
                     )
                     }
-                    <Divider />
-                    <Heading
-                        as="h4"
-                    >
-                        { t("console:develop.features.applications.forms.advancedAttributeSettings." +
-                            "sections.linkedAccounts.heading") }
-                    </Heading>
+                    { applicationConfig.attributeSettings.advancedAttributeSettings.showValidateLinkedLocalAccount
+                        && (<>
+                            <Divider />
+                            <Heading
+                                as="h4"
+                            >
+                                { t("console:develop.features.applications.forms.advancedAttributeSettings." +
+                                    "sections.linkedAccounts.heading") }
+                            </Heading>
+                        </>)
+                    }
                     <Divider hidden/>
                     { !applicationConfig.attributeSettings.advancedAttributeSettings.showMandateLinkedLocalAccount ?
                         (<Field.CheckboxLegacy


### PR DESCRIPTION
### Purpose
The "Linked Accounts" heading should not be shown when "Validate linked accounts" checkbox is hidden via the application configuration. 


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
