### PR TITLE
Handle username existence and non-existence similarly

### DIFF
--- a/.changeset/mean-cats-tell.md
+++ b/.changeset/mean-cats-tell.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.server-configurations.v1": patch
+"@wso2is/identity-apps-core": patch
+---
+
+handle username existence to prevent enumeration

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -3221,6 +3221,7 @@ export interface Extensions {
                             expiryTime: FormAttributes;
                             signUpConfirmation: FormAttributes;
                             activateImmediately: FormAttributes;
+                            handleExistingUsername: FormAttributes;
                             enable: FormAttributes;
                         };
                     };

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -3221,7 +3221,7 @@ export interface Extensions {
                             expiryTime: FormAttributes;
                             signUpConfirmation: FormAttributes;
                             activateImmediately: FormAttributes;
-                            handleExistingUsername: FormAttributes;
+                            showUsernameUnavailability: FormAttributes;
                             enable: FormAttributes;
                         };
                     };

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -3969,6 +3969,11 @@ export const extensions: Extensions = {
                                 hint: "This will enable email verification at the self-registration.",
                                 label: "Activate account immediately"
                             },
+                            handleExistingUsername: {
+                                msg: "If selected, both existing and non-existing usernames will be treated the same way, preventing username enumeration.",
+                                hint: "This will enable existing and non-existing usernames to be handled the same way at the self-registration.",
+                                label: "Handle existing username"
+                            },
                             signUpConfirmation: {
                                 recommendationMsg:
                                     "It is recommended to enable account verification for " + "self registration.",

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -3969,10 +3969,10 @@ export const extensions: Extensions = {
                                 hint: "This will enable email verification at the self-registration.",
                                 label: "Activate account immediately"
                             },
-                            handleExistingUsername: {
-                                msg: "If selected, both existing and non-existing usernames will be treated the same way, preventing username enumeration.",
-                                hint: "This will enable existing and non-existing usernames to be handled the same way at the self-registration.",
-                                label: "Handle existing username"
+                            showUsernameUnavailability: {
+                                msg: "If selected, a descriptive error message will be shown to the user if the username is already taken. However, this may lead to username enumeration.",
+                                hint: "This will enable a descriptive error message to be displayed when the username is unavailable at the self-registration.",
+                                label: "Show username unavailability"
                             },
                             signUpConfirmation: {
                                 recommendationMsg:

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -75,7 +75,7 @@
     PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
     Boolean isAutoLoginEnable = preferenceRetrievalClient.checkAutoLoginAfterSelfRegistrationEnabled(tenantDomain);
     Boolean isSelfRegistrationLockOnCreationEnabled = preferenceRetrievalClient.checkSelfRegistrationLockOnCreation(tenantDomain);
-    Boolean isHandleExistingUsernameEnabled = preferenceRetrievalClient.checkSelfRegistrationHandleExistingUsername(tenantDomain);
+    Boolean isShowUsernameUnavailabilityEnabled = preferenceRetrievalClient.checkSelfRegistrationShowUsernameUnavailability(tenantDomain);
     Boolean isAccountVerificationEnabled = preferenceRetrievalClient.checkSelfRegistrationSendConfirmationOnCreation(tenantDomain);
 
     boolean isSelfRegistrationWithVerification =
@@ -415,7 +415,7 @@
             }
             request.getRequestDispatcher("register.do").forward(request, response);
             return;
-        } else if (isAccountVerificationEnabled && isHandleExistingUsernameEnabled && usernameAlreadyExistsErrorCode.equals(errorCode)) {
+        } else if (isAccountVerificationEnabled && !isShowUsernameUnavailabilityEnabled && usernameAlreadyExistsErrorCode.equals(errorCode)) {
             request.setAttribute("callback", callback);
             if (StringUtils.isNotBlank(srtenantDomain)) {
                 request.setAttribute("srtenantDomain", srtenantDomain);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -68,12 +68,15 @@
     String SELF_REGISTRATION_WITHOUT_VERIFICATION_PAGE = "* self-registration-without-verification.jsp";
     String passwordPatternErrorCode = "20035";
     String usernamePatternErrorCode = "20045";
+    String usernameAlreadyExistsErrorCode = "20030";
     String AUTO_LOGIN_COOKIE_NAME = "ALOR";
     String AUTO_LOGIN_COOKIE_DOMAIN = "AutoLoginCookieDomain";
     String AUTO_LOGIN_FLOW_TYPE = "SIGNUP";
     PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
     Boolean isAutoLoginEnable = preferenceRetrievalClient.checkAutoLoginAfterSelfRegistrationEnabled(tenantDomain);
     Boolean isSelfRegistrationLockOnCreationEnabled = preferenceRetrievalClient.checkSelfRegistrationLockOnCreation(tenantDomain);
+    Boolean isHandleExistingUsernameEnabled = preferenceRetrievalClient.checkSelfRegistrationHandleExistingUsername(tenantDomain);
+    Boolean isAccountVerificationEnabled = preferenceRetrievalClient.checkSelfRegistrationSendConfirmationOnCreation(tenantDomain);
 
     boolean isSelfRegistrationWithVerification =
             Boolean.parseBoolean(request.getParameter("isSelfRegistrationWithVerification"));
@@ -412,6 +415,13 @@
             }
             request.getRequestDispatcher("register.do").forward(request, response);
             return;
+        } else if (isAccountVerificationEnabled && isHandleExistingUsernameEnabled && usernameAlreadyExistsErrorCode.equals(errorCode)) {
+            request.setAttribute("callback", callback);
+            if (StringUtils.isNotBlank(srtenantDomain)) {
+                request.setAttribute("srtenantDomain", srtenantDomain);
+            }
+            request.setAttribute("sessionDataKey", sessionDataKey);
+            request.getRequestDispatcher("self-registration-complete.jsp").forward(request, response);
         } else {
             if (!StringUtils.isBlank(username)) {
                 request.setAttribute("username", username);


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Add option to handle username existence and non-existence in the same way when account verification is enabled. The option `Show username unavailability` is added.

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/870
- https://github.com/wso2/carbon-identity-framework/pull/6046

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
