### PR TITLE
Add limit to the tenant association extraction API

### DIFF
--- a/.changeset/clever-colts-train.md
+++ b/.changeset/clever-colts-train.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.extensions.v1": patch
+---
+
+Add limit to the tenant association extraction

--- a/features/admin.extensions.v1/components/tenants/api/tenants.ts
+++ b/features/admin.extensions.v1/components/tenants/api/tenants.ts
@@ -30,6 +30,11 @@ export const getDomainQueryParam = (): string => {
     return `?domain=${ tenantDomain }`;
 };
 
+export const getLimitQueryParam = (): string => {
+
+    return "&limit=30";
+};
+
 const isPrivilegedUser = (): boolean => {
     const isPrivileged: boolean = store.getState()?.auth?.isPrivilegedUser ?? false;
 
@@ -137,7 +142,7 @@ export const getAssociatedTenants = (): Promise<TenantRequestResponse> => {
 
     const requestConfig: AxiosRequestConfig = {
         method: HttpMethods.GET,
-        url: getTenantResourceEndpoints().tenantAssociationApi + getDomainQueryParam()
+        url: getTenantResourceEndpoints().tenantAssociationApi + getDomainQueryParam() + getLimitQueryParam()
     };
 
     return httpClient(requestConfig)


### PR DESCRIPTION
### Purpose
> $subject to increase the default limit of 15 associations.