### PR TITLE
Fix secret show icon issue in Action UI

### DIFF
--- a/.changeset/fair-llamas-try.md
+++ b/.changeset/fair-llamas-try.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.actions.v1": patch
+---
+
+Fix secret show icon issue in action ui

--- a/features/admin.actions.v1/components/action-config-form.tsx
+++ b/features/admin.actions.v1/components/action-config-form.tsx
@@ -545,7 +545,7 @@ const ActionConfigForm: FunctionComponent<ActionConfigFormInterface> = ({
                                             required={ true }
                                             data-componentid={ `${ _componentId }-authentication-property-value` }
                                             name="valueAuthProperty"
-                                            type={ isShowSecret1 ? "text" : "password" }
+                                            type={ isShowSecret2 ? "text" : "password" }
                                             InputProps={ {
                                                 endAdornment: renderInputAdornmentOfSecret(
                                                     isShowSecret2,


### PR DESCRIPTION
### Purpose
- There was a minor bug in resolving show secret state in the value authentication secret box of API Key scheme in Actions UI.
- This PR will fix that issue.

### Related Issues
- https://github.com/wso2/product-is/issues/20751
