### PR TITLE
Add MTLS endpoints to info tab of OIDC applications

### DIFF
--- a/.changeset/grumpy-roses-sell.md
+++ b/.changeset/grumpy-roses-sell.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": minor
+"@wso2is/features": minor
+---
+
+Add MTLS endpoints to info portal

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -992,8 +992,8 @@ export const getOIDCApplicationConfigurations = (): Promise<OIDCApplicationConfi
                 introspectionEndpoint: response.data.introspection_endpoint,
                 jwksEndpoint: response.data.jwks_uri,
                 mtlsPushedAuthorizationRequestEndpoint:
-                    response.data.mtls_endpoint_aliases.pushed_authorization_request_endpoint,
-                mtlsTokenEndpoint: response.data.mtls_endpoint_aliases.token_endpoint,
+                    response.data.mtls_endpoint_aliases?.pushed_authorization_request_endpoint,
+                mtlsTokenEndpoint: response.data.mtls_endpoint_aliases?.token_endpoint,
                 pushedAuthorizationRequestEndpoint: response.data.pushed_authorization_request_endpoint,
                 sessionIframeEndpoint: response.data.check_session_iframe,
                 tokenEndpoint: response.data.token_endpoint,

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -991,6 +991,9 @@ export const getOIDCApplicationConfigurations = (): Promise<OIDCApplicationConfi
                 endSessionEndpoint: response.data.end_session_endpoint,
                 introspectionEndpoint: response.data.introspection_endpoint,
                 jwksEndpoint: response.data.jwks_uri,
+                mtlsPushedAuthorizationRequestEndpoint:
+                    response.data.mtls_endpoint_aliases.pushed_authorization_request_endpoint,
+                mtlsTokenEndpoint: response.data.mtls_endpoint_aliases.token_endpoint,
                 pushedAuthorizationRequestEndpoint: response.data.pushed_authorization_request_endpoint,
                 sessionIframeEndpoint: response.data.check_session_iframe,
                 tokenEndpoint: response.data.token_endpoint,

--- a/features/admin.applications.v1/components/edit-application.tsx
+++ b/features/admin.applications.v1/components/edit-application.tsx
@@ -1009,6 +1009,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
     const InfoTabPane = (): ReactElement => (
         <ResourceTab.Pane controlledSegmentation>
             <Info
+                appId={ application.id }
                 inboundProtocols={ application?.inboundProtocols }
                 isOIDCConfigLoading={ isOIDCConfigsLoading }
                 isSAMLConfigLoading={ isSAMLConfigsLoading }

--- a/features/admin.applications.v1/components/help-panel/index.ts
+++ b/features/admin.applications.v1/components/help-panel/index.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
+++ b/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
@@ -29,7 +29,7 @@ import {
 /**
  * Proptypes for the OIDC application configurations component.
  */
-interface OIDCConfigurationsPropsInterface extends IdentifiableComponentInterface {
+interface MtlsConfigurationsPropsInterface extends IdentifiableComponentInterface {
     /**
      * OIDC application configurations.
      */
@@ -47,14 +47,15 @@ interface OIDCConfigurationsPropsInterface extends IdentifiableComponentInterfac
   *
   * @returns MTLS OIDC application configurations Component.
   */
-export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterface> = (
-    props: OIDCConfigurationsPropsInterface
+export const MTLSOIDCConfigurations: FunctionComponent<MtlsConfigurationsPropsInterface> = (
+    props: MtlsConfigurationsPropsInterface
 ): ReactElement => {
 
     const {
         oidcConfigurations,
         [ "data-componentid" ]: componentId
     } = props;
+
     const { t } = useTranslation();
 
     return (

--- a/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
+++ b/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
@@ -33,7 +33,6 @@ import {
 
 /**
  * Get an identity client instance.
- *
  */
 const identityClient: AsgardeoSPAClient = AsgardeoSPAClient.getInstance();
 
@@ -41,6 +40,9 @@ const identityClient: AsgardeoSPAClient = AsgardeoSPAClient.getInstance();
  * Proptypes for the OIDC application configurations component.
  */
 interface OIDCConfigurationsPropsInterface extends IdentifiableComponentInterface {
+    /**
+     * OIDC application configurations.
+     */
     oidcConfigurations: OIDCApplicationConfigurationInterface;
     /**
      * Application template ID.

--- a/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
+++ b/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
@@ -17,7 +17,7 @@
  */
 
 import { AsgardeoSPAClient, OIDCEndpoints } from "@asgardeo/auth-react";
-import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { CopyInputField, GenericIcon } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
@@ -32,24 +32,15 @@ import {
 } from "../../models";
 
 /**
-  * OIDC application configurations Component.
-  *
-  * @param props - Props injected to the component.
-  *
-  * @returns OIDC application configurations Component.
-  */
-
-/**
  * Get an identity client instance.
  *
  */
 const identityClient: AsgardeoSPAClient = AsgardeoSPAClient.getInstance();
 
-
 /**
  * Proptypes for the OIDC application configurations component.
  */
-interface OIDCConfigurationsPropsInterface extends TestableComponentInterface {
+interface OIDCConfigurationsPropsInterface extends IdentifiableComponentInterface {
     oidcConfigurations: OIDCApplicationConfigurationInterface;
     /**
      * Application template ID.
@@ -57,20 +48,23 @@ interface OIDCConfigurationsPropsInterface extends TestableComponentInterface {
     templateId?: string;
 }
 
-
+/**
+  * MTLS OIDC application configurations Component.
+  *
+  * @param props - Props injected to the component.
+  *
+  * @returns MTLS OIDC application configurations Component.
+  */
 export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterface> = (
     props: OIDCConfigurationsPropsInterface
 ): ReactElement => {
 
-    const { t } = useTranslation();
-
-    const dispatch: Dispatch = useDispatch();
-
     const {
         oidcConfigurations,
-        [ "data-testid" ]: testId
+        [ "data-componentid" ]: testId
     } = props;
-
+    const { t } = useTranslation();
+    const dispatch: Dispatch = useDispatch();
     const [ endpoints, setEndpoints ] = useState<OIDCEndpointsInterface>(undefined);
 
     useEffect(() => {
@@ -161,5 +155,5 @@ export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsIn
  * Default props for the MTLS OIDC application Configurations component.
  */
 MTLSOIDCConfigurations.defaultProps = {
-    "data-testid": "applications-help-panel-mtls-oidc-configs"
+    "data-componentid": "applications-help-panel-mtls-oidc-configs"
 };

--- a/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
+++ b/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
@@ -16,25 +16,15 @@
  * under the License.
  */
 
-import { AsgardeoSPAClient, OIDCEndpoints } from "@asgardeo/auth-react";
-import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
-import { addAlert } from "@wso2is/core/store";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { CopyInputField, GenericIcon } from "@wso2is/react-components";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch } from "react-redux";
-import { Dispatch } from "redux";
-import { Form, Grid } from "semantic-ui-react";
+import { Grid } from "semantic-ui-react";
 import { getHelpPanelIcons } from "../../configs/ui";
 import {
-    OIDCApplicationConfigurationInterface,
-    OIDCEndpointsInterface
+    OIDCApplicationConfigurationInterface
 } from "../../models";
-
-/**
- * Get an identity client instance.
- */
-const identityClient: AsgardeoSPAClient = AsgardeoSPAClient.getInstance();
 
 /**
  * Proptypes for the OIDC application configurations component.
@@ -63,42 +53,12 @@ export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsIn
 
     const {
         oidcConfigurations,
-        [ "data-componentid" ]: testId
+        [ "data-componentid" ]: componentId
     } = props;
     const { t } = useTranslation();
-    const dispatch: Dispatch = useDispatch();
-    const [ endpoints, setEndpoints ] = useState<OIDCEndpointsInterface>(undefined);
-
-    useEffect(() => {
-        if (endpoints !== undefined) {
-            return;
-        }
-
-        // Fetch the server endpoints for OIDC applications.
-        identityClient.getOIDCServiceEndpoints()
-            .then((response: OIDCEndpoints) => {
-                setEndpoints({
-                    authorize: response?.authorizationEndpoint,
-                    jwks: response?.jwksUri,
-                    logout: response?.endSessionEndpoint,
-                    oidcSessionIFrame: response?.checkSessionIframe,
-                    revoke: response?.revocationEndpoint,
-                    token: response?.tokenEndpoint
-                });
-            })
-            .catch(() => {
-                dispatch(addAlert({
-                    description: t("applications:notifications.fetchOIDCServiceEndpoints" +
-                        ".genericError.description"),
-                    level: AlertLevels.ERROR,
-                    message: t("applications:notifications.fetchOIDCServiceEndpoints." +
-                        "genericError.message")
-                }));
-            });
-    });
 
     return (
-        <Form>
+        <>
             <Grid verticalAlign="middle">
                 <Grid.Row columns={ 2 }>
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
@@ -112,7 +72,7 @@ export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsIn
                             verticalAlign="middle"
                             spaced="right"
                         />
-                        <label data-testid={ `${ testId }-mtls-pushed-authorization-request-label` }>
+                        <label data-componentid={ `${ componentId }-mtls-pushed-authorization-request-label` }>
                             { t("applications:helpPanel.tabs.start.content." +
                                 "oidcConfigurations.labels.pushedAuthorizationRequest") }
                         </label>
@@ -120,7 +80,7 @@ export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsIn
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
                         <CopyInputField
                             value={ oidcConfigurations?.mtlsPushedAuthorizationRequestEndpoint  }
-                            data-testid={ `${ testId }-mtls-pushed-authorization-request-readonly-input` }
+                            data-componentid={ `${ componentId }-mtls-pushed-authorization-request-readonly-input` }
                         />
                     </Grid.Column>
                 </Grid.Row>
@@ -136,7 +96,7 @@ export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsIn
                             verticalAlign="middle"
                             spaced="right"
                         />
-                        <label data-testid={ `${ testId }-mtls-token-label` }>
+                        <label data-componentid={ `${ componentId }-mtls-token-label` }>
                             { t("applications:helpPanel.tabs.start.content." +
                                 "oidcConfigurations.labels.token") }
                         </label>
@@ -144,12 +104,12 @@ export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsIn
                     <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
                         <CopyInputField
                             value={ oidcConfigurations?.mtlsTokenEndpoint  }
-                            data-testid={ `${ testId }-mtls-token-readonly-input` }
+                            data-componentid={ `${ componentId }-mtls-token-readonly-input` }
                         />
                     </Grid.Column>
                 </Grid.Row>
             </Grid>
-        </Form>
+        </>
     );
 };
 

--- a/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
+++ b/features/admin.applications.v1/components/help-panel/mtls-oidc-configurations.tsx
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AsgardeoSPAClient, OIDCEndpoints } from "@asgardeo/auth-react";
+import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { CopyInputField, GenericIcon } from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
+import { Form, Grid } from "semantic-ui-react";
+import { getHelpPanelIcons } from "../../configs/ui";
+import {
+    OIDCApplicationConfigurationInterface,
+    OIDCEndpointsInterface
+} from "../../models";
+
+/**
+  * OIDC application configurations Component.
+  *
+  * @param props - Props injected to the component.
+  *
+  * @returns OIDC application configurations Component.
+  */
+
+/**
+ * Get an identity client instance.
+ *
+ */
+const identityClient: AsgardeoSPAClient = AsgardeoSPAClient.getInstance();
+
+
+/**
+ * Proptypes for the OIDC application configurations component.
+ */
+interface OIDCConfigurationsPropsInterface extends TestableComponentInterface {
+    oidcConfigurations: OIDCApplicationConfigurationInterface;
+    /**
+     * Application template ID.
+     */
+    templateId?: string;
+}
+
+
+export const MTLSOIDCConfigurations: FunctionComponent<OIDCConfigurationsPropsInterface> = (
+    props: OIDCConfigurationsPropsInterface
+): ReactElement => {
+
+    const { t } = useTranslation();
+
+    const dispatch: Dispatch = useDispatch();
+
+    const {
+        oidcConfigurations,
+        [ "data-testid" ]: testId
+    } = props;
+
+    const [ endpoints, setEndpoints ] = useState<OIDCEndpointsInterface>(undefined);
+
+    useEffect(() => {
+        if (endpoints !== undefined) {
+            return;
+        }
+
+        // Fetch the server endpoints for OIDC applications.
+        identityClient.getOIDCServiceEndpoints()
+            .then((response: OIDCEndpoints) => {
+                setEndpoints({
+                    authorize: response?.authorizationEndpoint,
+                    jwks: response?.jwksUri,
+                    logout: response?.endSessionEndpoint,
+                    oidcSessionIFrame: response?.checkSessionIframe,
+                    revoke: response?.revocationEndpoint,
+                    token: response?.tokenEndpoint
+                });
+            })
+            .catch(() => {
+                dispatch(addAlert({
+                    description: t("applications:notifications.fetchOIDCServiceEndpoints" +
+                        ".genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("applications:notifications.fetchOIDCServiceEndpoints." +
+                        "genericError.message")
+                }));
+            });
+    });
+
+    return (
+        <Form>
+            <Grid verticalAlign="middle">
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.par }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-mtls-pushed-authorization-request-label` }>
+                            { t("applications:helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.pushedAuthorizationRequest") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.mtlsPushedAuthorizationRequestEndpoint  }
+                            data-testid={ `${ testId }-mtls-pushed-authorization-request-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 2 }>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 6 }>
+                        <GenericIcon
+                            icon={ getHelpPanelIcons().endpoints.token }
+                            size="micro"
+                            square
+                            transparent
+                            inline
+                            className="left-icon"
+                            verticalAlign="middle"
+                            spaced="right"
+                        />
+                        <label data-testid={ `${ testId }-mtls-token-label` }>
+                            { t("applications:helpPanel.tabs.start.content." +
+                                "oidcConfigurations.labels.token") }
+                        </label>
+                    </Grid.Column>
+                    <Grid.Column mobile={ 8 } tablet={ 8 } computer={ 10 }>
+                        <CopyInputField
+                            value={ oidcConfigurations?.mtlsTokenEndpoint  }
+                            data-testid={ `${ testId }-mtls-token-readonly-input` }
+                        />
+                    </Grid.Column>
+                </Grid.Row>
+            </Grid>
+        </Form>
+    );
+};
+
+/**
+ * Default props for the MTLS OIDC application Configurations component.
+ */
+MTLSOIDCConfigurations.defaultProps = {
+    "data-testid": "applications-help-panel-mtls-oidc-configs"
+};

--- a/features/admin.applications.v1/components/settings/info.tsx
+++ b/features/admin.applications.v1/components/settings/info.tsx
@@ -172,13 +172,11 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                                         { isSAASDeployment && (
                                             <>
                                                 <Heading ellipsis as="h4">
-                                                    Mutual TLS Server Endpoints
+                                                    { t("applications:edit.sections.info.mtlsOidcHeading") }
                                                 </Heading>
                                                 <Heading as="h6" color="grey" compact>
-                                                    The following server endpoints will be useful for you to implement
-                                                     and configure authentication for your application using OpenID
-                                                     Connect where MTLS client authentication or certificate token
-                                                     binding is appplicable. Navigate to
+                                                    { t("applications:edit.sections.info.mtlsOidcSubHeading") }
+                                                    Navigate to
                                                     <Link
                                                         external={ false }
                                                         onClick={ () => {

--- a/features/admin.applications.v1/components/settings/info.tsx
+++ b/features/admin.applications.v1/components/settings/info.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider, Grid } from "semantic-ui-react";
 import { AppConstants, AppState, history } from "../../../admin.core.v1";
+import { applicationConfig } from "../../../admin.extensions.v1";
 import { ApplicationManagementConstants } from "../../constants";
 import CustomApplicationTemplate
     from "../../data/application-templates/templates/custom-application/custom-application.json";
@@ -105,8 +106,6 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
      */
     const PROTOCOLS_TAB_INDEX: number = 1;
 
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
-
     useEffect(() => {
         if (inboundProtocols == undefined) {
             return;
@@ -169,7 +168,7 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                                             templateId={ templateId }
                                         />
 
-                                        { isSAASDeployment && (
+                                        { applicationConfig.advancedConfigurations.showMtlsAliases && (
                                             <>
                                                 <Heading ellipsis as="h4">
                                                     { t("applications:edit.sections.info.mtlsOidcHeading") }

--- a/features/admin.applications.v1/components/settings/info.tsx
+++ b/features/admin.applications.v1/components/settings/info.tsx
@@ -22,13 +22,14 @@ import {
     DocumentationLink,
     EmphasizedSegment,
     Heading,
+    Link,
     useDocumentation
 } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider, Grid } from "semantic-ui-react";
-import { AppState } from "../../../admin.core.v1";
+import { AppConstants, AppState, history } from "../../../admin.core.v1";
 import { ApplicationManagementConstants } from "../../constants";
 import CustomApplicationTemplate
     from "../../data/application-templates/templates/custom-application/custom-application.json";
@@ -39,7 +40,7 @@ import {
     OIDCApplicationConfigurationInterface,
     SAMLApplicationConfigurationInterface
 } from "../../models";
-import { OIDCConfigurations, SAMLConfigurations } from "../help-panel";
+import { MTLSOIDCConfigurations, OIDCConfigurations, SAMLConfigurations } from "../help-panel";
 import { WSFederationConfigurations } from "../help-panel/ws-fed-configurations";
 
 /**
@@ -62,6 +63,10 @@ interface InfoPropsInterface extends LoadableComponentInterface, IdentifiableCom
      * Id of the application template
      */
     templateId: string;
+    /**
+     * Application id.
+     */
+    appId: string;
 }
 
 /**
@@ -76,6 +81,7 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
 ): ReactElement => {
 
     const {
+        appId,
         inboundProtocols,
         isOIDCConfigLoading,
         isSAMLConfigLoading,
@@ -93,6 +99,13 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
     const [ isSAML, setIsSAML ] = useState<boolean>(false);
     const [ isWSFed, setIsWSFed ] = useState<boolean>(false);
     const [ isLoading, setIsLoading ] = useState<boolean>(false);
+
+    /**
+     * Index of the protocols tab.
+     */
+    const PROTOCOLS_TAB_INDEX: number = 1;
+
+    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
 
     useEffect(() => {
         if (inboundProtocols == undefined) {
@@ -155,6 +168,40 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                                             oidcConfigurations={ oidcConfigurations }
                                             templateId={ templateId }
                                         />
+
+                                        { isSAASDeployment && (
+                                            <>
+                                                <Heading ellipsis as="h4">
+                                                    Mutual TLS Server Endpoints
+                                                </Heading>
+                                                <Heading as="h6" color="grey" compact>
+                                                    The following server endpoints will be useful for you to implement
+                                                     and configure authentication for your application using OpenID
+                                                     Connect where MTLS client authentication or certificate token
+                                                     binding is appplicable. Navigate to
+                                                    <Link
+                                                        external={ false }
+                                                        onClick={ () => {
+                                                            history.push(
+                                                                AppConstants.getPaths()
+                                                                    .get("APPLICATION_SIGN_IN_METHOD_EDIT")
+                                                                    .replace(":id", appId)
+                                                                    .replace(
+                                                                        ":tabName",
+                                                                        `#tab=${ PROTOCOLS_TAB_INDEX }`
+                                                                    )
+                                                            );
+                                                        } }
+                                                    > protocol </Link>
+                                                    tab to configure MTLS and certificate token binding.
+                                                </Heading>
+                                                <Divider hidden/>
+                                                <MTLSOIDCConfigurations
+                                                    oidcConfigurations={ oidcConfigurations }
+                                                    templateId={ templateId }
+                                                />
+                                            </>
+                                        ) }
                                     </>
                                 ) }
                                 { isOIDC && isSAML ? (

--- a/features/admin.applications.v1/components/settings/info.tsx
+++ b/features/admin.applications.v1/components/settings/info.tsx
@@ -100,6 +100,7 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
     const [ isSAML, setIsSAML ] = useState<boolean>(false);
     const [ isWSFed, setIsWSFed ] = useState<boolean>(false);
     const [ isLoading, setIsLoading ] = useState<boolean>(false);
+    const mtlsEndpointsPresent: boolean = oidcConfigurations.mtlsTokenEndpoint !== undefined;
 
     /**
      * Index of the protocols tab.
@@ -168,7 +169,8 @@ export const Info: FunctionComponent<InfoPropsInterface> = (
                                             templateId={ templateId }
                                         />
 
-                                        { applicationConfig.advancedConfigurations.showMtlsAliases && (
+                                        { applicationConfig.advancedConfigurations.showMtlsAliases &&
+                                        mtlsEndpointsPresent && (
                                             <>
                                                 <Heading ellipsis as="h4">
                                                     { t("applications:edit.sections.info.mtlsOidcHeading") }

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.scss
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.scss
@@ -20,3 +20,13 @@
     color: #01698a;
     background-color: #c3e6f6;
 }
+
+.oxygen-chip-div {
+    margin-left: "10px";
+    margin-top: "-10px";
+}
+
+.app-type-checkbox {
+    align-items: "center";
+    display: "flex";
+}

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.scss
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-export * from "./overview";
-export * from "./mtls-oidc-configurations";
-export * from "./oidc-configurations";
-export * from "./saml-configurations";
-export * from "./samples-guide";
+.oxygen-chip-preview {
+    color: #01698a;
+    background-color: #c3e6f6;
+}

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.scss
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.scss
@@ -16,17 +16,11 @@
  * under the License.
  */
 
-.oxygen-chip-preview {
-    color: #01698a;
-    background-color: #c3e6f6;
-}
-
 .oxygen-chip-div {
-    margin-left: "10px";
-    margin-top: "-10px";
+    margin: 0 0 1em 0.5em;
 }
 
 .app-type-checkbox {
-    align-items: "center";
-    display: "flex";
+    align-items: center;
+    display: flex;
 }

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.scss
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.scss
@@ -19,8 +19,3 @@
 .oxygen-chip-div {
     margin: 0 0 1em 0.5em;
 }
-
-.app-type-checkbox {
-    align-items: center;
-    display: flex;
-}

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -1136,7 +1136,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                         && isFAPIAppCreationEnabled
                         && (
                             <div className="pt-0 mt-0">
-                                <div style={{ alignItems: "center", display: "flex" }}>
+                                <div style={ { alignItems: "center", display: "flex" } }>
                                     <Field
                                         data-componentid={ `${ testId }-fapi-app-checkbox` }
                                         name={ "isFAPIApp" }
@@ -1152,7 +1152,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                                         ] }
                                     />
                                     { isSAASDeployment && (
-                                        <div style={{ marginLeft: "10px", marginTop: "-10px" }}>
+                                        <div style={ { marginLeft: "10px", marginTop: "-10px" } }>
                                             <Chip
                                                 label="PREVIEW"
                                                 className="oxygen-menu-item-chip oxygen-chip-preview" />

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -1151,11 +1151,11 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                                             }
                                         ] }
                                     />
-                                    { isSAASDeployment && (
+                                    { applicationConfig.advancedConfigurations.showFapiBetaChip && (
                                         <div className="oxygen-chip-div" >
                                             <Chip
-                                                label="PREVIEW"
-                                                className="oxygen-menu-item-chip oxygen-chip-preview" />
+                                                label="BETA"
+                                                className="oxygen-menu-item-chip oxygen-chip-beta" />
                                         </div>
                                     ) }
                                 </div>

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import Chip from "@oxygen-ui/react/Chip";
 import { Show } from "@wso2is/access-control";
 import useUIConfig from "../../../admin.core.v1/hooks/use-ui-configs";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
@@ -99,6 +100,7 @@ import {
 } from "../../models";
 import { ApplicationManagementUtils } from "../../utils/application-management-utils";
 import { ApplicationShareModal } from "../modals/application-share-modal";
+import "./minimal-application-create-wizard.scss";
 
 /**
  * Prop types of the `MinimalAppCreateWizard` component.
@@ -792,6 +794,8 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         document.getElementById("notification-div")?.scrollIntoView({ behavior: "smooth" });
     };
 
+    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
+
     /**
      * Checks whether the application name is valid.
      * @param value - Application name as a form value.
@@ -1132,20 +1136,29 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                         && isFAPIAppCreationEnabled
                         && (
                             <div className="pt-0 mt-0">
-                                <Field
-                                    data-componentid={ `${ testId }-fapi-app-checkbox` }
-                                    name={ "isFAPIApp" }
-                                    required={ false }
-                                    type="checkbox"
-                                    value={ [ "isFAPIApp" ] }
-                                    children={ [
-                                        {
-                                            label: t("applications:forms.generalDetails" +
-                                                ".fields.isFapiApp.label" ),
-                                            value: "fapiApp"
-                                        }
-                                    ] }
-                                />
+                                <div style={{ alignItems: "center", display: "flex" }}>
+                                    <Field
+                                        data-componentid={ `${ testId }-fapi-app-checkbox` }
+                                        name={ "isFAPIApp" }
+                                        required={ false }
+                                        type="checkbox"
+                                        value={ [ "isFAPIApp" ] }
+                                        children={ [
+                                            {
+                                                label: t("applications:forms.generalDetails" +
+                                                    ".fields.isFapiApp.label" ),
+                                                value: "fapiApp"
+                                            }
+                                        ] }
+                                    />
+                                    { isSAASDeployment && (
+                                        <div style={{ marginLeft: "10px", marginTop: "-10px" }}>
+                                            <Chip
+                                                label="PREVIEW"
+                                                className="oxygen-menu-item-chip oxygen-chip-preview" />
+                                        </div>
+                                    ) }
+                                </div>
                                 <Hint compact>
                                     { t("applications:forms.generalDetails.fields" +
                                         ".isFapiApp.hint" ) }

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -794,8 +794,6 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
         document.getElementById("notification-div")?.scrollIntoView({ behavior: "smooth" });
     };
 
-    const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
-
     /**
      * Checks whether the application name is valid.
      * @param value - Application name as a form value.

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import Box from "@oxygen-ui/react/Box";
 import Chip from "@oxygen-ui/react/Chip";
 import { Show } from "@wso2is/access-control";
 import useUIConfig from "../../../admin.core.v1/hooks/use-ui-configs";
@@ -1134,10 +1135,10 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                         && isFAPIAppCreationEnabled
                         && (
                             <div className="pt-0 mt-0">
-                                <div className="app-type-checkbox" >
+                                <Box display="flex" alignItems="center">
                                     <Field
                                         data-componentid={ `${ testId }-fapi-app-checkbox` }
-                                        name={ "isFAPIApp" }
+                                        name="isFAPIApp"
                                         required={ false }
                                         type="checkbox"
                                         value={ [ "isFAPIApp" ] }
@@ -1149,14 +1150,14 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                                             }
                                         ] }
                                     />
-                                    { applicationConfig.advancedConfigurations.showFapiBetaChip && (
+                                    { applicationConfig.advancedConfigurations.showFapiFeatureStatusChip && (
                                         <div className="oxygen-chip-div" >
                                             <Chip
-                                                label="BETA"
+                                                label={ t("common:beta") }
                                                 className="oxygen-menu-item-chip oxygen-chip-beta" />
                                         </div>
                                     ) }
-                                </div>
+                                </Box>
                                 <Hint compact>
                                     { t("applications:forms.generalDetails.fields" +
                                         ".isFapiApp.hint" ) }

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -1136,7 +1136,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                         && isFAPIAppCreationEnabled
                         && (
                             <div className="pt-0 mt-0">
-                                <div style={ { alignItems: "center", display: "flex" } }>
+                                <div className="app-type-checkbox" >
                                     <Field
                                         data-componentid={ `${ testId }-fapi-app-checkbox` }
                                         name={ "isFAPIApp" }
@@ -1152,7 +1152,7 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                                         ] }
                                     />
                                     { isSAASDeployment && (
-                                        <div style={ { marginLeft: "10px", marginTop: "-10px" } }>
+                                        <div className="oxygen-chip-div" >
                                             <Chip
                                                 label="PREVIEW"
                                                 className="oxygen-menu-item-chip oxygen-chip-preview" />

--- a/features/admin.applications.v1/models/application.ts
+++ b/features/admin.applications.v1/models/application.ts
@@ -674,6 +674,8 @@ export interface OIDCApplicationConfigurationInterface {
     sessionIframeEndpoint?: string;
     webFingerEndpoint?: string;
     dynamicClientRegistrationEndpoint?: string;
+    mtlsTokenEndpoint?: string;
+    mtlsPushedAuthorizationRequestEndpoint?: string;
 }
 
 /**

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -107,6 +107,8 @@ export const applicationConfig: ApplicationConfig = {
     advancedConfigurations: {
         showDefaultMyAccountApplicationEditPage: true,
         showEnableAuthorization: true,
+        showFapiBetaChip: false,
+        showMtlsAliases: false,
         showMyAccount: true,
         showMyAccountStatus: false,
         showReturnAuthenticatedIdPs: true,

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -107,7 +107,7 @@ export const applicationConfig: ApplicationConfig = {
     advancedConfigurations: {
         showDefaultMyAccountApplicationEditPage: true,
         showEnableAuthorization: true,
-        showFapiBetaChip: false,
+        showFapiFeatureStatusChip: false,
         showMtlsAliases: false,
         showMyAccount: true,
         showMyAccountStatus: false,

--- a/features/admin.extensions.v1/configs/models/application.ts
+++ b/features/admin.extensions.v1/configs/models/application.ts
@@ -33,6 +33,8 @@ import { SDKMetaInterface } from "../../application-templates/templates/single-p
 export interface ApplicationConfig {
     advancedConfigurations: {
         showEnableAuthorization: boolean;
+        showFapiBetaChip: boolean;
+        showMtlsAliases: boolean;
         showMyAccount: boolean;
         showMyAccountStatus: boolean;
         showDefaultMyAccountApplicationEditPage: boolean;

--- a/features/admin.extensions.v1/configs/models/application.ts
+++ b/features/admin.extensions.v1/configs/models/application.ts
@@ -33,7 +33,7 @@ import { SDKMetaInterface } from "../../application-templates/templates/single-p
 export interface ApplicationConfig {
     advancedConfigurations: {
         showEnableAuthorization: boolean;
-        showFapiBetaChip: boolean;
+        showFapiFeatureStatusChip: boolean;
         showMtlsAliases: boolean;
         showMyAccount: boolean;
         showMyAccountStatus: boolean;

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -396,6 +396,8 @@ export interface ApplicationsNS {
                 tabName: string;
             };
             info: {
+                mtlsOidcHeading: string;
+                mtlsOidcSubHeading: string;
                 oidcHeading: string;
                 oidcSubHeading: string;
                 samlHeading: string;

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -450,6 +450,10 @@ export const applications: ApplicationsNS = {
                 tabName: "General"
             },
             info: {
+                mtlsOidcHeading: "Mutual TLS Server Endpoints",
+                mtlsOidcSubHeading: "The following server endpoints will be useful for you to implement " +
+                    "and configure authentication for your application using OpenID Connect where MTLS " +
+                    "client authentication or certificate token binding is applicable. ",
                 oidcHeading: "Server Endpoints",
                 oidcSubHeading: "The following server endpoints will be useful for you to implement and " +
                     "configure authentication for your application using OpenID Connect.",


### PR DESCRIPTION
### Purpose
This PR adds MTLS endpoints to the info tab of the OIDC applications and a preview label for FAPI app creation.

<img width="726" alt="Screenshot 2024-04-30 at 15 18 14" src="https://github.com/wso2/identity-apps/assets/25494651/1a16b104-a835-433b-acd1-6fb4278765e7">


<img width="916" alt="Screenshot 2024-04-29 at 15 51 51" src="https://github.com/wso2/identity-apps/assets/25494651/baa068e0-8928-4b23-9ec2-bcfbe1723628">


### Related Issues
- 

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5659
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2440

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
