### PR TITLE
Skip applying the default branding preference when generated overrriden preferences are present

### DIFF
--- a/.changeset/dry-carrots-know.md
+++ b/.changeset/dry-carrots-know.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Skip applying default branding preference upon change

--- a/features/admin.branding.v1/components/branding-core.tsx
+++ b/features/admin.branding.v1/components/branding-core.tsx
@@ -222,7 +222,7 @@ const BrandingCore: FunctionComponent<BrandingCoreInterface> = (
             setIsBrandingConfigured(true);
         }
 
-        if  (!brandingPreference)  {
+        if  (!overridenBrandingPreference)  {
             setBrandingPreference(BrandingPreferenceUtils.migrateLayoutPreference(
                 BrandingPreferenceUtils.migrateThemePreference(
                     originalBrandingPreference.preference,


### PR DESCRIPTION
### Purpose
$subject

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
