### PR TITLE
Update logic for user reset password buttons' state

### DIFF
--- a/.changeset/long-mirrors-smoke.md
+++ b/.changeset/long-mirrors-smoke.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/features": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+---
+
+Update logic to disable Reset Password button in user profile.

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -1132,9 +1132,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                                         onActionClick={ (): void => {
                                                             setOpenChangePasswordModal(true);
                                                         } }
-                                                        isButtonDisabled={ accountLocked
-                                                            ? accountLocked
-                                                            : user[ userConfig.userProfileSchema ]?.accountLocked }
+                                                        isButtonDisabled={ accountLocked }
                                                         buttonDisableHint={ t("user:editUser." +
                                                             "dangerZoneGroup.passwordResetZone.buttonHint") }
                                                     />


### PR DESCRIPTION
### Purpose
There is a redundant condition to check the disabled state of the password reset button of a user in the user's profile.

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
