### PR TITLE
Fixed redirection issue in Go Back button in expired password reset error page

### DIFF
--- a/.changeset/yellow-rocks-destroy.md
+++ b/.changeset/yellow-rocks-destroy.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fixed redirection issue in Go Back button in expired password reset error page

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/error.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2016-2023, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2016-2024, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -44,6 +44,7 @@
     String errorMsg = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorMsg"));
     String errorCode = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorCode"));
     String invalidConfirmationErrorCode = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode();
+    String expiredConfirmationErrorCode = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_EXPIRED_CODE.getCode();
     String callback = request.getParameter("callback");
     boolean isValidCallback = true;
 
@@ -204,10 +205,11 @@
 
             var errorCodeFromParams = "<%=errorCode%>";
             var invalidConfirmationErrorCode = "<%=invalidConfirmationErrorCode%>";
+            var expiredConfirmationErrorCode = "<%=expiredConfirmationErrorCode%>";
 
-            // Check if the error is related to the confirmation code being invalid.
+            // Check if the error is related to the confirmation code being invalid or expired.
             // If so, navigate the users to the URL defined in `callback` URL param.
-            if (errorCodeFromParams === invalidConfirmationErrorCode) {
+            if (errorCodeFromParams === invalidConfirmationErrorCode || errorCodeFromParams === expiredConfirmationErrorCode) {
                 window.location.href = "<%=Encode.forHtmlAttribute(callback)%>";
 
                 return;


### PR DESCRIPTION
<!-- 
   READ THIS FIRST:
   - PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS.
   - PLEASE MAKE SURE TO ONLY ADD PUBLICLY ACCESSIBLE REFERENCES
-->

### Purpose

$subject

Fixes: https://github.com/wso2/product-is/issues/21060

### Goals

- The user is now redirected to the SP Callback URL/Login Page.

### Approach

- Check if the error is related to the confirmation code being expired.
- If so, navigate the users to the URL defined in `callback` URL param.

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
