### PR TITLE
Set suborg id as the tenant domain in redux store when switching to a suborganization

### DIFF
--- a/.changeset/empty-wombats-double.md
+++ b/.changeset/empty-wombats-double.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Set suborg id as the tenant domain in redux store when switching to a suborganization

--- a/features/admin.authentication.v1/hooks/use-sign-in.ts
+++ b/features/admin.authentication.v1/hooks/use-sign-in.ts
@@ -285,7 +285,7 @@ const useSignIn = (): UseSignInInterface => {
             || idToken.org_name === tenantDomainFromSubject
             || ((idToken.user_org === idToken.org_id) && idToken.org_name === tenantDomainFromSubject);
 
-        const tenantDomain: string = transformTenantDomain(orgName);
+        const tenantDomain: string = isFirstLevelOrg ? transformTenantDomain(orgName) : orgIdIdToken;
 
         const firstName: string = idToken?.given_name;
         const lastName: string = idToken?.family_name;
@@ -318,7 +318,7 @@ const useSignIn = (): UseSignInInterface => {
                 Object.assign(
                     CommonAuthenticateUtils.getSignInState(
                         response,
-                        transformTenantDomain(response.orgName)
+                        tenantDomain
                     ), {
                         associatedTenants: isPrivilegedUser ? tenantDomain : idToken?.associated_tenants,
                         defaultTenant: isPrivilegedUser ? tenantDomain : idToken?.default_tenant,


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
$subject

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
