### PR TITLE
Set tenant aware username in ALOR cookie

### DIFF
--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -91,6 +91,7 @@
     boolean isSaaSApp = Boolean.parseBoolean(request.getParameter("isSaaSApp"));
     boolean skipSignUpEnableCheck = Boolean.parseBoolean(request.getParameter("skipsignupenablecheck"));
     String policyURL = privacyPolicyURL;
+    String tenantAwareUsername = "";
 
     if (error) {
         request.setAttribute("error", true);
@@ -352,9 +353,14 @@
         selfRegisterApi.mePostCall(selfUserRegistrationRequest, requestHeaders);
         // Add auto login cookie.
         if (isAutoLoginEnable && !isSelfRegistrationLockOnCreationEnabled) {
+            if (StringUtils.isNotEmpty(user.getRealm())) {
+                tenantAwareUsername = user.getRealm() + "/" + username + "@" + user.getTenantDomain();
+            } else {
+                tenantAwareUsername = username + "@" + user.getTenantDomain();
+            }
             String cookieDomain = application.getInitParameter(AUTO_LOGIN_COOKIE_DOMAIN);
             JSONObject contentValueInJson = new JSONObject();
-            contentValueInJson.put("username", user.getUsername());
+            contentValueInJson.put("username", tenantAwareUsername);
             contentValueInJson.put("createdTime", System.currentTimeMillis());
             contentValueInJson.put("flowType", AUTO_LOGIN_FLOW_TYPE);
             if (StringUtils.isNotBlank(cookieDomain)) {


### PR DESCRIPTION
### Purpose
Set tenant aware username in autologin cookie. 
It was identified that setting the username without tenant domain appended in the auto-login cookie (ALOR) is an unintended behavior introduced with the unification effort [1]. Earlier the final username set in the cookie had always been tenant qualified in all products. Hence, we can reintroduce the tenant qualified behavior and revert the PR [2].

[1] https://github.com/wso2/identity-apps/pull/4034/files#diff-2586f3ce934cfd9e8d74f518bb46caf92617e429f47bc00f8241aa66e1c40590L256-L260

[2] https://github.com/wso2/carbon-identity-framework/pull/5374

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
