### PR TITLE
Add customization to login identifier

### DIFF
--- a/.changeset/little-crabs-fetch.md
+++ b/.changeset/little-crabs-fetch.md
@@ -1,0 +1,10 @@
+---
+"@wso2is/identity-apps-core": patch
+"@wso2is/i18n": patch
+"@wso2is/features": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/common": patch
+---
+
+Add branding to Identifier in Login and Password Recovery.

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/basic-auth-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/basic-auth-fragment.tsx
@@ -73,7 +73,12 @@ const BasicAuthFragment: FunctionComponent<BasicAuthFragmentInterface> = (
             <div className="segment-form">
                 <div className="ui large form">
                     <div className="field m-0">
-                        <label>Username</label>
+                        <label>
+                            {
+                                i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.LOGIN.IDENTIFIER.INPUT.LABEL,
+                                    "Username")
+                            }
+                        </label>
                         <div className="ui fluid left icon input">
                             <input
                                 type="text"
@@ -146,7 +151,7 @@ const BasicAuthFragment: FunctionComponent<BasicAuthFragmentInterface> = (
                     </div>
                     <div className="mt-4 mb-4">
                         <div className="mt-3 external-link-container text-small">
-                            { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.REGISTER_TEXT.MESSAGE, 
+                            { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.REGISTER_TEXT.MESSAGE,
                                 "Don't have an account? ") }
                             <a
                                 target="_self"
@@ -155,7 +160,7 @@ const BasicAuthFragment: FunctionComponent<BasicAuthFragmentInterface> = (
                                 rel="noopener noreferrer"
                                 data-testid="login-page-create-account-button"
                             >
-                                { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.REGISTER_TEXT.REGISTER, 
+                                { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.REGISTER_TEXT.REGISTER,
                                     "Register") }
                             </a>
                         </div>

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/password-recovery-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/password-recovery-fragment.tsx
@@ -58,7 +58,11 @@ const PasswordRecoveryFragment: FunctionComponent<PasswordRecoveryFragmentInterf
                                     type="text"
                                     id="usernameUserInput"
                                     name="usernameUserInput"
-                                    placeholder="Username"
+                                    placeholder={
+                                        i18n(CustomTextPreferenceConstants
+                                            .TEXT_BUNDLE_KEYS.PASSWORD_RECOVERY
+                                            .IDENTIFIER.INPUT.PLACEHOLDER, "Username")
+                                    }
                                     data-testid="login-page-username-input"
                                 />
                                 <i aria-hidden="true" className="user outline icon"></i>

--- a/features/admin.branding.v1/constants/custom-text-preference-constants.ts
+++ b/features/admin.branding.v1/constants/custom-text-preference-constants.ts
@@ -107,10 +107,20 @@ export class CustomTextPreferenceConstants {
         LOGIN: {
             BUTTON: string;
             HEADING: string;
+            IDENTIFIER: {
+                INPUT: {
+                    LABEL: string;
+                }
+            }
         };
         PASSWORD_RECOVERY: {
             HEADING: string;
             BODY: string;
+            IDENTIFIER: {
+                INPUT: {
+                    PLACEHOLDER: string;
+                }
+            }
             BUTTON: string;
         },
         PASSWORD_RESET: {
@@ -145,12 +155,22 @@ export class CustomTextPreferenceConstants {
         },
         LOGIN: {
             BUTTON: "login.button",
-            HEADING: "login.heading"
+            HEADING: "login.heading",
+            IDENTIFIER: {
+                INPUT: {
+                    LABEL: "login.identifier.input.label"
+                }
+            }
         },
         PASSWORD_RECOVERY: {
             BODY: "password.recovery.body",
             BUTTON: "password.recovery.button",
-            HEADING: "password.recovery.heading"
+            HEADING: "password.recovery.heading",
+            IDENTIFIER: {
+                INPUT: {
+                    PLACEHOLDER: "password.recovery.identifier.input.placeholder"
+                }
+            }
         },
         PASSWORD_RESET: {
             BUTTON: "password.reset.button",

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -33,6 +33,8 @@ terms.of.service=Terms of Service
 # EDITABLE=true,SCREEN="login",MULTI_LINE=false
 login.heading=Sign In
 # EDITABLE=true,SCREEN="login",MULTI_LINE=false
+login.identifier.input.label=Username
+# EDITABLE=true,SCREEN="login",MULTI_LINE=false
 login.button=Sign In
 # <!-- End of Login Screen Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -28,6 +28,7 @@ terms.of.service=Nutzungsbedingungen
 
 # <!-- Start of Login Screen Translations -->
 login.heading=Anmelden
+login.identifier.input.label=Nutzername
 login.button=Anmelden
 # <!-- End of Login Screen Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -28,6 +28,7 @@ terms.of.service=Términos de servicio
 
 # <!-- Start of Login Screen Translations -->
 login.heading=Iniciar sesión
+login.identifier.input.label=Correo electrónico
 login.button=Iniciar sesión
 # <!-- End of Login Screen Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -28,6 +28,7 @@ terms.of.service=Conditions d'utilisation
 
 # <!-- Start of Login Screen Translations -->
 login.heading=Se connecter
+login.identifier.input.label=Nom d'utilisateur
 login.button=Se connecter
 # <!-- End of Login Screen Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -28,6 +28,7 @@ terms.of.service=利用規約
 
 # <!-- Start of Login Screen Translations -->
 login.heading=サインイン
+login.identifier.input.label=ユーザー名
 login.button=サインイン
 # <!-- End of Login Screen Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -28,6 +28,7 @@ terms.of.service=Termos de Serviço
 
 # <!-- Start of Login Screen Translations -->
 login.heading=Entrar
+login.identifier.input.label=Nome de usuário
 login.button=Entrar
 # <!-- End of Login Screen Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -28,6 +28,7 @@ terms.of.service=Termos de serviço
 
 # <!-- Start of Login Screen Translations -->
 login.heading=Entrar
+login.identifier.input.label=Nome de usuário
 login.button=Entrar
 # <!-- End of Login Screen Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -28,6 +28,7 @@ terms.of.service=服务条款
 
 # <!-- Start of Login Screen Translations -->
 login.heading=登入
+login.identifier.input.label=电子邮件
 login.button=登入
 # <!-- End of Login Screen Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -475,11 +475,20 @@
    <% } %>
     <% if (!isIdentifierFirstLogin(inputType) && !isLoginHintAvailable(inputType)) { %>
             <div class="field m-0">
-                <% if (isMultiAttributeLoginEnabledInTenant) { %>
-                    <label><%=usernameLabel %></label>
-                <% } else { %>
-                    <label><%=AuthenticationEndpointUtil.i18n(resourceBundle, usernameLabel)%></label>
-                <% } %>
+                <% String loginInputLabel=i18n(resourceBundle, customText, "login.identifier.input.label" , "", false); %>
+                    <% if (StringUtils.isNotBlank(loginInputLabel)) { %>
+                        <label>
+                            <%= loginInputLabel %>
+                        </label>
+                        <% } else if (isMultiAttributeLoginEnabledInTenant) { %>
+                            <label>
+                                <%= usernameLabel %>
+                            </label>
+                            <% } else { %>
+                                <label>
+                                    <%= AuthenticationEndpointUtil.i18n(resourceBundle, usernameLabel) %>
+                                </label>
+                                <% } %>
                 <div class="ui fluid left icon input">
                 <input
                     type="text"

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -43,6 +43,8 @@ password.recovery.heading=Forgot Password?
 # EDITABLE=true,SCREEN="password-recovery",MULTI_LINE=true
 password.recovery.body=Don't worry, it happens. We will send you an email to reset your password.
 # EDITABLE=true,SCREEN="password-recovery",MULTI_LINE=false
+password.recovery.identifier.input.placeholder=Username
+# EDITABLE=true,SCREEN="password-recovery",MULTI_LINE=false
 password.recovery.button=Send Reset Link
 # <!-- End of Password Recovery Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
@@ -33,6 +33,7 @@ sign.up.button=Registrieren
 # <!-- Start of Password Recovery Translations -->
 password.recovery.heading=Passwort vergessen?
 password.recovery.body=Machen Sie sich keine Sorgen, das kann passieren. Eine E-Mail zum Zurücksetzen Ihres Passwortes wird Ihnen gesendet
+password.recovery.identifier.input.placeholder=Nutzername
 password.recovery.button=Reset-Link senden
 # <!-- End of Password Recovery Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_es_ES.properties
@@ -33,6 +33,7 @@ sign.up.button=Inscribirse
 # <!-- Start of Password Recovery Translations -->
 password.recovery.heading=¿Has olvidado tu contraseña?
 password.recovery.body=No te preocupes, sucede. Le enviaremos un correo electrónico para restablecer su contraseña.
+password.recovery.identifier.input.placeholder=Correo electrónico
 password.recovery.button=Enviar enlace de reinicio
 # <!-- End of Password Recovery Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
@@ -33,6 +33,7 @@ sign.up.button=S'inscrire
 # <!-- Start of Password Recovery Translations -->
 password.recovery.heading=Mot de passe oublié?
 password.recovery.body=Ne vous inquiétez pas, ça arrive. Nous vous enverrons un e-mail pour réinitialiser votre mot de passe.
+password.recovery.identifier.input.placeholder=Nom d'utilisateur
 password.recovery.button=Envoyer le lien de réinitialisation
 # <!-- End of Password Recovery Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_ja_JP.properties
@@ -33,6 +33,7 @@ sign.up.button=サインアップ
 # <!-- Start of Password Recovery Translations -->
 password.recovery.heading=パスワード
 password.recovery.body=心配する必要はありません。パスワードをリセットするためのメールをお送りします。
+password.recovery.identifier.input.placeholder=ユーザー名
 password.recovery.button=リセットリンクの送信
 # <!-- End of Password Recovery Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_BR.properties
@@ -33,6 +33,7 @@ sign.up.button=Cadastrar
 # <!-- Start of Password Recovery Translations -->
 password.recovery.heading=Esqueceu a senha?
 password.recovery.body=Não se preocupe, isso acontece. Enviaremos um e-mail para redefinir sua senha.
+password.recovery.identifier.input.placeholder=Nome de usuário
 password.recovery.button=Enviar link de redefinição
 # <!-- End of Password Recovery Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_PT.properties
@@ -33,6 +33,7 @@ sign.up.button=Inscrever-se
 # <!-- Start of Password Recovery Translations -->
 password.recovery.heading=Esqueceu a senha?
 password.recovery.body=Não se preocupe, isso acontece. Enviaremos um e-mail para redefinir sua senha.
+password.recovery.identifier.input.placeholder=Nome de usuário
 password.recovery.button=Enviar link de redefinição
 # <!-- End of Password Recovery Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_zh_CN.properties
@@ -33,6 +33,7 @@ sign.up.button=报名
 # <!-- Start of Password Recovery Translations -->
 password.recovery.heading=密码
 password.recovery.body=不用担心，它发生了。我们将向您发送电子邮件以重置您的密码。
+password.recovery.identifier.input.placeholder=用户名
 password.recovery.button=发送重置链接
 # <!-- End of Password Recovery Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -268,25 +268,17 @@
                            </label>
                            <% } %>
                             <div class="ui fluid left icon input">
-                                <% if (isMultiAttributeLoginEnabledInTenant) { %>
-                                    <input
-                                        placeholder="<%=usernameLabel%>"
-                                        id="usernameUserInput"
-                                        name="usernameUserInput"
-                                        type="text"
-                                        tabindex="0"
-                                        required
-                                    >
-                                <% } else { %>
-                                    <input
-                                        placeholder="<%=AuthenticationEndpointUtil.i18n(recoveryResourceBundle, usernameLabel)%>"
-                                        id="usernameUserInput"
-                                        name="usernameUserInput"
-                                        type="text"
-                                        tabindex="0"
-                                        required
-                                    >
-                                <% } %>
+                                <% String identifierPlaceholder=i18n(recoveryResourceBundle, customText, "password.recovery.identifier.input.placeholder" , "" , false); %>
+                                <% if (StringUtils.isNotBlank(identifierPlaceholder)) { %>
+                                    <input placeholder="<%=identifierPlaceholder%>" id="usernameUserInput" name="usernameUserInput" type="text"
+                                        tabindex="0" required>
+                                    <% } else if (isMultiAttributeLoginEnabledInTenant) { %>
+                                        <input placeholder="<%=usernameLabel%>" id="usernameUserInput" name="usernameUserInput" type="text"
+                                            tabindex="0" required>
+                                        <% } else { %>
+                                            <input placeholder="<%=AuthenticationEndpointUtil.i18n(recoveryResourceBundle, usernameLabel)%>"
+                                                id="usernameUserInput" name="usernameUserInput" type="text" tabindex="0" required>
+                                            <% } %>
                                 <i aria-hidden="true" class="user outline icon"></i>
                             </div>
                             <input id="username" name="username" type="hidden">

--- a/modules/i18n/src/models/namespaces/branding-ns.ts
+++ b/modules/i18n/src/models/namespaces/branding-ns.ts
@@ -49,6 +49,10 @@ export interface BrandingNS {
                 "login.heading": {
                     hint: string;
                 };
+                "login.identifier.input.label": {
+                    hint: string;
+                    warning?: string;
+                };
                 "sms.otp.heading": {
                     hint: string;
                 };
@@ -66,6 +70,10 @@ export interface BrandingNS {
                 };
                 "password.recovery.body": {
                     hint: string;
+                };
+                "password.recovery.identifier.input.placeholder": {
+                    hint: string;
+                    warning?: string;
                 };
                 "password.recovery.button": {
                     hint: string;
@@ -128,6 +136,10 @@ export interface BrandingNS {
             label: string;
             placeholder: string;
         };
+    };
+    connectors: {
+        multiAttributeLogin: string;
+        alternativeLoginIdentifier: string;
     };
     form: {
         actions: {

--- a/modules/i18n/src/translations/en-US/portals/branding.ts
+++ b/modules/i18n/src/translations/en-US/portals/branding.ts
@@ -57,6 +57,10 @@ export const branding: BrandingNS = {
                 "login.heading": {
                     hint: "The heading of the login box. If not set, {{productName}} defaults are used."
                 },
+                "login.identifier.input.label": {
+                    hint: "The label of the identifier input field in the login box. If not set, {{productName}} defaults are used.",
+                    warning: "<0>IMPORTANT</0>: Customizing the login identifier label will replace the dynamic label when {{feature}} are <1>configured</1>."
+                },
                 "sms.otp.heading": {
                     hint: "The heading of the SMS OTP box. If not set, {{productName}} defaults are used."
                 },
@@ -74,6 +78,10 @@ export const branding: BrandingNS = {
                 },
                 "password.recovery.body": {
                     hint: "The body text of the password recovery box. If not set, {{productName}} defaults are used."
+                },
+                "password.recovery.identifier.input.placeholder": {
+                    hint: "The placeholder of the identifier input field in the password recovery box. If not set, {{productName}} defaults are used.",
+                    warning: "<0>IMPORTANT</0>: Customizing the password recovery identifier placeholder will replace the dynamic placeholder when {{feature}} are <1>configured</1>."
                 },
                 "password.recovery.button": {
                     hint: "The text that appears on the main action button of the password recovery box. If not set, {{productName}} defaults are used."
@@ -136,6 +144,10 @@ export const branding: BrandingNS = {
             label: "Screen",
             placeholder: "Select screen"
         }
+    },
+    connectors: {
+        multiAttributeLogin: "Multi Attribute Login Identifiers",
+        alternativeLoginIdentifier: "Alternative Login Identifiers"
     },
     form: {
         actions: {


### PR DESCRIPTION
### Purpose

Add branding to the identifier(username) in Login and Password recovery pages.

- Login page
<img width="350" alt="Screenshot 2024-04-02 at 23 12 44" src="https://github.com/wso2/identity-apps/assets/67315176/68918092-77e1-4c67-b294-6218059a597e">

- Password recovery page
<img width="350" alt="Screenshot 2024-04-02 at 23 12 49" src="https://github.com/wso2/identity-apps/assets/67315176/95ed5aa2-6d72-4b48-94cc-3fb167d62111">

The customization added here will override the dynamic label applied if Alternative login identifiers are configured.

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
