### PR TITLE
Fix removing custom texts from branding preferences

### DIFF
--- a/features/admin.branding.v1/providers/branding-preference-provider.tsx
+++ b/features/admin.branding.v1/providers/branding-preference-provider.tsx
@@ -524,7 +524,7 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
                     const updatedValues: FormState<CustomTextInterface, CustomTextInterface> = cloneDeep(subscription);
 
                     if (updatedValues) {
-                        for (const key in resolvedCustomText?.preference?.text) {
+                        for (const key in customTextFallbacks?.preference?.text) {
                             // Check if the key is missing in the values object.
                             // Disable ESLint check for the next line until the cause of getting this error is fixed.
                             // eslint-disable-next-line no-unsafe-optional-chaining


### PR DESCRIPTION
### Purpose

The JSON editor in `Branding` > `Styles & Text` > `Text` > `JSON` allows adding custom key pair values but it doesn't allow to remove the custom keys. This PR fixes the issue by allowing the custom keys to be deleted while protecting default keys. The default keys are retrieved from the `resources/branding/i18n/screens/${screen}/${locale}.json` endpoint response.

### Related Issue
- https://github.com/wso2/product-is/issues/20638

Before Fix


https://github.com/user-attachments/assets/7fdcc01b-019c-41ce-b6bb-a188e4674628



After Fix


https://github.com/user-attachments/assets/61456b1a-b99c-4495-96b6-4f40117fae2d



### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
