### PR TITLE
Support email domain based organization discovery during self-registration.

### DIFF
--- a/.changeset/angry-knives-try.md
+++ b/.changeset/angry-knives-try.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Support email domain based organization discovery during self-registration.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -523,11 +523,13 @@ organization.login=Organization Login
 organization.name=Organization name
 organization.email=Organization email
 invalid.organization.discovery.input=Unable to identify the organization. Please check if the provided email domain is correct or provide the organization name to continue.
+invalid.organization.discovery.input.self.registration=Unable to identify the organization. Please check if the provided email domain is correct.
 invalid.organization.discovery.type=Given organization discovery type is invalid or not enabled.
 discovery.input.cannot.be.empty=Email cannot be empty.
 organization.name.cannot.be.empty=Organization name cannot be empty.
 provide.organization.name=Provide organization name
 provide.email.address=Provide email address
+self.registration.application.not.shared=The application is not shared with the organization associated with the provided email domain.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Username

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -529,7 +529,6 @@ discovery.input.cannot.be.empty=Email cannot be empty.
 organization.name.cannot.be.empty=Organization name cannot be empty.
 provide.organization.name=Provide organization name
 provide.email.address=Provide email address
-self.registration.application.not.shared=The application is not shared with the organization associated with the provided email domain.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Username

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -507,7 +507,6 @@ discovery.input.cannot.be.empty=E-Mail darf nicht leer sein.
 organization.name.cannot.be.empty=Der Name der Organisation darf nicht leer sein.
 provide.organization.name=Geben Sie den Namen der Organisation an
 provide.email.address=E-Mail-Adresse angeben
-self.registration.application.not.shared=Die Anwendung ist nicht mit der Organisation geteilt, die der angegebenen E-Mail-Domain zugeordnet ist.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nutzername

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -245,7 +245,7 @@ authentication.context.null.description=Dies geschieht normalerweise aufgrund ei
 authentication.flow.timeout=Es tut uns leid! Ihr Anmeldeversuch hat  zu lange gedauert
 authentication.flow.timeout.description=Anscheinend wurde der Anmeldevorgang aufgrund der Verzögerung beendet. Versuchen Sie es erneut. Wenn dieses Problem weiterhin besteht, wenden Sie sich bitte an den Administrator.
 authentication.flow.app.disabled=Entschuldigung! Die Anwendung ist deaktiviert.
-authentication.flow.app.disabled.description=Offenbar ist die Anwendung deaktiviert und der Zugriff auf die Anwendung ist eingeschr�nkt. Bitte wenden Sie sich an Ihren Administrator.
+authentication.flow.app.disabled.description=Offenbar ist die Anwendung deaktiviert und der Zugriff auf die Anwendung ist eingeschränkt. Bitte wenden Sie sich an Ihren Administrator.
 tracking.reference.id=Verfolgungsreferenz-ID
 copied=Kopiert
 select.language=Sprache auswählen
@@ -501,11 +501,13 @@ organization.login=Organisation Login
 organization.name=Name der Organisation
 organization.email=E-Mail der Organisation
 invalid.organization.discovery.input=Die Organisation konnte nicht identifiziert werden. Bitte geben Sie den Namen der Organisation an, um fortzufahren.
-invalid.organization.discovery.type=Der Erkennungstyp der angegebenen Organisation ist ung�ltig oder nicht aktiviert.
+invalid.organization.discovery.input.self.registration=Organisation konnte nicht identifiziert werden. Bitte überprüfen Sie, ob die angegebene E-Mail-Domain korrekt ist.
+invalid.organization.discovery.type=Der Erkennungstyp der angegebenen Organisation ist ungŸltig oder nicht aktiviert.
 discovery.input.cannot.be.empty=E-Mail darf nicht leer sein.
 organization.name.cannot.be.empty=Der Name der Organisation darf nicht leer sein.
 provide.organization.name=Geben Sie den Namen der Organisation an
 provide.email.address=E-Mail-Adresse angeben
+self.registration.application.not.shared=Die Anwendung ist nicht mit der Organisation geteilt, die der angegebenen E-Mail-Domain zugeordnet ist.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nutzername

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -239,8 +239,8 @@ authentication.context.null=¡Disculpe! Tuvimos que interrumpir su inicio de ses
 authentication.context.null.description=Esto generalmente ocurre debido a un retraso largo o una acción irregular en su proceso de inicio de sesión. Comience de nuevo y intente iniciar sesión nuevamente. Si el problema persiste, comuníquese con su administrador.
 authentication.flow.timeout=¡Perdón! Su intento de inicio de sesión fue tardar demasiado
 authentication.flow.timeout.description=Parece que el proceso de inicio de sesión terminó debido a la demora. Vamos a empezar de nuevo. Si este problema persiste, comuníquese con el administrador.
-authentication.flow.app.disabled=�Lo siento! La aplicaci�n est� deshabilitada.
-authentication.flow.app.disabled.description=Parece que la aplicaci�n est� deshabilitada y el acceso a la misma est� restringido. Por favor contacte a su administrador.
+authentication.flow.app.disabled=¡Lo siento! La aplicación está deshabilitada.
+authentication.flow.app.disabled.description=Parece que la aplicación está deshabilitada y el acceso a la misma está restringido. Por favor contacte a su administrador.
 tracking.reference.id=ID de referencia de seguimiento
 copied=Copiado
 select.language=Seleccione el idioma
@@ -501,11 +501,13 @@ organization.login=Inicio de sesión de la organización
 organization.name=Nombre de la Organización
 organization.email=Correo electrónico de la organización
 invalid.organization.discovery.input=No se puede identificar la organización. Proporcione el nombre de la organización para continuar.
-invalid.organization.discovery.type=El tipo de descubrimiento de organizaci�n determinado no es v�lido o no est� habilitado.
+invalid.organization.discovery.input.self.registration=No se puede identificar la organización. Por favor, verifique si el dominio de correo electrónico proporcionado es correcto.
+invalid.organization.discovery.type=El tipo de descubrimiento de organizacin determinado no es vlido o no est habilitado.
 discovery.input.cannot.be.empty=El correo electrónico no puede estar vacío.
 organization.name.cannot.be.empty=El nombre de la organización no puede estar vacío.
 provide.organization.name=Proporcionar el nombre de la organización
 provide.email.address=Proporcionar dirección de correo electrónico
+self.registration.application.not.shared=La aplicación de registro propio no está compartida con la organización.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nombre de usuario

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -507,7 +507,6 @@ discovery.input.cannot.be.empty=El correo electrónico no puede estar vacío.
 organization.name.cannot.be.empty=El nombre de la organización no puede estar vacío.
 provide.organization.name=Proporcionar el nombre de la organización
 provide.email.address=Proporcionar dirección de correo electrónico
-self.registration.application.not.shared=La aplicación de registro propio no está compartida con la organización.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nombre de usuario

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -243,8 +243,8 @@ authentication.context.null=Pardon! Nous avons dû interrompre votre connexion
 authentication.context.null.description=Cela se produit généralement en raison dun long retard ou dune action irrégulière dans votre processus de connexion. Recommençons et réessayons de nous connecter. Si le problème persiste, veuillez contacter votre administrateur.
 authentication.flow.timeout=Pardon! Votre tentative de connexion a pris trop de temps
 authentication.flow.timeout.description=Il semble que le processus de connexion s'est terminé en raison du retard. Recommençons. Si ce problème persiste, veuillez contacter l'administrateur.
-authentication.flow.app.disabled=D�sol�! L'application est d�sactiv�e.
-authentication.flow.app.disabled.description=Il semble que l'application soit d�sactiv�e et que l'acc�s � l'application soit restreint. Veuillez contacter votre administrateur.
+authentication.flow.app.disabled=Désolé! L'application est désactivée.
+authentication.flow.app.disabled.description=Il semble que l'application soit désactivée et que l'accès à l'application soit restreint. Veuillez contacter votre administrateur.
 tracking.reference.id=ID de référence de suivi
 copied=Copié
 select.language=Choisir la langue
@@ -502,11 +502,13 @@ organization.login=Connexion de l'organisation
 organization.name=Nom de l'organisation
 organization.email=E-mail de l'organisation
 invalid.organization.discovery.input=Impossible d'identifier l'organisation. Veuillez fournir le nom de l'organisation pour continuer.
-invalid.organization.discovery.type=Le type de d�couverte d�organisation donn� n�est pas valide ou n�est pas activ�.
+invalid.organization.discovery.input.self.registration=Impossible d'identifier l'organisation. Veuillez vérifier si le domaine de messagerie fourni est correct.
+invalid.organization.discovery.type=Le type de dŽcouverte dÕorganisation donnŽ nÕest pas valide ou nÕest pas activŽ.
 discovery.input.cannot.be.empty=L'e-mail ne peut pas être vide.
 organization.name.cannot.be.empty=Le nom de l'organisation ne peut pas être vide.
 provide.organization.name=Fournir le nom de l'organisation
 provide.email.address=Fournir une adresse e-mail
+self.registration.application.not.shared= L'application n'est pas partagée avec l'organisation associée au domaine de messagerie fourni.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nom d'utilisateur

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -508,7 +508,6 @@ discovery.input.cannot.be.empty=L'e-mail ne peut pas être vide.
 organization.name.cannot.be.empty=Le nom de l'organisation ne peut pas être vide.
 provide.organization.name=Fournir le nom de l'organisation
 provide.email.address=Fournir une adresse e-mail
-self.registration.application.not.shared= L'application n'est pas partagée avec l'organisation associée au domaine de messagerie fourni.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nom d'utilisateur

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -500,11 +500,13 @@ organization.login=組織ログイン
 organization.name=組織名
 organization.email=組織の電子メール
 invalid.organization.discovery.input=組織を特定できません。指定された電子メール ドメインが正しいかどうかを確認するか、組織名を入力して続行してください。
+invalid.organization.discovery.input.self.registration=組織を特定できません。指定されたメールドメインが正しいかどうか確認してください。
 invalid.organization.discovery.type=指定された組織検出タイプが無効であるか、有効になっていません。
 discovery.input.cannot.be.empty=電子メールを空にすることはできません。
 organization.name.cannot.be.empty=組織名を空にすることはできません。
 provide.organization.name=組織名を入力してください
 provide.email.address=メールアドレスを入力してください
+self.registration.application.not.shared=アプリケーションは、指定されたメールドメインに関連する組織と共有されていません。
 
 ## SCIM Attributes
 VXNlcm5hbWU_=ユーザー名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -506,7 +506,6 @@ discovery.input.cannot.be.empty=電子メールを空にすることはできま
 organization.name.cannot.be.empty=組織名を空にすることはできません。
 provide.organization.name=組織名を入力してください
 provide.email.address=メールアドレスを入力してください
-self.registration.application.not.shared=アプリケーションは、指定されたメールドメインに関連する組織と共有されていません。
 
 ## SCIM Attributes
 VXNlcm5hbWU_=ユーザー名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -241,8 +241,8 @@ authentication.context.null=Desculpe-nos! Tivemos que interromper seu login
 authentication.context.null.description=Isso geralmente acontece devido a uma longa demora ou uma ação irregular no seu processo de login. Vamos começar de novo e tentar logar novamente. Se o problema persistir, entre em contato com seu administrador.
 authentication.flow.timeout=Desculpe-nos! Sua tentativa de login estava demorando muito
 authentication.flow.timeout.description=Parece que o processo de login terminou por causa da demora. Vamos começar novamente. Se esse problema persistir, entre em contato com o administrador.
-authentication.flow.app.disabled=Desculpe! O aplicativo est� desativado.
-authentication.flow.app.disabled.description=Parece que o aplicativo est� desabilitado e o acesso ao aplicativo � restrito. Entre em contato com seu administrador.
+authentication.flow.app.disabled=Desculpe! O aplicativo está desativado.
+authentication.flow.app.disabled.description=Parece que o aplicativo está desabilitado e o acesso ao aplicativo é restrito. Entre em contato com seu administrador.
 tracking.reference.id=ID de referência de rastreamento
 copied=Copiado
 select.language=Selecione o idioma
@@ -497,11 +497,13 @@ organization=Organização
 organization.login=Login da organização
 organization.name=Nome da organização
 invalid.organization.discovery.input=Não foi possível identificar a organização. Forneça o nome da organização para continuar.
-invalid.organization.discovery.type=O tipo de descoberta da organiza��o � inv�lido ou n�o est� habilitado.
+invalid.organization.discovery.input.self.registration= Não foi possível identificar a organização. Verifique se o domínio de e-mail fornecido está correto.
+invalid.organization.discovery.type=O tipo de descoberta da organizao  invlido ou no est habilitado.
 discovery.input.cannot.be.empty=O e-mail não pode ficar vazio.
 organization.name.cannot.be.empty=O nome da organização não pode ficar vazio.
 provide.organization.name=Forneça o nome da organização
 provide.email.address=Forneça endereço de e-mail
+self.registration.application.not.shared=O aplicativo não está compartilhado com a organização associada ao domínio de e-mail fornecido.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nome de Usuário

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -503,7 +503,6 @@ discovery.input.cannot.be.empty=O e-mail não pode ficar vazio.
 organization.name.cannot.be.empty=O nome da organização não pode ficar vazio.
 provide.organization.name=Forneça o nome da organização
 provide.email.address=Forneça endereço de e-mail
-self.registration.application.not.shared=O aplicativo não está compartilhado com a organização associada ao domínio de e-mail fornecido.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nome de Usuário

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -244,8 +244,8 @@ authentication.context.null=Desculpe-nos! Tivemos que interromper sua entrada
 authentication.context.null.description=Isso geralmente acontece devido a um longo atraso ou uma ação irregular no seu processo de login. Vamos começar de novo e tente entrar novamente. Se o problema persistir, entre em contato com seu administrador.
 authentication.flow.timeout=Desculpe-nos! Sua tentativa de login estava demorando muito
 authentication.flow.timeout.description=Parece que o processo de login terminou por causa do atraso. Vamos começar novamente. Se esse problema persistir, entre em contato com o administrador.
-authentication.flow.app.disabled=Desculpe! O aplicativo est� desativado.
-authentication.flow.app.disabled.description=Parece que o aplicativo est� desabilitado e o acesso ao aplicativo � restrito. Entre em contato com seu administrador.
+authentication.flow.app.disabled=Desculpe! O aplicativo está desativado.
+authentication.flow.app.disabled.description=Parece que o aplicativo está desabilitado e o acesso ao aplicativo é restrito. Entre em contato com seu administrador.
 tracking.reference.id=ID de referência de rastreamento
 copied=Copiado
 select.language=Selecione o idioma
@@ -501,11 +501,13 @@ organization.login=Login da organização
 organization.name=Nome da organização
 organization.email=E-mail da organização
 invalid.organization.discovery.input=Não foi possível identificar a organização. Forneça o nome da organização para continuar.
-invalid.organization.discovery.type=O tipo de descoberta da organiza��o � inv�lido ou n�o est� habilitado.
+invalid.organization.discovery.input.self.registration= Não foi possível identificar a organização. Verifique se o domínio de e-mail fornecido está correto.
+invalid.organization.discovery.type=O tipo de descoberta da organizao  invlido ou no est habilitado.
 discovery.input.cannot.be.empty=O e-mail não pode ficar vazio.
 organization.name.cannot.be.empty=O nome da organização não pode ficar vazio.
 provide.organization.name=Forneça o nome da organização
 provide.email.address=Forneça endereço de e-mail
+self.registration.application.not.shared=O aplicativo não está compartilhado com a organização associada ao domínio de e-mail fornecido.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nome de usuário

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -507,7 +507,6 @@ discovery.input.cannot.be.empty=O e-mail não pode ficar vazio.
 organization.name.cannot.be.empty=O nome da organização não pode ficar vazio.
 provide.organization.name=Forneça o nome da organização
 provide.email.address=Forneça endereço de e-mail
-self.registration.application.not.shared=O aplicativo não está compartilhado com a organização associada ao domínio de e-mail fornecido.
 
 # SCIM Attributes
 VXNlcm5hbWU_=Nome de usuário

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -500,11 +500,13 @@ organization.login=组织登录
 organization.name=机构名称
 organization.email=组织邮箱
 invalid.organization.discovery.input=无法识别该组织。请检查提供的电子邮件域是否正确或提供组织名称以继续。
+invalid.organization.discovery.input.self.registration=无法识别组织。请检查提供的电子邮件域是否正确。
 invalid.organization.discovery.type=给定的组织发现类型无效或未启用。
 discovery.input.cannot.be.empty=电子邮件不能为空。
 organization.name.cannot.be.empty=组织名称不能为空。
 provide.organization.name=提供组织名称
 provide.email.address=提供电子邮件地址
+self.registration.application.not.shared=此应用程序未与关联提供的电子邮件域的组织共享。
 
 ## SCIM Attributes
 VXNlcm5hbWU_=用户名

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -506,7 +506,6 @@ discovery.input.cannot.be.empty=电子邮件不能为空。
 organization.name.cannot.be.empty=组织名称不能为空。
 provide.organization.name=提供组织名称
 provide.email.address=提供电子邮件地址
-self.registration.application.not.shared=此应用程序未与关联提供的电子邮件域的组织共享。
 
 ## SCIM Attributes
 VXNlcm5hbWU_=用户名

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -1270,6 +1270,12 @@
     <script src="util/string-utils.js"></script>
 
     <script>
+
+        <% if (Boolean.parseBoolean(request.getParameter("isSelfRegistration"))) { %>
+                $(".ui.segment").hide();
+                window.location = "<%=getRegistrationUrl(accountRegistrationEndpointContextURL, srURLEncodedURL, (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING))%>";
+        <% } %>
+
         function onMoment(notification) {
             displayGoogleSignIn(notification.isNotDisplayed() || notification.isSkippedMoment());
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -44,14 +44,13 @@
            errorMessage = request.getParameter(Constants.AUTH_FAILURE_MSG);
            if (errorMessage.equalsIgnoreCase("authentication.fail.message")) {
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
-            } else if (isSelfRegistration && errorMessage.equalsIgnoreCase("Can't identify organization")) {
+            } else if (isSelfRegistration && (errorMessage.equalsIgnoreCase("Can't identify organization") 
+               || errorMessage.equalsIgnoreCase("Organization is not associated with this application."))) {
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.input.self.registration");
             } else if (errorMessage.equalsIgnoreCase("Can't identify organization")) {
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.input");
             } else if (errorMessage.equalsIgnoreCase("invalid.organization.discovery.type")) {
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.type");
-            } else if (isSelfRegistration && errorMessage.equalsIgnoreCase("Organization is not associated with this application.")) {
-               errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "self.registration.application.not.shared");
             } else if (isErrorFallbackLocale) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle,"error.retry");
             }

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/org_discovery.jsp
@@ -30,6 +30,7 @@
    String idp = request.getParameter("idp");
    String authenticator = request.getParameter("authenticator");
    String sessionDataKey = request.getParameter(Constants.SESSION_DATA_KEY);
+   boolean isSelfRegistration = Boolean.parseBoolean(request.getParameter("isSelfRegistration"));
 
    String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
    String authenticationFailed = "false";
@@ -43,13 +44,17 @@
            errorMessage = request.getParameter(Constants.AUTH_FAILURE_MSG);
            if (errorMessage.equalsIgnoreCase("authentication.fail.message")) {
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "error.retry");
-           } else if (errorMessage.equalsIgnoreCase("Can't identify organization")) {
-                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.input");
-           } else if (errorMessage.equalsIgnoreCase("invalid.organization.discovery.type")) {
+            } else if (isSelfRegistration && errorMessage.equalsIgnoreCase("Can't identify organization")) {
+               errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.input.self.registration");
+            } else if (errorMessage.equalsIgnoreCase("Can't identify organization")) {
+               errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.input");
+            } else if (errorMessage.equalsIgnoreCase("invalid.organization.discovery.type")) {
                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invalid.organization.discovery.type");
-           } else if (isErrorFallbackLocale) {
-               errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle,"error.retry");
-           }
+            } else if (isSelfRegistration && errorMessage.equalsIgnoreCase("Organization is not associated with this application.")) {
+               errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "self.registration.application.not.shared");
+            } else if (isErrorFallbackLocale) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle,"error.retry");
+            }
        }
    }
 %>
@@ -93,7 +98,18 @@
          <layout:component componentName="MainSection">
             <div class="ui segment">
                <%-- page content --%>
+               <%
+                  if (isSelfRegistration) {
+               %>
+               <h2><%=AuthenticationEndpointUtil.i18n(resourceBundle, "continue.with")%> <%= AuthenticationEndpointUtil.i18n(resourceBundle, "organization.email") %></h2>
+               <%
+                  } else {
+               %>
                <h2><%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> <%= StringUtils.isNotBlank(idp) ? idp : AuthenticationEndpointUtil.i18n(resourceBundle, "organization.login") %></h2>
+
+               <%
+                  }
+               %>
                <div class="ui divider hidden"></div>
                <%
                   if ("true".equals(authenticationFailed)) {
@@ -105,37 +121,43 @@
                %>
                <div id="alertDiv"></div>
                <form class="ui large form" id="org_form" name="org_form" action="<%=commonauthURL%>" method="POST">
-                    <div class="field m-0 text-left required">
-                        <label><%=AuthenticationEndpointUtil.i18n(resourceBundle, "organization.email")%></label>
-                    </div>
-                    <input type="text" id='login_hint' name="login_hint" size='30'/>
+                  <div class="field m-0 text-left required">
+                     <label><%=AuthenticationEndpointUtil.i18n(resourceBundle, "organization.email")%></label>
+                  </div>
+                  <input type="text" id='login_hint' name="login_hint" size='30'/>
 
-                    <div class="mt-1" id="discoveryInputError" style="display: none;">
-                        <i class="red exclamation circle fitted icon"></i>
-                        <span class="validation-error-message" id="discoveryInputErrorText">
-                            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "discovery.input.cannot.be.empty")%>
-                        </span>
-                    </div>
-                    <input id="prompt" name="prompt" type="hidden" value="orgName">
-                    <input id="idp" name="idp" type="hidden" value="<%=Encode.forHtmlAttribute(idp)%>"/>
-                    <input id="authenticator" name="authenticator" type="hidden" value="<%=Encode.forHtmlAttribute(authenticator)%>"/>
-                    <input id="sessionDataKey" name="sessionDataKey" type="hidden" value="<%=Encode.forHtmlAttribute(sessionDataKey)%>"/>
-                    <div class="ui divider hidden"></div>
-                    <input type="submit" id="submitButton" onclick="submitDiscovery(); return false;"
-                        value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "submit")%>"
-                        class="ui primary large fluid button" />
-                   <div class="mt-1 align-center">
-                       <a href="javascript:navigateBackToLoginPage()" class="ui button secondary large fluid">
-                           <%=AuthenticationEndpointUtil.i18n(resourceBundle, "cancel")%>
-                       </a>
-                   </div>
-                    <div class="ui horizontal divider">
-                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
-                    </div>
-                    <div class="social-login blurring social-dimmer">
-                        <input type="submit" id="orgNameButton" onclick="enterOrgName();" class="ui primary basic button link-button"
-                            value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "provide.organization.name")%>">
-                    </div>
+                  <div class="mt-1" id="discoveryInputError" style="display: none;">
+                     <i class="red exclamation circle fitted icon"></i>
+                     <span class="validation-error-message" id="discoveryInputErrorText">
+                           <%=AuthenticationEndpointUtil.i18n(resourceBundle, "discovery.input.cannot.be.empty")%>
+                     </span>
+                  </div>
+                  <input id="prompt" name="prompt" type="hidden" value="orgName">
+                  <input id="idp" name="idp" type="hidden" value="<%=Encode.forHtmlAttribute(idp)%>"/>
+                  <input id="authenticator" name="authenticator" type="hidden" value="<%=Encode.forHtmlAttribute(authenticator)%>"/>
+                  <input id="sessionDataKey" name="sessionDataKey" type="hidden" value="<%=Encode.forHtmlAttribute(sessionDataKey)%>"/>
+                  <div class="ui divider hidden"></div>
+                  <input type="submit" id="submitButton" onclick="submitDiscovery(); return false;"
+                     value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "submit")%>"
+                     class="ui primary large fluid button" />
+                  <div class="mt-1 align-center">
+                     <a href="javascript:navigateBackToLoginPage()" class="ui button secondary large fluid">
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "cancel")%>
+                     </a>
+                  </div>
+                  <%
+                  if (!isSelfRegistration) {
+                  %>
+                  <div class="ui horizontal divider">
+                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
+                  </div>
+                  <div class="social-login blurring social-dimmer">
+                     <input type="submit" id="orgNameButton" onclick="enterOrgName();" class="ui primary basic button link-button"
+                           value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "provide.organization.name")%>">
+                  </div>
+                  <%
+                  }
+                  %>
                </form>
             </div>
          </layout:component>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -46,6 +46,8 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ConfiguredAuthenticatorsRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityProviderDataRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.IdentityProviderDataRetrievalClientException" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.OrganizationDiscoveryConfigDataRetrievalClient" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.OrganizationDiscoveryConfigDataRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.api.UsernameRecoveryApi" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.Claim" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.User" %>
@@ -123,6 +125,9 @@
     boolean isEmailUsernameEnabled = MultitenantUtils.isEmailUserName();
     boolean hideUsernameFieldWhenEmailAsUsernameIsEnabled = Boolean.parseBoolean(config.getServletContext().getInitParameter(
         "HideUsernameWhenEmailAsUsernameEnabled"));
+    OrganizationDiscoveryConfigDataRetrievalClient orgDiscoveryConfigRetrievalClient = new OrganizationDiscoveryConfigDataRetrievalClient();
+    Map<String, String> discoveryConfig;
+    String discoveredUsername = request.getParameter("discoveredUsername");
 
     String[] missingClaimList = new String[0];
     String[] missingClaimDisplayName = new String[0];
@@ -192,13 +197,28 @@
     boolean isLocal = false;
     boolean isFederated = false;
     boolean isBasic = false;
-    boolean isSSOLoginTheOnlyAuthenticatorConfigured = false;
+    boolean isSSOLoginAuthenticatorConfigured = false;
+    boolean emailDomainDiscoveryEnabled = false;
+    boolean emailDomainBasedSelfSignupEnabled = false;
     // Enable basic account creation flow if there are no authenticators configured.
     if (configuredAuthenticators == null) {
         isBasic = true;
     }
+
     JSONArray localAuthenticators = new JSONArray();
     JSONArray federatedAuthenticators = new JSONArray();
+
+    try {
+        discoveryConfig = orgDiscoveryConfigRetrievalClient.getDiscoveryConfiguration(tenantDomain);
+    } catch (OrganizationDiscoveryConfigDataRetrievalClientException e) {
+        discoveryConfig = null;
+    }
+
+    if (discoveryConfig != null) {
+        emailDomainDiscoveryEnabled = Boolean.parseBoolean(discoveryConfig.get("emailDomain.enable"));
+        emailDomainBasedSelfSignupEnabled = Boolean.parseBoolean(discoveryConfig.get("emailDomainBasedSelfSignup.enable"));
+    }
+
     if (configuredAuthenticators != null) {
         for ( int index = 0; index < configuredAuthenticators.length(); index++) {
             JSONObject step = (JSONObject)configuredAuthenticators.get(index);
@@ -216,16 +236,23 @@
             }
             if (stepId == 1) {
                 federatedAuthenticators = (JSONArray)step.get("federatedAuthenticators");
+
+                    for (int i = 0; i < federatedAuthenticators.length(); i++) {
+                        JSONObject jsonObject = federatedAuthenticators.getJSONObject(i);
+                        if (SSO_AUTHENTICATOR.equals(jsonObject.getString("type"))) {
+                            if (!emailDomainBasedSelfSignupEnabled) {
+                                federatedAuthenticators.remove(i);
+                            } else {
+                                isSSOLoginAuthenticatorConfigured = true;
+                            }
+                        }
+                    }   
+                
                 if (federatedAuthenticators.length() > 0) {
                     isFederated = true;
                 }
             }
         }
-    }
-    if (isFederated && federatedAuthenticators.length() == 1) {
-        JSONObject onlyAvailableFederatedAuthenticator = (JSONObject) federatedAuthenticators.get(0);
-        String authenticatorType = (String) onlyAvailableFederatedAuthenticator.get("type");
-        isSSOLoginTheOnlyAuthenticatorConfigured = authenticatorType.equals(SSO_AUTHENTICATOR);
     }
 
     if (request.getParameter(Constants.MISSING_CLAIMS) != null) {
@@ -630,7 +657,7 @@
                         </div>
                     </div>
                     <br>
-                    <% } else if (!StringUtils.equals(type, SSO_AUTHENTICATOR)) {
+                    <% } else {
 
                         String logoPath = imageURL;
                         if (!imageURL.isEmpty() && imageURL.contains("/")) {
@@ -739,7 +766,7 @@
                                 <input
                                     type="text"
                                     id="alphanumericUsernameUserInput"
-                                    value=""
+                                    value="<%=discoveredUsername != null ? Encode.forHtmlAttribute(discoveredUsername) : ""%>"
                                     name="usernameInput"
                                     tabindex="1"
                                     placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "enter.your.username")%>"
@@ -781,7 +808,7 @@
                                 <input
                                     type="email"
                                     id="usernameUserInput"
-                                    value=""
+                                    value="<%=discoveredUsername != null ? Encode.forHtmlAttribute(discoveredUsername) : ""%>"
                                     name="http://wso2.org/claims/emailaddress"
                                     tabindex="1"
                                     placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "enter.your.email")%>"
@@ -1536,7 +1563,6 @@
             // Dynamically render the configured authenticators.
             var hasFederated = false;
             var isBasicForm = true;
-            var isSSOLoginTheOnlyAuthenticatorConfigured = <%=isSSOLoginTheOnlyAuthenticatorConfigured%>;
             try {
                 var hasFederated = JSON.parse(<%=isFederated%>);
                 var isBasicForm = JSON.parse(<%=isBasic%>);
@@ -1544,13 +1570,25 @@
                 // Do nothing.
             }
 
-            if (hasFederated & !isSSOLoginTheOnlyAuthenticatorConfigured) {
-                $("#continue-with-email").show();
-                $("#federated-authenticators").show();
+            var isSSOLoginAuthenticatorConfigured = JSON.parse(<%=isSSOLoginAuthenticatorConfigured%>);
+            var emailDomainDiscoveryEnabled = JSON.parse(<%=emailDomainDiscoveryEnabled%>);
+            var emailDomainBasedSelfSignupEnabled = JSON.parse(<%=emailDomainBasedSelfSignupEnabled%>);
+            
+            if (isSSOLoginAuthenticatorConfigured && emailDomainDiscoveryEnabled && emailDomainBasedSelfSignupEnabled) {
+                var params = new URLSearchParams({
+                    idp: 'SSO',
+                    authenticator: 'OrganizationAuthenticator',
+                    sessionDataKey: "<%=Encode.forUriComponent(request.getParameter("sessionDataKey"))%>",
+                    isSelfRegistration: 'true'
+                });
+                document.location = "<%=commonauthURL%>?" + params.toString();
+            } else if(hasFederated){
+                    $("#continue-with-email").show();
+                    $("#federated-authenticators").show();
             } else {
                 $("#continue-with-email").hide();
                 $("#federated-authenticators").hide();
-                $("#basic-form").show();
+                $("#basic-form").show();        
             }
 
             var container;

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -245,6 +245,7 @@
                             } else {
                                 isSSOLoginAuthenticatorConfigured = true;
                             }
+                            break;
                         }
                     }   
                 


### PR DESCRIPTION
### Purpose
With this pr, the recovery portal will be improved to handle email domain based orgnization discovery for self-registration. Changes are made to the login.jsp, org_discovery.jsp and self-registration-username-request.jsp pages to handle new parameters

### Related issue
- https://github.com/wso2/product-is/issues/21608