### PR TITLE
[Hotfix] Separate out the deployment config for parent user invitation

### DIFF
--- a/.changeset/loud-humans-divide.md
+++ b/.changeset/loud-humans-divide.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/myaccount": patch
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+Separating the parent user invitation deployment configs

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -961,6 +961,36 @@
                 }
             },
             {% endif %}
+            {% if console.parent_user_invitation is defined %}
+            "parentUserInvitation": {
+                "disabledFeatures": [
+                    {% if console.parent_user_invitation.disabled_features is defined %}
+                    {% for feature in console.parent_user_invitation.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {% if console.parent_user_invitation.enabled is defined %} {{ console.parent_user_invitation.enabled }},
+                {% else %} true,
+                {% endif %}
+                "scopes": {
+                    {% if console.parent_user_invitation.scopes is defined %}
+                    {% for operation, scopes in console.parent_user_invitation.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "read": [],
+                        "update": [],
+                        "delete": []
+                    {% endif %}
+                }
+            },
+            {% endif %}
             {% if console.identity_providers is defined %}
             "identityProviders": {
                 "disabledFeatures": [

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -608,6 +608,25 @@
                     ]
                 }
             },
+            "parentUserInvitation": {
+                "enabled": true,
+                "disabledFeatures": [],
+                "scopes": {
+                    "delete": [
+                        "internal_guest_mgt_invite_delete",
+                        "internal_guest_mgt_user_delete"
+                    ],
+                    "read": [
+                        "internal_guest_mgt_invite_list"
+                    ],
+                    "create": [
+                        "internal_guest_mgt_invite_add"
+                    ],
+                    "update": [
+                        "internal_guest_mgt_invite_update"
+                    ]
+                }
+            },
             "identityProviders": {
                 "disabledFeatures": [],
                 "enabled": true,

--- a/features/admin.core.v1/models/config.ts
+++ b/features/admin.core.v1/models/config.ts
@@ -134,6 +134,10 @@ export interface FeatureConfigInterface {
      */
     guestUser?: FeatureAccessConfigInterface;
     /**
+     * Parent User Invite Feature
+     */
+    parentUserInvitation?: FeatureAccessConfigInterface;
+    /**
      * Identity provider management feature.
      */
     identityProviders?: FeatureAccessConfigInterface;

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -743,7 +743,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
             });
         }
         if (isSubOrganization() &&
-            featureConfig?.guestUser?.enabled &&
+            featureConfig?.parentUserInvitation?.enabled &&
             hasRequiredScopes(featureConfig?.guestUser, featureConfig?.guestUser?.scopes?.create, allowedScopes)) {
             dropDownOptions.push({
                 "data-componentid": `${componentId}-invite-parent-user`,
@@ -827,11 +827,13 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
             render: renderUsersList
         });
 
-        panes.push({
-            componentId: "invitations",
-            menuItem: t("parentOrgInvitations:tab.invitationsTab"),
-            render: renderInvitationsList
-        });
+        if (featureConfig?.parentUserInvitation?.enabled) {
+            panes.push({
+                componentId: "invitations",
+                menuItem: t("parentOrgInvitations:tab.invitationsTab"),
+                render: renderInvitationsList
+            });
+        }
 
         return panes;
     };


### PR DESCRIPTION
### Purpose
- $subject to keep the fine grain access to handle the feature properties.

### Related PRs
- Master : https://github.com/wso2/identity-apps/pull/6174