### PR TITLE
Provide proper name to SMS provider tabs

### DIFF
--- a/apps/console/src/features/sms-providers/pages/sms-providers.tsx
+++ b/apps/console/src/features/sms-providers/pages/sms-providers.tsx
@@ -31,7 +31,6 @@ import {
     PageLayout,
     useDocumentation
 } from "@wso2is/react-components";
-import smsProviderConfig from "../../../extensions/configs/sms-provider";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -40,6 +39,7 @@ import { Divider, Grid, Placeholder } from "semantic-ui-react";
 import CustomSMSProvider from "./custom-sms-provider";
 import TwilioSMSProvider from "./twilio-sms-provider";
 import VonageSMSProvider from "./vonage-sms-provider";
+import smsProviderConfig from "../../../extensions/configs/sms-provider";
 import { AccessControlConstants } from "../../access-control/constants/access-control";
 import { AuthenticatorManagementConstants } from "../../connections/constants/autheticator-constants";
 import {
@@ -559,13 +559,15 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                                             <Grid>
                                                 <Grid.Row columns={ 3 }>
                                                     { providerCards.map(
-                                                        (provider: SMSProviderCardInterface) => (
-                                                            <Grid.Column key={ provider.id }>
+                                                        (provider: SMSProviderCardInterface) => {
+                                                            const smsProviderName: string =
+                                                                        provider.name.toLocaleLowerCase();
+
+                                                            return (<Grid.Column key={ provider.id }>
                                                                 <InfoCard
                                                                     fluid
                                                                     data-componentid=
-                                                                        { `${componentId}
-                                                                                -sms-provider-info-card` }
+                                                                        { `${smsProviderName}-sms-provider-info-card` }
                                                                     image={ provider.icon }
                                                                     imageSize="x30"
                                                                     header={
@@ -585,7 +587,7 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                                                                     showCardAction={ false }
                                                                 />
                                                             </Grid.Column>
-                                                        )) }
+                                                            );}) }
                                                 </Grid.Row>
                                             </Grid>
                                         </div>


### PR DESCRIPTION
### Purpose
There were no unique identifier for SMS provider tabs to identify each tab to use in UI tests. Hence, adding a unique id using "data-componentid".

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
