### PR TITLE
Temporarily disable `no-extra-semi`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -142,6 +142,9 @@ module.exports = {
                 // Refer: https://github.com/wso2/product-is/issues/20659
                 "@typescript-eslint/no-empty-function": "off",
                 "@typescript-eslint/no-explicit-any": 0,
+                // Temporary disable the `no-extra-semi` rule.
+                // Refer: https://github.com/wso2/product-is/issues/20659
+                "@typescript-eslint/no-extra-semi": 0,
                 "@typescript-eslint/no-inferrable-types": "off",
                 "@typescript-eslint/no-unsafe-optional-chaining": "off",
                 "@typescript-eslint/no-unused-vars": [
@@ -179,6 +182,9 @@ module.exports = {
                 // In development, error level is set to `warn`. This will be overridden
                 // by the production env linting config.
                 "no-debugger": 1,
+                // Temporary disable the `no-extra-semi` rule.
+                // Refer: https://github.com/wso2/product-is/issues/20659
+                "no-extra-semi": 0,
                 // `no-undef` is discouraged in Typescript projects.
                 // https://github.com/typescript-eslint/typescript-eslint/issues/2477#issuecomment-686892459
                 "no-undef": 0,
@@ -260,6 +266,9 @@ module.exports = {
         "no-alert": 1,
         "no-console": "warn",
         "no-duplicate-imports": "warn",
+        // Temporary disable the `no-extra-semi` rule.
+        // Refer: https://github.com/wso2/product-is/issues/20659
+        "no-extra-semi": 0,
         "no-restricted-imports": [
             "error",
             {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Temporarily disable `no-extra-semi` rule.

### Related Issues
- https://github.com/wso2/product-is/issues/20659

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
