### PR TITLE
Fix minor bug in appearing hint upon checkbox tick

### DIFF
--- a/.changeset/giant-apes-beam.md
+++ b/.changeset/giant-apes-beam.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/features": patch
+"@wso2is/console": patch
+---
+
+Fix minor bug

--- a/features/admin.extensions.v1/components/account-login/pages/username-validation-edit.tsx
+++ b/features/admin.extensions.v1/components/account-login/pages/username-validation-edit.tsx
@@ -569,7 +569,7 @@ export const UsernameValidationEditPage: FunctionComponent<UsernameValidationEdi
                                                             hint={ !currentValues.isAlphanumericOnly ?
                                                                 t("extensions:manage.accountLogin.editPage." +
                                                                 "usernameSpecialCharsHint") : undefined }
-                                                            listen={ (value: boolean) => setInitialFormValues(
+                                                            listen={ (value: boolean) => setCurrentValues(
                                                                 { ...currentValues, isAlphanumericOnly: value }
                                                             ) }
                                                             width={ 16 }


### PR DESCRIPTION
### Purpose
In username validation page, hint of the custom username type should be visible when alphanumeric checkbox is disabled.
This PR will enable the hint without page refresh.


https://github.com/wso2/identity-apps/assets/75057725/676df594-a0b7-4cf2-8827-daf4708d0717

