### PR TITLE
Update GitHub Actions workflow to use Java 11

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -212,7 +212,7 @@ jobs:
       matrix:
         node-version: [ lts/* ]
         maven-version: [ 3.8.6 ]
-        java-version: [ 1.8 ]
+        java-version: [ 11 ]
         pnpm-version: [ 8.7.4 ]
     steps:
       - name: ⬇️ Checkout
@@ -225,11 +225,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: ☕ Set up JDK 1.8
+      - name: ☕ Set up JDK 11
         id: jdk-setup
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: "adopt"
           cache: maven
 
       - name: 🦩 Set up Maven


### PR DESCRIPTION
### Purpose
Upgraded to Java 11, due to PR builder failing for the newly added Mockito unit tests when using Java 8.

### Related Issues
- N/A

### Related PRs
- https://github.com/wso2/identity-apps/pull/6342

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
