### PR TITLE
Fix trusted app configs getting cleared issue

### DIFF
--- a/.changeset/chatty-drinks-compete.md
+++ b/.changeset/chatty-drinks-compete.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix trusted app configs getting cleared issue

--- a/features/admin.applications.v1/components/forms/advanced-configurations-form.tsx
+++ b/features/admin.applications.v1/components/forms/advanced-configurations-form.tsx
@@ -171,15 +171,15 @@ export const AdvancedConfigurationsForm: FunctionComponent<AdvancedConfiguration
                 saas: !!values.saas,
                 skipLoginConsent: !!values.skipConsentLogin,
                 skipLogoutConsent: !!values.skipConsentLogout,
-                trustedAppConfiguration: values.enableFIDOTrustedApps ?
-                    {
-                        // androidPackageName and appleAppId is same as clientAttestation.
-                        androidPackageName: values.androidPackageName,
-                        androidThumbprints: isEmpty(thumbprints) ? [] : thumbprints.split(","),
-                        appleAppId: values.appleAppId,
-                        isConsentGranted: isConsentGranted,
-                        isFIDOTrustedApp: values.enableFIDOTrustedApps
-                    } : undefined
+                trustedAppConfiguration: {
+                    // androidPackageName and appleAppId is same as clientAttestation.
+                    androidPackageName: values.enableFIDOTrustedApps ? values.androidPackageName : "",
+                    androidThumbprints: values.enableFIDOTrustedApps ?
+                        (isEmpty(thumbprints) ? [] : thumbprints.split(",")) : [],
+                    appleAppId: values.enableFIDOTrustedApps ? values.appleAppId : "",
+                    isConsentGranted: isConsentGranted,
+                    isFIDOTrustedApp: values.enableFIDOTrustedApps
+                }
             }
         };
 


### PR DESCRIPTION
<!-- PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS. DO NOT ERASE THE PR TEMPLATE. -->

### Purpose
If FIDO trusted apps feature is disabled, set each property inside trusted app metadata as empty and set isFIDOtrusted app attribute to false instead of setting the whole trusted app metadata object to null. 

This is done to resolve the issue of trusted app data getting cleared when the General or protocol tab is updated. This is happening because during such patch calls, the rest of the application advanced configuration attributes will be set as null except for the needed attribute, and therefore the trusted app metadata will be removed from the DB.

### Related Issues
https://github.com/wso2/product-is/issues/20882

### Related PRs
https://github.com/wso2/identity-apps/pull/6553

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)

<!-- Add any relevant comments -->


- [ ] Manual test round performed and verified.

<!-- Add any relevant comments -->


- [ ] UX/UI review done on the final implementation.

<!-- Add any relevant comments -->


- [ ] Documentation provided. (Add links if there are any)

<!-- Add any relevant comments -->


- [ ] Relevant backend changes deployed and verified

<!-- Add any relevant comments -->


- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)

<!-- Add any relevant comments -->


- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

<!-- Add any relevant comments -->


### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
