### PR TITLE
Hide Fido Trusted Origins section from sub orgs

### DIFF
--- a/.changeset/plenty-schools-taste.md
+++ b/.changeset/plenty-schools-taste.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.identity-providers.v1": patch
+---
+
+Hide fido trusted origins section from sub orgs

--- a/features/admin.identity-providers.v1/components/forms/authenticators/fido-authenticator-forms/fido-authenticator-form.tsx
+++ b/features/admin.identity-providers.v1/components/forms/authenticators/fido-authenticator-forms/fido-authenticator-form.tsx
@@ -88,7 +88,7 @@ export const FIDOAuthenticatorForm: FunctionComponent<FIDOAuthenticatorFormProps
         isLoading: fidoConnectorConfigFetchRequestIsLoading,
         error: fidoConnectorConfigFetchError,
         mutate: mutateFIDOConnectorConfigs
-    } = useFIDOConnectorConfigs();
+    } = useFIDOConnectorConfigs(!isSubOrganization());
 
     /**
      * Retrieve the list of FIDO trusted origins from the FIDO connector configuration response.
@@ -371,39 +371,43 @@ export const FIDOAuthenticatorForm: FunctionComponent<FIDOAuthenticatorFormProps
                 width={ 12 }
                 data-testid={ `${ testId }-enable-passkey-usernameless-authentication` }
             />
-            <URLInput
-                urlState={ FIDOTrustedOrigins }
-                setURLState={ (urls: string) => {
-                    if (urls !== undefined) {
-                        setFIDOTrustedOrigins(urls);
-                    }
-                } }
-                labelName={
-                    t("authenticationProvider:forms." +
+            {
+                !isSubOrganization() &&
+                (<URLInput
+                    urlState={ FIDOTrustedOrigins }
+                    setURLState={ (urls: string) => {
+                        if (urls !== undefined) {
+                            setFIDOTrustedOrigins(urls);
+                        }
+                    } }
+                    labelName={
+                        t("authenticationProvider:forms." +
                             "authenticatorSettings.fido2.trustedOrigins.label")
-                }
-                placeholder={
-                    t("authenticationProvider:forms." +
+                    }
+                    placeholder={
+                        t("authenticationProvider:forms." +
                             "authenticatorSettings.fido2.trustedOrigins.placeholder")
-                }
-                validationErrorMsg={
-                    t("authenticationProvider:forms." +
+                    }
+                    validationErrorMsg={
+                        t("authenticationProvider:forms." +
                             "authenticatorSettings.fido2.trustedOrigins.validations.invalid")
-                }
-                computerWidth={ 10 }
-                hint={
-                    t("authenticationProvider:forms." +
+                    }
+                    computerWidth={ 10 }
+                    hint={
+                        t("authenticationProvider:forms." +
                         "authenticatorSettings.fido2.trustedOrigins.hint")
-                }
-                addURLTooltip={ t("common:addURL") }
-                duplicateURLErrorMessage={ t("common:duplicateURLError") }
-                data-testid={ `${ testId }-fido-trusted-origin-input` }
-                required = { false }
-                showPredictions={ false }
-                isAllowEnabled={ false }
-                skipValidation
-                readOnly={ isReadOnly }
-            />
+                    }
+                    addURLTooltip={ t("common:addURL") }
+                    duplicateURLErrorMessage={ t("common:duplicateURLError") }
+                    data-testid={ `${ testId }-fido-trusted-origin-input` }
+                    required = { false }
+                    showPredictions={ false }
+                    isAllowEnabled={ false }
+                    skipValidation
+                    readOnly={ isReadOnly }
+                />)
+            }
+
             {
                 identityProviderConfig?.editIdentityProvider?.enableFIDOTrustedAppsConfiguration
                     ? (

--- a/features/admin.identity-providers.v1/components/forms/authenticators/fido-authenticator-forms/fido-authenticator-form.tsx
+++ b/features/admin.identity-providers.v1/components/forms/authenticators/fido-authenticator-forms/fido-authenticator-form.tsx
@@ -409,7 +409,7 @@ export const FIDOAuthenticatorForm: FunctionComponent<FIDOAuthenticatorFormProps
             }
 
             {
-                identityProviderConfig?.editIdentityProvider?.enableFIDOTrustedAppsConfiguration
+                identityProviderConfig?.editIdentityProvider?.enableFIDOTrustedAppsConfiguration && !isSubOrganization()
                     ? (
                         <FIDOTrustedApps
                             readOnly={ isReadOnly }


### PR DESCRIPTION
### Purpose
- To hide the FIDO trusted origins section from the sub orgs Passkey connection
- Because this section is in the process of revamping, for now we are hiding it from the UI for the sub orgs


### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
