### PR TITLE
Update email regex to allow special characters in user self registration username validation

### DIFF
--- a/.changeset/pretty-ears-mate.md
+++ b/.changeset/pretty-ears-mate.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Change user selfregistration email regex pattern to allow special charactors

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -2039,7 +2039,7 @@
 
                     return false;
             } else {
-                var usernamePattern = /^([\u00C0-\u00FFa-zA-Z0-9_\+\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,10})$/;
+                var usernamePattern = /(^[\u00C0-\u00FFa-zA-Z0-9](?:(?![!#$'+\\=^_.{|}~\-&]{2})[\u00C0-\u00FF\w!#$'+\\=^_.{|}~\-&]){0,63}(?=[\u00C0-\u00FFa-zA-Z0-9_]).\@(?![+.\-_])(?:(?![.+\-_]{2})[\w.+\-]){0,245}(?=[\u00C0-\u00FFa-zA-Z0-9]).\.[a-zA-Z]{2,10})$/;
                 if (!usernamePattern.test(usernameUserInput.value.trim()) && (emailRequired || !isAlphanumericUsernameEnabled())) {
                     username_error_msg_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Please.enter.valid.email")%>")
                     username_error_msg.show();


### PR DESCRIPTION
### Purpose
> $subject
Updating the regex in order to be aligned with the fix done in https://github.com/wso2/carbon-identity-framework/pull/5568
