### PR TITLE
Add navigation to progressive enrolment in the passkey alert

### DIFF
--- a/.changeset/selfish-cameras-beg.md
+++ b/.changeset/selfish-cameras-beg.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add navigation to progressive enrolment in the passkey alert

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -24,6 +24,7 @@ import {
     DocumentationLink,
     Heading,
     Hint,
+    Link,
     LinkButton,
     Message,
     PrimaryButton,
@@ -42,7 +43,14 @@ import { StepBasedFlow } from "./step-based-flow";
 import DefaultFlowConfigurationSequenceTemplate from "./templates/default-sequence.json";
 import useAuthenticationFlow from "../../../../authentication-flow-builder/hooks/use-authentication-flow";
 import { AuthenticatorManagementConstants } from "../../../../connections";
-import { AppState, ConfigReducerStateInterface, EventPublisher, FeatureConfigInterface } from "../../../../core";
+import {
+    AppConstants,
+    AppState,
+    ConfigReducerStateInterface,
+    EventPublisher,
+    FeatureConfigInterface,
+    history
+} from "../../../../core";
 import { getMultiFactorAuthenticatorDetails } from "../../../../identity-providers/api";
 import {
     IdentityProviderManagementConstants
@@ -778,8 +786,20 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
                                         "types.passkey.info.progressiveEnrollmentDisabled")
                                     }
                                 >
-                                Passkey progressive enrollment is disabled. Users must enroll
-                                their passkeys through <strong>My Account</strong> to use passwordless sign-in.
+                                    <Link
+                                        external={ false }
+                                        onClick={ () => {
+                                            history.push(
+                                                AppConstants.getPaths().get("IDP_EDIT")
+                                                    .replace(
+                                                        ":id", AuthenticatorManagementConstants.FIDO_AUTHENTICATOR_ID)
+                                            );
+                                        } }
+                                    >
+                                    Passkey progressive enrollment
+                                    </Link>
+                                    is disabled. Users must enroll
+                                    their passkeys through <strong>My Account</strong> to use passwordless sign-in.
                                 </Trans>
                                 <DocumentationLink
                                     link={ getLink("develop.applications.editApplication.signInMethod.fido") }

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms } from "@wso2is/forms";
@@ -32,7 +33,6 @@ import {
 } from "@wso2is/react-components";
 import { AxiosError, AxiosResponse } from "axios";
 import kebabCase from "lodash-es/kebabCase";
-import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
+++ b/apps/console/src/features/applications/components/settings/sign-on-methods/sign-in-method-customization.tsx
@@ -798,7 +798,7 @@ export const SignInMethodCustomization: FunctionComponent<SignInMethodCustomizat
                                     >
                                     Passkey progressive enrollment
                                     </Link>
-                                    is disabled. Users must enroll
+                                    &nbsp; is disabled. Users must enroll
                                     their passkeys through <strong>My Account</strong> to use passwordless sign-in.
                                 </Trans>
                                 <DocumentationLink

--- a/apps/console/src/features/authentication-flow-builder/components/authentication-flow-visual-editor.tsx
+++ b/apps/console/src/features/authentication-flow-builder/components/authentication-flow-visual-editor.tsx
@@ -19,9 +19,10 @@
 import Alert from "@oxygen-ui/react/Alert";
 import AlertTitle from "@oxygen-ui/react/AlertTitle";
 import Button from "@oxygen-ui/react/Button";
+import { AppConstants } from "@wso2is/common";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { DocumentationLink, useDocumentation } from "@wso2is/react-components";
+import { DocumentationLink, Link, useDocumentation } from "@wso2is/react-components";
 import classNames from "classnames";
 import cloneDeep from "lodash-es/cloneDeep";
 import React, {
@@ -62,8 +63,10 @@ import {
 } from "../../applications/models/application";
 import { AuthenticatorManagementConstants } from "../../connections";
 import useMultiFactorAuthenticatorDetails from "../../connections/api/use-multi-factor-authentication-details";
+import { history } from "../../core";
 import { IdentityProviderManagementConstants } from "../../identity-providers/constants";
 import { ConnectorPropertyInterface } from "../../server-configurations";
+import { FIDO_AUTHENTICATOR_ID } from "../constants/template-constants";
 import useAuthenticationFlow from "../hooks/use-authentication-flow";
 import "reactflow/dist/style.css";
 import "./authentication-flow-visual-editor.scss";
@@ -456,8 +459,19 @@ const AuthenticationFlowVisualEditor: FunctionComponent<AuthenticationFlowVisual
                                 "types.passkey.info.progressiveEnrollmentDisabled")
                             }
                         >
-                        Passkey progressive enrollment is disabled. Users must enroll
-                        their passkeys through <strong>My Account</strong> to use passwordless sign-in.
+                            <Link
+                                external={ false }
+                                onClick={ () => {
+                                    history.push(
+                                        AppConstants.getPaths().get("IDP_EDIT")
+                                            .replace(":id", FIDO_AUTHENTICATOR_ID)
+                                    );
+                                } }
+                            >
+                                Passkey progressive enrollment
+                            </Link>
+                                &nbsp; is disabled. Users must enroll
+                                their passkeys through <strong>My Account</strong> to use passwordless sign-in.
                         </Trans>
                         <DocumentationLink
                             link={ getLink("develop.applications.editApplication.signInMethod.fido") }

--- a/apps/console/src/features/authentication-flow-builder/constants/template-constants.ts
+++ b/apps/console/src/features/authentication-flow-builder/constants/template-constants.ts
@@ -19,3 +19,5 @@
 export const ELK_RISK_BASED_TEMPLATE_NAME: string = "ELK-Risk-Based";
 
 export const APPLE_LOGIN_SEQUENCE: string = "AppleSocialLoginSequence";
+
+export const FIDO_AUTHENTICATOR_ID: string = "RklET0F1dGhlbnRpY2F0b3I";

--- a/modules/i18n/src/translations/en-US/portals/console.ts
+++ b/modules/i18n/src/translations/en-US/portals/console.ts
@@ -1606,8 +1606,8 @@ export const console: ConsoleNS = {
                                                     "the Passkey in the <2>first step</2>, users need to add an adaptive " +
                                                     "script. Use the <4>Passkeys Progressive Enrollment</4> template in " +
                                                     "the <6>Sign-In-Method</6> tab of the application.",
-                                                    progressiveEnrollmentDisabled: "Passkey progressive enrollment is disabled. " +
-                                                    "Users must enroll their passkeys through <1>My Account</1> to use passwordless sign-in."
+                                                    progressiveEnrollmentDisabled: "<1>Passkey progressive enrollment</1> is disabled. " +
+                                                    "Users must enroll their passkeys through <2>My Account</2> to use passwordless sign-in."
                                                 }
                                             },
                                             emailOTP: {


### PR DESCRIPTION
### Purpose
> Add progressive enrolment navigation to alert.

https://github.com/wso2/identity-apps/assets/27746285/e47f5d29-8ae6-40f9-8e0f-d6ec0f955248

### Related Issues
- https://github.com/wso2/product-is/issues/19964

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
