### PR TITLE
Handle SSO authenticator logo for authentication portal

### DIFF
--- a/.changeset/lazy-eels-remember.md
+++ b/.changeset/lazy-eels-remember.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add SSO authenticator logo

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -70,6 +70,7 @@
     private static final String GITHUB_AUTHENTICATOR = "GithubAuthenticator";
     private static final String FACEBOOK_AUTHENTICATOR = "FacebookAuthenticator";
     private static final String OIDC_AUTHENTICATOR = "OpenIDConnectAuthenticator";
+    private static final String SSO_AUTHENTICATOR_NAME = "SSO";
     private static final String MICROSOFT_IDP = "Microsoft";
     private static final String ENTERPRISE_USER_LOGIN_AUTHENTICATOR = "EnterpriseIDPAuthenticator";
     private static final String ENTERPRISE_USER_LOGIN_ORG = "EnterpriseIDP_Org";
@@ -653,6 +654,10 @@
                                         String EXTERNAL_CONNECTION_PREFIX = "sign in with";
                                         if (StringUtils.startsWithIgnoreCase(idpDisplayName, EXTERNAL_CONNECTION_PREFIX)) {
                                             idpDisplayName = idpDisplayName.substring(EXTERNAL_CONNECTION_PREFIX.length());
+                                        }
+                                        // If IdP name is "SSO", need to handle as special case.
+                                        if (StringUtils.equalsIgnoreCase(idpName, SSO_AUTHENTICATOR_NAME)) {
+                                            imageURL = "libs/themes/default/assets/images/identity-providers/sso.svg";
                                         }
                             %>
                                 <% if (isHubIdp) { %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -91,6 +91,7 @@
     String FACEBOOK_AUTHENTICATOR = "FacebookAuthenticator";
     String OIDC_AUTHENTICATOR = "OpenIDConnectAuthenticator";
     String SSO_AUTHENTICATOR = "OrganizationAuthenticator";
+    String SSO_AUTHENTICATOR_NAME = "SSO";
     String commonauthURL = "../commonauth";
 
     boolean error = IdentityManagementEndpointUtil.getBooleanValue(request.getAttribute("error"));
@@ -549,6 +550,10 @@
                         String EXTERNAL_CONNECTION_PREFIX = "sign in with";
                         if (StringUtils.startsWithIgnoreCase(name, EXTERNAL_CONNECTION_PREFIX)) {
                             displayName = name.substring(EXTERNAL_CONNECTION_PREFIX.length());
+                        }
+                        // If IdP name is "SSO", need to handle as special case.
+                        if (StringUtils.equalsIgnoreCase(name, SSO_AUTHENTICATOR_NAME)) {
+                            imageURL = "libs/themes/default/assets/images/identity-providers/sso.svg";
                         }
 
                         if (StringUtils.equals(type,GOOGLE_AUTHENTICATOR)) {


### PR DESCRIPTION
### Description
For the SSO login option, it is not required to try to fetch the logo rather have a constant for the SSO IDP logo URL.