### PR TITLE
Use default preference when preference is undefined

### DIFF
--- a/.changeset/two-berries-wave.md
+++ b/.changeset/two-berries-wave.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Use default preference when preference is undefined

--- a/features/admin.ai.v1/providers/ai-branding-preference-provider.tsx
+++ b/features/admin.ai.v1/providers/ai-branding-preference-provider.tsx
@@ -30,6 +30,7 @@ import React, {
     useEffect,
     useState
 } from "react";
+import { BrandingPreferenceUtils } from "../../admin.branding.v1/utils";
 import useGetAIBrandingGenerationResult from "../api/use-get-ai-branding-generation-result";
 import AIFeatureContext from "../context/ai-branding-feature-context";
 import { BrandingGenerationResultAPIResponseInterface } from "../models/branding-preferences";
@@ -48,12 +49,16 @@ const AIBrandingPreferenceProvider: FunctionComponent<AIBrandingPreferenceProvid
 
     const { children } = props;
 
-    const { preference } = useBrandingPreference();
 
     const [ isGeneratingBranding, setGeneratingBranding ] = useState(false);
     const [ mergedBrandingPreference, setMergedBrandingPreference ] = useState<BrandingPreferenceInterface>(null);
     const [ operationId, setOperationId ] = useState<string>();
     const [ brandingGenerationCompleted, setBrandingGenerationCompleted ] = useState(false);
+
+    const { preference } = useBrandingPreference();
+
+    const brandingPreference: BrandingPreferenceInterface = preference?.preference ??
+    BrandingPreferenceUtils.getDefaultBrandingPreference();
 
     /**
      * Removes empty keys from an object.
@@ -113,9 +118,9 @@ const AIBrandingPreferenceProvider: FunctionComponent<AIBrandingPreferenceProvid
         const { theme } = removeEmptyKeys(data);
         const { activeTheme, LIGHT, DARK } = theme;
 
-        const mergedBrandingPreference: BrandingPreferenceInterface =  merge(cloneDeep(preference.preference), {
+        const mergedBrandingPreference: BrandingPreferenceInterface =  merge(cloneDeep(brandingPreference), {
             theme: {
-                ...preference.preference.theme,
+                ...brandingPreference.theme,
                 DARK: DARK,
                 LIGHT: LIGHT,
                 activeTheme: activeTheme

--- a/features/admin.ai.v1/providers/ai-branding-preference-provider.tsx
+++ b/features/admin.ai.v1/providers/ai-branding-preference-provider.tsx
@@ -58,7 +58,7 @@ const AIBrandingPreferenceProvider: FunctionComponent<AIBrandingPreferenceProvid
     const { preference } = useBrandingPreference();
 
     const brandingPreference: BrandingPreferenceInterface = preference?.preference ??
-    BrandingPreferenceUtils.getDefaultBrandingPreference();
+        BrandingPreferenceUtils.getDefaultBrandingPreference();
 
     /**
      * Removes empty keys from an object.

--- a/features/admin.branding.v1/components/branding-core.tsx
+++ b/features/admin.branding.v1/components/branding-core.tsx
@@ -251,7 +251,7 @@ const BrandingCore: FunctionComponent<BrandingCoreInterface> = (
         if (brandingPreferenceFetchRequestError.response?.data?.code
             === BrandingPreferencesConstants.BRANDING_NOT_CONFIGURED_ERROR_CODE) {
             setIsBrandingConfigured(false);
-            setBrandingPreference(DEFAULT_PREFERENCE);
+            setBrandingPreference(overridenBrandingPreference ?? DEFAULT_PREFERENCE);
 
             return;
         }
@@ -263,7 +263,7 @@ const BrandingCore: FunctionComponent<BrandingCoreInterface> = (
             message: t("extensions:develop.branding.notifications.fetch.genericError.message")
         }));
 
-        setBrandingPreference(DEFAULT_PREFERENCE);
+        setBrandingPreference(overridenBrandingPreference ?? DEFAULT_PREFERENCE);
     }, [ brandingPreferenceFetchRequestError ]);
 
     /**
@@ -489,6 +489,7 @@ const BrandingCore: FunctionComponent<BrandingCoreInterface> = (
                 if (setRequestLoadingState) {
                     setIsBrandingPreferenceUpdateRequestLoading(false);
                 }
+                mutateBrandingPreferenceFetchRequest();
             });
     };
 


### PR DESCRIPTION
### Purpose
There is a bug in the AI branding generation where merged preference throws an error when branding preference is undefined.
Here, we are defaulting to the Default Branding preference in that case.

### Related Issues
- https://github.com/wso2/product-is/issues/20039

### Related PRs
- Improvement over https://github.com/wso2/identity-apps/pull/5961

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
