### PR TITLE
Add legacy application token section

### DIFF
--- a/.changeset/ninety-feet-flow.md
+++ b/.changeset/ninety-feet-flow.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/i18n": patch
+---
+
+Introduce UI for legacy app token section.

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -295,8 +295,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     const requestObjectEncryptionMethod: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
     const subjectToken: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
     const applicationSubjectTokenExpiryInSeconds: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
-    const useClientIdAsSubClaimForAppTokensEle: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
-    const omitUsernameInIntrospectionRespForAppTokensEle: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const useClientIdAsSubClaimForAppTokensElement: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
+    const omitUsernameInIntrospectionRespForAppTokensElement: MutableRefObject<HTMLElement> = useRef<HTMLElement>();
 
     const [ isSPAApplication, setSPAApplication ] = useState<boolean>(false);
     const [ isOIDCWebApplication, setOIDCWebApplication ] = useState<boolean>(false);
@@ -2602,19 +2602,19 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                         <Trans
                                             i18nKey={ t("actions:fields.authentication.info.message") }
                                         >
-                                            You currently using an outdated behavior for application tokens.
+                                            You are currently using an outdated behavior for application tokens.
                                             Please follow the below guideline before migrating to the new behavior.
                                             <ol>
                                                 <li>
                                                     <strong>Client Application Changes:</strong>
-                                                    <p>Update your client application to no longer use the 
-                                                        <code>sub</code> claim to refer to the application
+                                                    <p>Update your client application to no longer use the&nbsp;
+                                                        <code>sub</code> attribute to refer to the application
                                                         owner&apos;s user ID in the application token.</p>
                                                 </li>
                                                 <li>
                                                     <strong>Introspection Response Updates:</strong>
-                                                    <p>Modify your application to stop relying on the
-                                                        <code>username</code> claim in the introspection endpoint
+                                                    <p>Modify your application to stop relying on the&nbsp;
+                                                        <code>username</code> field in the introspection endpoint
                                                         response for application tokens, as this claim will no
                                                         longer be included.</p>
                                                 </li>
@@ -2627,7 +2627,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 !useClientIdAsSubClaimForAppTokens && (
                                     <>
                                         <Field
-                                            ref={ useClientIdAsSubClaimForAppTokensEle }
+                                            ref={ useClientIdAsSubClaimForAppTokensElement }
                                             name="useClientIdAsSubClaimForAppTokens"
                                             required={ false }
                                             type="checkbox"
@@ -2667,7 +2667,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 (
                                     <>
                                         <Field
-                                            ref={ omitUsernameInIntrospectionRespForAppTokensEle }
+                                            ref={ omitUsernameInIntrospectionRespForAppTokensElement }
                                             name="omitUsernameInIntrospectionRespForAppTokens"
                                             required={ false }
                                             type="checkbox"

--- a/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.test.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/advance-attribute-settings.test.tsx
@@ -127,6 +127,7 @@ describe("Advance attribute settings in the attributes tab of Application Edit v
                     },
                     isFAPIApplication: false,
                     logout: {},
+                    omitUsernameInIntrospectionRespForAppTokens: false,
                     pkce: { mandatory: true, supportPlainTransformAlgorithm: false },
                     publicClient: true,
                     pushAuthorizationRequest: { requirePushAuthorizationRequest: false },
@@ -139,6 +140,7 @@ describe("Advance attribute settings in the attributes tab of Application Edit v
                         applicationSubjectTokenExpiryInSeconds: 180,
                         enable: false
                     },
+                    useClientIdAsSubClaimForAppTokens: false,
                     validateRequestObjectSignature: false
                 } }
                 data-testid={ "advanced-attribute-settings-form" }

--- a/features/admin.applications.v1/models/application-inbound.ts
+++ b/features/admin.applications.v1/models/application-inbound.ts
@@ -193,6 +193,8 @@ export interface OIDCDataInterface {
     subject?: SubjectConfigInterface;
     isFAPIApplication?: boolean;
     hybridFlow?: HybridFlowConfigurationInterface;
+    useClientIdAsSubClaimForAppTokens?: boolean;
+    omitUsernameInIntrospectionRespForAppTokens?: boolean;
 }
 
 /**

--- a/features/admin.applications.v1/pages/application-edit.scss
+++ b/features/admin.applications.v1/pages/application-edit.scss
@@ -19,3 +19,19 @@
 .application-branding-link {
     cursor: pointer;
 }
+
+.ignore-once-button {
+    color: #788997;
+}
+
+.banner-detail-card {
+    border: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    background: #fff;
+}
+
+.application-outdated-alert-expanded-view {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -1379,14 +1379,29 @@ export interface ApplicationsNS {
                 };
                 legacyApplicationTokens: {
                     heading: string;
+                    alert : {
+                        title: string;
+                        content: string;
+                        viewButton: string;
+                        cancelButton: string;
+                    }
+                    confirmationModal: {
+                        assertionHint: string;
+                        header: string;
+                        message: string;
+                        content: string;
+                    },
                     fields: {
+                        commonInstruction: string;
                         useClientIdAsSubClaimForAppTokens: {
-                            label: string,
-                            hint: string
+                            instruction: string;
+                            label: string;
+                            hint: string;
                         };
                         omitUsernameInIntrospectionRespForAppTokens: {
-                            label: string,
-                            hint: string
+                            instruction: string;
+                            label: string;
+                            hint: string;
                         };
                     }
                 };

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -1377,6 +1377,19 @@ export interface ApplicationsNS {
                         };
                     };
                 };
+                legacyApplicationTokens: {
+                    heading: string;
+                    fields: {
+                        useClientIdAsSubClaimForAppTokens: {
+                            label: string,
+                            hint: string
+                        };
+                        omitUsernameInIntrospectionRespForAppTokens: {
+                            label: string,
+                            hint: string
+                        };
+                    }
+                };
                 logoutURLs: {
                     heading: string;
                     fields: {

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1643,6 +1643,24 @@ export const applications: ApplicationsNS = {
                     },
                     heading: "ID Token"
                 },
+                legacyApplicationTokens: {
+                    heading: "Legacy Application Tokens",
+                    fields: {
+                        useClientIdAsSubClaimForAppTokens: {
+                            label: "Set client_id as the sub claim value for Application tokens",
+                            hint: "For application tokens, the sub claim was previosuly set to the "
+                            + "application owner's user_id. However, to support a more industry standard "
+                            + "solution, this value will be changed to the client ID for application tokens."
+                        },
+                        omitUsernameInIntrospectionRespForAppTokens: {
+                            label: "Omit sending username claim in the Introspection response for Application tokens",
+                            hint: "For access tokens, the previous behavior includes sending the username claim"
+                            + " in the introspection response. However, to support a more industry standard"
+                            + " solution, the introspection response for application tokens will no longer"
+                            + " include the username claim."
+                        }
+                    }
+                },
                 logoutURLs: {
                     fields: {
                         back: {

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1645,14 +1645,32 @@ export const applications: ApplicationsNS = {
                 },
                 legacyApplicationTokens: {
                     heading: "Legacy Application Tokens",
+                    alert : {
+                        title: "Application is outdated.",
+                        content: "This application is using an outdated behavior for application tokens. "
+                            + "Please follow the below guideline before migrating to the new behavior.",
+                        viewButton: "View Details",
+                        cancelButton: "Ignore Once"
+                    },
+                    confirmationModal: {
+                        header: "Have you done the relevant changes?",
+                        message: "Proceeding the action without making relevant change will cause the client application behavior break.",
+                        content: "By confirming the action,",
+                        assertionHint: "Please confirm your action"
+                    },
                     fields: {
+                        commonInstruction: "Change the customer-end applications accordingly to recieve the below updates.",
                         useClientIdAsSubClaimForAppTokens: {
+                            instruction: "Application access token <code>sub</code> attribute will be"
+                                + "<code>client_id</code> generated for an application.",
                             label: "Set client_id as the sub claim value for Application tokens",
                             hint: "For application tokens, the sub claim was previosuly set to the "
                             + "application owner's user_id. However, to support a more industry standard "
                             + "solution, this value will be changed to the client ID for application tokens."
                         },
                         omitUsernameInIntrospectionRespForAppTokens: {
+                            instruction: "Application access token, Introspection response will not include"
+                                + "the <code>username</code> attribute.",
                             label: "Omit sending username claim in the Introspection response for Application tokens",
                             hint: "For access tokens, the previous behavior includes sending the username claim"
                             + " in the introspection response. However, to support a more industry standard"

--- a/modules/react-components/src/components/page-header/page-header.tsx
+++ b/modules/react-components/src/components/page-header/page-header.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -41,6 +41,10 @@ export interface PageHeaderPropsInterface extends LoadableComponentInterface, Te
      * Column width for the action container grid.
      */
     actionColumnWidth?: SemanticWIDTHS;
+    /**
+     * Alert component displayed in the page header.
+     */
+    alertBanner?: ReactNode;
     /**
      * Go back button.
      */
@@ -127,6 +131,7 @@ export const PageHeader: React.FunctionComponent<PageHeaderPropsInterface> = (
     const {
         action,
         actionColumnWidth,
+        alertBanner,
         backButton,
         bottomMargin,
         className,
@@ -300,6 +305,9 @@ export const PageHeader: React.FunctionComponent<PageHeaderPropsInterface> = (
                                     </div>
                                 )
                         )
+                    }
+                    {
+                        alertBanner
                     }
                     {
                         action


### PR DESCRIPTION
<!-- 
   READ THIS FIRST:
   - PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS.
   - PLEASE MAKE SURE TO ONLY ADD PUBLICLY ACCESSIBLE REFERENCES
-->

### Purpose
This PR will add a Legacy Application token sention to maintain the below configs.
1. useClientIdAsSubClaimForAppTokens
2. omitUsernameInIntrospectionRespForAppTokens

The initial UI design is as follows.
<img width="1512" alt="Screenshot 2024-08-16 at 08 34 38" src="https://github.com/user-attachments/assets/87f5cfcc-eb74-4d9d-8a7b-eae31fe2fab2">


Please feel free to make suggestions for the design.

### Related Issues
- https://github.com/wso2/product-is/issues/20917

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
