### PR TITLE
Hide Add Group button for secondary readonly user stores

### DIFF
--- a/.changeset/pretty-pans-invent.md
+++ b/.changeset/pretty-pans-invent.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.groups.v1": patch
+---
+
+Hide Add Group button for secondary user stores

--- a/features/admin.groups.v1/pages/groups.tsx
+++ b/features/admin.groups.v1/pages/groups.tsx
@@ -144,7 +144,10 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     },[ groupsError ]);
 
     useEffect(() => {
-        if (!isSuperOrganization()) {
+        if (!(
+            isSuperOrganization()
+            || isFirstLevelOrganization()
+        )) {
             return;
         }
 


### PR DESCRIPTION
### Purpose
Hide Add Group button for secondary readonly user stores

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
