### PR TITLE
Fix locale displaying issue in console

### DIFF
--- a/.changeset/tiny-gifts-sing.md
+++ b/.changeset/tiny-gifts-sing.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/features": patch
+"@wso2is/console": patch
+---
+
+Fix locale display issue in console

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -62,7 +62,7 @@ import {
 } from "../../admin.roles.v2/models/roles";
 import { ConnectorPropertyInterface, ServerConfigurationsConstants  } from "../../admin.server-configurations.v1";
 import { updateUserInfo } from "../api";
-import { AdminAccountTypes, UserManagementConstants, LocaleJoiningSymbol } from "../constants";
+import { AdminAccountTypes, LocaleJoiningSymbol, UserManagementConstants } from "../constants";
 import { AccountConfigSettingsInterface, SchemaAttributeValueInterface, SubValueInterface } from "../models";
 
 /**
@@ -516,18 +516,21 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
     };
 
     /**
-     * The function returns the normalized format of locale
-     * 
-     * @param locale - locale value 
-     * @param localeJoiningSymbol - symbol used to join language and region parts of locale
+     * The function returns the normalized format of locale.
+     *
+     * @param locale - locale value.
+     * @param localeJoiningSymbol - symbol used to join language and region parts of locale.
      */
     const  normalizeLocaleFormat = (locale: string, localeJoiningSymbol: LocaleJoiningSymbol): string => {
         if (!locale) {
             return locale;
         }
-        let [language, region] = locale.split(/[-_]/);
+
+        let [ language, region ] = locale.split(/[-_]/);
+
         language = language.toLowerCase();
         region = region.toUpperCase();
+
         return `${language}${localeJoiningSymbol}${region}`;
     };
 
@@ -704,10 +707,14 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                 } else {
                                     opValue = schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY
                                         .get("EMAILS")
-                                        ? { emails: [ values.get(schema.name) ] } 
-                                        : schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY.get("LOCALE") 
-                                        ? { [schemaNames[0]]: normalizeLocaleFormat(values.get(schemaNames[0]) as string, LocaleJoiningSymbol.UNDERSCORE) } 
-                                        : { [schemaNames[0]]: values.get(schemaNames[0]) };
+                                        ? { emails: [ values.get(schema.name) ] }
+                                        : schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY
+                                            .get("LOCALE")
+                                            ? { [schemaNames[0]]: normalizeLocaleFormat(
+                                                values.get(schemaNames[0]) as string,
+                                                LocaleJoiningSymbol.UNDERSCORE
+                                            ) }
+                                            : { [schemaNames[0]]: values.get(schemaNames[0]) };
                                 }
                             } else {
                                 if(schema.extended) {
@@ -837,9 +844,13 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                     opValue = schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY
                                         .get("EMAILS")
                                         ? { emails: [ values.get(schema.name) ] }
-                                        : schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY.get("LOCALE") 
-                                        ? { [schemaNames[0]]: normalizeLocaleFormat(values.get(schemaNames[0]) as string, LocaleJoiningSymbol.UNDERSCORE) }
-                                        : { [schemaNames[0]]: values.get(schemaNames[0]) };
+                                        : schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY
+                                            .get("LOCALE")
+                                            ? { [schemaNames[0]]: normalizeLocaleFormat(
+                                                values.get(schemaNames[0]) as string,
+                                                LocaleJoiningSymbol.UNDERSCORE
+                                            ) }
+                                            : { [schemaNames[0]]: values.get(schemaNames[0]) };
                                 }
                             } else {
                                 if(schema.extended) {

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -62,7 +62,7 @@ import {
 } from "../../admin.roles.v2/models/roles";
 import { ConnectorPropertyInterface, ServerConfigurationsConstants  } from "../../admin.server-configurations.v1";
 import { updateUserInfo } from "../api";
-import { AdminAccountTypes, UserManagementConstants } from "../constants";
+import { AdminAccountTypes, UserManagementConstants, LocaleJoiningSymbol } from "../constants";
 import { AccountConfigSettingsInterface, SchemaAttributeValueInterface, SubValueInterface } from "../models";
 
 /**
@@ -516,6 +516,22 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
     };
 
     /**
+     * The function returns the normalized format of locale
+     * 
+     * @param locale - locale value 
+     * @param localeJoiningSymbol - symbol used to join language and region parts of locale
+     */
+    const  normalizeLocaleFormat = (locale: string, localeJoiningSymbol: LocaleJoiningSymbol): string => {
+        if (!locale) {
+            return locale;
+        }
+        let [language, region] = locale.split(/[-_]/);
+        language = language.toLowerCase();
+        region = region.toUpperCase();
+        return `${language}${localeJoiningSymbol}${region}`;
+    };
+
+    /**
      * This function returns the ID of the administrator role.
      *
      */
@@ -688,7 +704,9 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                 } else {
                                     opValue = schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY
                                         .get("EMAILS")
-                                        ? { emails: [ values.get(schema.name) ] }
+                                        ? { emails: [ values.get(schema.name) ] } 
+                                        : schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY.get("LOCALE") 
+                                        ? { [schemaNames[0]]: normalizeLocaleFormat(values.get(schemaNames[0]) as string, LocaleJoiningSymbol.UNDERSCORE) } 
                                         : { [schemaNames[0]]: values.get(schemaNames[0]) };
                                 }
                             } else {
@@ -819,6 +837,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                     opValue = schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY
                                         .get("EMAILS")
                                         ? { emails: [ values.get(schema.name) ] }
+                                        : schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY.get("LOCALE") 
+                                        ? { [schemaNames[0]]: normalizeLocaleFormat(values.get(schemaNames[0]) as string, LocaleJoiningSymbol.UNDERSCORE) }
                                         : { [schemaNames[0]]: values.get(schemaNames[0]) };
                                 }
                             } else {
@@ -1273,7 +1293,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                             { fieldName })
                     }
                     type="dropdown"
-                    value={ profileInfo.get(schema?.name) }
+                    value={ normalizeLocaleFormat(profileInfo.get(schema?.name), LocaleJoiningSymbol.HYPHEN) }
                     children={ [ {
                         "data-testid": `${ testId }-profile-form-locale-dropdown-empty` as string,
                         key: "empty-locale" as string,

--- a/features/admin.users.v1/constants/user-management-constants.ts
+++ b/features/admin.users.v1/constants/user-management-constants.ts
@@ -103,7 +103,8 @@ export class UserManagementConstants {
         .set("USERNAME", "userName")
         .set("NAME", "name")
         .set("DISPLAY_NAME", "displayName")
-        .set("ENTERPRISE_USER", "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User");
+        .set("ENTERPRISE_USER", "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User")
+        .set("LOCALE", "locale");
 
     /**
      * Set of SCIM2 enterprise attributes.
@@ -294,4 +295,14 @@ export enum InvitationStatus {
     ACCEPTED = "Accepted",
     PENDING = "Pending",
     EXPIRED = "Expired"
+}
+
+/**
+ * Enum for locale joining symbol.
+ *
+ * @readonly
+ */
+export enum LocaleJoiningSymbol {
+    HYPHEN = "-",
+    UNDERSCORE = "_"
 }


### PR DESCRIPTION
### Purpose
When the local claim value not in `en-US` format, user profile section in console failed to display the selected locale in the drop down menu. This fix will convert any format of locale values to a normalized form before display and before update. 
When display, the local will be converted to `en-US` format while when update it is converted to `en_US` format. The reason for converting different formats is,  the FE dropdown expect the locale to be in `en-US` format. Otherwise, it cannot detect the selected value correctly. But when updating the local claim, we need to convert the value to `en_US` format because email templates are stored in the registry using `en_US` format. So, if the local claim is not in that format, emails will not be sent using the selected locale template. 

In the future, we are planning to bring all the locales to a one normalized format. Until then we have fix this issue using the approach in this PR

