### PR TITLE
Load existingSMSProviders on originalSMSProviderConfig change

### DIFF
--- a/.changeset/friendly-boxes-enjoy.md
+++ b/.changeset/friendly-boxes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Load existingSMSProviders on originalSMSProviderConfig change

--- a/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
+++ b/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
@@ -95,40 +95,52 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
      * @param data - Data.
      */
     const handleUpdateSMSPublisher = ( event: React.FormEvent<HTMLInputElement>, data: CheckboxProps) => {
-        if (data.checked) {
-            // Add SMS Publisher when enabling the feature.
-            addSMSPublisher().then(() => {
+        
+        // Create SMS Publisher only if does not exist.
+        if (notificationSendersList.length === 0) {
+            if (data.checked) {
+                // Add SMS Publisher when enabling the feature.
+                addSMSPublisher().then(() => {
+                    setEnableSMSOTP(true);
+                    onActivate(true);
+                }).catch(() => {
+                    dispatch(addAlert({
+                        description: t("extensions:develop.identityProviders.smsOTP.settings" +
+                            ".errorNotifications.smsPublisherCreationError.description"),
+                        level: AlertLevels.ERROR,
+                        message: t("extensions:develop.identityProviders.smsOTP.settings" +
+                            ".errorNotifications.smsPublisherCreationError.message")
+                    }));
+                });
+            } else {
+                // Delete SMS Publisher when enabling the feature.
+                deleteSMSPublisher().then(() => {
+                    setEnableSMSOTP(false);
+                    onActivate(false);
+                }).catch((error: IdentityAppsApiException) => {
+                    const errorType : string = error.code === SMSOTPConstants.ErrorMessages
+                        .SMS_NOTIFICATION_SENDER_DELETION_ERROR_ACTIVE_SUBS.getErrorCode() ? "activeSubs" :
+                        ( error.code === SMSOTPConstants.ErrorMessages.
+                            SMS_NOTIFICATION_SENDER_DELETION_ERROR_CONNECTED_APPS.getErrorCode() ? "connectedApps"
+                            : "generic" );
+    
+                    dispatch(addAlert({
+                        description: t("extensions:develop.identityProviders.smsOTP.settings." +
+                            `errorNotifications.smsPublisherDeletionError.${errorType}.description`),
+                        level: AlertLevels.ERROR,
+                        message: t("extensions:develop.identityProviders.smsOTP.settings." +
+                            `errorNotifications.smsPublisherDeletionError.${errorType}.message`)
+                    }));
+                });
+            }
+        } else {
+            if (data.checked) {
                 setEnableSMSOTP(true);
                 onActivate(true);
-            }).catch(() => {
-                dispatch(addAlert({
-                    description: t("extensions:develop.identityProviders.smsOTP.settings" +
-                        ".errorNotifications.smsPublisherCreationError.description"),
-                    level: AlertLevels.ERROR,
-                    message: t("extensions:develop.identityProviders.smsOTP.settings" +
-                        ".errorNotifications.smsPublisherCreationError.message")
-                }));
-            });
-        } else {
-            // Delete SMS Publisher when enabling the feature.
-            deleteSMSPublisher().then(() => {
+            } else {
                 setEnableSMSOTP(false);
                 onActivate(false);
-            }).catch((error: IdentityAppsApiException) => {
-                const errorType : string = error.code === SMSOTPConstants.ErrorMessages
-                    .SMS_NOTIFICATION_SENDER_DELETION_ERROR_ACTIVE_SUBS.getErrorCode() ? "activeSubs" :
-                    ( error.code === SMSOTPConstants.ErrorMessages.
-                        SMS_NOTIFICATION_SENDER_DELETION_ERROR_CONNECTED_APPS.getErrorCode() ? "connectedApps"
-                        : "generic" );
-
-                dispatch(addAlert({
-                    description: t("extensions:develop.identityProviders.smsOTP.settings." +
-                        `errorNotifications.smsPublisherDeletionError.${errorType}.description`),
-                    level: AlertLevels.ERROR,
-                    message: t("extensions:develop.identityProviders.smsOTP.settings." +
-                        `errorNotifications.smsPublisherDeletionError.${errorType}.message`)
-                }));
-            });
+            }
         }
     };
 

--- a/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
+++ b/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
@@ -64,13 +64,8 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
                         value:string;
                     }[] = notificationSender.properties ? notificationSender.properties : [];
 
-                    if (notificationSender.name === "SMSPublisher" &&
-                        (channelValues.filter((prop : { key:string, value:string }) =>
-                            prop.key === "channel.type" && prop.value === "choreo")
-                            .length > 0)
-                    ) {
+                    if (notificationSender.name === "SMSPublisher") {
                         enableSMSOTP = true;
-
                         break;
                     }
                 }

--- a/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator.tsx
+++ b/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator.tsx
@@ -102,18 +102,12 @@ export const SmsOTPAuthenticator: FunctionComponent<SmsOTPAuthenticatorInterface
 
     return (
         <>
-            {
-                isChoreoEnabledAsSMSProvider && (
-                    <>
-                        <SmsOtpAuthenticatorActivationSection
-                            onActivate={
-                                (isActivated: boolean) => setIsReadOnly(isChoreoEnabledAsSMSProvider && !isActivated)
-                            }
-                        />
-                        <Divider hidden />
-                    </>
-                )
-            }
+            <SmsOtpAuthenticatorActivationSection
+                onActivate={
+                    (isActivated: boolean) => setIsReadOnly(isChoreoEnabledAsSMSProvider && !isActivated)
+                }
+            />
+            <Divider hidden />
             <SMSOTPAuthenticatorForm
                 initialValues={ initialValues }
                 metadata={ metadata }

--- a/apps/console/src/features/connections/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
+++ b/apps/console/src/features/connections/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
@@ -65,13 +65,8 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
                         value:string;
                     }[] = notificationSender.properties ? notificationSender.properties : [];
 
-                    if (notificationSender.name === "SMSPublisher" &&
-                        (channelValues.filter((prop : { key:string, value:string }) =>
-                            prop.key === "channel.type" && prop.value === "choreo")
-                            .length > 0)
-                    ) {
+                    if (notificationSender.name === "SMSPublisher") {
                         enableSMSOTP = true;
-
                         break;
                     }
                 }

--- a/apps/console/src/features/connections/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
+++ b/apps/console/src/features/connections/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
@@ -96,40 +96,52 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
      * @param data - Data.
      */
     const handleUpdateSMSPublisher = ( event: React.FormEvent<HTMLInputElement>, data: CheckboxProps) => {
-        if (data.checked) {
-            // Add SMS Publisher when enabling the feature.
-            addSMSPublisher().then(() => {
+        
+        // Create SMS Publisher only if does not exist.
+        if (notificationSendersList.length === 0) {
+            if (data.checked) {
+                // Add SMS Publisher when enabling the feature.
+                addSMSPublisher().then(() => {
+                    setEnableSMSOTP(true);
+                    onActivate(true);
+                }).catch(() => {
+                    dispatch(addAlert({
+                        description: t("extensions:develop.identityProviders.smsOTP.settings" +
+                            ".errorNotifications.smsPublisherCreationError.description"),
+                        level: AlertLevels.ERROR,
+                        message: t("extensions:develop.identityProviders.smsOTP.settings" +
+                            ".errorNotifications.smsPublisherCreationError.message")
+                    }));
+                });
+            } else {
+                // Delete SMS Publisher when enabling the feature.
+                deleteSMSPublisher().then(() => {
+                    setEnableSMSOTP(false);
+                    onActivate(false);
+                }).catch((error: IdentityAppsApiException) => {
+                    const errorType : string = error.code === AuthenticatorManagementConstants.ErrorMessages
+                        .SMS_NOTIFICATION_SENDER_DELETION_ERROR_ACTIVE_SUBS.getErrorCode() ? "activeSubs" :
+                        ( error.code === AuthenticatorManagementConstants.ErrorMessages
+                            .SMS_NOTIFICATION_SENDER_DELETION_ERROR_CONNECTED_APPS.getErrorCode() ? "connectedApps"
+                            : "generic" );
+    
+                    dispatch(addAlert({
+                        description: t("extensions:develop.identityProviders.smsOTP.settings." +
+                            `errorNotifications.smsPublisherDeletionError.${errorType}.description`),
+                        level: AlertLevels.ERROR,
+                        message: t("extensions:develop.identityProviders.smsOTP.settings." +
+                            `errorNotifications.smsPublisherDeletionError.${errorType}.message`)
+                    }));
+                });
+            }
+        } else {
+            if (data.checked) {
                 setEnableSMSOTP(true);
                 onActivate(true);
-            }).catch(() => {
-                dispatch(addAlert({
-                    description: t("extensions:develop.identityProviders.smsOTP.settings" +
-                        ".errorNotifications.smsPublisherCreationError.description"),
-                    level: AlertLevels.ERROR,
-                    message: t("extensions:develop.identityProviders.smsOTP.settings" +
-                        ".errorNotifications.smsPublisherCreationError.message")
-                }));
-            });
-        } else {
-            // Delete SMS Publisher when enabling the feature.
-            deleteSMSPublisher().then(() => {
+            } else {
                 setEnableSMSOTP(false);
                 onActivate(false);
-            }).catch((error: IdentityAppsApiException) => {
-                const errorType : string = error.code === AuthenticatorManagementConstants.ErrorMessages
-                    .SMS_NOTIFICATION_SENDER_DELETION_ERROR_ACTIVE_SUBS.getErrorCode() ? "activeSubs" :
-                    ( error.code === AuthenticatorManagementConstants.ErrorMessages
-                        .SMS_NOTIFICATION_SENDER_DELETION_ERROR_CONNECTED_APPS.getErrorCode() ? "connectedApps"
-                        : "generic" );
-
-                dispatch(addAlert({
-                    description: t("extensions:develop.identityProviders.smsOTP.settings." +
-                        `errorNotifications.smsPublisherDeletionError.${errorType}.description`),
-                    level: AlertLevels.ERROR,
-                    message: t("extensions:develop.identityProviders.smsOTP.settings." +
-                        `errorNotifications.smsPublisherDeletionError.${errorType}.message`)
-                }));
-            });
+            }
         }
     };
 

--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -137,7 +137,7 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
 
             setExistingSMSProviders(existingSMSProviderNames);
         }
-    },[ isSMSProviderConfigFetchRequestLoading ]);
+    },[ isSMSProviderConfigFetchRequestLoading, originalSMSProviderConfig ]);
 
     useEffect(() => {
         if (!originalSMSProviderConfig) {


### PR DESCRIPTION
### Purpose
> Load existingSMSProviders on originalSMSProviderConfig change.

### Related Issues
- 

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
