### PR TITLE
Fix appearing of learn more links in IS

### DIFF
--- a/.changeset/lemon-forks-crash.md
+++ b/.changeset/lemon-forks-crash.md
@@ -1,0 +1,11 @@
+---
+"@wso2is/admin.organizations.v1": patch
+"@wso2is/admin.org-insights.v1": patch
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/admin.claims.v1": patch
+"@wso2is/admin.groups.v1": patch
+"@wso2is/admin.roles.v2": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Fix appearance of learn more links in the console UI

--- a/features/admin.claims.v1/pages/claim-dialects.tsx
+++ b/features/admin.claims.v1/pages/claim-dialects.tsx
@@ -38,7 +38,8 @@ import {
     GridLayout,
     PageLayout,
     Popup,
-    PrimaryButton
+    PrimaryButton,
+    useDocumentation
 } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -66,6 +67,7 @@ const ClaimDialectsPage: FunctionComponent<ClaimDialectsPageInterface> = (
     const { [ "data-testid" ]: testId } = props;
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
@@ -241,8 +243,7 @@ const ClaimDialectsPage: FunctionComponent<ClaimDialectsPageInterface> = (
                     <>
                         { t("claims:dialects.pageLayout.list.description") }
                         <DocumentationLink
-                            link="manage.userStores.attributeMappings.learnMore"
-                            isLinkRef
+                            link={ getLink("manage.userStores.attributeMappings.learnMore") }
                         >
                             { t("extensions:common.learnMore") }
                         </DocumentationLink>

--- a/features/admin.extensions.v1/components/logs/pages/logs.tsx
+++ b/features/admin.extensions.v1/components/logs/pages/logs.tsx
@@ -23,7 +23,8 @@ import {
     DocumentationLink,
     PageLayout,
     ResourceTab,
-    ResourceTabPaneInterface
+    ResourceTabPaneInterface,
+    useDocumentation
 } from "@wso2is/react-components";
 import React, {
     FunctionComponent,
@@ -60,6 +61,7 @@ const LogsPage: FunctionComponent<LogsPageInterface> = (
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const handleTabChange = (e: SyntheticEvent, data: TabProps): void => {
         setActiveTabIndex(data.activeIndex as number);
@@ -134,8 +136,7 @@ const LogsPage: FunctionComponent<LogsPageInterface> = (
                     <>
                         { t("extensions:develop.monitor.pageHeader.description") }
                         <DocumentationLink
-                            link="manage.logs.learnMore"
-                            isLinkRef
+                            link={ getLink("manage.logs.learnMore") }
                         >
                             { t("extensions:common.learnMore") }
                         </DocumentationLink>

--- a/features/admin.groups.v1/pages/groups.tsx
+++ b/features/admin.groups.v1/pages/groups.tsx
@@ -40,7 +40,8 @@ import {
     EmptyPlaceholder,
     ListLayout,
     PageLayout,
-    PrimaryButton
+    PrimaryButton,
+    useDocumentation
 } from "@wso2is/react-components";
 import { AxiosResponse } from "axios";
 import find from "lodash-es/find";
@@ -80,6 +81,7 @@ const GROUPS_SORTING_OPTIONS: DropdownItemProps[] = [
 const GroupsPage: FunctionComponent<any> = (): ReactElement => {
     const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
@@ -316,8 +318,7 @@ const GroupsPage: FunctionComponent<any> = (): ReactElement => {
                 <>
                     { t("pages:groups.subTitle") }
                     <DocumentationLink
-                        link="manage.groups.learnMore"
-                        isLinkRef
+                        link={ getLink("manage.groups.learnMore") }
                     >
                         { t("extensions:common.learnMore") }
                     </DocumentationLink>

--- a/features/admin.org-insights.v1/pages/org-insights.tsx
+++ b/features/admin.org-insights.v1/pages/org-insights.tsx
@@ -19,7 +19,7 @@
 import { SelectChangeEvent } from "@mui/material";
 import MenuItem from "@oxygen-ui/react/MenuItem";
 import Select from "@oxygen-ui/react/Select";
-import { DocumentationLink, Hint, PageLayout } from "@wso2is/react-components";
+import { DocumentationLink, Hint, PageLayout, useDocumentation } from "@wso2is/react-components";
 import moment from "moment";
 import React, { FunctionComponent, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -42,6 +42,7 @@ const OrgInsightsPage: FunctionComponent = () => {
     const [ selectedActivityType, setSelectedActivityType ] = useState<ActivityType>(ActivityType.LOGIN);
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const handleDurationChange = (event: SelectChangeEvent) => {
         setDuration(Number(event.target.value));
@@ -75,7 +76,7 @@ const OrgInsightsPage: FunctionComponent = () => {
                 <>
                     { t("insights:description") }
                     <DocumentationLink
-                        link="manage.insights.learnMore"
+                        link={ getLink("manage.insights.learnMore") }
                         isLinkRef
                     >
                         { t("extensions:common.learnMore") }

--- a/features/admin.organizations.v1/pages/organizations.tsx
+++ b/features/admin.organizations.v1/pages/organizations.tsx
@@ -30,7 +30,7 @@ import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { I18n } from "@wso2is/i18n";
-import { DocumentationLink, ListLayout, PageLayout, PrimaryButton } from "@wso2is/react-components";
+import { DocumentationLink, ListLayout, PageLayout, PrimaryButton, useDocumentation } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import find from "lodash-es/find";
 import isEmpty from "lodash-es/isEmpty";
@@ -94,6 +94,8 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
 
     const { t } = useTranslation();
     const dispatch: Dispatch = useDispatch();
+    const { getLink } = useDocumentation();
+
     const hasOrganizationListViewPermissions: boolean = useRequiredScopes(
         featureConfig?.organizations?.scopes?.read
     );
@@ -523,8 +525,7 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
                     <>
                         { t("pages:organizations.subTitle") }
                         <DocumentationLink
-                            link="manage.organizations.learnMore"
-                            isLinkRef
+                            link={ getLink("manage.organizations.learnMore") }
                         >
                             { t("extensions:common.learnMore") }
                         </DocumentationLink>

--- a/features/admin.roles.v2/pages/role.tsx
+++ b/features/admin.roles.v2/pages/role.tsx
@@ -30,7 +30,7 @@ import { history } from "@wso2is/admin.core.v1/helpers";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import { AlertInterface, AlertLevels, IdentifiableComponentInterface, RolesInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { DocumentationLink, ListLayout, PageLayout, PrimaryButton } from "@wso2is/react-components";
+import { DocumentationLink, ListLayout, PageLayout, PrimaryButton, useDocumentation } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -59,6 +59,7 @@ const RolesPage: FunctionComponent<RolesPagePropsInterface> = (
 
     const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const { organizationType } = useGetCurrentOrganizationType();
     const featureConfig : FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
@@ -243,8 +244,7 @@ const RolesPage: FunctionComponent<RolesPagePropsInterface> = (
                     <>
                         { t("pages:roles.subTitle") }
                         <DocumentationLink
-                            link="develop.applications.roles.learnMore"
-                            isLinkRef
+                            link={ getLink("develop.applications.roles.learnMore") }
                         >
                             { t("extensions:common.learnMore") }
                         </DocumentationLink>

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -67,7 +67,8 @@ import {
     PageLayout,
     PrimaryButton,
     ResourceTab,
-    ResourceTabPaneInterface
+    ResourceTabPaneInterface,
+    useDocumentation
 } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import cloneDeep from "lodash-es/cloneDeep";
@@ -127,6 +128,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
     } = props;
 
     const { t } = useTranslation();
+    const { getLink } = useDocumentation();
 
     const dispatch: Dispatch<any> = useDispatch();
 
@@ -1000,8 +1002,7 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                 <>
                     { t("extensions:manage.users.usersSubTitle") }
                     <DocumentationLink
-                        link="manage.users.learnMore"
-                        isLinkRef
+                        link={ getLink("manage.users.learnMore") }
                     >
                         { t("extensions:common.learnMore") }
                     </DocumentationLink>


### PR DESCRIPTION
<!-- PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS. DO NOT ERASE THE PR TEMPLATE. -->

### Purpose
Fixes the appearing of learn more links in the console UI

$subject

### Related Issues
<!-- Mention the **PUBLIC** issue/s related to the pull request -->
- https://github.com/wso2/product-is/issues/20870

### Related PRs
<!-- Mention the related **PUBLIC** pull requests -->
- N/A

### Checklist
- [x] e2e cypress tests locally verified. (for internal contributers)

<!-- Add any relevant comments -->


- [x] Manual test round performed and verified.

<!-- Add any relevant comments -->


- [x] UX/UI review done on the final implementation.

<!-- Add any relevant comments -->


- [ ] Documentation provided. (Add links if there are any) - N/A

<!-- Add any relevant comments -->


- [ ] Relevant backend changes deployed and verified - N/A

<!-- Add any relevant comments -->


- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any) - N/A
<!-- Add any relevant comments -->


- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

<!-- Add any relevant comments -->


### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
