### PR TITLE
Fix header text wrap issue in resource card

### DIFF
--- a/.changeset/four-bags-compete.md
+++ b/.changeset/four-bags-compete.md
@@ -1,0 +1,10 @@
+---
+"@wso2is/theme": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/features": patch
+"@wso2is/identity-apps-core": patch
+"@wso2is/react-components": patch
+---
+
+Fix header text wrap issue in resource card.

--- a/modules/theme/src/themes/default/views/card.overrides
+++ b/modules/theme/src/themes/default/views/card.overrides
@@ -953,6 +953,7 @@
                 display:flex;
                 align-items:center;
                 white-space:break-spaces;
+                word-break: break-word;
             }
         }
         .card-subheader {

--- a/modules/theme/src/themes/default/views/card.overrides
+++ b/modules/theme/src/themes/default/views/card.overrides
@@ -945,15 +945,18 @@
             justify-content:space-between;
 
             .card-header {
-                font-weight:500;
+                font-weight: 500;
                 font-size: 20px;
-                padding-bottom: 10px;
-                padding-top:10px;
-                color:#444444;
-                display:flex;
-                align-items:center;
-                white-space:break-spaces;
+                margin-bottom: 10px;
+                margin-top: 10px;
+                color: #444444;
+                display: -webkit-box;
+                align-items: center;
+                white-space: break-spaces;
                 word-break: break-word;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
             }
         }
         .card-subheader {


### PR DESCRIPTION
### Purpose
Fix resource card header text so when a long identity provider name is added, the header text doesn't go outside the div.

Before
<img width="608" alt="Screenshot 2024-05-27 at 14 07 07" src="https://github.com/wso2/identity-apps/assets/67315176/89aaf25f-91fd-43e3-baaf-08a0cec79a82">

After fix
<img width="389" alt="Screenshot 2024-05-27 at 14 06 36" src="https://github.com/wso2/identity-apps/assets/67315176/f62f80c6-0cea-4959-b058-01c1c3593e32">

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
