### PR TITLE
Remove legacyAuthzRuntime check when transforming tenantDomain

### DIFF
--- a/.changeset/stale-tips-love.md
+++ b/.changeset/stale-tips-love.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Remove legacyAuthzRuntime check when transforming tenantDomain

--- a/apps/console/src/features/organizations/hooks/use-organizations.ts
+++ b/apps/console/src/features/organizations/hooks/use-organizations.ts
@@ -17,7 +17,6 @@
  */
 
 import { useContext } from "react";
-import useAuthorization from "../../authorization/hooks/use-authorization";
 import { MultitenantConstants } from "../../core/constants/multitenant-constants";
 import useAppSettings from "../../core/hooks/use-app-settings";
 import OrganizationsContext, { OrganizationsContextProps } from "../context/organizations-context";

--- a/apps/console/src/features/organizations/hooks/use-organizations.ts
+++ b/apps/console/src/features/organizations/hooks/use-organizations.ts
@@ -73,8 +73,6 @@ export interface UseOrganizationsInterface extends OrganizationsContextProps {
 const useOrganizations = (): UseOrganizationsInterface => {
     const context: OrganizationsContextProps = useContext(OrganizationsContext);
 
-    const { legacyAuthzRuntime } = useAuthorization();
-
     const { getLocalStorageSetting, setLocalStorageSetting, removeLocalStorageSetting } = useAppSettings();
 
     if (context === undefined) {
@@ -89,10 +87,8 @@ const useOrganizations = (): UseOrganizationsInterface => {
      */
     const transformTenantDomain = (tenantDomain: string): string => {
         // With the latest Authz framework, `carbon.super` is resolved as `Super`.
-        if (!legacyAuthzRuntime) {
-            if (tenantDomain === MultitenantConstants.SUPER_TENANT_DISPLAY_NAME) {
-                return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-            }
+        if (tenantDomain === MultitenantConstants.SUPER_TENANT_DISPLAY_NAME) {
+            return MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
         }
 
         return tenantDomain;


### PR DESCRIPTION
### Purpose
Removed the legacy authz runtime check when transforming the tenantDomain since the tenant domain is returned as `Super` even in the legacy runtime. 


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
