### PR TITLE
Add Trusted Apps UI to console

### DIFF
--- a/.changeset/few-beers-raise.md
+++ b/.changeset/few-beers-raise.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/i18n": patch
+---
+
+Add Trusted Apps UI to application configurations

--- a/.changeset/flat-schools-remember.md
+++ b/.changeset/flat-schools-remember.md
@@ -1,6 +1,0 @@
----
-"@wso2is/admin.applications.v1": patch
-"@wso2is/i18n": patch
----
-
-Add Trusted apps UI to application configurations

--- a/.changeset/flat-schools-remember.md
+++ b/.changeset/flat-schools-remember.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/i18n": patch
+---
+
+Add Trusted apps UI to application configurations

--- a/features/admin.applications.v1/components/forms/advanced-configurations-form.scss
+++ b/features/admin.applications.v1/components/forms/advanced-configurations-form.scss
@@ -19,3 +19,7 @@
 .client-attestation-info-alert {
     margin-bottom: 1rem;
 }
+
+.fido-enabled-warn-alert {
+    margin-top: 1rem;
+}

--- a/features/admin.applications.v1/components/forms/advanced-configurations-form.tsx
+++ b/features/admin.applications.v1/components/forms/advanced-configurations-form.tsx
@@ -24,10 +24,12 @@ import { isFeatureEnabled } from "@wso2is/core/helpers";
 import {
     AlertInterface,
     AlertLevels,
+    IdentifiableComponentInterface,
     TestableComponentInterface
 } from "@wso2is/core/models";
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
-import { ConfirmationModal, GenericIcon, Heading, URLInput  } from "@wso2is/react-components";
+import { ConfirmationModal, DocumentationLink, GenericIcon, Heading, URLInput, useDocumentation  }
+    from "@wso2is/react-components";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
     Fragment,
@@ -52,7 +54,7 @@ import "./advanced-configurations-form.scss";
 /**
  *  Advanced Configurations for the Application.
  */
-interface AdvancedConfigurationsFormPropsInterface extends TestableComponentInterface {
+interface AdvancedConfigurationsFormPropsInterface extends TestableComponentInterface, IdentifiableComponentInterface {
     config: AdvancedConfigurationsInterface;
     onSubmit: (values: any) => void;
     /**
@@ -92,11 +94,13 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
         template,
         isSubmitting,
         onAlertFired,
-        [ "data-testid" ]: testId
+        [ "data-testid" ]: testId,
+        [ "data-componentid" ]: componentId
     } = props;
 
     const { t } = useTranslation();
     const { UIConfig } = useUIConfig();
+    const { getLink } = useDocumentation();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
     const isApplicationNativeAuthenticationEnabled: boolean = isFeatureEnabled(featureConfig?.applications,
@@ -115,9 +119,11 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
     const [ isUserClickedClientAttestationWhenDisabled, setIsUserClickedClientAttestationWhenDisabled ] =
         useState<boolean>(false);
     const [ isFIDOTrustedAppsEnabled, setIsFIDOTrustedAppsEnabled ] = useState<boolean>(
-        config?.trustedAppConfiguration?.isFIDOTrustedApp);
+        config?.trustedAppConfiguration?.isFIDOTrustedApp
+    );
     const [ isConsentGranted, setIsConsentGranted ] = useState<boolean>(
-        config?.trustedAppConfiguration?.isConsentGranted);
+        config?.trustedAppConfiguration?.isConsentGranted
+    );
     const [ showFIDOConfirmationModal, setShowFIDOConfirmationModal ] = useState<boolean>(false);
     const [ showThumbprintsError, setShowThumbprinstError ] = useState(false);
     const [ thumbprints, setThumbprints ] = useState(config?.trustedAppConfiguration?.androidThumbprints?.join(","));
@@ -257,7 +263,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                             "advancedConfig.sections.clientAttestation.fields." +
                             "androidAttestationServiceCredentials.validations.empty");
                 }
-            } catch (ex: any) {
+            } catch (error) {
                 errors.androidAttestationServiceCredentials = t("applications:forms." +
                 "advancedConfig.sections.clientAttestation.fields." +
                 "androidAttestationServiceCredentials.validations.invalid");
@@ -551,19 +557,27 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                                         checked={ isFIDOTrustedAppsEnabled }
                                         value={
                                             isFIDOTrustedAppsEnabled ? [ "isFIDOTrustedApp" ] : []
-
                                         }
                                         listen={ handleFIDOActivation }
-                                        data-testid={ `${ testId }-enable-fido-trusted-apps` }
-                                        data-componentid={ `${ testId }-enable-fido-trusted-apps` }
+                                        data-componentid={ `${ componentId }-enable-fido-trusted-apps` }
                                         hint={ t("applications:forms.advancedConfig.sections." +
                                             "trustedApps.fields.enableFIDOTrustedApps.hint") }
                                     />
                                     {
-                                        <Alert severity="warning" className="fido-enabled-warn-alert">
-                                            { t("applications:forms.advancedConfig." +
-                                                "sections.trustedApps.alerts.trustedAppSettingsAlert") }
-                                        </Alert>
+                                        (applicationConfig.advancedConfigurations.showTrustedAppConsentWarning) && (
+                                            <Alert severity="warning" className="fido-enabled-warn-alert">
+                                                <>
+                                                    { t("applications:forms.advancedConfig." +
+                                                    "sections.trustedApps.alerts.trustedAppSettingsAlert") }
+                                                    <DocumentationLink
+                                                        link={ getLink("develop.applications.editApplication." +
+                                                    "common.advanced.trustedApps.learnMore") }
+                                                    >
+                                                        { t("extensions:common.learnMore") }
+                                                    </DocumentationLink>
+                                                </>
+                                            </Alert>
+                                        )
                                     }
                                 </Grid.Column>
                             </Grid.Row>
@@ -624,11 +638,8 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                                         maxLength={ 200 }
                                         minLength={ 3 }
                                         width={ 16 }
-                                        data-testid={
-                                            `${ testId }-platform-settings-android-package-name`
-                                        }
                                         data-componentid={
-                                            `${ testId }-platform-settings-android-package-name`
+                                            `${ componentId }-platform-settings-android-package-name`
                                         }
                                         disabled={ isPlatformSettingsUiDisabled }
                                     />
@@ -709,8 +720,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                                         maxLength={ 200 }
                                         minLength={ 3 }
                                         width={ 16 }
-                                        data-testid={ `${ testId }-platform-settings-apple-app-id` }
-                                        data-componentid={ `${ testId }-platform-settings-apple-app-id` }
+                                        data-componentid={ `${ componentId }-platform-settings-apple-app-id` }
                                         disabled={ isPlatformSettingsUiDisabled }
                                         readOnly={ readOnly }
                                     />
@@ -752,7 +762,7 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                     setShowFIDOConfirmationModal(false);
                 } }
                 closeOnDimmerClick={ false }
-                data-testid={ `${ testId }-trusted-apps-confirmation-modal` }
+                data-componentid={ `${ componentId }-trusted-apps-confirmation-modal` }
             >
                 <ConfirmationModal.Header data-testid={ `${ testId }-trusted-apps-confirmation-modal-header` }>
                     { t("applications:forms.advancedConfig.sections.trustedApps.modal.header") }
@@ -760,11 +770,13 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 <ConfirmationModal.Message
                     attached
                     warning
-                    data-testid={ `${ testId }-trusted-apps-confirmation-modal-message` }
+                    data-componentid={ `${ componentId }-trusted-apps-confirmation-modal-message` }
                 >
                     { t("applications:forms.advancedConfig.sections.trustedApps.modal.message") }
                 </ConfirmationModal.Message>
-                <ConfirmationModal.Content data-testid={ `${ testId }-trusted-apps-confirmation-modal-content` }>
+                <ConfirmationModal.Content
+                    data-componentid={ `${ componentId }-trusted-apps-confirmation-modal-content` }
+                >
                     { t("applications:forms.advancedConfig.sections.trustedApps.modal.content") }
                 </ConfirmationModal.Content>
             </ConfirmationModal>
@@ -776,5 +788,6 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
  * Default props for the application advanced configurations form component.
  */
 AdvancedConfigurationsForm.defaultProps = {
+    "data-componentid": "application-advanced-configurations-form",
     "data-testid": "application-advanced-configurations-form"
 };

--- a/features/admin.applications.v1/components/forms/advanced-configurations-form.tsx
+++ b/features/admin.applications.v1/components/forms/advanced-configurations-form.tsx
@@ -27,9 +27,11 @@ import {
     TestableComponentInterface
 } from "@wso2is/core/models";
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
-import { GenericIcon, Heading } from "@wso2is/react-components";
+import { ConfirmationModal, GenericIcon, Heading, URLInput  } from "@wso2is/react-components";
+
 import isEmpty from "lodash-es/isEmpty";
 import React, {
+    Fragment,
     FunctionComponent,
     MutableRefObject,
     ReactElement,
@@ -100,6 +102,8 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
     const isApplicationNativeAuthenticationEnabled: boolean = isFeatureEnabled(featureConfig?.applications,
         ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_NATIVE_AUTHENTICATION"));
+    const isTrustedAppsFeatureEnabled: boolean = isFeatureEnabled(featureConfig?.applications,
+        ApplicationManagementConstants.FEATURE_DICTIONARY.get("TRUSTED_APPS"));
 
     const formRef: MutableRefObject<FormPropsInterface> = useRef<FormPropsInterface>(null);
 
@@ -111,6 +115,14 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
     );
     const [ isUserClickedClientAttestationWhenDisabled, setIsUserClickedClientAttestationWhenDisabled ] =
         useState<boolean>(false);
+    const [ isFIDOTrustedAppsEnabled, setIsFIDOTrustedAppsEnabled ] = useState<boolean>(
+        config?.trustedAppConfiguration?.isFIDOTrustedApp);
+    const [ isConsentGranted, setIsConsentGranted ] = useState<boolean>(
+        config?.trustedAppConfiguration?.isConsentGranted);
+    const [ showFIDOConfirmationModal, setShowFIDOConfirmationModal ] = useState<boolean>(false);
+
+    const [ showThumbprintsError, setShowThumbprinstError ] = useState(false);
+    const [ thumbprints, setThumbprints ] = useState(config?.trustedAppConfiguration?.androidThumbprints?.join(","));
 
     /**
      * Update configuration.
@@ -143,8 +155,8 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
             advancedConfigurations: {
                 attestationMetaData: {
                     androidAttestationServiceCredentials: androidAttestationServiceCredentialsObject,
-                    androidPackageName: values.androidPackageName,
-                    appleAppId: values.appleAppId,
+                    androidPackageName: enableClientAttestation ? values.androidPackageName : "",
+                    appleAppId: enableClientAttestation ? values.appleAppId : "",
                     enableClientAttestation: enableClientAttestation
                 },
                 enableAPIBasedAuthentication: !!values.enableAPIBasedAuthentication,
@@ -152,7 +164,16 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 returnAuthenticatedIdpList: !!values.returnAuthenticatedIdpList,
                 saas: !!values.saas,
                 skipLoginConsent: !!values.skipConsentLogin,
-                skipLogoutConsent: !!values.skipConsentLogout
+                skipLogoutConsent: !!values.skipConsentLogout,
+                trustedAppConfiguration: values.enableFIDOTrustedApps ?
+                    {
+                        // androidPackageName and appleAppId is same as clientAttestation.
+                        androidPackageName: values.androidPackageName,
+                        androidThumbprints: isEmpty(thumbprints) ? [] : thumbprints.split(","),
+                        appleAppId: values.appleAppId,
+                        isConsentGranted: isConsentGranted,
+                        isFIDOTrustedApp: values.enableFIDOTrustedApps
+                    } : undefined
             }
         };
 
@@ -174,6 +195,19 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
      * To check if the client attestation methods UIs should be disabled.
      */
     const isClientAttestationMethodsUiDisabled: boolean = !isEnableClientAttestation || isClientAttestationUIDisabled;
+
+    /**
+     * To check if the platform settings UIs should be disabled.
+     */
+    const isPlatformSettingsUiDisabled: boolean = !isEnableClientAttestation && !isFIDOTrustedAppsEnabled;
+
+    /**
+     * To check if the feature is supported in the app template.
+     */
+    const isSupportedInAppTemplate: boolean = template?.id === ApplicationManagementConstants.CUSTOM_APPLICATION ||
+    template?.id === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC ||
+    template?.id === ApplicationManagementConstants.MOBILE ||
+    template?.id === ApplicationManagementConstants.TEMPLATE_IDS.get("oidcWeb");
 
     /**
      * To handle the enableAPIBasedAuthentication checkbox.
@@ -198,125 +232,171 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
 
         const errors: AdvancedConfigurationsInterface = {
             androidAttestationServiceCredentials: undefined,
-            androidPackageName: undefined
+            androidPackageName: undefined,
+            androidThumbprints: undefined
         };
 
-        // Validate the android package name and the android attestation service credentials if one of them is empty for
-        // the client attestation to be enabled for Android.
-        if (!values.androidPackageName?.toString().trim()
-            && values.androidAttestationServiceCredentials?.toString().trim()) {
+        let androidAttestationServiceCredentialsObject : JSON;
 
-            errors.androidPackageName = t("applications:forms.advancedConfig." +
-                "sections.applicationNativeAuthentication.fields." +
-                "android.fields.androidPackageName.validations.empty");
-        } else if (values.androidPackageName?.toString().trim()
-            && !values.androidAttestationServiceCredentials?.toString().trim()) {
+        if (values.enableClientAttestation) {
+            try {
+                if(!isEmpty(values.androidAttestationServiceCredentials)) {
+                    androidAttestationServiceCredentialsObject =
+                    JSON.parse(values.androidAttestationServiceCredentials);
 
-            errors.androidAttestationServiceCredentials = t("applications:forms." +
-                "advancedConfig.sections.applicationNativeAuthentication.fields." +
-                "android.fields.androidAttestationServiceCredentials.validations.empty");
+                }
+                // Validate the android package name and android attestation service credentials for client attestation.
+                // If one of them is empty throw an error.
+                if (!values.androidPackageName?.toString().trim()
+                    && Object.keys(androidAttestationServiceCredentialsObject).length) {
+
+                    errors.androidPackageName = t("applications:forms.advancedConfig." +
+                        "sections.platformSettings.fields." +
+                        "android.fields.androidPackageName.validations.emptyForAttestation");
+                } else if (values.androidPackageName?.toString().trim()
+                    && !Object.keys(androidAttestationServiceCredentialsObject).length) {
+
+                    errors.androidAttestationServiceCredentials = t("applications:forms." +
+                            "advancedConfig.sections.clientAttestation.fields." +
+                            "androidAttestationServiceCredentials.validations.empty");
+                }
+            } catch (ex: any) {
+                errors.androidAttestationServiceCredentials = t("applications:forms." +
+                "advancedConfig.sections.clientAttestation.fields." +
+                "androidAttestationServiceCredentials.validations.invalid");
+            }
+        } else if (values.enableFIDOTrustedApps) {
+            // Validate the android package name and android thumbprints for FIDO trusted apps.
+            // If one of them is empty throw an error.
+            if (!values.androidPackageName?.toString().trim()
+                && thumbprints?.toString().trim()) {
+
+                errors.androidPackageName = t("applications:forms.advancedConfig." +
+                    "sections.platformSettings.fields." +
+                    "android.fields.androidPackageName.validations.emptyForFIDO");
+            } else if (values.androidPackageName?.toString().trim()
+                && !thumbprints?.toString().trim()) {
+
+                setShowThumbprinstError(true);
+                errors.androidThumbprints = t("applications:forms." +
+                    "advancedConfig.sections.platformSettings.fields.android.fields." +
+                    "keyHashes.validations.empty");
+            }
         }
 
         return errors;
     };
 
+    /**
+     * Handle FIDO activation value with confirmation. Deactivation is not confirmed
+     */
+    const handleFIDOActivation = (shouldActivate: boolean) => {
+        shouldActivate ?
+            setShowFIDOConfirmationModal(true)
+            : setIsFIDOTrustedAppsEnabled(false);
+    };
+
     return (
-        <Form
-            id={ FORM_ID }
-            uncontrolledForm={ true }
-            ref={ formRef }
-            validate={ validateForm }
-            validateOnBlur={ false }
-            onSubmit={ (values: AdvancedConfigurationsInterface) => {
-                updateConfiguration(values);
-            } }
-        >
-            <Field.CheckboxLegacy
-                ariaLabel="Saas application"
-                name="saas"
-                label={ t("applications:forms.advancedConfig.fields.saas.label") }
-                required={ false }
-                value={ config?.saas ? [ "saas" ] : [] }
-                readOnly={ readOnly }
-                data-testid={ `${ testId }-sass-checkbox` }
-                data-componentid={ `${ testId }-sass-checkbox` }
-                hint={ t("applications:forms.advancedConfig.fields.saas.hint") }
-                hidden={ !UIConfig?.legacyMode?.saasApplications || !applicationConfig.advancedConfigurations.showSaaS }
-            />
-            <Field.CheckboxLegacy
-                ariaLabel="Skip consent login"
-                name="skipConsentLogin"
-                label={ t("applications:forms.advancedConfig.fields.skipConsentLogin" +
-                    ".label") }
-                required={ false }
-                value={ config?.skipLoginConsent ? [ "skipLoginConsent" ] : [] }
-                readOnly={ readOnly }
-                data-testid={ `${ testId }-skip-login-consent-checkbox` }
-                data-componentid={ `${ testId }-skip-login-consent-checkbox` }
-                hint={ t("applications:forms.advancedConfig.fields.skipConsentLogin.hint") }
-            />
-            {
-                SAMLWebApplicationTemplate?.id !== template?.id &&
-                (
-                    <Field.CheckboxLegacy
-                        ariaLabel="Skip consent logout"
-                        name="skipConsentLogout"
-                        label={
-                            t("applications:forms.advancedConfig.fields" +
-                                ".skipConsentLogout.label")
-                        }
-                        required={ false }
-                        value={ config?.skipLogoutConsent ? [ "skipLogoutConsent" ] : [] }
-                        readOnly={ readOnly }
-                        data-testid={ `${ testId }-skip-logout-consent-checkbox` }
-                        data-componentid={ `${ testId }-skip-logout-consent-checkbox` }
-                        hint={ t("applications:forms.advancedConfig.fields.skipConsentLogout" +
-                            ".hint"
-                        ) }
-                    />
-                )
-            }
-            <Field.CheckboxLegacy
-                ariaLabel="Return authenticated IDP list"
-                name="returnAuthenticatedIdpList"
-                label={ t("applications:forms.advancedConfig.fields." +
-                    "returnAuthenticatedIdpList.label"
-                ) }
-                required={ false }
-                value={ config?.returnAuthenticatedIdpList ? [ "returnAuthenticatedIdpList" ] : [] }
-                readOnly={ readOnly }
-                data-testid={ `${ testId }-return-authenticated-idp-list-checkbox` }
-                data-componentid={ `${ testId }-return-authenticated-idp-list-checkbox` }
-                hidden={ !applicationConfig.advancedConfigurations.showReturnAuthenticatedIdPs }
-                hint={ t("applications:forms.advancedConfig.fields" +
-                    ".returnAuthenticatedIdpList.hint"
-                ) }
-            />
-            <Field.CheckboxLegacy
-                ariaLabel="Enable authorization"
-                name="enableAuthorization"
-                label={ t("applications:forms.advancedConfig.fields." +
-                    "enableAuthorization.label"
-                ) }
-                required={ false }
-                value={ config?.enableAuthorization ? [ "enableAuthorization" ] : [] }
-                readOnly={ readOnly }
-                data-testid={ `${ testId }-enable-authorization-checkbox` }
-                data-componentid={ `${ testId }-enable-authorization-checkbox` }
-                hidden={
-                    !applicationConfig.advancedConfigurations.showEnableAuthorization
-                    || !UIConfig?.isXacmlConnectorEnabled }
-                hint={ t("applications:forms.advancedConfig.fields.enableAuthorization.hint") }
-            />
-            {
-                (
-                    isApplicationNativeAuthenticationEnabled &&
-                    (template?.id === ApplicationManagementConstants.CUSTOM_APPLICATION ||
-                    template?.id === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC ||
-                    template?.id === ApplicationManagementConstants.MOBILE ||
-                    template?.id === ApplicationManagementConstants.TEMPLATE_IDS.get("oidcWeb"))
-                ) && (
-                    <>
+        <>
+            <Form
+                id={ FORM_ID }
+                uncontrolledForm={ true }
+                ref={ formRef }
+                validate={ (anything: AdvancedConfigurationsInterface) => validateForm (anything) }
+                validateOnBlur={ false }
+                onSubmit={ (values: AdvancedConfigurationsInterface) => {
+                    updateConfiguration(values);
+                } }
+                initialValues={ {
+                    androidAttestationServiceCredentials:
+                    JSON.stringify(config?.attestationMetaData?.androidAttestationServiceCredentials || ""),
+                    androidPackageName: config?.attestationMetaData?.androidPackageName ||
+                        config?.trustedAppConfiguration?.androidPackageName,
+                    appleAppId: config?.trustedAppConfiguration?.appleAppId || config?.attestationMetaData?.appleAppId
+                } }
+            >
+                <Field.CheckboxLegacy
+                    ariaLabel="Saas application"
+                    name="saas"
+                    label={ t("applications:forms.advancedConfig.fields.saas.label") }
+                    required={ false }
+                    value={ config?.saas ? [ "saas" ] : [] }
+                    readOnly={ readOnly }
+                    data-testid={ `${ testId }-sass-checkbox` }
+                    data-componentid={ `${ testId }-sass-checkbox` }
+                    hint={ t("applications:forms.advancedConfig.fields.saas.hint") }
+                    hidden={ !UIConfig?.legacyMode?.saasApplications ||
+                        !applicationConfig.advancedConfigurations.showSaaS }
+                />
+                <Field.CheckboxLegacy
+                    ariaLabel="Skip consent login"
+                    name="skipConsentLogin"
+                    label={ t("applications:forms.advancedConfig.fields.skipConsentLogin" +
+                        ".label") }
+                    required={ false }
+                    value={ config?.skipLoginConsent ? [ "skipLoginConsent" ] : [] }
+                    readOnly={ readOnly }
+                    data-testid={ `${ testId }-skip-login-consent-checkbox` }
+                    data-componentid={ `${ testId }-skip-login-consent-checkbox` }
+                    hint={ t("applications:forms.advancedConfig.fields.skipConsentLogin.hint") }
+                />
+                {
+                    SAMLWebApplicationTemplate?.id !== template?.id &&
+                    (
+                        <Field.CheckboxLegacy
+                            ariaLabel="Skip consent logout"
+                            name="skipConsentLogout"
+                            label={
+                                t("applications:forms.advancedConfig.fields" +
+                                    ".skipConsentLogout.label")
+                            }
+                            required={ false }
+                            value={ config?.skipLogoutConsent ? [ "skipLogoutConsent" ] : [] }
+                            readOnly={ readOnly }
+                            data-testid={ `${ testId }-skip-logout-consent-checkbox` }
+                            data-componentid={ `${ testId }-skip-logout-consent-checkbox` }
+                            hint={ t("applications:forms.advancedConfig.fields.skipConsentLogout" +
+                                ".hint"
+                            ) }
+                        />
+                    )
+                }
+                <Field.CheckboxLegacy
+                    ariaLabel="Return authenticated IDP list"
+                    name="returnAuthenticatedIdpList"
+                    label={ t("applications:forms.advancedConfig.fields." +
+                        "returnAuthenticatedIdpList.label"
+                    ) }
+                    required={ false }
+                    value={ config?.returnAuthenticatedIdpList ? [ "returnAuthenticatedIdpList" ] : [] }
+                    readOnly={ readOnly }
+                    data-testid={ `${ testId }-return-authenticated-idp-list-checkbox` }
+                    data-componentid={ `${ testId }-return-authenticated-idp-list-checkbox` }
+                    hidden={ !applicationConfig.advancedConfigurations.showReturnAuthenticatedIdPs }
+                    hint={ t("applications:forms.advancedConfig.fields" +
+                        ".returnAuthenticatedIdpList.hint"
+                    ) }
+                />
+                <Field.CheckboxLegacy
+                    ariaLabel="Enable authorization"
+                    name="enableAuthorization"
+                    label={ t("applications:forms.advancedConfig.fields." +
+                        "enableAuthorization.label"
+                    ) }
+                    required={ false }
+                    value={ config?.enableAuthorization ? [ "enableAuthorization" ] : [] }
+                    readOnly={ readOnly }
+                    data-testid={ `${ testId }-enable-authorization-checkbox` }
+                    data-componentid={ `${ testId }-enable-authorization-checkbox` }
+                    hidden={
+                        !applicationConfig.advancedConfigurations.showEnableAuthorization
+                        || !UIConfig?.isXacmlConnectorEnabled }
+                    hint={ t("applications:forms.advancedConfig.fields.enableAuthorization.hint") }
+                />
+                {
+                    (
+                        isApplicationNativeAuthenticationEnabled && isSupportedInAppTemplate
+                    ) && (
                         <Grid>
                             <Grid.Row columns={ 2 }>
                                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
@@ -325,20 +405,9 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                                 </Grid.Column>
                                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                     <Heading as="h4">
-                                        { "App-Native Authentication" }
+                                        { t("applications:forms.advancedConfig." +
+                                        "sections.applicationNativeAuthentication.heading") }
                                     </Heading>
-
-                                    {
-                                        (
-                                            isClientAttestationUIDisabled &&
-                                            isUserClickedClientAttestationWhenDisabled
-                                        ) && (
-                                            <Alert severity="info" className="client-attestation-info-alert">
-                                                { t("applications:forms.advancedConfig." +
-                                                 "sections.applicationNativeAuthentication.alerts.clientAttestation") }
-                                            </Alert>
-                                        )
-                                    }
                                     <Field.CheckboxLegacy
                                         ariaLabel="Enable apiBasedAuthentication"
                                         name="enableAPIBasedAuthentication"
@@ -362,195 +431,337 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                                     />
                                 </Grid.Column>
                             </Grid.Row>
-                            {
-                                (
-                                    template?.id === ApplicationManagementConstants.CUSTOM_APPLICATION ||
-                                    template?.id === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC ||
-                                    template?.id === ApplicationManagementConstants.MOBILE
-                                ) && (
-                                    <>
-                                        <Grid.Row
-                                            columns={ 1 }
-                                            onClick={ handleWhenClientAttestationClickedWhenDisabled }>
-                                            <Grid.Column>
-                                                <Field.CheckboxLegacy
-                                                    ariaLabel="Enable attestation"
-                                                    name="enableClientAttestation"
-                                                    label={ t("applications:forms." +
-                                                        "advancedConfig.sections.applicationNativeAuthentication." +
-                                                        "fields.enableClientAttestation.label") }
-                                                    required={ false }
-                                                    readOnly={ readOnly }
-                                                    value={
-                                                        config?.attestationMetaData?.enableClientAttestation
-                                                            ? [ "enableClientAttestation" ]
-                                                            : []
-                                                    }
-                                                    listen={ setIsEnableClientAttestation }
-                                                    data-testid={ `${ testId }-enable-client-attestation` }
-                                                    data-componentid={ `${ testId }-enable-api-based-authentication` }
-                                                    disabled={ isClientAttestationUIDisabled }
-                                                    hint={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "enableClientAttestation.hint") }
-                                                />
-                                            </Grid.Column>
-                                        </Grid.Row>
-                                        <Grid.Row
-                                            columns={ 1 }
-                                            onClick={ handleWhenClientAttestationClickedWhenDisabled }>
-                                            <Grid.Column>
-                                                <Heading as="h5" bold="500">
-                                                    <GenericIcon
-                                                        size="micro"
-                                                        icon={ getTechnologyLogos().android }
-                                                        verticalAlign="middle"
-                                                        floated="left"
-                                                    />
-                                                    { t("applications:forms.advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "android.heading") }
-                                                </Heading>
-                                                <Field.Input
-                                                    ariaLabel="Android package name"
-                                                    inputType="default"
-                                                    name="androidPackageName"
-                                                    label={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "android.fields.androidPackageName.label") }
-                                                    required={ false }
-                                                    readOnly={ readOnly }
-                                                    value={ config?.attestationMetaData?.androidPackageName ?? "" }
-                                                    placeholder={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "android.fields.androidPackageName.placeholder") }
-                                                    hint={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "android.fields.androidPackageName.hint") }
-                                                    maxLength={ 200 }
-                                                    minLength={ 3 }
-                                                    width={ 16 }
-                                                    data-testid={
-                                                        `${ testId }-client-attestation-android-package-name`
-                                                    }
-                                                    data-componentid={
-                                                        `${ testId }-client-attestation-android-package-name`
-                                                    }
-                                                    disabled={ isClientAttestationMethodsUiDisabled }
-                                                />
-                                            </Grid.Column>
-                                        </Grid.Row>
-                                        <Grid.Row
-                                            columns={ 1 }
-                                            onClick={ handleWhenClientAttestationClickedWhenDisabled }>
-                                            <Grid.Column>
-                                                <Field.Textarea
-                                                    ariaLabel="Android service account credentials"
-                                                    inputType="description"
-                                                    name="androidAttestationServiceCredentials"
-                                                    label={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "android.fields.androidAttestationServiceCredentials.label") }
-                                                    placeholder={ t("applications:forms." +
-                                                        "advancedConfig.sections." +
-                                                        "applicationNativeAuthentication.fields.android.fields." +
-                                                        "androidAttestationServiceCredentials.placeholder") }
-                                                    value={
-                                                        config?.
-                                                            attestationMetaData?.androidAttestationServiceCredentials ?
-                                                            [ JSON.stringify(
-                                                                config?.
-                                                                    attestationMetaData?.
-                                                                    androidAttestationServiceCredentials,
-                                                                null, 4)
-                                                            ] : []
-                                                    }
-                                                    hint={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "android.fields.androidAttestationServiceCredentials.hint") }
-                                                    type="text"
-                                                    maxLength={ 5000 }
-                                                    minLength={ 30 }
-                                                    width={ 16 }
-                                                    data-testid={
-                                                        `${ testId }-client-attestation-android-account-credentials`
-                                                    }
-                                                    data-componentid={
-                                                        `${ testId }-client-attestation-android-account-credentials`
-                                                    }
-                                                    disabled={ isClientAttestationMethodsUiDisabled }
-                                                    readOnly={ readOnly }
-                                                />
-                                            </Grid.Column>
-                                        </Grid.Row>
-                                        <Grid.Row
-                                            columns={ 1 }
-                                            onClick={ handleWhenClientAttestationClickedWhenDisabled }>
-                                            <Grid.Column>
-                                                <Heading as="h5" bold="500">
-                                                    <GenericIcon
-                                                        size="micro"
-                                                        icon={ getTechnologyLogos().apple }
-                                                        floated="left"
-                                                        verticalAlign="middle"
-                                                    />
-                                                    { t("applications:forms.advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "apple.heading") }
-                                                </Heading>
-                                                <Field.Input
-                                                    ariaLabel="Apple App Id"
-                                                    inputType="default"
-                                                    name="appleAppId"
-                                                    label={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "apple.fields.appleAppId.label") }
-                                                    required={ false }
-                                                    placeholder={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "apple.fields.appleAppId.placeholder") }
-                                                    value={ config?.attestationMetaData?.appleAppId ?? "" }
-                                                    hint={ t("applications:forms." +
-                                                        "advancedConfig." +
-                                                        "sections.applicationNativeAuthentication.fields." +
-                                                        "apple.fields.appleAppId.hint") }
-                                                    maxLength={ 200 }
-                                                    minLength={ 3 }
-                                                    width={ 16 }
-                                                    data-testid={ `${ testId }-client-attestation-apple=app=id` }
-                                                    data-componentid={ `${ testId }-client-attestation-apple=app=id` }
-                                                    disabled={ isClientAttestationMethodsUiDisabled }
-                                                    readOnly={ readOnly }
-                                                />
-                                            </Grid.Column>
-                                        </Grid.Row>
-                                    </>
-                                ) }
+                            <Grid.Row
+                                columns={ 1 }
+                                onClick={ handleWhenClientAttestationClickedWhenDisabled }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                    <Divider />
+                                    <Heading as="h4">
+                                        { t("applications:forms.advancedConfig." +
+                                            "sections.clientAttestation.heading") }
+                                    </Heading>
+                                    {
+                                        (
+                                            isClientAttestationUIDisabled &&
+                                            isUserClickedClientAttestationWhenDisabled
+                                        ) && (
+                                            <Alert severity="info" className="client-attestation-info-alert">
+                                                { t("applications:forms.advancedConfig." +
+                                                    "sections.clientAttestation.alerts.clientAttestationAlert") }
+                                            </Alert>
+                                        )
+                                    }
+
+                                    <Field.CheckboxLegacy
+                                        ariaLabel="Enable attestation"
+                                        name="enableClientAttestation"
+                                        label={ t("applications:forms." +
+                                            "advancedConfig.sections.clientAttestation." +
+                                            "fields.enableClientAttestation.label") }
+                                        required={ false }
+                                        readOnly={ readOnly }
+                                        value={
+                                            config?.attestationMetaData?.enableClientAttestation
+                                                ? [ "enableClientAttestation" ]
+                                                : []
+                                        }
+                                        listen={ setIsEnableClientAttestation }
+                                        data-testid={ `${ testId }-enable-client-attestation` }
+                                        data-componentid={ `${ testId }-enable-api-based-authentication` }
+                                        disabled={ isClientAttestationUIDisabled }
+                                        hint={ t("applications:forms.advancedConfig." +
+                                            "sections.clientAttestation.fields." +
+                                            "enableClientAttestation.hint") }
+                                    />
+                                </Grid.Column>
+                            </Grid.Row>
+                            <Grid.Row
+                                columns={ 1 }
+                                onClick={ handleWhenClientAttestationClickedWhenDisabled }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                    <Field.Textarea
+                                        ariaLabel="Android service account credentials"
+                                        inputType="description"
+                                        name="androidAttestationServiceCredentials"
+                                        label={ t("applications:forms." +
+                                            "advancedConfig." +
+                                            "sections.clientAttestation.fields." +
+                                            "androidAttestationServiceCredentials.label") }
+                                        placeholder={ t("applications:forms." +
+                                            "advancedConfig.sections." +
+                                            "clientAttestation.fields." +
+                                            "androidAttestationServiceCredentials.placeholder") }
+                                        value={
+                                            config?.
+                                                attestationMetaData?.androidAttestationServiceCredentials ?
+                                                [ JSON.stringify(
+                                                    config?.
+                                                        attestationMetaData?.
+                                                        androidAttestationServiceCredentials,
+                                                    null, 4)
+                                                ] : []
+                                        }
+                                        hint={ t("applications:forms." +
+                                            "advancedConfig." +
+                                            "sections.clientAttestation.fields." +
+                                            "androidAttestationServiceCredentials.hint") }
+                                        type="text"
+                                        maxLength={ 5000 }
+                                        minLength={ 30 }
+                                        width={ 16 }
+                                        data-testid={
+                                            `${ testId }-client-attestation-android-account-credentials`
+                                        }
+                                        data-componentid={
+                                            `${ testId }-client-attestation-android-account-credentials`
+                                        }
+                                        disabled={ isClientAttestationMethodsUiDisabled }
+                                        readOnly={ readOnly }
+                                    />
+                                </Grid.Column>
+                            </Grid.Row>
                         </Grid>
-                    </>
-                ) }
-            <Field.Button
-                form={ FORM_ID }
-                size="small"
-                buttonType="primary_btn"
-                ariaLabel="Update button"
-                name="update-button"
-                data-testid={ `${ testId }-submit-button` }
-                data-componentid={ `${ testId }-submit-button` }
-                disabled={ isSubmitting }
-                loading={ isSubmitting }
-                hidden={ readOnly }
-                label={ t("common:update") }
-            />
-        </Form>
+                    )
+                }
+                {
+                    (
+                        isTrustedAppsFeatureEnabled && isSupportedInAppTemplate
+                    ) && (
+                        <Grid>
+                            <Grid.Row columns={ 1 }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                    <Divider />
+                                    <Heading as="h4">
+                                        { t("applications:forms.advancedConfig.sections.trustedApps.heading") }
+                                    </Heading>
+                                    <Field.CheckboxLegacy
+                                        ariaLabel="Enable FIDO Trusted Apps"
+                                        name="enableFIDOTrustedApps"
+                                        label={ t("applications:forms.advancedConfig.sections.trustedApps." +
+                                            "fields.enableFIDOTrustedApps.label") }
+                                        required={ false }
+                                        readOnly={ readOnly }
+                                        checked={ isFIDOTrustedAppsEnabled }
+                                        value={
+                                            isFIDOTrustedAppsEnabled ? [ "isFIDOTrustedApp" ] : []
+
+                                        }
+                                        listen={ handleFIDOActivation }
+                                        data-testid={ `${ testId }-enable-fido-trusted-apps` }
+                                        data-componentid={ `${ testId }-enable-fido-trusted-apps` }
+                                        hint={ t("applications:forms.advancedConfig.sections." +
+                                            "trustedApps.fields.enableFIDOTrustedApps.hint") }
+                                    />
+                                    {
+                                        <Alert severity="warning" className="fido-enabled-warn-alert">
+                                            { t("applications:forms.advancedConfig." +
+                                                "sections.trustedApps.alerts.trustedAppSettingsAlert") }
+                                        </Alert>
+                                    }
+                                </Grid.Column>
+                            </Grid.Row>
+                        </Grid>
+                    )
+                }
+                {
+                    (
+                        !isPlatformSettingsUiDisabled && isSupportedInAppTemplate
+                    ) && (
+                        <Grid>
+                            <Grid.Row columns={ 1 }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                    <Divider />
+                                    <Heading as="h4">
+                                        { t("applications:forms.advancedConfig." +
+                                            "sections.platformSettings.heading") }
+                                    </Heading>
+                                    <Heading subHeading as="h6">
+                                        { t("applications:forms.advancedConfig." +
+                                            "sections.platformSettings.subTitle") }
+                                    </Heading>
+                                </Grid.Column>
+                            </Grid.Row>
+                            <Grid.Row columns={ 1 }>
+                                <Grid.Column>
+                                    <Heading as="h5" bold="500">
+                                        <GenericIcon
+                                            size="micro"
+                                            icon={ getTechnologyLogos().android }
+                                            verticalAlign="middle"
+                                            floated="left"
+                                        />
+                                        { t("applications:forms.advancedConfig." +
+                                            "sections.platformSettings.fields." +
+                                            "android.heading") }
+                                    </Heading>
+                                    <Field.Input
+                                        ariaLabel="Android package name"
+                                        inputType="default"
+                                        name="androidPackageName"
+                                        label={ t("applications:forms." +
+                                            "advancedConfig." +
+                                            "sections.platformSettings.fields." +
+                                            "android.fields.androidPackageName.label") }
+                                        required={ false }
+                                        readOnly={ readOnly }
+                                        value={ (config?.attestationMetaData?.androidPackageName ||
+                                            config?.trustedAppConfiguration?.androidPackageName) ?? "" }
+                                        placeholder={ t("applications:forms." +
+                                            "advancedConfig." +
+                                            "sections.platformSettings.fields." +
+                                            "android.fields.androidPackageName.placeholder") }
+                                        hint={ t("applications:forms." +
+                                            "advancedConfig." +
+                                            "sections.platformSettings.fields." +
+                                            "android.fields.androidPackageName.hint") }
+                                        maxLength={ 200 }
+                                        minLength={ 3 }
+                                        width={ 16 }
+                                        data-testid={
+                                            `${ testId }-platform-settings-android-package-name`
+                                        }
+                                        data-componentid={
+                                            `${ testId }-platform-settings-android-package-name`
+                                        }
+                                        disabled={ isPlatformSettingsUiDisabled }
+                                    />
+                                </Grid.Column>
+                            </Grid.Row>
+                            <Grid.Row columns={ 1 }>
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                    { isFIDOTrustedAppsEnabled && (
+                                        <URLInput
+                                            isAllowEnabled={ false }
+                                            onlyOrigin={ false }
+                                            labelEnabled={ false }
+                                            urlState={ thumbprints }
+                                            setURLState={ (url: string) => setThumbprints(url) }
+                                            labelName={
+                                                t("applications:forms." +
+                                                    "advancedConfig.sections.platformSettings.fields." +
+                                                    "android.fields.keyHashes.label")
+                                            }
+                                            required={ false }
+                                            value={ thumbprints }
+                                            validation={ (value: string) => !value?.includes(",") }
+                                            placeholder={
+                                                t("applications:forms." +
+                                                    "advancedConfig.sections.platformSettings.fields." +
+                                                    "android.fields.keyHashes.placeholder")
+                                            }
+                                            validationErrorMsg={
+                                                t("applications:forms." +
+                                                    "advancedConfig.sections.platformSettings.fields." +
+                                                    "android.fields.keyHashes.validations.invalid")
+                                            }
+                                            showError={ showThumbprintsError }
+                                            setShowError={ setShowThumbprinstError }
+                                            hint={ t("applications:forms." +
+                                                "advancedConfig.sections.platformSettings.fields." +
+                                                "android.fields.keyHashes.hint") }
+                                            readOnly={ readOnly }
+                                            addURLTooltip={ t("applications:forms." +
+                                                "advancedConfig.sections.platformSettings.fields." +
+                                                "android.fields.keyHashes.tooltip") }
+                                            duplicateURLErrorMessage={ t("applications:forms." +
+                                                "advancedConfig.sections.platformSettings.fields." +
+                                                "android.fields.keyHashes.validations.duplicate") }
+                                            showPredictions={ false }
+                                            showLessContent={ t("common:showLess") }
+                                            showMoreContent={ t("common:showMore") }
+                                            disabled={ isPlatformSettingsUiDisabled }
+                                            skipInternalValidation
+                                        />) }
+                                </Grid.Column>
+                            </Grid.Row>
+                            <Grid.Row columns={ 1 }>
+                                <Grid.Column>
+                                    <Heading as="h5" bold="500">
+                                        <GenericIcon
+                                            size="micro"
+                                            icon={ getTechnologyLogos().apple }
+                                            floated="left"
+                                            verticalAlign="middle"
+                                        />
+                                        { t("applications:forms.advancedConfig.sections.platformSettings.fields." +
+                                            "apple.heading") }
+                                    </Heading>
+                                    <Field.Input
+                                        ariaLabel="Apple App Id"
+                                        inputType="default"
+                                        name="appleAppId"
+                                        label={ t("applications:forms.advancedConfig.sections.platformSettings." +
+                                            "fields.apple.fields.appleAppId.label") }
+                                        required={ false }
+                                        placeholder={ t("applications:forms.advancedConfig.sections.platformSettings." +
+                                            "fields.apple.fields.appleAppId.placeholder") }
+                                        value={ (config?.attestationMetaData?.appleAppId ||
+                                            config?.trustedAppConfiguration?.appleAppId) ?? "" }
+                                        hint={ t("applications:forms.advancedConfig.sections.platformSettings.fields." +
+                                            "apple.fields.appleAppId.hint") }
+                                        maxLength={ 200 }
+                                        minLength={ 3 }
+                                        width={ 16 }
+                                        data-testid={ `${ testId }-platform-settings-apple-app-id` }
+                                        data-componentid={ `${ testId }-platform-settings-apple-app-id` }
+                                        disabled={ isPlatformSettingsUiDisabled }
+                                        readOnly={ readOnly }
+                                    />
+                                </Grid.Column>
+                            </Grid.Row>
+                        </Grid>
+                    )
+                }
+                <Field.Button
+                    form={ FORM_ID }
+                    size="small"
+                    buttonType="primary_btn"
+                    ariaLabel="Update button"
+                    name="update-button"
+                    data-testid={ `${ testId }-submit-button` }
+                    data-componentid={ `${ testId }-submit-button` }
+                    disabled={ isSubmitting }
+                    loading={ isSubmitting }
+                    hidden={ readOnly }
+                    label={ t("common:update") }
+                />
+            </Form>
+            <ConfirmationModal
+                onClose={ (): void => setShowFIDOConfirmationModal(false) }
+                type="warning"
+                assertionHint={ t("applications:forms.advancedConfig.sections.trustedApps.modal.assertionHint") }
+                assertionType="checkbox"
+                open={ showFIDOConfirmationModal }
+                primaryAction={ t("common:confirm") }
+                secondaryAction={ t("common:cancel") }
+                onPrimaryActionClick={ (): void => {
+                    setIsFIDOTrustedAppsEnabled(true);
+                    setIsConsentGranted(true);
+                    setShowFIDOConfirmationModal(false);
+                } }
+                onSecondaryActionClick={ (): void => {
+                    setIsFIDOTrustedAppsEnabled(false);
+                    setIsConsentGranted(false);
+                    setShowFIDOConfirmationModal(false);
+                } }
+                closeOnDimmerClick={ false }
+                data-testid={ `${ testId }-trusted-apps-confirmation-modal` }
+            >
+                <ConfirmationModal.Header data-testid={ `${ testId }-trusted-apps-confirmation-modal-header` }>
+                    { t("applications:forms.advancedConfig.sections.trustedApps.modal.header") }
+                </ConfirmationModal.Header>
+                <ConfirmationModal.Message
+                    attached
+                    warning
+                    data-testid={ `${ testId }-trusted-apps-confirmation-modal-message` }
+                >
+                    { t("applications:forms.advancedConfig.sections.trustedApps.modal.message") }
+                </ConfirmationModal.Message>
+                <ConfirmationModal.Content data-testid={ `${ testId }-trusted-apps-confirmation-modal-content` }>
+                    { t("applications:forms.advancedConfig.sections.trustedApps.modal.content") }
+                </ConfirmationModal.Content>
+            </ConfirmationModal>
+        </>
     );
 };
 

--- a/features/admin.applications.v1/components/forms/advanced-configurations-form.tsx
+++ b/features/admin.applications.v1/components/forms/advanced-configurations-form.tsx
@@ -28,7 +28,6 @@ import {
 } from "@wso2is/core/models";
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
 import { ConfirmationModal, GenericIcon, Heading, URLInput  } from "@wso2is/react-components";
-
 import isEmpty from "lodash-es/isEmpty";
 import React, {
     Fragment,
@@ -120,7 +119,6 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
     const [ isConsentGranted, setIsConsentGranted ] = useState<boolean>(
         config?.trustedAppConfiguration?.isConsentGranted);
     const [ showFIDOConfirmationModal, setShowFIDOConfirmationModal ] = useState<boolean>(false);
-
     const [ showThumbprintsError, setShowThumbprinstError ] = useState(false);
     const [ thumbprints, setThumbprints ] = useState(config?.trustedAppConfiguration?.androidThumbprints?.join(","));
 
@@ -243,7 +241,6 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 if(!isEmpty(values.androidAttestationServiceCredentials)) {
                     androidAttestationServiceCredentialsObject =
                     JSON.parse(values.androidAttestationServiceCredentials);
-
                 }
                 // Validate the android package name and android attestation service credentials for client attestation.
                 // If one of them is empty throw an error.
@@ -451,7 +448,6 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                                             </Alert>
                                         )
                                     }
-
                                     <Field.CheckboxLegacy
                                         ariaLabel="Enable attestation"
                                         name="enableClientAttestation"
@@ -483,10 +479,21 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                                         ariaLabel="Android service account credentials"
                                         inputType="description"
                                         name="androidAttestationServiceCredentials"
-                                        label={ t("applications:forms." +
-                                            "advancedConfig." +
-                                            "sections.clientAttestation.fields." +
-                                            "androidAttestationServiceCredentials.label") }
+                                        label={ (
+                                            <>
+                                                <GenericIcon
+                                                    size="micro"
+                                                    icon={ getTechnologyLogos().android }
+                                                    floated="left"
+                                                    verticalAlign="middle"
+                                                    spaced="right"
+                                                />
+                                                { t("applications:forms." +
+                                                "advancedConfig." +
+                                                "sections.clientAttestation.fields." +
+                                                "androidAttestationServiceCredentials.label") }
+                                            </>
+                                        ) }
                                         placeholder={ t("applications:forms." +
                                             "advancedConfig.sections." +
                                             "clientAttestation.fields." +

--- a/features/admin.applications.v1/constants/application-management.ts
+++ b/features/admin.applications.v1/constants/application-management.ts
@@ -75,6 +75,7 @@ export class ApplicationManagementConstants {
         .set("APPLICATION_MYACCOUNT_SAAS_SETTINGS", "applications.myaccount.saasMyaccountSettings")
         .set("APPLICATION_ADD_MANAGEMENT_APPLICATIONS", "applications.add.managementApplications")
         .set("APPLICATIONS_SETTINGS", "applications.settings")
+        .set("TRUSTED_APPS", "applications.trustedApps")
 
     /**
      * Key for the `Edit Application` tag in the docs structure object.

--- a/features/admin.applications.v1/constants/application-management.ts
+++ b/features/admin.applications.v1/constants/application-management.ts
@@ -75,7 +75,7 @@ export class ApplicationManagementConstants {
         .set("APPLICATION_MYACCOUNT_SAAS_SETTINGS", "applications.myaccount.saasMyaccountSettings")
         .set("APPLICATION_ADD_MANAGEMENT_APPLICATIONS", "applications.add.managementApplications")
         .set("APPLICATIONS_SETTINGS", "applications.settings")
-        .set("TRUSTED_APPS", "applications.trustedApps")
+        .set("TRUSTED_APPS", "applications.trustedApps");
 
     /**
      * Key for the `Edit Application` tag in the docs structure object.
@@ -213,7 +213,7 @@ export class ApplicationManagementConstants {
     public static readonly ACCOUNT_SWITCH_GRANT: string = "account_switch";
     public static readonly CODE_TOKEN: string = "code token";
     public static readonly CODE_IDTOKEN: string = "code id_token";
-    public static readonly CODE_IDTOKEN_TOKEN: string = "code id_token token"
+    public static readonly CODE_IDTOKEN_TOKEN: string = "code id_token token";
     public static readonly  HYBRID_FLOW_ENABLE_CONFIG:string = "enable-hybrid-flow";
     public static readonly HYBRID_FLOW_RESPONSE_TYPE: string = "hybridFlowResponseType";
 
@@ -457,16 +457,16 @@ export class ApplicationManagementConstants {
         APP_NAME_MAX_LENGTH: number,
         APP_NAME_PATTERN: RegExp
     } = {
-        ACCESS_URL_ALLOWED_PLACEHOLDERS: [
-            "\\${UserTenantHint}",
-            "\\${organizationIdHint}"
-        ],
-        ACCESS_URL_MAX_LENGTH: 200,
-        ACCESS_URL_MIN_LENGTH: 3,
-        APP_DESCRIPTION_PATTERN: new RegExp("^[a-zA-Z0-9.+=!$#()@&%*~_-]+(?: [a-zA-Z0-9.+=!$#()@&%*~_-]+)*$", "gm"),
-        APP_NAME_MAX_LENGTH: 50,
-        APP_NAME_PATTERN: new RegExp("^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$")
-    };
+            ACCESS_URL_ALLOWED_PLACEHOLDERS: [
+                "\\${UserTenantHint}",
+                "\\${organizationIdHint}"
+            ],
+            ACCESS_URL_MAX_LENGTH: 200,
+            ACCESS_URL_MIN_LENGTH: 3,
+            APP_DESCRIPTION_PATTERN: new RegExp("^[a-zA-Z0-9.+=!$#()@&%*~_-]+(?: [a-zA-Z0-9.+=!$#()@&%*~_-]+)*$", "gm"),
+            APP_NAME_MAX_LENGTH: 50,
+            APP_NAME_PATTERN: new RegExp("^[a-zA-Z0-9._-]+(?: [a-zA-Z0-9._-]+)*$")
+        };
 
     public static readonly CONDITIONAL_AUTH_TOUR_STATUS_STORAGE_KEY: string = "isConditionalAuthTourViewed";
 

--- a/features/admin.applications.v1/models/application.ts
+++ b/features/admin.applications.v1/models/application.ts
@@ -277,7 +277,6 @@ export interface AdvancedConfigurationsInterface {
     androidPackageName?: string;
     androidAttestationServiceCredentials?: string;
     trustedAppConfiguration?: TrustedAppConfigurationsInterface
-    // Check if these configs are needed here
     enableFIDOTrustedApps?: boolean;
     isConsentGranted?: boolean;
     androidThumbprints?: string[];

--- a/features/admin.applications.v1/models/application.ts
+++ b/features/admin.applications.v1/models/application.ts
@@ -232,6 +232,17 @@ export interface AttestationMetaDataInterface {
 }
 
 /**
+ *  Captures trusted apps related configuration.
+ */
+export interface TrustedAppConfigurationsInterface {
+    isFIDOTrustedApp?: boolean;
+    isConsentGranted?: boolean;
+    androidPackageName?: string;
+    androidThumbprints?: string[];
+    appleAppId?: string;
+}
+
+/**
  *  Captures application advanced configuration related configuration.
  */
 export interface ApplicationAdvancedConfigurationsViewInterface {
@@ -265,6 +276,11 @@ export interface AdvancedConfigurationsInterface {
     enableClientAttestation?: boolean;
     androidPackageName?: string;
     androidAttestationServiceCredentials?: string;
+    trustedAppConfiguration?: TrustedAppConfigurationsInterface
+    // Check if these configs are needed here
+    enableFIDOTrustedApps?: boolean;
+    isConsentGranted?: boolean;
+    androidThumbprints?: string[];
     appleAppId?: string;
     skipConsentLogin?: boolean;
     skipConsentLogout?: boolean;

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -112,7 +112,8 @@ export const applicationConfig: ApplicationConfig = {
         showMyAccount: true,
         showMyAccountStatus: true,
         showReturnAuthenticatedIdPs: true,
-        showSaaS: true
+        showSaaS: true,
+        showTrustedAppConsentWarning: false
     },
     allowedGrantTypes: {
         // single page app template

--- a/features/admin.extensions.v1/configs/documentation.ts
+++ b/features/admin.extensions.v1/configs/documentation.ts
@@ -71,6 +71,11 @@ export const getDocumentationLinksExtension = () : DocumentationLinksExtensionIn
                         manageOIDCScopes: undefined
                     },
                     common: {
+                        advanced: {
+                            trustedApps: {
+                                learnMore: undefined
+                            }
+                        },
                         signInMethod: {
                             conditionalAuthenticaion: {
                                 ai: {

--- a/features/admin.extensions.v1/configs/models/application.ts
+++ b/features/admin.extensions.v1/configs/models/application.ts
@@ -40,6 +40,7 @@ export interface ApplicationConfig {
         showMyAccountStatus: boolean;
         showSaaS: boolean;
         showReturnAuthenticatedIdPs: boolean;
+        showTrustedAppConsentWarning: boolean;
     };
     allowedGrantTypes: Record<string, string[]>,
     generalSettings: {

--- a/features/admin.extensions.v1/configs/models/documentation.ts
+++ b/features/admin.extensions.v1/configs/models/documentation.ts
@@ -86,6 +86,11 @@ interface ApplicationsDocumentationLinksInterface {
             manageOIDCScopes: string;
         },
         common: {
+            advanced: {
+                trustedApps: {
+                    learnMore: string
+                }
+            },
             signInMethod: {
                 learnMore: string;
                 conditionalAuthenticaion: {

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -913,18 +913,58 @@ export interface ApplicationsNS {
             sections: {
                 applicationNativeAuthentication: {
                     heading: string;
-                    alerts: {
-                        clientAttestation: string;
-                    };
                     fields: {
                         enableAPIBasedAuthentication: {
                             hint: string;
                             label: string;
                         };
+                    };
+                };
+                clientAttestation: {
+                    heading: string;
+                    alerts: {
+                        clientAttestationAlert: string;
+                    };
+                    fields: {
                         enableClientAttestation: {
                             hint: string;
                             label: string;
                         };
+                        androidAttestationServiceCredentials: {
+                            hint: string;
+                            label: string;
+                            placeholder: string;
+                            validations: {
+                                empty: string;
+                                invalid: string;
+                            };
+                        };
+                    };
+                };
+                trustedApps: {
+                    heading: string;
+                    alerts: {
+                        trustedAppSettingsAlert: string;
+                        link: string;
+                    };
+                    fields: {
+                        enableFIDOTrustedApps: {
+                            hint: string;
+                            backLink: string;
+                            label: string;
+                        };
+                    };
+                    modal:{
+                        assertionHint: string;
+                        header: string;
+                        message: string;
+                        content: string;
+                    }
+                };
+                platformSettings: {
+                    heading: string;
+                    subTitle: string;
+                    fields: {
                         android: {
                             heading: string;
                             fields: {
@@ -933,16 +973,19 @@ export interface ApplicationsNS {
                                     label: string;
                                     placeholder: string;
                                     validations: {
-                                        empty: string;
+                                        emptyForAttestation: string;
+                                        emptyForFIDO: string;
                                     };
                                 };
-                                androidAttestationServiceCredentials: {
+                                keyHashes: {
                                     hint: string;
                                     label: string;
                                     placeholder: string;
                                     validations: {
-                                        empty: string;
+                                        invalidOrEmpty: string;
+                                        duplicate: string;
                                     };
+                                    tooltip: string;
                                 };
                             };
                         };

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1109,18 +1109,58 @@ export const applications: ApplicationsNS = {
             sections: {
                 applicationNativeAuthentication: {
                     heading: "App-Native Authentication",
-                    alerts: {
-                        clientAttestation: "For client attestation to work, the app-native authentication API must be enabled."
-                    },
                     fields: {
                         enableAPIBasedAuthentication: {
                             hint: "Select to authorize application to perform browserless, in-app authentication via app-native authentication API.",
                             label: "Enable app-native authentication API"
                         },
+                    }
+                },
+                clientAttestation: {
+                    heading: "Client Attestation",
+                    alerts: {
+                        clientAttestationAlert: "For client attestation to work, the app-native authentication API must be enabled."
+                    },
+                    fields: {
                         enableClientAttestation: {
                             hint: "Select to verify the integrity of the application by calling the attestation service of the hosting platform.",
                             label: "Enable client attestation"
                         },
+                        androidAttestationServiceCredentials: {
+                            hint: "Provide the Google service account credentials in the JSON format. This will be used to access the  Google Play Integrity Service.",
+                            label: "Service account credentials",
+                            placeholder: "Content of the JSON key file for the Google service account credentials",
+                            validations: {
+                                empty: "Google service account credentials are required for client attestation.",
+                                invalid: "Invalid Google service account credentials"
+                            }
+                        }
+                    }
+                },
+                trustedApps: {
+                    heading: "Trusted App Settings",
+                    alerts: {
+                        trustedAppSettingsAlert: "Enabling this feature will publish details under Platform Settings to a public endpoint shared across all Asgardeo organizations. This means that other organizations can access details about the application and the associated organization.",
+                        link: "Read for more."
+                    },
+                    fields: {
+                        enableFIDOTrustedApps: {
+                            hint: "Select to trust the app for user login with passkey. Provide the details of the application under ",
+                            backLink: "Platform Settings.",
+                            label: "Add as a FIDO trusted app"
+                        }
+                    },
+                    modal: {
+                        assertionHint : "I understand and wish to proceed.",
+                        header: "Are you sure?",
+                        message: "For validation purposes, Asgardeo requires that the details available under Platform Settings be listed on a public endpoint shared across all Asgardeo organizations.",
+                        content: ""
+                    }
+                },
+                platformSettings: {
+                    heading: "Platform Settings",
+                    subTitle: "The following platform specific configurations are needed when enabling client-attestation or trusted app related features",
+                    fields: {
                         android: {
                             heading: "Android",
                             fields: {
@@ -1129,17 +1169,21 @@ export const applications: ApplicationsNS = {
                                     label: "Package name",
                                     placeholder: "com.example.myapp",
                                     validations: {
-                                        empty: "Application package name is required for client attestation."
+                                        emptyForAttestation: "Application package name is required for client attestation.",
+                                        emptyForFIDO: "Application package name is required for FIDO trusted apps."
                                     }
                                 },
-                                androidAttestationServiceCredentials: {
-                                    hint: "Provide the Google service account credentials in the JSON format. This will be used to access the  Google Play Integrity Service.",
-                                    label: "Service account credentials",
-                                    placeholder: "Content of the JSON key file for the Google service account credentials",
+                                keyHashes: {
+                                    hint: "The SHA256 fingerprints related to the signing certificate of your application",
+                                    label: "Key Hashes",
+                                    placeholder: "D4:B9:A3",
                                     validations: {
-                                        empty: "Google service account credentials are required for client attestation."
-                                    }
-                                }
+                                        invalidOrEmpty: "Enter a valid key hash.",
+                                        duplicate: "Same key hashes added."
+                                    },
+                                    tooltip: "Add Thumbprint"
+
+                                },
                             }
                         },
                         apple: {

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1113,7 +1113,7 @@ export const applications: ApplicationsNS = {
                         enableAPIBasedAuthentication: {
                             hint: "Select to authorize application to perform browserless, in-app authentication via app-native authentication API.",
                             label: "Enable app-native authentication API"
-                        },
+                        }
                     }
                 },
                 clientAttestation: {
@@ -1183,7 +1183,7 @@ export const applications: ApplicationsNS = {
                                     },
                                     tooltip: "Add Thumbprint"
 
-                                },
+                                }
                             }
                         },
                         apple: {


### PR DESCRIPTION
This PR changes the Advanced Configurations page of Application configurations in the console app. 

Following changes are added:
- client attestation section is taken out of app-native authentication section as a seperate section.
- a new section is added for trusted app related features
- a new section added for platform specific configurations common for both client attestation and trusted app related features

Figma design: https://www.figma.com/proto/bGsPNcdkdYrZ1sdfNFTx6p/FIDO-Trusted-Apps?node-id=3-18&t=f63TAHja5dE8mtYb-1