### PR TITLE
Get cookie domain from proxy hostname if custom domain configured

### DIFF
--- a/.changeset/honest-zoos-behave.md
+++ b/.changeset/honest-zoos-behave.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+set proxy hostname as cookie domain when branded

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -23,6 +23,7 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="org.wso2.carbon.core.SameSiteCookie" %>
 <%@ page import="org.wso2.carbon.core.util.SignatureUtil" %>
+<%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
 <%@ page import="org.wso2.carbon.identity.mgt.constants.SelfRegistrationStatusCodes" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementServiceUtil" %>
@@ -358,7 +359,10 @@
             } else {
                 tenantAwareUsername = username + "@" + user.getTenantDomain();
             }
-            String cookieDomain = application.getInitParameter(AUTO_LOGIN_COOKIE_DOMAIN);
+            String domainName = application.getInitParameter(AUTO_LOGIN_COOKIE_DOMAIN);
+            String hostName = ServiceURLBuilder.create().build().getProxyHostName();
+            String cookieDomain = IdentityUtil.isSubdomain(domainName, hostName) ? domainName : hostName;
+
             JSONObject contentValueInJson = new JSONObject();
             contentValueInJson.put("username", tenantAwareUsername);
             contentValueInJson.put("createdTime", System.currentTimeMillis());


### PR DESCRIPTION
### Purpose
Get the cookie domain value from proxy hostname if custom domain has been configured. This is to resolve the cross-domain blocking issue when we use a static domain value even if custom domain has been configured.

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5941

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
