### PR TITLE
Stop marking MyAccount app as a shared with all organization

### DIFF
--- a/.changeset/popular-boxes-punch.md
+++ b/.changeset/popular-boxes-punch.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Stop sharing the myaccount app with organizations by default

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -248,7 +248,7 @@ public class AppPortalUtils {
         String appId = AppsCommonDataHolder.getInstance().getApplicationManagementService()
             .createApplication(serviceProvider, tenantDomain, appOwner);
 
-        if (!CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
+        if (!CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME && CONSOLE_APP.equals(appName)) {
             shareApplication(tenantDomain, tenantId, appId, appName, appOwner);
         }
     }

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -520,7 +520,7 @@ public class AppPortalUtils {
         spProperty1.setDisplayName("Is System Reserved Application");
         serviceProviderProperties.add(spProperty1);
 
-        // Make system applications shareable.
+        // Share the console application with all child organizations.
         if (ApplicationConstants.CONSOLE_APPLICATION_NAME.equals(serviceProvider.getApplicationName())) {
             ServiceProviderProperty spProperty2 = new ServiceProviderProperty();
             spProperty2.setName(SHARE_WITH_ALL_CHILDREN);

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthent
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.application.mgt.ApplicationConstants;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
@@ -52,6 +53,7 @@ import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.identity.apps.common.internal.AppsCommonDataHolder;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -510,19 +512,23 @@ public class AppPortalUtils {
             serviceProvider.setAccessUrl(accessUrl);
         }
 
-        // Make system applications shareable.
-        ServiceProviderProperty spProperty1 = new ServiceProviderProperty();
-        spProperty1.setName(SHARE_WITH_ALL_CHILDREN);
-        spProperty1.setValue("true");
-
+        List<ServiceProviderProperty> serviceProviderProperties = new ArrayList<>();
         // Mark as system reserved app.
-        ServiceProviderProperty spProperty2 = new ServiceProviderProperty();
-        spProperty2.setName(IS_SYSTEM_RESERVED_APP_FLAG);
-        spProperty2.setValue("true");
-        spProperty2.setDisplayName("Is System Reserved Application");
+        ServiceProviderProperty spProperty1 = new ServiceProviderProperty();
+        spProperty1.setName(IS_SYSTEM_RESERVED_APP_FLAG);
+        spProperty1.setValue("true");
+        spProperty1.setDisplayName("Is System Reserved Application");
+        serviceProviderProperties.add(spProperty1);
 
-        ServiceProviderProperty[] serviceProviderProperties = {spProperty1, spProperty2};
-        serviceProvider.setSpProperties(serviceProviderProperties);
+        // Make system applications shareable.
+        if (ApplicationConstants.CONSOLE_APPLICATION_NAME.equals(serviceProvider.getApplicationName())) {
+            ServiceProviderProperty spProperty2 = new ServiceProviderProperty();
+            spProperty2.setName(SHARE_WITH_ALL_CHILDREN);
+            spProperty2.setValue("true");
+            serviceProviderProperties.add(spProperty2);
+        }
+
+        serviceProvider.setSpProperties(serviceProviderProperties.toArray(new ServiceProviderProperty[0]));
 
         // Set role audience as 'application'
         AssociatedRolesConfig associatedRolesConfig = new AssociatedRolesConfig();


### PR DESCRIPTION
### Purpose
$subject

Stop marking the MyAccount application share with the all organizations. Depending on the use cases, the MyAccount application can be shared with all orgs or required orgs by the root organization administrators.