### PR TITLE
[Bug] Fix the issue with hidden fields in the sub-organization application general tab

### DIFF
--- a/.changeset/tasty-jars-admire.md
+++ b/.changeset/tasty-jars-admire.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix the issue with hidden fields in the sub-organization application general tab

--- a/features/admin.applications.v1/components/forms/general-details-form.tsx
+++ b/features/admin.applications.v1/components/forms/general-details-form.tsx
@@ -380,7 +380,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                             </Grid.Column>
                         </Grid.Row>
                     ) }
-                    { !UIConfig.systemAppsIdentifiers.includes(name) && (
+                    { !UIConfig.systemAppsIdentifiers.includes(name) && !isSubOrganizationType && (
                         <Grid.Row columns={ 1 }>
                             <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                 <Field.Input
@@ -397,7 +397,6 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                                             ".placeholder")
                                     }
                                     value={ name }
-                                    hidden={ isSubOrganizationType }
                                     readOnly={ readOnly || isSubOrganizationType }
                                     validation ={ (value: string) => validateName(value.toString().trim()) }
                                     maxLength={
@@ -410,7 +409,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                         </Grid.Row>
                     ) }
                     {
-                        name !== ApplicationManagementConstants.MY_ACCOUNT_APP_NAME && (
+                        name !== ApplicationManagementConstants.MY_ACCOUNT_APP_NAME && !isSubOrganizationType && (
                             <Grid.Row columns={ 1 }>
                                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                     <Field.Textarea
@@ -426,7 +425,6 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                                                 ".placeholder")
                                         }
                                         value={ description }
-                                        hidden={ isSubOrganizationType }
                                         readOnly={ readOnly }
                                         validation ={ (value: string) => validateDescription(value.toString().trim()) }
                                         maxLength={ 300 }
@@ -439,35 +437,36 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                         )
                     }
                     {
-                        <Grid.Row columns={ 1 } data-componentid="application-edit-general-details-form-image-url">
-                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
-                                <Field.Input
-                                    ariaLabel="Application image URL"
-                                    inputType="url"
-                                    name="imageUrl"
-                                    label={
-                                        t("applications:forms.generalDetails" +
-                                            ".fields.imageUrl.label")
-                                    }
-                                    required={ false }
-                                    placeholder={
-                                        t("applications:forms.generalDetails" +
-                                            ".fields.imageUrl.placeholder")
-                                    }
-                                    value={ imageUrl }
-                                    readOnly={ readOnly }
-                                    data-testid={ `${ testId }-application-image-url-input` }
-                                    maxLength={ 200 }
-                                    minLength={ 3 }
-                                    hint={
-                                        t("applications:forms.generalDetails" +
-                                            ".fields.imageUrl.hint")
-                                    }
-                                    width={ 16 }
-                                    hidden={ isSubOrganizationType || hiddenFields?.includes("imageUrl") }
-                                />
-                            </Grid.Column>
-                        </Grid.Row>
+                        !isSubOrganizationType && !hiddenFields?.includes("imageUrl") && (
+                            <Grid.Row columns={ 1 } data-componentid="application-edit-general-details-form-image-url">
+                                <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
+                                    <Field.Input
+                                        ariaLabel="Application image URL"
+                                        inputType="url"
+                                        name="imageUrl"
+                                        label={
+                                            t("applications:forms.generalDetails" +
+                                                ".fields.imageUrl.label")
+                                        }
+                                        required={ false }
+                                        placeholder={
+                                            t("applications:forms.generalDetails" +
+                                                ".fields.imageUrl.placeholder")
+                                        }
+                                        value={ imageUrl }
+                                        readOnly={ readOnly }
+                                        data-testid={ `${ testId }-application-image-url-input` }
+                                        maxLength={ 200 }
+                                        minLength={ 3 }
+                                        hint={
+                                            t("applications:forms.generalDetails" +
+                                                ".fields.imageUrl.hint")
+                                        }
+                                        width={ 16 }
+                                    />
+                                </Grid.Column>
+                            </Grid.Row>
+                        )
                     }
                     { (
                         !isM2MApplication
@@ -475,6 +474,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                             isMyAccountEnabled
                             || isSubOrg
                         )
+                        && !isSubOrganizationType
                     ) ? (
                             <Grid.Row columns={ 1 }>
                                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
@@ -528,7 +528,6 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                                                 }
                                             </Trans>
                                         ) }
-                                        hidden={ isSubOrganizationType }
                                         width={ 16 }
                                     />
                                 </Grid.Column>
@@ -536,7 +535,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                         ) : null
                     }
                     {
-                        !isM2MApplication && (
+                        !isM2MApplication && !isSubOrganizationType && (
                             <Grid.Row columns={ 1 }>
                                 <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
                                     <Field.Input
@@ -563,7 +562,6 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
                                             )
                                         }
                                         validation={ validateAccessURL }
-                                        hidden={ isSubOrganizationType }
                                         maxLength={ ApplicationManagementConstants
                                             .FORM_FIELD_CONSTRAINTS.ACCESS_URL_MAX_LENGTH }
                                         minLength={ ApplicationManagementConstants.FORM_FIELD_CONSTRAINTS


### PR DESCRIPTION
<!-- 
   READ THIS FIRST:
   - PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS.
   - PLEASE MAKE SURE TO ONLY ADD PUBLICLY ACCESSIBLE REFERENCES
-->

### Purpose
In the sub-organization's shared apps, the general tab currently displays all hidden input fields. This bug occurs because the form cannot recognize the hidden attribute when the field is placed inside a Grid or another container. To fix this, the hidden logic needs to be applied directly to the component's rendering condition.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f4f94917-4eb9-4c29-a191-8af9fecf71be">



### Related Issues
<!-- Mention the issue/s related to the pull request. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
