### PR TITLE
Prevent custom text preference delete request not being triggered on reverting branding when there is no branding is configured.

### DIFF
--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -1671,6 +1671,16 @@ export interface Extensions {
                         message: string;
                     };
                 };
+                customTextPreferenceDelete: {
+                    genericError: {
+                        description: string;
+                        message: string;
+                    },
+                    success: {
+                        description: string;
+                        message: string;
+                    }
+                };
                 fetch: {
                     customLayoutNotFound: {
                         description: string;

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -1895,6 +1895,16 @@ export const extensions: Extensions = {
                         message: "Reverting branding preferences"
                     }
                 },
+                customTextPreferenceDelete: {
+                    genericError: {
+                        description: "An error occurred while reverting the custom text preferences for {{ tenant }}.",
+                        message: "Couldn't revert custom text preferences"
+                    },
+                    success: {
+                        description: "Successfully reverted custom text preferences for {{ tenant }}.",
+                        message: "Revert successful"
+                    }
+                },
                 fetch: {
                     customLayoutNotFound: {
                         description: "There is no deployed custom layout for {{ tenant }}.",

--- a/features/admin-branding-v1/pages/branding.tsx
+++ b/features/admin-branding-v1/pages/branding.tsx
@@ -42,9 +42,9 @@ import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } 
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
-import { ExtendedFeatureConfigInterface } from "../../admin-extensions-v1/configs/models";
 import { EventPublisher } from "../../admin-core-v1";
 import { AppState } from "../../admin-core-v1/store";
+import { ExtendedFeatureConfigInterface } from "../../admin-extensions-v1/configs/models";
 import { useGetCurrentOrganizationType } from "../../admin-organizations-v1/hooks/use-get-organization-type";
 import { OrganizationResponseInterface } from "../../admin-organizations-v1/models/organizations";
 import { deleteBrandingPreference, updateBrandingPreference } from "../api";
@@ -515,83 +515,76 @@ const BrandingPage: FunctionComponent<BrandingPageInterface> = (
     /**
      * Handles the delete operation of branding preference via the API.
      */
-    const handleBrandingPreferenceDelete = (): void => {
+    const handleBrandingPreferenceDelete = async (): Promise<void> => {
 
         setIsBrandingPreferenceDeleteRequestLoading(true);
 
-        Promise.all([ deleteBrandingPreference(tenantDomain), deleteAllCustomTextPreferences() ])
-            .then(
-                (values: any) => {
-                    const [ deleteBrandingPreferenceResponse, deleteCustomTextPreferenceResponse ] = values;
+        try {
+            await deleteBrandingPreference(tenantDomain);
 
-                    const isBrandingPreferenceDeleteError: boolean =
-                    deleteBrandingPreferenceResponse instanceof IdentityAppsApiException;
-                    const isCustomTextPreferenceDeleteError: boolean =
-                    deleteCustomTextPreferenceResponse instanceof IdentityAppsApiException;
+            dispatch(addAlert<AlertInterface>({
+                description: t("extensions:develop.branding.notifications.delete.success.description",
+                    { tenant: tenantDomain }),
+                level: AlertLevels.SUCCESS,
+                message: t("extensions:develop.branding.notifications.delete.success.message")
+            }));
+        } catch (error: any) {
+            let description: string = t("extensions:develop.branding.notifications.delete.genericError" +
+            ".description", { tenant: tenantDomain });
+            let message: string = t("extensions:develop.branding.notifications.delete.genericError.message");
 
-                    if (isBrandingPreferenceDeleteError || isCustomTextPreferenceDeleteError) {
-                        dispatch(addAlert<AlertInterface>({
-                            description: t("extensions:develop.branding.notifications.delete.invalidStatus.description",
-                                { tenant: tenantDomain }),
-                            level: AlertLevels.ERROR,
-                            message: t("extensions:develop.branding.notifications.delete.invalidStatus.message")
-                        }));
+            // If branding is not configured, but user tried deleting anyway.
+            if (error.code === BrandingPreferencesConstants.BRANDING_NOT_CONFIGURED_ERROR_CODE) {
+                description = t("extensions:develop.branding.notifications.delete.notConfigured" +
+                ".description", { tenant: tenantDomain });
+                message = t("extensions:develop.branding.notifications.delete.notConfigured.message");
+            }
 
-                        return;
-                    }
+            dispatch(addAlert<AlertInterface>({
+                description: description,
+                level: AlertLevels.ERROR,
+                message: message
+            }));
+        }
 
-                    setIsBrandingConfigured(false);
-                    setBrandingPreference(DEFAULT_PREFERENCE);
-                    mutateBrandingPreferenceFetchRequest();
-                    mutateCustomTextPreferenceFetchRequest();
+        try {
+            await deleteAllCustomTextPreferences();
 
-                    // Increment the tabs component key to remount the component on branding revert.
-                    setPreferenceTabsComponentKey(preferenceTabsComponentKey + 1);
+            dispatch(addAlert<AlertInterface>({
+                description: t(
+                    "extensions:develop.branding.notifications.customTextPreferenceDelete.success.description",
+                    { tenant: tenantDomain }
+                ),
+                level: AlertLevels.SUCCESS,
+                message: t("extensions:develop.branding.notifications.delete.success.message")
+            }));
+        } catch (error: any) {
+            const description: string = t(
+                "extensions:develop.branding.notifications.customTextPreferenceDelete.genericError" +
+                    ".description",
+                { tenant: tenantDomain }
+            );
+            const message: string = t(
+                "extensions:develop.branding.notifications.customTextPreferenceDelete.genericError.message"
+            );
 
-                    if(organizationType !== OrganizationType.SUBORGANIZATION) {
-                        dispatch(addAlert<AlertInterface>({
-                            description: t("extensions:develop.branding.notifications.delete.success.description",
-                                { tenant: tenantDomain }),
-                            level: AlertLevels.SUCCESS,
-                            message: t("extensions:develop.branding.notifications.delete.success.message")
-                        }));
-                    } else {
-                        dispatch(addAlert<AlertInterface>({
-                            description: t(
-                                "extensions:develop.branding.notifications.delete." +
-                                "successWaiting.description",
-                                { tenant: tenantDomain }
-                            ),
-                            level: AlertLevels.WARNING,
-                            message: t("extensions:develop.branding.notifications.delete.successWaiting.message")
-                        }));
+            dispatch(addAlert<AlertInterface>({
+                description: description,
+                level: AlertLevels.ERROR,
+                message: message
+            }));
+        }
 
-                        handleSubOrgAlerts();
-                    }
-                }
-            ).catch((error: IdentityAppsApiException) => {
+        setIsBrandingConfigured(false);
+        setBrandingPreference(DEFAULT_PREFERENCE);
+        mutateBrandingPreferenceFetchRequest();
+        mutateCustomTextPreferenceFetchRequest();
 
-                let description: string = t("extensions:develop.branding.notifications.delete.genericError" +
-                    ".description", { tenant: tenantDomain });
-                let message: string = t("extensions:develop.branding.notifications.delete.genericError.message");
+        // Increment the tabs component key to remount the component on branding revert.
+        setPreferenceTabsComponentKey(preferenceTabsComponentKey + 1);
 
-                // If branding is not configured, but user tried deleting anyway.
-                if (error.code === BrandingPreferencesConstants.BRANDING_NOT_CONFIGURED_ERROR_CODE) {
-                    description = t("extensions:develop.branding.notifications.delete.notConfigured" +
-                        ".description", { tenant: tenantDomain });
-                    message = t("extensions:develop.branding.notifications.delete.notConfigured.message");
-                }
-
-                dispatch(addAlert<AlertInterface>({
-                    description: description,
-                    level: AlertLevels.ERROR,
-                    message: message
-                }));
-            })
-            .finally(() => {
-                setIsBrandingPreferenceDeleteRequestLoading(false);
-                setShowRevertConfirmationModal(false);
-            });
+        setIsBrandingPreferenceDeleteRequestLoading(false);
+        setShowRevertConfirmationModal(false);
     };
 
     return (
@@ -797,7 +790,7 @@ const BrandingPage: FunctionComponent<BrandingPageInterface> = (
                     primaryAction={ t("common:confirm") }
                     secondaryAction={ t("common:cancel") }
                     onSecondaryActionClick={ (): void => setShowRevertConfirmationModal(false) }
-                    onPrimaryActionClick={ (): void => handleBrandingPreferenceDelete() }
+                    onPrimaryActionClick={ handleBrandingPreferenceDelete }
                     data-componentid={ `${ componentId }-branding-preference-revert-confirmation-modal` }
                     closeOnDimmerClick={ false }
                     primaryActionLoading={ isBrandingPreferenceDeleteRequestLoading }


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
