### PR TITLE
Fix null pointer exception issue when branding layout isn't defined

### DIFF
--- a/.changeset/cuddly-melons-shout.md
+++ b/.changeset/cuddly-melons-shout.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Fix null pointer exception issue when branding layout isn't defined.

--- a/.changeset/quick-deers-bake.md
+++ b/.changeset/quick-deers-bake.md
@@ -1,5 +1,5 @@
 ---
-"@wso2is/features": patch
+"@wso2is/admin.branding.v1": patch
 ---
 
 Fix null pointer exception issue when branding layout isn't defined.

--- a/features/admin.branding.v1/components/branding-core.tsx
+++ b/features/admin.branding.v1/components/branding-core.tsx
@@ -237,19 +237,22 @@ const BrandingCore: FunctionComponent<BrandingCoreInterface> = (
         }
 
         if  (!overridenBrandingPreference)  {
-            setBrandingPreference(BrandingPreferenceUtils.migrateLayoutPreference(
-                BrandingPreferenceUtils.migrateThemePreference(
-                    originalBrandingPreference.preference,
-                    {
-                        theme: predefinedThemes
-                    }
-                ),
-                {
-                    layout: predefinedLayouts
-                }
-            ));
 
-            setSelectedLayout(brandingPreference?.layout?.activeLayout);
+            const migratedBrandingPreference: BrandingPreferenceInterface = BrandingPreferenceUtils
+                .migrateLayoutPreference(
+                    BrandingPreferenceUtils.migrateThemePreference(
+                        originalBrandingPreference.preference,
+                        {
+                            theme: predefinedThemes
+                        }
+                    ),
+                    {
+                        layout: predefinedLayouts
+                    }
+                );
+
+            setBrandingPreference(migratedBrandingPreference);
+            setSelectedLayout(migratedBrandingPreference?.layout?.activeLayout);
         }
 
     }, [ originalBrandingPreference ]);

--- a/features/admin.branding.v1/components/branding-core.tsx
+++ b/features/admin.branding.v1/components/branding-core.tsx
@@ -248,7 +248,8 @@ const BrandingCore: FunctionComponent<BrandingCoreInterface> = (
                     layout: predefinedLayouts
                 }
             ));
-            setSelectedLayout(originalBrandingPreference.preference.layout.activeLayout);
+
+            setSelectedLayout(brandingPreference?.layout?.activeLayout);
         }
 
     }, [ originalBrandingPreference ]);


### PR DESCRIPTION
### Purpose
Issue - When accessing the branding page, the console crashes due to a null pointer exception.
We have used the original API response which does not define a layout object to set the selected layout. Hence, this code line breaks execution.

Fix -  We set the layout after it is defined in the branding preference object. 

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
