### PR TITLE
Add component ids for organization discovery domain pages

### DIFF
--- a/.changeset/slow-weeks-listen.md
+++ b/.changeset/slow-weeks-listen.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Add component ids

--- a/features/admin.organization-discovery.v1/components/add-organization-discovery-domains.tsx
+++ b/features/admin.organization-discovery.v1/components/add-organization-discovery-domains.tsx
@@ -315,6 +315,7 @@ const AddOrganizationDiscoveryDomains: FunctionComponent<AddOrganizationDiscover
                                 multiple
                                 freeSolo
                                 disableCloseOnSelect
+                                data-componentid={ `${componentId}-form-organization-email-domain-field` }
                                 size="small"
                                 id="tags-filled"
                                 options={ optionsArray.map((option: string) => option) }


### PR DESCRIPTION
### Purpose
- $subject to identify the components uniquely.