### PR TITLE
Add quick start tab id

### DIFF
--- a/.changeset/eight-bulldogs-leave.md
+++ b/.changeset/eight-bulldogs-leave.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.extensions.v1": patch
+---
+
+Add quick start tab id

--- a/features/admin.extensions.v1/configs/models/application.ts
+++ b/features/admin.extensions.v1/configs/models/application.ts
@@ -181,6 +181,7 @@ export interface ApplicationConfig {
  * Unique identifiers for application edit tabs.
  */
 export enum ApplicationTabIDs {
+    QUICK_START = "quick-start",
     GENERAL = "general",
     PROTOCOL = "protocol",
     USER_ATTRIBUTES = "user-attributes",


### PR DESCRIPTION
<!-- PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS. DO NOT ERASE THE PR TEMPLATE. -->

### Purpose
Each tab in the application edit page should have a unique identifier. This PR introduces the missing tab ID for the Quick Start tab.

### Related Issues
<!-- Mention the **PUBLIC** issue/s related to the pull request -->
- https://github.com/wso2/product-is/issues/20107

### Related PRs
<!-- Mention the related **PUBLIC** pull requests -->
- N/A

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)

<!-- Add any relevant comments -->


- [ ] Manual test round performed and verified.

<!-- Add any relevant comments -->


- [ ] UX/UI review done on the final implementation.

<!-- Add any relevant comments -->


- [ ] Documentation provided. (Add links if there are any)

<!-- Add any relevant comments -->


- [ ] Relevant backend changes deployed and verified

<!-- Add any relevant comments -->


- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)

<!-- Add any relevant comments -->


- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

<!-- Add any relevant comments -->


### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
