### PR TITLE
Add missing class imports

### DIFF
--- a/.changeset/thin-boxes-attack.md
+++ b/.changeset/thin-boxes-attack.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add missing class imports

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/footer.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/footer.jsp
@@ -19,8 +19,11 @@
 <script src="libs/jquery_3.6.0/jquery-3.6.0.min.js"></script>
 <script src="libs/themes/wso2is/semantic.min.js"></script>
 
+<%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.Arrays" %>
 
 <%
     // Determining whether the application user is going to login is Console, as the maintenance banner


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Required class imported for the logic related to conditionally enabling downtime banner in recovery portal are missing. Therefore, users can't access the recovery portal in cloud deployment. 

This PR fixes the issue by adding the missing class imports.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
