### PR TITLE
Remove dependent update note from release docs

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -15,11 +15,7 @@ This repository uses [🦋 Changesets](https://github.com/changesets/changesets)
 pnpm changeset
 ```
 
-2. This will open a prompt to select the packages that have changed. Select **the changed packages and the dependents of the changed packages**, and press <kbd>Enter</kbd>.
-
-> ℹ️ Info:
-> 
-> To find out the dependent packages of a changed package, open a new terminal and run `pnpm nx graph` from the `identity-apps` root. Refer to https://nx.dev/features/explore-graph#explore-the-project-graph for more details.
+2. This will open a prompt to select the packages that have changed. Select **the changed packages**, and press <kbd>Enter</kbd>.
 
 ![changesets-001](../assets/images/develop/release/changesets-changed-packages-001.png)
 


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

With https://github.com/wso2/identity-apps/pull/5928, devs no longer need to manually specify the dependents of the changed packages in their changesets. Hence, removing the related note from the release guide.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
