### PR TITLE
Fix error during users fetch

### DIFF
--- a/.changeset/angry-falcons-wait.md
+++ b/.changeset/angry-falcons-wait.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Fix error during user fetch

--- a/features/admin.groups.v1/components/edit-group/edit-group.tsx
+++ b/features/admin.groups.v1/components/edit-group/edit-group.tsx
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import useUIConfig from "../../../admin.core.v1/hooks/use-ui-configs";
 import { hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertLevels, FeatureAccessConfigInterface, SBACInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
@@ -32,6 +31,7 @@ import { BasicGroupDetails } from "./edit-group-basic";
 import { EditGroupRoles } from "./edit-group-roles";
 import { GroupRolesV1List } from "./edit-group-roles-v1";
 import { GroupUsersList } from "./edit-group-users";
+import useUIConfig from "../../../admin.core.v1/hooks/use-ui-configs";
 import { FeatureConfigInterface } from "../../../admin.core.v1/models";
 import { AppState } from "../../../admin.core.v1/store";
 import { getUsersList } from "../../../admin.users.v1/api";
@@ -139,8 +139,10 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
 
         getUsersList(null, null, null, null, userstore)
             .then((response: UserListInterface) => {
-                setUsersList(response.Resources);
-                setSelectedUsersList(filterUsersList([ ...response.Resources ]));
+                if (response.Resources?.length > 0) {
+                    setUsersList(response.Resources);
+                    setSelectedUsersList(filterUsersList([ ...response.Resources ]));
+                }
             })
             .catch((error: AxiosError) => {
                 if (error?.response?.data?.description) {

--- a/features/admin.groups.v1/components/edit-group/edit-group.tsx
+++ b/features/admin.groups.v1/components/edit-group/edit-group.tsx
@@ -139,10 +139,8 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
 
         getUsersList(null, null, null, null, userstore)
             .then((response: UserListInterface) => {
-                if (response.Resources?.length > 0) {
-                    setUsersList(response.Resources);
-                    setSelectedUsersList(filterUsersList([ ...response.Resources ]));
-                }
+                setUsersList(response.Resources);
+                setSelectedUsersList(filterUsersList(response.Resources));
             })
             .catch((error: AxiosError) => {
                 if (error?.response?.data?.description) {
@@ -178,7 +176,7 @@ export const EditGroup: FunctionComponent<EditGroupProps> = (props: EditGroupPro
      */
     const filterUsersList = (usersToFilter: UserBasicInterface[]): UserBasicInterface[] => {
 
-        if (!group?.members || !Array.isArray(group.members) || group.members.length < 1) {
+        if (!group?.members || !Array.isArray(group.members) || group.members.length < 1 || !usersToFilter) {
             return;
         }
 


### PR DESCRIPTION
### Purpose
This PR fixes an issue in which an error message is displayed if the backend returned an empty user list in the groups page


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
