### PR TITLE
Set root domain of custom domain for ALOR cookie

### DIFF
--- a/.changeset/great-pears-applaud.md
+++ b/.changeset/great-pears-applaud.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+set root domain of proxy hostname in alor cookie

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -359,9 +359,8 @@
             } else {
                 tenantAwareUsername = username + "@" + user.getTenantDomain();
             }
-            String domainName = application.getInitParameter(AUTO_LOGIN_COOKIE_DOMAIN);
             String hostName = ServiceURLBuilder.create().build().getProxyHostName();
-            String cookieDomain = IdentityUtil.isSubdomain(domainName, hostName) ? domainName : hostName;
+            String cookieDomain = IdentityUtil.getRootDomain(hostName);
 
             JSONObject contentValueInJson = new JSONObject();
             contentValueInJson.put("username", tenantAwareUsername);


### PR DESCRIPTION
### Purpose
Set the root domain of proxy hostname in ALOR cookie. This is to resolve the cross-domain blocking issue when we use a static domain value even if custom domain has been configured.

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/5941
- https://github.com/wso2/carbon-identity-framework/pull/5944

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
