### PR TITLE
Fix include username and include orgname issue

### DIFF
--- a/.changeset/rich-laws-worry.md
+++ b/.changeset/rich-laws-worry.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Fix include user domain and include tenant domain issue

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
@@ -1106,8 +1106,8 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
                     claim: {
                         uri: advanceSettingValues?.subject.claim
                     },
-                    includeTenantDomain: getIncludeUserDomainFinalValue(advanceSettingValues),
-                    includeUserDomain: getIncludeOrgNameFinalValue(advanceSettingValues),
+                    includeTenantDomain: getIncludeOrgNameFinalValue(advanceSettingValues),
+                    includeUserDomain: getIncludeUserDomainFinalValue(advanceSettingValues),
                     mappedLocalSubjectMandatory: advanceSettingValues?.subject.mappedLocalSubjectMandatory,
                     useMappedLocalSubject: advanceSettingValues?.subject.useMappedLocalSubject
                 }


### PR DESCRIPTION
### Purpose
$subject
- To fix the `include user domain` and `include orgname` enabling issue when alternative subject identifier is enabled.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
