### PR TITLE
Remove delete option from default claims and dialects

### DIFF
--- a/.changeset/little-eagles-burn.md
+++ b/.changeset/little-eagles-burn.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/admin.claims.v1": patch
+"@wso2is/core": patch
+---
+
+remove delete option from default claims and dialects

--- a/features/admin.claims.v1/components/claims-list.tsx
+++ b/features/admin.claims.v1/components/claims-list.tsx
@@ -38,6 +38,7 @@ import {
     ExternalClaim,
     LoadableComponentInterface,
     ProfileSchemaInterface,
+    Property,
     SBACInterface,
     TestableComponentInterface
 } from "@wso2is/core/models";
@@ -1100,16 +1101,13 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
                             return true;
                         }
 
-                        if (attributeConfig.defaultScimMapping
-                            && Object.keys(attributeConfig.defaultScimMapping).length > 0) {
-                            const defaultSCIMClaims: Map<string, string> = attributeConfig
-                                .defaultScimMapping[claim.claimDialectURI];
-
-                            if (defaultSCIMClaims && defaultSCIMClaims.get(claim.claimURI)) {
-                                return true;
-                            } else {
-                                return false;
-                            }
+                        if (claim?.properties?.some((property: Property) =>
+                            property.key === ClaimManagementConstants.SYSTEM_CLAIM_PROPERTY_NAME
+                            && property.value === "true"
+                        )) {
+                            return true;
+                        } else {
+                            return false;
                         }
                     },
                     icon: (): SemanticICONS => "trash alternate",

--- a/features/admin.claims.v1/components/claims-list.tsx
+++ b/features/admin.claims.v1/components/claims-list.tsx
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { Show } from "@wso2is/access-control";
+import { Show, useRequiredScopes } from "@wso2is/access-control";
 import {
     AppConstants,
     AppState,
@@ -29,7 +29,6 @@ import { getProfileSchemas } from "@wso2is/admin.users.v1/api";
 import { getUserStores } from "@wso2is/admin.userstores.v1/api/user-stores";
 import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-stores";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
-import { hasRequiredScopes } from "@wso2is/core/helpers";
 import {
     AlertLevels,
     AttributeMapping,
@@ -71,7 +70,7 @@ import React,{
     useState
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { ThunkDispatch } from "redux-thunk";
 import { Header, Icon, ItemHeader, SemanticICONS } from "semantic-ui-react";
 import { EditExternalClaim } from "./edit";
@@ -226,7 +225,9 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
     const [ editClaim, setEditClaim ] = useState("");
     const [ editExternalClaim, setEditExternalClaim ] = useState<AddExternalClaim>(undefined);
 
-    const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
+    const hasAttributeCreatePermissions: boolean = useRequiredScopes(featureConfig?.attributeDialects?.scopes?.create);
+    const hasAttributeUpdatePermissions: boolean = useRequiredScopes(featureConfig?.attributeDialects?.scopes?.update);
+    const hasAttributeDeletePermissions: boolean = useRequiredScopes(featureConfig?.attributeDialects?.scopes?.delete);
 
     const dispatch: ThunkDispatch<AppState, any, any> = useDispatch();
 
@@ -819,18 +820,10 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
                 const showEditAction: boolean =
                     attributeConfig.externalAttributes.showActions(dialectID) &&
                     attributeConfig.externalAttributes.isAttributeEditable &&
-                    hasRequiredScopes(
-                        featureConfig?.attributeDialects,
-                        featureConfig?.attributeDialects?.scopes?.create,
-                        allowedScopes
-                    );
+                    hasAttributeCreatePermissions;
                 const showDeleteAction: boolean =
                     attributeConfig.externalAttributes.showDeleteIcon(dialectID, list) &&
-                    hasRequiredScopes(
-                        featureConfig?.attributeDialects,
-                        featureConfig?.attributeDialects?.scopes?.delete,
-                        allowedScopes
-                    );
+                    hasAttributeDeletePermissions;
 
                 return showEditAction || showDeleteAction;
             };
@@ -1015,22 +1008,19 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
         if (isLocalClaim(list)) {
             return [
                 {
-                    icon: (): SemanticICONS => !hasRequiredScopes(featureConfig?.attributeDialects,
-                        featureConfig?.attributeDialects?.scopes?.update, allowedScopes)
+                    icon: (): SemanticICONS => !hasAttributeUpdatePermissions
                         ? "eye"
                         : "pencil alternate",
                     onClick: (e: SyntheticEvent, claim: Claim | ExternalClaim | ClaimDialect): void => {
                         history.push(AppConstants.getPaths().get("LOCAL_CLAIMS_EDIT").replace(":id", claim?.id));
                     },
-                    popupText: (): string => hasRequiredScopes(featureConfig?.attributeDialects,
-                        featureConfig?.attributeDialects?.scopes?.update, allowedScopes)
+                    popupText: (): string => hasAttributeUpdatePermissions
                         ? t("common:edit")
                         : t("common:view"),
                     renderer: "semantic-icon"
                 },
                 attributeConfig.attributes.deleteAction && {
-                    hidden: (): boolean => !hasRequiredScopes(featureConfig?.attributeDialects,
-                        featureConfig?.attributeDialects?.scopes?.delete, allowedScopes),
+                    hidden: (): boolean => !hasAttributeDeletePermissions,
                     icon: (): SemanticICONS => "trash alternate",
                     onClick: (e: SyntheticEvent, claim: Claim | ExternalClaim | ClaimDialect): void =>
                         initDelete(ListType.LOCAL, claim),
@@ -1043,8 +1033,7 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
         if (isDialect(list)) {
             return [
                 {
-                    hidden: (): boolean => !hasRequiredScopes(featureConfig?.attributeDialects,
-                        featureConfig?.attributeDialects?.scopes?.create, allowedScopes),
+                    hidden: (): boolean => !hasAttributeCreatePermissions,
                     icon: (): SemanticICONS => "pencil alternate",
                     onClick: (e: SyntheticEvent, dialect: ClaimDialect): void => {
                         history.push(AppConstants.getPaths().get("EXTERNAL_DIALECT_EDIT").replace(":id", dialect.id));
@@ -1053,8 +1042,7 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
                     renderer: "semantic-icon"
                 },
                 attributeConfig.attributeMappings.deleteAction && {
-                    hidden: (): boolean => !hasRequiredScopes(featureConfig?.attributeDialects,
-                        featureConfig?.attributeDialects?.scopes?.delete, allowedScopes),
+                    hidden: (): boolean => !hasAttributeDeletePermissions,
                     icon: (): SemanticICONS => "trash alternate",
                     onClick: (e: SyntheticEvent, dialect: ClaimDialect): void => initDelete(ListType.DIALECT, dialect),
                     popupText: (): string => t("common:delete"),
@@ -1075,8 +1063,7 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
                 attributeConfig.externalAttributes.showActions(dialectID) && {
                     hidden: (): boolean => {
                         if (attributeConfig.externalAttributes.isAttributeEditable) {
-                            return !hasRequiredScopes(featureConfig?.attributeDialects,
-                                featureConfig?.attributeDialects?.scopes?.create, allowedScopes);
+                            return !hasAttributeCreatePermissions;
                         } else {
                             return !attributeConfig.externalAttributes.isAttributeEditable;
                         }
@@ -1095,8 +1082,7 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
                 },
                 attributeConfig.externalAttributes.showDeleteIcon(dialectID, list) && {
                     hidden: (claim: ExternalClaim): boolean => {
-                        if (!hasRequiredScopes(featureConfig?.attributeDialects,
-                            featureConfig?.attributeDialects?.scopes?.delete, allowedScopes)
+                        if (!hasAttributeDeletePermissions
                             || attributeConfig.externalAttributes.hideDeleteIcon(claim)) {
                             return true;
                         }
@@ -1156,8 +1142,7 @@ export const ClaimsList: FunctionComponent<ClaimsListPropsInterface> = (
     const resolveTableRowClick = (e: SyntheticEvent, item: Claim | ExternalClaim | ClaimDialect | any): void => {
 
         //Disables inline edit if create scope is not available
-        if (!hasRequiredScopes(featureConfig?.attributeDialects,
-            featureConfig?.attributeDialects?.scopes?.create, allowedScopes)) {
+        if (!hasAttributeCreatePermissions) {
             return;
         }
 

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { Show } from "@wso2is/access-control";
+import { Show, useRequiredScopes } from "@wso2is/access-control";
 import { AppConstants, AppState, FeatureConfigInterface, history } from "@wso2is/admin.core.v1";
 import { attributeConfig } from "@wso2is/admin.extensions.v1";
 import { SCIMConfigs } from "@wso2is/admin.extensions.v1/configs/scim";
@@ -31,7 +31,6 @@ import { useValidationConfigData } from "@wso2is/admin.validation.v1/api";
 import { ValidationFormInterface } from "@wso2is/admin.validation.v1/models";
 import { IdentityAppsError } from "@wso2is/core/errors";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
-import { hasRequiredScopes } from "@wso2is/core/helpers";
 import {
     AlertInterface,
     AlertLevels,
@@ -40,6 +39,7 @@ import {
     ProfileSchemaInterface,
     TestableComponentInterface
 } from "@wso2is/core/models";
+import { Property } from "@wso2is/core/src/models";
 import { addAlert, setProfileSchemaRequestLoadingStatus, setSCIMSchemas } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/form";
 import {
@@ -69,7 +69,6 @@ import { Dispatch } from "redux";
 import { Divider, Grid, Icon, Form as SemanticForm } from "semantic-ui-react";
 import { deleteAClaim, getExternalClaims, updateAClaim } from "../../../api";
 import { ClaimManagementConstants } from "../../../constants";
-import { Property } from "@wso2is/core/src/models";
 
 /**
  * Prop types for `EditBasicDetailsLocalClaims` component
@@ -126,6 +125,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const hasAttributeUpdatePermissions: boolean = useRequiredScopes(featureConfig?.attributeDialects?.scopes?.update);
     const [ hideSpecialClaims, setHideSpecialClaims ] = useState<boolean>(true);
     const [ usernameConfig, setUsernameConfig ] = useState<ValidationFormInterface>(undefined);
     const [ connector, setConnector ] = useState<GovernanceConnectorInterface>(undefined);
@@ -327,8 +327,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
         if (hideSpecialClaims) {
             return true;
         } else {
-            return !hasRequiredScopes(
-                featureConfig?.attributeDialects, featureConfig?.attributeDialects?.scopes?.update, allowedScopes);
+            return !hasAttributeUpdatePermissions;
         }
     }, [ featureConfig, allowedScopes, hideSpecialClaims ]);
 

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -69,6 +69,7 @@ import { Dispatch } from "redux";
 import { Divider, Grid, Icon, Form as SemanticForm } from "semantic-ui-react";
 import { deleteAClaim, getExternalClaims, updateAClaim } from "../../../api";
 import { ClaimManagementConstants } from "../../../constants";
+import { Property } from "@wso2is/core/src/models";
 
 /**
  * Prop types for `EditBasicDetailsLocalClaims` component
@@ -130,6 +131,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
     const [ connector, setConnector ] = useState<GovernanceConnectorInterface>(undefined);
     const [ accountVerificationEnabled, setAccountVerificationEnabled ] = useState<boolean>(false);
     const [ selfRegistrationEnabled, setSelfRegistrationEnabledEnabled ] = useState<boolean>(false);
+    const [ isSystemClaim, setIsSystemClaim ] = useState<boolean>(false);
 
     const { t } = useTranslation();
 
@@ -184,6 +186,13 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
         else {
             setHideSpecialClaims(true);
         }
+
+        setIsSystemClaim(
+            claim?.properties?.some((property: Property) =>
+                property.key === ClaimManagementConstants.SYSTEM_CLAIM_PROPERTY_NAME
+                && property.value === "true"
+            )
+        );
     }, [ claim, usernameConfig ]);
 
     useEffect(() => {
@@ -758,6 +767,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                 && !READONLY_CLAIM_CONFIGS.includes(claim?.claimURI)
                 && !hideSpecialClaims
                 && claim.claimURI !== ClaimManagementConstants.EMAIL_CLAIM_URI
+                && !isSystemClaim
                 && (
                     <Show
                         when={ featureConfig?.attributeDialects?.scopes?.delete }

--- a/features/admin.claims.v1/constants/claim-management-constants.ts
+++ b/features/admin.claims.v1/constants/claim-management-constants.ts
@@ -110,6 +110,17 @@ export class ClaimManagementConstants {
         ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM_SCHEMAS_CORE")
     ]
 
+    public static readonly SYSTEM_DIALECTS: string[] = [
+        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("OPENID_NET"),
+        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("LOCAL"),
+        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("OIDC"),
+        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM2_SCHEMAS_CORE"),
+        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM2_SCHEMAS_CORE_USER"),
+        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM2_SCHEMAS_EXT_ENT_USER"),
+        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM_SCHEMAS_CORE"),
+        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("XML_SOAP")
+    ];
+
     public static readonly CUSTOM_MAPPING: string = SCIMConfigs.custom;
 
     public static readonly OIDC_MAPPING: string[] = [
@@ -182,6 +193,8 @@ export class ClaimManagementConstants {
     public static readonly APPLICATION_ROLES_CLAIM_NAME: string = "application_roles";
 
     public static readonly EMPTY_STRING: string = "";
+
+    public static readonly SYSTEM_CLAIM_PROPERTY_NAME: string = "isSystemClaim";
 
     /**
      * The error code that is returned when there is no item in the list

--- a/features/admin.claims.v1/pages/external-dialect-edit.tsx
+++ b/features/admin.claims.v1/pages/external-dialect-edit.tsx
@@ -349,39 +349,40 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
 
             <Divider hidden />
 
-            { attributeConfig.attributeMappings.showDangerZone
-            && !ClaimManagementConstants.SYSTEM_DIALECTS.includes(dialect?.id)
-            && (
-                <Grid>
-                    <Grid.Row columns={ 1 }>
-                        <Grid.Column width={ 16 }>
-                            <Show
-                                when={ featureConfig?.oidcScopes?.scopes?.delete }
-                            >
-                                <DangerZoneGroup
-                                    sectionHeader={ t("common:dangerZone") }
-                                    data-testid={ `${ testId }-danger-zone-group` }
+            {
+                attributeConfig.attributeMappings.showDangerZone
+                && !ClaimManagementConstants.SYSTEM_DIALECTS.includes(dialect?.id)
+                && (
+                    <Grid>
+                        <Grid.Row columns={ 1 }>
+                            <Grid.Column width={ 16 }>
+                                <Show
+                                    when={ featureConfig?.oidcScopes?.scopes?.delete }
                                 >
-                                    <DangerZone
-                                        actionTitle={ t("claims:dialects." +
-                                            "dangerZone.actionTitle", {
-                                            type: resolveType(attributeType, true, true)
-                                        }) }
-                                        header={ t("claims:dialects.dangerZone.header", {
-                                            type: resolveType(attributeType, true)
-                                        }) }
-                                        subheader={ t("claims:dialects.dangerZone.subheader", {
-                                            type: resolveType(attributeType)
-                                        }) }
-                                        onActionClick={ () => setConfirmDelete(true) }
-                                        data-testid={ `${ testId }-dialect-delete-danger-zone` }
-                                    />
-                                </DangerZoneGroup>
-                            </Show>
-                        </Grid.Column>
-                    </Grid.Row>
-                </Grid>
-            ) }
+                                    <DangerZoneGroup
+                                        sectionHeader={ t("common:dangerZone") }
+                                        data-testid={ `${ testId }-danger-zone-group` }
+                                    >
+                                        <DangerZone
+                                            actionTitle={ t("claims:dialects." +
+                                                "dangerZone.actionTitle", {
+                                                type: resolveType(attributeType, true, true)
+                                            }) }
+                                            header={ t("claims:dialects.dangerZone.header", {
+                                                type: resolveType(attributeType, true)
+                                            }) }
+                                            subheader={ t("claims:dialects.dangerZone.subheader", {
+                                                type: resolveType(attributeType)
+                                            }) }
+                                            onActionClick={ () => setConfirmDelete(true) }
+                                            data-testid={ `${ testId }-dialect-delete-danger-zone` }
+                                        />
+                                    </DangerZoneGroup>
+                                </Show>
+                            </Grid.Column>
+                        </Grid.Row>
+                    </Grid>
+                ) }
             { attributeConfig.attributeMappings.showDangerZone && confirmDelete && deleteConfirmation() }
         </>
     );

--- a/features/admin.claims.v1/pages/external-dialect-edit.tsx
+++ b/features/admin.claims.v1/pages/external-dialect-edit.tsx
@@ -349,7 +349,9 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
 
             <Divider hidden />
 
-            { attributeConfig.attributeMappings.showDangerZone && (
+            { attributeConfig.attributeMappings.showDangerZone
+            && !ClaimManagementConstants.SYSTEM_DIALECTS.includes(dialect?.id)
+            && (
                 <Grid>
                     <Grid.Row columns={ 1 }>
                         <Grid.Column width={ 16 }>

--- a/features/admin.extensions.v1/configs/attribute.ts
+++ b/features/admin.extensions.v1/configs/attribute.ts
@@ -76,43 +76,6 @@ export const attributeConfig: AttributeConfig = {
     attributesPlaceholderAddButton: (attributeType: string): boolean => {
         return attributeType !== ClaimManagementConstants.SCIM;
     },
-    defaultScimMapping: {
-        "urn:ietf:params:scim:schemas:core:2.0": new Map()
-            .set("urn:ietf:params:scim:schemas:core:2.0:externalId","http://wso2.org/claims/externalid")
-            .set("urn:ietf:params:scim:schemas:core:2.0:id","http://wso2.org/claims/userid")
-            .set("urn:ietf:params:scim:schemas:core:2.0:meta.created","http://wso2.org/claims/created")
-            .set("urn:ietf:params:scim:schemas:core:2.0:meta.lastModified","http://wso2.org/claims/modified")
-            .set("urn:ietf:params:scim:schemas:core:2.0:meta.location","http://wso2.org/claims/location")
-            .set("urn:ietf:params:scim:schemas:core:2.0:meta.resourceType","http://wso2.org/claims/resourceType")
-            .set("urn:ietf:params:scim:schemas:core:2.0:meta.version","http://wso2.org/claims/metadata.version"),
-        "urn:ietf:params:scim:schemas:core:2.0:User": new Map()
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:active","http://wso2.org/claims/active")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:addresses#home.locality",
-                "http://wso2.org/claims/locality")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:addresses#home.postalCode",
-                "http://wso2.org/claims/postalcode")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:addresses#home.region",
-                "http://wso2.org/claims/region")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:addresses#home.streetAddress",
-                "http://wso2.org/claims/streetaddress")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:displayName","http://wso2.org/claims/displayName")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:emails","http://wso2.org/claims/emailaddress")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:groups","http://wso2.org/claims/groups")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:locale","http://wso2.org/claims/local")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:name.familyName","http://wso2.org/claims/lastname")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:name.formatted","http://wso2.org/claims/fullname")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:name.givenName","http://wso2.org/claims/givenname")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:name.middleName","http://wso2.org/claims/middleName")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:nickName","http://wso2.org/claims/nickname")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:phoneNumbers.mobile","http://wso2.org/claims/mobile")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:photos.thumbnail","http://wso2.org/claims/thumbnail")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:profileUrl","http://wso2.org/claims/url")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:roles.default","http://wso2.org/claims/roles")
-            .set("urn:ietf:params:scim:schemas:core:2.0:User:userName","http://wso2.org/claims/username"),
-        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": new Map()
-            .set("urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:manager.displayName",
-                "http://wso2.org/claims/manager.displayName")
-    },
     editAttributeMappings: {
         /**
          * Disables and marks the dialect add new attribute button as a

--- a/features/admin.extensions.v1/configs/models/attribute.ts
+++ b/features/admin.extensions.v1/configs/models/attribute.ts
@@ -81,11 +81,6 @@ export interface AttributeConfig {
         isSCIMCustomDialectAvailable: () => Promise<string>;
         isUserStoresHidden: (hiddenUserStores: string[]) => Promise<any[]>;
     }
-    defaultScimMapping: {
-        "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": Map<string, string>;
-        "urn:ietf:params:scim:schemas:core:2.0:User": Map<string, string>;
-        "urn:ietf:params:scim:schemas:core:2.0": Map<string, string>;
-    },
     systemClaims: string[];
     showCustomDialectInSCIM: boolean;
     isRowSelectable: (claim: Claim | ExternalClaim | ClaimDialect) => boolean;

--- a/modules/core/src/models/claim.ts
+++ b/modules/core/src/models/claim.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/modules/core/src/models/claim.ts
+++ b/modules/core/src/models/claim.ts
@@ -76,6 +76,7 @@ export interface ExternalClaim {
     claimDialectURI: string;
     mappedLocalClaimURI: string;
     localClaimDisplayName: string;
+    properties?: Property[];
 }
 
 /**


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
With the in-memory claim management feature, the default set of claim dialects and claims cannot be deleted. This PR, therefore, removes the delete option from the UI.

Local Claims Before

<img width="1497" alt="Screenshot 2024-10-31 at 10 17 02" src="https://github.com/user-attachments/assets/493b6a7d-48a6-442c-bcac-31a87afac9fa">


Local Claims After

<img width="1511" alt="Screenshot 2024-10-31 at 10 17 27" src="https://github.com/user-attachments/assets/3490b264-64fb-470b-8da7-62981399eef4">

External Claims Before

<img width="1512" alt="Screenshot 2024-10-31 at 10 24 22" src="https://github.com/user-attachments/assets/261391b9-0dd3-490d-a345-4cd969183136">


External Claims After

<img width="1512" alt="Screenshot 2024-10-31 at 10 25 49" src="https://github.com/user-attachments/assets/8d15fa2e-afb8-4f00-a6c4-b08921c0bbf3">

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6007
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2595

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets