### PR TITLE
Add data-testid to the organizations page

### DIFF
--- a/.changeset/thin-games-retire.md
+++ b/.changeset/thin-games-retire.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.organizations.v1": patch
+---
+
+Add data-testid to the organizations page

--- a/features/admin.organizations.v1/pages/organizations.tsx
+++ b/features/admin.organizations.v1/pages/organizations.tsx
@@ -573,6 +573,7 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
                             defaultSearchOperator="co"
                             triggerClearQuery={ triggerClearQuery }
                             data-componentid={ `${ testId }-list-advanced-search` }
+                            data-testid={ `${ testId }-list-advanced-search` }
                         >
                             { shouldShowMetaAttributeComponent && isFilterByMetadataAttributesEnabled && (
                                 <MetaAttributeAutoComplete


### PR DESCRIPTION
### Purpose
$subject

This PR fixes the issue of the **data-componentid**s of the Organization page Advance Search components not getting the **"organizations-list"** prefix as the other pages.

For example:
**organizations-list**-advanced-search-input
**organizations-list**-advanced-search-options-button
**organizations-list**-advanced-search-filter-attribute-dropdown

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets