### PR TITLE
Fix missing domain issue in user edit groups retrieval

### DIFF
--- a/.changeset/ten-walls-cover.md
+++ b/.changeset/ten-walls-cover.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.users.v1": patch
+---
+
+Fix missing domain issue in user edit groups retrieval

--- a/features/admin.users.v1/components/user-groups-edit.tsx
+++ b/features/admin.users.v1/components/user-groups-edit.tsx
@@ -103,8 +103,8 @@ export const UserGroupsList: FunctionComponent<UserGroupsPropsInterface> = (
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ existingGroupList, setExistingGroupList ] = useState([]);
 
-    const domain: string = user?.userName?.split("/").length > 1
-        ? user?.userName?.split[0]
+    const domain: string = user?.userName?.split("/")?.length > 1
+        ? user.userName.split("/")[0]
         : userstoresConfig.primaryUserstoreName;
 
     const {


### PR DESCRIPTION
<!-- 
   READ THIS FIRST:
   - PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS.
   - PLEASE MAKE SURE TO ONLY ADD PUBLICLY ACCESSIBLE REFERENCES
-->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This will fix the issue where the domain is missing in the request when retrieveing groups in the user edit page

### Related Issues
<!-- Mention the issue/s related to the pull request. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. -->
- N/A

### Checklist

- [x] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation. - N/A
- [ ] Documentation provided. (Add links if there are any) - N/A
- [ ] Relevant backend changes deployed and verified - N/A
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any) - N/A- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any) - N/A

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report - N/A
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
