### PR TITLE
Move to General tab on switch to `Application` in the Branding page

### DIFF
--- a/.changeset/sweet-peaches-invite.md
+++ b/.changeset/sweet-peaches-invite.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.branding.v1": patch
+---
+
+Move to General tab on switch to Application in the Branding page.

--- a/features/admin.branding.v1/components/branding-page-layout.tsx
+++ b/features/admin.branding.v1/components/branding-page-layout.tsx
@@ -70,7 +70,8 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
         brandingMode,
         setBrandingMode,
         selectedApplication,
-        setSelectedApplication
+        setSelectedApplication,
+        updateActiveTab
     } = useBrandingPreference();
 
     const {
@@ -263,14 +264,28 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                                                 value={ brandingMode }
                                                 disabled={ isBrandingAppsRedirect }
                                             >
-                                                <ToggleButton value={ BrandingModes.ORGANIZATION }>
+                                                <ToggleButton
+                                                    value={ BrandingModes.ORGANIZATION }
+                                                    onClick={ () => {
+                                                        updateActiveTab(
+                                                            BrandingPreferencesConstants.TABS.GENERAL_TAB_ID
+                                                        );
+                                                    } }
+                                                >
                                                     <BuildingIcon
                                                         className="toggle-button-icon"
                                                         size={ 14 }
                                                     />
                                                     { t("extensions:develop.branding.pageHeader.organization") }
                                                 </ToggleButton>
-                                                <ToggleButton value={ BrandingModes.APPLICATION }>
+                                                <ToggleButton
+                                                    value={ BrandingModes.APPLICATION }
+                                                    onClick={ () => {
+                                                        updateActiveTab(
+                                                            BrandingPreferencesConstants.TABS.GENERAL_TAB_ID
+                                                        );
+                                                    } }
+                                                >
                                                     <TilesIcon
                                                         className="toggle-button-icon"
                                                         size={ 14 }

--- a/features/admin.branding.v1/components/branding-page-layout.tsx
+++ b/features/admin.branding.v1/components/branding-page-layout.tsx
@@ -71,6 +71,7 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
         setBrandingMode,
         selectedApplication,
         setSelectedApplication,
+        activeTab,
         updateActiveTab
     } = useBrandingPreference();
 
@@ -264,14 +265,7 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                                                 value={ brandingMode }
                                                 disabled={ isBrandingAppsRedirect }
                                             >
-                                                <ToggleButton
-                                                    value={ BrandingModes.ORGANIZATION }
-                                                    onClick={ () => {
-                                                        updateActiveTab(
-                                                            BrandingPreferencesConstants.TABS.GENERAL_TAB_ID
-                                                        );
-                                                    } }
-                                                >
+                                                <ToggleButton value={ BrandingModes.ORGANIZATION }>
                                                     <BuildingIcon
                                                         className="toggle-button-icon"
                                                         size={ 14 }
@@ -281,6 +275,7 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                                                 <ToggleButton
                                                     value={ BrandingModes.APPLICATION }
                                                     onClick={ () => {
+                                                        activeTab === BrandingPreferencesConstants.TABS.TEXT_TAB_ID &&
                                                         updateActiveTab(
                                                             BrandingPreferencesConstants.TABS.GENERAL_TAB_ID
                                                         );

--- a/features/admin.branding.v1/components/branding-preference-tabs.tsx
+++ b/features/admin.branding.v1/components/branding-preference-tabs.tsx
@@ -170,6 +170,7 @@ export const BrandingPreferenceTabs: FunctionComponent<BrandingPreferenceTabsInt
         showCustomTextRevertAllConfirmationModal,
         setShowCustomTextRevertAllConfirmationModal
     ] = useState<boolean>(false);
+    const [ tabIndex, setTabIndex ] = useState<number>(0);
 
     /**
      * Sets the branding preference preview config.
@@ -480,6 +481,7 @@ export const BrandingPreferenceTabs: FunctionComponent<BrandingPreferenceTabsInt
 
         if (!isSplitView) {
             panes.push({
+                "data-tabid": BrandingPreferencesConstants.TABS.PREVIEW_TAB_ID,
                 menuItem: t("extensions:develop.branding.tabs.preview.label"),
                 render: PreviewPreferenceTabPane
             });
@@ -515,11 +517,29 @@ export const BrandingPreferenceTabs: FunctionComponent<BrandingPreferenceTabsInt
         return preferenceForPreview;
     };
 
+    /**
+     * Sets the tab index based on the active tab.
+     */
+    useEffect(() => {
+        const tabMapping: {[x: string]: number;} = {
+            [BrandingPreferencesConstants.TABS.GENERAL_TAB_ID]:
+                BrandingPreferencesConstants.TAB_INDEX.GENERAL_TAB_INDEX,
+            [BrandingPreferencesConstants.TABS.DESIGN_TAB_ID]: BrandingPreferencesConstants.TAB_INDEX.DESIGN_TAB_INDEX,
+            [BrandingPreferencesConstants.TABS.ADVANCED_TAB_ID]:
+                BrandingPreferencesConstants.TAB_INDEX.ADVANCED_TAB_INDEX,
+            [BrandingPreferencesConstants.TABS.TEXT_TAB_ID]: BrandingPreferencesConstants.TAB_INDEX.TEXT_TAB_INDEX,
+            [BrandingPreferencesConstants.TABS.PREVIEW_TAB_ID]: BrandingPreferencesConstants.TAB_INDEX.PREVIEW_TAB_INDEX
+        };
+
+        setTabIndex(tabMapping[activeTab] ?? 0);
+    }, [ activeTab ]);
+
     return (
         <Segment.Group horizontal className="basic branding-preference-tab-group" data-componentid={ componentId }>
             <Segment basic padded={ false }>
                 <ResourceTab
                     attached="top"
+                    activeIndex={ tabIndex }
                     secondary={ false }
                     pointing={ false }
                     onTabChange={ (

--- a/features/admin.branding.v1/constants/branding-preferences-constants.ts
+++ b/features/admin.branding.v1/constants/branding-preferences-constants.ts
@@ -103,11 +103,30 @@ export class BrandingPreferencesConstants {
         DESIGN_TAB_ID: string;
         GENERAL_TAB_ID: string;
         TEXT_TAB_ID: string;
+        PREVIEW_TAB_ID: string;
     } = {
             ADVANCED_TAB_ID: "advanced",
             DESIGN_TAB_ID: "design",
             GENERAL_TAB_ID: "general",
+            PREVIEW_TAB_ID: "preview",
             TEXT_TAB_ID: "text"
+        };
+
+    /**
+     * Branding preference tab indices.
+     */
+    public static readonly TAB_INDEX: {
+        ADVANCED_TAB_INDEX: number;
+        DESIGN_TAB_INDEX: number;
+        GENERAL_TAB_INDEX: number;
+        PREVIEW_TAB_INDEX: number;
+        TEXT_TAB_INDEX: number;
+    } = {
+            ADVANCED_TAB_INDEX: 2,
+            DESIGN_TAB_INDEX: 1,
+            GENERAL_TAB_INDEX: 0,
+            PREVIEW_TAB_INDEX: 4,
+            TEXT_TAB_INDEX: 3
         };
 
     /**


### PR DESCRIPTION
### Purpose
Move to the General tab when switching to app branding as Text branding isn't supported yet.

https://github.com/user-attachments/assets/636c4c9f-ad2f-4879-86fd-98704fd91298

### Related Issues
- https://github.com/wso2/product-is/issues/20694

### Related PRs
- 

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
