### PR TITLE
Fix not being able to set first name and last name to empty in user profile

### DIFF
--- a/.changeset/fair-months-whisper.md
+++ b/.changeset/fair-months-whisper.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.users.v1": patch
+---
+
+Fix not being able to set first name and last name to empty in user profile

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -814,11 +814,12 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                     };
                                 } else if (schemaNames[0] === UserManagementConstants.SCIM2_SCHEMA_DICTIONARY
                                     .get("NAME")) {
-                                    values.get(schema.name) && (
+
+                                    if (!values.get(schema.name) || values.get(schema.name) === "") {
                                         opValue = {
                                             name: { [schemaNames[1]]: values.get(schema.name) }
-                                        }
-                                    );
+                                        };
+                                    }
                                 } else {
                                     if (schemaNames[0].includes("addresses")) {
                                         if (schemaNames[0].split("#").length > 1) {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
