### PR TITLE
Add branding for the message in email link expiry page

### DIFF
--- a/.changeset/angry-suns-rhyme.md
+++ b/.changeset/angry-suns-rhyme.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/identity-apps-core": patch
+"@wso2is/i18n": patch
+"@wso2is/features": patch
+---
+
+Add branding for the message in email link expiry page.

--- a/docs/write-code/branding/ADD_TEXT_CUSTOMIZATION_TO_NEW_INTERFACES.md
+++ b/docs/write-code/branding/ADD_TEXT_CUSTOMIZATION_TO_NEW_INTERFACES.md
@@ -32,7 +32,7 @@ Here are the steps to add text customization in the interfaces:
    - Add the updated strings to other resource language files as well.
 
 5. **Update i18n in Namespaces File:**
-   - Update the `modules/i18n/src/models/namespaces/console-ns.ts` file with the relevant i18n keys for the screens and form fields.
+   - Update the `modules/i18n/src/models/namespaces/branding-ns.ts` file with the relevant i18n keys for the screens and form fields.
         - It should be in the following format:
           ```
           export const consoleNS = {

--- a/features/admin.branding.v1/components/preview/branding-preference-preview.tsx
+++ b/features/admin.branding.v1/components/preview/branding-preference-preview.tsx
@@ -42,12 +42,12 @@ import { Placeholder } from "semantic-ui-react";
 import { EmailTemplateScreenSkeleton } from "./email-template-screen-skeleton";
 import { LoginScreenSkeleton } from "./login-screen-skeleton";
 import { MyAccountScreenSkeleton } from "./my-account-screen-skeleton";
+import { AppState } from "../../../admin.core.v1/store";
 import { commonConfig } from "../../../admin.extensions.v1/configs";
 import { ReactComponent as CustomLayoutSuccessImg } from
     "../../../themes/wso2is/assets/images/branding/custom-layout-success.svg";
 import { ReactComponent as CustomLayoutWarningImg } from
     "../../../themes/wso2is/assets/images/branding/custom-layout-warning.svg";
-import { AppState } from "../../../admin.core.v1/store";
 import { useLayout, useLayoutStyle } from "../../api";
 import { usePreviewContent, usePreviewStyle } from "../../api/preview-skeletons";
 import { BrandingPreferenceMeta, LAYOUT_DATA, PredefinedLayouts } from "../../meta";

--- a/features/admin.branding.v1/components/preview/branding-preference-preview.tsx
+++ b/features/admin.branding.v1/components/preview/branding-preference-preview.tsx
@@ -264,6 +264,7 @@ export const BrandingPreferencePreview: FunctionComponent<BrandingPreferencePrev
         PreviewScreenType.LOGIN,
         PreviewScreenType.SIGN_UP,
         PreviewScreenType.COMMON,
+        PreviewScreenType.EMAIL_LINK_EXPIRY,
         PreviewScreenType.EMAIL_OTP,
         PreviewScreenType.SMS_OTP,
         PreviewScreenType.TOTP,

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx
@@ -18,6 +18,7 @@
 
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, { FunctionComponent, ReactElement } from "react";
+import { Placeholder } from "semantic-ui-react";
 import { CustomTextPreferenceConstants } from "../../../../constants/custom-text-preference-constants";
 import useBrandingPreference from "../../../../hooks/use-branding-preference";
 
@@ -41,13 +42,14 @@ const EmailLinkExpiryFragment: FunctionComponent<EmailLinkExpiryFragmentInterfac
 
     return (
         <div data-componentid={ componentId } >
-            <h2 style={ { color: "#d95858", height: "200px" } } className="mt-5">
+            <h2 style={ { color: "#d95858", height: "150px" } } className="mt-5">
                 { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.EMAIL_LINK_EXPIRY.MESSAGE,
                     "This link has expired.") }
             </h2>
-            <div>
-                <button className="ui primary button mb-2">Go Back</button>
-            </div>
+            <Placeholder style={ { animation: "unset", height: "50px", marginBottom: "50px", width: "315px" } }>
+                <Placeholder.Image />
+            </Placeholder>
+            <button className="ui primary button mb-2">Go Back</button>
         </div>
     );
 };

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx
@@ -42,11 +42,19 @@ const EmailLinkExpiryFragment: FunctionComponent<EmailLinkExpiryFragmentInterfac
 
     return (
         <div data-componentid={ componentId } >
-            <h2 style={ { color: "#d95858", height: "150px" } } className="mt-5">
+            <h2 style={ { color: "#d95858", minHeight: "150px" } } className="mt-5">
                 { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.EMAIL_LINK_EXPIRY.MESSAGE,
                     "This link has expired.") }
             </h2>
-            <Placeholder style={ { animation: "unset", height: "50px", marginBottom: "50px", width: "315px" } }>
+            <Placeholder style={ { animation: "unset", height: "40px" } }>
+                <Placeholder.Image />
+            </Placeholder>
+            <Placeholder style={ { animation: "unset", height: "20px", marginTop: "15px" } }>
+                <Placeholder.Image />
+            </Placeholder>
+            <Placeholder
+                style={ { animation: "unset", height: "20px", marginBottom: "50px", marginTop: "15px", width: "60%" } }
+            >
                 <Placeholder.Image />
             </Placeholder>
             <button className="ui primary button mb-2">Go Back</button>

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import React, { FunctionComponent, ReactElement } from "react";
+import { CustomTextPreferenceConstants } from "../../../../constants/custom-text-preference-constants";
+import useBrandingPreference from "../../../../hooks/use-branding-preference";
+
+/**
+ * Proptypes for the email-link-expiry fragment of login screen skeleton.
+ */
+export type EmailLinkExpiryFragmentInterface = IdentifiableComponentInterface;
+
+/**
+ * Email link expiry fragment component for the branding preview of Email Link Expiry screen.
+ *
+ * @param props - Props injected to the component.
+ * @returns Email link expiry fragment component.
+ */
+const EmailLinkExpiryFragment: FunctionComponent<EmailLinkExpiryFragmentInterface> = (
+    props: EmailLinkExpiryFragmentInterface
+): ReactElement => {
+    const { ["data-componentid"]: componentId } = props;
+
+    const { i18n } = useBrandingPreference();
+
+    return (
+        <div data-componentid={ componentId } >
+            <h2 style={ { color: "#d95858", height: "200px" } } className="mt-5">
+                { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.EMAIL_LINK_EXPIRY.MESSAGE,
+                    "This link has expired.") }
+            </h2>
+            <div>
+                <button className="ui primary button mb-2">Go Back</button>
+            </div>
+        </div>
+    );
+};
+
+/**
+ * Default props for the component.
+ */
+EmailLinkExpiryFragment.defaultProps = {
+    "data-componentid": "branding-preview-email-link-expiry-fragment"
+};
+
+export default EmailLinkExpiryFragment;

--- a/features/admin.branding.v1/components/preview/sign-in-box/sign-in-box.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/sign-in-box.tsx
@@ -23,6 +23,7 @@ import React, {
 } from "react";
 import BasicAuthFragment from "./fragments/basic-auth-fragment";
 import CommonFragment from "./fragments/common-fragment";
+import EmailLinkExpiryFragment from "./fragments/email-link-expiry-fragment";
 import EmailOTPFragment from "./fragments/email-otp-fragment";
 import PasswordRecoveryFragment from "./fragments/password-recovery-fragment";
 import PasswordResetFragment from "./fragments/password-reset-fragment";
@@ -78,6 +79,8 @@ const SignInBox: FunctionComponent<SignInBoxInterface> = (
             return <PasswordResetFragment />;
         } else if (selectedScreen === PreviewScreenType.PASSWORD_RESET_SUCCESS) {
             return <PasswordResetSuccessFragment />;
+        } else if (selectedScreen === PreviewScreenType.EMAIL_LINK_EXPIRY) {
+            return <EmailLinkExpiryFragment />;
         }
     };
 

--- a/features/admin.branding.v1/constants/custom-text-preference-constants.ts
+++ b/features/admin.branding.v1/constants/custom-text-preference-constants.ts
@@ -101,6 +101,9 @@ export class CustomTextPreferenceConstants {
 
     public static readonly TEXT_BUNDLE_KEYS: {
         COPYRIGHT: string;
+        EMAIL_LINK_EXPIRY: {
+            MESSAGE: string;
+        };
         EMAIL_OTP: {
             HEADING: string;
         }
@@ -150,6 +153,9 @@ export class CustomTextPreferenceConstants {
         }
     } = {
         COPYRIGHT: "copyright",
+        EMAIL_LINK_EXPIRY: {
+            MESSAGE: "email.link.expiry.message"
+        },
         EMAIL_OTP: {
             HEADING: "email.otp.heading"
         },

--- a/features/admin.branding.v1/models/branding-preferences.ts
+++ b/features/admin.branding.v1/models/branding-preferences.ts
@@ -565,6 +565,7 @@ export enum PreviewScreenType {
     COMMON = "common",
     LOGIN = "login",
     MY_ACCOUNT = "myaccount",
+    EMAIL_LINK_EXPIRY = "email-link-expiry",
     EMAIL_TEMPLATE = "email-template",
     SIGN_UP = "sign-up",
     EMAIL_OTP = "email-otp",

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -78,6 +78,11 @@ password.reset.success.body=An email with a password reset link and instructions
 password.reset.success.action=Back to application
 # <!-- End of Password Reset Success Translations -->
 
+# <!-- Start of Email Link Expiry Translations -->
+# EDITABLE=true,SCREEN="email-link-expiry",MULTI_LINE=false
+email.link.expiry.message=This link has expired.
+# <!-- End of Email Link Expiry Translations -->
+
 Wso2.identity.server=WSO2 Identity Server
 All.rights.reserved=All Rights Reserved.
 Inc=Inc
@@ -187,7 +192,6 @@ error=Error
 Cannot.obtain.username.from.server.response=Cannot obtain username from server response
 Enter.tenant.domain=Please enter your tenant domain.
 something.went.wrong.contact.admin=Something went wrong during the recovery process. Please contact identity admin.
-Invalid.reset.link=This link has expired.
 Set.Password=Set Password
 Continue=Continue
 Please.enter.valid.email=Please enter a valid email address.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
@@ -51,6 +51,10 @@ password.reset.success.body=Ein Link zum Zurücksetzen des Passworts wurde an Ih
 password.reset.success.action=Zurück zur Registrierung
 # <!-- End of Password Reset Success Translations -->
 
+# <!-- Start of Email Link Expiry Translations -->
+email.link.expiry.message=Dieser Link ist abgelaufen.
+# <!-- End of Email Link Expiry Translations -->
+
 Wso2.identity.server=WSO2 Identity Server
 All.rights.reserved=Alle Rechte vorbehalten.
 Inc=Inc.
@@ -160,7 +164,6 @@ error=Fehler
 Cannot.obtain.username.from.server.response=Benutzername kann nicht von der Serverantwort abgerufen werden
 Enter.tenant.domain=Bitte geben Sie Ihre Mieterdomain ein.
 something.went.wrong.contact.admin=Während des Wiederherstellungsprozesses ging etwas schief. Bitte wenden Sie sich an den Identitätsadministrator
-Invalid.reset.link=Dieser Link ist abgelaufen.
 Set.Password=Passwort erstellen
 Continue=Weiter
 Please.enter.valid.email=Bitte geben Sie eine gültige E-Mail-Adresse ein.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_es_ES.properties
@@ -51,6 +51,10 @@ password.reset.success.body=Se ha enviado un correo electrónico con un enlace e
 password.reset.success.action=Volver a la aplicación
 # <!-- End of Password Reset Success Translations -->
 
+# <!-- Start of Email Link Expiry Translations -->
+email.link.expiry.message=Este enlace ha expirado.
+# <!-- End of Email Link Expiry Translations -->
+
 Wso2.identity.server=WSO2 Identity Server
 All.rights.reserved=Todos los derechos reservados.
 Inc=Inc
@@ -160,7 +164,6 @@ error=Error
 Cannot.obtain.username.from.server.response=No se puede obtener el nombre de usuario de la respuesta del servidor
 Enter.tenant.domain=Ingrese su dominio de inquilino.
 something.went.wrong.contact.admin=Algo salió mal durante el proceso de recuperación. Póngase en contacto con Identity Admin.
-Invalid.reset.link=Este enlace ha expirado.
 Set.Password=Configurar la clave
 Continue=Continuar
 Please.enter.valid.email=Por favor, introduce una dirección de correo electrónico válida.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
@@ -51,6 +51,10 @@ password.reset.success.body=Un e-mail avec un lien de réinitialisation de mot d
 password.reset.success.action=Retour à la candidature
 # <!-- End of Password Reset Success Translations -->
 
+# <!-- Start of Email Link Expiry Translations -->
+email.link.expiry.message=Ce lien a expiré
+# <!-- End of Email Link Expiry Translations -->
+
 Wso2.identity.server=WSO2 Identity Server
 All.rights.reserved=Tous droits réservés.
 Inc=Inc
@@ -153,7 +157,6 @@ business.homepage=http://wso2.com/
 name=Nom
 error=Erreur
 something.went.wrong.contact.admin=Une erreur s'est produite lors du processus de récupération. Veuillez contacter l administrateur d'identité.
-Invalid.reset.link=Ce lien a expiré
 Set.Password=Définir le mot de passe
 Continue=Continue
 need.help.contact.us=Besoin d'aide? Contactez-nous via

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_ja_JP.properties
@@ -51,6 +51,10 @@ password.reset.success.body=パスワードリセットのリンクと手順が�
 password.reset.success.action=アプリケーションに戻る
 # <!-- End of Password Reset Success Translations -->
 
+# <!-- Start of Email Link Expiry Translations -->
+email.link.expiry.message=このリンクは有効期限が切れています。
+# <!-- End of Email Link Expiry Translations -->
+
 Wso2.identity.server=WSO2 アイデンティティサーバ
 All.rights.reserved=無断転載を禁じます。
 Inc=Inc
@@ -156,7 +160,6 @@ error=エラー
 Cannot.obtain.username.from.server.response=サーバーの応答からユーザー名を取得できません
 Enter.tenant.domain=テナントドメインを入力してください。
 something.went.wrong.contact.admin=認証プロセス中に問題が発生しました。ID管理者までご連絡ください。
-Invalid.reset.link=このリンクは有効期限が切れています。
 Set.Password=パスワード設定
 Continue=続行
 Please.enter.valid.email=有効なメールアドレスを入力してください。

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_BR.properties
@@ -51,6 +51,10 @@ password.reset.success.body=Um email com um link de redefinição de senha e ins
 password.reset.success.action=Voltar ao aplicativo
 # <!-- End of Password Reset Success Translations -->
 
+# <!-- Start of Email Link Expiry Translations -->
+email.link.expiry.message=Este link expirou.
+# <!-- End of Email Link Expiry Translations -->
+
 Wso2.identity.server=WSO2 Identity Server
 All.rights.reserved=Todos os direitos reservados.
 Inc=Inc
@@ -160,7 +164,6 @@ error=Erro
 Cannot.obtain.username.from.server.response=Não foi possível obter o nome de usuário na resposta do servidor
 Enter.tenant.domain=Por favor, insira seu domínio de tenant.
 something.went.wrong.contact.admin=Algo deu errado durante o processo de recuperação. Por favor, entre em contato com seu administrador.
-Invalid.reset.link=Este link expirou.
 Set.Password=Configurar senha
 Continue=Continuar
 Please.enter.valid.email=or favor, insira um endereço de e-mail válido.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_PT.properties
@@ -51,6 +51,10 @@ password.reset.success.body=Um email com um link de redefinição de senha e ins
 password.reset.success.action=De volta ao aplicativo
 # <!-- End of Password Reset Success Translations -->
 
+# <!-- Start of Email Link Expiry Translations -->
+email.link.expiry.message=Este link expirou.
+# <!-- End of Email Link Expiry Translations -->
+
 Wso2.identity.server=WSO2 Identity Server
 All.rights.reserved=Todos os direitos reservados.
 Inc=Inc
@@ -160,7 +164,6 @@ error=Erro
 Cannot.obtain.username.from.server.response=Não pode obter o nome de usuário da resposta do servidor
 Enter.tenant.domain=Por favor, insira seu domínio de tenant (locatário).
 something.went.wrong.contact.admin=Algo deu errado durante o processo de recuperação. Entre em contato com a identidade do Admin.
-Invalid.reset.link=Este link expirou.
 Set.Password=Configurar senha
 Continue=Prosseguir
 Please.enter.valid.email=Por favor insira um endereço de e-mail válido.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_zh_CN.properties
@@ -51,6 +51,10 @@ password.reset.success.body=带有密码重置链接的电子邮件已发送到�
 password.reset.success.action=返回应用程序
 # <!-- End of Password Reset Success Translations -->
 
+# <!-- Start of Email Link Expiry Translations -->
+email.link.expiry.message=此链接已过期。
+# <!-- End of Email Link Expiry Translations -->
+
 Wso2.identity.server=WSO2身份服务器
 All.rights.reserved=版权所有。
 Inc=Inc
@@ -156,7 +160,6 @@ error=错误
 Cannot.obtain.username.from.server.response=无法从服务器响应中获取用户名
 Enter.tenant.domain=请输入您的房客域。
 something.went.wrong.contact.admin=在身份验证过程中出现了问题。请联系身份管理员。
-Invalid.reset.link=此链接已过期。
 Set.Password=设置密码
 Continue=继续
 Please.enter.valid.email=请输入有效的电子邮件地址。

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/error.jsp
@@ -124,12 +124,12 @@
                         if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode()
                                 .equals(errorCode)) {
                     %>
-                        <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Invalid.reset.link")%>
+                        <%=i18n(recoveryResourceBundle, customText, "email.link.expiry.message")%>
                     <%
                         } else if (IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_CODE.getCode()
                                 .equals(errorCode)) {
                     %>
-                        <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Invalid.reset.link")%>
+                        <%=i18n(recoveryResourceBundle, customText, "email.link.expiry.message")%>
                     <% } else { %>
                         <%=IdentityManagementEndpointUtil.i18nBase64(recoveryResourceBundle, errorMsg)%>
                     <% } %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/branding-preferences.jsp
@@ -233,7 +233,7 @@
     String productWhiteLogoURL = "libs/themes/wso2is/assets/images/branding/logo-full-inverted.svg";
     String productWhiteLogoAlt = "WSO2 Identity Server Logo White Variation";
     String poweredByLogoURL = "";
-    String[] screenNames = {"common", "sign-up", "password-recovery", "password-reset", "password-reset-success"};
+    String[] screenNames = {"common", "sign-up", "password-recovery", "password-reset", "password-reset-success", "email-link-expiry"};
 
     // Constants used to create full custom layout name
     String PREFIX_FOR_CUSTOM_LAYOUT_NAME = "custom";

--- a/modules/i18n/src/models/namespaces/branding-ns.ts
+++ b/modules/i18n/src/models/namespaces/branding-ns.ts
@@ -34,6 +34,9 @@ export interface BrandingNS {
                 copyright: {
                     hint: string;
                 };
+                "email.link.expiry.message": {
+                    hint: string;
+                };
                 "privacy.policy": {
                     hint: string;
                 };
@@ -157,6 +160,7 @@ export interface BrandingNS {
     };
     screens: {
         common: string;
+        "email-link-expiry": string;
         login: string;
         "sms-otp": string;
         "email-otp": string;

--- a/modules/i18n/src/translations/en-US/portals/branding.ts
+++ b/modules/i18n/src/translations/en-US/portals/branding.ts
@@ -42,6 +42,9 @@ export const branding: BrandingNS = {
                 copyright: {
                     hint: "Text that appears at the footer of the login screens. You can use `{{currentYear}}` placeholder to automatically display the current year."
                 },
+                "email.link.expiry.message": {
+                    hint: "The message that appears when the email link expires. If not set, {{productName}} defaults are used."
+                },
                 "privacy.policy": {
                     hint: "The privacy policy text that appears at the footer of the login screens. If not set, {{productName}} defaults are used."
                 },
@@ -157,6 +160,7 @@ export const branding: BrandingNS = {
     },
     screens: {
         common: "Common",
+        "email-link-expiry": "Email Link Expiry",
         "email-otp": "Email OTP",
         "email-template": "Email Templates",
         login: "Login",


### PR DESCRIPTION
### Purpose
Add branding for the message in email link expiry page.

Field
<img width="450" alt="Screenshot 2024-05-16 at 22 43 49" src="https://github.com/wso2/identity-apps/assets/67315176/301a63e0-8a51-4a5c-8722-b80c3851266d">

Preview
<img width="380" alt="Screenshot 2024-05-17 at 13 09 25" src="https://github.com/wso2/identity-apps/assets/67315176/020b6e3c-bcdb-4841-ab0e-d8e4f366f753">

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
