### PR TITLE
Validate API key header field in Pre-Issue Access Token action

### DIFF
--- a/.changeset/chilly-rules-camp.md
+++ b/.changeset/chilly-rules-camp.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.actions.v1": patch
+"@wso2is/i18n": patch
+---
+
+Validate API key header field in Pre-Issue Access Token action

--- a/features/admin.actions.v1/components/action-config-form.tsx
+++ b/features/admin.actions.v1/components/action-config-form.tsx
@@ -220,6 +220,8 @@ const ActionConfigForm: FunctionComponent<ActionConfigFormInterface> = ({
             error.authenticationType = t("actions:fields.authenticationType.validations.empty");
         }
 
+        const apiKeyHeaderRegex: RegExp = /^[a-zA-Z0-9-.]+$/;
+
         switch (authenticationType) {
             case AuthenticationType.BASIC:
                 if(isCreateFormState || isAuthenticationUpdateFormState ||
@@ -250,6 +252,10 @@ const ActionConfigForm: FunctionComponent<ActionConfigFormInterface> = ({
                     if (!values?.headerAuthProperty) {
                         error.headerAuthProperty = t("actions:fields.authentication." +
                             "types.apiKey.properties.header.validations.empty");
+                    }
+                    if (!apiKeyHeaderRegex.test(values?.headerAuthProperty)) {
+                        error.headerAuthProperty = t("actions:fields.authentication." +
+                            "types.apiKey.properties.header.validations.invalid");
                     }
                     if (!values?.valueAuthProperty) {
                         error.valueAuthProperty = t("actions:fields.authentication." +
@@ -529,6 +535,12 @@ const ActionConfigForm: FunctionComponent<ActionConfigFormInterface> = ({
                                                 ".types.apiKey.properties.header.label") }
                                             placeholder={ t("actions:fields.authentication" +
                                                 ".types.apiKey.properties.header.placeholder") }
+                                            helperText={ (
+                                                <Hint className="hint" compact>
+                                                    { t("actions:fields.authentication" +
+                                                        ".types.apiKey.properties.header.hint") }
+                                                </Hint>
+                                            ) }
                                             component={ TextFieldAdapter }
                                             maxLength={ 100 }
                                             minLength={ 0 }

--- a/modules/i18n/src/models/namespaces/actions-ns.ts
+++ b/modules/i18n/src/models/namespaces/actions-ns.ts
@@ -52,10 +52,12 @@ export interface actionsNS {
                     name: string;
                     properties: {
                         header: {
+                            hint: string;
                             label: string;
                             placeholder: string;
                             validations: {
                                 empty: string
+                                invalid: string
                             };
                         };
                         value: {

--- a/modules/i18n/src/translations/en-US/portals/actions.ts
+++ b/modules/i18n/src/translations/en-US/portals/actions.ts
@@ -63,7 +63,7 @@ export const actions: actionsNS = {
                             placeholder: "Header",
                             validations: {
                                 empty: "Header is a required field.",
-                                invalid: "Please choose a valid name that adheres to the given guidelines."
+                                invalid: "Please choose a valid header name that adheres to the given guidelines."
                             }
                         },
                         value: {

--- a/modules/i18n/src/translations/en-US/portals/actions.ts
+++ b/modules/i18n/src/translations/en-US/portals/actions.ts
@@ -57,10 +57,13 @@ export const actions: actionsNS = {
                     name: "API Key",
                     properties: {
                         header: {
+                            hint: "Must be a string containing only letters (a-z, A-Z), numbers (0-9), " +
+                            "period (.) and hyphen (-).",
                             label: "Header",
                             placeholder: "Header",
                             validations: {
-                                empty: "Header is a required field."
+                                empty: "Header is a required field.",
+                                invalid: "Please choose a valid name that adheres to the given guidelines."
                             }
                         },
                         value: {


### PR DESCRIPTION
### Purpose
This PR adds input validation to the header field in the API Key Authentication scheme under the Pre-Issue Access Token action.

<img width="808" alt="image" src="https://github.com/user-attachments/assets/a0205f2b-6fa7-4d27-804a-808106e9fbf0">


### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/26436 

### Related PRs
- https://github.com/wso2/identity-apps/pull/6722

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
