### PR TITLE
Minor label name change in Actions UI

### DIFF
--- a/.changeset/shaggy-bags-invent.md
+++ b/.changeset/shaggy-bags-invent.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/i18n": patch
+---
+
+Minor label name change in action ui

--- a/modules/i18n/src/translations/en-US/portals/actions.ts
+++ b/modules/i18n/src/translations/en-US/portals/actions.ts
@@ -48,7 +48,7 @@ export const actions: actionsNS = {
                 " secrets of the external endpoint need to be updated.",
                 title: {
                     noneAuthType: "No authentication is configured.",
-                    otherAuthType: "<strong>{{ authType }}</strong> authentication type is configured."
+                    otherAuthType: "<strong>{{ authType }}</strong> authentication scheme is configured."
                 }
             },
             label: "Authentication",


### PR DESCRIPTION

### Purpose
This PR will modify the following label in Action UI.

before
<img width="783" alt="image" src="https://github.com/user-attachments/assets/1505ce4b-d759-461f-aa50-421e29c511dd">

after
<img width="795" alt="image" src="https://github.com/user-attachments/assets/e453e9d7-5a37-429d-a4f2-b3522ece36b7">


### Related Issues
<!-- Mention the issue/s related to the pull request. -->
- https://github.com/wso2/product-is/issues/20751

### Related PRs
<!-- Mention the related pull requests. -->
- https://github.com/wso2/identity-apps/pull/6845
