### PR TITLE
Hide private-key-jwt-config-edit option from console

### DIFF
--- a/.changeset/heavy-bees-smash.md
+++ b/.changeset/heavy-bees-smash.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.server-configurations.v1": patch
+"@wso2is/console": patch
+---
+
+Hide private-key-jwt-config-edit menu.

--- a/.changeset/heavy-bees-smash.md
+++ b/.changeset/heavy-bees-smash.md
@@ -3,4 +3,4 @@
 "@wso2is/console": patch
 ---
 
-Hide private-key-jwt-config-edit menu.
+Hide organization level private key JWT authentication configuration

--- a/apps/console/src/configs/routes.tsx
+++ b/apps/console/src/configs/routes.tsx
@@ -976,20 +976,6 @@ export const getAppViewRoutes = (): RouteInterface[] => {
                     path: AppConstants.getPaths().get("VALIDATION_CONFIG_EDIT"),
                     protected: true,
                     showOnSidePanel: false
-                },
-                {
-                    component: lazy(() =>
-                        import("@wso2is/admin.private-key-jwt.v1/pages/private-key-jwt-config-edit")
-                    ),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().jwtKey
-                    },
-                    id: "private-key-jwt-config-edit",
-                    name: "Private Key JWT Client Authentication for OIDC Configuration Edit",
-                    path: AppConstants.getPaths().get("PRIVATE_KEY_JWT_CONFIG_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
                 }
             ],
             component: lazy(() =>

--- a/features/admin.server-configurations.v1/utils/governance-connector-utils.ts
+++ b/features/admin.server-configurations.v1/utils/governance-connector-utils.ts
@@ -260,13 +260,6 @@ export class GovernanceConnectorUtils {
                         id: ServerConfigurationsConstants.SESSION_MANAGEMENT_CONNECTOR_ID,
                         route: AppConstants.getPaths().get("SESSION_MANAGEMENT"),
                         testId: "session-management-card"
-                    },
-                    {
-                        description: "Authentication via JWT signed with client's registered key.",
-                        header: "Private Key JWT Client Authentication (OIDC)",
-                        id: ServerConfigurationsConstants.PRIVATE_KEY_JWT_CLIENT_AUTH,
-                        route: AppConstants.getPaths().get("PRIVATE_KEY_JWT_CONFIG_EDIT"),
-                        testId: "private-key-jwt-client-auth-card"
                     }
                 ],
                 displayOrder: 1,

--- a/features/admin.server-configurations.v1/utils/governance-connector-utils.ts
+++ b/features/admin.server-configurations.v1/utils/governance-connector-utils.ts
@@ -135,7 +135,7 @@ export class GovernanceConnectorUtils {
             id: "VXNlciBPbmJvYXJkaW5n",
             name: "User Onboarding"
         }
-    ]
+    ];
 
     /**
      * Filter governance categories of a connector for a sub organization.


### PR DESCRIPTION
### Purpose
As the last phase of this issue https://github.com/wso2/product-is/issues/20546, we need to remove the console config available to alter the org level config. In this PR we will be hiding that option. In another effort we will be removing the whole component.

### Related Issues
- https://github.com/wso2/product-is/issues/20546

### Related PRs
- https://github.com/wso2/identity-apps/pull/6505

### Checklist
- [x] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [x] Documentation provided. (Add links if there are any)
- [x] Unit tests provided. (Add links if there are any)
- [x] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Ran FindSecurityBugs plugin and verified report?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
