### PR TITLE
Fixed issue in loading available meta attributes

### DIFF
--- a/.changeset/wise-moons-boil.md
+++ b/.changeset/wise-moons-boil.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.organizations.v1": patch
+---
+
+Fixed issue in loading available meta attributes

--- a/features/admin.organizations.v1/components/edit-organization/organization-attributes.tsx
+++ b/features/admin.organizations.v1/components/edit-organization/organization-attributes.tsx
@@ -41,6 +41,7 @@ import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { Grid } from "semantic-ui-react";
 import { patchOrganization } from "../../api";
+import { useGetOrganizationsMetaAttributes } from "../../api/use-get-organizations-meta-attributes";
 import {
     OrganizationAttributesInterface,
     OrganizationPatchData,
@@ -81,6 +82,10 @@ export const OrganizationAttributes: FunctionComponent<OrganizationAttributesPro
 
     const [ submit, setSubmit ] = useTrigger();
     const [ isSubmitting, setIsSubmitting ] = useState(false);
+
+    const {
+        mutate: mutateMetaAttributeGetRequest
+    } = useGetOrganizationsMetaAttributes(undefined, 10, undefined, undefined);
 
     const updateOrgAttributes: (data: KeyValue[]) => void = useCallback(
         (data: KeyValue[]) => {
@@ -171,7 +176,10 @@ export const OrganizationAttributes: FunctionComponent<OrganizationAttributesPro
                         })
                     );
                 })
-                .finally(() => setIsSubmitting(false));
+                .finally(() => {
+                    mutateMetaAttributeGetRequest();
+                    setIsSubmitting(false);
+                });
         },
         [ organization ]
     );


### PR DESCRIPTION
### Purpose
When meta attributes are added/deleted, the change is not reflected in the meta attribute autocomplete dropdown. This fix mutates the **useGetOrganizationsMetaAttributes** hook to repopulate the dropdown.

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributors)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets