### PR TITLE
Remove the implementation of showing the old QR code

### DIFF
--- a/.changeset/chatty-fishes-peel.md
+++ b/.changeset/chatty-fishes-peel.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": minor
+---
+
+Remove the implementation of showing the old qr code

--- a/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
+++ b/apps/myaccount/src/components/multi-factor-authentication/authenticators/totp-authenticator.tsx
@@ -684,7 +684,6 @@ export const TOTPAuthenticator: React.FunctionComponent<TOTPProps> = (
      * Render the totp QR code regenerate confirmation modal
      */
     const renderConfirmRegenerateModal = (): ReactElement => {
-        return (
             <Modal
                 data-testid={ `${testId}-regenerate-confirm-modal` }
                 size="small"


### PR DESCRIPTION
<!-- 
   READ THIS FIRST:
   - PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS.
   - PLEASE MAKE SURE TO ONLY ADD PUBLICLY ACCESSIBLE REFERENCES
-->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

**Previous UI**

<img width="468" alt="image" src="https://github.com/user-attachments/assets/27f2a4ee-33f3-4eee-a3da-035c65ba434b">

**New UI**

<img width="492" alt="image" src="https://github.com/user-attachments/assets/a86f0108-f502-4c8d-8172-0f08fa4cb83d">

With the new suggested change, we’ll be using refresh icon to generate the new qr code and won’t be showing the old qr code now. This behaviour is similar to backup code generation as well.

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
