### PR TITLE
Fix issue with listing unnecessary user stores under users tab on role edit page

### DIFF
--- a/.changeset/curly-books-itch.md
+++ b/.changeset/curly-books-itch.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/features": patch
+---
+
+Fix issue with listing unnecessary userstores

--- a/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
+++ b/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
@@ -159,8 +159,8 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
         }
 
         if (userStores) {
-            const availableUserStoreList: UserstoreDisplayItem[] = disabledUserstores
-                .includes(RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME)
+            const availableUserStoreList: UserstoreDisplayItem[] = disabledUserstores?.includes(
+                RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME)
                 ? []
                 : [
                     {


### PR DESCRIPTION
### Purpose
This PR removes the unnecessary user stores listed under the users tab in the roles edit page.

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
