### PR TITLE
Fix SMS OTP configs being always readonly

### DIFF
--- a/.changeset/gentle-terms-accept.md
+++ b/.changeset/gentle-terms-accept.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix SMS OTP configs being always readonly

--- a/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator.tsx
+++ b/apps/console/src/extensions/components/authenticators/sms-otp/sms-otp-authenticator.tsx
@@ -18,7 +18,7 @@
 
 import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
-import React, { FunctionComponent, ReactElement, useMemo } from "react";
+import React, { FunctionComponent, ReactElement } from "react";
 import { useSelector } from "react-redux";
 import { FeatureConfigInterface } from "../../../../features/core/models";
 import { AppState } from "../../../../features/core/store";
@@ -83,14 +83,8 @@ export const SmsOTPAuthenticator: FunctionComponent<SmsOTPAuthenticatorInterface
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const { isSubOrganization, organizationType } = useGetCurrentOrganizationType();
 
-    const isChoreoEnabledAsSMSProvider: boolean = useMemo(() => {
-        const disabledFeatures: string[] = featureConfig?.smsProviders?.disabledFeatures;
-
-        return !disabledFeatures?.includes("choreoAsSMSProvider");
-    }, [ featureConfig ]);
-
-    const isReadOnly: boolean = isChoreoEnabledAsSMSProvider
-        || !hasRequiredScopes(
+    const isReadOnly: boolean =
+        !hasRequiredScopes(
             featureConfig?.identityProviders,
             featureConfig?.identityProviders?.scopes?.update,
             allowedScopes,


### PR DESCRIPTION
### Purpose

It was decided to keep the SMS OTP configuration editable despite the absence of a configured SMS provider

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
