### PR TITLE
Application warning banner

### DIFF
--- a/.changeset/smooth-snakes-vanish.md
+++ b/.changeset/smooth-snakes-vanish.md
@@ -1,0 +1,11 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.connections.v1": patch
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/react-components": patch
+"@wso2is/admin.core.v1": patch
+"@wso2is/theme": patch
+"@wso2is/i18n": patch
+---
+
+Add outdated app banner and labels.

--- a/features/admin.applications.v1/api/use-get-application-inbound-configs.ts
+++ b/features/admin.applications.v1/api/use-get-application-inbound-configs.ts
@@ -20,6 +20,7 @@ import useRequest, { RequestErrorInterface, RequestResultInterface } from "@wso2
 import { store } from "@wso2is/admin.core.v1/store";
 import { HttpMethods } from "@wso2is/core/models";
 import { AxiosRequestConfig } from "axios";
+import { OIDCDataInterface } from "../models";
 
 /**
  * Hook to get the protocol configurations of an application.
@@ -29,7 +30,7 @@ import { AxiosRequestConfig } from "axios";
  * @param shouldFetch - Condition to check if data should be fetched.
  * @returns Response as a promise.
  */
-const useGetApplicationInboundConfigs = <Data = unknown, Error = RequestErrorInterface>(
+const useGetApplicationInboundConfigs = <Data = OIDCDataInterface, Error = RequestErrorInterface>(
     id: string,
     protocol: string,
     shouldFetch: boolean = true

--- a/features/admin.applications.v1/components/application-list.tsx
+++ b/features/admin.applications.v1/components/application-list.tsx
@@ -426,6 +426,23 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                                             ) }
                                         </div>
                                     </Grid>
+                                    <Grid alignItems="flex-end">
+                                        <div>
+                                            { ApplicationManagementUtils.getIfAppIsOutdated(app.applicationVersion) && (
+                                                <Label
+                                                    className="no-margin-left application-outdated-label"
+                                                    size="mini"
+                                                >
+                                                    <Trans
+                                                        i18nKey={
+                                                            t("applications:forms.inboundOIDC.sections"
+                                                                + ".outdatedApplications.label")
+                                                        }
+                                                    />
+                                                </Label>
+                                            ) }
+                                        </div>
+                                    </Grid>
                                     {
                                         ApplicationManagementUtils.isChoreoApplication(app)
                                             && (<Grid>

--- a/features/admin.applications.v1/components/application-list.tsx
+++ b/features/admin.applications.v1/components/application-list.tsx
@@ -426,23 +426,6 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                                             ) }
                                         </div>
                                     </Grid>
-                                    <Grid alignItems="flex-end">
-                                        <div>
-                                            { ApplicationManagementUtils.getIfAppIsOutdated(app.applicationVersion) && (
-                                                <Label
-                                                    className="no-margin-left application-outdated-label"
-                                                    size="mini"
-                                                >
-                                                    <Trans
-                                                        i18nKey={
-                                                            t("applications:forms.inboundOIDC.sections"
-                                                                + ".outdatedApplications.label")
-                                                        }
-                                                    />
-                                                </Label>
-                                            ) }
-                                        </div>
-                                    </Grid>
                                     {
                                         ApplicationManagementUtils.isChoreoApplication(app)
                                             && (<Grid>

--- a/features/admin.applications.v1/constants/application-management.ts
+++ b/features/admin.applications.v1/constants/application-management.ts
@@ -42,7 +42,7 @@ export class ApplicationManagementConstants {
     public static readonly DEFAULT_APPS: string[] = [ this.MY_ACCOUNT_APP_NAME ];
 
     /**
-     * Application latest version.
+     * When a new Application version is released, this variable should to be updated.
      */
     public static readonly LATEST_VERSION: string = "v1.0.0";
 

--- a/features/admin.applications.v1/constants/application-management.ts
+++ b/features/admin.applications.v1/constants/application-management.ts
@@ -42,6 +42,11 @@ export class ApplicationManagementConstants {
     public static readonly DEFAULT_APPS: string[] = [ this.MY_ACCOUNT_APP_NAME ];
 
     /**
+     * Application latest version.
+     */
+    public static readonly LATEST_VERSION: string = "v1.0.0";
+
+    /**
      * Private constructor to avoid object instantiation from outside
      * the class.
      */

--- a/features/admin.applications.v1/models/application.ts
+++ b/features/admin.applications.v1/models/application.ts
@@ -36,6 +36,7 @@ export interface ApplicationBasicInterface {
     id?: string;
     name: string;
     description?: string;
+    applicationVersion?: string;
     accessUrl?: string;
     clientId?: string;
     issuer?: string;
@@ -331,6 +332,7 @@ export interface ApplicationTemplateListItemInterface {
     id: string;
     name: string;
     description?: string;
+    applicationVersion?: string;
     image?: string;
     authenticationProtocol?: string;
     /**

--- a/features/admin.applications.v1/pages/application-edit.scss
+++ b/features/admin.applications.v1/pages/application-edit.scss
@@ -19,3 +19,37 @@
 .application-branding-link {
     cursor: pointer;
 }
+
+.ignore-once-button {
+    color: #788997;
+}
+
+.banner-detail-card {
+    border: 0;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    background: #fffaf3;
+    padding: 5px;
+    padding-left: 35px;
+}
+
+.banner-detail-content {
+    padding: 0;
+}
+
+.banner-grid {
+    padding-left: 30px;
+}
+
+.application-outdated-alert-expanded-view {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.spaced-list li {
+    margin-bottom: 10px;
+}
+
+.banner-wrapper {
+    margin-bottom: 20px;
+}

--- a/features/admin.applications.v1/pages/application-edit.scss
+++ b/features/admin.applications.v1/pages/application-edit.scss
@@ -53,3 +53,11 @@
 .banner-wrapper {
     margin-bottom: 20px;
 }
+
+.banner-view-hide-details {
+    min-width: 120px;
+}
+
+.banner-action {
+    margin: 0 0 1.5em 0 !important;
+}

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -160,7 +160,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
     const [ formData, setFormdata ] = useState<ApplicationInterface>(undefined);
 
     useEffect(() => {
-        if (application != undefined && applicationInboundConfigs != undefined) {
+        if (application && applicationInboundConfigs) {
             const isAppOutdated: boolean = ApplicationManagementUtils.isApplicationOutdated(
                 application?.applicationVersion, applicationInboundConfigs?.grantTypes);
 

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -617,6 +617,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
      * @returns Alert banner details.
      */
     const resolveBannerViewDetails = (): ReactElement => {
+
         return (
             <Forms
                 onSubmit={ handleBannerCheckBoxUpdate }
@@ -700,7 +701,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
      *
      * @returns Confirmation modal.
      */
-    const confirmationModal = () => {
+    const confirmationModal = (): ReactElement => {
         return (
             <ConfirmationModal
                 primaryActionLoading={ bannerUpdateLoading }
@@ -762,10 +763,10 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
     /**
      * Handles the banner data update action.
      */
-    const handleBannerCheckBoxUpdateConfirmation = async (): Promise<void> => {
+    const handleBannerCheckBoxUpdateConfirmation = (): void => {
         setBannerUpdateLoading(true);
 
-        return updateApplicationDetails(formData)
+        updateApplicationDetails(formData)
             .then(() => {
                 dispatch(addAlert({
                     description: t("applications:notifications.updateApplication.success" +

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -19,14 +19,11 @@
 import Alert from "@oxygen-ui/react/Alert";
 import AlertTitle from "@oxygen-ui/react/AlertTitle";
 import Button from "@oxygen-ui/react/Button";
-import Card from "@oxygen-ui/react/Card";
-import CardContent from "@oxygen-ui/react/CardContent";
 import Grid from "@oxygen-ui/react/Grid";
 import List from "@oxygen-ui/react/List";
 import ListItem from "@oxygen-ui/react/ListItem";
-import ListItemIcon from "@oxygen-ui/react/ListItemIcon";
 import ListItemText from "@oxygen-ui/react/ListItemText";
-import { CheckIcon } from "@oxygen-ui/react-icons";
+import Typography from "@oxygen-ui/react/Typography";
 import { useRequiredScopes } from "@wso2is/access-control";
 import ApplicationTemplateMetadataProvider from
     "@wso2is/admin.application-templates.v1/provider/application-template-metadata-provider";
@@ -63,7 +60,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router";
 import { Dispatch } from "redux";
-import { Label } from "semantic-ui-react";
+import { Icon, Label } from "semantic-ui-react";
 import { updateApplicationDetails } from "../api/application";
 import { useGetApplication } from "../api/use-get-application";
 import { EditApplication } from "../components/edit-application";
@@ -567,8 +564,10 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                             severity="warning"
                             action={
                                 (
-                                    <>
-                                        <Button onClick={ () => setViewBannerDetails(!viewBannerDetails) }>
+                                    <div>
+                                        <Button
+                                            data-componentid={ `${componentId}-outdated-app-view-details-button` }
+                                            onClick={ () => setViewBannerDetails(!viewBannerDetails) }>
                                             {
                                                 !viewBannerDetails ?
                                                     t("applications:forms.inboundOIDC.sections"
@@ -578,34 +577,37 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                             }
                                         </Button>
                                         <Button
+                                            data-componentid={ `${componentId}-outdated-app-ignore-button` }
                                             className="ignore-once-button"
                                             onClick={ () => setDisplayBanner(false) }>
-                                            { t("applications:forms.inboundOIDC.sections"
-                                                        + ".outdatedApplications.alert.cancelButton") }
+                                            <Icon
+                                                link={ true }
+                                                onClick={ () => setDisplayBanner(false) }
+                                                className=""
+                                                size="small"
+                                                color="grey"
+                                                name="close"
+                                                data-componentid={ `${componentId}-close-btn` }
+                                            />
                                         </Button>
-                                    </>
+                                    </div>
                                 )
                             }
                         >
                             <AlertTitle className="alert-title">
                                 <Trans components={ { strong: <strong/> } } >
                                     { t("applications:forms.inboundOIDC.sections.outdatedApplications"
-                                                + ".alert.title") }
+                                        + ".alert.title") }
                                 </Trans>
                             </AlertTitle>
                             <Trans>
                                 { t("applications:forms.inboundOIDC.sections.outdatedApplications"
-                                                    + ".alert.content") }
+                                        + ".alert.content") }
                             </Trans>
+                            {
+                                viewBannerDetails && resolveBannerViewDetails()
+                            }
                         </Alert>
-                        <Card
-                            className="banner-detail-card"
-                            hidden={ !viewBannerDetails }
-                        >
-                            <CardContent className="banner-detail-content">
-                                { resolveBannerViewDetails() }
-                            </CardContent>
-                        </Card>
                     </div>
                 )
         );
@@ -623,20 +625,22 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                 onSubmit={ handleBannerCheckBoxUpdate }
                 data-componentId={ `${componentId}-application-outdated-banner-form` }>
                 <Grid className="banner-grid">
-                    <List>
+                    <List dense>
                         <ListItem
                             sx={ {
                                 display: "list-item",
                                 listStyleType: "disc"
                             } }>
                             <ListItemText>
-                                <Trans
-                                    i18nKey={
-                                        t("applications:forms.inboundOIDC.sections"
+                                <Typography variant="body2" >
+                                    <Trans
+                                        i18nKey={
+                                            t("applications:forms.inboundOIDC.sections"
                                             + ".outdatedApplications.fields."
                                             + "versions.version100.useClientIdAsSubClaimOfAppTokens.instruction")
-                                    }
-                                />
+                                        }
+                                    />
+                                </Typography>
                                 <DocumentationLink
                                     link={
                                         getLink("develop.applications.editApplication.outdatedApplications.versions."
@@ -659,13 +663,15 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                 listStyleType: "disc"
                             } }>
                             <ListItemText>
-                                <Trans
-                                    i18nKey={
-                                        t("applications:forms.inboundOIDC.sections"
+                                <Typography variant="body2" >
+                                    <Trans
+                                        i18nKey={
+                                            t("applications:forms.inboundOIDC.sections"
                                             + ".outdatedApplications.fields.versions.version100."
                                             + "removeUsernameFromIntrospectionRespForAppTokens.instruction")
-                                    }
-                                />
+                                        }
+                                    />
+                                </Typography>
                                 <DocumentationLink
                                     link={
                                         getLink("develop.applications.editApplication.outdatedApplications.versions."
@@ -688,7 +694,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                 <Button
                     variant="contained"
                     type="submit"
-                    data-componentId={ `${componentId}-application-outdated-banner-button` }
+                    data-componentId={ `${componentId}-outdated-app-update-button` }
                 >
                     { t("common:update") }
                 </Button>
@@ -706,7 +712,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
         return (
             <ConfirmationModal
                 primaryActionLoading={ bannerUpdateLoading }
-                data-componentId={ `${componentId}-application-version-update-confirmation-modal` }
+                data-componentId={ `${componentId}-application-update-confirmation-modal` }
                 onClose={ (): void => setShowConfirmationModal(false) }
                 type="negative"
                 open={ showConfirmationModal }
@@ -722,12 +728,12 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                 closeOnDimmerClick={ false }
             >
                 <ConfirmationModal.Header
-                    data-componentId={ `${componentId}-application-version-update-confirmation-modal-header` }>
+                    data-componentId={ `${componentId}-application-update-confirmation-modal-header` }>
                     { t("applications:forms.inboundOIDC.sections.outdatedApplications"
                         + ".confirmationModal.header") }
                 </ConfirmationModal.Header>
                 <ConfirmationModal.Message
-                    data-componentId={ `${componentId}-application-version-update-confirmation-modal-message` }
+                    data-componentId={ `${componentId}-application-update-confirmation-modal-message` }
                     attached
                     negative
                 >
@@ -735,7 +741,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                         + ".confirmationModal.message") }
                 </ConfirmationModal.Message>
                 <ConfirmationModal.Content
-                    data-componentId={ `${componentId}-application-version-update-confirmation-modal-content` }
+                    data-componentId={ `${componentId}-application-update-confirmation-modal-content` }
                 >
                     { t("applications:forms.inboundOIDC.sections.outdatedApplications"
                         + ".confirmationModal.content") }
@@ -805,6 +811,10 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
             });
     };
 
+    console.log("application: ", application);
+    console.log("moderatedApplicationData: ", moderatedApplicationData);
+
+
     return (
         <TabPageLayout
             pageTitle="Edit Application"
@@ -824,7 +834,8 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                         <div className="with-label ellipsis" ref={ appDescElement }>
                             { resolveTemplateLabel() }
                             {
-                                ApplicationManagementUtils.getIfAppIsOutdated("v0.0.0") && (
+                                ApplicationManagementUtils.getIfAppIsOutdated(
+                                    moderatedApplicationData?.applicationVersion) && (
                                     <Label
                                         className="no-margin-left application-outdated-label"
                                         size="small"

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -18,6 +18,7 @@
 
 import Alert from "@oxygen-ui/react/Alert";
 import AlertTitle from "@oxygen-ui/react/AlertTitle";
+import Box from "@oxygen-ui/react/Box";
 import Button from "@oxygen-ui/react/Button";
 import Grid from "@oxygen-ui/react/Grid";
 import List from "@oxygen-ui/react/List";
@@ -561,8 +562,9 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                             severity="warning"
                             action={
                                 (
-                                    <div>
+                                    <Box display="flex">
                                         <Button
+                                            className="banner-view-hide-details"
                                             data-componentid={ `${componentId}-outdated-app-view-details-button` }
                                             onClick={ () => setViewBannerDetails(!viewBannerDetails) }>
                                             {
@@ -587,7 +589,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                                 data-componentid={ `${componentId}-close-btn` }
                                             />
                                         </Button>
-                                    </div>
+                                    </Box>
                                 )
                             }
                         >
@@ -636,22 +638,27 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                             <Trans
                                                 i18nKey={
                                                     t("applications:forms.inboundOIDC.sections"
-                                            + ".outdatedApplications.fields."
-                                            + "versions.version100.useClientIdAsSubClaimOfAppTokens.instruction")
+                                                        + ".outdatedApplications.fields.versions.version100."
+                                                        + "removeUsernameFromIntrospectionRespForAppTokens.instruction")
                                                 }
-                                            />
+                                            >
+                                                The <code>sub</code> attribute of an application access token now
+                                                returns the <code>client_id</code> generated for the application,
+                                                instead of the <code>userid</code> of the application owner.
+                                            </Trans>
                                         </Typography>
                                         <DocumentationLink
                                             link={
                                                 getLink("develop.applications.editApplication.outdatedApplications."
-                                            + "versions.version100.useClientIdAsSubClaimOfAppTokens.documentationLink")
+                                                + "versions.version100.removeUsernameFromIntrospectionRespForAppTokens."
+                                                + "documentationLink")
                                             }
                                             showEmptyLink={ false }
                                         >
                                             <Trans
                                                 i18nKey={
                                                     t("applications:forms.inboundOIDC.sections"
-                                                + ".outdatedApplications.documentationHint")
+                                                    + ".outdatedApplications.documentationHint")
                                                 }
                                             />
                                         </DocumentationLink>
@@ -672,23 +679,26 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                             <Trans
                                                 i18nKey={
                                                     t("applications:forms.inboundOIDC.sections"
-                                            + ".outdatedApplications.fields.versions.version100."
-                                            + "removeUsernameFromIntrospectionRespForAppTokens.instruction")
+                                                    + ".outdatedApplications.fields.versions"
+                                                    + ".version100.useClientIdAsSubClaimOfAppTokens.instruction")
                                                 }
-                                            />
+                                            >
+                                                The introspection responses for application access tokens no longer
+                                                return the <code>username</code> attribute.
+                                            </Trans>
                                         </Typography>
                                         <DocumentationLink
                                             link={
                                                 getLink("develop.applications.editApplication.outdatedApplications."
-                                            + "versions.version100.removeUsernameFromIntrospectionRespForAppTokens."
-                                            + "documentationLink")
+                                                + "versions.version100.useClientIdAsSubClaimOfAppTokens."
+                                                + "documentationLink")
                                             }
                                             showEmptyLink={ false }
                                         >
                                             <Trans
                                                 i18nKey={
                                                     t("applications:forms.inboundOIDC.sections"
-                                                + ".outdatedApplications.documentationHint")
+                                                    + ".outdatedApplications.documentationHint")
                                                 }
                                             />
                                         </DocumentationLink>
@@ -698,6 +708,14 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                         }
                     </List>
                 </Grid>
+                <Typography variant="body2" className="banner-action">
+                    <Trans
+                        i18nKey={
+                            t("applications:forms.inboundOIDC.sections"
+                            + ".outdatedApplications.alert.action")
+                        }
+                    />
+                </Typography>
                 <Button
                     variant="contained"
                     type="submit"

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -634,13 +634,13 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                     i18nKey={
                                         t("applications:forms.inboundOIDC.sections"
                                             + ".outdatedApplications.fields."
-                                            + "versions.version100.change1.instruction")
+                                            + "versions.version100.useClientIdAsSubClaimOfAppTokens.instruction")
                                     }
                                 />
                                 <DocumentationLink
                                     link={
                                         getLink("develop.applications.oudatedApplications.versions."
-                                            + "version100.change1.documentationLink")
+                                            + "version100.useClientIdAsSubClaimOfAppTokens.documentationLink")
                                     }
                                     showEmptyLink={ false }
                                 >
@@ -663,13 +663,13 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                     i18nKey={
                                         t("applications:forms.inboundOIDC.sections"
                                             + ".outdatedApplications.fields."
-                                            + "versions.version100.change2.instruction")
+                                            + "versions.version100.removeUsernameFromIntrospectionRespForAppTokens.instruction")
                                     }
                                 />
                                 <DocumentationLink
                                     link={
                                         getLink("develop.applications.oudatedApplications.versions."
-                                            + "version100.change2.documentationLink")
+                                            + "version100.removeUsernameFromIntrospectionRespForAppTokens.documentationLink")
                                     }
                                     showEmptyLink={ false }
                                 >

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -160,7 +160,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
 
     useEffect(() => {
         if (application != undefined && applicationInboundConfigs != undefined) {
-            const isAppOutdated: boolean = ApplicationManagementUtils.getIfAppIsOutdated(
+            const isAppOutdated: boolean = ApplicationManagementUtils.isApplicationOutdated(
                 application?.applicationVersion, applicationInboundConfigs?.grantTypes);
 
             setDisplayBanner(isAppOutdated);

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -639,7 +639,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                 />
                                 <DocumentationLink
                                     link={
-                                        getLink("develop.applications.oudatedApplications.versions."
+                                        getLink("develop.applications.editApplication.outdatedApplications.versions."
                                             + "version100.useClientIdAsSubClaimOfAppTokens.documentationLink")
                                     }
                                     showEmptyLink={ false }
@@ -662,14 +662,15 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                 <Trans
                                     i18nKey={
                                         t("applications:forms.inboundOIDC.sections"
-                                            + ".outdatedApplications.fields."
-                                            + "versions.version100.removeUsernameFromIntrospectionRespForAppTokens.instruction")
+                                            + ".outdatedApplications.fields.versions.version100."
+                                            + "removeUsernameFromIntrospectionRespForAppTokens.instruction")
                                     }
                                 />
                                 <DocumentationLink
                                     link={
-                                        getLink("develop.applications.oudatedApplications.versions."
-                                            + "version100.removeUsernameFromIntrospectionRespForAppTokens.documentationLink")
+                                        getLink("develop.applications.editApplication.outdatedApplications.versions."
+                                            + "version100.removeUsernameFromIntrospectionRespForAppTokens."
+                                            + "documentationLink")
                                     }
                                     showEmptyLink={ false }
                                 >

--- a/features/admin.applications.v1/utils/application-management-utils.ts
+++ b/features/admin.applications.v1/utils/application-management-utils.ts
@@ -104,7 +104,7 @@ export class ApplicationManagementUtils {
             });
     }
 
-    public static getIfAppIsOutdated(applicationVersion: string, grantTypes?: string[]): boolean {
+    public static isApplicationOutdated(applicationVersion: string, grantTypes?: string[]): boolean {
 
         if (applicationVersion != undefined
                 && grantTypes.includes(ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT)) {

--- a/features/admin.applications.v1/utils/application-management-utils.ts
+++ b/features/admin.applications.v1/utils/application-management-utils.ts
@@ -106,18 +106,23 @@ export class ApplicationManagementUtils {
 
     public static getIfAppIsOutdated(applicationVersion: string): boolean {
 
-        const appVersionArray: number[] = applicationVersion?.match(/\d+/g).map(Number);
-        const latestAppVersionArray: number[] = ApplicationManagementConstants.LATEST_VERSION.match(/\d+/g).map(Number);
+        if (applicationVersion != undefined) {
+            const appVersionArray: number[] = applicationVersion?.match(/\d+/g).map(Number);
+            const latestAppVersionArray: number[] = ApplicationManagementConstants
+                .LATEST_VERSION.match(/\d+/g).map(Number);
 
-        if (appVersionArray[0] < latestAppVersionArray[0]) {
-            return true;
-        } else if (appVersionArray[1] < latestAppVersionArray[1]) {
-            return true;
-        } else if (appVersionArray[2] < latestAppVersionArray[2]) {
-            return true;
-        } else {
-            return false;
+            if (appVersionArray[0] < latestAppVersionArray[0]) {
+                return true;
+            } else if (appVersionArray[1] < latestAppVersionArray[1]) {
+                return true;
+            } else if (appVersionArray[2] < latestAppVersionArray[2]) {
+                return true;
+            } else {
+                return false;
+            }
         }
+
+        return false;
     }
 
     /**

--- a/features/admin.applications.v1/utils/application-management-utils.ts
+++ b/features/admin.applications.v1/utils/application-management-utils.ts
@@ -104,9 +104,11 @@ export class ApplicationManagementUtils {
             });
     }
 
-    public static getIfAppIsOutdated(applicationVersion: string): boolean {
+    public static getIfAppIsOutdated(applicationVersion: string, grantTypes?: string[]): boolean {
 
-        if (applicationVersion != undefined) {
+        if (applicationVersion != undefined
+                && grantTypes.includes(ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT)) {
+
             const appVersionArray: number[] = applicationVersion?.match(/\d+/g).map(Number);
             const latestAppVersionArray: number[] = ApplicationManagementConstants
                 .LATEST_VERSION.match(/\d+/g).map(Number);

--- a/features/admin.applications.v1/utils/application-management-utils.ts
+++ b/features/admin.applications.v1/utils/application-management-utils.ts
@@ -107,7 +107,7 @@ export class ApplicationManagementUtils {
     public static isApplicationOutdated(applicationVersion: string, grantTypes?: string[]): boolean {
 
         if (applicationVersion != undefined
-                && grantTypes.includes(ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT)) {
+            && grantTypes.includes(ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT)) {
 
             const appVersionArray: number[] = applicationVersion?.match(/\d+/g).map(Number);
             const latestAppVersionArray: number[] = ApplicationManagementConstants

--- a/features/admin.applications.v1/utils/application-management-utils.ts
+++ b/features/admin.applications.v1/utils/application-management-utils.ts
@@ -104,6 +104,21 @@ export class ApplicationManagementUtils {
             });
     }
 
+    public static getIfAppIsOutdated(applicationVersion: string): boolean {
+
+        const appVersionArray: number[] = applicationVersion?.match(/\d+/g).map(Number);
+        const latestAppVersionArray: number[] = ApplicationManagementConstants.LATEST_VERSION.match(/\d+/g).map(Number);
+
+        if (appVersionArray[0] < latestAppVersionArray[0]) {
+            return true;
+        } else if (appVersionArray[1] < latestAppVersionArray[1]) {
+            return true;
+        } else if (appVersionArray[2] < latestAppVersionArray[2]) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     /**
      * Gets the list of available custom inbound protocols list and sets them in the redux store.

--- a/features/admin.connections.v1/models/connection.ts
+++ b/features/admin.connections.v1/models/connection.ts
@@ -337,6 +337,7 @@ export interface ApplicationBasicInterface {
     id?: string;
     name: string;
     description?: string;
+    applicationVersion?: string;
     accessUrl?: string;
     clientId?: string;
     issuer?: string;

--- a/features/admin.core.v1/models/common.ts
+++ b/features/admin.core.v1/models/common.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/features/admin.core.v1/models/common.ts
+++ b/features/admin.core.v1/models/common.ts
@@ -1,10 +1,19 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
  *
- * This software is the property of WSO2 LLC. and its suppliers, if any.
- * Dissemination of any information or reproduction of any material contained
- * herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
- * You may not alter or remove any copyright or other notice from copies of this content.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 import { LinkInterface } from "@wso2is/core/models";
@@ -75,6 +84,7 @@ export interface ApplicationBasicInterface {
     id?: string;
     name: string;
     description?: string;
+    applicationVersion?: string;
     accessUrl?: string;
     clientId?: string;
     issuer?: string;

--- a/features/admin.extensions.v1/configs/documentation.ts
+++ b/features/admin.extensions.v1/configs/documentation.ts
@@ -144,7 +144,7 @@ export const getDocumentationLinksExtension = () : DocumentationLinksExtensionIn
                             }
                         }
                     },
-                    oudatedApplications: {
+                    outdatedApplications: {
                         versions: {
                             version100: {
                                 removeUsernameFromIntrospectionRespForAppTokens: {

--- a/features/admin.extensions.v1/configs/documentation.ts
+++ b/features/admin.extensions.v1/configs/documentation.ts
@@ -147,10 +147,10 @@ export const getDocumentationLinksExtension = () : DocumentationLinksExtensionIn
                     oudatedApplications: {
                         versions: {
                             version100: {
-                                change1: {
+                                removeUsernameFromIntrospectionRespForAppTokens: {
                                     documentationLink: undefined
                                 },
-                                change2: {
+                                useClientIdAsSubClaimOfAppTokens: {
                                     documentationLink: undefined
                                 }
                             }

--- a/features/admin.extensions.v1/configs/documentation.ts
+++ b/features/admin.extensions.v1/configs/documentation.ts
@@ -144,6 +144,18 @@ export const getDocumentationLinksExtension = () : DocumentationLinksExtensionIn
                             }
                         }
                     },
+                    oudatedApplications: {
+                        versions: {
+                            version100: {
+                                change1: {
+                                    documentationLink: undefined
+                                },
+                                change2: {
+                                    documentationLink: undefined
+                                }
+                            }
+                        }
+                    },
                     samlApplication: {
                         advanced: {
                             learnMore: undefined

--- a/features/admin.extensions.v1/configs/models/documentation.ts
+++ b/features/admin.extensions.v1/configs/models/documentation.ts
@@ -137,7 +137,7 @@ interface ApplicationsDocumentationLinksInterface {
                 }
             }
         }
-        oudatedApplications: {
+        outdatedApplications: {
             versions: {
                 version100: {
                     removeUsernameFromIntrospectionRespForAppTokens: {

--- a/features/admin.extensions.v1/configs/models/documentation.ts
+++ b/features/admin.extensions.v1/configs/models/documentation.ts
@@ -137,6 +137,18 @@ interface ApplicationsDocumentationLinksInterface {
                 }
             }
         }
+        oudatedApplications: {
+            versions: {
+                version100: {
+                    change1: {
+                        documentationLink: string;
+                    },
+                    change2: {
+                        documentationLink: string;
+                    }
+                }
+            }
+        },
         oidcApplication: {
             advanced: {
                 learnMore: string;

--- a/features/admin.extensions.v1/configs/models/documentation.ts
+++ b/features/admin.extensions.v1/configs/models/documentation.ts
@@ -140,15 +140,15 @@ interface ApplicationsDocumentationLinksInterface {
         oudatedApplications: {
             versions: {
                 version100: {
-                    change1: {
+                    removeUsernameFromIntrospectionRespForAppTokens: {
                         documentationLink: string;
                     },
-                    change2: {
+                    useClientIdAsSubClaimOfAppTokens: {
                         documentationLink: string;
                     }
                 }
             }
-        },
+        }
         oidcApplication: {
             advanced: {
                 learnMore: string;

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -1377,6 +1377,37 @@ export interface ApplicationsNS {
                         };
                     };
                 };
+                outdatedApplications: {
+                    heading: string;
+                    alert : {
+                        title: string;
+                        content: string;
+                        viewButton: string;
+                        hideButton: string;
+                        cancelButton: string;
+                    }
+                    label: string;
+                    documentationHint: string;
+                    confirmationModal: {
+                        assertionHint: string;
+                        header: string;
+                        message: string;
+                        content: string;
+                    },
+                    fields: {
+                        commonInstruction: string;
+                        versions: {
+                            version100: {
+                                change1: {
+                                    instruction: string;
+                                },
+                                change2: {
+                                    instruction: string;
+                                }
+                            }
+                        };
+                    }
+                };
                 logoutURLs: {
                     heading: string;
                     fields: {

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -1398,10 +1398,10 @@ export interface ApplicationsNS {
                         commonInstruction: string;
                         versions: {
                             version100: {
-                                change1: {
+                                removeUsernameFromIntrospectionRespForAppTokens: {
                                     instruction: string;
                                 },
-                                change2: {
+                                useClientIdAsSubClaimOfAppTokens: {
                                     instruction: string;
                                 }
                             }

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -1378,13 +1378,12 @@ export interface ApplicationsNS {
                     };
                 };
                 outdatedApplications: {
-                    heading: string;
                     alert : {
                         title: string;
                         content: string;
                         viewButton: string;
                         hideButton: string;
-                        cancelButton: string;
+                        action: string;
                     }
                     label: string;
                     documentationHint: string;

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1643,6 +1643,37 @@ export const applications: ApplicationsNS = {
                     },
                     heading: "ID Token"
                 },
+                outdatedApplications: {
+                    heading: "Legacy Application Tokens",
+                    alert : {
+                        title: "Application is outdated.",
+                        content: "This application is using an outdated behavior of applications.",
+                        viewButton: "View Details",
+                        hideButton: "Hide Details",
+                        cancelButton: "Ignore Once"
+                    },
+                    label: "outdated",
+                    documentationHint: "More Details",
+                    confirmationModal: {
+                        header: "Have you done the relevant changes?",
+                        message: "Proceeding the action without making relevant change will cause the client application behavior break.",
+                        content: "Confirming the action will,",
+                        assertionHint: "Please confirm your action"
+                    },
+                    fields: {
+                        commonInstruction: "Following behavioral changes will be applied upon update.",
+                        versions: {
+                            version100: {
+                                change1: {
+                                    instruction: "Application access token sub attribute will be client_id generated for an application."
+                                },
+                                change2: {
+                                    instruction: "Introspection response for application access token will not include the username attribute."
+                                }
+                            }
+                        }
+                    }
+                },
                 logoutURLs: {
                     fields: {
                         back: {

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1644,13 +1644,12 @@ export const applications: ApplicationsNS = {
                     heading: "ID Token"
                 },
                 outdatedApplications: {
-                    heading: "Legacy Application Tokens",
                     alert : {
-                        title: "Application is outdated.",
-                        content: "This application is using an outdated behavior of applications.",
+                        title: "Update Required.",
+                        content: "We have updated the behavior of applications as follows.",
                         viewButton: "View Details",
                         hideButton: "Hide Details",
-                        cancelButton: "Ignore Once"
+                        action: "Before updating your application, be sure to update any usages of these attributes accordingly."
                     },
                     label: "Outdated",
                     documentationHint: "More Details",
@@ -1665,10 +1664,13 @@ export const applications: ApplicationsNS = {
                         versions: {
                             version100: {
                                 removeUsernameFromIntrospectionRespForAppTokens: {
-                                    instruction: "The introspection response for an application access token will not include the username attribute."
+                                    instruction: "The <1>sub</1> attribute of an application access token now returns the "
+                                        + "<3>client_id</3> generated for the application, instead of the <5>userid</5> of "
+                                        + "the application owner."
                                 },
                                 useClientIdAsSubClaimOfAppTokens: {
-                                    instruction: "The sub attribute of the application access token will be the client_id generated for the application."
+                                    instruction: "The introspection responses for application access tokens no longer "
+                                        + "return the <1>username</1> attribute."
                                 }
                             }
                         }

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1656,8 +1656,8 @@ export const applications: ApplicationsNS = {
                     documentationHint: "More Details",
                     confirmationModal: {
                         header: "Have you done the relevant changes?",
-                        message: "Proceeding the action without making relevant change will cause the client application behavior break.",
-                        content: "This action is irreversible and will permanently update the application.",
+                        message: "Proceeding without making the necessary changes will cause the client application's behavior to break.",
+                        content: "This action is irreversible and will result in a permanent update to the application.",
                         assertionHint: "Please confirm your action"
                     },
                     fields: {
@@ -1665,10 +1665,10 @@ export const applications: ApplicationsNS = {
                         versions: {
                             version100: {
                                 removeUsernameFromIntrospectionRespForAppTokens: {
-                                    instruction: "Introspection response for application access token will not include the username attribute."
+                                    instruction: "The introspection response for an application access token will not include the username attribute."
                                 },
                                 useClientIdAsSubClaimOfAppTokens: {
-                                    instruction: "Application access token sub attribute will be client_id generated for an application."
+                                    instruction: "The sub attribute of the application access token will be the client_id generated for the application."
                                 }
                             }
                         }

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1664,11 +1664,11 @@ export const applications: ApplicationsNS = {
                         commonInstruction: "Following behavioral changes will be applied upon update.",
                         versions: {
                             version100: {
-                                change1: {
-                                    instruction: "Application access token sub attribute will be client_id generated for an application."
-                                },
-                                change2: {
+                                removeUsernameFromIntrospectionRespForAppTokens: {
                                     instruction: "Introspection response for application access token will not include the username attribute."
+                                },
+                                useClientIdAsSubClaimOfAppTokens: {
+                                    instruction: "Application access token sub attribute will be client_id generated for an application."
                                 }
                             }
                         }

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1652,12 +1652,12 @@ export const applications: ApplicationsNS = {
                         hideButton: "Hide Details",
                         cancelButton: "Ignore Once"
                     },
-                    label: "outdated",
+                    label: "Outdated",
                     documentationHint: "More Details",
                     confirmationModal: {
                         header: "Have you done the relevant changes?",
                         message: "Proceeding the action without making relevant change will cause the client application behavior break.",
-                        content: "Confirming the action will,",
+                        content: "This action is irreversible and will permanently update the application.",
                         assertionHint: "Please confirm your action"
                     },
                     fields: {

--- a/modules/react-components/src/components/page-header/page-header.tsx
+++ b/modules/react-components/src/components/page-header/page-header.tsx
@@ -306,9 +306,7 @@ export const PageHeader: React.FunctionComponent<PageHeaderPropsInterface> = (
                                 )
                         )
                     }
-                    {
-                        alertBanner
-                    }
+                    { alertBanner }
                     {
                         action
                             ? (

--- a/modules/react-components/src/components/page-header/page-header.tsx
+++ b/modules/react-components/src/components/page-header/page-header.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -41,6 +41,10 @@ export interface PageHeaderPropsInterface extends LoadableComponentInterface, Te
      * Column width for the action container grid.
      */
     actionColumnWidth?: SemanticWIDTHS;
+    /**
+     * Alert component displayed in the page header.
+     */
+    alertBanner?: ReactNode;
     /**
      * Go back button.
      */
@@ -127,6 +131,7 @@ export const PageHeader: React.FunctionComponent<PageHeaderPropsInterface> = (
     const {
         action,
         actionColumnWidth,
+        alertBanner,
         backButton,
         bottomMargin,
         className,
@@ -300,6 +305,9 @@ export const PageHeader: React.FunctionComponent<PageHeaderPropsInterface> = (
                                     </div>
                                 )
                         )
+                    }
+                    {
+                        alertBanner
                     }
                     {
                         action

--- a/modules/theme/src/themes/default/elements/label.overrides
+++ b/modules/theme/src/themes/default/elements/label.overrides
@@ -148,8 +148,8 @@
 
 .ui.label {
     &.application-outdated-label {
-        color: #f28753;
-        background-color: #fff4ea;
+        color: #fd9200;
+        background-color: #fff4e5;
     }
 }
 

--- a/modules/theme/src/themes/default/elements/label.overrides
+++ b/modules/theme/src/themes/default/elements/label.overrides
@@ -142,6 +142,17 @@
     }
 }
 
+/*******************************
+      Application outdated Label
+*******************************/
+
+.ui.label {
+    &.application-outdated-label {
+        color: #f28753;
+        background-color: #fff4ea;
+    }
+}
+
 /***************************************
     Password Validation Error Labels
 ***************************************/


### PR DESCRIPTION
### Purpose
This PR will add a banner to the Application edit to maintain the below configs.

1. useClientIdAsSubClaimForAppTokens
2. omitUsernameInIntrospectionRespForAppTokens

The initial UI design is as follows.

https://github.com/user-attachments/assets/092abdbe-66a5-4813-98d4-1bdb359c6b4c

### Related Issues
- https://github.com/wso2/product-is/issues/20917

### Related PRs
- https://github.com/wso2/identity-apps/pull/6783

### Checklist

- [x] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [x] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [x] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [x] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
