### PR TITLE
Fix custom properties update issue for connections 

### DIFF
--- a/.changeset/tricky-pens-applaud.md
+++ b/.changeset/tricky-pens-applaud.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix custom properties update issue in connections

--- a/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
@@ -150,7 +150,7 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
         });
 
         const modifiedCustomProperties: any = !isEmpty(resolvedCustomProperties) ?
-            resolvedCustomProperties?.toString()?.split(",")?.map(
+            resolvedCustomProperties?.toString()?.split(", ")?.map(
                 (customProperty: string) => {
                     const keyValuePair: string[] = customProperty.split("=");
 

--- a/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
+++ b/apps/console/src/features/connections/components/edit/forms/components/common-pluggable-component-form.tsx
@@ -467,12 +467,6 @@ export const CommonPluggableComponentForm: FunctionComponent<CommonPluggableComp
                     return;
                 }
 
-                // Check whether the property already in dynamicValues?.properties.
-                if (dynamicValues?.properties?.find(
-                    (prop: CommonPluggableComponentPropertyInterface) => prop.key === property.key)) {
-                    return;
-                }
-
                 // Check whether the property is not in the metadata.
                 if (!metadata?.properties?.find(
                     (meta: CommonPluggableComponentMetaPropertyInterface) => meta.key === property.key)) {

--- a/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
+++ b/apps/console/src/features/connections/components/edit/settings/authenticator-settings.tsx
@@ -1000,9 +1000,6 @@ export const AuthenticatorSettings: FunctionComponent<IdentityProviderSettingsPr
                     mode={ AuthenticatorSettingsFormModes.EDIT }
                     authenticator={ authenticator }
                     metadata={ authenticator.meta }
-                    showCustomProperties={
-                        authenticator.id !== ConnectionManagementConstants.GITHUB_AUTHENTICATOR_ID
-                    }
                     initialValues={ authenticator.data }
                     onSubmit={ handleAuthenticatorConfigFormSubmit }
                     type={ authenticator.meta?.authenticatorId }


### PR DESCRIPTION
### Purpose
> Fix custom properties update issue for connections.

- Hide the custom properties field from the UI
- Fix the dropping of custom properties in the update API call
- Remove additional spaces in the custom properties update API call payload

https://github.com/wso2/identity-apps/assets/27746285/8019692a-03e4-49f0-9e9d-d39fbc75c003

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
