### PR TITLE
Fix Inconsistency with "New" Flag in M2M Application Template card.

### DIFF
--- a/.changeset/quick-emus-visit.md
+++ b/.changeset/quick-emus-visit.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.application-templates.v1": patch
+---
+
+Fix Inconsistency with "New" Flag in M2M Application Template card.

--- a/features/admin.application-templates.v1/components/application-template-card.scss
+++ b/features/admin.application-templates.v1/components/application-template-card.scss
@@ -37,12 +37,10 @@
     }
 
     .application-template-ribbon {
+        border-radius: 0;
         position: absolute;
         right: 0;
-        top: 13px;
         font-size: .8em;
-        font-weight: 500;
-        color: #fff;
         height: 24px;
         width: 100px;
         display: flex;
@@ -52,14 +50,6 @@
         justify-content: space-around;
         clip-path: polygon(4% 0,0 100%,100% 100%,100% 0,100% 0);
         -webkit-clip-path: polygon(4% 0,0 100%,100% 100%,100% 0,100% 0);
-
-        &.coming-soon {
-            background: linear-gradient(270deg,#ff9d4d 0,#ff7300 100%);
-        }
-
-        &.new {
-            background: #3fb81f;
-        }
     }
 
     .application-template-header {

--- a/features/admin.application-templates.v1/components/application-template-card.tsx
+++ b/features/admin.application-templates.v1/components/application-template-card.tsx
@@ -33,9 +33,8 @@ import classnames from "classnames";
 import React, { FunctionComponent, MouseEvent, ReactElement, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { ApplicationTemplateConstants } from "../constants/templates";
-import "./application-template-card.scss";
 import { ApplicationTemplateFeatureStatus, SupportedTechnologyMetadataInterface } from "../models/templates";
-import FeatureStatusLabel from "../../admin.extensions.v1/components/feature-gate/models/feature-gate";
+import "./application-template-card.scss";
 
 /**
  * Props for the application template card component.
@@ -174,18 +173,18 @@ const ApplicationTemplateCard: FunctionComponent<ApplicationTemplateCardPropsInt
                     </Typography>
                 </div>
                 {
-                featureStatus
-                    ? (
-                        <div className={ classnames("application-template-ribbon",
-                                resolveFeatureLabelClass(featureStatus) ) }
-                        >
-                            <span className="MuiChip-label">
-                                { resolveRibbonLabel(featureStatus) }
-                            </span>
-                        </div>
-                    )
-                    : null
-            }
+                    featureStatus
+                        ? (
+                            <div className={ classnames("application-template-ribbon",
+                                    resolveFeatureLabelClass(featureStatus) ) }
+                            >
+                                <span className="MuiChip-label">
+                                    { resolveRibbonLabel(featureStatus) }
+                                </span>
+                            </div>
+                        )
+                        : null
+                }
             </CardContent>
             <CardContent className="application-template-body">
                 <Tooltip title={ template?.description }>

--- a/features/admin.application-templates.v1/components/application-template-card.tsx
+++ b/features/admin.application-templates.v1/components/application-template-card.tsx
@@ -35,6 +35,7 @@ import { useTranslation } from "react-i18next";
 import { ApplicationTemplateConstants } from "../constants/templates";
 import "./application-template-card.scss";
 import { ApplicationTemplateFeatureStatus, SupportedTechnologyMetadataInterface } from "../models/templates";
+import FeatureStatusLabel from "../../admin.extensions.v1/components/feature-gate/models/feature-gate";
 
 /**
  * Props for the application template card component.
@@ -124,6 +125,21 @@ const ApplicationTemplateCard: FunctionComponent<ApplicationTemplateCardPropsInt
         }
     };
 
+    /**
+     * Resolve the corresponding class name for the current feature status label.
+     *
+     * @param featureStatus - Feature status from the template.
+     * @returns The class name for the feature status label.
+     */
+    const resolveFeatureLabelClass = (featureStatus: ApplicationTemplateFeatureStatus) => {
+        switch (featureStatus) {
+            case ApplicationTemplateFeatureStatus.COMING_SOON:
+                return "oxygen-chip-coming-soon";
+            case ApplicationTemplateFeatureStatus.NEW:
+                return "oxygen-chip-new";
+        }
+    };
+
     return (
         <Card
             key={ template?.id }
@@ -139,20 +155,6 @@ const ApplicationTemplateCard: FunctionComponent<ApplicationTemplateCardPropsInt
             }
             data-componentid={ `${componentId}-${template?.id}` }
         >
-            {
-                featureStatus
-                    ? (
-                        <div
-                            className={ classnames("application-template-ribbon", {
-                                "coming-soon": featureStatus === ApplicationTemplateFeatureStatus.COMING_SOON,
-                                "new": featureStatus === ApplicationTemplateFeatureStatus.NEW
-                            }) }
-                        >
-                            { resolveRibbonLabel(featureStatus) }
-                        </div>
-                    )
-                    : null
-            }
             <CardContent className="application-template-header">
                 <div className="application-template-image-container">
                     <img
@@ -171,6 +173,19 @@ const ApplicationTemplateCard: FunctionComponent<ApplicationTemplateCardPropsInt
                         { template?.name }
                     </Typography>
                 </div>
+                {
+                featureStatus
+                    ? (
+                        <div className={ classnames("application-template-ribbon",
+                                resolveFeatureLabelClass(featureStatus) ) }
+                        >
+                            <span className="MuiChip-label">
+                                { resolveRibbonLabel(featureStatus) }
+                            </span>
+                        </div>
+                    )
+                    : null
+            }
             </CardContent>
             <CardContent className="application-template-body">
                 <Tooltip title={ template?.description }>
@@ -186,6 +201,7 @@ const ApplicationTemplateCard: FunctionComponent<ApplicationTemplateCardPropsInt
                             (technology: SupportedTechnologyMetadataInterface) => (
                                 <Avatar
                                     sx={ { height: 20, width: 20 } }
+                                    variant="square"
                                     key={ technology?.displayName }
                                     className="application-template-supported-technology"
                                     alt={ technology?.displayName }

--- a/features/admin.application-templates.v1/components/application-template-card.tsx
+++ b/features/admin.application-templates.v1/components/application-template-card.tsx
@@ -175,7 +175,8 @@ const ApplicationTemplateCard: FunctionComponent<ApplicationTemplateCardPropsInt
                 {
                     featureStatus
                         ? (
-                            <div className={ classnames("application-template-ribbon",
+                            <div
+                                className={ classnames("application-template-ribbon",
                                     resolveFeatureLabelClass(featureStatus) ) }
                             >
                                 <span className="MuiChip-label">


### PR DESCRIPTION
### Purpose
Fix Inconsistency with "New" Flag in M2M Application Template card.

#### Screenshot
<img width="1800" alt="Screenshot 2024-08-21 at 15 37 53" src="https://github.com/user-attachments/assets/58f119d2-9850-4d24-95bb-9d0b3a225067">

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
