### PR TITLE
Add waiting page template for "prompt" conditional function

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -611,3 +611,7 @@ error.duo.user.not.found=Couldn't get the verified user name.
 error.mobile.not.found=User may not have a mobile number in user's profile for Duo Authentication. Please update it.
 error.mobile.not.found.duo=Unable to get the registered phone number from Duo. Authentication failed.
 error.number.mismatch.duo=Authentication failed due to mismatch in mobile numbers. Please update the correct registered duo mobile number in user profile.
+
+# Conditional authentication scripts
+prompt.template.internal.wait.greeting=Hello There!
+prompt.template.internal.wait.message=Please wait until we setup your environment...

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -589,3 +589,7 @@ error.duo.user.not.found=Der verifizierte Benutzername konnte nicht abgerufen we
 error.mobile.not.found=Der Benutzer hat möglicherweise keine Mobiltelefonnummer im Benutzerprofil für die Duo-Authentifizierung. Bitte aktualisieren Sie es.
 error.mobile.not.found.duo=Die registrierte Telefonnummer kann nicht von Duo abgerufen werden. Authentifizierung fehlgeschlagen.
 error.number.mismatch.duo=Die Authentifizierung ist aufgrund einer Nichtübereinstimmung der Mobiltelefonnummern fehlgeschlagen. Bitte aktualisieren Sie die korrekte registrierte Duo-Mobiltelefonnummer im Benutzerprofil.
+
+# Conditional authentication scripts (TODO: Translation)
+prompt.template.internal.wait.greeting=Hello There!
+prompt.template.internal.wait.message=Please wait until we setup your environment...

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -589,3 +589,7 @@ error.duo.user.not.found=No se pudo obtener el nombre de usuario verificado.
 error.mobile.not.found=Es posible que el usuario no tenga un número de teléfono móvil en su perfil para la autenticación Duo. Por favor actualícelo.
 error.mobile.not.found.duo=No se puede obtener el número de teléfono registrado de Duo. La autenticación falló.
 error.number.mismatch.duo=La autenticación falló debido a una discrepancia en los números de móvil. Actualice el número de móvil dúo registrado correcto en el perfil de usuario.
+
+# Conditional authentication scripts (TODO: Translation)
+prompt.template.internal.wait.greeting=Hello There!
+prompt.template.internal.wait.message=Please wait until we setup your environment...

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -590,3 +590,7 @@ error.duo.user.not.found=Impossible d'obtenir le nom d'utilisateur vérifié.
 error.mobile.not.found=L'utilisateur peut ne pas avoir de numéro de mobile dans son profil d'utilisateur pour l'authentification Duo. Veuillez le mettre à jour.
 error.mobile.not.found.duo=Impossible d'obtenir le numéro de téléphone enregistré auprès de Duo. Authentification échouée.
 error.number.mismatch.duo=L'authentification a échoué en raison d'une incohérence entre les numéros de mobile. Veuillez mettre à jour le numéro de mobile du duo enregistré correct dans le profil utilisateur.
+
+# Conditional authentication scripts (TODO: Translation)
+prompt.template.internal.wait.greeting=Hello There!
+prompt.template.internal.wait.message=Please wait until we setup your environment...

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -588,3 +588,7 @@ error.duo.user.not.found=認証されたユーザー名を取得できません�
 error.mobile.not.found=ユーザーのプロフィールに Duo 認証用の携帯電話番号が含まれていない可能性があります。更新してください。
 error.mobile.not.found.duo=Duo から登録された電話番号を取得できません。認証に失敗しました。
 error.number.mismatch.duo=携帯電話番号の不一致により認証に失敗しました。ユーザープロフィールに登録されている正しいデュオ携帯電話番号を更新してください。
+
+# Conditional authentication scripts (TODO: Translation)
+prompt.template.internal.wait.greeting=Hello There!
+prompt.template.internal.wait.message=Please wait until we setup your environment...

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -585,3 +585,7 @@ error.duo.user.not.found=Não foi possível obter o nome de usuário verificado.
 error.mobile.not.found=O usuário não pode ter um número de celular no perfil do usuário para Autenticação Duo. Por favor atualize-o.
 error.mobile.not.found.duo=Não foi possível obter o número de telefone registrado do Duo. Falha na autenticação.
 error.number.mismatch.duo=A autenticação falhou devido a incompatibilidade nos números de celular. Atualize o número de celular duo registrado correto no perfil do usuário.
+
+# Conditional authentication scripts (TODO: Translation)
+prompt.template.internal.wait.greeting=Hello There!
+prompt.template.internal.wait.message=Please wait until we setup your environment...

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -589,3 +589,7 @@ error.duo.user.not.found=Não foi possível obter o nome de usuário verificado.
 error.mobile.not.found=O usuário não pode ter um número de celular no perfil do usuário para Autenticação Duo. Por favor atualize-o.
 error.mobile.not.found.duo=Não foi possível obter o número de telefone registrado do Duo. Falha na autenticação.
 error.number.mismatch.duo=A autenticação falhou devido a incompatibilidade nos números de celular. Atualize o número de celular duo registrado correto no perfil do usuário.
+
+# Conditional authentication scripts (TODO: Translation)
+prompt.template.internal.wait.greeting=Hello There!
+prompt.template.internal.wait.message=Please wait until we setup your environment...

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -588,3 +588,7 @@ error.duo.user.not.found=无法获取经过验证的用户名。
 error.mobile.not.found=用户的个人资料中可能没有用于双重身份验证的手机号码。请更新它。
 error.mobile.not.found.duo=无法从 Duo 获取注册的电话号码。认证失败。
 error.number.mismatch.duo=由于手机号码不匹配，身份验证失败。请在用户个人资料中更新正确的注册双人手机号码。
+
+# Conditional authentication scripts (TODO: Translation)
+prompt.template.internal.wait.greeting=Hello There!
+prompt.template.internal.wait.message=Please wait until we setup your environment...

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/template-mapper.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/template-mapper.jsp
@@ -19,4 +19,5 @@
     templateMap.put("startAccountLink", "templates/startAccountLink.jsp");
     templateMap.put("finishAccountLink", "templates/finishAccountLink.jsp");
     templateMap.put("externalRedirect", "templates/externalRedirect.jsp");
+    templateMap.put("internalWait", "templates/internalWait.jsp");
 %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/internalWait.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/internalWait.jsp
@@ -1,0 +1,163 @@
+<%--
+ ~ Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ ~
+ ~ This software is the property of WSO2 LLC. and its suppliers, if any.
+ ~ Dissemination of any information or reproduction of any material contained
+ ~ herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+ ~ You may not alter or remove any copyright or other notice from copies of this content.
+--%>
+
+<%--  
+    This template is used to keep an user waiting using the adaptive auth dynamic prompt capability.
+    An example prompt usage in adaptive script is shown below. The parameters are optional and if not provided,
+    the default values will be used.
+
+    prompt("internalWait", {
+        "timeout": "<TIMEOUT_SECONDS>",
+        "greeting": "<GREETING_TEXT>",
+        "message": "<WAITING_MESSAGE>"
+    }, {
+        onSuccess: function(context) {
+            Log.info("Successfully redirected back from waiting page.");
+        },
+        onFail: function(context, data) {
+            Log.info("Error occurred during the prompt.");
+        }
+    });
+--%>
+
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ page import="java.io.File" %>
+<%@ page import="java.util.HashMap" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
+
+<jsp:directive.include file="../includes/init-url.jsp"/>
+
+<%-- Localization --%>
+<jsp:directive.include file="../includes/localize.jsp" />
+
+<%-- Branding Preferences --%>
+<jsp:directive.include file="../includes/branding-preferences.jsp"/>
+
+<%
+    // Read promptId from request.
+    String promptId = (String) request.getAttribute("promptId");
+
+    // Max timeout in seconds.
+    int maxTimeout = 20;
+
+    // Read the data from request.
+    Object dataObj = request.getAttribute("data");
+
+    // Extract and set properties from the request data.
+    Map<String, String> properties = new HashMap<>();
+    int timeout = 10;
+
+    // TODO: Set i18n mappings/ translations.
+    String greeting = "Hello There!";
+    String message = "Please wait until we setup your environment...";
+
+    if (dataObj instanceof Map) {
+        Map<String, Object> data = (Map<String, Object>) dataObj;
+
+        if (StringUtils.isNotBlank((String) data.get("timeout"))) {
+            timeout = Integer.parseInt((String) data.get("timeout"));
+
+            if (timeout > maxTimeout) {
+                timeout = maxTimeout;
+            }
+        }
+        if (StringUtils.isNotBlank((String) data.get("greeting"))) {
+            greeting = (String) data.get("greeting");
+        }
+        if (StringUtils.isNotBlank((String) data.get("message"))) {
+            message = (String) data.get("message");
+        }
+    }
+%>
+
+<head>
+    <%-- header --%>
+    <%
+        File headerFile = new File(getServletContext().getRealPath("extensions/header.jsp"));
+        if (headerFile.exists()) {
+    %>
+        <jsp:include page="../extensions/header.jsp"/>
+    <% } else { %>
+        <jsp:include page="../includes/header.jsp"/>
+    <% } %>
+
+    <script>
+        window.onload = function() {
+            var promptId = "<%= promptId %>";
+            var timeout = "<%= timeout %>";
+            var greeting = "<%= greeting %>";
+            var message = "<%= message %>";
+
+            // Add the promptID value as a hidden input field in the form.
+            var form = document.getElementById('myForm');
+            if (promptId) {
+                var promptIdInput = document.createElement('input');
+                promptIdInput.type = 'hidden';
+                promptIdInput.name = 'promptId';
+                promptIdInput.value = promptId;
+                form.appendChild(promptIdInput);
+            }
+
+            var greetingElement = document.getElementById('greeting');
+            greetingElement.innerText = greeting;
+
+            var messageElement = document.getElementById('message');
+            messageElement.innerText = message;
+
+            var spinnerElement = document.getElementById('spinner-container');
+            var countdownElement = document.getElementById('countdown');
+
+            // Set the countdown duration in seconds.
+            var secondsLeft = timeout;
+
+            countdownElement.innerText = secondsLeft;
+
+            // Start the countdown.
+            var countdownInterval = setInterval(function() {
+                secondsLeft--;
+                countdownElement.innerText = secondsLeft;
+
+                // Check if the countdown is completed.
+                if (secondsLeft <= 0) {
+                    clearInterval(countdownInterval);
+                    greetingElement.style.display = 'none';
+                    spinnerElement.style.display = 'none';
+                    messageElement.style.display = 'none';
+                    countdownElement.style.display = 'none';
+                    form.submit();
+                }
+            }, 1000);
+        };
+    </script>
+
+    <style>
+        #spinner-container {
+            position: relative;
+            margin-top: 40px;
+            margin-bottom: 40px;
+            background-color: unset;
+        }
+    </style>
+</head>
+<body>
+    <div class="ui">
+        <h2 id="greeting" class="ui header text-align:center"></h2>
+        <div id="spinner-container" class="ui active inverted dimmer">
+            <div class="ui massive loader"></div>
+        </div>
+        <p id="message" class="message text-align:center"></p>
+        <h4 id="countdown" class="message text-align:center"></h4>
+    </div>
+
+    <form id="myForm" action="<%= commonauthURL %>" method="post">
+        <input type="hidden" id="promptResp" name="promptResp" value="true">
+        <input type="hidden" id="customClaim" name="customClaim" value="PickedFromExternal">
+    </form>
+</body>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/internalWait.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/internalWait.jsp
@@ -31,6 +31,7 @@
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
 <%@ page import="org.apache.commons.lang.StringUtils" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 
 <jsp:directive.include file="../includes/init-url.jsp"/>
 
@@ -54,9 +55,9 @@
     Map<String, String> properties = new HashMap<>();
     int timeout = 10;
 
-    // TODO: Set i18n mappings/ translations.
-    String greeting = "Hello There!";
-    String message = "Please wait until we setup your environment...";
+    // Apply i18n translations for the default greeting and message.
+    String greeting = AuthenticationEndpointUtil.i18n(resourceBundle, "prompt.template.internal.wait.greeting");
+    String message = AuthenticationEndpointUtil.i18n(resourceBundle, "prompt.template.internal.wait.message");
 
     if (dataObj instanceof Map) {
         Map<String, Object> data = (Map<String, Object>) dataObj;


### PR DESCRIPTION
### Purpose
This PR introduces an internal waiting page to be used in the authentication flow using an adaptive authentication script through the `prompt` function.

**Template name:**
`internalWait`

**Parameters:**
@param {String} timeout - (Optional) An optional timeout period in seconds. Default timeout is `10` seconds.
@param {String} greeting - (Optional) Optional greeting. Default value will be `Hello There!`.
@param {String} message - (Optional) Optional message. Default value will be `Please wait until we setup your environment...`

**Sample usage:**
```
prompt("internalWait", {
    "timeout": "<TIMEOUT_SECONDS>",
    "greeting": "<GREETING_TEXT>",
    "message": "<WAITING_MESSAGE>"
}, {});
```

Example:
```
prompt("internalWait", {
    "timeout": "5",
    "greeting": "Hello There !",
    "message": "Please wait until we setup your environment..."
}, {
    onSuccess: function (context) {
        Log.info("Successfully redirected back from waiting page.");
    },
    onFail: function (context, data) {
        Log.info("Error occurred during the prompt.");
    }
});
```

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
