### PR TITLE
Add navigation to Invite User to Set Password in the Multiple User popup

### DIFF
--- a/.changeset/late-wolves-rescue.md
+++ b/.changeset/late-wolves-rescue.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/i18n": patch
+---
+
+Add navigation to Invite User to Set Password in the Multiple User popup

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -980,13 +980,13 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                     <Trans i18nKey="users:confirmations.addMultipleUser.content">
                         Invite User to Set Password should be enabled to add multiple users.
                         Please enable email invitations for user password setup from
-                            <Link
-                            onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
-                            .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
-                            .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
-                            external={ false }>
-                                Login & Registration settings
-                            </Link>
+                        <Link
+                        onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
+                        .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
+                        .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
+                        external={ false }>
+                            Login & Registration settings
+                        </Link>
                     </Trans>
                 </ConfirmationModal.Content>
             </ConfirmationModal>

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -981,10 +981,10 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                         Invite User to Set Password should be enabled to add multiple users.
                         Please enable email invitations for user password setup from
                         <Link
-                        onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
-                            .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
+                            onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
+                                .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
                                 .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
-                                external={ false }>
+                            external={ false }>
                             Login & Registration settings
                         </Link>
                     </Trans>

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -977,18 +977,17 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                     { t("users:confirmations.addMultipleUser.message") }
                 </ConfirmationModal.Message>
                 <ConfirmationModal.Content>
-                    <Trans i18nKey="users:confirmations.addMultipleUser.content">
-                        Invite User to Set Password should be enabled to add multiple users.
-                        Please enable email invitations for user password setup from 
-                            <Link
-                                onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
-                                    .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
-                                    .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
-                                external={ false }
-                            >
-                                Login & Registration settings
-                            </Link>
-                    </Trans>
+                <Trans i18nKey="users:confirmations.addMultipleUser.content">
+                    Invite User to Set Password should be enabled to add multiple users.
+                    Please enable email invitations for user password setup from
+                        <Link
+                        onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
+                        .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
+                        .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
+                        external={ false }>
+                            Login & Registration settings
+                        </Link>
+                </Trans>
                 </ConfirmationModal.Content>
             </ConfirmationModal>
         );

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -977,17 +977,17 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                     { t("users:confirmations.addMultipleUser.message") }
                 </ConfirmationModal.Message>
                 <ConfirmationModal.Content>
-                <Trans i18nKey="users:confirmations.addMultipleUser.content">
-                    Invite User to Set Password should be enabled to add multiple users.
-                    Please enable email invitations for user password setup from
-                        <Link
-                        onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
-                        .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
-                        .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
-                        external={ false }>
-                            Login & Registration settings
-                        </Link>
-                </Trans>
+                    <Trans i18nKey="users:confirmations.addMultipleUser.content">
+                        Invite User to Set Password should be enabled to add multiple users.
+                        Please enable email invitations for user password setup from
+                            <Link
+                            onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
+                            .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
+                            .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
+                            external={ false }>
+                                Login & Registration settings
+                            </Link>
+                    </Trans>
                 </ConfirmationModal.Content>
             </ConfirmationModal>
         );

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -63,6 +63,7 @@ import {
     ConfirmationModal,
     DocumentationLink,
     EmptyPlaceholder,
+    Link,
     ListLayout,
     PageLayout,
     PrimaryButton,
@@ -79,7 +80,7 @@ import React, {
     useEffect,
     useMemo,
     useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router";
 import { Dispatch } from "redux";
@@ -976,7 +977,18 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                     { t("users:confirmations.addMultipleUser.message") }
                 </ConfirmationModal.Message>
                 <ConfirmationModal.Content>
-                    { t("users:confirmations.addMultipleUser.content") }
+                    <Trans i18nKey="users:confirmations.addMultipleUser.content">
+                        Invite User to Set Password should be enabled to add multiple users.
+                        Please enable email invitations for user password setup from 
+                            <Link
+                                onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
+                                    .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
+                                    .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
+                                external={ false }
+                            >
+                                Login & Registration settings
+                            </Link>
+                    </Trans>
                 </ConfirmationModal.Content>
             </ConfirmationModal>
         );

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -982,9 +982,9 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                         Please enable email invitations for user password setup from
                         <Link
                         onClick={ () => history.push(AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT")
-                        .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
-                        .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
-                        external={ false }>
+                            .replace(":categoryId", ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID)
+                                .replace(":connectorId", ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID)) }
+                                external={ false }>
                             Login & Registration settings
                         </Link>
                     </Trans>

--- a/modules/i18n/src/translations/en-US/portals/users.ts
+++ b/modules/i18n/src/translations/en-US/portals/users.ts
@@ -82,7 +82,7 @@ export const users: usersNS = {
             header: "Before you proceed",
             message: "Invite users option is disabled",
             content: "Invite User to Set Password should be enabled to add multiple users. " +
-                "Please enable email invitations for user password setup from Login & Registration settings.",
+                "Please enable email invitations for user password setup from <1>Login & Registration settings</1>.",
             assertionHint: "Please confirm your action."
         }
     },

--- a/modules/i18n/src/translations/en-US/portals/users.ts
+++ b/modules/i18n/src/translations/en-US/portals/users.ts
@@ -18,14 +18,18 @@
 import { usersNS } from "../../../models";
 
 export const users: usersNS = {
+    addUserDropDown: {
+        addNewUser:  "Single User",
+        bulkImport: "Multiple Users"
+    },
     addUserType: {
         createUser: {
-            title: "Create user",
-            description: "Create a user in your organization."
+            description: "Create a user in your organization.",
+            title: "Create user"
         },
         inviteParentUser: {
-            title: "Invite parent user",
-            description: "Invite user from the parent organization."
+            description: "Invite user from the parent organization.",
+            title: "Invite parent user"
         }
     },
     advancedSearch: {
@@ -59,11 +63,14 @@ export const users: usersNS = {
         assignUserRoleBtn: "Assign roles",
         metaColumnBtn: "Columns"
     },
-    addUserDropDown: {
-        addNewUser:  "Single User",
-        bulkImport: "Multiple Users"
-    },
     confirmations: {
+        addMultipleUser: {
+            assertionHint: "Please confirm your action.",
+            content: "Invite User to Set Password should be enabled to add multiple users. " +
+                "Please enable email invitations for user password setup from <1>Login & Registration settings</1>.",
+            header: "Before you proceed",
+            message: "Invite users option is disabled"
+        },
         terminateAllSessions: {
             assertionHint: "Please confirm your action.",
             content: "If you proceed with this action, the user will be logged out of all active " +
@@ -77,13 +84,6 @@ export const users: usersNS = {
                 "session. They will loose the progress of any ongoing tasks. Please proceed with caution.",
             header: "Are you sure?",
             message: "This action is irreversible and will permanently terminate the session."
-        },
-        addMultipleUser: {
-            header: "Before you proceed",
-            message: "Invite users option is disabled",
-            content: "Invite User to Set Password should be enabled to add multiple users. " +
-                "Please enable email invitations for user password setup from <1>Login & Registration settings</1>.",
-            assertionHint: "Please confirm your action."
         }
     },
     consumerUsers: {
@@ -101,19 +101,19 @@ export const users: usersNS = {
         }
     },
     editUser: {
+        placeholders: {
+            undefinedUser: {
+                action: "Go back to users",
+                subtitles: "It looks like the requested user does not exist.",
+                title: "User not found"
+            }
+        },
         tab: {
             menuItems: {
                 0: "Profile",
                 1: "Groups",
                 2: "Roles",
                 3: "Active Sessions"
-            }
-        },
-        placeholders: {
-            undefinedUser: {
-                action: "Go back to users",
-                subtitles: "It looks like the requested user does not exist.",
-                title: "User not found"
             }
         }
     },
@@ -177,50 +177,6 @@ export const users: usersNS = {
             }
         },
         bulkImportUser: {
-            validation: {
-                emptyRowError: {
-                    description: "Selected file contains no data.",
-                    message: "Empty File"
-                },
-                columnMismatchError: {
-                    description: "Some data rows of the file does not match the required column count. " +
-                        "Please review and correct the data.",
-                    message: "Column Count Mismatch"
-                },
-                emptyHeaderError: {
-                    description: "Ensure that the first row contains the headers for each column.",
-                    message: "Missing Column Headers"
-                },
-                missingRequiredHeaderError: {
-                    description: "The following header(s) are required but are missing in the CSV file: " +
-                    "{{ headers }}.",
-                    message: "Missing Required Column Headers"
-                },
-                blockedHeaderError: {
-                    description: "The following header(s) are not allowed: {{headers}}.",
-                    message: "Blocked Column Headers"
-                },
-                duplicateHeaderError: {
-                    description: "The following headers are duplicated: {{headers}}.",
-                    message: "Duplicate Column Headers"
-                },
-                invalidHeaderError: {
-                    description: "The following headers are invalid: {{headers}}.",
-                    message: "Invalid Column Headers"
-                },
-                emptyDataField: {
-                    description: "The data field '{{dataField}}' must not be empty.",
-                    message: "Empty Data Field"
-                },
-                invalidRole: {
-                    description: "{{role}} does not exist.",
-                    message: "Role Not Found"
-                },
-                invalidGroup: {
-                    description: "{{group}} does not exist.",
-                    message: "Group Not Found"
-                }
-            },
             submit: {
                 error: {
                     description: "{{description}}",
@@ -238,6 +194,50 @@ export const users: usersNS = {
             timeOut: {
                 description: "Some users may not have been created.",
                 message: "The request has timed out"
+            },validation: {
+                blockedHeaderError: {
+                    description: "The following header(s) are not allowed: {{headers}}.",
+                    message: "Blocked Column Headers"
+                },
+                columnMismatchError: {
+                    description: "Some data rows of the file does not match the required column count. " +
+                        "Please review and correct the data.",
+                    message: "Column Count Mismatch"
+                },
+                duplicateHeaderError: {
+                    description: "The following headers are duplicated: {{headers}}.",
+                    message: "Duplicate Column Headers"
+                },
+                emptyDataField: {
+                    description: "The data field '{{dataField}}' must not be empty.",
+                    message: "Empty Data Field"
+                },
+                emptyHeaderError: {
+                    description: "Ensure that the first row contains the headers for each column.",
+                    message: "Missing Column Headers"
+                },
+                emptyRowError: {
+                    description: "Selected file contains no data.",
+                    message: "Empty File"
+                },
+                invalidGroup: {
+                    description: "{{group}} does not exist.",
+                    message: "Group Not Found"
+                },
+                invalidHeaderError: {
+                    description: "The following headers are invalid: {{headers}}.",
+                    message: "Invalid Column Headers"
+                },
+
+                invalidRole: {
+                    description: "{{role}} does not exist.",
+                    message: "Role Not Found"
+                },
+                missingRequiredHeaderError: {
+                    description: "The following header(s) are required but are missing in the CSV file: " +
+                    "{{ headers }}.",
+                    message: "Missing Required Column Headers"
+                }
             }
         },
         deleteUser: {


### PR DESCRIPTION
### Purpose
Add navigation to Invite User to Set Password in the Multiple User popup

<img width="518" alt="Screenshot 2024-08-20 at 15 55 55" src="https://github.com/user-attachments/assets/c235218d-a836-4ed4-88bc-13424d15842c">

### Related Issues
https://github.com/wso2/product-is/issues/20944

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
