### PR TITLE
Revert "Exclude logic related to spId when sp is present in request params"

### DIFF
--- a/.changeset/large-balloons-itch.md
+++ b/.changeset/large-balloons-itch.md
@@ -1,5 +1,0 @@
----
-"@wso2is/identity-apps-core": major
----
-
-update condition logic

--- a/.changeset/short-bananas-greet.md
+++ b/.changeset/short-bananas-greet.md
@@ -1,5 +1,0 @@
----
-"@wso2is/identity-apps-core": major
----
-
-Exclude logic execution of spId when sp is present in request params

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-complete.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-complete.jsp
@@ -124,7 +124,9 @@
     if (StringUtils.isNotBlank(spId)) {
         try {
             ApplicationDataRetrievalClient applicationDataRetrieval = new ApplicationDataRetrievalClient();
-            if (!sp.equals("My Account")) {
+            if (spId.equals("My_Account")) {
+                sp = "My Account";
+            } else {
                 sp = applicationDataRetrieval.getApplicationName(tenantDomain,spId);
             }
         } catch (Exception e) {


### PR DESCRIPTION
Reverts wso2/identity-apps#5819

Changeset was released as major version bump. Hence, reverting.