### PR TITLE
Fix the claim dialect issue in force password reset.

### DIFF
--- a/.changeset/unlucky-swans-bake.md
+++ b/.changeset/unlucky-swans-bake.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Add conditional dilect selection to fix the claim dilect issue in the force password reset.

--- a/features/admin.extensions.v1/configs/models/scim.ts
+++ b/features/admin.extensions.v1/configs/models/scim.ts
@@ -30,10 +30,10 @@ export interface SCIMConfigInterface {
         accountDisabled: string,
         accountLocked: string,
         askPassword: string,
+        forcePasswordReset: string,
         isReadOnlyUser: string,
         oneTimePassword: string,
-        profileUrl: string,
-        forcePasswordReset: string,
+        profileUrl: string
     };
     scimDialectID: {
         customEnterpriseSchema: string,

--- a/features/admin.extensions.v1/configs/models/scim.ts
+++ b/features/admin.extensions.v1/configs/models/scim.ts
@@ -32,7 +32,8 @@ export interface SCIMConfigInterface {
         askPassword: string,
         isReadOnlyUser: string,
         oneTimePassword: string,
-        profileUrl: string
+        profileUrl: string,
+        forcePasswordReset: string,
     };
     scimDialectID: {
         customEnterpriseSchema: string,

--- a/features/admin.extensions.v1/configs/scim.ts
+++ b/features/admin.extensions.v1/configs/scim.ts
@@ -38,10 +38,10 @@ export const SCIMConfigs: SCIMConfigInterface = {
         accountDisabled: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.accountDisabled",
         accountLocked: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.accountLocked",
         askPassword: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.askPassword",
+        forcePasswordReset: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.forcePasswordReset",
         isReadOnlyUser: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.isReadOnlyUser",
         oneTimePassword: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.oneTimePassword",
-        profileUrl: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.profileUrl",
-        forcePasswordReset: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.forcePasswordReset"
+        profileUrl: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.profileUrl"
     },
     serverSupportedClaimsAvailable: [
         "urn:scim:schemas:core:1.0",

--- a/features/admin.extensions.v1/configs/scim.ts
+++ b/features/admin.extensions.v1/configs/scim.ts
@@ -40,7 +40,8 @@ export const SCIMConfigs: SCIMConfigInterface = {
         askPassword: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.askPassword",
         isReadOnlyUser: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.isReadOnlyUser",
         oneTimePassword: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.oneTimePassword",
-        profileUrl: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.profileUrl"
+        profileUrl: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.profileUrl",
+        forcePasswordReset: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.forcePasswordReset"
     },
     serverSupportedClaimsAvailable: [
         "urn:scim:schemas:core:1.0",

--- a/features/admin.users.v1/components/user-change-password.tsx
+++ b/features/admin.users.v1/components/user-change-password.tsx
@@ -16,12 +16,12 @@
  * under the License.
  */
 import { AppConstants, AppState, FeatureConfigInterface, SharedUserStoreUtils, history } from "@wso2is/admin.core.v1";
+import { SCIMConfigs } from "@wso2is/admin.extensions.v1";
 import { PatchRoleDataInterface } from "@wso2is/admin.roles.v2/models/roles";
 import {
     ConnectorPropertyInterface,
     ServerConfigurationsConstants
 } from "@wso2is/admin.server-configurations.v1";
-import { SCIMConfigs } from "@wso2is/admin.extensions.v1";
 import {
     PRIMARY_USERSTORE,
     USERSTORE_REGEX_PROPERTIES

--- a/features/admin.users.v1/components/user-change-password.tsx
+++ b/features/admin.users.v1/components/user-change-password.tsx
@@ -21,6 +21,7 @@ import {
     ConnectorPropertyInterface,
     ServerConfigurationsConstants
 } from "@wso2is/admin.server-configurations.v1";
+import { SCIMConfigs } from "@wso2is/admin.extensions.v1";
 import {
     PRIMARY_USERSTORE,
     USERSTORE_REGEX_PROPERTIES
@@ -219,7 +220,10 @@ export const ChangePasswordComponent: FunctionComponent<ChangePasswordPropsInter
                 {
                     "op": "add",
                     "value": {
-                        [ProfileConstants.SCIM2_WSO2_USER_SCHEMA]: {
+                        [ SCIMConfigs?.scimEnterpriseUserClaimUri?.forcePasswordReset?.
+                            startsWith(ProfileConstants.SCIM2_ENT_USER_SCHEMA)
+                            ? ProfileConstants.SCIM2_ENT_USER_SCHEMA
+                            : ProfileConstants.SCIM2_WSO2_USER_SCHEMA ]: {
                             "forcePasswordReset": true
                         }
                     }


### PR DESCRIPTION
### Purpose
Force password reset is not working in the identity apps due to issue in the claim dialect. 
This was solved by selecting the claim conditionaly.

### Related Issues
- Fix https://github.com/wso2/product-is/issues/20630

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
