### PR TITLE
Fix build artifact issues after `nx` 17 upgrade

### DIFF
--- a/apps/console/project.json
+++ b/apps/console/project.json
@@ -90,7 +90,8 @@
                     "optimization": false,
                     "sourceMap": true,
                     "vendorChunk": true,
-                    "verbose": true
+                    "verbose": true,
+                    "extractCss": false
                 },
                 "production": {
                     "index": "index.jsp",
@@ -100,7 +101,8 @@
                     "outputHashing": "all",
                     "sourceMap": false,
                     "extractLicenses": false,
-                    "verbose": true
+                    "verbose": true,
+                    "extractCss": false
                 }
             }
         },

--- a/apps/console/webpack.config.ts
+++ b/apps/console/webpack.config.ts
@@ -561,10 +561,13 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
 
         if (rule.test.toString().includes("svg") && rule.test instanceof RegExp) {
             rule.use instanceof Array && rule.use.forEach((item: RuleSetUseItem) => {
-                if (typeof item !== "string" && (item as any).loader.includes("url-loader")) {
+                if (
+                    typeof item !== "string" &&
+                    ((item as any).loader.includes("url-loader") || (item as any).loader.includes("file-loader"))
+                ) {
                     (item as any).options.name = isProduction
-                        ? `${ RELATIVE_PATHS.staticMedia }/[contenthash].[ext]`
-                        : `${ RELATIVE_PATHS.staticMedia }/[path][name].[ext]`;
+                        ? `${RELATIVE_PATHS.staticMedia}/[contenthash].[ext]`
+                        : `${RELATIVE_PATHS.staticMedia}/[path][name].[ext]`;
                 }
             });
         }

--- a/apps/myaccount/project.json
+++ b/apps/myaccount/project.json
@@ -85,7 +85,8 @@
                     "optimization": false,
                     "sourceMap": true,
                     "vendorChunk": true,
-                    "verbose": true
+                    "verbose": true,
+                    "extractCss": false
                 },
                 "production": {
                     "index": "index.jsp",
@@ -95,7 +96,8 @@
                     "outputHashing": "all",
                     "sourceMap": false,
                     "extractLicenses": false,
-                    "verbose": true
+                    "verbose": true,
+                    "extractCss": false
                 }
             }
         },

--- a/apps/myaccount/webpack.config.ts
+++ b/apps/myaccount/webpack.config.ts
@@ -584,7 +584,10 @@ module.exports = (config: WebpackOptionsNormalized, context: NxWebpackContextInt
         if (rule.test.toString().includes("svg") && rule.test instanceof RegExp) {
             rule.use instanceof Array &&
                 rule.use.forEach((item: RuleSetUseItem) => {
-                    if (typeof item !== "string" && (item as any).loader.includes("url-loader")) {
+                    if (
+                        typeof item !== "string" &&
+                        ((item as any).loader.includes("url-loader") || (item as any).loader.includes("file-loader"))
+                    ) {
                         (item as any).options.name = isProduction
                             ? `${RELATIVE_PATHS.staticMedia}/[contenthash].[ext]`
                             : `${RELATIVE_PATHS.staticMedia}/[path][name].[ext]`;


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
- `nx` 17 webpack plugin has `extractCSS` property true by default. This makes the `scss` imports to be extracted as a separate CSS file instead of embedding in the JS chuck as previous.
- Also in the 17 release, `svg` file loader is used. Hence the custom webpack logic to move the files in to the `static/media` was not working.

*Console Artifact - PROBLEMATIC*

<img width="1091" alt="Screenshot 2024-07-23 at 13 59 08" src="https://github.com/user-attachments/assets/a38137ba-6a90-403e-898e-388a70168378">

*Console Artifact - CORRECT*

<img width="416" alt="Screenshot 2024-07-22 at 23 14 43" src="https://github.com/user-attachments/assets/177891b4-a0bb-4290-b608-3ac9cdd4f172">

### Related Issues
- https://github.com/wso2/product-is/issues/20692
- https://github.com/wso2/product-is/issues/20749

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
