### PR TITLE
Add excludeSystemPortals param to applications get request

### DIFF
--- a/.changeset/brave-weeks-serve.md
+++ b/.changeset/brave-weeks-serve.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/features": patch
+---
+
+Add excludeSystemPortals param to applications get request.

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -213,8 +213,12 @@ export const updateApplicationDetails = (
  *
  * @returns A promise containing the response.
  */
-export const getApplicationList = (limit: number, offset: number,
-    filter: string): Promise<ApplicationListInterface> => {
+export const getApplicationList = (
+    limit: number,
+    offset: number,
+    filter: string,
+    excludeSystemPortals:boolean = true
+): Promise<ApplicationListInterface> => {
     const requestConfig: AxiosRequestConfig = {
         headers: {
             "Accept": "application/json",
@@ -225,7 +229,8 @@ export const getApplicationList = (limit: number, offset: number,
         params: {
             filter,
             limit,
-            offset
+            offset,
+            excludeSystemPortals
         },
         url: store.getState().config.endpoints.applications
     };
@@ -255,7 +260,8 @@ export const useApplicationList = <Data = ApplicationListInterface, Error = Requ
     limit?: number,
     offset?: number,
     filter?: string,
-    shouldFetch: boolean = true
+    shouldFetch: boolean = true,
+    excludeSystemPortals: boolean = true
 ): RequestResultInterface<Data, Error> => {
 
     const requestConfig: AxiosRequestConfig = shouldFetch
@@ -269,7 +275,8 @@ export const useApplicationList = <Data = ApplicationListInterface, Error = Requ
                 attributes,
                 filter,
                 limit,
-                offset
+                offset,
+                excludeSystemPortals
             },
             url: store.getState().config.endpoints.applications
         }

--- a/features/admin.applications.v1/api/application.ts
+++ b/features/admin.applications.v1/api/application.ts
@@ -227,10 +227,10 @@ export const getApplicationList = (
         },
         method: HttpMethods.GET,
         params: {
+            excludeSystemPortals,
             filter,
             limit,
-            offset,
-            excludeSystemPortals
+            offset
         },
         url: store.getState().config.endpoints.applications
     };
@@ -273,10 +273,10 @@ export const useApplicationList = <Data = ApplicationListInterface, Error = Requ
             method: HttpMethods.GET,
             params: {
                 attributes,
+                excludeSystemPortals,
                 filter,
                 limit,
-                offset,
-                excludeSystemPortals
+                offset
             },
             url: store.getState().config.endpoints.applications
         }

--- a/features/admin.applications.v1/pages/applications.tsx
+++ b/features/admin.applications.v1/pages/applications.tsx
@@ -309,14 +309,6 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
         if (applicationList?.applications) {
             const appList: ApplicationListInterface = cloneDeep(applicationList);
 
-            // Remove the system apps from the application list.
-            if (!UIConfig?.legacyMode?.applicationListSystemApps) {
-                appList.applications = appList.applications.filter((item: ApplicationListItemInterface) =>
-                    !ApplicationManagementConstants.SYSTEM_APPS.includes(item.name)
-                    && !ApplicationManagementConstants.DEFAULT_APPS.includes(item.name)
-                );
-            }
-
             appList.count = appList.count - (applicationList.applications.length - appList.applications.length);
             appList.totalResults = appList.totalResults -
                 (applicationList.applications.length - appList.applications.length);


### PR DESCRIPTION
Add excludeSystemPortals parameter for get all applications query. This will exclude system portals defined in the server wide config [1] in applications get call if the parameter is set for true. 


[1] https://github.com/wso2/carbon-identity-framework/blob/da79dc6ebb25359ab3177140df501dc899b41172/features/identity-core/org.wso2.carbon.identity.core.server.feature/resources/identity.xml.j2#L4031