### PR TITLE
Update `invite-flow` callback URL

### DIFF
--- a/.changeset/wise-bikes-swim.md
+++ b/.changeset/wise-bikes-swim.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Update invite-flow callback URL

--- a/apps/console/src/auth.html
+++ b/apps/console/src/auth.html
@@ -368,7 +368,7 @@
                             auth.initialize(authConfig);
                             auth.signIn();
                         } else {
-                            window.location = applicationDomain+'/authenticate?disable_silent_sign_in=true&invite_user=true';
+                            window.location = applicationDomain + '/<%= htmlWebpackPlugin.options.basename %>?disable_silent_sign_in=true&invite_user=true';
                         }
                     } else {
                         auth.initialize(authConfig);


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
In the `invite-user` flow in legacy authz runtime, the context path should be taken from the `basename` configured in the `deployment.config.json` rather than hard coding.

### Related Issues
- https://github.com/wso2/product-is/issues/18999

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
