### PR TITLE
SMS OTP publisher fixes

### DIFF
--- a/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
+++ b/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
@@ -46,6 +46,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
     const { onActivate } = props;
     const { t } = useTranslation();
     const [ isEnableSMSOTP, setEnableSMSOTP ] = useState<boolean>(false);
+    const [ isChoreoSMSOTPProvider, setChoreoSMSOTPProvider ] = useState<boolean>(true);
     const dispatch: Dispatch = useDispatch();
 
     const {
@@ -57,6 +58,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
         if (!notificationSendersListFetchRequestError) {
             if (notificationSendersList) {
                 let enableSMSOTP: boolean = false;
+                let ischoeroSMSOTP: boolean = false;
 
                 for (const notificationSender of notificationSendersList) {
                     const channelValues: {
@@ -64,16 +66,19 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
                         value:string;
                     }[] = notificationSender.properties ? notificationSender.properties : [];
 
+                    if (notificationSender.name === "SMSPublisher") {
+                        enableSMSOTP = true;
+                    }
+
                     if (notificationSender.name === "SMSPublisher" &&
                         (channelValues.filter((prop : { key:string, value:string }) =>
                             prop.key === "channel.type" && prop.value === "choreo")
                             .length > 0)
                     ) {
-                        enableSMSOTP = true;
-
-                        break;
+                        ischoeroSMSOTP = true;
                     }
                 }
+                setChoreoSMSOTPProvider(ischoeroSMSOTP);
                 setEnableSMSOTP(enableSMSOTP);
                 onActivate(enableSMSOTP);
             }
@@ -98,6 +103,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
         if (data.checked) {
             // Add SMS Publisher when enabling the feature.
             addSMSPublisher().then(() => {
+                setChoreoSMSOTPProvider(true);
                 setEnableSMSOTP(true);
                 onActivate(true);
             }).catch(() => {
@@ -112,6 +118,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
         } else {
             // Delete SMS Publisher when enabling the feature.
             deleteSMSPublisher().then(() => {
+                setChoreoSMSOTPProvider(false);
                 setEnableSMSOTP(false);
                 onActivate(false);
             }).catch((error: IdentityAppsApiException) => {
@@ -135,6 +142,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
     return (
         <>
             <Checkbox
+                disabled={ !isChoreoSMSOTPProvider && isEnableSMSOTP }
                 toggle
                 label={ (!isEnableSMSOTP
                     ? t("extensions:develop.identityProviders.smsOTP.settings." +

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -2176,8 +2176,8 @@ export const extensions: Extensions = {
             smsOTP: {
                 settings: {
                     smsOtpEnableDisableToggle: {
-                        labelEnable: "Enable SMS OTP",
-                        labelDisable: "Disable SMS OTP "
+                        labelEnable: "Add default choreo SMS OTP provider",
+                        labelDisable: "Remove default choreo SMS OTP provider"
                     },
                     enableRequiredNote: {
                         message: "Asgardeo publishes events to Choreo to enable SMS OTP, where Choreo " +
@@ -2197,16 +2197,16 @@ export const extensions: Extensions = {
                         smsPublisherDeletionError: {
                             generic: {
                                 message: "Error Occurred",
-                                description: "Error occurred while trying to disable SMS OTP."
+                                description: "Error occurred while trying to remove default choreo SMS OTP provider."
                             },
                             activeSubs: {
                                 message: "Error Occurred",
-                                description: "Error occurred while trying to disable SMS OTP. SMS Publisher has " +
-                                    "active subscriptions."
+                                description: "Error occurred while trying to remove default choreo SMS OTP provider." +
+                                    " SMS Publisher has active subscriptions."
                             },
                             connectedApps: {
                                 message: "Error Occurred",
-                                description: "Error occurred while trying to disable SMS OTP. " +
+                                description: "Error occurred while trying to remove default choreo SMS OTP provider. " +
                                     "There are applications using this connection."
                             }
                         }

--- a/apps/console/src/features/connections/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
+++ b/apps/console/src/features/connections/components/authenticators/sms-otp/sms-otp-authenticator-activation-section.tsx
@@ -47,6 +47,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
     const { onActivate } = props;
     const { t } = useTranslation();
     const [ isEnableSMSOTP, setEnableSMSOTP ] = useState<boolean>(false);
+    const [ isChoreoSMSOTPProvider, setChoreoSMSOTPProvider ] = useState<boolean>(true);
     const dispatch: Dispatch = useDispatch();
 
     const {
@@ -58,6 +59,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
         if (!notificationSendersListFetchRequestError) {
             if (notificationSendersList) {
                 let enableSMSOTP: boolean = false;
+                let ischoeroSMSOTP: boolean = false;
 
                 for (const notificationSender of notificationSendersList) {
                     const channelValues: {
@@ -65,16 +67,19 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
                         value:string;
                     }[] = notificationSender.properties ? notificationSender.properties : [];
 
+                    if (notificationSender.name === "SMSPublisher") {
+                        enableSMSOTP = true;
+                    }
+
                     if (notificationSender.name === "SMSPublisher" &&
                         (channelValues.filter((prop : { key:string, value:string }) =>
                             prop.key === "channel.type" && prop.value === "choreo")
                             .length > 0)
                     ) {
-                        enableSMSOTP = true;
-
-                        break;
+                        ischoeroSMSOTP = true;
                     }
                 }
+                setChoreoSMSOTPProvider(ischoeroSMSOTP);
                 setEnableSMSOTP(enableSMSOTP);
                 onActivate(enableSMSOTP);
             }
@@ -99,6 +104,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
         if (data.checked) {
             // Add SMS Publisher when enabling the feature.
             addSMSPublisher().then(() => {
+                setChoreoSMSOTPProvider(true);
                 setEnableSMSOTP(true);
                 onActivate(true);
             }).catch(() => {
@@ -113,6 +119,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
         } else {
             // Delete SMS Publisher when enabling the feature.
             deleteSMSPublisher().then(() => {
+                setChoreoSMSOTPProvider(false);
                 setEnableSMSOTP(false);
                 onActivate(false);
             }).catch((error: IdentityAppsApiException) => {
@@ -150,6 +157,7 @@ export const SmsOtpAuthenticatorActivationSection: FunctionComponent<SmsOtpAuthe
                 </Trans>
             </Message>
             <Checkbox
+                disabled={ !isChoreoSMSOTPProvider && isEnableSMSOTP }
                 toggle
                 label={ (!isEnableSMSOTP
                     ? t("extensions:develop.identityProviders.smsOTP.settings." +

--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -61,6 +61,7 @@ import {
     SMSProviderSettingsState
 } from "../models";
 import "./sms-providers.scss";
+import { AuthenticatorManagementConstants } from "../../connections/constants/autheticator-constants";
 
 type SMSProviderPageInterface = IdentifiableComponentInterface;
 
@@ -124,7 +125,7 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
         error: smsProviderConfigFetchRequestError
     } = useSMSProviders();
     const [ isLoading, setIsLoading ] = useState(true);
-
+    const [ isChoreoSMSOTPProvider, setChoreoSMSOTPProvider ] = useState<boolean>(false);
     const [ existingSMSProviders, setExistingSMSProviders ] = useState<string[]>([]);
 
     useEffect(() => {
@@ -133,11 +134,17 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
 
             originalSMSProviderConfig?.forEach((smsProvider: SMSProviderAPIResponseInterface) => {
                 existingSMSProviderNames.push(smsProvider.provider + "SMSProvider");
+                
+                smsProvider.properties?.forEach((prop: { key: string, value: string }) => {
+                    if (prop.key === "channel.type" && prop.value === "choreo") {
+                        setChoreoSMSOTPProvider(true);
+                    }
+                });
             });
 
             setExistingSMSProviders(existingSMSProviderNames);
         }
-    },[ isSMSProviderConfigFetchRequestLoading ]);
+    },[ isSMSProviderConfigFetchRequestLoading, originalSMSProviderConfig ]);
 
     useEffect(() => {
         if (!originalSMSProviderConfig) {
@@ -236,7 +243,7 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
         setSmsProviderSettings({ ...smsProviderSettings, selectedProvider });
     };
 
-    const handleSubmit = (values: SMSProviderInterface) => {
+    const handleSubmit = async (values: SMSProviderInterface) => {
         setIsSubmitting(true);
         const { selectedProvider } = smsProviderSettings;
 
@@ -278,10 +285,32 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
             submittingValues.providerURL = values.providerURL;
         }
 
-        const handleSMSConfigValues: Promise<SMSProviderAPIResponseInterface> =
-            existingSMSProviders.length >= 1
+        let handleSMSConfigValues: Promise<SMSProviderAPIResponseInterface>;
+        if (isChoreoSMSOTPProvider) {
+            try {
+                await deleteSMSProviders();
+            } catch (error: any) {
+                const errorType : string = error.code === AuthenticatorManagementConstants.ErrorMessages
+                        .SMS_NOTIFICATION_SENDER_DELETION_ERROR_ACTIVE_SUBS.getErrorCode() ? "activeSubs" :
+                        ( error.code === AuthenticatorManagementConstants.ErrorMessages
+                            .SMS_NOTIFICATION_SENDER_DELETION_ERROR_CONNECTED_APPS.getErrorCode() ? "connectedApps"
+                            : "generic" );
+    
+                    dispatch(addAlert({
+                        description: t("extensions:develop.identityProviders.smsOTP.settings." +
+                            `errorNotifications.smsPublisherDeletionError.${errorType}.description`),
+                        level: AlertLevels.ERROR,
+                        message: t("extensions:develop.identityProviders.smsOTP.settings." +
+                            `errorNotifications.smsPublisherDeletionError.${errorType}.message`)
+                    }));
+                    return;
+            }
+            handleSMSConfigValues = createSMSProvider(submittingValues);
+        } else {
+            handleSMSConfigValues = existingSMSProviders.length >= 1
                 ? updateSMSProvider(submittingValues)
                 : createSMSProvider(submittingValues);
+        }
 
         handleSMSConfigValues.then((updatedData: SMSProviderAPIInterface) => {
             const updatedSMSProvider: SMSProviderInterface = {


### PR DESCRIPTION
### Purpose
> This PR contains the following changes.
- Add `default choreo SMS Provider` ONLY if no other SMS Provider is configured.
- Allow toggle ONLY if no `SMS Provider` is configured by the user. Disable the toggle when A new SMS Provider is configured by the user. (Twilio/Vonage/Custom)
- Change the toggle button message.
- Adding new SMS provider should first delete the existing default choreo SMS provider, if exist.

### Related Issues
- None.

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
