### PR TITLE
Prevent fidp param being attached to post logout redirect URI if the signing-in org is a sub organization

### DIFF
--- a/.changeset/thin-snails-build.md
+++ b/.changeset/thin-snails-build.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.authentication.v1": patch
+---
+
+Prevent fidp param being attached to post logout redirect URI if the signing-in org is a sub organization

--- a/features/admin.authentication.v1/hooks/use-sign-in.ts
+++ b/features/admin.authentication.v1/hooks/use-sign-in.ts
@@ -460,13 +460,14 @@ const useSignIn = (): UseSignInInterface => {
                  * If,
                  *  (i) the experimental Platform IdP is enabled, and
                  *  (ii) the user is not a privileged user, and
-                 *  (iii) the currently signed-in organization is not super organization,
+                 *  (iii) the currently signed-in organization is not the super organization or a suborganization
                  * We need to append the `homeRealmId` of the platform IdP as a `fidp` query
                  * param to the post logout redirect URL.
                  * */
                 if (__experimental__platformIdP?.enabled
                         && !isPrivilegedUser
                         && orgType !== OrganizationType.SUPER_ORGANIZATION
+                        && orgType !== OrganizationType.SUBORGANIZATION
                 ) {
                     if (!signOutRedirectURL) {
                         signOutRedirectURL = new URL(window["AppUtils"]?.getConfig()?.logoutCallbackURL);


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
