### PR TITLE
Prevent showing email when username and email are same in the my account user profile dropdown

### DIFF
--- a/.changeset/friendly-dingos-accept.md
+++ b/.changeset/friendly-dingos-accept.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Added a condition to prevent showing email when username and email are same

--- a/.changeset/friendly-dingos-accept.md
+++ b/.changeset/friendly-dingos-accept.md
@@ -2,4 +2,4 @@
 "@wso2is/myaccount": patch
 ---
 
-Added a condition to prevent showing email when username and email are same
+Prevent showing email when username and email are same

--- a/apps/myaccount/src/components/shared/header.tsx
+++ b/apps/myaccount/src/components/shared/header.tsx
@@ -17,12 +17,6 @@
  */
 
 import { useColorScheme } from "@mui/material";
-import {
-    ArrowRightFromBracketIcon,
-    ChevronDownIcon,
-    LanguageIcon,
-    RectangleLineIcon
-} from "@oxygen-ui/react-icons";
 import Alert from "@oxygen-ui/react/Alert";
 import Button from "@oxygen-ui/react/Button";
 import Flag from "@oxygen-ui/react/CountryFlag";
@@ -34,6 +28,12 @@ import ListItemIcon from "@oxygen-ui/react/ListItemIcon";
 import ListItemText from "@oxygen-ui/react/ListItemText";
 import Menu from "@oxygen-ui/react/Menu";
 import MenuItem from "@oxygen-ui/react/MenuItem";
+import {
+    ArrowRightFromBracketIcon,
+    ChevronDownIcon,
+    LanguageIcon,
+    RectangleLineIcon
+} from "@oxygen-ui/react-icons";
 import { useThemeProvider } from "@wso2is/common.branding.v1/hooks/use-theme-provider";
 import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
 import {

--- a/apps/myaccount/src/components/shared/header.tsx
+++ b/apps/myaccount/src/components/shared/header.tsx
@@ -340,6 +340,16 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
         return "";
     };
 
+    const resolveEmail = (): string => {
+        let email: string = profileInfo?.email ?? profileInfo?.emails[profileInfo.emails.length - 1];
+
+        if (email === resolveUsername()) {
+            // When both the username and email are the same, the email is not shown.
+            email = "";
+        }
+        return email;
+    };
+
     return (
         <OxygenHeader
             className="is-header"
@@ -396,7 +406,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
                 title: theme?.images?.myAccountLogo?.title ?? config.ui.appName
             } }
             user={ {
-                email: profileInfo?.email ?? profileInfo?.emails[profileInfo.emails.length - 1],
+                email: resolveEmail(),
                 image: profileInfo?.profileUrl,
                 name: resolveUsername()
             } }

--- a/apps/myaccount/src/components/shared/header.tsx
+++ b/apps/myaccount/src/components/shared/header.tsx
@@ -17,6 +17,12 @@
  */
 
 import { useColorScheme } from "@mui/material";
+import {
+    ArrowRightFromBracketIcon,
+    ChevronDownIcon,
+    LanguageIcon,
+    RectangleLineIcon
+} from "@oxygen-ui/react-icons";
 import Alert from "@oxygen-ui/react/Alert";
 import Button from "@oxygen-ui/react/Button";
 import Flag from "@oxygen-ui/react/CountryFlag";
@@ -28,12 +34,6 @@ import ListItemIcon from "@oxygen-ui/react/ListItemIcon";
 import ListItemText from "@oxygen-ui/react/ListItemText";
 import Menu from "@oxygen-ui/react/Menu";
 import MenuItem from "@oxygen-ui/react/MenuItem";
-import {
-    ArrowRightFromBracketIcon,
-    ChevronDownIcon,
-    LanguageIcon,
-    RectangleLineIcon
-} from "@oxygen-ui/react-icons";
 import { useThemeProvider } from "@wso2is/common.branding.v1/hooks/use-theme-provider";
 import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
 import {
@@ -347,6 +347,7 @@ export const Header: FunctionComponent<HeaderPropsInterface> = (
             // When both the username and email are the same, the email is not shown.
             email = "";
         }
+
         return email;
     };
 


### PR DESCRIPTION
## Purpose
> $subject

### Previous Behaviour
#### When Username and Email are different.
![image](https://github.com/wso2/identity-apps/assets/75057725/b5f56547-1610-4d82-8fd3-d7561133db48)

#### When Username and Email are same.
<img width="501" alt="image" src="https://github.com/wso2/identity-apps/assets/75057725/498153f1-6319-484c-bdee-9d20244126ad">

### Behaviour after the fix
#### When Username and Email are different.
![image](https://github.com/wso2/identity-apps/assets/75057725/b5f56547-1610-4d82-8fd3-d7561133db48)

#### When Username and Email are same.
<img width="496" alt="image" src="https://github.com/wso2/identity-apps/assets/75057725/d3950bfa-d226-47e6-ae11-10499a028f2f">
