### PR TITLE
Enable OIDC session management by default for console

### DIFF
--- a/.changeset/nasty-rabbits-visit.md
+++ b/.changeset/nasty-rabbits-visit.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+Enable OIDC session management by default

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -39,6 +39,7 @@
     "idpConfigs": {
         "logoutEndpointURL": "${serverOrigin}/oidc/logout",
         "oidcSessionIFrameEndpointURL": "${serverOrigin}/oidc/checksession",
+        "enableOIDCSessionManagement": true,
         "baseUrls": [],
         "clockTolerance": 300,
         "storage": "webWorker",

--- a/features/admin.authentication.v1/utils/authenticate-utils.ts
+++ b/features/admin.authentication.v1/utils/authenticate-utils.ts
@@ -56,7 +56,8 @@ export class AuthenticateUtils {
             clientID: window["AppUtils"]?.getConfig()?.clientID,
             clockTolerance: window[ "AppUtils" ]?.getConfig().idpConfigs?.clockTolerance,
             disableTrySignInSilently: new URL(location.href).searchParams.get("disable_silent_sign_in") === "true",
-            enableOIDCSessionManagement: false,
+            enableOIDCSessionManagement: window["AppUtils"]?.getConfig().idpConfigs?.enableOIDCSessionManagement
+                ?? true,
             enablePKCE: window["AppUtils"]?.getConfig()?.idpConfigs?.enablePKCE ?? true,
             endpoints: {
                 authorizationEndpoint: window["AppUtils"]?.getConfig()?.idpConfigs?.authorizeEndpointURL,


### PR DESCRIPTION
### Purpose
OIDC session management has been turned off due to a regression. This PR enables it back.

### Related Issues
- https://github.com/wso2/product-is/issues/20181

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
