### PR TITLE
Dynamically change the button text for the scim attribute tabs

### DIFF
--- a/.changeset/great-snakes-pay.md
+++ b/.changeset/great-snakes-pay.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/i18n": patch
+---
+
+Dynamically change the button text for scim attribute tabs

--- a/features/admin.claims.v1/components/edit/external-dialect/edit-external-claims.tsx
+++ b/features/admin.claims.v1/components/edit/external-dialect/edit-external-claims.tsx
@@ -76,13 +76,13 @@ interface EditExternalClaimsPropsInterface extends TestableComponentInterface {
      */
     mappedLocalClaims: string[];
     /**
-     * Is the button enabled.
+     * Is the attribute button enabled.
      */
-    isButtonEnabled: boolean;
+    isAttributeButtonEnabled: boolean;
     /**
-     * Button Text.
+     * Attribute button Text.
      */
-    buttonText: string;
+    attributeButtonText: string;
     /**
      * Update mapped claims on delete or edit
      */
@@ -113,8 +113,8 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
         attributeType,
         attributeUri,
         mappedLocalClaims,
-        isButtonEnabled,
-        buttonText,
+        isAttributeButtonEnabled,
+        attributeButtonText,
         updateMappedClaims,
         [ "data-testid" ]: testId
     } = props;
@@ -365,7 +365,7 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
                             featureConfig?.attributeDialects,
                             featureConfig?.attributeDialects?.scopes?.create,
                             allowedScopes
-                        ) && isButtonEnabled
+                        ) && isAttributeButtonEnabled
                         && (
                             /**
                              * `loading` property is used to check whether the current selected
@@ -391,7 +391,7 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
                             >
                                 <Icon name="add" />
                                 {
-                                    buttonText
+                                    attributeButtonText
                                 }
                             </PrimaryButton>
                         )

--- a/features/admin.claims.v1/components/edit/external-dialect/edit-external-claims.tsx
+++ b/features/admin.claims.v1/components/edit/external-dialect/edit-external-claims.tsx
@@ -76,6 +76,14 @@ interface EditExternalClaimsPropsInterface extends TestableComponentInterface {
      */
     mappedLocalClaims: string[];
     /**
+     * Is the button enabled.
+     */
+    isButtonEnabled: boolean;
+    /**
+     * Button Text.
+     */
+    buttonText: string;
+    /**
      * Update mapped claims on delete or edit
      */
     updateMappedClaims?: Dispatch<SetStateAction<boolean>>;
@@ -105,6 +113,8 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
         attributeType,
         attributeUri,
         mappedLocalClaims,
+        isButtonEnabled,
+        buttonText,
         updateMappedClaims,
         [ "data-testid" ]: testId
     } = props;
@@ -349,37 +359,43 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
             totalListSize={ filteredClaims?.length }
             rightActionPanel={
                 (<>
-                    { attributeConfig?.editAttributeMappings?.showAddExternalAttributeButton(dialectID) &&
-                    hasRequiredScopes(
-                        featureConfig?.attributeDialects,
-                        featureConfig?.attributeDialects?.scopes?.create,
-                        allowedScopes
-                    ) && (
-                        /**
-                         * `loading` property is used to check whether the current selected
-                         * dialect is same as the dialect which the claims are loaded.
-                         * If it's different, this condition will wait until the correct
-                         * dialects are loaded onto the view.
-                         */
-                        <PrimaryButton
-                            loading={ claims && attributeUri !== claims[0]?.claimDialectURI }
-                            onClick={ (): void => {
-                                if (attributeUri !== claims[0]?.claimDialectURI) {
-                                    return;
+                    {
+                        attributeConfig?.editAttributeMappings?.showAddExternalAttributeButton(dialectID)
+                        && hasRequiredScopes(
+                            featureConfig?.attributeDialects,
+                            featureConfig?.attributeDialects?.scopes?.create,
+                            allowedScopes
+                        ) && isButtonEnabled
+                        && (
+                            /**
+                             * `loading` property is used to check whether the current selected
+                             * dialect is same as the dialect which the claims are loaded.
+                             * If it's different, this condition will wait until the correct
+                             * dialects are loaded onto the view.
+                             */
+                            <PrimaryButton
+                                loading={ claims && attributeUri !== claims[0]?.claimDialectURI }
+                                onClick={ (): void => {
+                                    if (attributeUri !== claims[0]?.claimDialectURI) {
+                                        return;
+                                    }
+                                    setShowAddExternalClaim(true);
+                                } }
+                                disabled={
+                                    (
+                                        showAddExternalClaim
+                                        || (claims && attributeUri !== claims[0]?.claimDialectURI)
+                                    )
                                 }
-                                setShowAddExternalClaim(true);
-                            } }
-                            disabled={ showAddExternalClaim || (claims && attributeUri !== claims[0]?.claimDialectURI) }
-                            data-testid={ `${testId}-list-layout-add-button` }
-                        >
-                            <Icon name="add" />
-                            {
-                                t("claims:external.pageLayout.edit.primaryAction",
-                                    { type: resolveType(attributeType, true) }
-                                )
-                            }
-                        </PrimaryButton>
-                    ) }
+                                data-testid={ `${testId}-list-layout-add-button` }
+                            >
+                                <Icon name="add" />
+                                {
+                                    buttonText
+                                }
+                            </PrimaryButton>
+                        )
+                    }
                     { attributeType === ClaimManagementConstants.OIDC &&
                     featureConfig?.oidcScopes?.enabled &&
                     hasRequiredScopes(

--- a/features/admin.claims.v1/constants/claim-management-constants.ts
+++ b/features/admin.claims.v1/constants/claim-management-constants.ts
@@ -127,11 +127,33 @@ export class ClaimManagementConstants {
     public static readonly SCIM_TABS: {
         name: string;
         uri: string;
+        isButtonEnabled: boolean;
+        buttonText: string;
     }[] = [
-        { name: "Core Schema", uri: "urn:ietf:params:scim:schemas:core:2.0" },
-        { name: "User Schema", uri: "urn:ietf:params:scim:schemas:core:2.0:User" },
-        { name: "Enterprise Schema", uri: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User" },
-        { name: "Core 1.0 Schema", uri: "urn:scim:schemas:core:1.0" }
+        {
+            buttonText: "",
+            isButtonEnabled: false,
+            name: "Core Schema",
+            uri: "urn:ietf:params:scim:schemas:core:2.0"
+        },
+        {
+            buttonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction",
+            isButtonEnabled: true,
+            name: "User Schema",
+            uri: "urn:ietf:params:scim:schemas:core:2.0:User"
+        },
+        {
+            buttonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction" ,
+            isButtonEnabled: true,
+            name: "Enterprise Schema",
+            uri: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        },
+        {
+            buttonText: "",
+            isButtonEnabled: true,
+            name: "Core 1.0 Schema",
+            uri: "urn:scim:schemas:core:1.0"
+        }
     ];
 
     public static readonly EIDAS_TABS: {

--- a/features/admin.claims.v1/constants/claim-management-constants.ts
+++ b/features/admin.claims.v1/constants/claim-management-constants.ts
@@ -127,30 +127,30 @@ export class ClaimManagementConstants {
     public static readonly SCIM_TABS: {
         name: string;
         uri: string;
-        isButtonEnabled: boolean;
-        buttonText: string;
+        isAttributeButtonEnabled: boolean;
+        attributeButtonText: string;
     }[] = [
         {
-            buttonText: "",
-            isButtonEnabled: false,
+            attributeButtonText: "",
+            isAttributeButtonEnabled: false,
             name: "Core Schema",
             uri: "urn:ietf:params:scim:schemas:core:2.0"
         },
         {
-            buttonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction",
-            isButtonEnabled: true,
+            attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction",
+            isAttributeButtonEnabled: true,
             name: "User Schema",
             uri: "urn:ietf:params:scim:schemas:core:2.0:User"
         },
         {
-            buttonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction" ,
-            isButtonEnabled: true,
+            attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction" ,
+            isAttributeButtonEnabled: true,
             name: "Enterprise Schema",
             uri: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
         },
         {
-            buttonText: "",
-            isButtonEnabled: true,
+            attributeButtonText: "",
+            isAttributeButtonEnabled: true,
             name: "Core 1.0 Schema",
             uri: "urn:scim:schemas:core:1.0"
         }

--- a/features/admin.claims.v1/pages/attribute-mappings.tsx
+++ b/features/admin.claims.v1/pages/attribute-mappings.tsx
@@ -395,7 +395,12 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
             if (type === ClaimManagementConstants.SCIM) {
                 const panes: StrictTabProps[ "panes" ] = [];
 
-                ClaimManagementConstants.SCIM_TABS.forEach((tab: { name: string; uri: string }) => {
+                ClaimManagementConstants.SCIM_TABS.forEach((tab: {
+                    name: string;
+                    uri: string;
+                    isButtonEnabled: boolean;
+                    buttonText: string;
+                }) => {
                     if (!SCIMConfigs.hideCore1Schema || SCIMConfigs.scim.core1Schema !== tab.uri) {
                         const dialect: ClaimDialect = dialects?.find(
                             (dialect: ClaimDialect) => dialect.dialectURI === tab.uri
@@ -412,6 +417,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                             attributeType={ type }
                                             mappedLocalClaims={ mappedLocalclaims }
                                             updateMappedClaims={ setTriggerFetchMappedClaims }
+                                            isButtonEnabled={ tab.isButtonEnabled }
+                                            buttonText= { t(tab.buttonText) }
                                         />
                                     </ResourceTab.Pane>
                                 )
@@ -435,6 +442,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                         attributeUri={ dialect.dialectURI }
                                         mappedLocalClaims={ mappedLocalclaims }
                                         updateMappedClaims={ setTriggerFetchMappedClaims }
+                                        isButtonEnabled={ true }
+                                        buttonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
                                     />
                                 </ResourceTab.Pane>
                             )
@@ -448,7 +457,12 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
             if (type === ClaimManagementConstants.EIDAS) {
                 const panes: StrictTabProps[ "panes" ] = [];
 
-                ClaimManagementConstants.EIDAS_TABS.forEach((tab: { name: string; uri: string }) => {
+                ClaimManagementConstants.EIDAS_TABS.forEach((tab: {
+                    name: string;
+                    uri: string;
+                    isButtonEnabled: boolean;
+                    buttonText: string;
+                }) => {
                     const dialect: ClaimDialect = dialects?.find(
                         (dialect: ClaimDialect) => dialect.dialectURI === tab.uri
                     );
@@ -464,6 +478,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                         attributeType={ type }
                                         mappedLocalClaims={ mappedLocalclaims }
                                         updateMappedClaims={ setTriggerFetchMappedClaims }
+                                        isButtonEnabled={ tab.isButtonEnabled }
+                                        buttonText= { tab.buttonText }
                                     />
                                 </ResourceTab.Pane>
                             )
@@ -485,6 +501,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                 attributeUri={ dialect.dialectURI }
                                 mappedLocalClaims={ mappedLocalclaims }
                                 updateMappedClaims={ setTriggerFetchMappedClaims }
+                                isButtonEnabled={ true }
+                                buttonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
                             />
                         </ResourceTab.Pane>
                     )
@@ -516,6 +534,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                         attributeUri={ dialects &&  dialects[ 0 ]?.dialectURI }
                         mappedLocalClaims={ mappedLocalclaims }
                         updateMappedClaims={ setTriggerFetchMappedClaims }
+                        isButtonEnabled={ true }
+                        buttonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
                     />
                 ) }
             </PageLayout>

--- a/features/admin.claims.v1/pages/attribute-mappings.tsx
+++ b/features/admin.claims.v1/pages/attribute-mappings.tsx
@@ -398,8 +398,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                 ClaimManagementConstants.SCIM_TABS.forEach((tab: {
                     name: string;
                     uri: string;
-                    isButtonEnabled: boolean;
-                    buttonText: string;
+                    isAttributeButtonEnabled: boolean;
+                    attributeButtonText: string;
                 }) => {
                     if (!SCIMConfigs.hideCore1Schema || SCIMConfigs.scim.core1Schema !== tab.uri) {
                         const dialect: ClaimDialect = dialects?.find(
@@ -417,8 +417,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                             attributeType={ type }
                                             mappedLocalClaims={ mappedLocalclaims }
                                             updateMappedClaims={ setTriggerFetchMappedClaims }
-                                            isButtonEnabled={ tab.isButtonEnabled }
-                                            buttonText= { t(tab.buttonText) }
+                                            isAttributeButtonEnabled={ tab.isAttributeButtonEnabled }
+                                            attributeButtonText= { t(tab.attributeButtonText) }
                                         />
                                     </ResourceTab.Pane>
                                 )
@@ -442,8 +442,9 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                         attributeUri={ dialect.dialectURI }
                                         mappedLocalClaims={ mappedLocalclaims }
                                         updateMappedClaims={ setTriggerFetchMappedClaims }
-                                        isButtonEnabled={ true }
-                                        buttonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
+                                        isAttributeButtonEnabled={ true }
+                                        attributeButtonText=
+                                            { t("claims:external.pageLayout.edit.attributePrimaryAction") }
                                     />
                                 </ResourceTab.Pane>
                             )
@@ -460,8 +461,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                 ClaimManagementConstants.EIDAS_TABS.forEach((tab: {
                     name: string;
                     uri: string;
-                    isButtonEnabled: boolean;
-                    buttonText: string;
+                    isAttributeButtonEnabled: boolean;
+                    attributeButtonText: string;
                 }) => {
                     const dialect: ClaimDialect = dialects?.find(
                         (dialect: ClaimDialect) => dialect.dialectURI === tab.uri
@@ -478,8 +479,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                         attributeType={ type }
                                         mappedLocalClaims={ mappedLocalclaims }
                                         updateMappedClaims={ setTriggerFetchMappedClaims }
-                                        isButtonEnabled={ tab.isButtonEnabled }
-                                        buttonText= { tab.buttonText }
+                                        isAttributeButtonEnabled={ tab.isAttributeButtonEnabled }
+                                        attributeButtonText= { tab.attributeButtonText }
                                     />
                                 </ResourceTab.Pane>
                             )
@@ -501,8 +502,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                 attributeUri={ dialect.dialectURI }
                                 mappedLocalClaims={ mappedLocalclaims }
                                 updateMappedClaims={ setTriggerFetchMappedClaims }
-                                isButtonEnabled={ true }
-                                buttonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
+                                isAttributeButtonEnabled={ true }
+                                attributeButtonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
                             />
                         </ResourceTab.Pane>
                     )
@@ -534,8 +535,8 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                         attributeUri={ dialects &&  dialects[ 0 ]?.dialectURI }
                         mappedLocalClaims={ mappedLocalclaims }
                         updateMappedClaims={ setTriggerFetchMappedClaims }
-                        isButtonEnabled={ true }
-                        buttonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
+                        isAttributeButtonEnabled={ true }
+                        attributeButtonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
                     />
                 ) }
             </PageLayout>

--- a/features/admin.claims.v1/pages/external-dialect-edit.tsx
+++ b/features/admin.claims.v1/pages/external-dialect-edit.tsx
@@ -61,6 +61,14 @@ interface ExternalDialectEditPageInterface extends TestableComponentInterface {
      */
     mappedLocalClaims: string[];
     /**
+     * Is the button enabled.
+     */
+    isButtonEnabled: boolean;
+    /**
+     * Button Text.
+     */
+    buttonText: string;
+    /**
      * Update mapped claims on delete or edit
      */
     updateMappedClaims?: ReactDispatch<SetStateAction<boolean>>;
@@ -79,6 +87,8 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
         attributeType,
         attributeUri,
         mappedLocalClaims,
+        isButtonEnabled,
+        buttonText,
         updateMappedClaims,
         [ "data-testid" ]: testId,
         id: dialectId
@@ -333,6 +343,8 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
                 attributeUri={ attributeUri }
                 mappedLocalClaims={ mappedLocalClaims }
                 updateMappedClaims={ updateMappedClaims }
+                isButtonEnabled={ isButtonEnabled }
+                buttonText={ buttonText }
             />
 
             <Divider hidden />

--- a/features/admin.claims.v1/pages/external-dialect-edit.tsx
+++ b/features/admin.claims.v1/pages/external-dialect-edit.tsx
@@ -61,13 +61,13 @@ interface ExternalDialectEditPageInterface extends TestableComponentInterface {
      */
     mappedLocalClaims: string[];
     /**
-     * Is the button enabled.
+     * Is the attribute button enabled.
      */
-    isButtonEnabled: boolean;
+    isAttributeButtonEnabled: boolean;
     /**
-     * Button Text.
+     * Attribute button Text.
      */
-    buttonText: string;
+    attributeButtonText: string;
     /**
      * Update mapped claims on delete or edit
      */
@@ -87,8 +87,8 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
         attributeType,
         attributeUri,
         mappedLocalClaims,
-        isButtonEnabled,
-        buttonText,
+        isAttributeButtonEnabled,
+        attributeButtonText,
         updateMappedClaims,
         [ "data-testid" ]: testId,
         id: dialectId
@@ -343,8 +343,8 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
                 attributeUri={ attributeUri }
                 mappedLocalClaims={ mappedLocalClaims }
                 updateMappedClaims={ updateMappedClaims }
-                isButtonEnabled={ isButtonEnabled }
-                buttonText={ buttonText }
+                isAttributeButtonEnabled={ isAttributeButtonEnabled }
+                attributeButtonText={ attributeButtonText }
             />
 
             <Divider hidden />

--- a/modules/i18n/src/models/namespaces/claims-ns.ts
+++ b/modules/i18n/src/models/namespaces/claims-ns.ts
@@ -306,7 +306,8 @@ export interface ClaimsNS {
         pageLayout: {
             edit: {
                 header: string;
-                primaryAction: string;
+                attributeMappingPrimaryAction: string;
+                attributePrimaryAction: string;
             };
         };
         placeholders: {

--- a/modules/i18n/src/translations/en-US/portals/claims.ts
+++ b/modules/i18n/src/translations/en-US/portals/claims.ts
@@ -325,8 +325,9 @@ export const claims: ClaimsNS = {
         },
         pageLayout: {
             edit: {
-                header: "Add {{type}} Attribute",
-                primaryAction: "New Attribute"
+                attributeMappingPrimaryAction: "Add Attribute Mappingg",
+                attributePrimaryAction: "New Attribute",
+                header: "Add {{type}} Attribute"
             }
         },
         placeholders: {


### PR DESCRIPTION
### Purpose
Dynamically change the button text for the scim attribute tabs.

1. **Core schema:** Remove the `New Attribute` button

2. **User schema and Enterprise schema:** Rename the Add Attribute button to `Add Attribute Mapping`

3. **Custom schema:** Leave the `New Attribute` button as it is. No change

https://github.com/wso2/identity-apps/assets/27746285/cceeb899-54df-4a22-bff0-4ba5d087c368

### Related Issues
- None

### Related PRs
- None

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
