### PR TITLE
Support replacing organizationid hint in access url for password reset flow

### DIFF
--- a/.changeset/tasty-fans-listen.md
+++ b/.changeset/tasty-fans-listen.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Support replacing organizationid hint in access url for password reset flow

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-confirm.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-confirm.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2016-2023, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2016-2024, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -58,6 +58,7 @@
     String callback = request.getParameter("callback");
     String sp = Encode.forJava(request.getParameter("sp"));
     String spAccessUrl = "";
+    String orgId = request.getParameter("orgid");
     if (StringUtils.isBlank(callback)) {
         callback = request.getParameter("redirect_uri");
     }
@@ -144,6 +145,7 @@
         request.setAttribute(IdentityManagementEndpointConstants.TENANT_DOMAIN, tenantDomain);
         request.setAttribute("passwordExpired", passwordExpired);
         request.setAttribute("sp", sp);
+        request.setAttribute("orgid", orgId);
         request.getRequestDispatcher("passwordreset.do").forward(request, response);
     } else {
         request.setAttribute("error", true);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2016-2023, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2016-2024, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -79,6 +79,7 @@
     String sp = Encode.forJava(request.getParameter("sp"));
     String userStoreDomain = request.getParameter(USERSTORE_DOMAIN);
     String type = request.getParameter("type");
+    String orgId = request.getParameter("orgid");
     String username = null;
     String tenantAwareUsername = null;
     String applicationName = null;
@@ -123,6 +124,8 @@
                     applicationName);
             applicationAccessURLWithoutEncoding = IdentityManagementEndpointUtil.replaceUserTenantHintPlaceholder(
                     applicationAccessURLWithoutEncoding, userTenantDomain);
+            applicationAccessURLWithoutEncoding = IdentityManagementEndpointUtil.getOrganizationIdHintReplacedURL(
+                    applicationAccessURLWithoutEncoding, orgId);
         } catch (ApplicationDataRetrievalClientException e) {
             // Ignored and fallback to login page url.
         }

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2016-2023, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2016-2024, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -45,6 +45,7 @@
     String username = request.getParameter("username");
     String userStoreDomain = request.getParameter("userstoredomain");
     String type = request.getParameter("type");
+    String orgId = request.getParameter("orgid");
     String spId = request.getParameter("spId");
     String sp = Encode.forJava(request.getParameter("sp"));
     boolean passwordExpired = IdentityManagementEndpointUtil.getBooleanValue(request.getAttribute("passwordExpired"));
@@ -247,6 +248,13 @@
                             %>
                             <div>
                                 <input type="hidden" name="type" value="<%=Encode.forHtmlAttribute(type) %>"/>
+                            </div>
+                            <%
+                                }
+                                if (StringUtils.isNotBlank(orgId)) {
+                            %>
+                            <div>
+                                <input type="hidden" name="orgid" value="<%=Encode.forHtmlAttribute(orgId) %>"/>
                             </div>
                             <%
                                 }


### PR DESCRIPTION
### Purpose
$Subject
Part of https://github.com/wso2/product-is/issues/20247

### Related Issues
-

### Related PRs
- Depends on https://github.com/wso2/carbon-identity-framework/pull/5646

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
