### PR TITLE
Add config to disable alternative subject identifier UI elements from applications

### DIFF
--- a/.changeset/soft-pandas-act.md
+++ b/.changeset/soft-pandas-act.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add config to disable alternative subject identifier

--- a/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/apps/console/src/features/applications/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -385,7 +385,8 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                         { t("console:develop.features.applications.forms.advancedAttributeSettings." +
                             "sections.subject.heading") }
                     </Heading>
-                    { onlyOIDCConfigured && (
+                    { (onlyOIDCConfigured &&
+                        !disabledFeatures?.includes("applications.attributes.alternativeSubjectIdentifier")) && (
                         <>
                             <Checkbox
                                 ariaLabel={ t("console:develop.features.applications.forms.advancedAttributeSettings." +
@@ -436,7 +437,8 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                         value={ initialSubject?.includeUserDomain ? [ "includeUserDomain" ] : [] }
                         readOnly={ readOnly }
                         data-testid={ `${ componentId }-subject-iInclude-user-domain-checkbox` }
-                        hidden={ resolveSubjectAttributeHiddenStatus() }
+                        hidden={ disabledFeatures?.includes("applications.attributes.alternativeSubjectIdentifier")
+                            || resolveSubjectAttributeHiddenStatus() }
                         hint={
                             t("console:develop.features.applications.forms.advancedAttributeSettings" +
                                 ".sections.subject.fields.subjectIncludeUserDomain.hint")
@@ -453,7 +455,8 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                         value={ initialSubject?.includeTenantDomain ? [ "includeTenantDomain" ] : [] }
                         readOnly={ readOnly }
                         data-testid={ `${ componentId }-subject-include-tenant-domain-checkbox` }
-                        hidden={ resolveSubjectAttributeHiddenStatus() }
+                        hidden={ disabledFeatures?.includes("applications.attributes.alternativeSubjectIdentifier")
+                            || resolveSubjectAttributeHiddenStatus() }
                         hint={
                             t("console:develop.features.applications.forms.advancedAttributeSettings" +
                                 ".sections.subject.fields.subjectIncludeTenantDomain.hint")


### PR DESCRIPTION
### Purpose
When the config is enabled, alternative subject identifier, user store domain and tenant domain checkboxes will be hidden 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
