### PR TITLE
Prevent multiple scopes api calls in the api authorization tab

### DIFF
--- a/.changeset/hip-coins-kiss.md
+++ b/.changeset/hip-coins-kiss.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Prevent multiple scopes API calls in the API Authorization

--- a/features/admin.applications.v1/api/use-scopes-of-api-resources.ts
+++ b/features/admin.applications.v1/api/use-scopes-of-api-resources.ts
@@ -33,8 +33,7 @@ import { AuthorizedPermissionListItemInterface } from "../models/api-authorizati
  * @throws `IdentityAppsApiException`
  */
 const useScopesOfAPIResources = <Data = AuthorizedPermissionListItemInterface[], Error = RequestErrorInterface>(
-    apiResourceId: string,
-    shouldFetch: boolean = false
+    apiResourceId: string
 ): RequestResultInterface<Data, Error> => {
 
     const requestConfig: AxiosRequestConfig = {
@@ -47,7 +46,7 @@ const useScopesOfAPIResources = <Data = AuthorizedPermissionListItemInterface[],
     };
 
     const { data, error, isValidating, mutate } = useRequest<Data, Error>(
-        (apiResourceId && shouldFetch)
+        (apiResourceId)
             ? requestConfig
             : null
     );

--- a/features/admin.applications.v1/api/use-scopes-of-api-resources.ts
+++ b/features/admin.applications.v1/api/use-scopes-of-api-resources.ts
@@ -33,7 +33,8 @@ import { AuthorizedPermissionListItemInterface } from "../models/api-authorizati
  * @throws `IdentityAppsApiException`
  */
 const useScopesOfAPIResources = <Data = AuthorizedPermissionListItemInterface[], Error = RequestErrorInterface>(
-    apiResourceId: string
+    apiResourceId: string,
+    shouldFetch: boolean = false
 ): RequestResultInterface<Data, Error> => {
 
     const requestConfig: AxiosRequestConfig = {
@@ -45,7 +46,11 @@ const useScopesOfAPIResources = <Data = AuthorizedPermissionListItemInterface[],
         url: `${ store.getState().config.endpoints.apiResources }/${ apiResourceId }/scopes`
     };
 
-    const { data, error, isValidating, mutate } = useRequest<Data, Error>(apiResourceId ? requestConfig: null);
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(
+        (apiResourceId && shouldFetch)
+            ? requestConfig
+            : null
+    );
 
     return {
         data,

--- a/features/admin.applications.v1/api/use-scopes-of-api-resources.ts
+++ b/features/admin.applications.v1/api/use-scopes-of-api-resources.ts
@@ -17,11 +17,11 @@
  */
 
 import { HttpMethods } from "@wso2is/core/models";
+import { AxiosRequestConfig } from "axios";
 import useRequest, {
     RequestErrorInterface,
     RequestResultInterface
 } from "../../admin.core.v1/hooks/use-request";
-import { AxiosRequestConfig } from "axios";
 import { store } from "../../admin.core.v1/store";
 import { AuthorizedPermissionListItemInterface } from "../models/api-authorization";
 

--- a/features/admin.applications.v1/components/api-authorization/scope-form.tsx
+++ b/features/admin.applications.v1/components/api-authorization/scope-form.tsx
@@ -106,7 +106,6 @@ export const ScopeForm: FunctionComponent<ScopeFormInterface> = (
     const [ isSelectAllDisabled, setIsSelectAllDisabled ] = useState<boolean>(false);
     const [ isSelectNoneDisabled, setIsSelectNoneDisabled ] = useState<boolean>(false);
 
-
     /**
      * Check if the place holders should be shown.
      */

--- a/features/admin.applications.v1/components/api-authorization/scope-form.tsx
+++ b/features/admin.applications.v1/components/api-authorization/scope-form.tsx
@@ -35,7 +35,6 @@ import { Dispatch } from "redux";
 import { Dropdown, DropdownItemProps, DropdownProps, Form, Grid, Header } from "semantic-ui-react";
 import { FeatureConfigInterface } from "../../../admin.core.v1";
 import { patchScopesOfAuthorizedAPI } from "../../api/api-authorization";
-import useScopesOfAPIResources from "../../api/use-scopes-of-api-resources";
 import {
     AuthorizedAPIListItemInterface,
     AuthorizedPermissionListItemInterface
@@ -59,6 +58,14 @@ interface ScopeFormInterface extends
      */
     isScopesAvailableForUpdate: boolean;
     /**
+     * Current API resource scopes list.
+     */
+    currentAPIResourceScopeListData: AuthorizedPermissionListItemInterface[];
+    /**
+     * Current API resource scopes list loading.
+     */
+    isCurrentAPIResourceScopeListDataLoading: boolean
+    /**
      * Bulk change all authorized scopes.
      */
     bulkChangeAllAuthorizedScopes: (scopes: AuthorizedPermissionListItemInterface[], removed: boolean) => void;
@@ -79,6 +86,8 @@ export const ScopeForm: FunctionComponent<ScopeFormInterface> = (
         subscribedAPIResource,
         isScopesAvailableForUpdate,
         bulkChangeAllAuthorizedScopes,
+        currentAPIResourceScopeListData,
+        isCurrentAPIResourceScopeListDataLoading,
         ["data-componentid"]: componentId
     } = props;
 
@@ -97,26 +106,6 @@ export const ScopeForm: FunctionComponent<ScopeFormInterface> = (
     const [ isSelectAllDisabled, setIsSelectAllDisabled ] = useState<boolean>(false);
     const [ isSelectNoneDisabled, setIsSelectNoneDisabled ] = useState<boolean>(false);
 
-    const {
-        data: currentAPIResourceScopeListData,
-        isLoading: isCurrentAPIResourceScopeListDataLoading,
-        error: currentAPIResourceScopeListFetchError
-    } = useScopesOfAPIResources(subscribedAPIResource?.id);
-
-    /**
-     * The following useEffect is used to handle if any error occurs while fetching API resource scopes.
-     */
-    useEffect(() => {
-        if (currentAPIResourceScopeListFetchError) {
-            dispatch(addAlert<AlertInterface>({
-                description: t("extensions:develop.apiResource.notifications.getAPIResources" +
-                    ".genericError.description"),
-                level: AlertLevels.ERROR,
-                message: t("extensions:develop.apiResource.notifications.getAPIResources" +
-                    ".genericError.message")
-            }));
-        }
-    }, [ currentAPIResourceScopeListFetchError ]);
 
     /**
      * Check if the place holders should be shown.

--- a/features/admin.applications.v1/components/api-authorization/subscribed-api-resources.tsx
+++ b/features/admin.applications.v1/components/api-authorization/subscribed-api-resources.tsx
@@ -149,6 +149,12 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
     const [ m2mApplication, setM2MApplication ] = useState<boolean>(false);
     const dispatch: Dispatch = useDispatch();
 
+    const {
+        data: currentAPIResourceScopeListData,
+        isLoading: isCurrentAPIResourceScopeListDataLoading,
+        error: currentAPIResourceScopeListFetchError
+    } = useScopesOfAPIResources(activeSubscribedAPIResource);
+
     /**
      * Initialize the subscribed API Resources list to the searched list.
      */
@@ -168,12 +174,6 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
             );
         }
     }, [ allAuthorizedScopes ]);
-
-    const {
-        data: currentAPIResourceScopeListData,
-        isLoading: isCurrentAPIResourceScopeListDataLoading,
-        error: currentAPIResourceScopeListFetchError
-    } = useScopesOfAPIResources(activeSubscribedAPIResource, !!activeSubscribedAPIResource);
 
     /**
      * Check whether the application is an M2M application.

--- a/features/admin.applications.v1/components/api-authorization/subscribed-api-resources.tsx
+++ b/features/admin.applications.v1/components/api-authorization/subscribed-api-resources.tsx
@@ -16,7 +16,8 @@
  * under the License.
  */
 
-import { IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
+import { AlertInterface, AlertLevels, IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
 import { I18n } from "@wso2is/i18n";
 import {
     Code,
@@ -31,16 +32,18 @@ import {
     SegmentedAccordion,
     SegmentedAccordionTitleActionInterface
 } from "@wso2is/react-components";
-import { getEmptyPlaceholderIllustrations, history } from "../../../admin.core.v1";
-import { RequestErrorInterface } from "../../../admin.core.v1/hooks/use-request";
 import { AxiosError } from "axios";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
 import { Form, Grid, Header, Icon, Input } from "semantic-ui-react";
 import { ScopeForm } from "./scope-form";
 import { APIResourcesConstants } from "../../../admin.api-resources.v2/constants";
 import { APIResourceInterface } from "../../../admin.api-resources.v2/models";
-import { FeatureConfigInterface } from "../../../admin.core.v1";
+import { FeatureConfigInterface, getEmptyPlaceholderIllustrations, history } from "../../../admin.core.v1";
+import { RequestErrorInterface } from "../../../admin.core.v1/hooks/use-request";
+import useScopesOfAPIResources from "../../api/use-scopes-of-api-resources";
 import { Policy } from "../../constants/api-authorization";
 import { ApplicationTemplateIdTypes } from "../../models";
 import {
@@ -144,6 +147,7 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
         useState<AuthorizedAPIListItemInterface[]>(null);
     const [ copyScopesValue, setCopyScopesValue ] = useState<string>(null);
     const [ m2mApplication, setM2MApplication ] = useState<boolean>(false);
+    const dispatch: Dispatch = useDispatch();
 
     /**
      * Initialize the subscribed API Resources list to the searched list.
@@ -165,6 +169,12 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
         }
     }, [ allAuthorizedScopes ]);
 
+    const {
+        data: currentAPIResourceScopeListData,
+        isLoading: isCurrentAPIResourceScopeListDataLoading,
+        error: currentAPIResourceScopeListFetchError
+    } = useScopesOfAPIResources(activeSubscribedAPIResource, !!activeSubscribedAPIResource);
+
     /**
      * Check whether the application is an M2M application.
      */
@@ -173,6 +183,21 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
             setM2MApplication(true);
         }
     }, [ templateId ]);
+
+    /**
+     * Handle if any error occurs while fetching API resource scopes.
+     */
+    useEffect(() => {
+        if (currentAPIResourceScopeListFetchError) {
+            dispatch(addAlert<AlertInterface>({
+                description: t("extensions:develop.apiResource.notifications.getAPIResources" +
+                    ".genericError.description"),
+                level: AlertLevels.ERROR,
+                message: t("extensions:develop.apiResource.notifications.getAPIResources" +
+                    ".genericError.message")
+            }));
+        }
+    }, [ currentAPIResourceScopeListFetchError ]);
 
     /**
      * Navigate to the API Resources page.
@@ -357,6 +382,8 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
             subscribedAPIResource={ subscribedAPIResource }
             isScopesAvailableForUpdate={ isScopesAvailableForUpdate }
             bulkChangeAllAuthorizedScopes={ bulkChangeAllAuthorizedScopes }
+            currentAPIResourceScopeListData={ currentAPIResourceScopeListData }
+            isCurrentAPIResourceScopeListDataLoading={ isCurrentAPIResourceScopeListDataLoading }
         />
     );
 


### PR DESCRIPTION
### Purpose
Prevent multiple scopes API calls in the API authorization tab

https://github.com/wso2/identity-apps/assets/27746285/d36109d0-7776-4228-8168-6655ba0fcf92

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
