### PR TITLE
resolve ldap user store pagination issue

### DIFF
--- a/.changeset/happy-adults-repair.md
+++ b/.changeset/happy-adults-repair.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+Fix LDAP userstore pagination

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -49,8 +49,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router";
 import { Dispatch } from "redux";
 import { Dropdown, DropdownItemProps, DropdownProps, Icon, PaginationProps, TabProps } from "semantic-ui-react";
-import { userstoresConfig } from "../../admin.extensions.v1";
-import { FeatureGateConstants } from "../../admin.extensions.v1/components/feature-gate/constants/feature-gate";
 import {
     AdvancedSearchWithBasicFilters,
     AppConstants,
@@ -64,6 +62,8 @@ import {
     getEmptyPlaceholderIllustrations,
     history
 } from "../../admin.core.v1";
+import { userstoresConfig } from "../../admin.extensions.v1";
+import { FeatureGateConstants } from "../../admin.extensions.v1/components/feature-gate/constants/feature-gate";
 import { useGetCurrentOrganizationType } from "../../admin.organizations.v1/hooks/use-get-organization-type";
 import {
     ConnectorPropertyInterface,
@@ -554,6 +554,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
         } else {
             setSelectedUserStore(data.value as string);
         }
+        setListOffset(0);
     };
 
     const onUserDelete = (): void => {
@@ -684,7 +685,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                         />) : null
                 }
                 showPagination={ true }
-                totalPages={ Math.ceil(usersList?.totalResults / listItemLimit) }
+                totalPages={ resolveTotalPages() }
                 totalListSize={ usersList?.totalResults }
                 paginationOptions={ {
                     disableNextButton: !isNextPageAvailable


### PR DESCRIPTION
### Purpose
Fix the following issues
- `next` button not working for LDAP userstores
- When switching back to `primary` user store from `LDAP` userstore's second page, if there are no second page in `primary` user store, no entries are shown.


https://github.com/wso2/identity-apps/assets/59327626/baf2732e-d6ce-4ab5-8675-58e9120c9266

### Related Issues
- https://github.com/wso2/product-is/issues/20234
