### PR TITLE
Enable self registration link when email OTP is the only step in authentication flow

### DIFF
--- a/.changeset/spicy-walls-glow.md
+++ b/.changeset/spicy-walls-glow.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Enable self registration link when email otp is the only step in authentication flow

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/identifierauth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/identifierauth.jsp
@@ -362,7 +362,7 @@
 </form>
 <%
 if (!StringUtils.equals("CONSOLE",clientId)
-        && !StringUtils.equals("MY_ACCOUNT",clientId) && isFederatedOptionsAvailable && !isMagicLink &&
+        && !StringUtils.equals("MY_ACCOUNT",clientId) && !isMagicLink &&
         isSelfSignUpEnabledInTenant && isSelfSignUpEnabledInTenantPreferences) {
         String urlParameters = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
 %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -1517,31 +1517,23 @@
             %>
 
             // Dynamically render the configured authenticators.
-            var hasLocal = false;
             var hasFederated = false;
             var isBasicForm = true;
             var isSSOLoginTheOnlyAuthenticatorConfigured = <%=isSSOLoginTheOnlyAuthenticatorConfigured%>;
             try {
-                var hasLocal=JSON.parse(<%=isLocal%>);
                 var hasFederated = JSON.parse(<%=isFederated%>);
                 var isBasicForm = JSON.parse(<%=isBasic%>);
             } catch(error) {
                 // Do nothing.
             }
 
-            if (hasLocal & hasFederated & !isSSOLoginTheOnlyAuthenticatorConfigured) {
+            if (hasFederated & !isSSOLoginTheOnlyAuthenticatorConfigured) {
                 $("#continue-with-email").show();
-                $("#federated-authenticators").show();
-            } else if (hasFederated & !isSSOLoginTheOnlyAuthenticatorConfigured) {
                 $("#federated-authenticators").show();
             } else {
                 $("#continue-with-email").hide();
                 $("#federated-authenticators").hide();
-                if (hasLocal || isBasicForm) {
-                    $("#basic-form").show();
-                } else {
-                    $("#basic-form").hide();
-                }
+                $("#basic-form").show();
             }
 
             var container;


### PR DESCRIPTION
### Purpose
Enable self-registration link when email OTP is the only step in the authentication flow.

<img width="656" alt="Screenshot 2024-06-25 at 10 02 30" src="https://github.com/wso2/identity-apps/assets/27746285/5443c21f-ce65-43e7-a233-5cf069698e6e">

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
