### PR TITLE
Add eye icon to secrets in sms providers

### DIFF
--- a/.changeset/moody-hornets-double.md
+++ b/.changeset/moody-hornets-double.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/features": patch
+"@wso2is/console": patch
+---
+
+Add eye icon to secret input fields in sms providers

--- a/features/admin.sms-providers.v1/pages/twilio-sms-provider.tsx
+++ b/features/admin.sms-providers.v1/pages/twilio-sms-provider.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import InputAdornment from "@oxygen-ui/react/InputAdornment";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { FinalFormField, TextFieldAdapter } from "@wso2is/form";
 import {
@@ -23,9 +24,9 @@ import {
     Hint,
     PrimaryButton
 } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Divider, Grid } from "semantic-ui-react";
+import { Divider, Grid, Icon } from "semantic-ui-react";
 import { SMSProviderConstants } from "../constants";
 
 interface TwilioSMSProviderPageInterface extends IdentifiableComponentInterface {
@@ -42,6 +43,24 @@ const TwilioSMSProvider: FunctionComponent<TwilioSMSProviderPageInterface> = (
         isReadOnly
     } = props;
     const { t } = useTranslation();
+    const [ isShow, setIsShow ] = useState(false);
+
+    const renderInputAdornment = (): ReactElement => {
+
+        return (
+            <InputAdornment position="end">
+                <Icon
+                    link={ true }
+                    className="list-icon reset-field-to-default-adornment"
+                    size="small"
+                    color="grey"
+                    name={ !isShow ? "eye" : "eye slash" }
+                    data-testid={ "view-button" }
+                    onClick={ () => { setIsShow(!isShow); } }
+                />
+            </InputAdornment>
+        );
+    };
 
     return (
         <EmphasizedSegment className="form-wrapper" padded={ "very" }>
@@ -90,7 +109,9 @@ const TwilioSMSProvider: FunctionComponent<TwilioSMSProviderPageInterface> = (
                             required={ true }
                             data-componentid={ `${componentId}-twilio-secret` }
                             name="twilioSecret"
-                            type="password"
+                            hidePassword={ t("common:hidePassword") }
+                            showPassword={ t("common:showPassword") }
+                            type={ isShow ? "text" : "password" }
                             label={ t("smsProviders:form.twilio.authToken.label") }
                             placeholder={ t("smsProviders:form.twilio.authToken.placeholder") }
                             helperText={ (
@@ -99,6 +120,9 @@ const TwilioSMSProvider: FunctionComponent<TwilioSMSProviderPageInterface> = (
                                 </Hint>
                             ) }
                             component={ TextFieldAdapter }
+                            InputProps={ {
+                                endAdornment: renderInputAdornment()
+                            } }
                             maxLength={ SMSProviderConstants.SMS_PROVIDER_CONFIG_FIELD_MAX_LENGTH }
                             minLength={ SMSProviderConstants.SMS_PROVIDER_CONFIG_FIELD_MIN_LENGTH }
                             autoComplete="new-password"

--- a/features/admin.sms-providers.v1/pages/twilio-sms-provider.tsx
+++ b/features/admin.sms-providers.v1/pages/twilio-sms-provider.tsx
@@ -45,22 +45,20 @@ const TwilioSMSProvider: FunctionComponent<TwilioSMSProviderPageInterface> = (
     const { t } = useTranslation();
     const [ isShow, setIsShow ] = useState(false);
 
-    const renderInputAdornment = (): ReactElement => {
+    const renderInputAdornment = (): ReactElement => (
+        <InputAdornment position="end">
+            <Icon
+                link={ true }
+                className="list-icon reset-field-to-default-adornment"
+                size="small"
+                color="grey"
+                name={ !isShow ? "eye" : "eye slash" }
+                data-testid={ "view-button" }
+                onClick={ () => { setIsShow(!isShow); } }
+            />
+        </InputAdornment>
+    );
 
-        return (
-            <InputAdornment position="end">
-                <Icon
-                    link={ true }
-                    className="list-icon reset-field-to-default-adornment"
-                    size="small"
-                    color="grey"
-                    name={ !isShow ? "eye" : "eye slash" }
-                    data-testid={ "view-button" }
-                    onClick={ () => { setIsShow(!isShow); } }
-                />
-            </InputAdornment>
-        );
-    };
 
     return (
         <EmphasizedSegment className="form-wrapper" padded={ "very" }>

--- a/features/admin.sms-providers.v1/pages/vonage-sms-provider.tsx
+++ b/features/admin.sms-providers.v1/pages/vonage-sms-provider.tsx
@@ -46,22 +46,19 @@ const VonageSMSProvider: FunctionComponent<VonageSMSProviderPageInterface> = (
     const { t } = useTranslation();
     const [ isShow, setIsShow ] = useState(false);
 
-    const renderInputAdornment = (): ReactElement => {
-
-        return (
-            <InputAdornment position="end">
-                <Icon
-                    link={ true }
-                    className="list-icon reset-field-to-default-adornment"
-                    size="small"
-                    color="grey"
-                    name={ !isShow ? "eye" : "eye slash" }
-                    data-testid={ "view-button" }
-                    onClick={ () => { setIsShow(!isShow); } }
-                />
-            </InputAdornment>
-        );
-    };
+    const renderInputAdornment = (): ReactElement => (
+        <InputAdornment position="end">
+            <Icon
+                link={ true }
+                className="list-icon reset-field-to-default-adornment"
+                size="small"
+                color="grey"
+                name={ !isShow ? "eye" : "eye slash" }
+                data-testid={ "view-button" }
+                onClick={ () => { setIsShow(!isShow); } }
+            />
+        </InputAdornment>
+    );
 
     return (
         <EmphasizedSegment className="form-wrapper" padded={ "very" }>

--- a/features/admin.sms-providers.v1/pages/vonage-sms-provider.tsx
+++ b/features/admin.sms-providers.v1/pages/vonage-sms-provider.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import InputAdornment from "@oxygen-ui/react/InputAdornment";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { FinalFormField, TextFieldAdapter } from "@wso2is/form";
 import {
@@ -23,9 +24,9 @@ import {
     Hint,
     PrimaryButton
 } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Divider, Grid } from "semantic-ui-react";
+import { Divider, Grid, Icon } from "semantic-ui-react";
 import { SMSProviderConstants } from "../constants";
 
 interface VonageSMSProviderPageInterface extends IdentifiableComponentInterface {
@@ -43,6 +44,24 @@ const VonageSMSProvider: FunctionComponent<VonageSMSProviderPageInterface> = (
     } = props;
 
     const { t } = useTranslation();
+    const [ isShow, setIsShow ] = useState(false);
+
+    const renderInputAdornment = (): ReactElement => {
+
+        return (
+            <InputAdornment position="end">
+                <Icon
+                    link={ true }
+                    className="list-icon reset-field-to-default-adornment"
+                    size="small"
+                    color="grey"
+                    name={ !isShow ? "eye" : "eye slash" }
+                    data-testid={ "view-button" }
+                    onClick={ () => { setIsShow(!isShow); } }
+                />
+            </InputAdornment>
+        );
+    };
 
     return (
         <EmphasizedSegment className="form-wrapper" padded={ "very" }>
@@ -81,6 +100,7 @@ const VonageSMSProvider: FunctionComponent<VonageSMSProviderPageInterface> = (
                     </Grid.Column>
                     <Grid.Column>
                         <FinalFormField
+                            className="addon-field-wrapper"
                             key="vonageSecret"
                             width={ 16 }
                             FormControlProps={ {
@@ -92,7 +112,7 @@ const VonageSMSProvider: FunctionComponent<VonageSMSProviderPageInterface> = (
                             data-componentid={ `${componentId}-vonage-secret` }
                             name="vonageSecret"
                             inputType="password"
-                            type="password"
+                            type={ isShow ? "text" : "password" }
                             label={ t("smsProviders:form.vonage.authToken.label") }
                             placeholder={ t("smsProviders:form.vonage.authToken.placeholder") }
                             helperText={ (
@@ -104,6 +124,9 @@ const VonageSMSProvider: FunctionComponent<VonageSMSProviderPageInterface> = (
                             maxLength={ SMSProviderConstants.SMS_PROVIDER_CONFIG_FIELD_MAX_LENGTH }
                             minLength={ SMSProviderConstants.SMS_PROVIDER_CONFIG_FIELD_MIN_LENGTH }
                             autoComplete="new-password"
+                            InputProps={ {
+                                endAdornment: renderInputAdornment()
+                            } }
                         />
                     </Grid.Column>
                 </Grid.Row>


### PR DESCRIPTION
### Purpose
Add eye icon to secrets in sms providers

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
