### PR TITLE
Consider Enterprise User Schema when Displaying User Profiles in Console

### DIFF
--- a/.changeset/tall-beers-drum.md
+++ b/.changeset/tall-beers-drum.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Consider enterprise user schema when displaying user profiles in Console.

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -315,10 +315,10 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                 return;
                             }
 
-                            if (schema.extended && userInfo[userConfig.userProfileSchema]
-                                && userInfo[userConfig.userProfileSchema][schemaNames[0]]) {
+                            if (schema.extended && userInfo[ProfileConstants.SCIM2_ENT_USER_SCHEMA]
+                                && userInfo[ProfileConstants.SCIM2_ENT_USER_SCHEMA][schemaNames[0]]) {
                                 tempProfileInfo.set(
-                                    schema.name, userInfo[userConfig.userProfileSchema][schemaNames[0]]
+                                    schema.name, userInfo[ProfileConstants.SCIM2_ENT_USER_SCHEMA][schemaNames[0]]
                                 );
 
                                 return;
@@ -396,10 +396,10 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                 return;
                             }
 
-                            if (schema.extended && userInfo[userConfig.userProfileSchema]
-                                && userInfo[userConfig.userProfileSchema][schemaNames[0]]) {
+                            if (schema.extended && userInfo[ProfileConstants.SCIM2_ENT_USER_SCHEMA]
+                                && userInfo[ProfileConstants.SCIM2_ENT_USER_SCHEMA][schemaNames[0]]) {
                                 tempProfileInfo.set(
-                                    schema.name, userInfo[ProfileConstants.SCIM2_WSO2_CUSTOM_SCHEMA][schemaNames[0]]
+                                    schema.name, userInfo[ProfileConstants.SCIM2_ENT_USER_SCHEMA][schemaNames[0]]
                                 );
 
                                 return;


### PR DESCRIPTION
### Purpose
- Consider claims in `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` schema when displaying user profiles in Console.

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation. - N/A
- [x] Documentation provided. (Add links if there are any) - N/A
- [x] Unit tests provided. (Add links if there are any) - N/A
- [x] Integration tests provided. (Add links if there are any) - N/A

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
