### PR TITLE
Move `SaaS` My Account settings page enable/disable flag to deployment level

### DIFF
--- a/.changeset/thick-radios-trade.md
+++ b/.changeset/thick-radios-trade.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+Move SaaS My Account settings config to deployment level

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -343,7 +343,8 @@
             "applications": {
                 "disabledFeatures": [
                     "applications.loginFlow.legacyEditor",
-                    "applications.loginFlow.ai"
+                    "applications.loginFlow.ai",
+                    "applications.myaccount.saasMyaccountSettings"
                 ],
                 "enabled": true,
                 "scopes": {

--- a/features/admin.applications.v1/constants/application-management.ts
+++ b/features/admin.applications.v1/constants/application-management.ts
@@ -70,6 +70,7 @@ export class ApplicationManagementConstants {
         .set("APPLICATION_EDIT_INFO", "applications.edit.info")
         .set("FAPI_APP_CREATION", "applications.create.fapi")
         .set("APPLICATION_NATIVE_AUTHENTICATION", "applications.native.authentication")
+        .set("APPLICATION_MYACCOUNT_SAAS_SETTINGS", "applications.myaccount.saasMyaccountSettings")
 
     /**
      * Key for the `Edit Application` tag in the docs structure object.

--- a/features/admin.applications.v1/pages/applications.tsx
+++ b/features/admin.applications.v1/pages/applications.tsx
@@ -129,6 +129,9 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
+    const applicationDisabledFeatures: string[] = useSelector((state: AppState) => {
+        return state.config.ui.features?.applications?.disabledFeatures;
+    });
 
     const [ searchQuery, setSearchQuery ] = useState<string>("");
     const [ listSortingStrategy, setListSortingStrategy ] = useState<DropdownItemProps>(
@@ -390,7 +393,11 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
      * Navigate to the my account edit page.
      */
     const navigateToMyAccountSettings = (): void => {
-        if (applicationConfig?.advancedConfigurations?.showDefaultMyAccountApplicationEditPage) {
+        if (
+            applicationDisabledFeatures?.includes(
+                ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_MYACCOUNT_SAAS_SETTINGS")
+            )
+        ) {
             if (strongAuth) {
                 history.push({
                     pathname: AppConstants.getPaths().get("APPLICATION_EDIT").replace(

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -105,7 +105,6 @@ const isIdentityClaim = (claim: ExtendedClaimInterface | ExtendedExternalClaimIn
 
 export const applicationConfig: ApplicationConfig = {
     advancedConfigurations: {
-        showDefaultMyAccountApplicationEditPage: true,
         showEnableAuthorization: true,
         showMyAccount: true,
         showMyAccountStatus: false,

--- a/features/admin.extensions.v1/configs/models/application.ts
+++ b/features/admin.extensions.v1/configs/models/application.ts
@@ -35,7 +35,6 @@ export interface ApplicationConfig {
         showEnableAuthorization: boolean;
         showMyAccount: boolean;
         showMyAccountStatus: boolean;
-        showDefaultMyAccountApplicationEditPage: boolean;
         showSaaS: boolean;
         showReturnAuthenticatedIdPs: boolean;
     };


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
ATM, `SaaS` My Account settings page enable/disable flag is in the file level, we need to move it to `deployment.config.json` level.

### Related Issues
- https://github.com/wso2/product-is/issues/20184

### Related PRs
- `framework`: https://github.com/wso2/carbon-identity-framework/pull/5660/files

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
