### PR TITLE
Fix myaccount url with the tenanted path in Access URLs

### DIFF
--- a/.changeset/fair-bulldogs-collect.md
+++ b/.changeset/fair-bulldogs-collect.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix myaccount url to contain tenanted path

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
@@ -265,7 +265,7 @@
     <%
         String myaccountUrl = application.getInitParameter("MyAccountURL");
         if (StringUtils.isEmpty(myaccountUrl)) {
-            myaccountUrl = ServiceURLBuilder.create().addPath(MY_ACCOUNT).build().getAbsolutePublicURL();
+            myaccountUrl = ServiceURLBuilder.create().setTenant(insightsTenantIdentifier).build().getAbsolutePublicURL();
         }
     %>
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
@@ -264,8 +264,10 @@
 
     <%
         String myaccountUrl = application.getInitParameter("MyAccountURL");
-        if (StringUtils.isEmpty(myaccountUrl)) {
-            myaccountUrl = ServiceURLBuilder.create().setTenant(insightsTenantIdentifier).build().getAbsolutePublicURL();
+        if (StringUtils.isNotEmpty(myaccountUrl)) {
+            myaccountUrl = myaccountUrl + "/t/" + tenantDomain;
+        } else {
+            myaccountUrl = ServiceURLBuilder.create().setTenant(tenantDomain).build().getAbsolutePublicURL();
         }
     %>
 


### PR DESCRIPTION
### Purpose

Fix myaccount url with the tenanted path in Access URL

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
