### PR TITLE
Replace absolute import paths with relative imports in console app

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -285,7 +285,19 @@ module.exports = {
                         name: "@oxygen-ui/react"
                     }
                 ],
-                patterns: [ "@wso2is/**/dist/**", "lodash/**", "lodash/fp/**" ]
+                patterns: [ 
+                    "@wso2is/**/dist/**",
+                    "lodash/**", 
+                    "lodash/fp/**",
+                    // prevents using absolute import paths such as "apps/console/src/**/*", "modules/react"
+                    // TODO: show an error message in the editor when an absolute import is used[1]. Currently
+                    // it's not working for some reason[2].
+                    // 
+                    // [1] https://eslint.org/docs/latest/rules/no-restricted-imports#options:~:text=%22no%2Drestricted%2Dimports%22%3A%20%5B%22error%22%2C%20%7B%0A%20%20%20%20%22patterns,deprecated%2C%20except%20the%20modules%20in%20import2/good.%22%0A%20%20%20%20%7D%5D%0A%7D%5D
+                    // [2] https://stackoverflow.com/questions/68126222/lint-rule-no-restricted-imports-throw-error-when-patterns-group-specified
+                    "apps/**/*",
+                    "modules/**/*"
+                ]
             }
         ],
         "no-trailing-spaces": "warn",

--- a/apps/console/jest.config.ts
+++ b/apps/console/jest.config.ts
@@ -37,16 +37,19 @@ module.exports = {
         "node"
     ],
     moduleNameMapper: {
-        "\\.(css|less)$": "<rootDir>/test-configs/__mocks__/style-file.ts",
+        "\\.(css|less|scss)$": "<rootDir>/test-configs/__mocks__/style-file.ts",
         "\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|md)$":
             "<rootDir>/test-configs/__mocks__/file.ts",
         "\\.svg": "<rootDir>/test-configs/__mocks__/svgr.ts",
         "^@unit-testing(.*)$": "<rootDir>/test-configs/utils",
         "^lodash-es/(.*)$": "<rootDir>/../../node_modules/lodash/$1",
-        "^react($|/.+)": "<rootDir>/../../node_modules/react$1",
+        "^react($|/.+)": "<rootDir>/node_modules/react$1",
         "@wso2is/form": "<rootDir>/../../modules/form/dist",
         "@wso2is/forms": "<rootDir>/../../modules/forms/dist",
+        "@wso2is/common": "<rootDir>/../../modules/common/dist",
+        "@wso2is/dynamic-forms":  "<rootDir>/../../modules/dynamic-forms/dist",
         "@wso2is/react-components": "<rootDir>/../../modules/react-components/dist",
+        "@oxygen-ui/react": "<rootDir>/node_modules/@oxygen-ui/react"
     },
     modulePaths: [
         "<rootDir>"
@@ -69,7 +72,8 @@ module.exports = {
         "^.+\\.(ts|tsx)?$": "ts-jest"
     },
     transformIgnorePatterns: [
-        "/node_modules/?(?!@wso2is)"
+        "/node_modules/?(?!@wso2is)",
+        "/node_modules/(?!@oxygen-ui/react/)"
     ],
-    verbose: true
+    verbose: true,
 };

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -30,7 +30,7 @@
         "postbuild": "node scripts/post-build.js",
         "poststart": "pnpm run postbuild",
         "start": "pnpm prestart && pnpm nx run console:serve && pnpm poststart",
-        "test": "pnpm jest --passWithNoTests",
+        "test": "jest --passWithNoTests",
         "test:watch": "pnpm run test --watchAll",
         "start:profile": "pnpm run start -- --env ENABLE_BUILD_PROFILER=true",
         "start:verbose": "pnpm run start -- --env LOG_LEVEL=verbose",

--- a/apps/console/src/extensions/components/account-login/pages/alternative-login-identifier-edit.tsx
+++ b/apps/console/src/extensions/components/account-login/pages/alternative-login-identifier-edit.tsx
@@ -42,10 +42,10 @@ import {
 } from "@wso2is/react-components";
 import {
     ServerConfigurationsConstants
-} from "apps/console/src/features/server-configurations/constants";
+} from "../../../../features/server-configurations/constants";
 import { AxiosError } from "axios";
 import isEmpty from "lodash-es/isEmpty";
-import { IdentityAppsError } from "modules/core/dist/types/errors";
+import { IdentityAppsError } from "@wso2is/core/errors";
 import React, {
     FunctionComponent,
     ReactElement,

--- a/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
+++ b/apps/console/src/extensions/components/account-login/pages/username-validation-edit.tsx
@@ -26,13 +26,13 @@ import {
     PageLayout,
     Text
 } from "@wso2is/react-components";
-import { updateValidationConfigData, useValidationConfigData } from "apps/console/src/features/validation/api";
+import { updateValidationConfigData, useValidationConfigData } from "../../../../features/validation/api";
 import {
     ValidationConfInterface,
     ValidationDataInterface,
     ValidationFormInterface,
     ValidationPropertyInterface
-} from "apps/console/src/features/validation/models";
+} from "../../../../features/validation/models";
 import { AxiosError } from "axios";
 import React, {
     FunctionComponent,

--- a/apps/console/src/extensions/components/api-resources/api/api-resources.ts
+++ b/apps/console/src/extensions/components/api-resources/api/api-resources.ts
@@ -22,7 +22,7 @@ import { HttpMethods } from "@wso2is/core/models";
 import useRequest, {
     RequestErrorInterface,
     RequestResultInterface
-} from "apps/console/src/features/core/hooks/use-request";
+} from "../../../../features/core/hooks/use-request";
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { store } from "../../../../features/core/store";
 import { APIResourcesConstants } from "../constants";

--- a/apps/console/src/extensions/components/api-resources/components/api-resource-panes/permission-api-resource.tsx
+++ b/apps/console/src/extensions/components/api-resources/components/api-resource-panes/permission-api-resource.tsx
@@ -28,7 +28,7 @@ import {
     ListLayout,
     PrimaryButton
 } from "@wso2is/react-components";
-import { getEmptyPlaceholderIllustrations } from "apps/console/src/features/core";
+import { getEmptyPlaceholderIllustrations } from "../../../../../features/core";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Icon, Input } from "semantic-ui-react";

--- a/apps/console/src/extensions/components/api-resources/components/api-resource-panes/permission-list-api-resource.tsx
+++ b/apps/console/src/extensions/components/api-resources/components/api-resource-panes/permission-list-api-resource.tsx
@@ -21,7 +21,7 @@ import { CommonUtils } from "@wso2is/core/utils";
 import {
     DataTable, EmptyPlaceholder, LinkButton, PrimaryButton, TableActionsInterface, TableColumnInterface
 } from "@wso2is/react-components";
-import { getEmptyPlaceholderIllustrations } from "apps/console/src/features/core";
+import { getEmptyPlaceholderIllustrations } from "../../../../../features/core";
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Header, Icon, Label, SemanticICONS } from "semantic-ui-react";

--- a/apps/console/src/extensions/components/api-resources/components/api-resources-list.tsx
+++ b/apps/console/src/extensions/components/api-resources/components/api-resources-list.tsx
@@ -29,7 +29,7 @@ import {
     TableActionsInterface,
     TableColumnInterface
 } from "@wso2is/react-components";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/extensions/components/api-resources/constants/api-resources-constants.ts
+++ b/apps/console/src/extensions/components/api-resources/constants/api-resources-constants.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { AppConstants } from "apps/console/src/features/core";
+import { AppConstants } from "../../../../features/core";
 
 /**
  * Class containing API resources constants.

--- a/apps/console/src/extensions/components/application/api/api-authorization/api-authorization.ts
+++ b/apps/console/src/extensions/components/application/api/api-authorization/api-authorization.ts
@@ -22,7 +22,7 @@ import { HttpMethods } from "@wso2is/core/models";
 import useRequest, {
     RequestErrorInterface,
     RequestResultInterface
-} from "apps/console/src/features/core/hooks/use-request";
+} from "../../../../../features/core/hooks/use-request";
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { store } from "../../../../../features/core/store";
 import { 

--- a/apps/console/src/extensions/components/application/components/api-authorization/api-authorization.tsx
+++ b/apps/console/src/extensions/components/application/components/api-authorization/api-authorization.tsx
@@ -29,7 +29,7 @@ import {
     PrimaryButton,
     useDocumentation
 } from "@wso2is/react-components";
-import { RequestErrorInterface } from "apps/console/src/features/core/hooks/use-request";
+import { RequestErrorInterface } from "../../../../../features/core/hooks/use-request";
 import { AxiosError } from "axios";
 import React, {
     Fragment,

--- a/apps/console/src/extensions/components/application/components/api-authorization/subscribed-api-resources.tsx
+++ b/apps/console/src/extensions/components/application/components/api-authorization/subscribed-api-resources.tsx
@@ -32,8 +32,8 @@ import {
     SegmentedAccordion,
     SegmentedAccordionTitleActionInterface
 } from "@wso2is/react-components";
-import { getEmptyPlaceholderIllustrations, history } from "apps/console/src/features/core";
-import { RequestErrorInterface } from "apps/console/src/features/core/hooks/use-request";
+import { getEmptyPlaceholderIllustrations, history } from "../../../../../features/core";
+import { RequestErrorInterface } from "../../../../../features/core/hooks/use-request";
 import { AxiosError } from "axios";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";

--- a/apps/console/src/extensions/components/application/components/application-roles/application-role-mapping.tsx
+++ b/apps/console/src/extensions/components/application/components/application-roles/application-role-mapping.tsx
@@ -25,7 +25,7 @@ import {
     Heading,
     PrimaryButton
 } from "@wso2is/react-components";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, { MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";

--- a/apps/console/src/extensions/components/audit-logs/audit-logs.tsx
+++ b/apps/console/src/extensions/components/audit-logs/audit-logs.tsx
@@ -21,7 +21,7 @@ import { EmptyPlaceholder,
     LinkButton,
     Message,
     PrimaryButton } from "@wso2is/react-components";
-import { getEmptyPlaceholderIllustrations } from "apps/console/src/features/core";
+import { getEmptyPlaceholderIllustrations } from "../../../features/core";
 import React, {
     MutableRefObject,
     ReactElement,

--- a/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator.tsx
+++ b/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator.tsx
@@ -21,8 +21,8 @@ import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import {
     CommonAuthenticatorFormInitialValuesInterface,
     CommonAuthenticatorFormMetaInterface
-} from "apps/console/src/features/identity-providers/models/identity-provider";
-import { Divider } from "modules/react-components/node_modules/semantic-ui-react";
+} from "../../../../features/identity-providers/models/identity-provider";
+import { Divider } from "semantic-ui-react";
 import React, { FunctionComponent, ReactElement, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import {

--- a/apps/console/src/extensions/components/diagnostic-logs/diagnostic-logs.tsx
+++ b/apps/console/src/extensions/components/diagnostic-logs/diagnostic-logs.tsx
@@ -22,7 +22,7 @@ import { EmptyPlaceholder,
     LinkButton,
     Message,
     PrimaryButton } from "@wso2is/react-components";
-import { getEmptyPlaceholderIllustrations } from "apps/console/src/features/core";
+import { getEmptyPlaceholderIllustrations } from "../../../features/core";
 import React, {
     MutableRefObject,
     ReactElement,

--- a/apps/console/src/extensions/components/groups/constants/groups-constants.ts
+++ b/apps/console/src/extensions/components/groups/constants/groups-constants.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { AppConstants } from "apps/console/src/features/core";
+import { AppConstants } from "../../../../features/core";
 
 /**
  * Class containing Groups constants.

--- a/apps/console/src/extensions/components/groups/edit-group/edit-group-users.tsx
+++ b/apps/console/src/extensions/components/groups/edit-group/edit-group-users.tsx
@@ -39,7 +39,7 @@ import {
 } from "@wso2is/react-components";
 import escapeRegExp from "lodash-es/escapeRegExp";
 import isEmpty from "lodash-es/isEmpty";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, {
     Dispatch,
     FormEvent,

--- a/apps/console/src/extensions/components/logs/pages/logs.tsx
+++ b/apps/console/src/extensions/components/logs/pages/logs.tsx
@@ -20,7 +20,7 @@ import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import {
     PageLayout,
     ResourceTab } from "@wso2is/react-components";
-import { AppState, FeatureConfigInterface } from "apps/console/src/features/core";
+import { AppState, FeatureConfigInterface } from "../../../../features/core";
 import React, {
     FunctionComponent,
     ReactElement,

--- a/apps/console/src/extensions/components/subscription/api/subscription.ts
+++ b/apps/console/src/extensions/components/subscription/api/subscription.ts
@@ -20,8 +20,8 @@ import useRequest, {
     RequestConfigInterface,
     RequestErrorInterface,
     RequestResultInterface
-} from "apps/console/src/features/core/hooks/use-request";
-import { HttpMethods } from "modules/core/src/models";
+} from "../../../../features/core/hooks/use-request";
+import { HttpMethods } from "@wso2is/core/models";
 import { Config } from "../../../../features/core";
 import { useGetCurrentOrganizationType } from "../../../../features/organizations/hooks/use-get-organization-type";
 import { getDomainQueryParam } from "../../tenants/api/tenants";

--- a/apps/console/src/extensions/components/user-stores/components/create/general-user-store-details.tsx
+++ b/apps/console/src/extensions/components/user-stores/components/create/general-user-store-details.tsx
@@ -19,7 +19,7 @@
 import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { SBACInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms, RadioChild, Validation } from "@wso2is/forms";
-import { FeatureConfigInterface } from "apps/console/src/features/core";
+import { FeatureConfigInterface } from "../../../../../features/core";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";

--- a/apps/console/src/extensions/components/users/utils/user-management-utils.ts
+++ b/apps/console/src/extensions/components/users/utils/user-management-utils.ts
@@ -17,7 +17,7 @@
  */
 
 import { ProfileSchemaInterface } from "@wso2is/core/models";
-import { store } from "apps/console/src/features/core";
+import { store } from "../../../../features/core";
 import {
     UserManagementConstants
 } from "../../../../features/users/constants/user-management-constants";

--- a/apps/console/src/extensions/components/users/wizard/steps/admin-user-basic.tsx
+++ b/apps/console/src/extensions/components/users/wizard/steps/admin-user-basic.tsx
@@ -29,7 +29,7 @@ import {
     useDocumentation
 } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import { UserListInterface } from "apps/console/src/features/users/models/user";
+import { UserListInterface } from "../../../../../features/users/models/user";
 import { AxiosResponse } from "axios";
 import debounce, { DebouncedFunc } from "lodash-es/debounce";
 import isEmpty from "lodash-es/isEmpty";

--- a/apps/console/src/features/applications/api/use-get-application.ts
+++ b/apps/console/src/features/applications/api/use-get-application.ts
@@ -17,7 +17,7 @@
  */
 
 import { AxiosRequestConfig } from "axios";
-import { HttpMethods } from "modules/core/src/models";
+import { HttpMethods } from "@wso2is/core/models";
 import useRequest, { RequestErrorInterface, RequestResultInterface } from "../../core/hooks/use-request";
 import { store } from "../../core/store";
 import { ApplicationInterface } from "../models/application";

--- a/apps/console/src/features/applications/api/use-scopes-of-api-resources.ts
+++ b/apps/console/src/features/applications/api/use-scopes-of-api-resources.ts
@@ -20,7 +20,7 @@ import { HttpMethods } from "@wso2is/core/models";
 import useRequest, {
     RequestErrorInterface,
     RequestResultInterface
-} from "apps/console/src/features/core/hooks/use-request";
+} from "../../core/hooks/use-request";
 import { AxiosRequestConfig } from "axios";
 import { store } from "../../core/store";
 import { AuthorizedPermissionListItemInterface } from "../models/api-authorization";

--- a/apps/console/src/features/applications/api/use-subscribed-api-resources.ts
+++ b/apps/console/src/features/applications/api/use-subscribed-api-resources.ts
@@ -20,7 +20,7 @@ import { HttpMethods } from "@wso2is/core/models";
 import useRequest, {
     RequestErrorInterface,
     RequestResultInterface
-} from "apps/console/src/features/core/hooks/use-request";
+} from "../../core/hooks/use-request";
 import { AxiosRequestConfig } from "axios";
 import { store } from "../../core/store";
 import { AuthorizedAPIListItemInterface } from "../models/api-authorization";

--- a/apps/console/src/features/applications/components/api-authorization/subscribed-api-resources.tsx
+++ b/apps/console/src/features/applications/components/api-authorization/subscribed-api-resources.tsx
@@ -31,8 +31,8 @@ import {
     SegmentedAccordion,
     SegmentedAccordionTitleActionInterface
 } from "@wso2is/react-components";
-import { getEmptyPlaceholderIllustrations, history } from "apps/console/src/features/core";
-import { RequestErrorInterface } from "apps/console/src/features/core/hooks/use-request";
+import { getEmptyPlaceholderIllustrations, history } from "../../../core";
+import { RequestErrorInterface } from "../../../core/hooks/use-request";
 import { AxiosError } from "axios";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/apps/console/src/features/applications/components/application-danger-zone.tsx
+++ b/apps/console/src/features/applications/components/application-danger-zone.tsx
@@ -21,7 +21,7 @@ import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ConfirmationModal, DangerZone, DangerZoneGroup } from "@wso2is/react-components";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -20,7 +20,7 @@ import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
 import { Field, Form } from "@wso2is/form";
 import { Code, Heading, Hint, Text } from "@wso2is/react-components";
-import useUIConfig from "modules/common/src/hooks/use-ui-configs";
+import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import React, { FormEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Checkbox, CheckboxProps, Divider } from "semantic-ui-react";

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection-oidc.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-selection-oidc.tsx
@@ -31,8 +31,8 @@ import {
     SegmentedAccordionTitleActionInterface,
     useDocumentation
 } from "@wso2is/react-components";
-import { OIDCScopesClaimsListInterface } from "apps/console/src/features/oidc-scopes";
-import { IdentifiableComponentInterface } from "modules/core/src/models";
+import { OIDCScopesClaimsListInterface } from "../../../../oidc-scopes";
+import { IdentifiableComponentInterface } from "@wso2is/core/src/models";
 import React, {
     ChangeEvent,
     Fragment,

--- a/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/attribute-settings.tsx
@@ -29,11 +29,11 @@ import {
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ConfirmationModal, ContentLoader, EmphasizedSegment } from "@wso2is/react-components";
-import { useOIDCScopesList } from "apps/console/src/features/oidc-scopes/api/oidc-scopes";
+import { useOIDCScopesList } from "../../../../oidc-scopes/api/oidc-scopes";
 import {
     OIDCScopesClaimsListInterface,
     OIDCScopesListInterface
-} from "apps/console/src/features/oidc-scopes/models/oidc-scopes";
+} from "../../../../oidc-scopes/models/oidc-scopes";
 import get from "lodash-es/get";
 import isEmpty from "lodash-es/isEmpty";
 import sortBy from "lodash-es/sortBy";

--- a/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/role-mapping.tsx
@@ -21,7 +21,7 @@ import { addAlert } from "@wso2is/core/store";
 import { DynamicField, KeyValue } from "@wso2is/forms";
 import { Heading } from "@wso2is/react-components";
 import { AxiosResponse } from "axios";
-import useUIConfig from "modules/common/src/hooks/use-ui-configs";
+import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -31,7 +31,7 @@ import {
 } from "@wso2is/react-components";
 import { AxiosError, AxiosResponse } from "axios";
 import kebabCase from "lodash-es/kebabCase";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -20,7 +20,7 @@ import Chip from "@oxygen-ui/react/Chip";
 import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Code, Heading, InfoCard, Popup, Text } from "@wso2is/react-components";
-import { AppState } from "apps/console/src/features/core";
+import { AppState } from "../../../../../core";
 import classNames from "classnames";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";

--- a/apps/console/src/features/applications/components/wizard/application-create-wizard.tsx
+++ b/apps/console/src/features/applications/components/wizard/application-create-wizard.tsx
@@ -27,7 +27,7 @@ import isEmpty from "lodash-es/isEmpty";
 import isEqual from "lodash-es/isEqual";
 import merge from "lodash-es/merge";
 import set from "lodash-es/set";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";

--- a/apps/console/src/features/applications/components/wizard/protocol-selection-wizard-form.tsx
+++ b/apps/console/src/features/applications/components/wizard/protocol-selection-wizard-form.tsx
@@ -17,7 +17,7 @@
  */
 
 import { AnimatedAvatar, AppAvatar, EmptyPlaceholder, GenericIcon } from "@wso2is/react-components";
-import { IdentifiableComponentInterface } from "modules/core/src/models";
+import { IdentifiableComponentInterface } from "@wso2is/core/src/models";
 import React, {
     FunctionComponent,
     MutableRefObject,

--- a/apps/console/src/features/authentication-flow-builder/components/nodes/sign-in-box-node/fragments/basic-sign-in-option-controls.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/nodes/sign-in-box-node/fragments/basic-sign-in-option-controls.tsx
@@ -18,7 +18,7 @@
 
 import IconButton from "@oxygen-ui/react/IconButton";
 import Tooltip from "@oxygen-ui/react/Tooltip";
-import { IdentifiableComponentInterface } from "modules/core/src/models";
+import { IdentifiableComponentInterface } from "@wso2is/core/src/models";
 import React, { MouseEvent, PropsWithChildren, ReactElement, ReactNode, SVGProps } from "react";
 
 // TODO: Move this to Oxygen UI once https://github.com/wso2/oxygen-ui/issues/158 is fixed.

--- a/apps/console/src/features/authentication-flow-builder/providers/authentication-flow-provider.tsx
+++ b/apps/console/src/features/authentication-flow-builder/providers/authentication-flow-provider.tsx
@@ -19,7 +19,7 @@
 import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import { AlertLevels, FeatureAccessConfigInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { applicationConfig } from "apps/console/src/extensions";
+import { applicationConfig } from "../../../extensions";
 import cloneDeep from "lodash-es/cloneDeep";
 import isEmpty from "lodash-es/isEmpty";
 import isEqual from "lodash-es/isEqual";

--- a/apps/console/src/features/branding/api/use-get-branding-preference.ts
+++ b/apps/console/src/features/branding/api/use-get-branding-preference.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { HttpMethods } from "modules/core/src/models";
+import { HttpMethods } from "@wso2is/core/models";
 import { store } from "../../core";
 import { I18nConstants } from "../../core/constants/i18n-constants";
 import useRequest, {

--- a/apps/console/src/features/branding/constants/branding-preferences-constants.ts
+++ b/apps/console/src/features/branding/constants/branding-preferences-constants.ts
@@ -17,7 +17,7 @@
  */
 
 import { IdentityAppsError } from "@wso2is/core/errors";
-import { commonConfig } from "apps/console/src/extensions";
+import { commonConfig } from "../../../extensions";
 import { PredefinedLayouts } from "../meta/layouts";
 import { BrandingPreferenceInterface, PredefinedThemes, ThemeConfigInterface } from "../models";
 

--- a/apps/console/src/features/claims/components/add/add-external-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-external-claim.tsx
@@ -20,7 +20,7 @@ import { AlertLevels, Claim, ClaimsGetParams, ExternalClaim, TestableComponentIn
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms, Validation, useTrigger } from "@wso2is/forms";
 import { Code, ContentLoader, Link, Message, PrimaryButton } from "@wso2is/react-components";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/features/claims/components/add/add-local-claim.tsx
+++ b/apps/console/src/features/claims/components/add/add-local-claim.tsx
@@ -23,7 +23,7 @@ import { FormValue, useTrigger } from "@wso2is/forms";
 import { LinkButton, PrimaryButton, Steps, useWizardAlert } from "@wso2is/react-components";
 import { AxiosResponse } from "axios";
 import isEmpty from "lodash-es/isEmpty";
-import { ClaimDialect } from "modules/core/src/models";
+import { ClaimDialect } from "@wso2is/core/src/models";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/features/claims/pages/attribute-mappings.tsx
+++ b/apps/console/src/features/claims/pages/attribute-mappings.tsx
@@ -27,7 +27,7 @@ import {
     useDocumentation
 } from "@wso2is/react-components";
 import Axios from "axios";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/features/claims/pages/attribute-verification-settings.tsx
+++ b/apps/console/src/features/claims/pages/attribute-verification-settings.tsx
@@ -21,7 +21,7 @@ import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/form";
 import { ContentLoader, EmphasizedSegment, PageLayout } from "@wso2is/react-components";
-import { ServerConfigurationsConstants } from "apps/console/src/features/server-configurations/constants";
+import { ServerConfigurationsConstants } from "../../server-configurations/constants";
 import { AxiosError } from "axios";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";

--- a/apps/console/src/features/connections/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -22,7 +22,7 @@ import Typography from "@oxygen-ui/react/Typography";
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { DropdownChild, Field, Form } from "@wso2is/form";
 import { Code, FormInputLabel, FormSection } from "@wso2is/react-components";
-import { identityProviderConfig } from "apps/console/src/extensions";
+import { identityProviderConfig } from "../../../../../../extensions";
 import React, { FunctionComponent, PropsWithChildren, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";

--- a/apps/console/src/features/connections/components/edit/forms/general-details-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/general-details-form.tsx
@@ -20,7 +20,7 @@ import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Form } from "@wso2is/form";
 import { EmphasizedSegment, Heading } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import { IdentityProviderManagementConstants } from "apps/console/src/features/identity-providers/constants";
+import { IdentityProviderManagementConstants } from "../../../../identity-providers/constants";
 import React, { FunctionComponent, ReactElement, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";

--- a/apps/console/src/features/connections/components/edit/settings/advance-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/advance-settings.tsx
@@ -19,7 +19,7 @@
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmphasizedSegment } from "@wso2is/react-components";
-import { IdentityProviderManagementConstants } from "apps/console/src/features/identity-providers/constants";
+import { IdentityProviderManagementConstants } from "../../../../identity-providers/constants";
 import { AxiosError } from "axios";
 import React, { Dispatch, FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/apps/console/src/features/connections/components/edit/settings/idp-certificates/idp-certificates.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/idp-certificates/idp-certificates.tsx
@@ -34,7 +34,7 @@ import {
     SwitcherOptionProps
 } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import { IdentityProviderManagementConstants } from "apps/console/src/features/identity-providers/constants";
+import { IdentityProviderManagementConstants } from "../../../../../identity-providers/constants";
 import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/features/connections/components/edit/settings/idp-certificates/idp-cetificates-list.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/idp-certificates/idp-cetificates-list.tsx
@@ -35,7 +35,7 @@ import {
     ResourceListItem,
     UserAvatar
 } from "@wso2is/react-components";
-import { IdentityProviderManagementConstants } from "apps/console/src/features/identity-providers/constants";
+import { IdentityProviderManagementConstants } from "../../../../../identity-providers/constants";
 import moment from "moment";
 import React, { FC, PropsWithChildren, ReactElement, ReactNode, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";

--- a/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-list.tsx
@@ -24,8 +24,8 @@ import {
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmptyPlaceholder, ListLayout, PrimaryButton } from "@wso2is/react-components";
-import { UsersConstants } from "apps/console/src/extensions/components/users/constants/users";
-import { UserStoreDropdownItem } from "apps/console/src/features/userstores/models";
+import { UsersConstants } from "../../../../../extensions/components/users/constants/users";
+import { UserStoreDropdownItem } from "../../../../userstores/models";
 import React, { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";

--- a/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-table.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/administrators-list/administrators-table.tsx
@@ -35,7 +35,7 @@ import {
     UserAvatar,
     useConfirmationModalAlert
 } from "@wso2is/react-components";
-import { UserManagementUtils } from "apps/console/src/extensions/components/users/utils/user-management-utils";
+import { UserManagementUtils } from "../../../../../extensions/components/users/utils/user-management-utils";
 import moment from "moment";
 import React, { ReactElement, ReactNode, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/apps/console/src/features/console-settings/components/console-administrators/invited-administrators/invited-administrators-list.tsx
+++ b/apps/console/src/features/console-settings/components/console-administrators/invited-administrators/invited-administrators-list.tsx
@@ -23,7 +23,7 @@ import {
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmptyPlaceholder, ListLayout, PrimaryButton } from "@wso2is/react-components";
-import { PRIMARY_USERSTORE, UsersConstants } from "apps/console/src/extensions/components/users/constants/users";
+import { PRIMARY_USERSTORE, UsersConstants } from "../../../../../extensions/components/users/constants/users";
 import React, { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";

--- a/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
+++ b/apps/console/src/features/identity-providers/components/edit-multi-factor-authenticator.tsx
@@ -20,7 +20,7 @@ import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, LoadableComponentInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ContentLoader, EmphasizedSegment, ResourceTab, ResourceTabPaneInterface } from "@wso2is/react-components";
-import { authenticatorConfig } from "apps/console/src/extensions/configs/authenticator";
+import { authenticatorConfig } from "../../../extensions/configs/authenticator";
 import get from "lodash-es/get";
 import React, { FunctionComponent, ReactElement, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/apps/console/src/features/identity-providers/components/settings/attribute-management/role-mapping-settings.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/attribute-management/role-mapping-settings.tsx
@@ -18,7 +18,7 @@
 import { RoleListInterface, RolesInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { DynamicField, KeyValue } from "@wso2is/forms";
 import { Heading, Hint } from "@wso2is/react-components";
-import { useGetCurrentOrganizationType } from "apps/console/src/features/organizations/hooks/use-get-organization-type";
+import { useGetCurrentOrganizationType } from "../../../../organizations/hooks/use-get-organization-type";
 import { AxiosError, AxiosResponse } from "axios";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";

--- a/apps/console/src/features/identity-providers/components/settings/outbound-provisioning/outbound-provisioning-roles.tsx
+++ b/apps/console/src/features/identity-providers/components/settings/outbound-provisioning/outbound-provisioning-roles.tsx
@@ -32,7 +32,7 @@ import { getRolesList } from "../../../../roles/api";
 import { updateIDPRoleMappings } from "../../../api";
 import { IdentityProviderRolesInterface } from "../../../models";
 import { handleGetRoleListError, handleUpdateIDPRoleMappingsError } from "../../utils";
-import { useGetCurrentOrganizationType } from "apps/console/src/features/organizations/hooks/use-get-organization-type";
+import { useGetCurrentOrganizationType } from "../../../../organizations/hooks/use-get-organization-type";
 
 interface OutboundProvisioningRolesPropsInterface extends TestableComponentInterface {
     idpId: string;

--- a/apps/console/src/features/identity-verification-providers/components/identity-verification-provider-list.tsx
+++ b/apps/console/src/features/identity-verification-providers/components/identity-verification-provider-list.tsx
@@ -29,7 +29,7 @@ import {
     TableActionsInterface,
     TableColumnInterface
 } from "@wso2is/react-components";
-import { hasRequiredScopes } from "modules/core/helpers";
+import { hasRequiredScopes } from "@wso2is/core/helpers";
 import React, { FunctionComponent, ReactElement, ReactNode, SyntheticEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";

--- a/apps/console/src/features/identity-verification-providers/pages/identity-verification-provider-edit.tsx
+++ b/apps/console/src/features/identity-verification-providers/pages/identity-verification-provider-edit.tsx
@@ -22,7 +22,7 @@ import {
     AppAvatar,
     TabPageLayout
 } from "@wso2is/react-components";
-import { hasRequiredScopes } from "modules/core/helpers";
+import { hasRequiredScopes } from "@wso2is/core/helpers";
 import React, {
     FunctionComponent,
     ReactElement,

--- a/apps/console/src/features/oidc-scopes/components/edit-oidc-scope.tsx
+++ b/apps/console/src/features/oidc-scopes/components/edit-oidc-scope.tsx
@@ -30,7 +30,7 @@ import {
     TableColumnInterface,
     TableDataInterface
 } from "@wso2is/react-components";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, {
     FunctionComponent,
     MutableRefObject,

--- a/apps/console/src/features/roles/utils/role-management-utils.ts
+++ b/apps/console/src/features/roles/utils/role-management-utils.ts
@@ -18,7 +18,7 @@
 
 import { RoleGroupsInterface } from "@wso2is/core/models";
 import { I18n } from "@wso2is/i18n";
-import { SCIMConfigs } from "apps/console/src/extensions/configs/scim";
+import { SCIMConfigs } from "../../../extensions/configs/scim";
 import { AxiosResponse } from "axios";
 import isEmpty from "lodash-es/isEmpty";
 import { AppConstants } from "../../../features/core";

--- a/apps/console/src/features/server-configurations/forms/self-registration-form.tsx
+++ b/apps/console/src/features/server-configurations/forms/self-registration-form.tsx
@@ -20,9 +20,9 @@ import { ProfileSchemaInterface, TestableComponentInterface } from "@wso2is/core
 import { Field, Form, FormFieldMessage } from "@wso2is/form";
 import { ConfirmationModal, Text } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import { AppState } from "apps/console/src/features/core";
-import { getUsernameConfiguration } from "apps/console/src/features/users/utils/user-management-utils";
-import { useValidationConfigData } from "apps/console/src/features/validation/api";
+import { AppState } from "../../core";
+import { getUsernameConfiguration } from "../../users/utils/user-management-utils";
+import { useValidationConfigData } from "../../validation/api";
 import get from "lodash-es/get";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";

--- a/apps/console/src/features/server/components/remote-logging-config-form.tsx
+++ b/apps/console/src/features/server/components/remote-logging-config-form.tsx
@@ -33,7 +33,7 @@ import {
 import { AxiosError } from "axios";
 import startCase from "lodash-es/startCase";
 import toLower from "lodash-es/toLower";
-import { AlertInterface, AlertLevels, IdentifiableComponentInterface } from "modules/core/src/models";
+import { AlertInterface, AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";

--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -31,7 +31,7 @@ import {
     PageLayout,
     useDocumentation
 } from "@wso2is/react-components";
-import smsProviderConfig from "apps/console/src/extensions/configs/sms-provider";
+import smsProviderConfig from "../../../extensions/configs/sms-provider";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/features/users/components/guests/models/invite.ts
+++ b/apps/console/src/features/users/components/guests/models/invite.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { InviteUserStatus } from "apps/console/src/extensions/components/users/models";
+import { InviteUserStatus } from "../../../../../extensions/components/users/models";
 import { ReactNode } from "react";
 import { GroupsInterface } from "../../../../groups";
 

--- a/apps/console/src/features/users/components/user-change-password.tsx
+++ b/apps/console/src/features/users/components/user-change-password.tsx
@@ -20,7 +20,7 @@ import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertInterface, AlertLevels, ProfileInfoInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms, RadioChild, Validation, useTrigger } from "@wso2is/forms";
 import { LinkButton, Message, PasswordValidation, PrimaryButton } from "@wso2is/react-components";
-import { IdentityAppsApiException } from "modules/core/dist/types/exceptions";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React,
 {
     FunctionComponent,

--- a/apps/console/src/features/users/pages/users.tsx
+++ b/apps/console/src/features/users/pages/users.tsx
@@ -34,8 +34,8 @@ import {
     ResourceTab,
     ResourceTabPaneInterface
 } from "@wso2is/react-components";
-import { UsersConstants } from "apps/console/src/extensions/components/users/constants";
-import { InvitationStatus } from "apps/console/src/extensions/components/users/models";
+import { UsersConstants } from "../../../extensions/components/users/constants";
+import { InvitationStatus } from "../../../extensions/components/users/models";
 import { AxiosError, AxiosResponse } from "axios";
 import React, {
     FunctionComponent,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2122,6 +2122,10 @@ importers:
 
 packages:
 
+  /@aashutoshrathi/word-wrap@1.2.6:
+    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+    engines: {node: '>=0.10.0'}
+
   /@adobe/css-tools@4.0.1:
     resolution: {integrity: sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==}
     dev: true
@@ -2235,7 +2239,7 @@ packages:
   /@babel/code-frame@7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.23.4
 
   /@babel/code-frame@7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
@@ -6527,7 +6531,7 @@ packages:
       ajv: 6.12.6
       debug: 4.3.4(supports-color@6.1.0)
       espree: 7.3.1
-      globals: 13.17.0
+      globals: 13.24.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       js-yaml: 3.13.1
@@ -9922,7 +9926,7 @@ packages:
     peerDependencies:
       typescript: ^3 || ^4 || ^5
     dependencies:
-      esquery: 1.4.0
+      esquery: 1.5.0
       typescript: 4.8.2
     dev: true
 
@@ -14579,7 +14583,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.36.1
-      eslint-visitor-keys: 3.3.0
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /@ungap/promise-all-settled@1.1.2:
@@ -19354,6 +19358,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
   /eslint-webpack-plugin@2.7.0(eslint@7.32.0)(webpack@5.84.1):
     resolution: {integrity: sha512-bNaVVUvU4srexGhVcayn/F4pJAz19CWBkKoMx7aSQ4wtTbZQCnG5O9LHCE42mM+JSKOUp7n6vd5CIwzj7lOVGA==}
     engines: {node: '>= 10.13.0'}
@@ -19406,13 +19415,13 @@ packages:
       eslint-utils: 2.1.0
       eslint-visitor-keys: 2.1.0
       espree: 7.3.1
-      esquery: 1.4.0
+      esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
       functional-red-black-tree: 1.0.1
       glob-parent: 5.1.2
-      globals: 13.17.0
+      globals: 13.24.0
       ignore: 4.0.6
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -19423,10 +19432,10 @@ packages:
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
-      optionator: 0.9.1
+      optionator: 0.9.3
       progress: 2.0.3
       regexpp: 3.2.0
-      semver: 7.3.7
+      semver: 7.5.4
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
       table: 6.8.0
@@ -19459,6 +19468,13 @@ packages:
 
   /esquery@1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
+    engines: {node: '>=0.10'}
+    dependencies:
+      estraverse: 5.3.0
+    dev: true
+
+  /esquery@1.5.0:
+    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
@@ -20719,8 +20735,8 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
-  /globals@13.17.0:
-    resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
+  /globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -26144,16 +26160,16 @@ packages:
       type-check: 0.3.2
       word-wrap: 1.2.3
 
-  /optionator@0.9.1:
-    resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
+  /optionator@0.9.3:
+    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
     dependencies:
+      '@aashutoshrathi/word-wrap': 1.2.6
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
-      word-wrap: 1.2.3
 
   /ora@5.3.0:
     resolution: {integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==}


### PR DESCRIPTION
### Purpose

The current unit tests in the console app fails due to the use of absolute paths in the codebase. This PR fixes the absolute paths by replacing those with relative paths and also updates the eslint config to throw an error on using absolute imports.

**Please note that the existing ESLint warnings haven't been fixed due to the size of the PR.**

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
