### PR TITLE
Fix email templates not updating branding preferences when reverted

### DIFF
--- a/.changeset/proud-news-obey.md
+++ b/.changeset/proud-news-obey.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.branding.v1": patch
+---
+
+Fix email templates not updating branding preferences when reverted

--- a/features/admin.branding.v1/providers/branding-preference-provider.tsx
+++ b/features/admin.branding.v1/providers/branding-preference-provider.tsx
@@ -252,7 +252,8 @@ const BrandingPreferenceProvider: FunctionComponent<BrandingPreferenceProviderPr
      * Moderates the Branding Peference response.
      */
     useEffect(() => {
-        if (!originalBrandingPreference) {
+        if (!originalBrandingPreference || brandingPreferenceFetchRequestError?.response?.data?.code
+            === BrandingPreferencesConstants.BRANDING_NOT_CONFIGURED_ERROR_CODE) {
             return;
         }
 


### PR DESCRIPTION
<!-- 
   READ THIS FIRST:
   - PLEASE NOTE THAT IT'S MANDATORY TO FILL IN THE PULL REQUEST TEMPLATE WHEN SUBMITTING PULL REQUESTS.
   - PLEASE MAKE SURE TO ONLY ADD PUBLICLY ACCESSIBLE REFERENCES
-->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
$subject

### Related Issues
<!-- Mention the issue/s related to the pull request. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
