### PR TITLE
Fix revert button for individual custom text configuration fields not appearing in text tab in branding page

### DIFF
--- a/.changeset/clean-nails-tie.md
+++ b/.changeset/clean-nails-tie.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/form": patch
+---
+
+Fix revert button for individual custom text configuration fields not appearing in text tab in branding page

--- a/apps/console/src/features/branding/components/custom-text/custom-text-fields.scss
+++ b/apps/console/src/features/branding/components/custom-text/custom-text-fields.scss
@@ -16,10 +16,6 @@
  * under the License.
  */
 
-.reset-field-to-default-adornment {
-    margin-right: -6px;
-}
-
 .branding-preference-custom-text-fields {
 
     .MuiInputBase-root {

--- a/apps/console/src/features/branding/components/custom-text/custom-text-fields.scss
+++ b/apps/console/src/features/branding/components/custom-text/custom-text-fields.scss
@@ -16,6 +16,10 @@
  * under the License.
  */
 
+.reset-field-to-default-adornment {
+    margin-right: 6px;
+}
+
 .branding-preference-custom-text-fields {
 
     .MuiInputBase-root {

--- a/apps/console/src/features/branding/components/custom-text/custom-text-fields.tsx
+++ b/apps/console/src/features/branding/components/custom-text/custom-text-fields.tsx
@@ -138,6 +138,7 @@ const CustomTextFields: FunctionComponent<CustomTextFieldsProps> = (props: Custo
                 >
                     <IconButton
                         aria-label="Reset field to default"
+                        className="reset-field-to-default-adornment"
                         onClick={ () =>
                             resetCustomTextField(
                                 fieldName.replaceAll("_", "."),

--- a/apps/console/src/features/branding/components/custom-text/custom-text-fields.tsx
+++ b/apps/console/src/features/branding/components/custom-text/custom-text-fields.tsx
@@ -136,22 +136,19 @@ const CustomTextFields: FunctionComponent<CustomTextFieldsProps> = (props: Custo
                         t("console:brandingCustomText.form.genericFieldResetTooltip")
                     }
                 >
-                    <div>
-                        <IconButton
-                            aria-label="Reset field to default"
-                            className="reset-field-to-default-adornment"
-                            onClick={ () =>
-                                resetCustomTextField(
-                                    fieldName.replaceAll("_", "."),
-                                    selectedScreen,
-                                    selectedLocale
-                                )
-                            }
-                            edge="end"
-                        >
-                            <ArrowRotateLeft height={ 12 } width={ 12 } />
-                        </IconButton>
-                    </div>
+                    <IconButton
+                        aria-label="Reset field to default"
+                        onClick={ () =>
+                            resetCustomTextField(
+                                fieldName.replaceAll("_", "."),
+                                selectedScreen,
+                                selectedLocale
+                            )
+                        }
+                        edge="end"
+                    >
+                        <ArrowRotateLeft height={ 12 } width={ 12 } />
+                    </IconButton>
                 </Tooltip>
             </InputAdornment>
         );

--- a/modules/form/src/components/adapters/text-field-adapter.tsx
+++ b/modules/form/src/components/adapters/text-field-adapter.tsx
@@ -59,6 +59,7 @@ const TextFieldAdapter: FunctionComponent<TextFieldAdapterPropsInterface> = (
         helperText,
         required,
         readOnly,
+        endAdornment,
         ...rest
     } = props;
 
@@ -74,14 +75,15 @@ const TextFieldAdapter: FunctionComponent<TextFieldAdapterPropsInterface> = (
                 margin="dense"
                 { ...FormControlProps }
                 { ...input }
-                { ...rest }
                 // TODO: Remove this once the `required` prop is supported by the Oxygen UI TextField component.
                 InputLabelProps={ {
                     required
                 } }
                 InputProps={ {
+                    endAdornment,
                     readOnly
                 } }
+                { ...rest }
             />
             { isError && <FormHelperText error>{ meta.error || meta.submitError }</FormHelperText> }
             { helperText && <FormHelperText>{ helperText }</FormHelperText> }


### PR DESCRIPTION
### Purpose
> Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. Remove this placeholder when you're editing.

<img width="1499" alt="Screenshot 2024-03-20 at 17 37 04" src="https://github.com/wso2/identity-apps/assets/41533942/ca14dc3e-2e9b-4440-96ce-84dcf4e6e122">

$subject

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
