### PR TITLE
Display the scopes field in m2m guide only when API's are authorized

### DIFF
--- a/.changeset/nice-windows-obey.md
+++ b/.changeset/nice-windows-obey.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.extensions.v1": patch
+---
+
+diplay the scope field only when API's are authorized

--- a/features/admin.extensions.v1/application-templates/shared/components/m2m-custom-configuration.tsx
+++ b/features/admin.extensions.v1/application-templates/shared/components/m2m-custom-configuration.tsx
@@ -168,6 +168,10 @@ export const M2MCustomConfiguration: FC<M2MCustomConfigurationPropsInterface> = 
         tokenRequest = tokenRequest.concat(` -d 'scope=${copyScopesValue}'`);
     }
 
+    const isScopeAvailable = (value: string) => {
+        return value != null && value.trim() !== "";
+    };
+
     const renderConfigurationFields = (): ReactElement => {
         return (
             <>
@@ -250,36 +254,38 @@ export const M2MCustomConfiguration: FC<M2MCustomConfigurationPropsInterface> = 
                                         className="mt-2"
                                     />
                                 </Form.Field>
-                                <Form.Field>
-                                    <label>
-                                        {
-                                            t("extensions:develop.applications.quickstart.mobileApp" +
-                                                ".configurations.scope.label")
-                                        }
-                                        <Hint className="mt-0 mb-0" popup>
-                                            <Trans
-                                                i18nKey={
-                                                    "extensions:develop.applications.quickstart" +
-                                                    ".m2m.configurations.scopes"
-                                                }
-                                            >
-                                                The list of authorized scopes.
-                                                Include required scopes by authorizing APIs through the
-                                                <a
-                                                    className="link pointing"
-                                                    onClick={ onAPIAuthorizationTabClick }
+                                { isScopeAvailable(copyScopesValue) && (
+                                    <Form.Field>
+                                        <label>
+                                            {
+                                                t("extensions:develop.applications.quickstart.mobileApp" +
+                                                    ".configurations.scope.label")
+                                            }
+                                            <Hint className="mt-0 mb-0" popup>
+                                                <Trans
+                                                    i18nKey={
+                                                        "extensions:develop.applications.quickstart" +
+                                                        ".m2m.configurations.scopes"
+                                                    }
                                                 >
-                                                    API Authorization
-                                                </a>
-                                                tab.
-                                            </Trans>
-                                        </Hint>
-                                    </label>
-                                    <CopyInputField
-                                        value={ copyScopesValue }
-                                        data-componentid={ `${ componentId }-scope-readonly-input` }
-                                    />
-                                </Form.Field>
+                                                    The list of authorized scopes.
+                                                    Include required scopes by authorizing APIs through the
+                                                    <a
+                                                        className="link pointing"
+                                                        onClick={ onAPIAuthorizationTabClick }
+                                                    >
+                                                        API Authorization
+                                                    </a>
+                                                    tab.
+                                                </Trans>
+                                            </Hint>
+                                        </label>
+                                        <CopyInputField
+                                            value={ copyScopesValue }
+                                            data-componentid={ `${ componentId }-scope-readonly-input` }
+                                        />
+                                    </Form.Field>
+                                )}
                                 <Form.Field>
                                     <label>
                                         {

--- a/features/admin.extensions.v1/application-templates/shared/components/m2m-custom-configuration.tsx
+++ b/features/admin.extensions.v1/application-templates/shared/components/m2m-custom-configuration.tsx
@@ -285,7 +285,7 @@ export const M2MCustomConfiguration: FC<M2MCustomConfigurationPropsInterface> = 
                                             data-componentid={ `${ componentId }-scope-readonly-input` }
                                         />
                                     </Form.Field>
-                                )}
+                                ) }
                                 <Form.Field>
                                     <label>
                                         {

--- a/features/admin.extensions.v1/application-templates/shared/components/m2m-custom-configuration.tsx
+++ b/features/admin.extensions.v1/application-templates/shared/components/m2m-custom-configuration.tsx
@@ -168,10 +168,6 @@ export const M2MCustomConfiguration: FC<M2MCustomConfigurationPropsInterface> = 
         tokenRequest = tokenRequest.concat(` -d 'scope=${copyScopesValue}'`);
     }
 
-    const isScopeAvailable = (value: string) => {
-        return value != null && value.trim() !== "";
-    };
-
     const renderConfigurationFields = (): ReactElement => {
         return (
             <>
@@ -254,7 +250,7 @@ export const M2MCustomConfiguration: FC<M2MCustomConfigurationPropsInterface> = 
                                         className="mt-2"
                                     />
                                 </Form.Field>
-                                { isScopeAvailable(copyScopesValue) && (
+                                { !!copyScopesValue && (
                                     <Form.Field>
                                         <label>
                                             {


### PR DESCRIPTION
### Purpose
$subject

### Related Issues
- 

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
