### PR TITLE
Bug fixes and improvements to the console settings page

### DIFF
--- a/.changeset/great-queens-mate.md
+++ b/.changeset/great-queens-mate.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.roles.v2": patch
+---
+
+Reuse the business logic for determining available userstores user assign view in individual roles

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-list.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-list.tsx
@@ -178,7 +178,7 @@ const AdministratorsList: FunctionComponent<AdministratorsListProps> = (
     useEffect(() => {
         setSelectedUserStore(
             isPrivilegedUsersInConsoleSettingsEnabled && selectedAdministratorGroup === "administrators"
-                ? undefined
+                ? PRIMARY_USERSTORE
                 : userstoresConfig?.primaryUserstoreName
         );
     },[ isPrivilegedUsersInConsoleSettingsEnabled, selectedAdministratorGroup ]);

--- a/features/admin.console-settings.v1/components/console-roles/console-roles-edit/console-roles-edit.tsx
+++ b/features/admin.console-settings.v1/components/console-roles/console-roles-edit/console-roles-edit.tsx
@@ -218,7 +218,11 @@ const ConsoleRolesEdit: FunctionComponent<ConsoleRolesEditPropsInterface> = (
                             isReadOnly={ !hasRolesUpdatePermissions }
                             role={ roleObject }
                             onRoleUpdate={ onRoleUpdate }
-                            activeUserStore={ isPrivilegedUsersInConsoleSettingsEnabled ? activeUserStore : null }
+                            activeUserStore={
+                                isPrivilegedUsersInConsoleSettingsEnabled && isFirstLevelOrganization()
+                                    ? activeUserStore
+                                    : null
+                            }
                             tabIndex={ 3 }
                         />
                     </ResourceTab.Pane>

--- a/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
+++ b/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
@@ -195,34 +195,6 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
         setSelectedUsersFromUserStore(usersFromSelectedStore);
     },[ role, selectedUserStoreDomainName ]);
 
-    // useEffect(() => {
-    //     if (!userStores) {
-    //         return;
-    //     }
-
-    //     if (userStores) {
-    //         const availableUserStoreList: UserstoreDisplayItem[] = disabledUserstores?.includes(
-    //             RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME)
-    //             ? []
-    //             : [
-    //                 {
-    //                     id: RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME,
-    //                     name: t("users:userstores.userstoreOptions.primary")
-    //                 }
-    //             ];
-
-    //         setAvailableUserStores(
-    //             [
-    //                 ...availableUserStoreList,
-    //                 ...userStores.map((userStore: UserStoreListItem) => ({
-    //                     id: userStore.id,
-    //                     name: userStore.name
-    //                 }))
-    //             ]
-    //         );
-    //     }
-    // }, [ userStores ]);
-
     /**
      * Set available to select users.
      */

--- a/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
+++ b/features/admin.roles.v2/components/edit-role/edit-role-users.tsx
@@ -29,10 +29,8 @@ import Select from "@oxygen-ui/react/Select";
 import TextField from "@oxygen-ui/react/TextField";
 import { updateResources } from "@wso2is/admin.core.v1/api/bulk-operations";
 import { getEmptyPlaceholderIllustrations } from "@wso2is/admin.core.v1/configs/ui";
-import { AppState } from "@wso2is/admin.core.v1/store";
 import { userstoresConfig } from "@wso2is/admin.extensions.v1/configs/userstores";
 import { GroupsInterface } from "@wso2is/admin.groups.v1/models/groups";
-import { RemoteUserStoreConstants } from "@wso2is/admin.remote-userstores.v1/constants/remote-user-stores";
 import { useUsersList } from "@wso2is/admin.users.v1/api";
 import {
     PatchBulkUserDataInterface,
@@ -41,8 +39,10 @@ import {
     PatchUserRemoveOpInterface,
     UserBasicInterface
 } from "@wso2is/admin.users.v1/models";
-import { useUserStores } from "@wso2is/admin.userstores.v1/api";
-import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-stores";
+import { getAUserStore, useUserStores } from "@wso2is/admin.userstores.v1/api";
+import {
+    UserStoreDropdownItem, UserStoreListItem, UserStorePostData, UserStoreProperty
+} from "@wso2is/admin.userstores.v1/models/user-stores";
 import { AlertLevels, IdentifiableComponentInterface, RolesMemberInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EmphasizedSegment, EmptyPlaceholder, Heading, PrimaryButton } from "@wso2is/react-components";
@@ -59,7 +59,7 @@ import React, {
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { Icon } from "semantic-ui-react";
 import { AutoCompleteRenderOption } from "./edit-role-common/auto-complete-render-option";
@@ -68,8 +68,6 @@ import { RoleConstants, Schemas } from "../../constants";
 import { RoleEditSectionsInterface } from "../../models/roles";
 import { RoleManagementUtils } from "../../utils/role-management-utils";
 import "./edit-role.scss";
-
-type UserstoreDisplayItem = Omit<UserStoreListItem,"description" | "self" | "enabled">
 
 type RoleUsersPropsInterface = IdentifiableComponentInterface & RoleEditSectionsInterface;
 
@@ -89,15 +87,12 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
     const { t } = useTranslation();
     const dispatch: Dispatch = useDispatch();
 
-    const disabledUserstores: string[] = useSelector(
-        (state: AppState) => state.config.ui.features.userStores.disabledFeatures);
-
     const [ userSearchValue, setUserSearchValue ] = useState<string>(undefined);
     const [ isUserSearchLoading, setUserSearchLoading ] = useState<boolean>(false);
     const [ users, setUsers ] = useState<UserBasicInterface[]>([]);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
     const [ activeOption, setActiveOption ] = useState<GroupsInterface|UserBasicInterface>(undefined);
-    const [ availableUserStores, setAvailableUserStores ] = useState<UserstoreDisplayItem[]>([]);
+    const [ availableUserStores, setAvailableUserStores ] = useState<UserStoreDropdownItem[]>([]);
     const [ selectedUserStoreDomainName, setSelectedUserStoreDomainName ] = useState<string>();
     const [ isPlaceholderVisible, setIsPlaceholderVisible ] = useState<boolean>(true);
     const [ selectedUsersFromUserStore, setSelectedUsersFromUserStore ] = useState<UserBasicInterface[]>([]);
@@ -107,6 +102,44 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
         data: userStores,
         isLoading: isUserStoresLoading
     } = useUserStores(null);
+
+    useEffect(() => {
+        if (userStores && !isUserStoresLoading) {
+            const storeOptions: UserStoreDropdownItem[] = [
+                {
+                    key: -1,
+                    text: userstoresConfig?.primaryUserstoreName,
+                    value: userstoresConfig?.primaryUserstoreName
+                }
+            ];
+
+            let storeOption: UserStoreDropdownItem = {
+                key: null,
+                text: "",
+                value: ""
+            };
+
+            userStores?.forEach((store: UserStoreListItem, index: number) => {
+                if (store?.name?.toUpperCase() !== userstoresConfig?.primaryUserstoreName) {
+                    getAUserStore(store.id).then((response: UserStorePostData) => {
+                        const isDisabled: boolean = response.properties.find(
+                            (property: UserStoreProperty) => property.name === "Disabled")?.value === "true";
+
+                        if (!isDisabled) {
+                            storeOption = {
+                                key: index,
+                                text: store.name,
+                                value: store.name
+                            };
+                            storeOptions.push(storeOption);
+                        }
+                    });
+                }
+            });
+
+            setAvailableUserStores(storeOptions);
+        }
+    }, [ userStores, isUserStoresLoading ]);
 
     const {
         data: userResponse,
@@ -162,33 +195,33 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
         setSelectedUsersFromUserStore(usersFromSelectedStore);
     },[ role, selectedUserStoreDomainName ]);
 
-    useEffect(() => {
-        if (!userStores) {
-            return;
-        }
+    // useEffect(() => {
+    //     if (!userStores) {
+    //         return;
+    //     }
 
-        if (userStores) {
-            const availableUserStoreList: UserstoreDisplayItem[] = disabledUserstores?.includes(
-                RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME)
-                ? []
-                : [
-                    {
-                        id: RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME,
-                        name: t("users:userstores.userstoreOptions.primary")
-                    }
-                ];
+    //     if (userStores) {
+    //         const availableUserStoreList: UserstoreDisplayItem[] = disabledUserstores?.includes(
+    //             RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME)
+    //             ? []
+    //             : [
+    //                 {
+    //                     id: RemoteUserStoreConstants.PRIMARY_USER_STORE_NAME,
+    //                     name: t("users:userstores.userstoreOptions.primary")
+    //                 }
+    //             ];
 
-            setAvailableUserStores(
-                [
-                    ...availableUserStoreList,
-                    ...userStores.map((userStore: UserStoreListItem) => ({
-                        id: userStore.id,
-                        name: userStore.name
-                    }))
-                ]
-            );
-        }
-    }, [ userStores ]);
+    //         setAvailableUserStores(
+    //             [
+    //                 ...availableUserStoreList,
+    //                 ...userStores.map((userStore: UserStoreListItem) => ({
+    //                     id: userStore.id,
+    //                     name: userStore.name
+    //                 }))
+    //             ]
+    //         );
+    //     }
+    // }, [ userStores ]);
 
     /**
      * Set available to select users.
@@ -425,13 +458,14 @@ export const RoleUsersList: FunctionComponent<RoleUsersPropsInterface> = (
                                                     >
                                                         { isUserStoresLoading
                                                             ? <p>{ t("common:loading") }</p>
-                                                            : availableUserStores?.map((userstore: UserStoreListItem) =>
-                                                                (<MenuItem
-                                                                    key={ userstore.name }
-                                                                    value={ userstore.id }
-                                                                >
-                                                                    { userstore.name }
-                                                                </MenuItem>)
+                                                            : availableUserStores?.map(
+                                                                (userstore: UserStoreDropdownItem) =>
+                                                                    (<MenuItem
+                                                                        key={ userstore.key }
+                                                                        value={ userstore.value }
+                                                                    >
+                                                                        { userstore.text }
+                                                                    </MenuItem>)
                                                             )
                                                         }
                                                     </Select>


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

- Reuse the business logic for determining available userstores in user assign view in individual roles

Previously the userstore dropdown in the user assign view in individual roles was populated based on a hardcoded disabled userstore list. The business logic is improved with this PR to dynamically check for the active status of each userstore available and display only the active userstores in the dropdown.

- Fix userstore not being appended in retrieving admins in root org console settings in managed deployment

- [Pass active user store externally to user assign view in role edit view under console roles, only if the current organization is a first level organization

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
