### PR TITLE
Hide application enable/disable element for sub-org Myaccount

### DIFF
--- a/.changeset/pink-cheetahs-tie.md
+++ b/.changeset/pink-cheetahs-tie.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Hide application enable/disable element for sub-org Myaccount

--- a/features/admin.applications.v1/components/edit-application.tsx
+++ b/features/admin.applications.v1/components/edit-application.tsx
@@ -462,7 +462,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                         />
                     </DangerZoneGroup>
                 </Show>
-            )}
+            ) }
             <ConfirmationModal
                 onClose={ (): void => setShowDisableConfirmationModal(false) }
                 type="warning"

--- a/features/admin.applications.v1/components/edit-application.tsx
+++ b/features/admin.applications.v1/components/edit-application.tsx
@@ -438,29 +438,31 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 <MyAccountOverview/>
             </ResourceTab.Pane>
             <Divider hidden />
-            <Show
-                when={ applicationsUpdateScopes }
-            >
-                <DangerZoneGroup
-                    sectionHeader={ t("applications:dangerZoneGroup.header") }
+            { !isSubOrganization() && (
+                <Show
+                    when={ applicationsUpdateScopes }
                 >
-                    <DangerZone
-                        actionTitle={ t("applications:dangerZoneGroup.disableApplication.actionTitle",
-                            { state: application.applicationEnabled ? t("common:disable") : t("common:enable") }) }
-                        header={ t("applications:dangerZoneGroup.disableApplication.header",
-                            { state: application.applicationEnabled ? t("common:disable") : t("common:enable") } ) }
-                        subheader={ application.applicationEnabled
-                            ? t("applications:dangerZoneGroup.disableApplication.subheader")
-                            : t("applications:dangerZoneGroup.disableApplication.subheader2") }
-                        onActionClick={ undefined }
-                        toggle={ {
-                            checked: application.applicationEnabled,
-                            onChange: handleAppEnableDisableToggleChange
-                        } }
-                        data-testid={ `${ componentId }-danger-zone-disable` }
-                    />
-                </DangerZoneGroup>
-            </Show>
+                    <DangerZoneGroup
+                        sectionHeader={ t("applications:dangerZoneGroup.header") }
+                    >
+                        <DangerZone
+                            actionTitle={ t("applications:dangerZoneGroup.disableApplication.actionTitle",
+                                { state: application.applicationEnabled ? t("common:disable") : t("common:enable") }) }
+                            header={ t("applications:dangerZoneGroup.disableApplication.header",
+                                { state: application.applicationEnabled ? t("common:disable") : t("common:enable") } ) }
+                            subheader={ application.applicationEnabled
+                                ? t("applications:dangerZoneGroup.disableApplication.subheader")
+                                : t("applications:dangerZoneGroup.disableApplication.subheader2") }
+                            onActionClick={ undefined }
+                            toggle={ {
+                                checked: application.applicationEnabled,
+                                onChange: handleAppEnableDisableToggleChange
+                            } }
+                            data-testid={ `${ componentId }-danger-zone-disable` }
+                        />
+                    </DangerZoneGroup>
+                </Show>
+            )}
             <ConfirmationModal
                 onClose={ (): void => setShowDisableConfirmationModal(false) }
                 type="warning"


### PR DESCRIPTION
<!-- 
   READ THIS FIRST:
   - PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS.
   - PLEASE MAKE SURE TO ONLY ADD PUBLICLY ACCESSIBLE REFERENCES
-->

### Purpose
$subject

After the fix root org Myaccount shows the application enable/disable element and suborg Myaccount doesn't show that element. Sub-org myaccount application enable status is inherited from the root org.

**Root org**
![Screenshot from 2024-09-24 11-29-54](https://github.com/user-attachments/assets/068be96b-89a7-4993-833b-e5c3aff4dcb8)

**Sub-org**

![Screenshot from 2024-09-24 11-29-05](https://github.com/user-attachments/assets/f283e160-1da5-4998-8bd0-f0f5139b442f)

### Related Issues
<!-- Mention the issue/s related to the pull request. -->
https://github.com/wso2/product-is/issues/21149

### Related PRs
<!-- Mention the related pull requests. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
