### PR TITLE
Add missing `beta` label to alternative login identifiers

### DIFF
--- a/.changeset/two-shoes-reply.md
+++ b/.changeset/two-shoes-reply.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add beta label to alternative login idnetifiers

--- a/apps/console/src/features/server-configurations/components/governance-connector-grid.tsx
+++ b/apps/console/src/features/server-configurations/components/governance-connector-grid.tsx
@@ -37,10 +37,12 @@ import {
 import Avatar from "@oxygen-ui/react/Avatar";
 import Card from "@oxygen-ui/react/Card";
 import CardContent from "@oxygen-ui/react/CardContent";
+import Chip from "@oxygen-ui/react/Chip";
 import Typography from "@oxygen-ui/react/Typography";
 import { IdentifiableComponentInterface, LoadableComponentInterface } from "@wso2is/core/models";
 import { ContentLoader } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { serverConfigurationConfig } from "../../../extensions";
 import { AppConstants, history } from "../../core";
 import "./governance-connector-grid.scss";
@@ -78,6 +80,8 @@ const GovernanceConnectorCategoriesGrid: FunctionComponent<GovernanceConnectorCa
         connectorCategories,
         dynamicConnectors
     } = props;
+
+    const { t } = useTranslation();
 
     /**
      * Combine the connectors and dynamic connectors and group them by category.
@@ -241,6 +245,17 @@ const GovernanceConnectorCategoriesGrid: FunctionComponent<GovernanceConnectorCa
                                                         <div>
                                                             <Typography variant="h6">
                                                                 { connector.header }
+                                                                { connector.status &&
+                                                                (
+                                                                    <Chip
+                                                                        size="small"
+                                                                        sx= { { marginLeft: 1 } }
+                                                                        label= { t(`common:${connector.status}`)
+                                                                            .toUpperCase() }
+                                                                        className = { `oxygen-chip-${ connector.status
+                                                                            .toLowerCase() }` }
+                                                                    />)
+                                                                }
                                                             </Typography>
                                                         </div>
                                                     </CardContent>

--- a/apps/console/src/features/server-configurations/models/governance-connectors.ts
+++ b/apps/console/src/features/server-configurations/models/governance-connectors.ts
@@ -51,6 +51,7 @@ export interface GovernanceConnectorInterface {
     isCustom?: boolean;
     route?: string;
     testId?: string;
+	status?: string;
 }
 
 export interface GovernanceConnectorCategoryInterface {

--- a/apps/console/src/features/server-configurations/utils/governance-connector-utils.ts
+++ b/apps/console/src/features/server-configurations/utils/governance-connector-utils.ts
@@ -196,6 +196,7 @@ export class GovernanceConnectorUtils {
                         id: ServerConfigurationsConstants.ALTERNATIVE_LOGIN_IDENTIFIER,
                         route: AppConstants.getPaths()
                             .get("ALTERNATIVE_LOGIN_IDENTIFIER_EDIT"),
+                        status: "beta",
                         testId: "alternative-login-identifier-card"
                     },
                     {


### PR DESCRIPTION
### Purpose
- Add beta label to the Alternative login identifiers section

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
