### PR TITLE
Modify few data-componentids in Actions UI

### DIFF
--- a/.changeset/rotten-deers-cough.md
+++ b/.changeset/rotten-deers-cough.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.actions.v1": patch
+---
+
+Fix data-componentids in actions component

--- a/features/admin.actions.v1/components/action-config-form.tsx
+++ b/features/admin.actions.v1/components/action-config-form.tsx
@@ -368,7 +368,9 @@ const ActionConfigForm: FunctionComponent<ActionConfigFormInterface> = ({
                 return (
                     <Alert severity="info">
                         <AlertTitle
-                            className="alert-title">
+                            className="alert-title"
+                            data-componentid={ `${ _componentId }-authentication-info-box-title` }
+                        >
                             <Trans
                                 i18nKey={
                                     authenticationType === AuthenticationType.NONE ?
@@ -688,7 +690,7 @@ const ActionConfigForm: FunctionComponent<ActionConfigFormInterface> = ({
                     } }
                     ariaLabel="endpointUri"
                     required={ true }
-                    data-componentid={ `${ _componentId }-action-name` }
+                    data-componentid={ `${ _componentId }-action-endpointUri` }
                     name="endpointUri"
                     type="text"
                     label={ t("actions:fields.endpoint.label") }

--- a/features/admin.actions.v1/pages/action-configuration-page.tsx
+++ b/features/admin.actions.v1/pages/action-configuration-page.tsx
@@ -365,7 +365,7 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
                         sectionHeader={ t("actions:dangerZoneGroup.header") }
                     >
                         <DangerZone
-                            data-componentid={ `${ _componentId }-delete-action-of-type-${ actionTypeApiPath}` }
+                            data-componentid={ `${ _componentId }-danger-zone` }
                             actionTitle={
                                 t("actions:dangerZoneGroup.revertConfig.actionTitle")
                             }

--- a/features/admin.actions.v1/pages/actions.tsx
+++ b/features/admin.actions.v1/pages/actions.tsx
@@ -209,7 +209,10 @@ export const ActionTypesListingPage: FunctionComponent<ActionTypesListingPageInt
 
         if (count > 0) {
             return (
-                <div className="status-tag">
+                <div
+                    className="status-tag"
+                    data-componentid={ `${ _componentId }-${ actionType }-configured-status-tag` }
+                >
                     <CircleCheckFilledIcon className="icon-configured"/>
                     <Typography  className="text-configured" variant="h6">
                         { t("actions:status.configured") }
@@ -218,7 +221,10 @@ export const ActionTypesListingPage: FunctionComponent<ActionTypesListingPageInt
             );
         } else {
             return (
-                <div className="status-tag">
+                <div
+                    className="status-tag"
+                    data-componentid={ `${ _componentId }-${ actionType }-not-configured-status-tag` }
+                >
                     <Typography  className="text-not-configured" variant="h6">
                         {  t("actions:status.notConfigured") }
                     </Typography>


### PR DESCRIPTION
### Purpose
> $subject
Add few missing data-componentids and modified few others inorder to facilitate the functionalities in E2E tests

### Related Issues
<!-- Mention the issue/s related to the pull request. -->
- https://github.com/wso2/product-is/issues/20751

### Related PRs
<!-- Mention the related pull requests. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
