### PR TITLE
Update danger zone hiding logic

### DIFF
--- a/.changeset/nervous-scissors-greet.md
+++ b/.changeset/nervous-scissors-greet.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Update danger zone hiding logic

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -25,6 +25,7 @@ import {
     MultiValueAttributeInterface,
     ProfileInfoInterface,
     ProfileSchemaInterface,
+    RolesMemberInterface,
     TestableComponentInterface
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
@@ -190,6 +191,9 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
     user[userConfig.userProfileSchema]?.accountLocked === true;
     const accountDisabled: boolean = user[userConfig.userProfileSchema]?.accountDisabled === "true";
     const oneTimePassword: string = user[userConfig.userProfileSchema]?.oneTimePassword;
+    const isCurrentUserAdmin: boolean = user?.roles?.some((role: RolesMemberInterface) =>
+        role.display === administratorConfig.adminRoleName) ?? false;
+
 
     useEffect(() => {
 
@@ -1099,14 +1103,14 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         }
 
         const resolvedUsername: string = resolveUsernameOrDefaultEmail(user, false);
-        const isUserSystemAdminOrTenantAdminOrCurrentLoggedInUser: boolean =
-            [ tenantAdmin, adminUsername ]?.includes(resolvedUsername) || authenticatedUser?.includes(resolvedUsername);
+        const isUserCurrentLoggedInUser: boolean =
+            authenticatedUser?.includes(resolvedUsername);
 
         return (
             <>
                 {
                     (!isReadOnly || allowDeleteOnly || isUserManagedByParentOrg)
-                    && !isUserSystemAdminOrTenantAdminOrCurrentLoggedInUser ? (
+                    && (!isCurrentUserAdmin || !isUserCurrentLoggedInUser) ? (
                             <Show
                                 when={ featureConfig?.users?.scopes?.delete }
                             >

--- a/features/admin.users.v1/components/users-list.tsx
+++ b/features/admin.users.v1/components/users-list.tsx
@@ -52,7 +52,6 @@ import {
 import { SCIMConfigs } from "../../admin.extensions.v1/configs/scim";
 import { userConfig } from "../../admin.extensions.v1/configs/user";
 import { userstoresConfig } from "../../admin.extensions.v1/configs/userstores";
-import { useGetCurrentOrganizationType } from "../../admin.organizations.v1/hooks/use-get-organization-type";
 import { RealmConfigInterface } from "../../admin.server-configurations.v1";
 import { deleteUser } from "../api";
 import { UserManagementConstants } from "../constants";
@@ -151,7 +150,6 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
         onColumnSelectionChange,
         onListItemClick,
         onSearchQueryClear,
-        realmConfigs,
         searchQuery,
         selection,
         showListItemActions,
@@ -165,14 +163,13 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
     const { t } = useTranslation();
     const dispatch: Dispatch = useDispatch();
 
-    const { isSubOrganization } = useGetCurrentOrganizationType();
-
     const [ showDeleteConfirmationModal, setShowDeleteConfirmationModal ] = useState<boolean>(false);
     const [ deletingUser, setDeletingUser ] = useState<UserBasicInterface>(undefined);
     const [ loading, setLoading ] = useState(false);
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const authenticatedUser: string = useSelector((state: AppState) => state?.auth?.providedUsername);
+    const isAuthUserPrivileged: boolean = useSelector((state: AppState) => state.auth.isPrivilegedUser);
 
     const handleUserEdit = (userId: string) => {
         history.push(AppConstants.getPaths().get("USER_EDIT").replace(":id", userId));
@@ -488,8 +485,7 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
                     UserManagementConstants.FEATURE_DICTIONARY.get("USER_DELETE"))
                     || !hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.delete, allowedScopes)
                     || readOnlyUserStores?.includes(userStore.toString())
-                    || (getUserNameWithoutDomain(user?.userName) === realmConfigs?.adminUser && !isSubOrganization())
-                    || authenticatedUser === getUserNameWithoutDomain(user?.userName);
+                    || authenticatedUser === getUserNameWithoutDomain(user?.userName) && isAuthUserPrivileged;
             },
             icon: (): SemanticICONS => "trash alternate",
             onClick: (e: SyntheticEvent, user: UserBasicInterface): void => {


### PR DESCRIPTION
### Purpose
Updated the danger zone hiding logic to incorporate the new admin roles and to make sure the danger zone is shown when an admin creates a business user account with the same email

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
