### PR TITLE
Improve case in sensitive attribute toggle

### DIFF
--- a/.changeset/giant-garlics-repeat.md
+++ b/.changeset/giant-garlics-repeat.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Improve case insensitive user attribute handling toggle

--- a/features/admin.userstores.v1/components/edit/edit-user-details-userstore.tsx
+++ b/features/admin.userstores.v1/components/edit/edit-user-details-userstore.tsx
@@ -483,7 +483,11 @@ export const EditUserDetails: FunctionComponent<EditUserDetailsPropsInterface> =
                                                         ? (
                                                             <Field
                                                                 name={ property.name }
-                                                                value={ property.value ?? property.defaultValue }
+                                                                value={ !property.value
+                                                                    ? property.defaultValue
+                                                                    : property.value === "false"
+                                                                        ? "false"
+                                                                        : "true" }
                                                                 type="toggle"
                                                                 key={ index }
                                                                 required={ false }


### PR DESCRIPTION
$subject

The logic for handling the toggle is changed to treat false if it is set to false or if it is empty set the default value. For all the other cases it is treated as true.

### Related Issues
- https://github.com/wso2/product-is/issues/21251
