### PR TITLE
Clean up and separate out the legacy `onSignIn` hook in Console

### DIFF
--- a/.changeset/chilly-houses-wash.md
+++ b/.changeset/chilly-houses-wash.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+Refactor `use-sign` hook

--- a/apps/console/src/public/startup-config.js
+++ b/apps/console/src/public/startup-config.js
@@ -1,12 +1,31 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// eslint-disable-next-line no-unused-vars
 var startupConfig = {
-    subdomainApplication: false,
+    enableDefaultPreLoader: true,
+    legacyAuthzRuntime: false,
+    orgPrefix: "o",
     pathExtension: "",
-    superTenant: "carbon.super",
-    superTenantProxy: "carbon.super",
     serverUrl: "https://localhost:9443",
     serverUrlGlobal: "https://localhost:9443",
-    tenantPrefix: "t",
-    orgPrefix: "o",
-    enableDefaultPreLoader: true,
-    legacyAuthzRuntime: false
+    subdomainApplication: false,
+    superTenant: "carbon.super",
+    superTenantProxy: "carbon.super",
+    tenantPrefix: "t"
 };

--- a/apps/myaccount/src/public/startup-config.js
+++ b/apps/myaccount/src/public/startup-config.js
@@ -1,12 +1,31 @@
+/**
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// eslint-disable-next-line no-unused-vars
 var startupConfig = {
-    subdomainApplication: false,
+    enableDefaultPreLoader: true,
+    legacyAuthzRuntime: false,
+    orgPrefix: "o",
     pathExtension: "",
-    superTenant: "carbon.super",
-    superTenantProxy: "carbon.super",
     serverUrl: "https://localhost:9443",
     serverUrlGlobal: "https://localhost:9443",
-    tenantPrefix: "t",
-    orgPrefix: 'o',
-    enableDefaultPreLoader: true,
-    legacyAuthzRuntime: false
+    subdomainApplication: false,
+    superTenant: "carbon.super",
+    superTenantProxy: "carbon.super",
+    tenantPrefix: "t"
 };

--- a/features/admin.authentication.v1/hooks/use-sign-in.ts
+++ b/features/admin.authentication.v1/hooks/use-sign-in.ts
@@ -122,79 +122,89 @@ const useSignIn = (): UseSignInInterface => {
      * Resolves and sets the custom server host.
      *
      * @param orgType - Type of the organization. Ex: sub organization, etc.
+     */
+    const setCustomServerHost = (orgType: string): void => {
+        // In case of failure customServerHost is set to the serverHost.
+        let customServerHost: string = Config?.getDeploymentConfig()?.serverHost;
+
+        const isSuperTenant: boolean = window["AppUtils"]?.isSuperTenant();
+        const isSubOrganization: boolean = orgType === OrganizationType.SUBORGANIZATION &&
+            window["AppUtils"]?.getConfig()?.organizationName.length > 0;
+
+        if (!window["AppUtils"]?.getConfig()?.requireSuperTenantInUrls && isSuperTenant) {
+            // Removing super tenant from the server host.
+            const customServerHostSplit: string[] = customServerHost?.split("/t/");
+
+            if (customServerHostSplit?.length > 0) {
+                customServerHost = customServerHostSplit[0];
+            }
+        }
+
+        if (isSubOrganization) {
+            customServerHost = `${Config?.getDeploymentConfig()?.serverOrigin}/${
+                window["AppUtils"]?.getConfig()?.organizationPrefix}/${
+                window["AppUtils"]?.getConfig()?.organizationName}`;
+        }
+
+        window["AppUtils"]?.updateCustomServerHost(customServerHost);
+
+        // Update store with custom server host.
+        dispatch(setDeploymentConfigs<DeploymentConfigInterface>(Config?.getDeploymentConfig()));
+
+        // Set the deployment configs in the context.
+        setDeploymentConfig(Config?.getDeploymentConfig());
+
+        // Update runtime configurations.
+        ContextUtils.setRuntimeConfig(Config?.getDeploymentConfig());
+    };
+
+    /**
+     * Resolves and sets the custom server host.
+     *
+     * @deprecated Use `setCustomServerHost()` instead.
+     * @param orgType - Type of the organization. Ex: sub organization, etc.
      * @param wellKnownEndpoint - Wellknown discovery endpoint.
      */
-    const setCustomServerHost = (orgType: string, wellKnownEndpoint: string): void => {
+    const setLegacyCustomServerHost = (orgType: string, wellKnownEndpoint: string): void => {
         const disabledFeatures: string[] = window["AppUtils"]?.getConfig()?.ui?.features?.branding?.disabledFeatures;
 
-        if (legacyAuthzRuntime && !disabledFeatures?.includes("branding.hostnameUrlBranding")) {
-            // Set configurations related to hostname branding.
-            axios
-                .get(wellKnownEndpoint)
-                .then((response: AxiosResponse) => {
-                    // Use token endpoint to extract the host url.
-                    const splitted: string[] = response?.data?.token_endpoint?.split("/") ?? [];
-
-                    let serverHost: string = splitted?.slice(0, -2)?.join("/");
-
-                    if (orgType === OrganizationType.SUBORGANIZATION) {
-                        serverHost = `${Config?.getDeploymentConfig()?.serverOrigin}/${
-                            window["AppUtils"]?.getConfig()?.organizationPrefix
-                        }/${window["AppUtils"]?.getConfig()?.organizationName}`;
-                    }
-
-                    window["AppUtils"]?.updateCustomServerHost(serverHost);
-                })
-                .catch((error: any) => {
-                    // In case of failure customServerHost is set to the serverHost.
-                    window["AppUtils"]?.updateCustomServerHost(Config?.getDeploymentConfig()?.serverHost);
-
-                    throw error;
-                })
-                .finally(() => {
-                    // Update store with custom server host.
-                    dispatch(setDeploymentConfigs<DeploymentConfigInterface>(Config?.getDeploymentConfig()));
-
-                    // Set the deployment configs in the context.
-                    setDeploymentConfig(Config?.getDeploymentConfig());
-
-                    // Update runtime configurations.
-                    ContextUtils.setRuntimeConfig(Config?.getDeploymentConfig());
-                });
-        } else {
-            // In case of failure customServerHost is set to the serverHost.
-            let customServerHost: string = Config?.getDeploymentConfig()?.serverHost;
-
-            const isSuperTenant: boolean = window["AppUtils"]?.isSuperTenant();
-            const isSubOrganization: boolean = orgType === OrganizationType.SUBORGANIZATION &&
-                window["AppUtils"]?.getConfig()?.organizationName.length > 0;
-
-            if (!window["AppUtils"]?.getConfig()?.requireSuperTenantInUrls && isSuperTenant) {
-                // Removing super tenant from the server host.
-                const customServerHostSplit: string[] = customServerHost?.split("/t/");
-
-                if (customServerHostSplit?.length > 0) {
-                    customServerHost = customServerHostSplit[0];
-                }
-            }
-
-            if (isSubOrganization) {
-                customServerHost = `${Config?.getDeploymentConfig()?.serverOrigin}/${
-                    window["AppUtils"]?.getConfig()?.organizationPrefix}/${
-                    window["AppUtils"]?.getConfig()?.organizationName}`;
-            }
-
-            window["AppUtils"]?.updateCustomServerHost(customServerHost);
-
-            // Update store with custom server host.
-            dispatch(setDeploymentConfigs<DeploymentConfigInterface>(Config?.getDeploymentConfig()));
-
-            // Set the deployment configs in the context.
-            setDeploymentConfig(Config?.getDeploymentConfig());
-
-            // Update runtime configurations.
-            ContextUtils.setRuntimeConfig(Config?.getDeploymentConfig());
+        if (disabledFeatures?.includes("branding.hostnameUrlBranding")) {
+            return;
         }
+
+        // Set configurations related to hostname branding.
+        axios
+            .get(wellKnownEndpoint)
+            .then((response: AxiosResponse) => {
+                // Use token endpoint to extract the host url.
+                const splitted: string[] = response?.data?.token_endpoint?.split("/") ?? [];
+
+                let serverHost: string = splitted?.slice(0, -2)?.join("/");
+
+                if (orgType === OrganizationType.SUBORGANIZATION) {
+                    serverHost = `${Config?.getDeploymentConfig()?.serverOrigin}/${
+                        window["AppUtils"]?.getConfig()?.organizationPrefix
+                    }/${window["AppUtils"]?.getConfig()?.organizationName}`;
+                }
+
+                window["AppUtils"]?.updateCustomServerHost(serverHost);
+            })
+            .catch((error: any) => {
+                // In case of failure customServerHost is set to the serverHost.
+                window["AppUtils"]?.updateCustomServerHost(Config?.getDeploymentConfig()?.serverHost);
+
+                throw error;
+            })
+            .finally(() => {
+                // Update store with custom server host.
+                dispatch(setDeploymentConfigs<DeploymentConfigInterface>(Config?.getDeploymentConfig()));
+
+                // Set the deployment configs in the context.
+                setDeploymentConfig(Config?.getDeploymentConfig());
+
+                // Update runtime configurations.
+                ContextUtils.setRuntimeConfig(Config?.getDeploymentConfig());
+            });
     };
 
     /**
@@ -218,7 +228,41 @@ const useSignIn = (): UseSignInInterface => {
         onSignInSuccessRedirect: (idToken: DecodedIDTokenPayload) => void,
         onAppReady: () => void
     ): Promise<void> => {
-        let logoutUrl: string;
+        if (legacyAuthzRuntime) {
+            await legacyOnSignIn(
+                response,
+                onTenantResolve,
+                onSignInSuccessRedirect,
+                onAppReady
+            );
+
+            return;
+        }
+
+        await _onSignIn(
+            response,
+            onTenantResolve,
+            onSignInSuccessRedirect,
+            onAppReady
+        );
+    };
+
+    /**
+     * Handles the sign-in process for the new authorization server.
+     *
+     * @param response - The basic user information returned from the sign-in process.
+     * @param onTenantResolve - Callback to be triggered when tenant is resolved.
+     * @param onSignInSuccessRedirect - Callback to be triggered when sign in is successful.
+     * @param onAppReady - Callback to be triggered when the app is ready.
+     *
+     * @returns A promise.
+     */
+    const _onSignIn = async (
+        response: BasicUserInfo,
+        onTenantResolve: (tenantDomain: string) => void,
+        onSignInSuccessRedirect: (idToken: DecodedIDTokenPayload) => void,
+        onAppReady: () => void
+    ): Promise<void> => {
         let logoutRedirectUrl: string;
 
         const idToken: DecodedIDTokenPayload = await getDecodedIDToken();
@@ -240,7 +284,7 @@ const useSignIn = (): UseSignInInterface => {
             || idToken.org_name === tenantDomainFromSubject
             || ((idToken.user_org === idToken.org_id) && idToken.org_name === tenantDomainFromSubject);
 
-        let tenantDomain: string = transformTenantDomain(orgName);
+        const tenantDomain: string = transformTenantDomain(orgName);
 
         const firstName: string = idToken?.given_name;
         const lastName: string = idToken?.family_name;
@@ -260,10 +304,6 @@ const useSignIn = (): UseSignInInterface => {
                     })
             )
         );
-
-        if (legacyAuthzRuntime) {
-            tenantDomain = tenantDomainFromSubject;
-        }
 
         onTenantResolve(tenantDomain);
 
@@ -288,10 +328,6 @@ const useSignIn = (): UseSignInInterface => {
         dispatch(setOrganizationType(orgType));
         window["AppUtils"].updateOrganizationType(orgType);
         dispatch(setUserOrganizationId(userOrganizationId));
-
-        if (legacyAuthzRuntime) {
-            dispatch(setIsFirstLevelOrganization(isFirstLevelOrg));
-        }
 
         if (window["AppUtils"].getConfig().organizationName || isFirstLevelOrg) {
             // We are actually getting the orgId here rather than orgName
@@ -364,64 +400,9 @@ const useSignIn = (): UseSignInInterface => {
         // Update runtime configurations.
         ContextUtils.setRuntimeConfig(Config.getDeploymentConfig());
 
-        // TODO: Test This properly.
-        logoutUrl = window[ "AppUtils" ].getConfig().idpConfigs?.logoutEndpointURL;
+        const logoutUrl: string = window[ "AppUtils" ].getConfig().idpConfigs?.logoutEndpointURL;
 
-        if (legacyAuthzRuntime) {
-            // Update post_logout_redirect_uri of logout_url with tenant qualified url
-            if (sessionStorage.getItem(LOGOUT_URL)) {
-                logoutUrl = sessionStorage.getItem(LOGOUT_URL);
-
-                if (
-                    !window[ "AppUtils" ].getConfig().accountApp
-                        .commonPostLogoutUrl
-                ) {
-                    // If there is a base name, replace the `post_logout_redirect_uri` with the tenanted base name.
-                    if (window[ "AppUtils" ].getConfig().appBase) {
-                        logoutUrl = logoutUrl.replace(
-                            window[ "AppUtils" ].getAppBase(),
-                            window[ "AppUtils" ].getAppBaseWithTenant()
-                        );
-                        logoutRedirectUrl = window[ "AppUtils" ]
-                            .getConfig()
-                            .logoutCallbackURL.replace(
-                                window[ "AppUtils" ].getAppBase(),
-                                window[ "AppUtils" ].getAppBaseWithTenant()
-                            );
-                    } else {
-                        logoutUrl = logoutUrl.replace(
-                            window[ "AppUtils" ].getConfig().logoutCallbackURL,
-                            window[ "AppUtils" ].getConfig().clientOrigin +
-                            window[ "AppUtils" ].getConfig().routes.login
-                        );
-                        logoutRedirectUrl =
-                            window[ "AppUtils" ].getConfig().clientOrigin +
-                            window[ "AppUtils" ].getConfig().routes.login;
-                    }
-                }
-
-                // If an override URL is defined in config, use that instead.
-                if (
-                    window[ "AppUtils" ].getConfig().idpConfigs?.logoutEndpointURL
-                ) {
-                    logoutUrl = AuthenticateUtils.resolveIdpURLSAfterTenantResolves(
-                        logoutUrl,
-                        window[ "AppUtils" ].getConfig().idpConfigs
-                            .logoutEndpointURL
-                    );
-                }
-
-                sessionStorage.setItem(LOGOUT_URL, logoutUrl);
-            }
-        }
-
-        let wellKnownEndpoint: string = Config.getServiceResourceEndpoints().wellKnown;
-
-        if (!legacyAuthzRuntime) {
-            // FIXME: Skipping /o/ appending from the `getServiceResourceEndpoints` level seems to be not working.
-            wellKnownEndpoint = wellKnownEndpoint.replace("/o/", "/");
-            dispatch(setIsFirstLevelOrganization(isFirstLevelOrg));
-        }
+        dispatch(setIsFirstLevelOrganization(isFirstLevelOrg));
 
         onAppReady();
 
@@ -497,7 +478,286 @@ const useSignIn = (): UseSignInInterface => {
         }
 
         onSignInSuccessRedirect(idToken);
-        setCustomServerHost(orgType, wellKnownEndpoint);
+        setCustomServerHost(orgType);
+    };
+
+    /**
+     * Handles the sign-in process for legacy authorization server.
+     *
+     * @deprecated This is deprecated and will be removed in the next major release.
+     * @param response - The basic user information returned from the sign-in process.
+     * @param onTenantResolve - Callback to be triggered when tenant is resolved.
+     * @param onSignInSuccessRedirect - Callback to be triggered when sign in is successful.
+     * @param onAppReady - Callback to be triggered when the app is ready.
+     *
+     * @returns A promise.
+     */
+    const legacyOnSignIn = async (
+        response: BasicUserInfo,
+        onTenantResolve: (tenantDomain: string) => void,
+        onSignInSuccessRedirect: (idToken: DecodedIDTokenPayload) => void,
+        onAppReady: () => void
+    ): Promise<void> => {
+        let logoutUrl: string;
+        let logoutRedirectUrl: string;
+
+        const idToken: DecodedIDTokenPayload = await getDecodedIDToken();
+        const isPrivilegedUser: boolean =
+            idToken?.amr?.length > 0
+                ? idToken?.amr[0] === "EnterpriseIDPAuthenticator"
+                : false;
+        const event: Event = new Event(CommonConstantsCore.AUTHENTICATION_SUCCESSFUL_EVENT);
+
+        dispatchEvent(event);
+
+        const orgIdIdToken: string = idToken.org_id;
+        const orgName: string = idToken.org_name;
+        const userOrganizationId: string = idToken.user_org;
+        const tenantDomainFromSubject: string = CommonAuthenticateUtils.deriveTenantDomainFromSubject(
+            response.sub
+        );
+        const isFirstLevelOrg: boolean = !idToken.user_org
+            || idToken.org_name === tenantDomainFromSubject
+            || ((idToken.user_org === idToken.org_id) && idToken.org_name === tenantDomainFromSubject);
+
+        let tenantDomain: string = transformTenantDomain(orgName);
+
+        const firstName: string = idToken?.given_name;
+        const lastName: string = idToken?.family_name;
+        const fullName: string = firstName ? firstName + (lastName ? " " + lastName : "") : response.email;
+
+        await dispatch(
+            setSignIn<AuthenticatedUserInfo & TenantListInterface>(
+                Object.assign(
+                    CommonAuthenticateUtils.getSignInState(
+                        response,
+                        transformTenantDomain(response.orgName)
+                    ), {
+                        associatedTenants: isPrivilegedUser ? tenantDomain : idToken?.associated_tenants,
+                        defaultTenant: isPrivilegedUser ? tenantDomain : idToken?.default_tenant,
+                        fullName: fullName,
+                        isPrivilegedUser: isPrivilegedUser
+                    })
+            )
+        );
+
+        tenantDomain = tenantDomainFromSubject;
+
+        onTenantResolve(tenantDomain);
+
+        let orgType: OrganizationType;
+
+        // Update the organization name with the newly resolved org.
+        if (!isFirstLevelOrg) {
+            window["AppUtils"].updateOrganizationName(orgIdIdToken);
+        } else {
+            // Update the app base name with the newly resolved tenant.
+            window[ "AppUtils" ].updateTenantQualifiedBaseName(tenantDomain);
+        }
+
+        if (isFirstLevelOrg && tenantDomain === AppConstants.getSuperTenant()) {
+            orgType = OrganizationType.SUPER_ORGANIZATION;
+        } else if (isFirstLevelOrg) {
+            orgType = OrganizationType.FIRST_LEVEL_ORGANIZATION;
+        } else {
+            orgType = OrganizationType.SUBORGANIZATION;
+        }
+
+        dispatch(setOrganizationType(orgType));
+        window["AppUtils"].updateOrganizationType(orgType);
+        dispatch(setUserOrganizationId(userOrganizationId));
+        dispatch(setIsFirstLevelOrganization(isFirstLevelOrg));
+
+        if (window["AppUtils"].getConfig().organizationName || isFirstLevelOrg) {
+            // We are actually getting the orgId here rather than orgName
+            const orgId: string = isFirstLevelOrg ? orgIdIdToken : window["AppUtils"].getConfig().organizationName;
+
+            // Setting a dummy object until real data comes from the API
+            dispatch(
+                setOrganization({
+                    attributes: [],
+                    created: new Date().toString(),
+                    description: "",
+                    domain: "",
+                    id: orgId,
+                    lastModified: new Date().toString(),
+                    name: orgName,
+                    parent: {
+                        id: "",
+                        ref: ""
+                    },
+                    status: "",
+                    type: ""
+                })
+            );
+
+            if (!isPrivilegedUser && orgIdIdToken != orgId) {
+                dispatch(setCurrentOrganization(orgName));
+
+                // This is to make sure the endpoints are generated with the organization path.
+                await dispatch(setServiceResourceEndpoints(Config.getServiceResourceEndpoints()));
+
+                // Sets the resource endpoints in the context.
+                setResourceEndpoints(Config.getServiceResourceEndpoints() as any);
+
+                try {
+                    response = await switchOrganization(orgId);
+                } catch (e) {
+                    // TODO: Handle error
+                }
+
+                onTenantResolve(response.orgId);
+                dispatch(setCurrentOrganization(response.orgName));
+            }
+        }
+
+        dispatch(setGetOrganizationLoading(false));
+
+        const endpoints: Record<string, any> = Config.getServiceResourceEndpoints();
+
+        // Update the endpoints with tenant path.
+        await dispatch(setServiceResourceEndpoints(endpoints));
+
+        // Sets the resource endpoints in the context.
+        setResourceEndpoints(endpoints);
+
+        // When the tenant domain changes, we have to reset the auth callback in session storage.
+        // If not, it will hang and the app will be unresponsive with in the tab.
+        // We can skip clearing the callback for super tenant since we do not put it in the path.
+        if (tenantDomain !== AppConstants.getSuperTenant()) {
+            // If the auth callback already has the logged in tenant's path, we can skip the reset.
+            if (
+                !CommonAuthenticateUtils.isValidAuthenticationCallbackUrl(
+                    CommonAppConstants.CONSOLE_APP,
+                    AppConstants.getTenantPath()
+                )
+            ) {
+                CommonAuthenticateUtils.removeAuthenticationCallbackUrl(CommonAppConstants.CONSOLE_APP);
+            }
+        }
+
+        // Update runtime configurations.
+        ContextUtils.setRuntimeConfig(Config.getDeploymentConfig());
+
+        logoutUrl = window[ "AppUtils" ].getConfig().idpConfigs?.logoutEndpointURL;
+
+        // Update post_logout_redirect_uri of logout_url with tenant qualified url
+        if (sessionStorage.getItem(LOGOUT_URL)) {
+            logoutUrl = sessionStorage.getItem(LOGOUT_URL);
+
+            if (
+                !window[ "AppUtils" ].getConfig().accountApp
+                    .commonPostLogoutUrl
+            ) {
+                // If there is a base name, replace the `post_logout_redirect_uri` with the tenanted base name.
+                if (window[ "AppUtils" ].getConfig().appBase) {
+                    logoutUrl = logoutUrl.replace(
+                        window[ "AppUtils" ].getAppBase(),
+                        window[ "AppUtils" ].getAppBaseWithTenant()
+                    );
+                    logoutRedirectUrl = window[ "AppUtils" ]
+                        .getConfig()
+                        .logoutCallbackURL.replace(
+                            window[ "AppUtils" ].getAppBase(),
+                            window[ "AppUtils" ].getAppBaseWithTenant()
+                        );
+                } else {
+                    logoutUrl = logoutUrl.replace(
+                        window[ "AppUtils" ].getConfig().logoutCallbackURL,
+                        window[ "AppUtils" ].getConfig().clientOrigin +
+                        window[ "AppUtils" ].getConfig().routes.login
+                    );
+                    logoutRedirectUrl =
+                        window[ "AppUtils" ].getConfig().clientOrigin +
+                        window[ "AppUtils" ].getConfig().routes.login;
+                }
+            }
+
+            // If an override URL is defined in config, use that instead.
+            if (
+                window[ "AppUtils" ].getConfig().idpConfigs?.logoutEndpointURL
+            ) {
+                logoutUrl = AuthenticateUtils.resolveIdpURLSAfterTenantResolves(
+                    logoutUrl,
+                    window[ "AppUtils" ].getConfig().idpConfigs
+                        .logoutEndpointURL
+                );
+            }
+
+            sessionStorage.setItem(LOGOUT_URL, logoutUrl);
+        }
+
+        onAppReady();
+
+        sessionStorage.setItem(CommonConstants.SESSION_STATE, response?.sessionState);
+
+        getOIDCServiceEndpoints()
+            .then((response: OIDCEndpoints) => {
+                let authorizationEndpoint: string = response.authorizationEndpoint;
+                let oidcSessionIframeEndpoint: string = response.checkSessionIframe;
+                let tokenEndpoint: string = response.tokenEndpoint;
+
+                // If `authorize` endpoint is overridden, save that in the session.
+                if (window["AppUtils"].getConfig().idpConfigs?.authorizeEndpointURL) {
+                    authorizationEndpoint = AuthenticateUtils.resolveIdpURLSAfterTenantResolves(
+                        authorizationEndpoint,
+                        window["AppUtils"].getConfig().idpConfigs.authorizeEndpointURL
+                    );
+                }
+
+                // If `oidc session iframe` endpoint is overridden, save that in the session.
+                if (window["AppUtils"].getConfig().idpConfigs?.oidcSessionIFrameEndpointURL) {
+                    oidcSessionIframeEndpoint = AuthenticateUtils.resolveIdpURLSAfterTenantResolves(
+                        oidcSessionIframeEndpoint,
+                        window["AppUtils"].getConfig().idpConfigs.oidcSessionIFrameEndpointURL
+                    );
+                }
+
+                // If `token` endpoint is overridden, save that in the session.
+                if (window["AppUtils"].getConfig().idpConfigs?.tokenEndpointURL) {
+                    tokenEndpoint = AuthenticateUtils.resolveIdpURLSAfterTenantResolves(
+                        tokenEndpoint,
+                        window["AppUtils"].getConfig().idpConfigs.tokenEndpointURL
+                    );
+                }
+
+                if (isPrivilegedUser) {
+                    logoutRedirectUrl =
+                        window["AppUtils"].getConfig().clientOrigin + window["AppUtils"].getConfig().routes.login;
+                }
+
+                sessionStorage.setItem(AUTHORIZATION_ENDPOINT, authorizationEndpoint);
+                sessionStorage.setItem(OIDC_SESSION_IFRAME_ENDPOINT, oidcSessionIframeEndpoint);
+                sessionStorage.setItem(TOKEN_ENDPOINT, tokenEndpoint);
+
+                updateConfig({
+                    endpoints: {
+                        authorizationEndpoint: authorizationEndpoint,
+                        checkSessionIframe: oidcSessionIframeEndpoint,
+                        endSessionEndpoint: logoutUrl.split("?")[0],
+                        tokenEndpoint: tokenEndpoint
+                    },
+                    signOutRedirectURL: logoutRedirectUrl
+                });
+            })
+            .catch((error: any) => {
+                throw error;
+            });
+
+        await dispatch(
+            getProfileInformation(
+                Config.getServiceResourceEndpoints().me,
+                window["AppUtils"].getConfig().clientOriginWithTenant,
+                true
+            )
+        );
+
+        if (isFirstLevelOrg) {
+            await dispatch(getServerConfigurations());
+        }
+
+        onSignInSuccessRedirect(idToken);
+        setLegacyCustomServerHost(orgType, Config.getServiceResourceEndpoints().wellKnown);
     };
 
     /**
@@ -512,10 +772,6 @@ const useSignIn = (): UseSignInInterface => {
      * @returns Derived logout redirect URL.
      */
     const deriveLogoutRedirectForSubOrgLogins = (currentLogoutRedirect: string, userOrg: string, orgId: string) => {
-        if (legacyAuthzRuntime) {
-            return currentLogoutRedirect;
-        }
-
         let logoutRedirectUrl: string = currentLogoutRedirect;
 
         // When a first level tenant login happens, `user_org` is undefined.


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Separate the `onSignIn` hook in Console based on the runtime to clearly separate logic.

### Related Issues
- https://github.com/wso2/product-is/issues/18999

### Related PRs
- Original PR: https://github.com/wso2/identity-apps/pull/5878
- Revert PR: https://github.com/wso2/identity-apps/pull/5930

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
