### PR TITLE
Remove \ from self-registration email regex

### DIFF
--- a/.changeset/four-chicken-love.md
+++ b/.changeset/four-chicken-love.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Remove \ from self-registration email regex

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -2039,7 +2039,7 @@
 
                     return false;
             } else {
-                var usernamePattern = /(^[\u00C0-\u00FFa-zA-Z0-9](?:(?![!#$'+\\=^_.{|}~\-&]{2})[\u00C0-\u00FF\w!#$'+\\=^_.{|}~\-&]){0,63}(?=[\u00C0-\u00FFa-zA-Z0-9_]).\@(?![+.\-_])(?:(?![.+\-_]{2})[\w.+\-]){0,245}(?=[\u00C0-\u00FFa-zA-Z0-9]).\.[a-zA-Z]{2,10})$/;
+                var usernamePattern = /(^[\u00C0-\u00FFa-zA-Z0-9](?:(?![!#$'+=^_.{|}~\-&]{2})[\u00C0-\u00FF\w!#$'+=^_.{|}~\-&]){0,63}(?=[\u00C0-\u00FFa-zA-Z0-9_]).\@(?![+.\-_])(?:(?![.+\-_]{2})[\w.+\-]){0,245}(?=[\u00C0-\u00FFa-zA-Z0-9]).\.[a-zA-Z]{2,10})$/;
                 if (!usernamePattern.test(usernameUserInput.value.trim()) && (emailRequired || !isAlphanumericUsernameEnabled())) {
                     username_error_msg_text.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Please.enter.valid.email")%>")
                     username_error_msg.show();


### PR DESCRIPTION
### Proposed changes in this pull request
By this PR https://github.com/wso2/identity-apps/pull/5652, the email regex has been updated to provide the support to special characters in the email username.
Even the `\` character is also allowed by the PR the RFC spec[1] is not allowing that character. 
Hence removing it from this PR.

[1] - https://datatracker.ietf.org/doc/html/rfc3696#page-5:~:text=!%20%23%20%24%20%25%20%26%20%27%20*%20%2B%20%2D%20/%20%3D%20%3F%20%20%5E%20_%20%60%20.%20%7B%20%7C%20%7D%20

