### PR TITLE
Set console callback URL if set as a configuration

### DIFF
--- a/.changeset/orange-seals-fold.md
+++ b/.changeset/orange-seals-fold.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Set defined callback URL for the console portal app initilization

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalConstants.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalConstants.java
@@ -43,6 +43,7 @@ public class AppPortalConstants {
     public static final String SYSTEM_PROP_SKIP_SERVER_INITIALIZATION = "skipServerInitialization";
 
     public static final String CONSOLE_APP = "Console";
+    public static final String CONSOLE_CALLBACK_URL = "Console.CallbackURL";
 
     private AppPortalConstants() {
 

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -67,6 +67,7 @@ import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.APPLICATIO
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 import static org.wso2.identity.apps.common.util.AppPortalConstants.AppPortal.CONSOLE;
 import static org.wso2.identity.apps.common.util.AppPortalConstants.CONSOLE_APP;
+import static org.wso2.identity.apps.common.util.AppPortalConstants.CONSOLE_CALLBACK_URL;
 import static org.wso2.identity.apps.common.util.AppPortalConstants.DISPLAY_NAME_CLAIM_URI;
 import static org.wso2.identity.apps.common.util.AppPortalConstants.EMAIL_CLAIM_URI;
 import static org.wso2.identity.apps.common.util.AppPortalConstants.GRANT_TYPE_ACCOUNT_SWITCH;
@@ -135,6 +136,10 @@ public class AppPortalUtils {
                     + "|" + callbackUrl.replace(portalPath, "/t/(.*)/o/(.*)" + portalPath)
                     + ")";
             }
+        }
+        String consoleCallbackUrl = IdentityUtil.getProperty(CONSOLE_CALLBACK_URL);
+        if (StringUtils.isNotEmpty(consoleCallbackUrl)) {
+            callbackUrl = consoleCallbackUrl;
         }
         oAuthConsumerAppDTO.setCallbackUrl(callbackUrl);
         oAuthConsumerAppDTO.setBypassClientCredentials(true);

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -138,7 +138,7 @@ public class AppPortalUtils {
             }
         }
         String consoleCallbackUrl = IdentityUtil.getProperty(CONSOLE_CALLBACK_URL);
-        if (StringUtils.isNotEmpty(consoleCallbackUrl)) {
+        if (StringUtils.isNotEmpty(consoleCallbackUrl) && StringUtils.equals(CONSOLE_APP, applicationName)) {
             callbackUrl = consoleCallbackUrl;
         }
         oAuthConsumerAppDTO.setCallbackUrl(callbackUrl);


### PR DESCRIPTION
### Purpose
$subject

The console app is created on tenant creation. The default callback URL is set for the console app.
If there is a callback URL defined for the console, with this improvement, the callback URL will be updated accordingly.

The solution should be further revisited for find an optimal of not setting the defined callback URL in the database, rather replace on fetching the callback URL upon get the callback url of the console app.

This PR is merged for the IDaaS improvement.