### PR TITLE
Hide self signup URL input in branding for sub organizations

### DIFF
--- a/.changeset/strong-kids-repair.md
+++ b/.changeset/strong-kids-repair.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Hide self signup URL input in branding for sub organizations

--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -16,11 +16,11 @@
  * under the License.
  */
 
+import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
 import { Field, Form } from "@wso2is/form";
 import { Code, Heading, Hint, Text } from "@wso2is/react-components";
-import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import React, { FormEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Checkbox, CheckboxProps, Divider } from "semantic-ui-react";

--- a/apps/console/src/features/branding/components/advanced/advance-form.tsx
+++ b/apps/console/src/features/branding/components/advanced/advance-form.tsx
@@ -25,6 +25,7 @@ import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, MutableRefObject, ReactElement, Ref, forwardRef, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Placeholder } from "semantic-ui-react";
+import { useGetCurrentOrganizationType } from "../../../organizations/hooks/use-get-organization-type";
 import { BrandingPreferencesConstants } from "../../constants";
 import { BrandingURLPreferenceConstants } from "../../constants/url-preference-constants";
 import { BrandingPreferenceInterface } from "../../models";
@@ -92,6 +93,8 @@ export const AdvanceForm: FunctionComponent<AdvanceFormPropsInterface> = forward
     } = props;
 
     const { t } = useTranslation();
+
+    const { isFirstLevelOrganization, isSuperOrganization  } = useGetCurrentOrganizationType();
 
     const [ privacyPolicyURL, setPrivacyPolicyURL ] = useState<string>(initialValues.urls.privacyPolicyURL);
     const [ termsOfUseURL, setTermsOfUseURL ] = useState<string>(initialValues.urls.termsOfUseURL);
@@ -261,34 +264,40 @@ export const AdvanceForm: FunctionComponent<AdvanceFormPropsInterface> = forward
                 data-testid={ `${ componentId }-cookie-policy-url` }
                 validation={ validateTemplatableURLs }
             />
-            <Field.Input
-                ariaLabel="Branding preference self signup URL"
-                inputType="url"
-                name="urls.selfSignUpURL"
-                label={ t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.label") }
-                placeholder={
-                    t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.placeholder")
-                }
-                hint={ (
-                    <Trans
-                        i18nKey="extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.hint"
-                    >
+            { (isFirstLevelOrganization() || isSuperOrganization()) && (
+                <Field.Input
+                    ariaLabel="Branding preference self signup URL"
+                    inputType="url"
+                    name="urls.selfSignUpURL"
+                    label={ t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.label") }
+                    placeholder={
+                        t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.placeholder")
+                    }
+                    hint={ (
+                        <Trans
+                            i18nKey="extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.hint"
+                        >
                         Link to your organization&apos;s Self Signup webpage. You can use placeholders like
-                        <Code>&#123;&#123;lang&#125;&#125;</Code>, <Code>&#123;&#123;country&#125;&#125;</Code>,
+                            <Code>&#123;&#123;lang&#125;&#125;</Code>, <Code>&#123;&#123;country&#125;&#125;</Code>,
                         or <Code>&#123;&#123;locale&#125;&#125;</Code> to customize the URL for different
                         regions or languages.
-                    </Trans>
-                ) }
-                required={ false }
-                value={ initialValues.urls.selfSignUpURL }
-                readOnly={ readOnly }
-                maxLength={ BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MAX_LENGTH }
-                minLength={ BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MIN_LENGTH }
-                listen={ (value: string) =>  setSelfSignUpURL(value) }
-                width={ 16 }
-                data-testid={ `${ componentId }-self-signup-url` }
-                validation={ validateTemplatableURLs }
-            />
+                        </Trans>
+                    ) }
+                    required={ false }
+                    value={ initialValues.urls.selfSignUpURL }
+                    readOnly={ readOnly }
+                    maxLength={
+                        BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MAX_LENGTH
+                    }
+                    minLength={
+                        BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MIN_LENGTH
+                    }
+                    listen={ (value: string) =>  setSelfSignUpURL(value) }
+                    width={ 16 }
+                    data-testid={ `${ componentId }-self-signup-url` }
+                    validation={ validateTemplatableURLs }
+                />
+            ) }
         </Form>
     );
 });


### PR DESCRIPTION
### Purpose

<img width="1512" alt="Screenshot 2024-03-08 at 15 19 42" src="https://github.com/wso2/identity-apps/assets/41533942/bb2b0747-5a80-4160-abdd-60bee703dbf2">

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
