### PR TITLE
Remove primary userstore from userstore dropdown in groups section

### DIFF
--- a/.changeset/great-queens-marry.md
+++ b/.changeset/great-queens-marry.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Remove primary userstore from userstore dropdown in groups section

--- a/features/admin.groups.v1/pages/groups.tsx
+++ b/features/admin.groups.v1/pages/groups.tsx
@@ -161,8 +161,8 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
         const storeOptions: DropdownItemProps[] = [
             {
                 key: -1,
-                text: "Primary",
-                value: PRIMARY_USERSTORE
+                text: userstoresConfig.primaryUserstoreName,
+                value: userstoresConfig.primaryUserstoreName
             }
         ];
 
@@ -181,22 +181,24 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                     }
 
                     response.data.map((store: UserstoreListResponseInterface, index: number) => {
-                        setUserStoreRequestLoading(true);
-                        getAUserStore(store.id).then((response: UserStorePostData) => {
-                            const isDisabled: boolean = response.properties.find(
-                                (property: UserStoreProperty) => property.name === "Disabled")?.value === "true";
+                        if (store.name.toUpperCase() !== userstoresConfig.primaryUserstoreName) {
+                            setUserStoreRequestLoading(true);
+                            getAUserStore(store.id).then((response: UserStorePostData) => {
+                                const isDisabled: boolean = response.properties.find(
+                                    (property: UserStoreProperty) => property.name === "Disabled")?.value === "true";
 
-                            if (!isDisabled) {
-                                storeOption = {
-                                    key: index,
-                                    text: store.name,
-                                    value: store.name
-                                };
-                                storeOptions.push(storeOption);
-                            }
-                        }).finally(() => {
-                            setUserStoreRequestLoading(false);
-                        });
+                                if (!isDisabled) {
+                                    storeOption = {
+                                        key: index,
+                                        text: store.name,
+                                        value: store.name
+                                    };
+                                    storeOptions.push(storeOption);
+                                }
+                            }).finally(() => {
+                                setUserStoreRequestLoading(false);
+                            });
+                        }
                     });
 
                     setUserStoresList(storeOptions);


### PR DESCRIPTION
### Purpose
Remove primary userstore from userstore dropdown in groups section

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
