### PR TITLE
Remove auth params `waitingConfigs` from the back to multi option uri & improve internalWait.jsp

### DIFF
--- a/.changeset/stale-timers-yawn.md
+++ b/.changeset/stale-timers-yawn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": major
+---
+
+Remove auth param waitingConfigs from multioption uri and improve internalWait.jsp

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -205,7 +205,7 @@
         Map<String, Object> authParamMap = ((AuthenticationRequestWrapper) request).getAuthParams();
 
         // Remove `waitingConfigs` auth param from the query map since `internalWait` prompt related auth params
-        // doesn't need to add to the multi-option uri.
+        // doesn't need to be added to the multi-option uri.
         if (authParamMap != null && !authParamMap.isEmpty() && queryParamMap != null && !queryParamMap.isEmpty()) {
             if (authParamMap.containsKey("waitingConfigs") && authParamMap.containsKey("waitingType")) {
                 queryParamMap.remove("waitingConfigs");

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -44,6 +44,7 @@
 <%@ page import="org.apache.commons.collections.MapUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.client.model.AuthenticationRequestWrapper" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 
 <%@ include file="includes/localize.jsp" %>
@@ -200,7 +201,17 @@
 
         // Build the query string using the parameter map since the query string can contain fewer parameters
         // due to parameter filtering.
-        String queryParamString = AuthenticationEndpointUtil.resolveQueryString(request.getParameterMap());
+        Map<String, String[]> queryParamMap = request.getParameterMap();
+        Map<String, Object> authParamMap = ((AuthenticationRequestWrapper) request).getAuthParams();
+
+        // Remove `waitingConfigs` auth param from the query map since `internalWait` prompt related auth params
+        // doesn't need to add to the multi-option uri.
+        if (authParamMap != null && !authParamMap.isEmpty() && queryParamMap != null && !queryParamMap.isEmpty()) {
+            if (authParamMap.containsKey("waitingConfigs") && authParamMap.containsKey("waitingType")) {
+                queryParamMap.remove("waitingConfigs");
+            }
+        }
+        String queryParamString = AuthenticationEndpointUtil.resolveQueryString(queryParamMap);
         multiOptionURIParam = "&multiOptionURI=" + Encode.forUriComponent(baseURL + queryParamString);
     }
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/internalWait.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/templates/internalWait.jsp
@@ -58,14 +58,22 @@
     if (requestDataObject instanceof Map) {
         Map<String, Object> requestData = (Map<String, Object>) requestDataObject;
 
-        if (StringUtils.isNotBlank((String) requestData.get("type"))) {
+        if (StringUtils.isNotBlank((String) requestData.get("waitingType"))) {
+            if (WaitingMethods.contains((String) requestData.get("waitingType"))) {
+                type = Encode.forJavaScriptAttribute((String) requestData.get("waitingType"));
+            }
+        } else if (StringUtils.isNotBlank((String) requestData.get("type"))) {
             if (WaitingMethods.contains((String) requestData.get("type"))) {
                 type = Encode.forJavaScriptAttribute((String) requestData.get("type"));
             }
         }
 
         // Process the function data.
-        Map<String, Object> functionData = (Map<String, Object>) requestData.get("data");
+        Map<String, Object> functionData = (Map<String, Object>) requestData.get("waitingConfigs");
+        if (functionData == null) {
+            functionData = (Map<String, Object>) requestData.get("data");
+        }
+
 
         if (functionData != null) {
             // Set the greeting and message.


### PR DESCRIPTION
### Purpose
- Remove internalWait prompt related auth param waitingConfigs` from the multi-option uri
- Improve internal wait.jsp to honour new internal wait prompt related data

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/25194
- https://github.com/wso2-enterprise/asgardeo-product/issues/25236


### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
