### PR TITLE
Prevent choreo sms provider configs being autofilled in custom SMS provider configuration form

### DIFF
--- a/.changeset/unlucky-tables-smash.md
+++ b/.changeset/unlucky-tables-smash.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/features": patch
+"@wso2is/console": patch
+---
+
+Prevent choreo sms provider configs being autofilled in custom SMS provider configuration form

--- a/features/admin-sms-providers-v1/pages/sms-providers.tsx
+++ b/features/admin-sms-providers-v1/pages/sms-providers.tsx
@@ -31,7 +31,6 @@ import {
     PageLayout,
     useDocumentation
 } from "@wso2is/react-components";
-import smsProviderConfig from "../../admin-extensions-v1/configs/sms-provider";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -48,6 +47,7 @@ import {
     FeatureConfigInterface
 } from "../../admin-core-v1";
 import { history } from "../../admin-core-v1/helpers";
+import smsProviderConfig from "../../admin-extensions-v1/configs/sms-provider";
 import { createSMSProvider, deleteSMSProviders, updateSMSProvider, useSMSProviders } from "../api";
 import { providerCards } from "../configs/provider-cards";
 import { SMSProviderConstants } from "../constants";
@@ -548,7 +548,7 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                                 onSubmit={ handleSubmit }
                                 validate={ validateForm }
                                 initialValues={
-                                    smsProviderSettings?.selectedProvider
+                                    smsProviderSettings?.selectedProvider && !isChoreoSMSOTPProvider
                                         ? smsProviderSettings
                                             ?.providerParams[smsProviderSettings?.selectedProvider]
                                         :  {}


### PR DESCRIPTION
### Purpose

$subject

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
