### PR TITLE
Fix localize Or and Username labels in Authentication Portal and Recovery Portal

### DIFF
--- a/.changeset/ten-ghosts-dream.md
+++ b/.changeset/ten-ghosts-dream.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix localize Or and Username labels in Authentication Portal and Recovery Portal

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/username-label-resolver.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/username-label-resolver.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -44,7 +44,7 @@
                 String i18nKey = null;
         
                 if (StringUtils.equals(attribute, USERNAME_CLAIM_URI)) {
-                    i18nKey = "Username";
+                    i18nKey = "username";
                 } else if (StringUtils.equals(attribute, EMAIL_CLAIM_URI )) {
                     i18nKey = "email";
                 } else if (StringUtils.equals(attribute, MOBILE_CLAIM_URI)) {
@@ -61,8 +61,9 @@
             }
 
             if (attributeList.size() > 0) {
+                String orString = AuthenticationEndpointUtil.i18n(resourceBundle, "or"); 
                 usernameLabel = String.join(", ", attributeList.subList(0, attributeList.size() - 1))
-                    + (attributeList.size() > 1 ? " or " : "")
+                    + (attributeList.size() > 1 ? " " + orString + " " : "")
                     + attributeList.get(attributeList.size() - 1);
             }
 

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/username-label-resolver.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/username-label-resolver.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -43,7 +43,7 @@
                 String i18nKey = null;
         
                 if (StringUtils.equals(attribute, USERNAME_CLAIM_URI)) {
-                    i18nKey = "Username";
+                    i18nKey = "username";
                 } else if (StringUtils.equals(attribute, EMAIL_CLAIM_URI )) {
                     i18nKey = "email";
                 } else if (StringUtils.equals(attribute, MOBILE_CLAIM_URI)) {
@@ -59,8 +59,9 @@
                 }
             }
             if (attributeList.size() > 0) {
+                String orString = AuthenticationEndpointUtil.i18n(resourceBundle, "or"); 
                 usernameLabel = String.join(", ", attributeList.subList(0, attributeList.size() - 1))
-                    + (attributeList.size() > 1 ? " or " : "")
+                    + (attributeList.size() > 1 ? " " + orString + " " : "")
                     + attributeList.get(attributeList.size() - 1);
             }
         return usernameLabel;


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-is/issues/20936

- The i18nKey variable is set to "Username" instead of "username". The username string does not get translated correctly due to this.
- The string "or" is defined directly without resolving it according to the specific locale. Both of these needs to be fixed.

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
