### PR TITLE
Enable the conditional script on adaptive script select

### DIFF
--- a/.changeset/angry-kings-train.md
+++ b/.changeset/angry-kings-train.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Enable the conditional script on adaptive script select

--- a/apps/console/src/features/authentication-flow-builder/components/predefined-flows-side-panel/predefined-flows-side-panel.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/predefined-flows-side-panel/predefined-flows-side-panel.tsx
@@ -172,7 +172,8 @@ const PredefinedFlowsSidePanel: FunctionComponent<PredefinedFlowsSidePanelPropsI
         adaptiveAuthTemplates,
         authenticators,
         defaultAuthenticationSequence,
-        updateAuthenticationSequence
+        updateAuthenticationSequence,
+        onConditionalAuthenticationToggle
     } = useAuthenticationFlow();
 
     const authenticatorsMeta: GenericAuthenticatorInterface[] = Object.values(
@@ -702,6 +703,9 @@ const PredefinedFlowsSidePanel: FunctionComponent<PredefinedFlowsSidePanelPropsI
             };
         }
 
+        // Since the adaptive auth templates contains a script,
+        // need to enable the toggle. Else the script will be ignored on update.
+        onConditionalAuthenticationToggle(true);
         updateAuthenticationSequence(newSequence);
     };
 


### PR DESCRIPTION
### Purpose

When adaptive auth templates are selected, the toggle isn't getting enabled and once you update, the script gets lost.
This PR enables the adaptive auth section once a user selects a conditional template.

### Related Issues
- Fixes https://github.com/wso2-enterprise/asgardeo-product/issues/22370

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
