### PR TITLE
[improvement] Move session refresh logic to Application level

### DIFF
--- a/apps/console/src/init/init.ts
+++ b/apps/console/src/init/init.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { CommonConstants } from "@wso2is/core/constants";
 import TimerWorker from "@wso2is/core/workers/timer.worker";
 import { UAParser } from "ua-parser-js";
 import { AppUtils } from "./app-utils";
@@ -70,6 +71,11 @@ function handleTimeOut(_idleSecondsCounter: number, _sessionAgeCounter: number,
         window.history.pushState(state, null, searchParam);
 
         dispatchEvent(new MessageEvent("session-timeout", { data: state }));
+    }
+
+    if (_sessionAgeCounter % SESSION_REFRESH_TIMEOUT === 0
+            && _idleSecondsCounter < SESSION_REFRESH_TIMEOUT) {
+        dispatchEvent(new MessageEvent(CommonConstants.SESSION_REFRESH_EVENT));
     }
 
     return _sessionAgeCounter;

--- a/apps/console/src/init/init.ts
+++ b/apps/console/src/init/init.ts
@@ -73,6 +73,7 @@ function handleTimeOut(_idleSecondsCounter: number, _sessionAgeCounter: number,
         dispatchEvent(new MessageEvent("session-timeout", { data: state }));
     }
 
+    // Refresh session every SESSION_REFRESH_TIMEOUT seconds if the user is active.
     if (_sessionAgeCounter % SESSION_REFRESH_TIMEOUT === 0
             && _idleSecondsCounter < SESSION_REFRESH_TIMEOUT) {
         dispatchEvent(new MessageEvent(CommonConstants.SESSION_REFRESH_EVENT));

--- a/features/admin.authentication.v1/utils/authenticate-utils.ts
+++ b/features/admin.authentication.v1/utils/authenticate-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/features/admin.authentication.v1/utils/authenticate-utils.ts
+++ b/features/admin.authentication.v1/utils/authenticate-utils.ts
@@ -73,7 +73,7 @@ export class AuthenticateUtils {
             responseMode: window["AppUtils"]?.getConfig()?.idpConfigs?.responseMode ?? responseModeFallback,
             scope: window["AppUtils"]?.getConfig()?.idpConfigs?.scope ?? [ TokenConstants.SYSTEM_SCOPE ],
             sendCookiesInRequests: true,
-            sessionRefreshInterval: window[ "AppUtils" ]?.getConfig()?.session?.sessionRefreshTimeOut,
+            sessionRefreshInterval: -1,
             signInRedirectURL: window["AppUtils"]?.getConfig()?.loginCallbackURL,
             signOutRedirectURL: window["AppUtils"]?.getConfig()?.loginCallbackURL,
             storage: AuthenticateUtils.resolveStorage() as Storage.WebWorker,

--- a/modules/core/src/constants/common-constants.ts
+++ b/modules/core/src/constants/common-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,30 +25,27 @@ export class CommonConstants {
      * Private constructor to avoid object instantiation from outside
      * the class.
      *
-     * @hideconstructor
      */
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     private constructor() { }
 
     /**
      * Generic Axios fetch request error message.
-     * @constant
-     * @type {string}
-     * @default
      */
     public static readonly AXIOS_FETCH_REQUEST_ERROR_MESSAGE: string = "An error occurred while executing the request";
 
     /**
      * Key which will appear on the URL to denote session timeout state.
-     * This should be same as the key used in session management logic in `index.(jsp|html) files in portals.
-     * @type {string}
+     * This should be same as the key used in session management logic in `index.(jsp|html)` files in portals.
      */
     public static readonly SESSION_TIMEOUT_WARNING_URL_SEARCH_PARAM_KEY: string = "session_timeout_warning";
     /**
      * The name of the event dispatched when authentication successful.
-     * @constant
-     * @type {string}
-     * @default
      */
     public static readonly AUTHENTICATION_SUCCESSFUL_EVENT: string = "authentication-successful";
+
+    /**
+     * The name of the event dispatched when session refresh is required.
+     */
+    public static readonly SESSION_REFRESH_EVENT: string = "session-refresh";
 }

--- a/modules/react-components/src/providers/session-management/session-management-provider.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-provider.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -193,11 +193,20 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
                 setShowSessionTimeoutModal(JSON.parse(timeout));
             };
 
+            const sessionRefreshListener = (_: MessageEventInit) => {
+                if (onLoginAgain) {
+                    onLoginAgain();
+                }
+            };
+
             window.addEventListener("session-timeout", sessionTimeoutListener);
+
+            window.addEventListener(CommonConstants.SESSION_REFRESH_EVENT, sessionRefreshListener);
 
             return () => {
                 performCleanupTasks();
-                window.removeEventListener("session-timeout",sessionTimeoutListener);
+                window.removeEventListener("session-timeout", sessionTimeoutListener);
+                window.removeEventListener(CommonConstants.SESSION_REFRESH_EVENT, sessionRefreshListener);
             };
         }, []);
 

--- a/modules/react-components/src/providers/session-management/session-management-provider.tsx
+++ b/modules/react-components/src/providers/session-management/session-management-provider.tsx
@@ -193,6 +193,9 @@ export const SessionManagementProvider: FunctionComponent<PropsWithChildren<
                 setShowSessionTimeoutModal(JSON.parse(timeout));
             };
 
+            /**
+             * A listener to handle periodic session refresh.
+             */
             const sessionRefreshListener = (_: MessageEventInit) => {
                 if (onLoginAgain) {
                     onLoginAgain();


### PR DESCRIPTION
### Purpose
Session refresh logic is moved to the Console application level. And disabled from the SDK. Improvement is done to avoid sending session refresh calls when the user is inactive.

### Related Issues
- https://github.com/wso2/product-is/issues/20181

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
