### PR TITLE
Fix issue for getting unauthorized for users without tenant association

### DIFF
--- a/.changeset/cold-parents-decide.md
+++ b/.changeset/cold-parents-decide.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix issue for getting unauthorized for users without tenant association

--- a/apps/console/src/hooks/use-routes.tsx
+++ b/apps/console/src/hooks/use-routes.tsx
@@ -42,6 +42,7 @@ import { getAppViewRoutes } from "../configs/routes";
 export type useRoutesInterface = {
     filterRoutes: (
         onRoutesFilterComplete: () => void,
+        isUserTenantless: boolean,
         isFirstLevelOrg?: boolean
     ) => void;
 };
@@ -67,11 +68,12 @@ const useRoutes = (): useRoutesInterface => {
      * Filter the routes based on the user roles and permissions.
      *
      * @param onRoutesFilterComplete - Callback to be called after the routes are filtered.
+     * @param isUserTenantless - Indicates whether the user have any associated tenant.
      * @param isFirstLevelOrg - Is the current organization the first level organization.
      *
      * @returns A promise containing void.
      */
-    const filterRoutes = async (onRoutesFilterComplete: () => void): Promise<void> => {
+    const filterRoutes = async (onRoutesFilterComplete: () => void, isUserTenantless: boolean): Promise<void> => {
         if (
             isEmpty(allowedScopes) ||
             !featureConfig.applications ||
@@ -154,7 +156,7 @@ const useRoutes = (): useRoutesInterface => {
             dispatch(setDeveloperVisibility(false));
         }
 
-        if (sanitizedAppRoutes.length < 1) {
+        if (sanitizedAppRoutes.length < 1 && !isUserTenantless) {
             history.push({
                 pathname: AppConstants.getPaths().get("UNAUTHORIZED"),
                 search:

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -117,7 +117,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
 
     const [ renderApp, setRenderApp ] = useState<boolean>(false);
     const [ routesFiltered, setRoutesFiltered ] = useState<boolean>(false);
-    const [ isRedirectingToTenantCreation, setRedirectingToTenantCreation ] = useState<boolean>(false);
+    const [ isUserTenantless, setIsUserTenantless ] = useState(undefined);
 
     useEffect(() => {
         dispatch(
@@ -231,11 +231,11 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                                 idToken.sub))
                         ? AppConstants.getAppHomePath()
                         : AuthenticationCallbackUrl;
-
+                setIsUserTenantless(false);
                 history.push(location);
             } else {
-                // If there is no assocation, the user should be redirected to creation flow.
-                setRedirectingToTenantCreation(true);
+                // If there is no association, the user should be redirected to creation flow.
+                setIsUserTenantless(true);
                 history.push({
                     pathname: AppConstants.getPaths().get(
                         "CREATE_TENANT"
@@ -350,12 +350,12 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
     }, [ state.isAuthenticated ]);
 
     useEffect(() => {
-        if (!state.isAuthenticated || isRedirectingToTenantCreation) {
+        if (!state.isAuthenticated || isUserTenantless === undefined) {
             return;
         }
 
-        filterRoutes(() => setRoutesFiltered(true), isFirstLevelOrg);
-    }, [ filterRoutes, state.isAuthenticated, isFirstLevelOrg, isRedirectingToTenantCreation ]);
+        filterRoutes(() => setRoutesFiltered(true), isUserTenantless, isFirstLevelOrg);
+    }, [ filterRoutes, state.isAuthenticated, isFirstLevelOrg, isUserTenantless ]);
 
     return (
         <SecureApp

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -231,6 +231,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
                                 idToken.sub))
                         ? AppConstants.getAppHomePath()
                         : AuthenticationCallbackUrl;
+
                 setIsUserTenantless(false);
                 history.push(location);
             } else {

--- a/apps/console/src/protected-app.tsx
+++ b/apps/console/src/protected-app.tsx
@@ -351,7 +351,7 @@ export const ProtectedApp: FunctionComponent<AppPropsInterface> = (): ReactEleme
     }, [ state.isAuthenticated ]);
 
     useEffect(() => {
-        if (!state.isAuthenticated || isUserTenantless === undefined) {
+        if (!state.isAuthenticated) {
             return;
         }
 


### PR DESCRIPTION
### Purpose
- $Subject

### Related PRs
- https://github.com/wso2/identity-apps/pull/6687

### Flows to be tested 

#### Asgardeo:

- [x] - Privileged user login to console - should successfully log in.
- [x] - Invited admin (alex) login to console - should successfully log in.
- [x] - Invited admin (alex) trying to login to console after privileged user removes the invited admin from the administrator role - should be redirected to the tenant creation page and should be able to create a new organization.
Note : Copy the console URL of the newly created organization.
- [x] - Privileged user trying to login to console of the newly created organization by the invited admin (alex) - should be redirected to the unauthorized page.
- [x] - Consumer user login to console - should display a login failed message on the login page.

#### Identity Server:

- [x] - Super admin login to console - should successfully log in.
- [x] - Invited admin login to console - should successfully log in.
- [x] - Sub-organization admin login to console - should successfully log in.

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
