### PR TITLE
Add ability to hide the super tenant in App Client URLs

### DIFF
--- a/.changeset/strange-bikes-check.md
+++ b/.changeset/strange-bikes-check.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/myaccount": patch
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+Add support to skip super tenant from app urls

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -57,9 +57,6 @@
     {% if console.super_tenant_proxy_name is defined %}
         "superTenantProxy" : "{{ console.super_tenant_proxy_name }}",
     {% endif %}
-    {% if tenant_context.enable_tenant_qualified_urls is defined && tenant_context.require_super_tenant_in_urls is defined %}
-    "requireSuperTenantInUrls" : {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }},
-    {% endif %}
     {% if console.doc_site_path is defined %}
     "docSiteUrl": "{{ console.doc_site_path }}",
     {% endif %}
@@ -173,6 +170,12 @@
     {% endif %}
     {% if legacy_mode.enabled is defined %}
     "legacyMode": {{ legacy_mode.enabled }},
+    {% endif %}
+    {% if tenant_context is defined %}
+    "tenantContext": {
+        "enableTenantQualifiedUrls": {{ tenant_context.enable_tenant_qualified_urls }},
+        "requireSuperTenantInUrls": {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }}
+    },
     {% endif %}
     "ui": {
         "announcements": [

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -173,8 +173,9 @@
     {% endif %}
     {% if tenant_context is defined %}
     "tenantContext": {
-        "enableTenantQualifiedUrls": {{ tenant_context.enable_tenant_qualified_urls }},
-        "requireSuperTenantInUrls": {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }}
+        "enableTenantQualifiedUrls": {{ tenant_context.enable_tenant_qualified_urls | default(true) }},
+        "requireSuperTenantInUrls": {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls | default(false) }},
+        "requireSuperTenantInAppUrls": {{ tenant_context.require_super_tenant_in_app_urls | default(true) }}
     },
     {% endif %}
     "ui": {

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -305,7 +305,6 @@ export const AppUtils: any = (function() {
                 organizationPrefix: this.getOrganizationPrefix(),
                 organizationType: this.getOrganizationType(),
                 productVersionConfig: _config.ui.productVersionConfig,
-                requireSuperTenantInUrls: _config.requireSuperTenantInUrls,
                 routes: {
                     home: this.constructAppPaths(_config.routePaths.home),
                     login: this.constructAppPaths(_config.routePaths.login),
@@ -316,6 +315,7 @@ export const AppUtils: any = (function() {
                 session: _config.session,
                 superTenant: this.getSuperTenant(),
                 tenant: (this.isSuperTenant()) ? this.getSuperTenant() : this.getTenantName(),
+                tenantContext: _config.tenantContext,
                 tenantPath: this.getTenantPath(),
                 tenantPathWithoutSuperTenant: this.getTenantPath(true),
                 tenantPrefix: this.getTenantPrefix(),
@@ -468,7 +468,7 @@ export const AppUtils: any = (function() {
                 return (tenantName) ? tenantName : "";
             }
 
-            return (_config.requireSuperTenantInUrls)
+            return (_config.tenantContext?.requireSuperTenantInUrls)
                 ? this.getSuperTenant()
                 : "";
         },
@@ -573,7 +573,6 @@ export const AppUtils: any = (function() {
                 "clientOrigin": window.location.origin,
                 "contextPath": _args.contextPath,
                 "legacyAuthzRuntime": _args.legacyAuthzRuntime || false,
-                "requireSuperTenantInUrls" : _args.requireSuperTenantInUrls || false,
                 "serverOrigin": _args.serverOrigin || fallbackServerOrigin
             };
 

--- a/apps/console/src/init/app-utils.ts
+++ b/apps/console/src/init/app-utils.ts
@@ -203,11 +203,14 @@ export const AppUtils: any = (function() {
                     : "" }`;
             }
 
-            const tenantPath: string = this.getTenantPath(true)
-                || `/${this.getTenantPrefix()}/${this.getSuperTenant()}`;
+            let tenantPath: string = this.getTenantPath(true);
             const appBaseName: string = _config.appBaseName
                 ? `/${_config.appBaseName}`
                 : "";
+
+            if (_config.tenantContext?.requireSuperTenantInAppUrls && !tenantPath) {
+                tenantPath = `/${this.getTenantPrefix()}/${this.getSuperTenant()}`;
+            }
 
             return `${ tenantPath }${ this.getOrganizationPath() }${ appBaseName }`;
         },
@@ -481,14 +484,15 @@ export const AppUtils: any = (function() {
          * @returns Tenant path.
          */
         getTenantPath: function (skipSuperTenant: boolean = false) {
+            if (skipSuperTenant && (this.getTenantName() === this.getSuperTenant() || this.getTenantName() === "")) {
+                return urlPathForSuperTenantOriginsFallback;
+            }
+
+            const tenantDomain: string = this.getTenantName();
+
             if (_config.legacyAuthzRuntime) {
                 if (this.getOrganizationName()) {
                     return "";
-                }
-
-                if (skipSuperTenant
-                    && (this.getTenantName() === this.getSuperTenant() || this.getTenantName() === "")) {
-                    return urlPathForSuperTenantOriginsFallback;
                 }
 
                 // For non-SaaS apps, no need to have tenanted paths.
@@ -496,12 +500,12 @@ export const AppUtils: any = (function() {
                     return "/";
                 }
 
-                return (this.getTenantName() !== "") ?
-                    "/" + this.getTenantPrefix() + "/" + this.getTenantName() : "";
+                return (tenantDomain !== "") ?
+                    "/" + this.getTenantPrefix() + "/" + tenantDomain : "";
             }
 
-            return (this.getTenantName() !== "")
-                ? `/${this.getTenantPrefix()}/${this.getTenantName()}`
+            return (tenantDomain !== "")
+                ? `/${this.getTenantPrefix()}/${tenantDomain}`
                 : "";
         },
 

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -159,9 +159,12 @@
     },
     "getProfileInfoFromIDToken": false,
     "superTenantProxy": "",
-    "requireSuperTenantInUrls" : false,
     "legacyAuthzRuntime": false,
     "legacyMode": false,
+    "tenantContext": {
+        "enableTenantQualifiedUrls": true,
+        "requireSuperTenantInUrls": false
+    },
     "ui": {
         "announcements": [],
         "appCopyright": "${copyright} ${year} WSO2 LLC.",

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -163,7 +163,8 @@
     "legacyMode": false,
     "tenantContext": {
         "enableTenantQualifiedUrls": true,
-        "requireSuperTenantInUrls": false
+        "requireSuperTenantInUrls": false,
+        "requireSuperTenantInAppUrls": true
     },
     "ui": {
         "announcements": [],

--- a/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
+++ b/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
@@ -95,9 +95,6 @@
     {% if myaccount.super_tenant_proxy_name is defined %}
         "superTenantProxy" : "{{ myaccount.super_tenant_proxy_name }}",
     {% endif %}
-    {% if tenant_context.enable_tenant_qualified_urls is defined && tenant_context.require_super_tenant_in_urls is defined %}
-    "requireSuperTenantInUrls" : {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }},
-    {% endif %}
     {% if myaccount.idp_configs is defined %}
     "idpConfigs": {
         {% if myaccount.idp_configs.items() is defined %}
@@ -133,6 +130,12 @@
     },
     {% if legacy_authz_runtime.enable is defined %}
         "legacyAuthzRuntime": {{ legacy_authz_runtime.enable }},
+    {% endif %}
+    {% if tenant_context is defined %}
+    "tenantContext": {
+        "enableTenantQualifiedUrls": {{ tenant_context.enable_tenant_qualified_urls }},
+        "requireSuperTenantInUrls": {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }}
+    },
     {% endif %}
     "ui": {
         "announcements": [

--- a/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
+++ b/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
@@ -133,8 +133,9 @@
     {% endif %}
     {% if tenant_context is defined %}
     "tenantContext": {
-        "enableTenantQualifiedUrls": {{ tenant_context.enable_tenant_qualified_urls }},
-        "requireSuperTenantInUrls": {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls }}
+        "enableTenantQualifiedUrls": {{ tenant_context.enable_tenant_qualified_urls | default(true) }},
+        "requireSuperTenantInUrls": {{ tenant_context.enable_tenant_qualified_urls && tenant_context.require_super_tenant_in_urls | default(false) }},
+        "requireSuperTenantInAppUrls": {{ tenant_context.require_super_tenant_in_app_urls | default(true) }}
     },
     {% endif %}
     "ui": {

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -367,7 +367,7 @@ export const AppUtils: AppUtilsInterface = (function() {
                 return (tenantName) ? tenantName : "";
             }
 
-            return (_config.requireSuperTenantInUrls)
+            return (_config.tenantContext?.requireSuperTenantInUrls)
                 ? this.getSuperTenant()
                 : "";
         },
@@ -439,7 +439,6 @@ export const AppUtils: AppUtilsInterface = (function() {
                 "clientOrigin": window.location.origin,
                 "consoleAppOrigin": _args.consoleAppOrigin || _args.serverOrigin || fallbackServerOrigin,
                 "contextPath": _args.contextPath,
-                "requireSuperTenantInUrls" : _args.requireSuperTenantInUrls || false,
                 "serverOrigin": _args.serverOrigin || fallbackServerOrigin
             };
 

--- a/apps/myaccount/src/init/app-utils.ts
+++ b/apps/myaccount/src/init/app-utils.ts
@@ -177,11 +177,14 @@ export const AppUtils: AppUtilsInterface = (function() {
                     : "" }`;
             }
 
-            const tenantPath: string = this.getTenantPath(true)
-                || `/${this.getTenantPrefix()}/${this.getSuperTenant()}`;
+            let tenantPath: string = this.getTenantPath(true);
             const appBaseName: string = _config.appBaseName
                 ? `/${_config.appBaseName}`
                 : "";
+
+            if (_config.tenantContext?.requireSuperTenantInAppUrls && !tenantPath) {
+                tenantPath = `/${this.getTenantPrefix()}/${this.getSuperTenant()}`;
+            }
 
             return `${ tenantPath }${ this.getOrganizationPath() }${ appBaseName }`;
         },
@@ -381,7 +384,6 @@ export const AppUtils: AppUtilsInterface = (function() {
          * @returns Tenant path.
          */
         getTenantPath: function(skipSuperTenant: boolean = false, forIdPUrls?: boolean) {
-
             if (skipSuperTenant && (this.getTenantName() === this.getSuperTenant() || this.getTenantName() === "")) {
                 return urlPathForSuperTenantOriginsFallback;
             }

--- a/apps/myaccount/src/public/deployment.config.json
+++ b/apps/myaccount/src/public/deployment.config.json
@@ -42,6 +42,10 @@
         "checkSessionInterval": 3.0
     },
     "legacyAuthzRuntime": false,
+    "tenantContext": {
+        "enableTenantQualifiedUrls": true,
+        "requireSuperTenantInUrls": false
+    },
     "ui": {
         "announcements": [],
         "appCopyright": "${copyright} ${year} WSO2 LLC.",

--- a/apps/myaccount/src/public/deployment.config.json
+++ b/apps/myaccount/src/public/deployment.config.json
@@ -44,7 +44,8 @@
     "legacyAuthzRuntime": false,
     "tenantContext": {
         "enableTenantQualifiedUrls": true,
-        "requireSuperTenantInUrls": false
+        "requireSuperTenantInUrls": false,
+        "requireSuperTenantInAppUrls": true
     },
     "ui": {
         "announcements": [],

--- a/features/admin.authentication.v1/hooks/use-sign-in.ts
+++ b/features/admin.authentication.v1/hooks/use-sign-in.ts
@@ -132,7 +132,7 @@ const useSignIn = (): UseSignInInterface => {
         const isSubOrganization: boolean = orgType === OrganizationType.SUBORGANIZATION &&
             window["AppUtils"]?.getConfig()?.organizationName.length > 0;
 
-        if (!window["AppUtils"]?.getConfig()?.requireSuperTenantInUrls && isSuperTenant) {
+        if (!window["AppUtils"]?.getConfig()?.tenantContext?.requireSuperTenantInUrls && isSuperTenant) {
             // Removing super tenant from the server host.
             const customServerHostSplit: string[] = customServerHost?.split("/t/");
 


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Add `requireSuperTenantInAppUrls` to skip `carbon.super` from app URLs.

**via TOML**

```toml
[tenant_context]
require_super_tenant_in_app_urls = false
```

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
