### PR TITLE
Separate out `api-resources.v1` & `api-resources.v2`

### DIFF
--- a/.changeset/curvy-carrots-invite.md
+++ b/.changeset/curvy-carrots-invite.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/core": patch
+"@wso2is/features": patch
+---
+
+Separate out `api-resources.v1` & `api-resources.v2`

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1783,7 +1783,8 @@
         {% endif %}
         "legacyMode": {
             {% if legacy_mode.enable == true %}
-            "apiResources": false,
+            "apiResourcesV1": false,
+            "apiResourcesV2": false,
             "applicationListSystemApps": true,
             "applicationOIDCSubjectIdentifier": true,
             "applicationRequestPathAuthentication": true,

--- a/features/admin.api-resources.v1/configs/ui.ts
+++ b/features/admin.api-resources.v1/configs/ui.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,10 +17,10 @@
  */
 
 import { FunctionComponent, SVGProps } from "react";
-import { ReactComponent as AuthorizeIcon } from 
-    "../../../../themes/default/assets/images/icons/account-policy-icon.svg";
-import { ReactComponent as DocumentIcon } from "../../../../themes/default/assets/images/icons/document-icon.svg";
-import { ReactComponent as KeyIcon } from "../../../../themes/default/assets/images/icons/key-icon.svg";
+import { ReactComponent as AuthorizeIcon } from
+    "../../themes/default/assets/images/icons/account-policy-icon.svg";
+import { ReactComponent as DocumentIcon } from "../../themes/default/assets/images/icons/document-icon.svg";
+import { ReactComponent as KeyIcon } from "../../themes/default/assets/images/icons/key-icon.svg";
 
 export const getAPIResourceWizardStepIcons = (): {
     general: FunctionComponent<SVGProps<SVGSVGElement>>;

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -408,7 +408,7 @@ export const applicationConfig: ApplicationConfig = {
             // Enable the API authorization tab for supported templates when the api resources config is enabled.
             if (
                 apiResourceFeatureEnabled && !application?.advancedConfigurations?.fragment &&
-                legacyMode?.apiResources &&
+                legacyMode?.apiResourcesV1 &&
                 (
                     application?.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
                     || application?.templateId === MobileAppTemplate?.id

--- a/features/admin.extensions.v1/configs/common.tsx
+++ b/features/admin.extensions.v1/configs/common.tsx
@@ -18,6 +18,7 @@
 
 import { UserGroupIcon } from "@oxygen-ui/react-icons";
 import { LegacyModeInterface, RouteInterface } from "@wso2is/core/models";
+import { APIResourcesConstants } from "features/admin.api-resources.v1/constants";
 import React, { lazy } from "react";
 import { CommonConfig } from "./models";
 import { getSidePanelIcons } from "../../admin.core.v1/configs/ui";
@@ -36,46 +37,6 @@ export const commonConfig: CommonConfig = {
     enableOrganizationAssociations: false,
     extendedRoutes: () => {
         const routes: RouteInterface[] = [
-            {
-                category: "console:develop.features.sidePanel.categories.application",
-                children: [
-                    {
-                        component: lazy(() =>
-                            import("../../admin.api-resources.v2/pages/api-resource-edit")
-                        ),
-                        exact: true,
-                        id: "apiResources-edit",
-                        name: "extensions:develop.sidePanel.apiResources",
-                        path: AppConstants.getPaths().get("API_RESOURCE_EDIT"),
-                        protected: true,
-                        showOnSidePanel: false
-                    },
-                    {
-                        component: lazy(() =>
-                            import("../../admin.api-resources.v2/pages/api-resources-internal-list")
-                        ),
-                        exact: true,
-                        id: "apiResources-list",
-                        name: "extensions:develop.sidePanel.apiResources",
-                        path: AppConstants.getPaths().get("API_RESOURCES_CATEGORY"),
-                        protected: true,
-                        showOnSidePanel: false
-                    }
-                ],
-                component: lazy(() =>
-                    import("../../admin.api-resources.v2/pages/api-resources")
-                ),
-                exact: true,
-                icon: {
-                    icon: import("../assets/images/icons/api-resources-icon.svg")
-                },
-                id: "apiResources",
-                name: "extensions:develop.sidePanel.apiResources",
-                order: 2,
-                path: AppConstants.getPaths().get("API_RESOURCES"),
-                protected: true,
-                showOnSidePanel: legacyMode?.apiResources
-            },
             {
                 category: "extensions:manage.sidePanel.categories.userManagement",
                 children: [
@@ -207,6 +168,81 @@ export const commonConfig: CommonConfig = {
                 showOnSidePanel: false
             }
         ];
+
+        if (legacyMode?.apiResourcesV1) {
+            routes.unshift({
+                category: "console:develop.features.sidePanel.categories.application",
+                children: [
+                    {
+                        component: lazy(() =>
+                            import("../../admin.api-resources.v1/pages/api-resource-edit")
+                        ),
+                        exact: true,
+                        id: "apiResources-edit",
+                        name: "extensions:develop.sidePanel.apiResources",
+                        path: APIResourcesConstants.getPaths().get("API_RESOURCE_EDIT"),
+                        protected: true,
+                        showOnSidePanel: false
+                    }
+                ],
+                component: lazy(() =>
+                    import("../../admin.api-resources.v1/pages/api-resources")
+                ),
+                exact: true,
+                icon: {
+                    icon: import("../assets/images/icons/api-resources-icon.svg")
+                },
+                id: "apiResources",
+                name: "extensions:develop.sidePanel.apiResources",
+                order: 2,
+                path: APIResourcesConstants.getPaths().get("API_RESOURCES"),
+                protected: true,
+                showOnSidePanel: legacyMode?.apiResourcesV1
+            });
+        }
+
+        if (legacyMode?.apiResourcesV2) {
+            routes.unshift({
+                category: "console:develop.features.sidePanel.categories.application",
+                children: [
+                    {
+                        component: lazy(() =>
+                            import("../../admin.api-resources.v2/pages/api-resource-edit")
+                        ),
+                        exact: true,
+                        id: "apiResources-edit",
+                        name: "extensions:develop.sidePanel.apiResources",
+                        path: AppConstants.getPaths().get("API_RESOURCE_EDIT"),
+                        protected: true,
+                        showOnSidePanel: false
+                    },
+                    {
+                        component: lazy(() =>
+                            import("../../admin.api-resources.v2/pages/api-resources-internal-list")
+                        ),
+                        exact: true,
+                        id: "apiResources-list",
+                        name: "extensions:develop.sidePanel.apiResources",
+                        path: AppConstants.getPaths().get("API_RESOURCES_CATEGORY"),
+                        protected: true,
+                        showOnSidePanel: false
+                    }
+                ],
+                component: lazy(() =>
+                    import("../../admin.api-resources.v2/pages/api-resources")
+                ),
+                exact: true,
+                icon: {
+                    icon: import("../assets/images/icons/api-resources-icon.svg")
+                },
+                id: "apiResources",
+                name: "extensions:develop.sidePanel.apiResources",
+                order: 2,
+                path: AppConstants.getPaths().get("API_RESOURCES"),
+                protected: true,
+                showOnSidePanel: legacyMode?.apiResourcesV1
+            });
+        }
 
         if (legacyMode?.rolesV1) {
             routes.push(

--- a/modules/core/src/models/core.ts
+++ b/modules/core/src/models/core.ts
@@ -211,7 +211,8 @@ export interface SVGRLoadedInterface {
 }
 
 export interface LegacyModeInterface {
-    apiResources: boolean;
+    apiResourcesV1: boolean;
+    apiResourcesV2: boolean;
     applicationListSystemApps: boolean;
     applicationOIDCSubjectIdentifier: boolean;
     applicationRequestPathAuthentication: boolean;


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
ATM, there's only one `apiResource` boolean flag in the `legacyMode` config.
Since there are two versions of `api-resources` present, legacy mode customers should selectively choose the version.

### Related Issues
- https://github.com/wso2/product-is/issues/20186

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5625

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
