### PR TITLE
Fix incorrect template label appearing for fragment apps

### DIFF
--- a/apps/console/src/features/applications/pages/application-edit.tsx
+++ b/apps/console/src/features/applications/pages/application-edit.tsx
@@ -489,6 +489,27 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                 allowedScopes);
     };
 
+    /**
+     * Resolves the application template label.
+     *
+     * @returns Template label.
+     */
+    const resolveTemplateLabel = (): ReactElement => {
+        if (application?.advancedConfigurations?.fragment) {
+            return (
+                <Label size="small">
+                    { t("console:develop.features.applications.list.labels.fragment") }
+                </Label>
+            );
+        }
+
+        if (applicationTemplate?.name) {
+            return <Label size="small">{ applicationTemplate.name }</Label>;
+        }
+
+        return null;
+    };
+
     return (
         <TabPageLayout
             pageTitle="Edit Application"
@@ -506,9 +527,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                     tenantDomain, applicationTemplate?.name)
                     ?? (
                         <div className="with-label ellipsis" ref={ appDescElement }>
-                            { applicationTemplate?.name && (
-                                <Label size="small">{ applicationTemplate.name }</Label>
-                            ) }
+                            { resolveTemplateLabel() }
                             {
                                 ApplicationManagementUtils.isChoreoApplication(application)
                                     && (<Label


### PR DESCRIPTION
### Purpose

Fix incorrect template label appearing for fragment apps

Before:

<img width="1680" alt="Screenshot 2024-03-14 at 15 36 05" src="https://github.com/wso2/identity-apps/assets/25959096/0d6ec7a6-5a72-4bbd-9710-98652427cb00">

After:

<img width="1680" alt="Screenshot 2024-03-14 at 15 32 00" src="https://github.com/wso2/identity-apps/assets/25959096/26275b20-cebd-47a6-b301-8d8aa2213949">


### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
