### PR TITLE
Fix broken i18n in add authenticator modal

### DIFF
--- a/.changeset/healthy-years-poke.md
+++ b/.changeset/healthy-years-poke.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix broken i18n in add authenticator modal

--- a/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
+++ b/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
@@ -727,12 +727,13 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
                         : (
                             <div>
                                 <EmptyPlaceholder
-                                    subtitle={
-                                        [
-                                            t("applications:placeholders" +
-                                                ".emptyAuthenticatorsList.subtitles")
-                                        ]
-                                    }
+                                    subtitle={ [
+                                        t(
+                                            "applications:placeholders" +
+                                            ".emptyAuthenticatorsList.subtitles",
+                                            { type: searchQuery }
+                                        )
+                                    ] }
                                 />
                                 {
                                     allowSocialLoginAddition && (


### PR DESCRIPTION
### Purpose
Fix broken i18n in add authenticator modal

**Before**
<img width="714" alt="Screenshot 2024-06-10 at 10 53 30" src="https://github.com/wso2/identity-apps/assets/27746285/9526902f-39f9-4bd4-b96e-d110f9828519">

**After**
<img width="714" alt="Screenshot 2024-06-10 at 10 53 02" src="https://github.com/wso2/identity-apps/assets/27746285/e8ff0547-361a-43a1-80fb-6768db2dc043">


### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
