### PR TITLE
Add Invalid Org Discovery Type Error Message

### DIFF
--- a/.changeset/gold-bees-rhyme.md
+++ b/.changeset/gold-bees-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add invalid org discovery type error message.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -523,6 +523,7 @@ organization.login=Organization Login
 organization.name=Organization name
 organization.email=Organization email
 invalid.organization.discovery.input=Unable to identify the organization. Please check if the provided email domain is correct or provide the organization name to continue.
+invalid.organization.discovery.type=Given organization discovery type is invalid or not enabled.
 discovery.input.cannot.be.empty=Email cannot be empty.
 organization.name.cannot.be.empty=Organization name cannot be empty.
 provide.organization.name=Provide organization name

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -501,6 +501,7 @@ organization.login=Organisation Login
 organization.name=Name der Organisation
 organization.email=E-Mail der Organisation
 invalid.organization.discovery.input=Die Organisation konnte nicht identifiziert werden. Bitte geben Sie den Namen der Organisation an, um fortzufahren.
+invalid.organization.discovery.type=Der Erkennungstyp der angegebenen Organisation ist ungültig oder nicht aktiviert.
 discovery.input.cannot.be.empty=E-Mail darf nicht leer sein.
 organization.name.cannot.be.empty=Der Name der Organisation darf nicht leer sein.
 provide.organization.name=Geben Sie den Namen der Organisation an

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -501,6 +501,7 @@ organization.login=Inicio de sesión de la organización
 organization.name=Nombre de la Organización
 organization.email=Correo electrónico de la organización
 invalid.organization.discovery.input=No se puede identificar la organización. Proporcione el nombre de la organización para continuar.
+invalid.organization.discovery.type=El tipo de descubrimiento de organizaci�n determinado no es v�lido o no est� habilitado.
 discovery.input.cannot.be.empty=El correo electrónico no puede estar vacío.
 organization.name.cannot.be.empty=El nombre de la organización no puede estar vacío.
 provide.organization.name=Proporcionar el nombre de la organización

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -502,6 +502,7 @@ organization.login=Connexion de l'organisation
 organization.name=Nom de l'organisation
 organization.email=E-mail de l'organisation
 invalid.organization.discovery.input=Impossible d'identifier l'organisation. Veuillez fournir le nom de l'organisation pour continuer.
+invalid.organization.discovery.type=Le type de découverte d’organisation donné n’est pas valide ou n’est pas activé.
 discovery.input.cannot.be.empty=L'e-mail ne peut pas √™tre vide.
 organization.name.cannot.be.empty=Le nom de l'organisation ne peut pas √™tre vide.
 provide.organization.name=Fournir le nom de l'organisation

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -500,6 +500,7 @@ organization.login=組織ログイン
 organization.name=組織名
 organization.email=組織の電子メール
 invalid.organization.discovery.input=組織を特定できません。指定された電子メール ドメインが正しいかどうかを確認するか、組織名を入力して続行してください。
+invalid.organization.discovery.type=指定された組織検出タイプが無効であるか、有効になっていません。
 discovery.input.cannot.be.empty=電子メールを空にすることはできません。
 organization.name.cannot.be.empty=組織名を空にすることはできません。
 provide.organization.name=組織名を入力してください

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -497,6 +497,7 @@ organization=Organização
 organization.login=Login da organização
 organization.name=Nome da organização
 invalid.organization.discovery.input=Não foi possível identificar a organização. Forneça o nome da organização para continuar.
+invalid.organization.discovery.type=O tipo de descoberta da organiza��o � inv�lido ou n�o est� habilitado.
 discovery.input.cannot.be.empty=O e-mail não pode ficar vazio.
 organization.name.cannot.be.empty=O nome da organização não pode ficar vazio.
 provide.organization.name=Forneça o nome da organização

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -501,6 +501,7 @@ organization.login=Login da organização
 organization.name=Nome da organização
 organization.email=E-mail da organização
 invalid.organization.discovery.input=Não foi possível identificar a organização. Forneça o nome da organização para continuar.
+invalid.organization.discovery.type=O tipo de descoberta da organiza��o � inv�lido ou n�o est� habilitado.
 discovery.input.cannot.be.empty=O e-mail não pode ficar vazio.
 organization.name.cannot.be.empty=O nome da organização não pode ficar vazio.
 provide.organization.name=Forneça o nome da organização

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -500,6 +500,7 @@ organization.login=组织登录
 organization.name=机构名称
 organization.email=组织邮箱
 invalid.organization.discovery.input=无法识别该组织。请检查提供的电子邮件域是否正确或提供组织名称以继续。
+invalid.organization.discovery.type=给定的组织发现类型无效或未启用。
 discovery.input.cannot.be.empty=电子邮件不能为空。
 organization.name.cannot.be.empty=组织名称不能为空。
 provide.organization.name=提供组织名称

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -45,8 +45,8 @@
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
            } else if (errorMessage.equalsIgnoreCase("Can't identify organization")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.input");
-           } else if (errorMessage.equalsIgnoreCase("Organization discovery type is invalid or not enabled")) {
-                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.type");
+           } else if (errorMessage.equalsIgnoreCase("invalid.organization.discovery.type")) {
+               errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.type");
            } else if (isErrorFallbackLocale) {
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle,"error.retry");
            }

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -45,6 +45,8 @@
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
            } else if (errorMessage.equalsIgnoreCase("Can't identify organization")) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.input");
+           } else if (errorMessage.equalsIgnoreCase("Organization discovery type is invalid or not enabled")) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.type");
            } else if (isErrorFallbackLocale) {
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle,"error.retry");
            }


### PR DESCRIPTION
<!-- 
   READ THIS FIRST:
   - PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS.
   - PLEASE MAKE SURE TO ONLY ADD PUBLICLY ACCESSIBLE REFERENCES
-->

### Purpose
- Add error message support for invalid organization discovery type in email domain based organization discovery.

### Related Issues
- https://github.com/wso2/product-is/issues/20953

### Related PRs
- https://github.com/wso2-extensions/identity-auth-organization-login/pull/45

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
