### PR TITLE
Set updating email domains Immediately in state on input change

### DIFF
--- a/.changeset/heavy-pens-grab.md
+++ b/.changeset/heavy-pens-grab.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Fixed issue causing input value disappearance when configuring additional email domains in email domain discovery edit view

--- a/features/admin.organization-discovery.v1/components/edit-organization-discovery-domains.tsx
+++ b/features/admin.organization-discovery.v1/components/edit-organization-discovery-domains.tsx
@@ -213,6 +213,8 @@ const EditOrganizationDiscoveryDomains: FunctionComponent<EditOrganizationDiscov
      * @param emailDomainList - Email domains.
      */
     const validateEmailDomainCreation = async (emailDomainList: string[]) => {
+        setEmailDomains(emailDomainList);
+
         // Convert email domain list to a lower case array.
         emailDomainList = emailDomainList.map((emailDomain: string) => emailDomain.toLowerCase());
 
@@ -221,6 +223,7 @@ const EditOrganizationDiscoveryDomains: FunctionComponent<EditOrganizationDiscov
         if (!isEmailDomainValid) {
             setIsEmailDomainDataError(true);
             emailDomainList.pop();
+            setEmailDomains(emailDomainList);
 
             return;
         }
@@ -231,11 +234,10 @@ const EditOrganizationDiscoveryDomains: FunctionComponent<EditOrganizationDiscov
         if (!isEmailDomainAvailable) {
             setIsEmailDomainAvailableError(true);
             emailDomainList.pop();
+            setEmailDomains(emailDomainList);
 
             return;
         }
-
-        setEmailDomains(emailDomainList);
     };
 
     return (


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

When a new email domain is entered in the email domain discovery edit form, the entered value is disappeared for some time before it appears in the autocomplete input box. This is due to the updated email domain list being set in state after checking domain availability and domain validation.

This PR will change the implementation to immediately set the updated email domain list in state and then do the validation and availability check and update the state accordingly, so that the valid email domains entered immediately appear in the input box on enter.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
