### PR TITLE
Fix issues with passing custom `onChange` to `TextFieldAdapter`

### DIFF
--- a/.changeset/tame-taxis-kick.md
+++ b/.changeset/tame-taxis-kick.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/form": patch
+---
+
+Fix issues with passing custom `onChange` to `TextFieldAdapter`

--- a/modules/form/src/components/adapters/text-field-adapter.tsx
+++ b/modules/form/src/components/adapters/text-field-adapter.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,7 +19,7 @@
 import { FormControlProps } from "@oxygen-ui/react/FormControl";
 import FormHelperText from "@oxygen-ui/react/FormHelperText";
 import TextField from "@oxygen-ui/react/TextField";
-import React, { FunctionComponent, ReactElement } from "react";
+import React, { ChangeEvent, FunctionComponent, ReactElement } from "react";
 import { FieldRenderProps } from "react-final-form";
 import "./text-field-adapter.scss";
 
@@ -60,6 +60,7 @@ const TextFieldAdapter: FunctionComponent<TextFieldAdapterPropsInterface> = (
         required,
         readOnly,
         endAdornment,
+        onChange,
         ...rest
     } = props;
 
@@ -75,6 +76,10 @@ const TextFieldAdapter: FunctionComponent<TextFieldAdapterPropsInterface> = (
                 margin="dense"
                 { ...FormControlProps }
                 { ...input }
+                onChange={ (e: ChangeEvent<HTMLInputElement>) => {
+                    input.onChange((e?.target as any)?.value as string);
+                    onChange(e as any);
+                } }
                 // TODO: Remove this once the `required` prop is supported by the Oxygen UI TextField component.
                 InputLabelProps={ {
                     required


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
- Fix passed custom onChange callback wasn't firing properly.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
