### PR TITLE
Display warning notifications when Identifier First is added as the only 1FA

### DIFF
--- a/.changeset/gorgeous-dogs-change.md
+++ b/.changeset/gorgeous-dogs-change.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Display warning notifications when Identifier First is added as the only 1FA

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
@@ -265,7 +265,7 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
     /**
      * Validate the authentication steps.
      *
-     * @param options - Authenticator options.
+     * @param steps - Authenticator steps.
      * @returns True or false - Is steps are valid or not.
      */
     const validateSteps = (steps: AuthenticationStepInterface[]): boolean => {

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
@@ -43,10 +43,15 @@ import {
 import {
     ApplicationInterface,
     AuthenticationSequenceInterface,
-    AuthenticationSequenceType
+    AuthenticationSequenceType,
+    AuthenticationStepInterface,
+    AuthenticatorInterface
 } from "../../applications/models/application";
 import { AdaptiveScriptUtils } from "../../applications/utils/adaptive-script-utils";
 import { AppState } from "../../core/store";
+import {
+    IdentityProviderManagementConstants
+} from "../../identity-providers/constants/identity-provider-management-constants";
 import { OrganizationType } from "../../organizations/constants/organization-constants";
 import useAuthenticationFlow from "../hooks/use-authentication-flow";
 import { AuthenticationFlowBuilderModes, AuthenticationFlowBuilderModesInterface } from "../models/flow-builder";
@@ -232,6 +237,12 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
             };
         }
 
+        const isValid: boolean = validateSteps(newSequence?.steps);
+
+        if (!isValid) {
+            return;
+        }
+
         updateAuthenticationSequenceFromAPI(applicationMetaData?.id, payload)
             .then(() => {
                 dispatch(
@@ -250,6 +261,74 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
             })
             .finally(() => refetchApplication());
     };
+
+    /**
+     * Validates if the step deletion is valid.
+     *
+     * @param options - Authenticator options.
+     * @returns True or false - Is steps are valid or not.
+     */
+    const validateSteps = (steps: AuthenticationStepInterface[]): boolean => {
+
+        // Don't allow identifier first being the only authenticator in the flow.
+        if ( steps.length === 1
+            && steps[ 0 ].options.length === 1
+            && steps[ 0 ].options[ 0 ].authenticator
+                === IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR ) {
+            dispatch(
+                addAlert({
+                    description: t(
+                        "console:develop.features.applications.notifications.updateOnlyIdentifierFirstError" +
+                        ".description"
+                    ),
+                    level: AlertLevels.WARNING,
+                    message: t(
+                        "console:develop.features.applications.notifications.updateOnlyIdentifierFirstError" +
+                        ".message"
+                    )
+                })
+            );
+
+            return false;
+        }
+
+        // Don't allow identifier first being with another authenticator in the 1FA flow.
+        if (
+            steps.length === 1
+            && steps[0].options.length > 1
+            && handleIdentifierFirstInStep(steps[0].options)
+        ) {
+            dispatch(
+                addAlert({
+                    description: t(
+                        "console:develop.features.applications.notifications.updateIdentifierFirstInFirstStepError" +
+                        ".description"
+                    ),
+                    level: AlertLevels.WARNING,
+                    message: t(
+                        "console:develop.features.applications.notifications.updateIdentifierFirstInFirstStepError" +
+                        ".message"
+                    )
+                })
+            );
+
+            return false;
+        }
+
+        return true;
+    };
+
+    /**
+     * Check if the options include the Identifier First as an authenticator.
+     *
+     * @param options - Authenticator options.
+     * @returns true or false - Options include Identifier First or not.
+     */
+    const handleIdentifierFirstInStep = (options: AuthenticatorInterface[]): boolean =>
+        options.some(
+            (option: AuthenticatorInterface) =>
+                option.authenticator === IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR
+        );
 
     return (
         <Box className="sign-in-method-split-view">

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-builder.tsx
@@ -263,7 +263,7 @@ const AuthenticationFlowBuilder: FunctionComponent<AuthenticationFlowBuilderProp
     };
 
     /**
-     * Validates if the step deletion is valid.
+     * Validate the authentication steps.
      *
      * @param options - Authenticator options.
      * @returns True or false - Is steps are valid or not.


### PR DESCRIPTION
### Purpose
> Display warning notifications when Identifier First is added as the only 1FA.

**Identifier First is the only 1FA**

<img width="1440" alt="Screenshot 2024-03-12 at 14 31 18" src="https://github.com/wso2/identity-apps/assets/27746285/e2d7c0d5-1843-4027-93fe-baacb5b5c9c6">

**Identifier First + another authenticator as the only 1FA**

<img width="1440" alt="Screenshot 2024-03-12 at 14 31 37" src="https://github.com/wso2/identity-apps/assets/27746285/0d3b6459-1618-4759-98d1-c091050086df">

### Related Issues
- https://github.com/wso2/product-is/issues/19970

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
