### PR TITLE
Handle passwords containing special characters when updating password via my account

### DIFF
--- a/.changeset/silly-rivers-compete.md
+++ b/.changeset/silly-rivers-compete.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Handle passwords containing special characters when updating password via my account.

--- a/apps/myaccount/src/api/change-password.ts
+++ b/apps/myaccount/src/api/change-password.ts
@@ -45,12 +45,16 @@ export const updatePassword = (currentPassword: string, newPassword: string): Pr
     // See https://github.com/asgardio/asgardio-js-oidc-sdk/issues/45 for progress.
     // httpRequest.disableHandler();
 
+    const username: string = [
+        store.getState().authenticationInformation?.profileInfo.userName,
+        "@",
+        store.getState().authenticationInformation.tenantDomain
+    ].join("");
+    // In case the password contains non-ascii characters, converting to valid ascii format.
+    const encoder: TextEncoder = new TextEncoder();
+    const encodedPassword: string = String.fromCharCode(...encoder.encode(currentPassword));
+
     const requestConfig: AxiosRequestConfig = {
-        auth: {
-            password: currentPassword,
-            username: [ store.getState().authenticationInformation?.profileInfo.userName, "@",
-                store.getState().authenticationInformation.tenantDomain ].join("")
-        },
         data: {
             Operations: [
                 {
@@ -63,6 +67,7 @@ export const updatePassword = (currentPassword: string, newPassword: string): Pr
             schemas: [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ]
         },
         headers: {
+            "Authorization": `Basic ${btoa(username + ":" + encodedPassword)}`,
             "Content-Type": "application/json"
         },
         method: HttpMethods.PATCH,


### PR DESCRIPTION
## Purpose
When updating the password through the My Account portal, the update request fails if the new password contains special characters from other languages (e.g., ç, æ, ô, £). This occurs due to incorrect encoding when constructing the Authorization header. This PR addresses the issue by correctly encoding these special characters.

### Related issue
- https://github.com/wso2/product-is/issues/20957

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
