### PR TITLE
Remove OIDC Endpoints from 'Info' Section in M2M Applications

### DIFF
--- a/.changeset/large-poems-melt.md
+++ b/.changeset/large-poems-melt.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Remove OIDC endpoints from info tab in M2M application

--- a/.changeset/proud-walls-bake.md
+++ b/.changeset/proud-walls-bake.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+remove OIDC endpoints from info tab in M2M application

--- a/.changeset/proud-walls-bake.md
+++ b/.changeset/proud-walls-bake.md
@@ -1,5 +1,0 @@
----
-"@wso2is/console": patch
----
-
-remove OIDC endpoints from info tab in M2M application

--- a/features/admin.applications.v1/components/help-panel/oidc-configurations.tsx
+++ b/features/admin.applications.v1/components/help-panel/oidc-configurations.tsx
@@ -155,30 +155,34 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                         />
                     </Grid.Column>
                 </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.authorize }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-authorize-label` }>
-                            { t("applications:helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.authorize") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.authorizeEndpoint }
-                            data-testid={ `${ testId }-authorize-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
+                { (
+                    templateId !== ApplicationManagementConstants.M2M_APP_TEMPLATE_ID
+                ) && (
+                    <Grid.Row columns={ 2 }>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
+                            <GenericIcon
+                                icon={ getHelpPanelIcons().endpoints.authorize }
+                                size="micro"
+                                square
+                                transparent
+                                inline
+                                className="left-icon"
+                                verticalAlign="middle"
+                                spaced="right"
+                            />
+                            <label data-testid={ `${ testId }-authorize-label` }>
+                                { t("applications:helpPanel.tabs.start.content." +
+                                    "oidcConfigurations.labels.authorize") }
+                            </label>
+                        </Grid.Column>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
+                            <CopyInputField
+                                value={ oidcConfigurations?.authorizeEndpoint }
+                                data-testid={ `${ testId }-authorize-readonly-input` }
+                            />
+                        </Grid.Column>
+                    </Grid.Row>
+                ) }
                 <Grid.Row columns={ 2 }>
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
                         <GenericIcon
@@ -203,30 +207,34 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                         />
                     </Grid.Column>
                 </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.userInfo }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-userInfo-label` }>
-                            { t("applications:helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.userInfo") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.userEndpoint }
-                            data-testid={ `${ testId }-userInfo-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
+                { (
+                    templateId !== ApplicationManagementConstants.M2M_APP_TEMPLATE_ID
+                ) && (
+                    <Grid.Row columns={ 2 }>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
+                            <GenericIcon
+                                icon={ getHelpPanelIcons().endpoints.userInfo }
+                                size="micro"
+                                square
+                                transparent
+                                inline
+                                className="left-icon"
+                                verticalAlign="middle"
+                                spaced="right"
+                            />
+                            <label data-testid={ `${ testId }-userInfo-label` }>
+                                { t("applications:helpPanel.tabs.start.content." +
+                                    "oidcConfigurations.labels.userInfo") }
+                            </label>
+                        </Grid.Column>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
+                            <CopyInputField
+                                value={ oidcConfigurations?.userEndpoint }
+                                data-testid={ `${ testId }-userInfo-readonly-input` }
+                            />
+                        </Grid.Column>
+                    </Grid.Row>
+                ) }
                 <Grid.Row columns={ 2 }>
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
                         <GenericIcon
@@ -251,30 +259,34 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                         />
                     </Grid.Column>
                 </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.jwks }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-jwks-label` }>
-                            { t("applications:helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.jwks") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.jwksEndpoint }
-                            data-testid={ `${ testId }-jwks-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
+                { (
+                    templateId !== ApplicationManagementConstants.M2M_APP_TEMPLATE_ID
+                ) && (
+                    <Grid.Row columns={ 2 }>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
+                            <GenericIcon
+                                icon={ getHelpPanelIcons().endpoints.jwks }
+                                size="micro"
+                                square
+                                transparent
+                                inline
+                                className="left-icon"
+                                verticalAlign="middle"
+                                spaced="right"
+                            />
+                            <label data-testid={ `${ testId }-jwks-label` }>
+                                { t("applications:helpPanel.tabs.start.content." +
+                                    "oidcConfigurations.labels.jwks") }
+                            </label>
+                        </Grid.Column>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
+                            <CopyInputField
+                                value={ oidcConfigurations?.jwksEndpoint }
+                                data-testid={ `${ testId }-jwks-readonly-input` }
+                            />
+                        </Grid.Column>
+                    </Grid.Row>
+                ) }
                 <Grid.Row columns={ 2 }>
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
                         <GenericIcon
@@ -299,54 +311,54 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                         />
                     </Grid.Column>
                 </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.logout }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-logout-label` }>
-                            { t("applications:helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.endSession") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.endSessionEndpoint  }
-                            data-testid={ `${ testId }-logout-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
-                <Grid.Row columns={ 2 }>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
-                        <GenericIcon
-                            icon={ getHelpPanelIcons().endpoints.par }
-                            size="micro"
-                            square
-                            transparent
-                            inline
-                            className="left-icon"
-                            verticalAlign="middle"
-                            spaced="right"
-                        />
-                        <label data-testid={ `${ testId }-pushed-authorization-request-label` }>
-                            { t("applications:helpPanel.tabs.start.content." +
-                                "oidcConfigurations.labels.pushedAuthorizationRequest") }
-                        </label>
-                    </Grid.Column>
-                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
-                        <CopyInputField
-                            value={ oidcConfigurations?.pushedAuthorizationRequestEndpoint  }
-                            data-testid={ `${ testId }-pushed-authorization-request-readonly-input` }
-                        />
-                    </Grid.Column>
-                </Grid.Row>
+                { (
+                    templateId !== ApplicationManagementConstants.M2M_APP_TEMPLATE_ID
+                ) && (
+                    <><Grid.Row columns={ 2 }>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
+                            <GenericIcon
+                                icon={ getHelpPanelIcons().endpoints.logout }
+                                size="micro"
+                                square
+                                transparent
+                                inline
+                                className="left-icon"
+                                verticalAlign="middle"
+                                spaced="right" />
+                            <label data-testid={ `${testId}-logout-label` }>
+                                { t("applications:helpPanel.tabs.start.content." +
+                                    "oidcConfigurations.labels.endSession") }
+                            </label>
+                        </Grid.Column>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
+                            <CopyInputField
+                                value={ oidcConfigurations?.endSessionEndpoint }
+                                data-testid={ `${testId}-logout-readonly-input` } />
+                        </Grid.Column>
+                    </Grid.Row>
+                    <Grid.Row columns={ 2 }>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
+                            <GenericIcon
+                                icon={ getHelpPanelIcons().endpoints.par }
+                                size="micro"
+                                square
+                                transparent
+                                inline
+                                className="left-icon"
+                                verticalAlign="middle"
+                                spaced="right" />
+                            <label data-testid={ `${testId}-pushed-authorization-request-label`}>
+                                { t("applications:helpPanel.tabs.start.content." +
+                                        "oidcConfigurations.labels.pushedAuthorizationRequest")}
+                            </label>
+                        </Grid.Column>
+                        <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
+                            <CopyInputField
+                                value={ oidcConfigurations?.pushedAuthorizationRequestEndpoint }
+                                data-testid={ `${testId}-pushed-authorization-request-readonly-input` } />
+                        </Grid.Column>
+                    </Grid.Row></>
+                ) }
                 {
                     featureConfig?.server?.enabled && (
                         <>

--- a/features/admin.applications.v1/components/help-panel/oidc-configurations.tsx
+++ b/features/admin.applications.v1/components/help-panel/oidc-configurations.tsx
@@ -347,9 +347,9 @@ export const OIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterf
                                 className="left-icon"
                                 verticalAlign="middle"
                                 spaced="right" />
-                            <label data-testid={ `${testId}-pushed-authorization-request-label`}>
+                            <label data-testid={ `${testId}-pushed-authorization-request-label` }>
                                 { t("applications:helpPanel.tabs.start.content." +
-                                        "oidcConfigurations.labels.pushedAuthorizationRequest")}
+                                        "oidcConfigurations.labels.pushedAuthorizationRequest") }
                             </label>
                         </Grid.Column>
                         <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>


### PR DESCRIPTION
### Purpose
$subject

Following endpoints will be removed from M2M application info tab
- Authorize
- UserInfo
- JWKS
- Logout
- Pushed Authorization Request


![Screenshot from 2024-04-16 12-31-03](https://github.com/wso2/identity-apps/assets/28682701/51d073dd-da16-45de-9ecd-5b7a34ec2b08)

### Related Issues
- https://github.com/wso2/product-is/issues/20051

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
