### PR TITLE
Fix translating the email otp error message

### DIFF
--- a/.changeset/wet-peas-hide.md
+++ b/.changeset/wet-peas-hide.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix email otp error message translating issue

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -79,6 +79,7 @@
             if (errorMessage.equalsIgnoreCase("authentication.fail.message")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry.code.invalid");
             }
+            System.out.println("------------------------"+ errorMessage)
         }
     }
 %>
@@ -176,7 +177,7 @@
                 <%
                     if ("true".equals(authenticationFailed)) {
                 %>
-                <div class="ui negative message" id="failed-msg"><%=AuthenticationEndpointUtil.i18n(resourceBundle, Encode.forJava(errorMessage))%>
+                <div class="ui negative message" id="failed-msg"><%=Encode.forHtmlContent(errorMessage)%>
                 </div>
                 <div class="ui divider hidden"></div>
                 <% } %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -79,7 +79,6 @@
             if (errorMessage.equalsIgnoreCase("authentication.fail.message")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry.code.invalid");
             }
-            System.out.println("------------------------"+ errorMessage)
         }
     }
 %>


### PR DESCRIPTION
### Purpose
-  $subject
- Use the correct encoding to the error message when entering the incorrect email otp. 

### Related Issues
- Issue `#1` or (None)

### Related PRs
- Related PR `#1` or (None)

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
