### PR TITLE
Fix issue with loading tenant create page for users without associated tenants

### DIFF
--- a/.changeset/wicked-moose-shave.md
+++ b/.changeset/wicked-moose-shave.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix issue with loading tenant create page for users without associated tenants

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -213,7 +213,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                 has(idToken, "associated_tenants") ||
                 isPrivilegedUser ||
                 isOrgSwitch ||
-                isNotPlatformIdPFederatedUser != undefined && isNotPlatformIdPFederatedUser
+                isNotPlatformIdPFederatedUser !== undefined && isNotPlatformIdPFederatedUser
             ) {
                 // If there is an association, the user should be redirected to console landing page.
                 const location: string =

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -193,7 +193,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                     : false;
 
             let isOrgSwitch: boolean = false;
-            let isNotPlatformIdPFederatedUser: boolean = true;
+            let isNotPlatformIdPFederatedUser: boolean;
 
             if (has(idToken, "org_id") && has(idToken, "user_org")) {
                 isOrgSwitch = (idToken?.org_id !== idToken?.user_org);
@@ -213,7 +213,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                 has(idToken, "associated_tenants") ||
                 isPrivilegedUser ||
                 isOrgSwitch ||
-                isNotPlatformIdPFederatedUser
+                isNotPlatformIdPFederatedUser != undefined && isNotPlatformIdPFederatedUser
             ) {
                 // If there is an association, the user should be redirected to console landing page.
                 const location: string =


### PR DESCRIPTION
### Purpose
Create tenant page is not loaded when users does not has associated tenants. This PR will fix this issue

### Related PRs
- https://github.com/wso2/identity-apps/pull/5976

