### PR TITLE
[POC] Open and close bulk user import wizard based on URL state

### DIFF
--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -113,6 +113,26 @@ type UsersPageInterface = IdentifiableComponentInterface & RouteComponentProps &
 const TEMP_RESOURCE_LIST_ITEM_LIMIT_OFFSET: number = 1;
 const NUMBER_OF_PAGES_FOR_LDAP: number = 100;
 
+const useUrlState = () => {
+    const searchParams: URLSearchParams = new URLSearchParams(window.location.search);
+
+    const updateSearchParams = (key: string,value: string) => {
+        const url: URL = new URL(window.location.href);
+
+        url.searchParams.set(key, value);
+        window.history.pushState(null, "", url.toString());
+    };
+
+    return {
+        searchParams,
+        updateSearchParams
+    };
+};
+
+const userListPageUrlParams: any = {
+    BULK_USER_IMPORT_WIZARD_OPEN: "bulkImportWizard"
+};
+
 /**
  * Users info page.
  *
@@ -132,7 +152,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
 
     const dispatch: Dispatch<any> = useDispatch();
     const { legacyAuthzRuntime }  = useAuthorization();
-    const searchParams: URLSearchParams = new URLSearchParams(window.location.search);
+    const { searchParams, updateSearchParams } = useUrlState();
 
     const showStatusLabelForNewAuthzRuntimeFeatures: boolean =
         window["AppUtils"]?.getConfig()?.ui?.showStatusLabelForNewAuthzRuntimeFeatures;
@@ -402,7 +422,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
 
     useEffect(() => {
         setShowMultipleInviteConfirmationModal(
-            searchParams.get("bulkImportWizard") === "true"
+            searchParams.get(userListPageUrlParams.BULK_USER_IMPORT_WIZARD_OPEN) === "true"
             && !connectorConfigLoading
             && !emailVerificationEnabled
         );
@@ -675,10 +695,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
      * Handles the `onClose` callback action from the bulk import wizard.
      */
     const handleBulkImportWizardClose = (): void => {
-        const url: URL = new URL(window.location.href);
-
-        url.searchParams.set("bulkImportWizard", "false");
-        window.history.pushState(null, "", url.toString());
+        updateSearchParams(userListPageUrlParams.BULK_USER_IMPORT_WIZARD_OPEN, "false");
         mutateUserListFetchRequest();
     };
 
@@ -801,11 +818,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
 
                 break;
             case UserAddOptionTypes.BULK_IMPORT:
-                // eslint-disable-next-line no-case-declarations
-                const url: URL = new URL(window.location.href);
-
-                url.searchParams.set("bulkImportWizard", "true");
-                window.history.pushState(null, "", url.toString());
+                updateSearchParams(userListPageUrlParams.BULK_USER_IMPORT_WIZARD_OPEN, "false");
 
                 break;
             case UserAccountTypesMain.INTERNAL:
@@ -970,11 +983,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 data-componentid={ `${componentId}-select-multiple-invite-confirmation-modal` }
                 onClose={ (): void => {
                     setShowMultipleInviteConfirmationModal(false);
-
-                    const url: URL = new URL(window.location.href);
-
-                    url.searchParams.set("bulkImportWizard", "false");
-                    window.history.pushState(null, "", url.toString());
+                    updateSearchParams(userListPageUrlParams.BULK_USER_IMPORT_WIZARD_OPEN, "false");
                 } }
                 type="warning"
                 open={ showMultipleInviteConfirmationModal }
@@ -982,10 +991,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 onPrimaryActionClick={ (): void => {
                     setShowMultipleInviteConfirmationModal(false);
 
-                    const url: URL = new URL(window.location.href);
-
-                    url.searchParams.set("bulkImportWizard", "false");
-                    window.history.pushState(null, "", url.toString());
+                    updateSearchParams(userListPageUrlParams.BULK_USER_IMPORT_WIZARD_OPEN, "false");
                 } }
                 closeOnDimmerClick={ false }
             >
@@ -1059,7 +1065,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 )
             }
             {
-                searchParams.get("bulkImportWizard") === "true"
+                searchParams.get(userListPageUrlParams.BULK_USER_IMPORT_WIZARD_OPEN) === "true"
                 && !connectorConfigLoading
                 && emailVerificationEnabled
                 && (

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -132,6 +132,8 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
 
     const dispatch: Dispatch<any> = useDispatch();
     const { legacyAuthzRuntime }  = useAuthorization();
+    const searchParams: URLSearchParams = new URLSearchParams(window.location.search);
+
     const showStatusLabelForNewAuthzRuntimeFeatures: boolean =
         window["AppUtils"]?.getConfig()?.ui?.showStatusLabelForNewAuthzRuntimeFeatures;
 
@@ -148,7 +150,6 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
     const [ activeTabIndex, setActiveTabIndex ] = useState<number>(0);
     const [ listItemLimit, setListItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);
     const [ showWizard, setShowWizard ] = useState<boolean>(false);
-    const [ showBulkImportWizard, setShowBulkImportWizard ] = useState<boolean>(false);
     const [ readOnlyUserStoresList, setReadOnlyUserStoresList ] = useState<string[]>([]);
     const [ triggerClearQuery, setTriggerClearQuery ] = useState<boolean>(false);
     const [ emailVerificationEnabled, setEmailVerificationEnabled ] = useState<boolean>(undefined);
@@ -401,11 +402,11 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
 
     useEffect(() => {
         setShowMultipleInviteConfirmationModal(
-            showBulkImportWizard
+            searchParams.get("bulkImportWizard") === "true"
             && !connectorConfigLoading
             && !emailVerificationEnabled
         );
-    }, [ showBulkImportWizard, connectorConfigLoading ]);
+    }, [ searchParams, connectorConfigLoading ]);
 
     /**
      * Handles parent user invitation pagination.
@@ -674,7 +675,10 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
      * Handles the `onClose` callback action from the bulk import wizard.
      */
     const handleBulkImportWizardClose = (): void => {
-        setShowBulkImportWizard(false);
+        const url: URL = new URL(window.location.href);
+
+        url.searchParams.set("bulkImportWizard", "false");
+        window.history.pushState(null, "", url.toString());
         mutateUserListFetchRequest();
     };
 
@@ -797,7 +801,11 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
 
                 break;
             case UserAddOptionTypes.BULK_IMPORT:
-                setShowBulkImportWizard(true);
+                // eslint-disable-next-line no-case-declarations
+                const url: URL = new URL(window.location.href);
+
+                url.searchParams.set("bulkImportWizard", "true");
+                window.history.pushState(null, "", url.toString());
 
                 break;
             case UserAccountTypesMain.INTERNAL:
@@ -962,14 +970,22 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 data-componentid={ `${componentId}-select-multiple-invite-confirmation-modal` }
                 onClose={ (): void => {
                     setShowMultipleInviteConfirmationModal(false);
-                    setShowBulkImportWizard(false);
+
+                    const url: URL = new URL(window.location.href);
+
+                    url.searchParams.set("bulkImportWizard", "false");
+                    window.history.pushState(null, "", url.toString());
                 } }
                 type="warning"
                 open={ showMultipleInviteConfirmationModal }
                 primaryAction={ t("common:close") }
                 onPrimaryActionClick={ (): void => {
                     setShowMultipleInviteConfirmationModal(false);
-                    setShowBulkImportWizard(false);
+
+                    const url: URL = new URL(window.location.href);
+
+                    url.searchParams.set("bulkImportWizard", "false");
+                    window.history.pushState(null, "", url.toString());
                 } }
                 closeOnDimmerClick={ false }
             >
@@ -1043,7 +1059,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 )
             }
             {
-                showBulkImportWizard
+                searchParams.get("bulkImportWizard") === "true"
                 && !connectorConfigLoading
                 && emailVerificationEnabled
                 && (


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Open bulk user import wizard on setting `bulkImportWizard=true` in URL and close on setting `bulkImportWizard=false`.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
