### PR TITLE
Fix issue with SMS OTP checkbox not enabling in My Account settings page

### DIFF
--- a/.changeset/mighty-cougars-punch.md
+++ b/.changeset/mighty-cougars-punch.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix SMS OTP checkbox enabling in My Account settings page

--- a/apps/console/src/extensions/components/my-account/constants/my-account.ts
+++ b/apps/console/src/extensions/components/my-account/constants/my-account.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -42,5 +42,4 @@ export enum TotpConfigAttributeTypes {
 }
 
 export const CHANNEL_TYPE: string = "SMSPublisher";
-export const SMS_OTP_RESOURCE_KEY: string = "channel.type";
-export const SMS_OTP_RESOURCE_VALUE: string = "choreo";
+export const VALID_SMS_OTP_PROVIDERS: string[] = [ "choreo", "Twilio", "Custom", "Vonage" ];

--- a/apps/console/src/extensions/components/my-account/constants/my-account.ts
+++ b/apps/console/src/extensions/components/my-account/constants/my-account.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2022-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/apps/console/src/extensions/components/my-account/pages/my-account-edit.tsx
+++ b/apps/console/src/extensions/components/my-account/pages/my-account-edit.tsx
@@ -60,14 +60,12 @@ import {
 import {
     CHANNEL_TYPE,
     MyAccountAttributeTypes,
-    SMS_OTP_RESOURCE_KEY,
-    SMS_OTP_RESOURCE_VALUE,
-    TotpConfigAttributeTypes
+    TotpConfigAttributeTypes,
+    VALID_SMS_OTP_PROVIDERS
 } from "../constants";
 import {
     MyAccountFormInterface,
     MyAccountPortalStatusInterface,
-    NotificationSenderProperty,
     TotpConfigPortalStatusInterface
 } from "../models";
 
@@ -282,13 +280,8 @@ export const MyAccountSettingsEditPage: FunctionComponent<MyAccountSettingsEditP
                 let enableSMSOTP: boolean = false;
 
                 for (const notificationSender of notificationSendersList) {
-                    const channelValues: NotificationSenderProperty[] =
-                        notificationSender.properties ? notificationSender.properties : [];
-
-                    const containsProperty: boolean = channelValues.filter((prop: NotificationSenderProperty) =>
-                        prop.key === SMS_OTP_RESOURCE_KEY && prop.value === SMS_OTP_RESOURCE_VALUE).length > 0;
-
-                    if (notificationSender.name === CHANNEL_TYPE && containsProperty) {
+                    if (notificationSender.name === CHANNEL_TYPE &&
+                            VALID_SMS_OTP_PROVIDERS.includes(notificationSender.provider)) {
                         enableSMSOTP = true;
 
                         break;


### PR DESCRIPTION
### Purpose
$subject

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
