### PR TITLE
Make system roles not clickable when `isEditingSystemRolesAllowed` config is false

### DIFF
--- a/.changeset/thirty-eels-juggle.md
+++ b/.changeset/thirty-eels-juggle.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Make system roles not clickable when isEditingSystemRolesAllowed is false

--- a/features/admin.roles.v2/components/role-list.tsx
+++ b/features/admin.roles.v2/components/role-list.tsx
@@ -101,6 +101,8 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
     const administratorRoleDisplayName: string = useSelector(
         (state: AppState) => state?.config?.ui?.administratorRoleDisplayName);
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const isEditingSystemRolesAllowed: boolean =
+        useSelector((state: AppState) => state?.config?.ui?.isSystemRolesEditAllowed);
 
     const isReadOnly: boolean = useMemo(() => {
         return !isFeatureEnabled(userRolesFeatureConfig,
@@ -325,7 +327,10 @@ export const RoleList: React.FunctionComponent<RoleListProps> = (props: RoleList
                 columns={ resolveTableColumns() }
                 data={ roleList?.Resources }
                 onRowClick={
-                    (e: SyntheticEvent, role: RolesInterface): void => {
+                    (_e: SyntheticEvent, role: RolesInterface): void => {
+                        if (!isEditingSystemRolesAllowed && role?.meta?.systemRole) {
+                            return;
+                        }
                         handleRoleEdit(role?.id);
                     }
                 }


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
$subject

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
