### PR TITLE
[Impersonation] Add JWT access token validation to configure subject token

### DIFF
--- a/.changeset/cyan-poets-invent.md
+++ b/.changeset/cyan-poets-invent.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+JWT access token check for subject token config

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -220,6 +220,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const [ showCallbackURLField, setShowCallbackURLField ] = useState<boolean>(undefined);
     const [ hideRefreshTokenGrantType, setHideRefreshTokenGrantType ] = useState<boolean>(false);
     const [ selectedGrantTypes, setSelectedGrantTypes ] = useState<string[]>(undefined);
+    const [ isJWTAccessTokenTypeSelected, setJWTAccessTokenTypeSelected ] =useState<boolean>(false);
     const [ isGrantChanged, setGrantChanged ] = useState<boolean>(false);
     const [ showRegenerateConfirmationModal, setShowRegenerateConfirmationModal ] = useState<boolean>(false);
     const [ showRevokeConfirmationModal, setShowRevokeConfirmationModal ] = useState<boolean>(false);
@@ -337,6 +338,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const PKCE_KEY: string = "PKCE";
     const ENABLE_PKCE_CHECKBOX_VALUE: string = "mandatory";
     const SUPPORT_PKCE_PLAIN_ALGORITHM_VALUE: string = "supportPlainTransformAlgorithm";
+    const JWT: string = "JWT";
 
     /**
      * The listener handler for the enable PKCE toggle form field. This function
@@ -583,6 +585,19 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
             setAllowedOrigins(initialValues?.allowedOrigins.toString());
         }
 
+    }, [ initialValues ]);
+
+
+    /**
+     * Check whether which access token type is enabled.
+     */
+    useEffect(() => {
+
+        if (initialValues?.accessToken) {
+            setJWTAccessTokenTypeSelected(initialValues?.accessToken?.type === JWT);
+        } else {
+            setJWTAccessTokenTypeSelected(metadata?.accessTokenType?.defaultValue === JWT);
+        }
     }, [ initialValues ]);
 
     /**
@@ -2566,6 +2581,11 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 }
                                 type="radio"
                                 children={ getAllowedListForAccessToken(metadata?.accessTokenType, false) }
+                                listen={ (values: Map<string, FormValue>) => {
+                                    setJWTAccessTokenTypeSelected(
+                                        values.get("type") === JWT
+                                    );
+                                } }
                                 readOnly={ readOnly }
                                 data-testid={ `${ testId }-access-token-type-radio-group` }
                             />
@@ -3020,6 +3040,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 && !isSystemApplication
                 && !isDefaultApplication
                 && isSubjectTokenFeatureAvailable
+                && isJWTAccessTokenTypeSelected
                 && (
                     <>
                         <Grid.Row columns={ 2 }>

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -598,7 +598,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         } else {
             setJWTAccessTokenTypeSelected(metadata?.accessTokenType?.defaultValue === JWT);
         }
-    }, [ initialValues ]);
+    }, [ initialValues, metadata ]);
 
     /**
      * Sets if subject token is enabled.


### PR DESCRIPTION
### Purpose
Subject token issuance should only work for JWT type access token with this fix we are adding that condition

### Related Issues
https://github.com/wso2/product-is/issues/20066

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
