### PR TITLE
Fix incorrect logic in hiding subject type input when it's disabled via deployment config

### DIFF
--- a/.changeset/three-geckos-serve.md
+++ b/.changeset/three-geckos-serve.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix incorrect logic in hiding subject type input when it's disabled via deployment config

--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -16,11 +16,11 @@
  * under the License.
  */
 
+import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
 import { Field, Form } from "@wso2is/form";
 import { Code, Heading, Hint, Text } from "@wso2is/react-components";
-import useUIConfig from "@wso2is/common/src/hooks/use-ui-configs";
 import React, { FormEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -461,7 +461,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                     />
                     <Divider hidden />
                     { onlyOIDCConfigured
-                      && disabledFeatures?.includes("applications.attributes.subjectType")
+                      && !disabledFeatures?.includes("applications.attributes.subjectType")
                       && (
                           <div>
                               <Text>


### PR DESCRIPTION
### Purpose

$subject

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
