### PR TITLE
Disable application roles

### DIFF
--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -233,7 +233,7 @@
             },
             "applicationRoles": {
                 "disabledFeatures": [],
-                "enabled": true,
+                "enabled": false,
                 "scopes": {
                     "update": [],
                     "read": [],


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Application roles are related to the legacy runtime and it's deprecated in IS 7 and onwards. However, the related feature configs still indicate that it is enabled. This causes groups page to show the old application roles related UIs instead of new UI for new authz runtime.

The reason this didn't affect the IS7 pack was that the group related routes were not unified back then. Since they are unified now, this issue started to appear in the latest IS build.

Therefore, this PR is to disable application roles through deployment configs.

### Related Issues
- fixes https://github.com/wso2/product-is/issues/20355

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
