### PR TITLE
Hide multi emails and mobiles per user feature specific claims in self-register page

### DIFF
--- a/.changeset/plenty-deers-serve.md
+++ b/.changeset/plenty-deers-serve.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Hide multi emails and mobiles per user feature specific attributes from self-registration page

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -986,6 +986,10 @@
                                                 !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/groups") &&
                                                 !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/role") &&
                                                 !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/url") &&
+                                                !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/emailAddresses") &&
+                                                !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/verifiedEmailAddresses") &&
+                                                !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/mobileNumbers") &&
+                                                !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/verifiedMobileNumbers") &&
                                                 !(claim.getReadOnly() != null ? claim.getReadOnly() : false)) {
                                             String claimURI = claim.getUri();
                                             String claimValue = request.getParameter(claimURI);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -580,6 +580,10 @@
                                                 !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/groups") &&
                                                 !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/role") &&
                                                 !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/url") &&
+                                                !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/emailAddresses") &&
+                                                !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/verifiedEmailAddresses") &&
+                                                !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/mobileNumbers") &&
+                                                !StringUtils.equals(claim.getUri(), "http://wso2.org/claims/verifiedMobileNumbers") &&
                                                 !(claim.getReadOnly() != null ? claim.getReadOnly() : false)) {
                                             String claimURI = claim.getUri();
                                             String claimValue = request.getParameter(claimURI);


### PR DESCRIPTION
Hide newly introduced following claims from Self registration page.
- `http://wso2.org/claims/emailAddresses`
- `http://wso2.org/claims/verifiedEmailAddresses`
- `http://wso2.org/claims/mobileNumbers`
-  `http://wso2.org/claims/verifiedMobileNumbers`

Previous:
![before](https://github.com/user-attachments/assets/ad96a264-a088-4422-89c5-51c6a5934888)

After Fix:
![after](https://github.com/user-attachments/assets/a96d1ba9-6ef0-44a0-9628-16dd1909bb6a)

### Related Issues

### Related PRs
- https://github.com/wso2/identity-apps/pull/6931