### PR TITLE
Provide proper name to SMS provider tabs

### DIFF
--- a/.changeset/four-lemons-grow.md
+++ b/.changeset/four-lemons-grow.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+Provide proper name to SMS provider tabs

--- a/features/admin.sms-providers.v1/pages/sms-providers.tsx
+++ b/features/admin.sms-providers.v1/pages/sms-providers.tsx
@@ -565,7 +565,7 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                                                             const smsProviderName: string =
                                                                     provider?.name?.toLocaleLowerCase();
 
-                                                            return (<Grid.Column key={ provider.id }>
+                                                            return (<Grid.Column key={ provider?.id }>
                                                                 <InfoCard
                                                                     fluid
                                                                     data-componentid=

--- a/features/admin.sms-providers.v1/pages/sms-providers.tsx
+++ b/features/admin.sms-providers.v1/pages/sms-providers.tsx
@@ -563,7 +563,7 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                                                             // Get the provider name in lower case to use as the
                                                             // data-componentid.
                                                             const smsProviderName: string =
-                                                                    provider.name.toLocaleLowerCase();
+                                                                    provider?.name?.toLocaleLowerCase();
 
                                                             return (<Grid.Column key={ provider.id }>
                                                                 <InfoCard

--- a/features/admin.sms-providers.v1/pages/sms-providers.tsx
+++ b/features/admin.sms-providers.v1/pages/sms-providers.tsx
@@ -559,13 +559,17 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                                             <Grid>
                                                 <Grid.Row columns={ 3 }>
                                                     { providerCards.map(
-                                                        (provider: SMSProviderCardInterface) => (
-                                                            <Grid.Column key={ provider.id }>
+                                                        (provider: SMSProviderCardInterface) => {
+                                                            // Get the provider name in lower case to use as the
+                                                            // data-componentid.
+                                                            const smsProviderName: string =
+                                                                    provider.name.toLocaleLowerCase();
+
+                                                            return (<Grid.Column key={ provider.id }>
                                                                 <InfoCard
                                                                     fluid
                                                                     data-componentid=
-                                                                        { `${componentId}
-                                                                                -sms-provider-info-card` }
+                                                                        { `${smsProviderName}-sms-provider-info-card` }
                                                                     image={ provider.icon }
                                                                     imageSize="x30"
                                                                     header={
@@ -584,8 +588,9 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
                                                                     showSetupGuideButton={ false }
                                                                     showCardAction={ false }
                                                                 />
-                                                            </Grid.Column>
-                                                        )) }
+                                                            </Grid.Column>);
+                                                        })
+                                                    }
                                                 </Grid.Row>
                                             </Grid>
                                         </div>


### PR DESCRIPTION
### Purpose
There were no unique identifier for SMS provider tabs to identify each tab to use in UI tests. Hence, adding a unique id using "data-componentid".

### Related Issues
None

### Related PRs
None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
