### PR TITLE
Rename "orgDiscovery" Param to "login_hint"

### DIFF
--- a/.changeset/hot-balloons-deny.md
+++ b/.changeset/hot-balloons-deny.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Rename "orgDiscovery" param to "login_hint"

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -108,7 +108,7 @@
                     <div class="field m-0 text-left required">
                         <label><%=AuthenticationEndpointUtil.i18n(resourceBundle, "organization.email")%></label>
                     </div>
-                    <input type="text" id='orgDiscovery' name="orgDiscovery" size='30'/>
+                    <input type="text" id='login_hint' name="login_hint" size='30'/>
 
                     <div class="mt-1" id="discoveryInputError" style="display: none;">
                         <i class="red exclamation circle fitted icon"></i>
@@ -171,7 +171,7 @@
 
       <script type="text/javascript">
          function enterOrgName() {
-            document.getElementById("orgDiscovery").disabled = true;
+            document.getElementById("login_hint").disabled = true;
             document.getElementById("org_form").submit();
          }
 
@@ -182,7 +182,7 @@
 
          function submitDiscovery() {
             // Show error message when discovery input is empty.
-            if (document.getElementById("orgDiscovery").value.length <= 0) {
+            if (document.getElementById("login_hint").value.length <= 0) {
                 showEmptyDiscoveryInputErrorMessage();
                 return;
             }


### PR DESCRIPTION
### Purpose
- Rename `orgDiscovery` param to `login_hint` in order to utilize a standard dialect.

### Related Issues
- https://github.com/wso2/product-is/issues/20953

### Related PRs
- https://github.com/wso2-extensions/identity-auth-organization-login/pull/45
- https://github.com/wso2-extensions/identity-auth-organization-login/pull/46
- https://github.com/wso2/identity-apps/pull/6805

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
