### PR TITLE
Fix default selected user store being set to undefined in role assign view

### DIFF
--- a/.changeset/smooth-pants-hear.md
+++ b/.changeset/smooth-pants-hear.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.roles.v2": patch
+---
+
+Fix default selected user store being set to undefined in role assign view

--- a/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
+++ b/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
@@ -128,11 +128,14 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
         const userNameChunks: string[] = user.userName.split("/");
 
         return (userNameChunks.length === 1 && userStoreName === "PRIMARY")
-        || (userNameChunks.length === 2 && userNameChunks[0] === userStoreName.toUpperCase());
+        || (userNameChunks.length === 2 && userNameChunks[0] === userStoreName?.toUpperCase());
     };
 
     useEffect(() => {
-        setSelectedUserStoreDomainName(activeUserStore);
+        const defaultSelectedUserStore: string = activeUserStore ??
+            disabledUserstores.includes(RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME) ? "DEFAULT" : "PRIMARY"
+
+        setSelectedUserStoreDomainName(defaultSelectedUserStore);
     }, [ activeUserStore ]);
 
     useEffect(() => {

--- a/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
+++ b/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
@@ -133,7 +133,7 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
 
     useEffect(() => {
         const defaultSelectedUserStore: string = activeUserStore ??
-            disabledUserstores.includes(RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME) ? "DEFAULT" : "PRIMARY"
+            disabledUserstores.includes(RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME) ? "DEFAULT" : "PRIMARY";
 
         setSelectedUserStoreDomainName(defaultSelectedUserStore);
     }, [ activeUserStore ]);


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
