### PR TITLE
Add i18n for logs

### DIFF
--- a/.changeset/cuddly-actors-rule.md
+++ b/.changeset/cuddly-actors-rule.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+add i18n for logs

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -2337,8 +2337,8 @@ export interface Extensions {
             };
         };
         monitor: {
-            logs : {
-                tabs : {
+            logs: {
+                tabs: {
                     audit: string,
                     diagnostic: string
                 }

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -2337,6 +2337,12 @@ export interface Extensions {
             };
         };
         monitor: {
+            logs : {
+                tabs : {
+                    audit: string,
+                    diagnostic: string
+                }
+            },
             filter: {
                 advancedSearch: {
                     attributes: {

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -2626,6 +2626,12 @@ export const extensions: Extensions = {
             }
         },
         monitor: {
+            logs : {
+                tabs : {
+                    audit: "Audit",
+                    diagnostic: "Diagnostic"
+                }
+            },
             filter: {
                 advancedSearch: {
                     attributes: {

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -2626,8 +2626,8 @@ export const extensions: Extensions = {
             }
         },
         monitor: {
-            logs : {
-                tabs : {
+            logs: {
+                tabs: {
                     audit: "Audit",
                     diagnostic: "Diagnostic"
                 }

--- a/features/admin.extensions.v1/components/logs/pages/logs.tsx
+++ b/features/admin.extensions.v1/components/logs/pages/logs.tsx
@@ -21,7 +21,8 @@ import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import {
     PageLayout,
     ResourceTab,
-    ResourceTabPaneInterface } from "@wso2is/react-components";
+    ResourceTabPaneInterface
+} from "@wso2is/react-components";
 import React, {
     FunctionComponent,
     ReactElement,
@@ -83,7 +84,7 @@ const LogsPage: FunctionComponent<LogsPageInterface> = (
             componentId: "diagnostic-logs",
             menuItem: (
                 <MenuItem key="text" className="item-with-chip">
-                    Dianostic
+                    { t("extensions:develop.monitor.logs.tabs.diagnostic") }
                 </MenuItem>
             ),
             render: renderLogContentDiagnosticNew
@@ -94,7 +95,7 @@ const LogsPage: FunctionComponent<LogsPageInterface> = (
             componentId: "audit-logs",
             menuItem: (
                 <MenuItem key="text" className="item-with-chip">
-                    Audit
+                    { t("extensions:develop.monitor.logs.tabs.audit") }
                     <Chip
                         size="small"
                         label={ t("common:beta").toUpperCase() }


### PR DESCRIPTION
### Purpose
This adds i18n for log tab headers

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
