### PR TITLE
Add support to enable/Disable Application Access

### DIFF
--- a/.changeset/tiny-suits-attend.md
+++ b/.changeset/tiny-suits-attend.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/i18n": patch
+"@wso2is/console": patch
+"@wso2is/features": patch
+---
+
+Add support to change application status

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -150,6 +150,7 @@ export const disableApplication = <T>(id: string, status: boolean): Promise<T> =
                     response,
                     response.config);
             }
+
             return Promise.resolve(response.data as T);
         }).catch((error: AxiosError) => {
             throw new IdentityAppsApiException(

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -122,32 +122,43 @@ export const deleteApplication = (id: string): Promise<any> => {
 };
 
 /**
- * Deletes an application when the relevant id is passed in.
+ * Disables an application when the relevant id is passed in.
  *
  * @param id - ID of the application.
  * @returns A promise containing the response.
+ * @throws IdentityAppsApiException
  */
-export const disableApplication = (id: string, status: boolean): Promise<any> => {
+export const disableApplication = <T>(id: string, status: boolean): Promise<T> => {
     const requestConfig: AxiosRequestConfig = {
         data: { "applicationEnabled":status },
         headers: {
             "Accept": "application/json",
-            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
             "Content-Type": "application/json"
         },
         method: HttpMethods.PATCH,
-        url: store.getState().config.endpoints.applications + "/" + id
+        url: `${ store.getState().config.endpoints.applications }/${  id }`
     };
 
     return httpClient(requestConfig)
         .then((response: AxiosResponse) => {
             if (response.status !== 200) {
-                return Promise.reject(new Error("Failed to disable the application."));
+                throw new IdentityAppsApiException(
+                    ApplicationManagementConstants.APPLICATION_STATUS_UPDATE_INVALID_STATUS_CODE_ERROR,
+                    null,
+                    response.status,
+                    response.request,
+                    response,
+                    response.config);
             }
-
-            return Promise.resolve(response);
+            return Promise.resolve(response.data as T);
         }).catch((error: AxiosError) => {
-            return Promise.reject(error);
+            throw new IdentityAppsApiException(
+                ApplicationManagementConstants.APPLICATION_STATUS_UPDATE_ERROR,
+                error.stack,
+                error.code,
+                error.request,
+                error.response,
+                error.config);
         });
 };
 

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -122,6 +122,36 @@ export const deleteApplication = (id: string): Promise<any> => {
 };
 
 /**
+ * Deletes an application when the relevant id is passed in.
+ *
+ * @param id - ID of the application.
+ * @returns A promise containing the response.
+ */
+export const disableApplication = (id: string, status: boolean): Promise<any> => {
+    const requestConfig: AxiosRequestConfig = {
+        data: { "applicationEnabled":status },
+        headers: {
+            "Accept": "application/json",
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.PATCH,
+        url: store.getState().config.endpoints.applications + "/" + id
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 200) {
+                return Promise.reject(new Error("Failed to disable the application."));
+            }
+
+            return Promise.resolve(response);
+        }).catch((error: AxiosError) => {
+            return Promise.reject(error);
+        });
+};
+
+/**
  * Updates the application with basic details.
  *
  * @param app - Basic info about the application.

--- a/features/admin.applications.v1/components/settings/general-application-settings.tsx
+++ b/features/admin.applications.v1/components/settings/general-application-settings.tsx
@@ -243,28 +243,26 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
         setShowDisableConfirmationModal(true);
     };
 
-
     /**
      * Disables an application.
      */
-    const handleApplicationDisable = () => {
+    const handleApplicationDisable = (): void => {
         setIsDisableInProgress(true);
-        const state : string = enableStatus ? "enabled" : "disabled";
-        const state2 : string = enableStatus ? "enable" : "disable";
-
         disableApplication(appId, enableStatus)
             .then(() => {
                 setIsDisableInProgress(false);
                 dispatch(addAlert({
                     description: t("applications:notifications.disableApplication.success" +
-                            ".description", { state }),
+                            ".description", {  state: enableStatus ? "enabled" : "disabled" }),
                     level: AlertLevels.SUCCESS,
-                    message: t("applications:notifications.disableApplication.success.message", { state })
+                    message: t("applications:notifications.disableApplication.success.message",
+                        { state: enableStatus ? "enabled" : "disabled" })
                 }));
                 setShowDisableConfirmationModal(false);
                 onUpdate(appId);
             })
             .catch((error: AxiosError) => {
+                setIsDisableInProgress(false);
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(addAlert({
                         description: error.response.data.description,
@@ -278,7 +276,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
 
                 dispatch(addAlert({
                     description: t("applications:notifications.disableApplication" +
-                        ".genericError.description", { state2 }),
+                        ".genericError.description", {  state: enableStatus ? "enable" : "disable" }),
                     level: AlertLevels.ERROR,
                     message: t("applications:notifications.disableApplication.genericError" +
                         ".message")

--- a/features/admin.applications.v1/components/settings/general-application-settings.tsx
+++ b/features/admin.applications.v1/components/settings/general-application-settings.tsx
@@ -250,7 +250,6 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
         setIsDisableInProgress(true);
         disableApplication(appId, enableStatus)
             .then(() => {
-                setIsDisableInProgress(false);
                 dispatch(addAlert({
                     description: t("applications:notifications.disableApplication.success" +
                             ".description", {  state: enableStatus ? "enabled" : "disabled" }),
@@ -262,7 +261,6 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                 onUpdate(appId);
             })
             .catch((error: AxiosError) => {
-                setIsDisableInProgress(false);
                 if (error.response && error.response.data && error.response.data.description) {
                     dispatch(addAlert({
                         description: error.response.data.description,
@@ -283,6 +281,7 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                 }));
             })
             .finally(() => {
+                setIsDisableInProgress(false);
                 setIsSubmitting(false);
             });
     };

--- a/features/admin.applications.v1/components/settings/general-application-settings.tsx
+++ b/features/admin.applications.v1/components/settings/general-application-settings.tsx
@@ -30,12 +30,12 @@ import {
     EmphasizedSegment
 } from "@wso2is/react-components";
 import { AxiosError } from "axios";
-import React, { FunctionComponent, ReactElement, useState } from "react";
+import React, { FormEvent, FunctionComponent, ReactElement, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
-import { Divider } from "semantic-ui-react";
-import { deleteApplication, updateApplicationDetails } from "../../api";
+import { CheckboxProps, Divider } from "semantic-ui-react";
+import { deleteApplication, disableApplication, updateApplicationDetails } from "../../api";
 import {
     ApplicationInterface,
     ApplicationTemplateListItemInterface
@@ -144,8 +144,11 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
     const UIConfig: UIConfigInterface = useSelector((state: AppState) => state?.config?.ui);
 
     const [ showDeleteConfirmationModal, setShowDeleteConfirmationModal ] = useState<boolean>(false);
+    const [ showDisableConfirmationModal, setShowDisableConfirmationModal ] = useState<boolean>(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ isDeletionInProgress, setIsDeletionInProgress ] = useState<boolean>(false);
+    const [ isDisableInProgress, setIsDisableInProgress ] = useState<boolean>(false);
+    const [ enableStatus, setEnableStatus ] = useState<boolean>(false);
 
     /**
      * Deletes an application.
@@ -226,6 +229,60 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                     message: t("applications:notifications.updateApplication.genericError" +
                         ".message")
                 }));
+            });
+    };
+
+    /**
+     * Handles the toggle change to show confirmation modal.
+     *
+     * @param event - Form event.
+     * @param data - Checkbox data.
+     */
+    const handleAppEnableDisableToggleChange = (event: FormEvent<HTMLInputElement>, data: CheckboxProps): void => {
+        setEnableStatus(data.checked);
+        setShowDisableConfirmationModal(true);
+    };
+
+
+    /**
+     * Disables an application.
+     */
+    const handleApplicationDisable = () => {
+        setIsDisableInProgress(true);
+        const state : string = enableStatus ? "enabled" : "disabled";
+        const state2 : string = enableStatus ? "enable" : "disable";
+
+        disableApplication(appId, enableStatus)
+            .then(() => {
+                setIsDisableInProgress(false);
+                dispatch(addAlert({
+                    description: t("applications:notifications.disableApplication.success" +
+                            ".description", { state }),
+                    level: AlertLevels.SUCCESS,
+                    message: t("applications:notifications.disableApplication.success.message", { state })
+                }));
+                setShowDisableConfirmationModal(false);
+                onUpdate(appId);
+            })
+            .catch((error: AxiosError) => {
+                if (error.response && error.response.data && error.response.data.description) {
+                    dispatch(addAlert({
+                        description: error.response.data.description,
+                        level: AlertLevels.ERROR,
+                        message: t("applications:notifications.disableApplication.error" +
+                            ".message")
+                    }));
+
+                    return;
+                }
+
+                dispatch(addAlert({
+                    description: t("applications:notifications.disableApplication" +
+                        ".genericError.description", { state2 }),
+                    level: AlertLevels.ERROR,
+                    message: t("applications:notifications.disableApplication.genericError" +
+                        ".message")
+                }));
             })
             .finally(() => {
                 setIsSubmitting(false);
@@ -254,26 +311,48 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
         if (!application?.advancedConfigurations?.fragment) {
             return (
                 <Show
-                    when={ featureConfig?.applications?.scopes?.delete }
+                    when={ featureConfig?.applications?.scopes?.delete ||  featureConfig?.applications?.scopes?.update }
                 >
                     <DangerZoneGroup
                         sectionHeader={ t("applications:dangerZoneGroup.header") }
                     >
-                        <DangerZone
-                            actionTitle={
-                                t("applications:dangerZoneGroup.deleteApplication" +
-                                    ".actionTitle")
-                            }
-                            header={
-                                t("applications:dangerZoneGroup.deleteApplication.header")
-                            }
-                            subheader={
-                                t("applications:dangerZoneGroup.deleteApplication" +
-                                    ".subheader")
-                            }
-                            onActionClick={ (): void => setShowDeleteConfirmationModal(true) }
-                            data-testid={ `${ componentId }-danger-zone` }
-                        />
+                        <Show when={ featureConfig?.applications?.scopes?.update }>
+                            <DangerZone
+                                actionTitle={ t("applications:dangerZoneGroup.disableApplication.actionTitle",
+                                    { state: application.applicationEnabled ?
+                                        t("common:disable") : t("common:enable") }) }
+                                header={ t("applications:dangerZoneGroup.disableApplication.header",
+                                    { state: application.applicationEnabled ?
+                                        t("common:disable") : t("common:enable") } ) }
+                                subheader={ application.applicationEnabled ?
+                                    t("applications:dangerZoneGroup.disableApplication.subheader")
+                                    : t("applications:dangerZoneGroup.disableApplication.subheader2") }
+
+                                onActionClick={ undefined }
+                                toggle={ {
+                                    checked: application.applicationEnabled,
+                                    onChange: handleAppEnableDisableToggleChange
+                                } }
+                                data-testid={ `${ componentId }-danger-zone-disable` }
+                            />
+                        </Show>
+                        <Show when={ featureConfig?.applications?.scopes?.delete }>
+                            <DangerZone
+                                actionTitle={
+                                    t("applications:dangerZoneGroup.deleteApplication" +
+                                        ".actionTitle")
+                                }
+                                header={
+                                    t("applications:dangerZoneGroup.deleteApplication.header")
+                                }
+                                subheader={
+                                    t("applications:dangerZoneGroup.deleteApplication" +
+                                        ".subheader")
+                                }
+                                onActionClick={ (): void => setShowDeleteConfirmationModal(true) }
+                                data-testid={ `${ componentId }-danger-zone` }
+                            />
+                        </Show>
                     </DangerZoneGroup>
                 </Show>
             );
@@ -398,6 +477,48 @@ export const GeneralApplicationSettings: FunctionComponent<GeneralApplicationSet
                                     </>
                                 )
                         }
+                    </ConfirmationModal>
+                    <ConfirmationModal
+                        onClose={ (): void => setShowDisableConfirmationModal(false) }
+                        type="warning"
+                        open={ showDisableConfirmationModal }
+                        primaryAction={ t("common:confirm") }
+                        secondaryAction={ t("common:cancel") }
+                        onSecondaryActionClick={ (): void => setShowDisableConfirmationModal(false) }
+                        onPrimaryActionClick={ (): void => handleApplicationDisable() }
+                        closeOnDimmerClick={ false }
+                        primaryActionLoading={ isDisableInProgress }
+                        data-testid={ `${ componentId }-application-disable-confirmation-modal` }
+                    >
+                        <ConfirmationModal.Header
+                            data-testid={
+                                `${ componentId }-application-disable-confirmation-modal-header`
+                            }
+                        >
+                            { enableStatus
+                                ? t("applications:confirmations.enableApplication.header")
+                                : t("applications:confirmations.disableApplication.header") }
+                        </ConfirmationModal.Header>
+                        <ConfirmationModal.Message
+                            attached
+                            warning
+                            data-testid={
+                                `${ componentId }-application-disable-confirmation-modal-message`
+                            }
+                        >
+                            { enableStatus
+                                ? t("applications:confirmations.enableApplication.message")
+                                : t("applications:confirmations.disableApplication.message") }
+                        </ConfirmationModal.Message>
+                        <ConfirmationModal.Content
+                            data-testid={
+                                `${ componentId }-application-disable-confirmation-modal-content`
+                            }
+                        >
+                            { enableStatus
+                                ? t("applications:confirmations.enableApplication.content")
+                                : t("applications:confirmations.disableApplication.content") }
+                        </ConfirmationModal.Content>
                     </ConfirmationModal>
                 </>
             ) :

--- a/features/admin.applications.v1/constants/application-management.ts
+++ b/features/admin.applications.v1/constants/application-management.ts
@@ -327,6 +327,12 @@ export class ApplicationManagementConstants {
     public static readonly MYACCOUNT_STATUS_UPDATE_INVALID_STATUS_CODE_ERROR: string = "Received an " +
         "invalid status code while updating status of the My Account Portal.";
 
+    public static readonly APPLICATION_STATUS_UPDATE_INVALID_STATUS_CODE_ERROR: string = "Received an " +
+        "invalid status code while updating the status of the application. ";
+
+    public static readonly APPLICATION_STATUS_UPDATE_ERROR: string = "Error occurred while updating the " +
+        "status of the application. ";
+
     public static readonly SECOND_FACTOR_AUTHENTICATORS_DROPPABLE_ID: string = "second-factor-authenticators";
     public static readonly EXTERNAL_AUTHENTICATORS_DROPPABLE_ID: string = "external-authenticators";
     public static readonly SOCIAL_LOGIN_HEADER: string = "Social Login";

--- a/features/admin.applications.v1/models/application.ts
+++ b/features/admin.applications.v1/models/application.ts
@@ -42,6 +42,7 @@ export interface ApplicationBasicInterface {
     realm?: string;
     templateId?: string;
     isManagementApp?: boolean;
+    applicationEnabled?:boolean;
     advancedConfigurations?: AdvancedConfigurationsInterface;
     associatedRoles?: AssociatedRolesInterface;
 }

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -152,7 +152,6 @@ export interface ApplicationsNS {
             content: string;
             assertionHint: string;
         },
-
         deleteOutboundProvisioningIDP: {
             header: string;
             message: string;

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -140,6 +140,19 @@ export interface ApplicationsNS {
             content: string;
             assertionHint: string;
         };
+        disableApplication: {
+            header: string;
+            message: string;
+            content: string;
+            assertionHint: string;
+        },
+        enableApplication: {
+            header: string;
+            message: string;
+            content: string;
+            assertionHint: string;
+        },
+
         deleteOutboundProvisioningIDP: {
             header: string;
             message: string;
@@ -248,6 +261,12 @@ export interface ApplicationsNS {
             header: string;
             subheader: string;
         };
+        disableApplication: {
+            actionTitle: string
+            header: string;
+            subheader: string;
+            subheader2: string
+        },
     };
     edit: {
         sections: {
@@ -2335,6 +2354,20 @@ export interface ApplicationsNS {
                 description: string;
             };
         };
+        disableApplication: {
+            error: {
+                message: string;
+                description: string;
+            };
+            genericError: {
+                message: string;
+                description: string;
+            };
+            success: {
+                message: string;
+                description: string;
+            };
+        },
         updateAuthenticationFlow: {
             error: {
                 message: string;

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -197,6 +197,21 @@ export const applications: ApplicationsNS = {
             message: "If you delete this application, authentication flows for this application will " +
                 "stop working. Please proceed with caution."
         },
+        disableApplication: {
+            header: "Are you sure?",
+            content: "This may cause the consumers being unable to access the application. This is temporary and" +
+            "reversible by enabling the application.",
+            message: "If you disable this application, consumers will not be able to access the application. "+
+            "And the application may loose access to user data. Please proceed with caution.",
+            assertionHint: "Please confirm your action."
+        },
+        enableApplication: {
+            header: "Are you sure?",
+            content: "This may lead to consumers accessing the application. This action is reversible.",
+            message: "If you enable this application, consumers will have the access to the application. "+
+            "And the application can gain access to user data. Please proceed with caution.",
+            assertionHint: "Please confirm your action."
+        },
         deleteOutboundProvisioningIDP: {
             assertionHint: "Please type <1>{{ name }}</1> to confirm.",
             content: "If you delete this outbound provisioning IDP, you will not be able to get it back. " +
@@ -282,6 +297,14 @@ export const applications: ApplicationsNS = {
             header: "Delete application",
             subheader: "Once the application is deleted, it cannot be recovered and the clients " +
                 "using this application will no longer work."
+        },
+        disableApplication: {
+            actionTitle: "{{ state }} application",
+            header: "{{ state }} application",
+            subheader: "Once the application is disabled, it will not be accessible by the consumers." +
+                " And the application also can not access consumer data.",
+            subheader2: "Enable the application to be accessible by the consumers. " +
+            "After enabling, application can access consumer data"
         },
         header: "Danger Zone"
     },
@@ -2696,6 +2719,20 @@ export const applications: ApplicationsNS = {
             success: {
                 description: "Successfully updated the application.",
                 message: "Update successful"
+            }
+        },
+        disableApplication: {
+            error: {
+                description: "{{description}}",
+                message: "Update error"
+            },
+            genericError: {
+                description: "Failed to {{state}} the application.",
+                message: "Something went wrong"
+            },
+            success: {
+                description: "Successfully {{state}} the application.",
+                message: "Application {{state}}. "
             }
         },
         updateAuthenticationFlow: {


### PR DESCRIPTION
### Purpose
This PR add support to enable and disable application access from the general settings page.

### Related Issues
- https://github.com/wso2/product-is/issues/20378

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
