### PR TITLE
Remove All user stores option from the user store dropdown in groups section

### DIFF
--- a/.changeset/popular-apes-rhyme.md
+++ b/.changeset/popular-apes-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/admin.groups.v1": patch
+---
+
+Remove All user stores option from the user store dropdown in groups section

--- a/features/admin.extensions.v1/components/groups/groups-list.tsx
+++ b/features/admin.extensions.v1/components/groups/groups-list.tsx
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2021-2024, WSO2 LLC. (https://www.wso2.com).
  *
-groupList?.length * WSO2 LLC. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/features/admin.extensions.v1/components/groups/groups-list.tsx
+++ b/features/admin.extensions.v1/components/groups/groups-list.tsx
@@ -1,7 +1,7 @@
 /**
  * Copyright (c) 2021-2024, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 LLC. licenses this file to you under the Apache License,
+groupList?.length * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -170,7 +170,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
             );
         }
 
-        if (groupList?.length === 0) {
+        if (groupList?.length !== 0) {
             return (
                 <>
                     <Show

--- a/features/admin.extensions.v1/components/groups/groups-list.tsx
+++ b/features/admin.extensions.v1/components/groups/groups-list.tsx
@@ -170,7 +170,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
             );
         }
 
-        if (selectedUserStoreOption && groupList?.length === 0) {
+        if (groupList?.length === 0) {
             return (
                 <>
                     <Show

--- a/features/admin.extensions.v1/components/groups/groups-list.tsx
+++ b/features/admin.extensions.v1/components/groups/groups-list.tsx
@@ -170,7 +170,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
             );
         }
 
-        if (groupList?.length !== 0) {
+        if (selectedUserStoreOption && groupList?.length === 0) {
             return (
                 <>
                     <Show
@@ -178,8 +178,7 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
                     >
                         <EmptyPlaceholder
                             data-testid={ `${ testId }-empty-list-empty-placeholder` }
-                            action={ (selectedUserStoreOption === CONSUMER_USERSTORE
-                                || selectedUserStoreOption === GroupConstants.ALL_GROUPS)
+                            action={ selectedUserStoreOption === CONSUMER_USERSTORE
                                 && (
                                     <PrimaryButton
                                         data-testid={ `${ testId }-empty-list-empty-placeholder-add-button` }

--- a/features/admin.extensions.v1/components/groups/pages/groups.tsx
+++ b/features/admin.extensions.v1/components/groups/pages/groups.tsx
@@ -104,7 +104,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     const excludeMembers: string = "members";
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
-    const [ userStoreOption, setuserStoreOption ] = useState<string>();
+    const [ userStoreOption, setuserStoreOption ] = useState<string>(userstoresConfig.primaryUserstoreNam);
     const [ enabledUserStores, setEnabledUserStores ] = useState<UserStoreListItem[]>([]);
 
     const {
@@ -120,11 +120,6 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
         isLoading: isUserStoreListFetchRequestLoading,
         error: userStoreListFetchRequestError
     } = useUserStores(null);
-
-    useEffect(() => {
-        userStoreList?.length >= 1
-        && setuserStoreOption(userStoreList[0].name);
-    }, [ userStoreList ]);
 
     /**
      * Moderate Groups response from the API.
@@ -419,7 +414,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
      */
     const filterUserStores = (option: string): void => {
         setPaginatedFilteredGroups(groupList?.filter((group: GroupsInterface) => {
-            return (group.displayName.includes(option?.toUpperCase()));
+            return (group.displayName.includes(option.toUpperCase()));
         }));
     };
 
@@ -443,9 +438,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
             pageTitle="Groups"
             action={
                 !isGroupListFetchRequestLoading
-                && (
-                    userStoreOption === CONSUMER_USERSTORE
-                )
+                && userStoreOption === CONSUMER_USERSTORE
                 && originalGroupList.totalResults > 0
                 && (
                     <Show

--- a/features/admin.extensions.v1/components/groups/pages/groups.tsx
+++ b/features/admin.extensions.v1/components/groups/pages/groups.tsx
@@ -32,7 +32,6 @@ import {
     searchGroupList,
     useGroupList
 } from "@wso2is/admin.groups.v1";
-import { GroupConstants } from "@wso2is/admin.groups.v1/constants";
 import { useUserStores } from "@wso2is/admin.userstores.v1/api/user-stores";
 import { CONSUMER_USERSTORE } from "@wso2is/admin.userstores.v1/constants/user-store-constants";
 import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-stores";
@@ -49,7 +48,6 @@ import {
 import { AxiosResponse } from "axios";
 import cloneDeep from "lodash-es/cloneDeep";
 import find from "lodash-es/find";
-import union from "lodash-es/union";
 import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -106,7 +104,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     const excludeMembers: string = "members";
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
-    const [ userStoreOption, setuserStoreOption ] = useState<string>(GroupConstants.ALL_GROUPS);
+    const [ userStoreOption, setuserStoreOption ] = useState<string>();
     const [ enabledUserStores, setEnabledUserStores ] = useState<UserStoreListItem[]>([]);
 
     const {
@@ -122,6 +120,11 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
         isLoading: isUserStoreListFetchRequestLoading,
         error: userStoreListFetchRequestError
     } = useUserStores(null);
+
+    useEffect(() => {
+        userStoreList?.length >= 1
+        && setuserStoreOption(userStoreList[0].name);
+    }, [ userStoreList ]);
 
     /**
      * Moderate Groups response from the API.
@@ -415,13 +418,8 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
      * Handles the user store wise filtering for groups.
      */
     const filterUserStores = (option: string): void => {
-        if(option === GroupConstants.ALL_GROUPS){
-            setPaginatedFilteredGroups(paginatedGroups);
-
-            return;
-        }
         setPaginatedFilteredGroups(groupList?.filter((group: GroupsInterface) => {
-            return (group.displayName.includes(option.toUpperCase()));
+            return (group.displayName.includes(option?.toUpperCase()));
         }));
     };
 
@@ -430,7 +428,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
      */
     const addDefaultValueToDropDownOptions = (): DropdownItemProps[] => {
 
-        const userStoreOptions: DropdownItemProps[] = cloneDeep(enabledUserStores)?.map(
+        return cloneDeep(userStoreList)?.map(
             (item: UserStoreListItem, index: number) => {
                 return {
                     key: index,
@@ -438,12 +436,6 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                     value: item.name.toUpperCase()
                 };
             });
-
-        return union([ {
-            key: GroupConstants.ALL_GROUPS,
-            text: GroupConstants.ALL_GROUPS,
-            value: GroupConstants.ALL_GROUPS
-        } ], userStoreOptions);
     };
 
     return (
@@ -453,9 +445,8 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                 !isGroupListFetchRequestLoading
                 && (
                     userStoreOption === CONSUMER_USERSTORE
-                    || userStoreOption === GroupConstants.ALL_GROUPS
                 )
-                && originalGroupList?.totalResults > 0
+                && originalGroupList.totalResults > 0
                 && (
                     <Show
                         when={ featureConfig?.groups?.scopes?.create }

--- a/features/admin.extensions.v1/components/groups/pages/groups.tsx
+++ b/features/admin.extensions.v1/components/groups/pages/groups.tsx
@@ -53,6 +53,7 @@ import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { Dropdown, DropdownItemProps, DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
+import { userstoresConfig } from "../../../configs";
 import { UserStoreUtils } from "../../../utils/user-store-utils";
 import { GroupList } from "../groups-list";
 import { CreateGroupWizard } from "../wizard";
@@ -104,7 +105,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     const excludeMembers: string = "members";
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
-    const [ userStoreOption, setuserStoreOption ] = useState<string>(userstoresConfig.primaryUserstoreNam);
+    const [ userStoreOption, setuserStoreOption ] = useState<string>(userstoresConfig.primaryUserstoreName);
     const [ enabledUserStores, setEnabledUserStores ] = useState<UserStoreListItem[]>([]);
 
     const {

--- a/features/admin.extensions.v1/components/groups/pages/groups.tsx
+++ b/features/admin.extensions.v1/components/groups/pages/groups.tsx
@@ -440,7 +440,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
             action={
                 !isGroupListFetchRequestLoading
                 && userStoreOption === CONSUMER_USERSTORE
-                && originalGroupList.totalResults > 0
+                && originalGroupList?.totalResults > 0
                 && (
                     <Show
                         when={ featureConfig?.groups?.scopes?.create }

--- a/features/admin.groups.v1/constants/group-constants.ts
+++ b/features/admin.groups.v1/constants/group-constants.ts
@@ -43,11 +43,6 @@ export class GroupConstants {
         .set("GROUP_DELETE", "groups.delete")
         .set("GROUP_READ", "groups.read")
 
-    /**
-     * Set all groups option
-     */
-    public static ALL_GROUPS: string = "All user stores";
-
     public static ALL_USER_STORES_OPTION_VALUE: string = "all";
 
     public static readonly PRIMARY_USER_STORE_OPTION_VALUE: string = "primary";

--- a/features/admin.groups.v1/constants/group-constants.ts
+++ b/features/admin.groups.v1/constants/group-constants.ts
@@ -43,7 +43,5 @@ export class GroupConstants {
         .set("GROUP_DELETE", "groups.delete")
         .set("GROUP_READ", "groups.read")
 
-    public static ALL_USER_STORES_OPTION_VALUE: string = "all";
-
     public static readonly PRIMARY_USER_STORE_OPTION_VALUE: string = "primary";
 }

--- a/features/admin.groups.v1/pages/groups.tsx
+++ b/features/admin.groups.v1/pages/groups.tsx
@@ -51,7 +51,6 @@ import { Dropdown, DropdownItemProps, DropdownProps, Icon, PaginationProps } fro
 import { deleteGroupById, useGroupList } from "../api";
 import { GroupList } from "../components";
 import { CreateGroupWizardUpdated } from "../components/wizard/create-group-wizard-updated";
-import { GroupConstants } from "../constants";
 import { GroupsInterface, WizardStepsFormTypes } from "../models";
 
 const GROUPS_SORTING_OPTIONS: DropdownItemProps[] = [

--- a/features/admin.groups.v1/pages/groups.tsx
+++ b/features/admin.groups.v1/pages/groups.tsx
@@ -234,11 +234,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     };
 
     const handleDomainChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
-        if (data.value === GroupConstants.ALL_USER_STORES_OPTION_VALUE) {
-            setUserStore(null);
-        } else {
-            setUserStore(data.value as string);
-        }
+        setUserStore(data.value as string);
     };
 
     const handlePaginationChange = (event: React.MouseEvent<HTMLAnchorElement>, data: PaginationProps) => {

--- a/features/admin.groups.v1/pages/groups.tsx
+++ b/features/admin.groups.v1/pages/groups.tsx
@@ -233,7 +233,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     };
 
     const handleDomainChange = (event: React.MouseEvent<HTMLAnchorElement>, data: DropdownProps) => {
-        setUserStore(data.value as string);
+        setUserStore(data?.value as string);
     };
 
     const handlePaginationChange = (event: React.MouseEvent<HTMLAnchorElement>, data: PaginationProps) => {


### PR DESCRIPTION
### Purpose
Remove All user stores option from the user store dropdown in groups section

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
