### PR TITLE
Add config to enable/disable the users tab in roles section and roles tab in users section 

### DIFF
--- a/.changeset/chilly-hounds-join.md
+++ b/.changeset/chilly-hounds-join.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.roles.v2": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Add config to enable/disable the users tab in roles section and roles tab in users section

--- a/features/admin.roles.v2/components/edit-role/edit-role.tsx
+++ b/features/admin.roles.v2/components/edit-role/edit-role.tsx
@@ -159,7 +159,7 @@ export const EditRole: FunctionComponent<EditRoleProps> = (props: EditRoleProps)
         ];
 
         if (!userRolesDisabledFeatures?.includes(
-            LocalRoleConstants.USERS_TAB
+            LocalRoleConstants.FEATURE_DICTIONARY.get("ROLE_USERS")
         )) {
             panes.push(
                 {

--- a/features/admin.roles.v2/components/edit-role/edit-role.tsx
+++ b/features/admin.roles.v2/components/edit-role/edit-role.tsx
@@ -78,6 +78,9 @@ export const EditRole: FunctionComponent<EditRoleProps> = (props: EditRoleProps)
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const administratorRoleDisplayName: string = useSelector(
         (state: AppState) => state?.config?.ui?.administratorRoleDisplayName);
+    const userRolesDisabledFeatures: string[] = useSelector((state: AppState) => {
+        return state.config.ui.features?.userRoles?.disabledFeatures;
+    });
 
     const isReadOnly: boolean = useMemo(() => {
         return !isFeatureEnabled(featureConfig,
@@ -152,21 +155,28 @@ export const EditRole: FunctionComponent<EditRoleProps> = (props: EditRoleProps)
                         />
                     </ResourceTab.Pane>
                 )
-            },
-            {
-                menuItem: t("roles:edit.menuItems.users"),
-                render: () => (
-                    <ResourceTab.Pane controlledSegmentation attached={ false }>
-                        <RoleUsersList
-                            isReadOnly={ isReadOnly || isUserReadOnly }
-                            role={ roleObject }
-                            onRoleUpdate={ onRoleUpdate }
-                            tabIndex={ 3 }
-                        />
-                    </ResourceTab.Pane>
-                )
             }
         ];
+
+        if (!userRolesDisabledFeatures?.includes(
+            LocalRoleConstants.USERS_TAB
+        )) {
+            panes.push(
+                {
+                    menuItem: t("roles:edit.menuItems.users"),
+                    render: () => (
+                        <ResourceTab.Pane controlledSegmentation attached={ false }>
+                            <RoleUsersList
+                                isReadOnly={ isReadOnly || isUserReadOnly }
+                                role={ roleObject }
+                                onRoleUpdate={ onRoleUpdate }
+                                tabIndex={ 3 }
+                            />
+                        </ResourceTab.Pane>
+                    )
+                }
+            );
+        }
 
         return panes;
     };

--- a/features/admin.roles.v2/constants/role-constants.ts
+++ b/features/admin.roles.v2/constants/role-constants.ts
@@ -50,7 +50,8 @@ export class RoleConstants {
         .set("ROLE_CREATE", "roles.create")
         .set("ROLE_UPDATE", "roles.update")
         .set("ROLE_DELETE", "roles.delete")
-        .set("ROLE_READ", "roles.read");
+        .set("ROLE_READ", "roles.read")
+        .set("ROLE_USERS", "roles.edit.users");
 
     public static readonly SUPER_ADMIN_PERMISSION_KEY: string = "/permission/protected";
 

--- a/features/admin.roles.v2/constants/role-constants.ts
+++ b/features/admin.roles.v2/constants/role-constants.ts
@@ -91,6 +91,11 @@ export class RoleConstants {
      * filter query for audience type organization.
      */
     public static readonly ROLE_AUDIENCE_ORGANIZATION_FILTER: string = "audience.type eq organization";
+
+    /**
+     * Users tab in the Roles section.
+     */
+    public static readonly USERS_TAB: string = "usersTab";
 }
 
 /**

--- a/features/admin.roles.v2/constants/role-constants.ts
+++ b/features/admin.roles.v2/constants/role-constants.ts
@@ -92,11 +92,6 @@ export class RoleConstants {
      * filter query for audience type organization.
      */
     public static readonly ROLE_AUDIENCE_ORGANIZATION_FILTER: string = "audience.type eq organization";
-
-    /**
-     * Users tab in the Roles section.
-     */
-    public static readonly USERS_TAB: string = "usersTab";
 }
 
 /**

--- a/features/admin.users.v1/components/edit-user.tsx
+++ b/features/admin.users.v1/components/edit-user.tsx
@@ -101,6 +101,10 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
         (state: AppState) => state?.config?.ui?.isGroupAndRoleSeparationEnabled);
     const roleV1Enabled: boolean = UIConfig?.legacyMode?.rolesV1;
 
+    const userRolesDisabledFeatures: string[] = useSelector((state: AppState) => {
+        return state.config.ui.features?.users?.disabledFeatures;
+    });
+
     const [ isReadOnly, setReadOnly ] = useState<boolean>(false);
     const [ isSuperAdmin, setIsSuperAdmin ] = useState<boolean>(false);
     const [ isSelectedSuperAdmin, setIsSelectedSuperAdmin ] = useState<boolean>(false);
@@ -234,7 +238,8 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                 </ResourceTab.Pane>
             )
         },
-        !isSubOrganization()
+        !userRolesDisabledFeatures?.includes(UserManagementConstants.ROLES_TAB)
+        && isSuperOrganization()
         && !legacyAuthzRuntime
         && roleV1Enabled
             ? {
@@ -252,7 +257,8 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                 )
             } : null,
         // ToDo - Enabled only for root organizations as BE doesn't have full SCIM support for organizations yet
-        !isSubOrganization()
+        !userRolesDisabledFeatures?.includes(UserManagementConstants.ROLES_TAB)
+        && isSuperOrganization()
         && !legacyAuthzRuntime
         && !roleV1Enabled
             ? {

--- a/features/admin.users.v1/components/edit-user.tsx
+++ b/features/admin.users.v1/components/edit-user.tsx
@@ -238,8 +238,8 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                 </ResourceTab.Pane>
             )
         },
-        !userRolesDisabledFeatures?.includes(UserManagementConstants.ROLES_TAB)
-        && isSuperOrganization()
+        !userRolesDisabledFeatures?.includes(UserManagementConstants.FEATURE_DICTIONARY.get("USER_ROLES"))
+        && !isSubOrganization()
         && !legacyAuthzRuntime
         && roleV1Enabled
             ? {
@@ -257,8 +257,8 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                 )
             } : null,
         // ToDo - Enabled only for root organizations as BE doesn't have full SCIM support for organizations yet
-        !userRolesDisabledFeatures?.includes(UserManagementConstants.ROLES_TAB)
-        && isSuperOrganization()
+        !userRolesDisabledFeatures?.includes(UserManagementConstants.FEATURE_DICTIONARY.get("USER_ROLES"))
+        && !isSubOrganization()
         && !legacyAuthzRuntime
         && !roleV1Enabled
             ? {

--- a/features/admin.users.v1/constants/user-management-constants.ts
+++ b/features/admin.users.v1/constants/user-management-constants.ts
@@ -63,7 +63,8 @@ export class UserManagementConstants {
         .set("USER_CREATE", "users.create")
         .set("USER_UPDATE", "users.update")
         .set("USER_DELETE", "users.delete")
-        .set("USER_READ", "users.read");
+        .set("USER_READ", "users.read")
+        .set("USER_ROLES", "users.edit.roles");
 
     // API errors
     public static readonly USER_INFO_UPDATE_ERROR: string = "Could not update the user information.";
@@ -153,9 +154,6 @@ export class UserManagementConstants {
     public static readonly MANAGED_BY_PARENT_TEXT: string = "Parent Organization";
 
     public static readonly GLOBE: string = "globe";
-
-    // Roles tab in the Users section.
-    public static readonly ROLES_TAB: string = "rolesTab";
 }
 
 /**

--- a/features/admin.users.v1/constants/user-management-constants.ts
+++ b/features/admin.users.v1/constants/user-management-constants.ts
@@ -153,6 +153,9 @@ export class UserManagementConstants {
     public static readonly MANAGED_BY_PARENT_TEXT: string = "Parent Organization";
 
     public static readonly GLOBE: string = "globe";
+
+    // Roles tab in the Users section.
+    public static readonly ROLES_TAB: string = "rolesTab";
 }
 
 /**


### PR DESCRIPTION
### Purpose
Add config to enable/disable the `users` tab in roles section and `roles` tab in users section 

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
