### PR TITLE
Fix broken i18n string in sub-organization edit organization role page placeholder

### DIFF
--- a/.changeset/honest-shoes-pay.md
+++ b/.changeset/honest-shoes-pay.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix broken i18n string in sub-organization edit organization role page placeholder

--- a/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-groups.tsx
+++ b/apps/console/src/features/organizations/components/edit-organization-role/edit-organization-groups.tsx
@@ -690,7 +690,7 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
                                                         "emptyPlaceholder.title") }
                                                 subtitle={ [
                                                     t("console:manage.features.roles.edit.groups.placeholders." +
-                                                            "emptyPlaceholder.subtitles")
+                                                            "emptyPlaceholder.subtitles.0")
                                                 ] }
                                                 action={
                                                     !isReadOnly && (


### PR DESCRIPTION
### Purpose

$subject

<img width="1199" alt="Screenshot 2024-03-05 at 17 08 55" src="https://github.com/wso2/identity-apps/assets/41533942/1a28f659-8afc-4163-b886-9d1d99cc630b">


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
