### PR TITLE
Only render the danger zone when the group object is available

### DIFF
--- a/.changeset/purple-dingos-work.md
+++ b/.changeset/purple-dingos-work.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.groups.v1": patch
+---
+
+Only render the danger zone when the group object is available

--- a/features/admin.groups.v1/components/edit-group/edit-group-basic.tsx
+++ b/features/admin.groups.v1/components/edit-group/edit-group-basic.tsx
@@ -387,35 +387,37 @@ export const BasicGroupDetails: FunctionComponent<BasicGroupProps> = (props: Bas
                 )
             }
             {
-                showGroupDeleteConfirmation &&
-                (<ConfirmationModal
-                    onClose={ (): void => setShowDeleteConfirmationModal(false) }
-                    type="negative"
-                    open={ showGroupDeleteConfirmation }
-                    assertionHint={ t("roles:edit.basics.confirmation.assertionHint") }
-                    assertionType="checkbox"
-                    primaryAction="Confirm"
-                    secondaryAction="Cancel"
-                    onSecondaryActionClick={ (): void => setShowDeleteConfirmationModal(false) }
-                    onPrimaryActionClick={ (): void => handleOnDelete(groupObject.id) }
-                    data-testid={
-                        isGroup
-                            ? `${ testId }-group-confirmation-modal`
-                            : `${ testId }-role-confirmation-modal`
-                    }
-                >
-                    <ConfirmationModal.Header>
-                        { t("roles:edit.basics.confirmation.header") }
-                    </ConfirmationModal.Header>
-                    <ConfirmationModal.Message attached negative>
-                        { t("roles:edit.basics.confirmation.message",
-                            { type: isGroup ? "group." : "role." }) }
-                    </ConfirmationModal.Message>
-                    <ConfirmationModal.Content>
-                        { t("roles:edit.basics.confirmation.content",
-                            { type: isGroup ? "group" : "role" }) }
-                    </ConfirmationModal.Content>
-                </ConfirmationModal>)
+                showGroupDeleteConfirmation
+                && groupObject.id
+                && (
+                    <ConfirmationModal
+                        onClose={ (): void => setShowDeleteConfirmationModal(false) }
+                        type="negative"
+                        open={ showGroupDeleteConfirmation }
+                        assertionHint={ t("roles:edit.basics.confirmation.assertionHint") }
+                        assertionType="checkbox"
+                        primaryAction="Confirm"
+                        secondaryAction="Cancel"
+                        onSecondaryActionClick={ (): void => setShowDeleteConfirmationModal(false) }
+                        onPrimaryActionClick={ (): void => handleOnDelete(groupObject.id) }
+                        data-testid={
+                            isGroup
+                                ? `${ testId }-group-confirmation-modal`
+                                : `${ testId }-role-confirmation-modal`
+                        }
+                    >
+                        <ConfirmationModal.Header>
+                            { t("roles:edit.basics.confirmation.header") }
+                        </ConfirmationModal.Header>
+                        <ConfirmationModal.Message attached negative>
+                            { t("roles:edit.basics.confirmation.message",
+                                { type: isGroup ? "group." : "role." }) }
+                        </ConfirmationModal.Message>
+                        <ConfirmationModal.Content>
+                            { t("roles:edit.basics.confirmation.content",
+                                { type: isGroup ? "group" : "role" }) }
+                        </ConfirmationModal.Content>
+                    </ConfirmationModal>)
             }
         </>
     );

--- a/features/admin.groups.v1/components/edit-group/edit-group-basic.tsx
+++ b/features/admin.groups.v1/components/edit-group/edit-group-basic.tsx
@@ -388,7 +388,7 @@ export const BasicGroupDetails: FunctionComponent<BasicGroupProps> = (props: Bas
             }
             {
                 showGroupDeleteConfirmation
-                && groupObject.id
+                && groupObject?.id
                 && (
                     <ConfirmationModal
                         onClose={ (): void => setShowDeleteConfirmationModal(false) }


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
$subject

### Related Issues
- N/A 

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
