### PR TITLE
Cleanup identity-providers feature (Pt.07)

### DIFF
--- a/.changeset/flat-garlics-bake.md
+++ b/.changeset/flat-garlics-bake.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.core.v1": minor
+---
+
+Expose `isLoading` property from `useRequest` hook

--- a/.changeset/nasty-snakes-refuse.md
+++ b/.changeset/nasty-snakes-refuse.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.identity-providers.v1": minor
+"@wso2is/admin.applications.v1": minor
+"@wso2is/admin.connections.v1": minor
+"@wso2is/console": minor
+---
+
+Update Login flow authenticator modal to use connection templates list via API

--- a/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
+++ b/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
@@ -18,6 +18,8 @@
 
 import useAuthenticationFlow from "@wso2is/admin.authentication-flow-builder.v1/hooks/use-authentication-flow";
 import { ConnectionManagementConstants, ConnectionTemplateCategoryInterface } from "@wso2is/admin.connections.v1";
+import { AuthenticatorMeta } from "@wso2is/admin.connections.v1/meta/authenticator-meta";
+import { ConnectionTemplateManagementUtils } from "@wso2is/admin.connections.v1/utils/connection-template-utils";
 import { ConnectionsManagementUtils } from "@wso2is/admin.connections.v1/utils/connection-utils";
 import { getEmptyPlaceholderIllustrations } from "@wso2is/admin.core.v1/configs/ui";
 import useDeploymentConfig from "@wso2is/admin.core.v1/hooks/use-deployment-configs";
@@ -27,16 +29,12 @@ import { getIdPIcons } from "@wso2is/admin.identity-providers.v1/configs/ui";
 import {
     IdentityProviderManagementConstants
 } from "@wso2is/admin.identity-providers.v1/constants/identity-provider-management-constants";
-import { AuthenticatorMeta } from "@wso2is/admin.identity-providers.v1/meta/authenticator-meta";
 import {
     AuthenticatorCategories,
     GenericAuthenticatorInterface,
     IdentityProviderTemplateInterface,
     IdentityProviderTemplateItemInterface
 } from "@wso2is/admin.identity-providers.v1/models/identity-provider";
-import {
-    IdentityProviderManagementUtils
-} from "@wso2is/admin.identity-providers.v1/utils/identity-provider-management-utils";
 import {
     IdentityProviderTemplateManagementUtils
 } from "@wso2is/admin.identity-providers.v1/utils/identity-provider-template-management-utils";
@@ -213,9 +211,12 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
      * Fetches IdP templates if not available.
      */
     useEffect(() => {
+        console.log("Checking for IdP templates");
+
         if (groupedIDPTemplates) {
             return;
         }
+        console.log("Fetching IdP templates");
 
         IdentityProviderTemplateManagementUtils.getIdentityProviderTemplates();
     }, [ groupedIDPTemplates ]);
@@ -270,7 +271,7 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
         templates: IdentityProviderTemplateInterface[]
     ): Promise<void | ConnectionTemplateCategoryInterface[]> => {
 
-        return IdentityProviderTemplateManagementUtils.categorizeTemplates(templates)
+        return ConnectionTemplateManagementUtils.categorizeTemplates(templates)
             .then((response: ConnectionTemplateCategoryInterface[]) => {
 
                 let tags: string[] = [];
@@ -343,7 +344,7 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
         const labels: string[] = [];
 
         authenticators.filter((authenticator: GenericAuthenticatorInterface) => {
-            IdentityProviderManagementUtils.getAuthenticatorLabels(authenticator).filter((label: string) => {
+            AuthenticatorMeta.getAuthenticatorLabels(authenticator).filter((label: string) => {
                 if (!labels.includes(label)) {
                     labels.push(label);
                 }
@@ -433,7 +434,7 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
                 return true;
             }
 
-            return IdentityProviderManagementUtils.getAuthenticatorLabels(authenticator)
+            return AuthenticatorMeta.getAuthenticatorLabels(authenticator)
                 .some((selectedLabel: string) => filterLabels.includes(selectedLabel));
         };
 
@@ -446,7 +447,7 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
             const name: string = authenticator?.displayName?.toLocaleLowerCase();
 
             if (name.includes(query)
-                || IdentityProviderManagementUtils.getAuthenticatorLabels(authenticator)
+                || AuthenticatorMeta.getAuthenticatorLabels(authenticator)
                     .some((tag: string) => tag?.toLocaleLowerCase()?.includes(query)
                         || startCase(tag)?.toLocaleLowerCase()?.includes(query))
                 || authenticator.category?.toLocaleLowerCase()?.includes(query)
@@ -582,7 +583,7 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
                                                     comingSoonRibbonLabel={ t("common:comingSoon") }
                                                     resourceDescription={ template.description }
                                                     resourceImage={
-                                                        IdentityProviderManagementUtils
+                                                        ConnectionsManagementUtils
                                                             .resolveTemplateImage(template.image, getIdPIcons())
                                                     }
                                                     tags={ template.tags }
@@ -641,7 +642,7 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
                                             className={ `filter-label ${ isSelected ? "active" : "" }` }
                                             onClick={ () => handleAuthenticatorFilter(label) }
                                         >
-                                            { IdentityProviderManagementUtils.getAuthenticatorLabelDisplayName(label) }
+                                            { label }
                                             { isSelected && <Icon name="check"/> }
                                         </Label>
                                     );

--- a/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
+++ b/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/add-authenticator-modal.tsx
@@ -211,12 +211,9 @@ export const AddAuthenticatorModal: FunctionComponent<AddAuthenticatorModalProps
      * Fetches IdP templates if not available.
      */
     useEffect(() => {
-        console.log("Checking for IdP templates");
-
         if (groupedIDPTemplates) {
             return;
         }
-        console.log("Fetching IdP templates");
 
         IdentityProviderTemplateManagementUtils.getIdentityProviderTemplates();
     }, [ groupedIDPTemplates ]);

--- a/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
+++ b/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/authenticators.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,6 +18,7 @@
 
 import Chip from "@oxygen-ui/react/Chip";
 import { AuthenticatorManagementConstants } from "@wso2is/admin.connections.v1";
+import { AuthenticatorMeta } from "@wso2is/admin.connections.v1/meta/authenticator-meta";
 import { ConnectionsManagementUtils } from "@wso2is/admin.connections.v1/utils/connection-utils";
 import { AppState } from "@wso2is/admin.core.v1";
 import useUIConfig from "@wso2is/admin.core.v1/hooks/use-ui-configs";
@@ -25,7 +26,6 @@ import { applicationConfig } from "@wso2is/admin.extensions.v1";
 import {
     IdentityProviderManagementConstants
 } from "@wso2is/admin.identity-providers.v1/constants/identity-provider-management-constants";
-import { AuthenticatorMeta } from "@wso2is/admin.identity-providers.v1/meta/authenticator-meta";
 import {
     AuthenticatorCategories,
     GenericAuthenticatorInterface

--- a/features/admin.authentication-flow-builder.v1/components/__tests__/authentication-flow-option-add-modal.test.tsx
+++ b/features/admin.authentication-flow-builder.v1/components/__tests__/authentication-flow-option-add-modal.test.tsx
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+/* eslint-disable sort-keys */
+
 import DeploymentConfigProvider from "@wso2is/admin.core.v1/providers/deployment-config-provider";
 import ResourceEndpointsProvider from "@wso2is/admin.core.v1/providers/resource-enpoints-provider";
 import UserPreferenceProvider from "@wso2is/admin.core.v1/providers/user-preferences-provider";
@@ -26,6 +28,112 @@ import { fullPermissions } from "./__mocks__/permissions";
 import AuthenticationFlowOptionAddModal, {
     AuthenticationFlowOptionAddModalPropsInterface
 } from "../authentication-flow-option-add-modal";
+
+jest.mock("@wso2is/admin.connections.v1/api/use-get-connection-templates", () => (
+    {
+        useGetConnectionTemplates: () => ([
+            {
+                "id": "google-idp",
+                "name": "Google",
+                "description": "Login users with existing Google accounts.",
+                "image": "assets/images/logos/google.svg",
+                "displayOrder": 1,
+                "tags": [
+                    "Social-Login",
+                    "APIAuth"
+                ],
+                "category": "DEFAULT",
+                "type": "connections",
+                "self": "/api/server/v1/extensions/connections/google-idp"
+            },
+            {
+                "id": "microsoft-idp",
+                "name": "Microsoft",
+                "description": "Enable login for users with existing Microsoft accounts.",
+                "image": "assets/images/logos/microsoft.svg",
+                "displayOrder": 2,
+                "tags": [
+                    "Social-Login",
+                    "APIAuth"
+                ],
+                "category": "DEFAULT",
+                "type": "connections",
+                "self": "/api/server/v1/extensions/connections/microsoft-idp"
+            },
+            {
+                "id": "facebook-idp",
+                "name": "Facebook",
+                "description": "Login users with existing Facebook accounts.",
+                "image": "assets/images/logos/facebook.svg",
+                "displayOrder": 3,
+                "tags": [
+                    "Social-Login",
+                    "APIAuth"
+                ],
+                "category": "DEFAULT",
+                "type": "connections",
+                "self": "/api/server/v1/extensions/connections/facebook-idp"
+            },
+            {
+                "id": "github-idp",
+                "name": "GitHub",
+                "description": "Login users with existing GitHub accounts.",
+                "image": "assets/images/logos/github.svg",
+                "displayOrder": 4,
+                "tags": [
+                    "Social-Login",
+                    "APIAuth"
+                ],
+                "category": "DEFAULT",
+                "type": "connections",
+                "self": "/api/server/v1/extensions/connections/github-idp"
+            },
+            {
+                "id": "apple-idp",
+                "name": "Apple",
+                "description": "Login users with their Apple IDs.",
+                "image": "assets/images/logos/apple.svg",
+                "displayOrder": 5,
+                "tags": [
+                    "Social-Login"
+                ],
+                "category": "DEFAULT",
+                "type": "connections",
+                "self": "/api/server/v1/extensions/connections/apple-idp"
+            },
+            {
+                "category": "DEFAULT",
+                // eslint-disable-next-line max-len
+                "description": "Enable login for users with their accounts in your existing identity providers via standard authentication protocols.",
+                "enabled": true,
+                "displayOrder": 7,
+                "id": "enterprise-protocols",
+                "docLink": "/guides/authentication/enterprise-login/",
+                "image": "assets/images/logos/enterprise.svg",
+                "name": "Enterprise",
+                "services": [],
+                "disabled": false,
+                "type": "ENTERPRISE",
+                "tags": [
+                    "OIDC",
+                    "SAML"
+                ],
+                "templateId": "enterprise-idp"
+            },
+            {
+                "id": "expert-mode-idp",
+                "name": "Expert Mode",
+                "description": "Create a new Connection with minimum configurations.",
+                "image": "assets/images/logos/expert.svg",
+                "displayOrder": 11,
+                "tags": [],
+                "category": "DEFAULT",
+                "type": "connections",
+                "self": "/api/server/v1/extensions/connections/expert-mode-idp"
+            }
+        ])
+    }
+));
 
 describe("AuthenticationFlowOptionAddModal", () => {
     const defaultProps: AuthenticationFlowOptionAddModalPropsInterface = {

--- a/features/admin.authentication-flow-builder.v1/components/__tests__/authentication-flow-option-add-modal.test.tsx
+++ b/features/admin.authentication-flow-builder.v1/components/__tests__/authentication-flow-option-add-modal.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,6 +17,7 @@
  */
 
 import DeploymentConfigProvider from "@wso2is/admin.core.v1/providers/deployment-config-provider";
+import ResourceEndpointsProvider from "@wso2is/admin.core.v1/providers/resource-enpoints-provider";
 import UserPreferenceProvider from "@wso2is/admin.core.v1/providers/user-preferences-provider";
 import { render, screen } from "@wso2is/unit-testing/utils";
 import React from "react";
@@ -35,7 +36,9 @@ describe("AuthenticationFlowOptionAddModal", () => {
         render(
             <UserPreferenceProvider>
                 <DeploymentConfigProvider>
-                    <AuthenticationFlowOptionAddModal { ...defaultProps } />
+                    <ResourceEndpointsProvider>
+                        <AuthenticationFlowOptionAddModal { ...defaultProps } />
+                    </ResourceEndpointsProvider>
                 </DeploymentConfigProvider>
             </UserPreferenceProvider>
             , { allowedScopes: fullPermissions });

--- a/features/admin.connections.v1/api/connections.ts
+++ b/features/admin.connections.v1/api/connections.ts
@@ -324,6 +324,7 @@ export const useGetConnectionTemplate = <Data = ConnectionTemplateInterface, Err
 
 /**
  * Hook to get the connection template list with limit and offset.
+ * @deprecated - Use `useGetConnectionTemplates` from `use-get-connection-templates.ts`
  *
  * @param limit - Maximum Limit of the connection templates.
  * @param offset - Offset for get to start.

--- a/features/admin.connections.v1/api/use-get-connection-templates.ts
+++ b/features/admin.connections.v1/api/use-get-connection-templates.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import useRequest, {
+    RequestConfigInterface,
+    RequestErrorInterface,
+    RequestResultInterface
+} from "@wso2is/admin.core.v1/hooks/use-request";
+import useResourceEndpoints from "@wso2is/admin.core.v1/hooks/use-resource-endpoints";
+import useUIConfig from "@wso2is/admin.core.v1/hooks/use-ui-configs";
+import { HttpMethods } from "@wso2is/core/models";
+import { ConnectionManagementConstants } from "../constants/connection-constants";
+import { ConnectionTemplateInterface } from "../models/connection";
+import { loadLocalFileBasedConnectionTemplateGroups } from "../utils/connection-template-utils";
+
+/**
+ * Hook to get the connection template list with limit and offset.
+ *
+ * @param limit - Maximum Limit of the connection templates.
+ * @param offset - Offset for get to start.
+ * @param filter - Search filter.
+ * @param shouldFetch - Whether the request should be fetched.
+ * @param isLoginFlow - Whether the templates list is for login flow.
+ *
+ * @returns Requested connections.
+ */
+export const useGetConnectionTemplates = <Data = ConnectionTemplateInterface[], Error = RequestErrorInterface>(
+    limit?: number,
+    offset?: number,
+    filter?: string,
+    shouldFetch: boolean = true,
+    isLoginFlow: boolean = false
+): RequestResultInterface<Data, Error> => {
+
+    const { resourceEndpoints } = useResourceEndpoints();
+    const { UIConfig } = useUIConfig();
+
+    const requestConfig: RequestConfigInterface = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        params: {
+            filter,
+            limit,
+            offset
+        },
+        url: resourceEndpoints.extensions + "/connections"
+    };
+
+    const {
+        data,
+        error,
+        isValidating,
+        mutate,
+        isLoading
+    } = useRequest<Data, Error>(shouldFetch ? requestConfig : null);
+
+    let filteredData: ConnectionTemplateInterface[] = undefined;
+
+    if (data) {
+        const hiddenConnectionTemplateIds: string[] = [
+            ConnectionManagementConstants.IDP_TEMPLATE_IDS.LINKEDIN,
+            ConnectionManagementConstants.IDP_TEMPLATE_IDS
+                .ORGANIZATION_ENTERPRISE_IDP,
+            ConnectionManagementConstants.IDP_TEMPLATE_IDS.ENTERPRISE,
+            ConnectionManagementConstants.IDP_TEMPLATE_IDS.OIDC,
+            ConnectionManagementConstants.IDP_TEMPLATE_IDS.SAML,
+            ...UIConfig?.hiddenConnectionTemplates
+        ];
+
+        // Trusted token issuer is not useful for login flow.
+        if (isLoginFlow) {
+            hiddenConnectionTemplateIds.push(ConnectionManagementConstants.TRUSTED_TOKEN_TEMPLATE_ID);
+        }
+
+        const fetchedConnectionTemplates: ConnectionTemplateInterface[] = data as ConnectionTemplateInterface[];
+
+        // Filter out the hidden connection templates.
+        filteredData = fetchedConnectionTemplates.filter((template: ConnectionTemplateInterface) => {
+            return !hiddenConnectionTemplateIds.includes(template.id);
+        });
+
+        // Append the local file based connection templates.
+        filteredData = [ ...filteredData, ...loadLocalFileBasedConnectionTemplateGroups() ];
+
+        // Sort the connection templates based on the display order.
+        filteredData.sort((a: ConnectionTemplateInterface, b: ConnectionTemplateInterface) => {
+            return a.displayOrder - b.displayOrder;
+        });
+    }
+
+    return {
+        data: filteredData as Data,
+        error: error,
+        isLoading,
+        isValidating,
+        mutate
+    };
+};

--- a/features/admin.connections.v1/api/use-get-connection-templates.ts
+++ b/features/admin.connections.v1/api/use-get-connection-templates.ts
@@ -82,7 +82,7 @@ export const useGetConnectionTemplates = <Data = ConnectionTemplateInterface[], 
             ConnectionManagementConstants.IDP_TEMPLATE_IDS.ENTERPRISE,
             ConnectionManagementConstants.IDP_TEMPLATE_IDS.OIDC,
             ConnectionManagementConstants.IDP_TEMPLATE_IDS.SAML,
-            ...UIConfig?.hiddenConnectionTemplates
+            ...(UIConfig?.hiddenConnectionTemplates || [])
         ];
 
         // Trusted token issuer is not useful for login flow.

--- a/features/admin.connections.v1/configs/templates.ts
+++ b/features/admin.connections.v1/configs/templates.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-import { ConnectionTemplatesConfigInterface } from "../models/connection";
-import DefaultConnectionTemplateCategory from "../meta/templates-meta/categories/default.json";
-import EnterpriseConnetionTemplateGroup from "../meta/templates-meta/groups/enterprise.json";
 import keyBy from "lodash-es/keyBy";
 import values from "lodash-es/values";
+import DefaultConnectionTemplateCategory from "../meta/templates-meta/categories/default.json";
+import EnterpriseConnetionTemplateGroup from "../meta/templates-meta/groups/enterprise.json";
+import { ConnectionTemplatesConfigInterface } from "../models/connection";
 
 export const getConnectionTemplatesConfig = (): ConnectionTemplatesConfigInterface => {
 
@@ -48,85 +48,6 @@ export const getConnectionTemplatesConfig = (): ConnectionTemplatesConfigInterfa
                 ],
                 "id"
             )
-        ),
-        templates: [
-            {
-                content: {
-                    quickStart: "./identity-provider-templates/templates/google/quick-start.tsx"
-                },
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.google?.enabled ?? true,
-                id: "google-idp",
-                resource: "./identity-provider-templates/templates/google/google.json"
-            },
-            {
-                content: {
-                    quickStart: "./identity-provider-templates/templates/github/quick-start.tsx"
-                },
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.github?.enabled ?? true,
-                id: "github-idp",
-                resource: "./identity-provider-templates/templates/github/github.json"
-            },
-            {
-                content: {
-                    quickStart: "./identity-provider-templates/templates/facebook/quick-start.tsx"
-                },
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.facebook?.enabled ?? true,
-                id: "facebook-idp",
-                resource: "./identity-provider-templates/templates/facebook/facebook.json"
-            },
-            {
-                content: {},
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.
-                    enterpriseOIDC?.enabled ?? true,
-                id: "enterprise-oidc-idp",
-                resource: "./identity-provider-templates/templates/oidc/oidc.json"
-            },
-            {
-                content: {},
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.
-                    enterpriseSAML?.enabled ?? true,
-                id: "enterprise-saml-idp",
-                resource: "./identity-provider-templates/templates/saml/saml.json"
-            },
-            {
-                content: {
-                    quickStart: "./identity-provider-templates/templates/microsoft/quick-start.tsx"
-                },
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.microsoft?.enabled ?? true,
-                id: "microsoft-idp",
-                resource: "./identity-provider-templates/templates/microsoft/microsoft.json"
-            },
-            {
-                content: {},
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.linkedin?.enabled ?? true,
-                id: "linkedin-idp",
-                resource: "./identity-provider-templates/templates/linkedin/linkedin.json"
-            },
-            {
-                content: {
-                    quickStart: "./identity-provider-templates/templates/apple/quick-start.tsx"
-                },
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.apple?.enabled ?? true,
-                id: "apple-idp",
-                resource: "./identity-provider-templates/templates/apple/apple.json"
-            },
-            {
-                content: {
-                    quickStart: "./identity-provider-templates/templates/hypr/quick-start.tsx"
-                },
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.hypr?.enabled ?? true,
-                id: "hypr-idp",
-                resource: "./identity-provider-templates/templates/hypr/hypr.json"
-            },
-            {
-                content: {
-                    quickStart: "./identity-provider-templates/templates/swe/quick-start.tsx",
-                    wizardHelp: "./identity-provider-templates/templates/swe/create-wizard-help.tsx"
-                },
-                enabled: window["AppUtils"].getConfig().ui.identityProviderTemplates?.swe?.enabled ?? true,
-                id: "swe-idp",
-                resource: "./identity-provider-templates/templates/swe/swe.json"
-            }
-        ]
+        )
     };
 };

--- a/features/admin.connections.v1/constants/autheticator-constants.ts
+++ b/features/admin.connections.v1/constants/autheticator-constants.ts
@@ -71,7 +71,7 @@ export class AuthenticatorManagementConstants {
     /**
 	 * UUID of the Multi-Factor Authenticators governance connector category.
 	 */
-	public static readonly MFA_CONNECTOR_CATEGORY_ID: string = "TXVsdGkgRmFjdG9yIEF1dGhlbnRpY2F0b3Jz";
+    public static readonly MFA_CONNECTOR_CATEGORY_ID: string = "TXVsdGkgRmFjdG9yIEF1dGhlbnRpY2F0b3Jz";
 
     /**
      * Set of internal idps which are forbidden from deleting.
@@ -116,15 +116,15 @@ export class AuthenticatorManagementConstants {
         OTP_LENGTH_MIN_VALUE: number;
     } = {
 
-        EXPIRY_TIME_MAX_LENGTH: 10000,
-        EXPIRY_TIME_MAX_VALUE: 1440,
-        EXPIRY_TIME_MIN_LENGTH: 1,
-        EXPIRY_TIME_MIN_VALUE: 1,
-        OTP_LENGTH_MAX_LENGTH: 2,
-        OTP_LENGTH_MAX_VALUE: 10,
-        OTP_LENGTH_MIN_LENGTH: 1,
-        OTP_LENGTH_MIN_VALUE: 4
-    };
+            EXPIRY_TIME_MAX_LENGTH: 10000,
+            EXPIRY_TIME_MAX_VALUE: 1440,
+            EXPIRY_TIME_MIN_LENGTH: 1,
+            EXPIRY_TIME_MIN_VALUE: 1,
+            OTP_LENGTH_MAX_LENGTH: 2,
+            OTP_LENGTH_MAX_VALUE: 10,
+            OTP_LENGTH_MIN_LENGTH: 1,
+            OTP_LENGTH_MIN_VALUE: 4
+        };
 
     public static readonly SMS_OTP_AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS: {
         EXPIRY_TIME_MAX_LENGTH: number;
@@ -141,19 +141,19 @@ export class AuthenticatorManagementConstants {
         ALLOWED_RESEND_ATTEMPT_COUNT_MAX_VALUE: number;
     } = {
 
-        ALLOWED_RESEND_ATTEMPT_COUNT_MAX_LENGTH: 10000,
-        ALLOWED_RESEND_ATTEMPT_COUNT_MAX_VALUE: 100,
-        ALLOWED_RESEND_ATTEMPT_COUNT_MIN_LENGTH: 1,
-        ALLOWED_RESEND_ATTEMPT_COUNT_MIN_VALUE: 0,
-        EXPIRY_TIME_MAX_LENGTH: 4,
-        EXPIRY_TIME_MAX_VALUE: 1440,
-        EXPIRY_TIME_MIN_LENGTH: 1,
-        EXPIRY_TIME_MIN_VALUE: 1,
-        OTP_LENGTH_MAX_LENGTH: 2,
-        OTP_LENGTH_MAX_VALUE: 10,
-        OTP_LENGTH_MIN_LENGTH: 1,
-        OTP_LENGTH_MIN_VALUE: 4
-    };
+            ALLOWED_RESEND_ATTEMPT_COUNT_MAX_LENGTH: 10000,
+            ALLOWED_RESEND_ATTEMPT_COUNT_MAX_VALUE: 100,
+            ALLOWED_RESEND_ATTEMPT_COUNT_MIN_LENGTH: 1,
+            ALLOWED_RESEND_ATTEMPT_COUNT_MIN_VALUE: 0,
+            EXPIRY_TIME_MAX_LENGTH: 4,
+            EXPIRY_TIME_MAX_VALUE: 1440,
+            EXPIRY_TIME_MIN_LENGTH: 1,
+            EXPIRY_TIME_MIN_VALUE: 1,
+            OTP_LENGTH_MAX_LENGTH: 2,
+            OTP_LENGTH_MAX_VALUE: 10,
+            OTP_LENGTH_MIN_LENGTH: 1,
+            OTP_LENGTH_MIN_VALUE: 4
+        };
 
     /**
      * Apple Authenticator Settings Form element constraints.
@@ -170,17 +170,17 @@ export class AuthenticatorManagementConstants {
         TEAM_ID_MAX_LENGTH: number,
         TEAM_ID_MIN_LENGTH: number
     } = {
-        ADDITIONAL_QUERY_PARAMS_MAX_LENGTH: 1000,
-        ADDITIONAL_QUERY_PARAMS_MIN_LENGTH: 0,
-        KEY_ID_MAX_LENGTH: 10,
-        KEY_ID_MIN_LENGTH: 10,
-        PRIVATE_KEY_MAX_LENGTH: 1000,
-        PRIVATE_KEY_MIN_LENGTH: 100,
-        SECRET_VALIDITY_PERIOD_MAX_LENGTH: 8,
-        SECRET_VALIDITY_PERIOD_MIN_LENGTH: 2,
-        TEAM_ID_MAX_LENGTH: 10,
-        TEAM_ID_MIN_LENGTH: 10
-    };
+            ADDITIONAL_QUERY_PARAMS_MAX_LENGTH: 1000,
+            ADDITIONAL_QUERY_PARAMS_MIN_LENGTH: 0,
+            KEY_ID_MAX_LENGTH: 10,
+            KEY_ID_MIN_LENGTH: 10,
+            PRIVATE_KEY_MAX_LENGTH: 1000,
+            PRIVATE_KEY_MIN_LENGTH: 100,
+            SECRET_VALIDITY_PERIOD_MAX_LENGTH: 8,
+            SECRET_VALIDITY_PERIOD_MIN_LENGTH: 2,
+            TEAM_ID_MAX_LENGTH: 10,
+            TEAM_ID_MIN_LENGTH: 10
+        };
 
     /**
      * Google Authenticator Settings Form element constraints.
@@ -361,15 +361,15 @@ export class AuthenticatorManagementConstants {
         SMS_NOTIFICATION_SENDER_DELETION_ERROR_ACTIVE_SUBS: IdentityAppsError;
         SMS_NOTIFICATION_SENDER_DELETION_ERROR_CONNECTED_APPS: IdentityAppsError;
     } = {
-        SMS_NOTIFICATION_SENDER_DELETION_ERROR_ACTIVE_SUBS: new IdentityAppsError(
-            "NSM-65015",
-            "Failed to delete SMS notification sender due to the existence of active subscriptions"
-        ),
-        SMS_NOTIFICATION_SENDER_DELETION_ERROR_CONNECTED_APPS: new IdentityAppsError(
-            "NSM-60008",
-            "There are applications using this connection."
-        )
-    }
+            SMS_NOTIFICATION_SENDER_DELETION_ERROR_ACTIVE_SUBS: new IdentityAppsError(
+                "NSM-65015",
+                "Failed to delete SMS notification sender due to the existence of active subscriptions"
+            ),
+            SMS_NOTIFICATION_SENDER_DELETION_ERROR_CONNECTED_APPS: new IdentityAppsError(
+                "NSM-60008",
+                "There are applications using this connection."
+            )
+        };
 
     public static readonly DEPRECATED_SCIM1_PROVISIONING_CONNECTOR_ID: string = "c2NpbQ";
 }

--- a/features/admin.connections.v1/constants/autheticator-constants.ts
+++ b/features/admin.connections.v1/constants/autheticator-constants.ts
@@ -50,6 +50,7 @@ export class AuthenticatorManagementConstants {
     public static readonly SAML_AUTHENTICATOR_ID: string = "U0FNTFNTT0F1dGhlbnRpY2F0b3I";
     public static readonly PASSIVE_STS_AUTHENTICATOR_ID: string = "UGFzc2l2ZVNUU0F1dGhlbnRpY2F0b3I";
     public static readonly ORGANIZATION_ENTERPRISE_AUTHENTICATOR_ID: string = "T3JnYW5pemF0aW9uQXV0aGVudGljYXRvcg";
+    public static readonly IPROOV_AUTHENTICATOR_ID: string = "SXByb292QXV0aGVudGljYXRvcg";
 
     public static readonly PASSIVE_STS_AUTHENTICATOR_NAME: string = "PassiveSTSAuthenticator";
     public static readonly SAML_AUTHENTICATOR_NAME: string = "SAMLSSOAuthenticator";

--- a/features/admin.connections.v1/constants/connection-constants.ts
+++ b/features/admin.connections.v1/constants/connection-constants.ts
@@ -63,7 +63,7 @@ export class ConnectionManagementConstants {
     public static readonly MICROSOFT_AUTHENTICATOR_ID: string = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I";
     public static readonly APPLE_AUTHENTICATOR_ID: string = "QXBwbGVPSURDQXV0aGVudGljYXRvcg";
     public static readonly HYPR_AUTHENTICATOR_ID: string = "SFlQUkF1dGhlbnRpY2F0b3I";
-    public static readonly SIWE_AUTHENTICATOR_ID: string = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I"
+    public static readonly SIWE_AUTHENTICATOR_ID: string = "T3BlbklEQ29ubmVjdEF1dGhlbnRpY2F0b3I";
 
     // Known Social/Enterprise authenticator names;
     public static readonly GOOGLE_OIDC_AUTHENTICATOR_NAME: string = "GoogleOIDCAuthenticator";
@@ -169,7 +169,7 @@ export class ConnectionManagementConstants {
         "idp:notifications.apiLimitReachedError.error.description",
         "idp:notifications.apiLimitReachedError.error.message",
         "cec1f247-32fd-4624-9915-f469195a53ac"
-    )
+    );
 
     public static readonly ORG_ENTERPRISE_CONNECTION_ID: string  = "organization-enterprise-idp";
 
@@ -219,7 +219,7 @@ export class ConnectionManagementConstants {
         ENTERPRISE_PROTOCOLS: string;
     } = {
         ENTERPRISE_PROTOCOLS: "enterprise-protocols"
-    }
+    };
 
     /**
      * Set of IDP template Ids.

--- a/features/admin.connections.v1/constants/connection-constants.ts
+++ b/features/admin.connections.v1/constants/connection-constants.ts
@@ -213,6 +213,15 @@ export class ConnectionManagementConstants {
     };
 
     /**
+     * Set of connection template group Ids.
+     */
+    public static readonly CONNECTION_TEMPLATE_GROUPS: {
+        ENTERPRISE_PROTOCOLS: string;
+    } = {
+        ENTERPRISE_PROTOCOLS: "enterprise-protocols"
+    }
+
+    /**
      * Set of IDP template Ids.
      */
     public static readonly IDP_TEMPLATE_IDS: {

--- a/features/admin.connections.v1/meta/authenticator-meta.ts
+++ b/features/admin.connections.v1/meta/authenticator-meta.ts
@@ -21,6 +21,8 @@ import { ReactNode, lazy } from "react";
 import { getConnectionIcons } from "../configs/ui";
 import { AuthenticatorManagementConstants } from "../constants/autheticator-constants";
 import { AuthenticatorCategories, AuthenticatorLabels } from "../models/authenticators";
+import { FederatedAuthenticatorInterface } from "../models/connection";
+import { ConnectionManagementConstants } from "../constants/connection-constants";
 
 export class AuthenticatorMeta {
 
@@ -77,33 +79,68 @@ export class AuthenticatorMeta {
      *
      * @returns Authenticator labels.
      */
-    public static getAuthenticatorLabels(authenticatorId: string): string[] {
+    public static getAuthenticatorLabels(authenticator: FederatedAuthenticatorInterface): string[] {
 
-        return get({
+        const authenticatorId: string = authenticator?.authenticatorId;
+
+        const authenticatorLabels: string[] = get({
             [ AuthenticatorManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR_ID ]: [ AuthenticatorLabels.HANDLERS ],
             [ AuthenticatorManagementConstants.FIDO_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.PASSWORDLESS,
-                AuthenticatorLabels.PASSKEY
+                AuthenticatorLabels.PASSWORDLESS, AuthenticatorLabels.PASSKEY
             ],
             [ AuthenticatorManagementConstants.TOTP_AUTHENTICATOR_ID ]: [
                 AuthenticatorLabels.SECOND_FACTOR, AuthenticatorLabels.MULTI_FACTOR
             ],
+            [ ConnectionManagementConstants.GOOGLE_OIDC_AUTHENTICATOR_ID ]: [
+                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
+            ],
+            [ ConnectionManagementConstants.GITHUB_AUTHENTICATOR_ID ]: [
+                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
+            ],
+            [ ConnectionManagementConstants.FACEBOOK_AUTHENTICATOR_ID ]: [
+                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
+            ],
+            [ ConnectionManagementConstants.TWITTER_AUTHENTICATOR_ID ]: [
+                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
+            ],
             [ AuthenticatorManagementConstants.OIDC_AUTHENTICATOR_ID ]: [
                 AuthenticatorLabels.OIDC
             ],
-            [ AuthenticatorManagementConstants.SAML_AUTHENTICATOR_ID ]: [
+            [ ConnectionManagementConstants.SAML_AUTHENTICATOR_ID ]: [
                 AuthenticatorLabels.SAML
             ],
             [ AuthenticatorManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.MULTI_FACTOR
+                AuthenticatorLabels.PASSWORDLESS, AuthenticatorLabels.MULTI_FACTOR
             ],
             [ AuthenticatorManagementConstants.SMS_OTP_AUTHENTICATOR_ID ]: [
                 AuthenticatorLabels.MULTI_FACTOR
             ],
             [ AuthenticatorManagementConstants.MAGIC_LINK_AUTHENTICATOR_ID ]: [
                 AuthenticatorLabels.PASSWORDLESS
+            ],
+            [ ConnectionManagementConstants.APPLE_AUTHENTICATOR_ID ]: [
+                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
+            ],
+            [ ConnectionManagementConstants.HYPR_AUTHENTICATOR_ID ]: [
+                AuthenticatorLabels.PASSWORDLESS
+            ],
+            [ AuthenticatorManagementConstants.IPROOV_AUTHENTICATOR_ID ]: [
+                AuthenticatorLabels.PASSWORDLESS
+            ],
+            [ AuthenticatorManagementConstants.ACTIVE_SESSION_LIMIT_HANDLER_AUTHENTICATOR_ID ]: [
+                AuthenticatorLabels.HANDLERS
             ]
-        }, authenticatorId);
+        }, authenticatorId, []);
+
+        if (authenticator?.tags?.includes(AuthenticatorLabels.API_AUTHENTICATION)) {
+            if (authenticatorLabels) {
+                return [ ...authenticatorLabels, AuthenticatorLabels.API_AUTHENTICATION ];
+            } else {
+                return [ AuthenticatorLabels.API_AUTHENTICATION ];
+            }
+        }
+
+        return authenticatorLabels;
     }
 
     /**

--- a/features/admin.connections.v1/meta/authenticator-meta.ts
+++ b/features/admin.connections.v1/meta/authenticator-meta.ts
@@ -133,11 +133,7 @@ export class AuthenticatorMeta {
         }, authenticatorId, []);
 
         if (authenticator?.tags?.includes(AuthenticatorLabels.API_AUTHENTICATION)) {
-            if (authenticatorLabels) {
-                return [ ...authenticatorLabels, AuthenticatorLabels.API_AUTHENTICATION ];
-            } else {
-                return [ AuthenticatorLabels.API_AUTHENTICATION ];
-            }
+            return [ ...authenticatorLabels, AuthenticatorLabels.API_AUTHENTICATION ];
         }
 
         return authenticatorLabels;

--- a/features/admin.connections.v1/meta/authenticator-meta.ts
+++ b/features/admin.connections.v1/meta/authenticator-meta.ts
@@ -20,9 +20,9 @@ import get from "lodash-es/get";
 import { ReactNode, lazy } from "react";
 import { getConnectionIcons } from "../configs/ui";
 import { AuthenticatorManagementConstants } from "../constants/autheticator-constants";
+import { ConnectionManagementConstants } from "../constants/connection-constants";
 import { AuthenticatorCategories, AuthenticatorLabels } from "../models/authenticators";
 import { FederatedAuthenticatorInterface } from "../models/connection";
-import { ConnectionManagementConstants } from "../constants/connection-constants";
 
 export class AuthenticatorMeta {
 

--- a/features/admin.connections.v1/models/connection.ts
+++ b/features/admin.connections.v1/models/connection.ts
@@ -612,7 +612,6 @@ export interface TemplateConfigInterface<T = Record<string, unknown>> {
 export interface ConnectionTemplatesConfigInterface {
     categories: TemplateConfigInterface<ConnectionTemplateCategoryInterface>[] | any;
     groups?: TemplateConfigInterface<ConnectionTemplateGroupInterface>[] | any;
-    templates: TemplateConfigInterface<any>[] | any;
 }
 
 /**

--- a/features/admin.connections.v1/utils/connection-template-utils.ts
+++ b/features/admin.connections.v1/utils/connection-template-utils.ts
@@ -145,9 +145,11 @@ export class ConnectionTemplateManagementUtils {
      * Group the identity provider templates.
      * @param templates - Templates list to be grouped.
      */
-    private static async groupConnectionTemplates(
+    public static async groupConnectionTemplates(
         templates: ConnectionTemplateInterface[]
     ): Promise<ConnectionTemplateInterface[]> {
+        console.log("Grouping templates: connection templates");
+
 
         const groupedTemplates: ConnectionTemplateInterface[] = [];
 
@@ -201,7 +203,7 @@ export class ConnectionTemplateManagementUtils {
      * Once called it will return the available groups from the
      * {@link getConnectionTemplatesConfig}
      */
-    private static async loadLocalFileBasedIdentityProviderTemplateGroups():
+    public static async loadLocalFileBasedIdentityProviderTemplateGroups():
         Promise<(ConnectionTemplateGroupInterface |
             Promise<ConnectionTemplateGroupInterface>)[]> {
 

--- a/features/admin.connections.v1/utils/connection-template-utils.ts
+++ b/features/admin.connections.v1/utils/connection-template-utils.ts
@@ -210,6 +210,8 @@ export class ConnectionTemplateManagementUtils {
 
         getConnectionTemplatesConfig().groups.forEach(
             async (config: TemplateConfigInterface<ConnectionTemplateGroupInterface>) => {
+                console.log("config", config);
+
                 if (!config.enabled) return;
                 groups.push(
                     config.resource as (ConnectionTemplateGroupInterface |
@@ -217,6 +219,8 @@ export class ConnectionTemplateManagementUtils {
                 );
             }
         );
+        console.log("groups", groups);
+
 
         return Promise.all([ ...groups ]);
 
@@ -257,4 +261,18 @@ export const getCertificateOptionsForTemplate = (templateId: string): { JWKS: bo
     }
 
     return undefined;
+};
+
+/**
+ * Utility function to load local file based connection template groups.
+ *
+ * @returns Array of connection template groups.
+ */
+export const loadLocalFileBasedConnectionTemplateGroups = (): ConnectionTemplateGroupInterface[] => {
+
+    return getConnectionTemplatesConfig().groups.map((groupConfig: TemplateConfigInterface<ConnectionTemplateGroupInterface>) => {
+        if (groupConfig.enabled) {
+            return groupConfig.resource as ConnectionTemplateGroupInterface;
+        }
+    });
 };

--- a/features/admin.connections.v1/utils/connection-template-utils.ts
+++ b/features/admin.connections.v1/utils/connection-template-utils.ts
@@ -148,8 +148,6 @@ export class ConnectionTemplateManagementUtils {
     public static async groupConnectionTemplates(
         templates: ConnectionTemplateInterface[]
     ): Promise<ConnectionTemplateInterface[]> {
-        console.log("Grouping templates: connection templates");
-
 
         const groupedTemplates: ConnectionTemplateInterface[] = [];
 

--- a/features/admin.connections.v1/utils/connection-template-utils.ts
+++ b/features/admin.connections.v1/utils/connection-template-utils.ts
@@ -210,7 +210,6 @@ export class ConnectionTemplateManagementUtils {
 
         getConnectionTemplatesConfig().groups.forEach(
             async (config: TemplateConfigInterface<ConnectionTemplateGroupInterface>) => {
-                console.log("config", config);
 
                 if (!config.enabled) return;
                 groups.push(
@@ -219,8 +218,6 @@ export class ConnectionTemplateManagementUtils {
                 );
             }
         );
-        console.log("groups", groups);
-
 
         return Promise.all([ ...groups ]);
 
@@ -270,9 +267,10 @@ export const getCertificateOptionsForTemplate = (templateId: string): { JWKS: bo
  */
 export const loadLocalFileBasedConnectionTemplateGroups = (): ConnectionTemplateGroupInterface[] => {
 
-    return getConnectionTemplatesConfig().groups.map((groupConfig: TemplateConfigInterface<ConnectionTemplateGroupInterface>) => {
-        if (groupConfig.enabled) {
-            return groupConfig.resource as ConnectionTemplateGroupInterface;
-        }
-    });
+    return getConnectionTemplatesConfig().groups.map(
+        (groupConfig: TemplateConfigInterface<ConnectionTemplateGroupInterface>) => {
+            if (groupConfig.enabled) {
+                return groupConfig.resource as ConnectionTemplateGroupInterface;
+            }
+        });
 };

--- a/features/admin.core.v1/hooks/use-request.ts
+++ b/features/admin.core.v1/hooks/use-request.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -109,7 +109,7 @@ const useRequest = <Data = unknown, Error = unknown>(
         ...config
     };
 
-    const { data: response, error, isValidating, mutate } = useSWR<AxiosResponse<Data>, AxiosError<Error>>(
+    const { data: response, error, isValidating, mutate, isLoading } = useSWR<AxiosResponse<Data>, AxiosError<Error>>(
         request && JSON.stringify(request),
         /**
          * NOTE: Typescript thinks `request` can be `null` here, but the fetcher
@@ -144,6 +144,7 @@ const useRequest = <Data = unknown, Error = unknown>(
     return {
         data: response && response.data,
         error,
+        isLoading,
         isValidating,
         mutate,
         response

--- a/features/admin.identity-providers.v1/meta/authenticator-meta.ts
+++ b/features/admin.identity-providers.v1/meta/authenticator-meta.ts
@@ -16,12 +16,12 @@
  * under the License.
  */
 
-import { ConnectionManagementConstants } from "@wso2is/admin.connections.v1";
+import { AuthenticatorLabels, ConnectionManagementConstants } from "@wso2is/admin.connections.v1";
 import get from "lodash-es/get";
 import { ReactNode } from "react";
 import { getAuthenticatorIcons } from "../configs/ui";
 import { IdentityProviderManagementConstants } from "../constants";
-import { AuthenticatorCategories, AuthenticatorLabels, FederatedAuthenticatorInterface } from "../models";
+import { AuthenticatorCategories, FederatedAuthenticatorInterface } from "../models";
 
 export class AuthenticatorMeta {
 
@@ -79,77 +79,6 @@ export class AuthenticatorMeta {
             [ IdentityProviderManagementConstants.X509_CERTIFICATE_AUTHENTICATOR_ID ]: "Authenticate clients using " +
                 "client certificates."
         }, authenticatorId);
-    }
-
-    /**
-     * Get Authenticator Labels.
-     *
-     * @param authenticatorId - Authenticator ID.
-     *
-     * @returns Authenticator labels.
-     */
-    public static getAuthenticatorLabels(authenticator: FederatedAuthenticatorInterface): string[] {
-
-        const authenticatorId: string = authenticator?.authenticatorId;
-
-        const authenticatorLabels: string[] = get({
-            [ IdentityProviderManagementConstants.IDENTIFIER_FIRST_AUTHENTICATOR_ID ]: [ AuthenticatorLabels.HANDLERS ],
-            [ IdentityProviderManagementConstants.FIDO_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.PASSWORDLESS, AuthenticatorLabels.PASSKEY
-            ],
-            [ IdentityProviderManagementConstants.TOTP_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.SECOND_FACTOR, AuthenticatorLabels.MULTI_FACTOR
-            ],
-            [ IdentityProviderManagementConstants.GOOGLE_OIDC_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
-            ],
-            [ IdentityProviderManagementConstants.GITHUB_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
-            ],
-            [ IdentityProviderManagementConstants.FACEBOOK_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
-            ],
-            [ IdentityProviderManagementConstants.TWITTER_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
-            ],
-            [ IdentityProviderManagementConstants.OIDC_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.OIDC
-            ],
-            [ ConnectionManagementConstants.SAML_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.SAML
-            ],
-            [ IdentityProviderManagementConstants.EMAIL_OTP_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.PASSWORDLESS, AuthenticatorLabels.MULTI_FACTOR
-            ],
-            [ IdentityProviderManagementConstants.SMS_OTP_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.MULTI_FACTOR
-            ],
-            [ IdentityProviderManagementConstants.MAGIC_LINK_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.PASSWORDLESS
-            ],
-            [ IdentityProviderManagementConstants.APPLE_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.SOCIAL, AuthenticatorLabels.OIDC
-            ],
-            [ IdentityProviderManagementConstants.HYPR_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.PASSWORDLESS
-            ],
-            [ IdentityProviderManagementConstants.IPROOV_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.PASSWORDLESS
-            ],
-            [ IdentityProviderManagementConstants.ACTIVE_SESSION_LIMIT_HANDLER_AUTHENTICATOR_ID ]: [
-                AuthenticatorLabels.HANDLERS
-            ]
-        }, authenticatorId);
-
-        if (authenticator?.tags?.includes(AuthenticatorLabels.API_AUTHENTICATION)) {
-            if (authenticatorLabels) {
-                return [ ...authenticatorLabels, AuthenticatorLabels.API_AUTHENTICATION ];
-            } else {
-                return [ AuthenticatorLabels.API_AUTHENTICATION ];
-            }
-        }
-
-        return authenticatorLabels;
     }
 
     /**

--- a/features/admin.identity-providers.v1/meta/authenticator-meta.ts
+++ b/features/admin.identity-providers.v1/meta/authenticator-meta.ts
@@ -21,7 +21,7 @@ import get from "lodash-es/get";
 import { ReactNode } from "react";
 import { getAuthenticatorIcons } from "../configs/ui";
 import { IdentityProviderManagementConstants } from "../constants";
-import { AuthenticatorCategories, FederatedAuthenticatorInterface } from "../models";
+import { AuthenticatorCategories } from "../models";
 
 export class AuthenticatorMeta {
 

--- a/features/admin.identity-providers.v1/models/identity-provider.ts
+++ b/features/admin.identity-providers.v1/models/identity-provider.ts
@@ -622,24 +622,6 @@ export interface IdentityProviderFormValuesInterface {
 }
 
 /**
- * Authenticator Labels.
- * @readonly
- */
-export enum AuthenticatorLabels {
-    SOCIAL = "Social-Login",
-    FIRST_FACTOR = "First Factor",
-    SECOND_FACTOR = "2FA",
-    MULTI_FACTOR = "MFA",
-    OIDC = "OIDC",
-    SAML = "SAML",
-    PASSWORDLESS = "Passwordless",
-    HANDLERS = "Handlers",
-    USERNAMELESS = "Usernameless",
-    PASSKEY = "Passkey",
-    API_AUTHENTICATION = "APIAuth"
-}
-
-/**
  * Authenticator Categories.
  * @readonly
  */

--- a/features/admin.identity-providers.v1/utils/identity-provider-management-utils.ts
+++ b/features/admin.identity-providers.v1/utils/identity-provider-management-utils.ts
@@ -17,12 +17,8 @@
  */
 
 import { getConnections } from "@wso2is/admin.connections.v1/api/connections";
-import { DocPanelUICardInterface } from "@wso2is/admin.core.v1";
-import { Config } from "@wso2is/admin.core.v1/configs";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
-import { ImageUtils, URLUtils } from "@wso2is/core/utils";
 import axios, { AxiosError } from "axios";
-import camelCase from "lodash-es/camelCase";
 import isEmpty from "lodash-es/isEmpty";
 import { getLocalAuthenticators } from "../api";
 import { IdentityProviderManagementConstants } from "../constants";
@@ -30,12 +26,9 @@ import { AuthenticatorMeta } from "../meta";
 import {
     FederatedAuthenticatorInterface,
     FederatedAuthenticatorListItemInterface,
-    FederatedAuthenticatorListResponseInterface,
     GenericAuthenticatorInterface,
-    IdentityProviderInterface,
     IdentityProviderListResponseInterface,
     LocalAuthenticatorInterface,
-    MultiFactorAuthenticatorInterface,
     ProvisioningInterface,
     StrictIdentityProviderInterface
 } from "../models";
@@ -53,9 +46,8 @@ export class IdentityProviderManagementUtils {
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     private constructor() { }
 
-
-
     /**
+     * @deprecated
      * Modifies the federated and local authenticators to convert them to a more
      * generic model which will be easier to handle.
      *
@@ -219,158 +211,5 @@ export class IdentityProviderManagementUtils {
                     error.response,
                     error.config);
             });
-    }
-
-    /**
-     * Generate IDP template docs for the help panel.
-     *
-     * @param raw - Object with IDP template and corresponding docs links.
-     *
-     * @returns Generated docs.
-     */
-    public static generateIDPTemplateDocs = (raw: Record<string, unknown>): DocPanelUICardInterface[] => {
-        if (typeof raw !== "object") {
-            return [];
-        }
-
-        const templates: DocPanelUICardInterface[] = [];
-
-        for (const [ key, value ] of Object.entries(raw)) {
-            templates.push({
-                displayName: key,
-                docs: value.toString(),
-                image: camelCase(key).toLowerCase(),
-                name: camelCase(key).toLowerCase()
-            });
-        }
-
-        return templates;
-    };
-
-    /**
-     * Get the labels for a particular authenticator.
-     *
-     * @param authenticator - Authenticator.
-     *
-     * @returns Labels.
-     */
-    public static getAuthenticatorLabels(authenticator: GenericAuthenticatorInterface): string[] {
-
-        return AuthenticatorMeta.getAuthenticatorLabels(authenticator?.defaultAuthenticator)
-            ? AuthenticatorMeta.getAuthenticatorLabels(authenticator?.defaultAuthenticator)
-            : [];
-    }
-
-    /**
-     * Get the Authenticator label display name.
-     *
-     * @param name - Raw name.
-     *
-     * @returns Authenticator label display name.
-     */
-    public static getAuthenticatorLabelDisplayName(name: string): string {
-
-        return name;
-    }
-
-    /**
-     * Checks if the template image URL is a valid image URL and if not checks if it's
-     * available in the passed in icon set.
-     *
-     * @param image - Input image.
-     *
-     * @returns Predefined image if available. If not, return input parameter.
-     */
-    public static resolveTemplateImage(image: string | any, icons: Record<string, any>): string | any {
-
-        if (image) {
-            if (typeof image !== "string") {
-                return image;
-            }
-
-            if ((URLUtils.isHttpsUrl(image) || URLUtils.isHttpUrl(image)) && ImageUtils.isValidImageExtension(image)) {
-                return image;
-            }
-
-            if (URLUtils.isDataUrl(image)) {
-                return image;
-            }
-
-            if (!icons) {
-                return image;
-            }
-        }
-        const match: string = Object.keys(icons).find((key: string) => key.toString() === image);
-
-        return match ? icons[ match ] : icons[ "default" ] ?? image;
-    }
-
-    /**
-     * Type-guard to check if the connector is an Identity Provider.
-     *
-     * @param connector - Checking connector.
-     *
-     * @returns Whether the connector is IdentityProviderInterface.
-     */
-    public static isConnectorIdentityProvider(connector: IdentityProviderInterface
-        | MultiFactorAuthenticatorInterface): connector is IdentityProviderInterface {
-
-        return (connector as IdentityProviderInterface)?.federatedAuthenticators !== undefined;
-    }
-
-    public static buildAuthenticatorsFilterQuery(searchQuery: string, filters: string[]): string {
-
-        if (isEmpty(filters) || !Array.isArray(filters) || filters.length <= 0) {
-            return searchQuery;
-        }
-
-        let query: string = searchQuery
-            ? `${ searchQuery } and (`
-            : "(";
-
-        if (filters.length > 1) {
-            filters.map((filter: string, index: number) => {
-                query = `${ query }tag eq ${ filter }${ (index === filters.length - 1) ? ")" : " or " }`;
-            });
-        } else {
-            query = `${ query }tag eq ${ filters[ 0 ] })`;
-        }
-
-        return query.trim();
-    }
-
-    /**
-     * Resolve tags for an IDP.
-     * `tags` appear inside the `federatedAuthenticators.authenticators` array. Hence, we need to iterate
-     * and find out the default authenticator and extract the tags.
-     *
-     * @param federatedAuthenticators - Federated authenticators.
-     *
-     * @returns Tags.
-     */
-    public static resolveIDPTags(federatedAuthenticators: FederatedAuthenticatorListResponseInterface): string[] {
-
-        if (!federatedAuthenticators?.defaultAuthenticatorId
-            || !Array.isArray(federatedAuthenticators.authenticators)) {
-
-            return [];
-        }
-
-        const found: FederatedAuthenticatorListItemInterface = federatedAuthenticators.authenticators
-            .find((authenticator: FederatedAuthenticatorListItemInterface) => {
-                return authenticator.authenticatorId === federatedAuthenticators.defaultAuthenticatorId;
-            });
-
-        return Array.isArray(found.tags) ? found.tags : [];
-    }
-
-    /**
-     * Resolve and get the `commonauth` Endpoint.
-     *
-     * @returns commonauth endpoint.
-     */
-    public static getCommonAuthEndpoint(): string {
-
-        return `${ Config.getDeploymentConfig().customServerHost }/commonauth`;
     }
 }

--- a/features/admin.identity-providers.v1/utils/identity-provider-template-management-utils.ts
+++ b/features/admin.identity-providers.v1/utils/identity-provider-template-management-utils.ts
@@ -15,25 +15,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { ConnectionTemplateCategoryInterface, ConnectionTemplateGroupInterface } from "@wso2is/admin.connections.v1";
+import { ConnectionTemplateManagementUtils } from "@wso2is/admin.connections.v1/utils/connection-template-utils";
 import { store } from "@wso2is/admin.core.v1";
-import { I18n } from "@wso2is/i18n";
 import { AxiosError } from "axios";
-import groupBy from "lodash-es/groupBy";
 import { getIdentityProviderTemplateList } from "../api";
 import { handleGetIDPTemplateListError } from "../components/utils/common-utils";
-import { getIdPCapabilityIcons } from "../configs/ui";
 import { TemplateConfigInterface, getIdentityProviderTemplatesConfig } from "../data/identity-provider-templates";
 import ExpertModeIdPTemplate from "../data/identity-provider-templates/templates/expert-mode/expert-mode.json";
 import {
     IdentityProviderTemplateInterface,
     IdentityProviderTemplateListItemInterface,
-    IdentityProviderTemplateListResponseInterface,
-    SupportedServices,
-    SupportedServicesInterface
-} from "../models";
+    IdentityProviderTemplateListResponseInterface} from "../models";
 import { setIdentityProviderTemplates } from "../store";
-import { ConnectionTemplateManagementUtils } from "@wso2is/admin.connections.v1/utils/connection-template-utils";
 
 /**
  * Utility class for IDP Templates related operations.

--- a/features/admin.identity-providers.v1/utils/identity-provider-template-management-utils.ts
+++ b/features/admin.identity-providers.v1/utils/identity-provider-template-management-utils.ts
@@ -25,7 +25,8 @@ import ExpertModeIdPTemplate from "../data/identity-provider-templates/templates
 import {
     IdentityProviderTemplateInterface,
     IdentityProviderTemplateListItemInterface,
-    IdentityProviderTemplateListResponseInterface} from "../models";
+    IdentityProviderTemplateListResponseInterface
+} from "../models";
 import { setIdentityProviderTemplates } from "../store";
 
 /**

--- a/features/admin.identity-providers.v1/utils/identity-provider-template-management-utils.ts
+++ b/features/admin.identity-providers.v1/utils/identity-provider-template-management-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -33,6 +33,7 @@ import {
     SupportedServicesInterface
 } from "../models";
 import { setIdentityProviderTemplates } from "../store";
+import { ConnectionTemplateManagementUtils } from "@wso2is/admin.connections.v1/utils/connection-template-utils";
 
 /**
  * Utility class for IDP Templates related operations.
@@ -72,13 +73,13 @@ export class IdentityProviderTemplateManagementUtils {
                         = IdentityProviderTemplateManagementUtils.resolveHelpContent(response);
 
                     if (!skipGrouping) {
-                        IdentityProviderTemplateManagementUtils.groupIdentityProviderTemplates(templates)
+                        ConnectionTemplateManagementUtils.groupConnectionTemplates(templates)
                             .then((groups: IdentityProviderTemplateInterface[]) => {
                                 if (sort) {
-                                    templates = IdentityProviderTemplateManagementUtils
-                                        .sortIdentityProviderTemplates(templates);
-                                    groups = IdentityProviderTemplateManagementUtils
-                                        .sortIdentityProviderTemplates(groups);
+                                    templates = ConnectionTemplateManagementUtils
+                                        .sortConnectionTemplates(templates);
+                                    groups = ConnectionTemplateManagementUtils
+                                        .sortConnectionTemplates(groups);
                                 }
                                 store.dispatch(setIdentityProviderTemplates(templates));
                                 store.dispatch(setIdentityProviderTemplates(groups, true));
@@ -94,8 +95,8 @@ export class IdentityProviderTemplateManagementUtils {
 
                     if (sort) {
                         templatesWithServices =
-                            IdentityProviderTemplateManagementUtils
-                                .sortIdentityProviderTemplates(templatesWithServices);
+                            ConnectionTemplateManagementUtils
+                                .sortConnectionTemplates(templatesWithServices);
                     }
 
                     store.dispatch(setIdentityProviderTemplates(templatesWithServices));
@@ -129,75 +130,12 @@ export class IdentityProviderTemplateManagementUtils {
     };
 
     /**
-     * Retrieve the IDP template identified by the template ID from local files.
-     *
-     * @param templateId - ID of the template.
-     * @param _skipGrouping - Skip grouping of templates.
-     * @param sort - Should the returning templates be sorted.
-     * @returns Identity provider template.
-     */
-    public static getIdentityProviderTemplate = (templateId: string, _skipGrouping: boolean = false,
-        sort: boolean = true): Promise<IdentityProviderTemplateInterface> => {
-
-        return IdentityProviderTemplateManagementUtils.loadLocalFileBasedTemplates()
-            .then((response: any): any => {
-
-                response = response.filter((template: IdentityProviderTemplateListItemInterface) => {
-                    return template.id === templateId;
-                });
-                const templates: any = IdentityProviderTemplateManagementUtils
-                    .resolveHelpContent(response);
-
-                let templatesWithServices: IdentityProviderTemplateInterface[] =
-                    IdentityProviderTemplateManagementUtils.interpretAvailableTemplates(templates);
-
-                if (sort) {
-                    templatesWithServices =
-                        IdentityProviderTemplateManagementUtils.sortIdentityProviderTemplates(templatesWithServices);
-                }
-
-                return Promise.resolve(templatesWithServices[0]);
-            });
-    };
-
-    /**
-     * Build supported services from the given service identifiers.
-     *
-     * @param serviceIdentifiers - Set of service identifiers.
-     */
-    public static buildSupportedServices = (serviceIdentifiers: string[]): SupportedServicesInterface[] => {
-        return serviceIdentifiers?.map((serviceIdentifier: string): SupportedServicesInterface => {
-            switch (serviceIdentifier) {
-                case SupportedServices.AUTHENTICATION:
-                    return {
-                        displayName: I18n.instance.t(
-                            "console:develop.pages.authenticationProviderTemplate.supportServices." +
-                                "authenticationDisplayName"
-                        ),
-                        logo: getIdPCapabilityIcons()[SupportedServices.AUTHENTICATION],
-                        name: SupportedServices.AUTHENTICATION
-                    };
-                case SupportedServices.PROVISIONING:
-                    return {
-                        displayName: I18n.instance.t(
-                            "console:develop.pages.authenticationProviderTemplate.supportServices." +
-                                "provisioningDisplayName"
-                        ),
-                        logo: getIdPCapabilityIcons()[SupportedServices.PROVISIONING],
-                        name: SupportedServices.PROVISIONING
-                    };
-            }
-        });
-    };
-
-
-    /**
      * Interpret available templates from the response templates.
      *
      * @param templates - List of response templates.
      * @returns List of templates.
      */
-    public static interpretAvailableTemplates = (templates: any[]):
+    private static interpretAvailableTemplates = (templates: any[]):
         IdentityProviderTemplateInterface[] => {
         return templates?.map((eachTemplate: any) => {
             if (eachTemplate?.services[ 0 ] === "") {
@@ -208,141 +146,11 @@ export class IdentityProviderTemplateManagementUtils {
             } else {
                 return {
                     ...eachTemplate,
-                    services: IdentityProviderTemplateManagementUtils.buildSupportedServices(eachTemplate?.services)
+                    services: ConnectionTemplateManagementUtils.buildSupportedServices(eachTemplate?.services)
                 };
             }
         });
     };
-
-    /**
-     * Sort the IDP templates based on display order.
-     *
-     * @param templates - App templates.
-     * @returns Sorted templates.
-     */
-    private static sortIdentityProviderTemplates(
-        templates: IdentityProviderTemplateInterface[]): IdentityProviderTemplateInterface[] {
-
-        const identityProviderTemplates: IdentityProviderTemplateInterface[] = [ ...templates ];
-
-        // Sort templates based on displayOrder.
-        identityProviderTemplates.sort((a: IdentityProviderTemplateInterface, b: IdentityProviderTemplateInterface) =>
-            (a.displayOrder !== -1 ? a.displayOrder : Infinity) - (b.displayOrder !== -1 ? b.displayOrder : Infinity));
-
-        return identityProviderTemplates;
-    }
-
-    /**
-     * Categorize the IDP templates.
-     *
-     * @param templates - Templates list.
-     * @returns Categorized templates.
-     */
-    public static categorizeTemplates(
-        templates: IdentityProviderTemplateInterface[]): Promise<void | ConnectionTemplateCategoryInterface[]> {
-
-        let categorizedTemplates: ConnectionTemplateCategoryInterface[] = [];
-
-        const groupedByCategory: Record<string, IdentityProviderTemplateInterface[]> = groupBy(templates, "category");
-
-        return this.loadLocalFileBasedTemplateCategories()
-            .then((categories: ConnectionTemplateCategoryInterface[]) => {
-
-                categorizedTemplates = [ ...categories ];
-
-                categorizedTemplates.forEach((category: ConnectionTemplateCategoryInterface) => {
-                    if (Object.prototype.hasOwnProperty.call(groupedByCategory, category.id)) {
-                        category.templates = groupedByCategory[ category.id ];
-                    }
-                });
-
-                return categorizedTemplates;
-            })
-            .catch(() => {
-                return categorizedTemplates;
-            });
-    }
-
-    /**
-     * Group the identity provider templates.
-     * @param templates - Identity provider templates.
-     */
-    private static async groupIdentityProviderTemplates(
-        templates: IdentityProviderTemplateInterface[]
-    ): Promise<IdentityProviderTemplateInterface[]> {
-
-        const groupedTemplates: IdentityProviderTemplateInterface[] = [];
-
-        return IdentityProviderTemplateManagementUtils
-            .loadLocalFileBasedIdentityProviderTemplateGroups()
-            .then((response: ConnectionTemplateGroupInterface[]) => {
-                templates.forEach((template: IdentityProviderTemplateInterface) => {
-                    if (!template.templateGroup) {
-                        groupedTemplates.push(template);
-
-                        return;
-                    }
-                    const group: ConnectionTemplateGroupInterface = response
-                        .find((group: ConnectionTemplateGroupInterface) => {
-                            return group.id === template.templateGroup;
-                        });
-
-                    if (!group) {
-                        groupedTemplates.push(template);
-
-                        return;
-                    }
-                    if (groupedTemplates.some((groupedTemplate: IdentityProviderTemplateInterface) =>
-                        groupedTemplate.id === template.templateGroup)) {
-                        groupedTemplates.forEach(
-                            (editingTemplate: IdentityProviderTemplateInterface, index: number) => {
-                                if (editingTemplate.id === template.templateGroup) {
-                                    groupedTemplates[ index ] = {
-                                        ...group,
-                                        subTemplates: [ ...editingTemplate.subTemplates, template ]
-                                    };
-
-                                    return;
-                                }
-                            });
-
-                        return;
-                    }
-                    groupedTemplates.push({
-                        ...group,
-                        subTemplates: [ template ]
-                    });
-                });
-
-                return groupedTemplates;
-            });
-
-    }
-
-    /**
-     * Once called it will return the available groups from the
-     * {@link getIdentityProviderTemplatesConfig}
-     */
-    private static async loadLocalFileBasedIdentityProviderTemplateGroups():
-        Promise<(ConnectionTemplateGroupInterface |
-            Promise<ConnectionTemplateGroupInterface>)[]> {
-
-        const groups: (ConnectionTemplateGroupInterface
-            | Promise<ConnectionTemplateGroupInterface>)[] = [];
-
-        getIdentityProviderTemplatesConfig().groups.forEach(
-            async (config: TemplateConfigInterface<ConnectionTemplateGroupInterface>) => {
-                if (!config.enabled) return;
-                groups.push(
-                    config.resource as (ConnectionTemplateGroupInterface |
-                        Promise<ConnectionTemplateGroupInterface>)
-                );
-            }
-        );
-
-        return Promise.all([ ...groups ]);
-
-    }
 
     /**
      * Loads local file based IDP templates.
@@ -368,33 +176,6 @@ export class IdentityProviderTemplateManagementUtils {
             });
 
         return Promise.all([ ...templates ]);
-    }
-
-    /**
-     * Loads local file based IDP template categories.
-     *
-     * @returns Local file based IDP template categories.
-     */
-    private static async loadLocalFileBasedTemplateCategories(): Promise<(ConnectionTemplateCategoryInterface
-        | Promise<ConnectionTemplateCategoryInterface>)[]> {
-
-        const categories: (ConnectionTemplateCategoryInterface
-            | Promise<ConnectionTemplateCategoryInterface>)[] = [];
-
-        getIdentityProviderTemplatesConfig().categories
-            .forEach(async (config: TemplateConfigInterface<ConnectionTemplateCategoryInterface>) => {
-                if (!config.enabled) {
-                    return;
-                }
-
-                categories.push(
-                    config.resource as (
-                        ConnectionTemplateCategoryInterface
-                        | Promise<ConnectionTemplateCategoryInterface>)
-                );
-            });
-
-        return Promise.all([ ...categories ]);
     }
 
     /**


### PR DESCRIPTION
### Purpose
- Remove redundant util functions from `identity-providers` feature.
- Update Login flow's add authenticator modal to use connection templates list via API.

https://github.com/user-attachments/assets/bd62726c-a631-43e8-aec9-912bcbb723d0


### Related Issues
- https://github.com/wso2/product-is/issues/20580

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
