### PR TITLE
Add name to the alternative subject identifier checkbox

### DIFF
--- a/.changeset/polite-oranges-add.md
+++ b/.changeset/polite-oranges-add.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Add name to the alternative subject identifier checkbox

--- a/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.tsx
@@ -443,6 +443,7 @@ export const AdvanceAttributeSettings: FunctionComponent<AdvanceAttributeSetting
                         !disabledFeatures?.includes("applications.attributes.alternativeSubjectIdentifier")) && (
                         <>
                             <Checkbox
+                                name= "enableAlternativeSubjectIdentifier"
                                 ariaLabel={ t("applications:forms.advancedAttributeSettings." +
                                     "sections.subject.fields.alternateSubjectAttribute.label") }
                                 data-componentid={ `${ componentId }-reassign-subject-attribute-checkbox` }


### PR DESCRIPTION
### Purpose
$subject
To catch the checkbox in e2e tests

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
