### PR TITLE
Improve the API key header field regex in the Pre-Issue Access Token action

### DIFF
--- a/.changeset/fuzzy-pots-join.md
+++ b/.changeset/fuzzy-pots-join.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.actions.v1": patch
+"@wso2is/i18n": patch
+---
+
+Improve header field regex

--- a/features/admin.actions.v1/components/action-config-form.tsx
+++ b/features/admin.actions.v1/components/action-config-form.tsx
@@ -220,7 +220,7 @@ const ActionConfigForm: FunctionComponent<ActionConfigFormInterface> = ({
             error.authenticationType = t("actions:fields.authenticationType.validations.empty");
         }
 
-        const apiKeyHeaderRegex: RegExp = /^[a-zA-Z0-9-.]+$/;
+        const apiKeyHeaderRegex: RegExp = /^[a-zA-Z0-9][a-zA-Z0-9-.]+$/;
 
         switch (authenticationType) {
             case AuthenticationType.BASIC:

--- a/modules/i18n/src/translations/en-US/portals/actions.ts
+++ b/modules/i18n/src/translations/en-US/portals/actions.ts
@@ -58,7 +58,7 @@ export const actions: actionsNS = {
                     properties: {
                         header: {
                             hint: "Must be a string containing only letters (a-z, A-Z), numbers (0-9), " +
-                            "period (.) and hyphen (-).",
+                            "period (.) and hyphen (-), and should start with an alphanumeric character.",
                             label: "Header",
                             placeholder: "Header",
                             validations: {


### PR DESCRIPTION
### Purpose
This PR improved the regex of the API key header field in the pre-issue access token action. This further refines the hint associated with the above text field to comply with the updated regex.

<img width="822" alt="image" src="https://github.com/user-attachments/assets/1fc60e81-7d87-4f47-9636-699daa019cb2">

### Related PRs
- https://github.com/wso2/identity-apps/pull/6926

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
