### PR TITLE
Improve email domain discovery page to incorporate new configuration for enabling email domain discovery for self-registration

### DIFF
--- a/.changeset/shiny-bulldogs-bathe.md
+++ b/.changeset/shiny-bulldogs-bathe.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.organization-discovery.v1": patch
+"@wso2is/i18n": patch
+---
+
+Improve email domain discovery page to incorporate new configuration for enabling email domain discovery for self-registration.

--- a/.changeset/short-insects-occur.md
+++ b/.changeset/short-insects-occur.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.server-configurations.v1": minor
+---
+
+Add new method to get governance connector details.

--- a/features/admin.organization-discovery.v1/api/update-organization-discovery-config.ts
+++ b/features/admin.organization-discovery.v1/api/update-organization-discovery-config.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AsgardeoSPAClient, HttpClientInstance } from "@asgardeo/auth-react";
+import { store } from "@wso2is/admin.core.v1/store";
+import { HttpMethods } from "@wso2is/core/models";
+import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
+import { OrganizationDiscoveryConfigInterface } from "../models/organization-discovery";
+
+/**
+ * Get an axios instance.
+ */
+const httpClient: HttpClientInstance = AsgardeoSPAClient.getInstance()
+    .httpRequest.bind(AsgardeoSPAClient.getInstance());
+
+/**
+ * Update organization discovery configurations
+ *
+ * @param properties - Data that needs to be updated.
+ */
+export const updateOrganizationDiscoveryConfig = (
+    properties: OrganizationDiscoveryConfigInterface
+): Promise<any> => {
+    const requestConfig: AxiosRequestConfig = {
+        data: properties,
+        headers: {
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.PUT,
+        url: `${ store.getState().config.endpoints.organizations }/organization-configs/discovery`
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 200) {
+                return Promise.reject(new Error("Failed to update organization discovery configs."));
+            }
+
+            return Promise.resolve(response?.data);
+        }).catch((error: AxiosError) => {
+            return Promise.reject(error?.response?.data);
+        });
+};
+
+export default updateOrganizationDiscoveryConfig;

--- a/features/admin.organization-discovery.v1/api/use-get-organization-discovery-config.ts
+++ b/features/admin.organization-discovery.v1/api/use-get-organization-discovery-config.ts
@@ -36,7 +36,8 @@ import {
  * @returns SWR response object containing the data, error, isValidating, mutate.
  */
 const useGetOrganizationDiscoveryConfig = <
-    Data = OrganizationDiscoveryConfigInterface & { isOrganizationDiscoveryEnabled: boolean },
+    Data = OrganizationDiscoveryConfigInterface & { isOrganizationDiscoveryEnabled: boolean,
+        isEmailDomainBasedSelfRegistrationEnabled: boolean },
     Error = RequestErrorInterface
 >(shouldFetch: boolean = true): RequestResultInterface<Data, Error> => {
     const requestConfig: RequestConfigInterface = {
@@ -53,12 +54,17 @@ const useGetOrganizationDiscoveryConfig = <
     });
 
     let isOrganizationDiscoveryEnabled: boolean = false;
+    let isEmailDomainBasedSelfRegistrationEnabled: boolean = false;
 
     if ((data as OrganizationDiscoveryConfigInterface)?.properties) {
         (data as OrganizationDiscoveryConfigInterface).properties?.forEach(
             (property: OrganizationDiscoveryConfigPropertyInterface) => {
-                if (property.key === "emailDomain.enable") {
+                if (property.key === "emailDomain.enable" && property.value === "true") {
                     isOrganizationDiscoveryEnabled = true;
+                }
+
+                if (property.key === "emailDomainBasedSelfSignup.enable" && property.value === "true") {
+                    isEmailDomainBasedSelfRegistrationEnabled = true;
                 }
             }
         );
@@ -83,6 +89,7 @@ const useGetOrganizationDiscoveryConfig = <
 
     return {
         data: {
+            isEmailDomainBasedSelfRegistrationEnabled,
             isOrganizationDiscoveryEnabled,
             ...data
         },

--- a/features/admin.organization-discovery.v1/api/use-get-organization-discovery-config.ts
+++ b/features/admin.organization-discovery.v1/api/use-get-organization-discovery-config.ts
@@ -26,7 +26,8 @@ import { HttpMethods } from "@wso2is/core/models";
 import { OrganizationDiscoveryConfigConstants } from "../constants/organization-discovery-config-constants";
 import {
     OrganizationDiscoveryConfigInterface,
-    OrganizationDiscoveryConfigPropertyInterface
+    OrganizationDiscoveryConfigPropertyInterface,
+    OrganizationDiscoveryResponseInterface
 } from "../models/organization-discovery";
 
 /**
@@ -36,8 +37,7 @@ import {
  * @returns SWR response object containing the data, error, isValidating, mutate.
  */
 const useGetOrganizationDiscoveryConfig = <
-    Data = OrganizationDiscoveryConfigInterface & { isOrganizationDiscoveryEnabled: boolean,
-        isEmailDomainBasedSelfRegistrationEnabled: boolean },
+    Data = OrganizationDiscoveryResponseInterface,
     Error = RequestErrorInterface
 >(shouldFetch: boolean = true): RequestResultInterface<Data, Error> => {
     const requestConfig: RequestConfigInterface = {
@@ -59,11 +59,13 @@ const useGetOrganizationDiscoveryConfig = <
     if ((data as OrganizationDiscoveryConfigInterface)?.properties) {
         (data as OrganizationDiscoveryConfigInterface).properties?.forEach(
             (property: OrganizationDiscoveryConfigPropertyInterface) => {
-                if (property.key === "emailDomain.enable" && property.value === "true") {
+                if (property.key === OrganizationDiscoveryConfigConstants.EMAIL_DOMAIN_DISCOVERY_PROPERTY_KEY
+                    && property.value === "true") {
                     isOrganizationDiscoveryEnabled = true;
                 }
 
-                if (property.key === "emailDomainBasedSelfSignup.enable" && property.value === "true") {
+                if (property.key === OrganizationDiscoveryConfigConstants.EMAIL_DOMAIN_DISCOVERY_SELF_REG_PROPERTY_KEY
+                    && property.value === "true") {
                     isEmailDomainBasedSelfRegistrationEnabled = true;
                 }
             }

--- a/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.scss
+++ b/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.scss
@@ -1,3 +1,21 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 .discoverable-organizations-list-layout {
     .top-action-panel {
         display: flex;

--- a/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.scss
+++ b/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.scss
@@ -1,0 +1,15 @@
+.discoverable-organizations-list-layout {
+    .top-action-panel {
+        display: flex;
+        flex-direction: row-reverse;
+        flex-wrap: nowrap;
+        align-content: center;
+        justify-content: flex-start;
+        align-items: center;
+        gap: 10px;
+
+        >.ui.grid {
+            flex-grow: 1;
+        }
+    }
+}

--- a/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.tsx
+++ b/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.tsx
@@ -216,7 +216,7 @@ const DiscoverableOrganizationsListLayout: FunctionComponent<DiscoverableOrganiz
                                     AppConstants.getPaths().get("ASSIGN_ORGANIZATION_DISCOVERY_DOMAINS")
                                 );
                             } }
-                            data-componentid={ `${ componentId }-list-layout-assign-button` }
+                            data-componentid={ `${ componentId }-assign-button` }
                         >
                             <Icon name="add" />
                             { t("organizationDiscovery:emailDomains.actions.assign") }

--- a/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.tsx
+++ b/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.tsx
@@ -51,7 +51,6 @@ export interface DiscoverableOrganizationsListLayoutPropsInterface extends Ident
     onListItemLimitChange: (limit: number) => void;
     onListOffsetChange: (offset: number) => void;
     onSearchQueryChange: (query: string) => void;
-
 }
 
 /**
@@ -60,21 +59,17 @@ export interface DiscoverableOrganizationsListLayoutPropsInterface extends Ident
  * @param props - Props injected to the component.
  * @returns Discoverable organization list layout component.
  */
-const DiscoverableOrganizationsListLayout: FunctionComponent<DiscoverableOrganizationsListLayoutPropsInterface> = (
-    props: DiscoverableOrganizationsListLayoutPropsInterface
-): ReactElement => {
-
-    const {
-        discoverableOrganizations,
-        listItemLimit,
-        isDiscoverableOrganizationsFetchRequestLoading,
-        featureConfig,
-        searchQuery,
-        onListItemLimitChange,
-        onListOffsetChange,
-        onSearchQueryChange,
-        [ "data-componentid" ]: componentId
-    } = props;
+const DiscoverableOrganizationsListLayout: FunctionComponent<DiscoverableOrganizationsListLayoutPropsInterface> = ({
+    discoverableOrganizations,
+    listItemLimit,
+    isDiscoverableOrganizationsFetchRequestLoading,
+    featureConfig,
+    searchQuery,
+    onListItemLimitChange,
+    onListOffsetChange,
+    onSearchQueryChange,
+    ["data-componentid"]: componentId = "discoverable-organizations-list-layout"
+}: DiscoverableOrganizationsListLayoutPropsInterface): ReactElement => {
 
     const ORGANIZATIONS_LIST_SORTING_OPTIONS: DropdownItemProps[] = [
         {
@@ -244,13 +239,6 @@ const DiscoverableOrganizationsListLayout: FunctionComponent<DiscoverableOrganiz
             />
         </ListLayout>
     );
-};
-
-/**
- * Default props for the component.
- */
-DiscoverableOrganizationsListLayout.defaultProps = {
-    "data-componentid": "discoverable-organizations-list-layout"
 };
 
 export default DiscoverableOrganizationsListLayout;

--- a/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.tsx
+++ b/features/admin.organization-discovery.v1/components/discoverable-organizations-list-layout.tsx
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Show } from "@wso2is/access-control";
+import { EventPublisher, FeatureConfigInterface } from "@wso2is/admin.core.v1";
+import { AdvancedSearchWithBasicFilters } from "@wso2is/admin.core.v1/components";
+import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
+import { history } from "@wso2is/admin.core.v1/helpers/history";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { I18n } from "@wso2is/i18n";
+import { ListLayout, PrimaryButton } from "@wso2is/react-components";
+import find from "lodash-es/find";
+import React, {
+    FunctionComponent,
+    MouseEvent,
+    ReactElement,
+    ReactNode,
+    SyntheticEvent,
+    useCallback,
+    useState } from "react";
+import { useTranslation } from "react-i18next";
+import { DropdownItemProps, DropdownProps, Icon, PaginationProps } from "semantic-ui-react";
+import DiscoverableOrganizationsList from "./discoverable-organizations-list";
+import { OrganizationListWithDiscoveryInterface } from "../models/organization-discovery";
+import "./discoverable-organizations-list-layout.scss";
+
+/**
+ * Props interface of {@link DiscoverableOrganizationsListLayout}
+ */
+export interface DiscoverableOrganizationsListLayoutPropsInterface extends IdentifiableComponentInterface {
+    discoverableOrganizations: OrganizationListWithDiscoveryInterface
+    listItemLimit: number;
+    isDiscoverableOrganizationsFetchRequestLoading: boolean;
+    featureConfig: FeatureConfigInterface;
+    searchQuery: string;
+    onListItemLimitChange: (limit: number) => void;
+    onListOffsetChange: (offset: number) => void;
+    onSearchQueryChange: (query: string) => void;
+
+}
+
+/**
+ * Layout for the discoverable organizations list.
+ *
+ * @param props - Props injected to the component.
+ * @returns Discoverable organization list layout component.
+ */
+const DiscoverableOrganizationsListLayout: FunctionComponent<DiscoverableOrganizationsListLayoutPropsInterface> = (
+    props: DiscoverableOrganizationsListLayoutPropsInterface
+): ReactElement => {
+
+    const {
+        discoverableOrganizations,
+        listItemLimit,
+        isDiscoverableOrganizationsFetchRequestLoading,
+        featureConfig,
+        searchQuery,
+        onListItemLimitChange,
+        onListOffsetChange,
+        onSearchQueryChange,
+        [ "data-componentid" ]: componentId
+    } = props;
+
+    const ORGANIZATIONS_LIST_SORTING_OPTIONS: DropdownItemProps[] = [
+        {
+            key: 0,
+            text: I18n.instance.t("organizationDiscovery:advancedSearch." +
+            "form.dropdown.filterAttributeOptions.organizationName") as ReactNode,
+            value: "organizationName"
+        }
+    ];
+
+    const eventPublisher: EventPublisher = EventPublisher.getInstance();
+    const { t } = useTranslation();
+    const [ triggerClearQuery, setTriggerClearQuery ] = useState<boolean>(false);
+    const [ listSortingStrategy, setListSortingStrategy ] = useState<DropdownItemProps>(
+        ORGANIZATIONS_LIST_SORTING_OPTIONS[ 0 ]
+    );
+
+    /**
+     * Handles the `onFilter` callback action from the
+     * organization search component.
+     *
+     * @param query - Search query.
+     */
+    const handleOrganizationFilter: (query: string) => void = useCallback(
+        (query: string): void => {
+            onSearchQueryChange(query);
+        },
+        [ onSearchQueryChange ]
+    );
+
+    /**
+     * Handles the `onSearchQueryClear` callback action.
+     */
+    const handleSearchQueryClear: () => void = useCallback((): void => {
+        setTriggerClearQuery(!triggerClearQuery);
+        onSearchQueryChange("");
+    }, [ onSearchQueryChange, triggerClearQuery ]);
+
+    /**
+     * Handles per page dropdown page.
+     *
+     * @param event - Mouse event.
+     * @param data - Dropdown data.
+     */
+    const handleItemsPerPageDropdownChange = (event: MouseEvent<HTMLAnchorElement>, data: DropdownProps): void => {
+        onListItemLimitChange(data.value as number);
+    };
+
+    /**
+     * Handles the pagination change.
+     *
+     * @param event - Mouse event.
+     * @param data - Pagination component data.
+     */
+    const handlePaginationChange = (event: MouseEvent<HTMLAnchorElement>, data: PaginationProps) => {
+        const offsetValue: number = ((data.activePage as number) - 1) * listItemLimit;
+
+        onListOffsetChange(offsetValue);
+    };
+
+    /**
+     * Sets the list sorting strategy.
+     *
+     * @param event - The event.
+     * @param data - Dropdown data.
+     */
+    const handleListSortingStrategyOnChange = (event: SyntheticEvent<HTMLElement>, data: DropdownProps): void => {
+        setListSortingStrategy(
+            find(ORGANIZATIONS_LIST_SORTING_OPTIONS, (option: DropdownItemProps) => {
+                return data.value === option.value;
+            })
+        );
+    };
+
+    /**
+     * Checks if the `Next` page nav button should be shown.
+     *
+     * @param orgList - List of discoverable organizations.
+     * @returns `true` if `Next` page nav button should be shown.
+     */
+    const shouldShowNextPageNavigation = (orgList: OrganizationListWithDiscoveryInterface): boolean => {
+        return orgList?.startIndex + orgList?.count !== orgList?.totalResults + 1;
+    };
+
+    return (
+        <ListLayout
+            advancedSearch={ (
+                <AdvancedSearchWithBasicFilters
+                    onFilter={ handleOrganizationFilter }
+                    filterAttributeOptions={ [
+                        {
+                            key: 0,
+                            text: t("organizationDiscovery:advancedSearch." +
+                            "form.dropdown.filterAttributeOptions.organizationName"),
+                            value: "organizationName"
+                        }
+                    ] }
+                    filterAttributePlaceholder={ t(
+                        "organizationDiscovery:advancedSearch.form" +
+                                ".inputs.filterAttribute.placeholder"
+                    ) }
+                    filterConditionsPlaceholder={ t(
+                        "organizationDiscovery:advancedSearch.form" +
+                                ".inputs.filterCondition.placeholder"
+                    ) }
+                    filterValuePlaceholder={ t(
+                        "organizationDiscovery:advancedSearch.form" +
+                        ".inputs.filterValue.placeholder"
+                    ) }
+                    placeholder={ t(
+                        "organizationDiscovery:advancedSearch.placeholder"
+                    ) }
+                    defaultSearchAttribute="organizationName"
+                    defaultSearchOperator="co"
+                    triggerClearQuery={ triggerClearQuery }
+                    data-componentid={ `${ componentId }-list-advanced-search` }
+                />
+            ) }
+            currentListSize={ discoverableOrganizations?.organizations?.length }
+            listItemLimit={ listItemLimit }
+            onItemsPerPageDropdownChange={ handleItemsPerPageDropdownChange }
+            onPageChange={ handlePaginationChange }
+            onSortStrategyChange={ handleListSortingStrategyOnChange }
+            showTopActionPanel={
+                isDiscoverableOrganizationsFetchRequestLoading ||
+                        !(!searchQuery && discoverableOrganizations?.organizations?.length <= 0)
+            }
+            sortOptions={ ORGANIZATIONS_LIST_SORTING_OPTIONS }
+            sortStrategy={ listSortingStrategy }
+            topActionPanelExtension={
+                (
+                    <Show when={ featureConfig?.organizationDiscovery?.scopes?.create }>
+                        <PrimaryButton
+                            disabled={ isDiscoverableOrganizationsFetchRequestLoading }
+                            loading={ isDiscoverableOrganizationsFetchRequestLoading }
+                            onClick={ () => {
+                                eventPublisher.publish("organization-click-assign-email-domain-button");
+                                history.push(
+                                    AppConstants.getPaths().get("ASSIGN_ORGANIZATION_DISCOVERY_DOMAINS")
+                                );
+                            } }
+                            data-componentid={ `${ componentId }-list-layout-assign-button` }
+                        >
+                            <Icon name="add" />
+                            { t("organizationDiscovery:emailDomains.actions.assign") }
+                        </PrimaryButton>
+                    </Show>
+                ) }
+            totalPages={ 10 }
+            totalListSize={ discoverableOrganizations?.organizations?.length }
+            isLoading={ isDiscoverableOrganizationsFetchRequestLoading }
+            paginationOptions={ {
+                disableNextButton: !shouldShowNextPageNavigation(discoverableOrganizations)
+            } }
+            data-componentid={ `${ componentId }-list-layout` }
+            className="discoverable-organizations-list-layout"
+            showPagination
+        >
+            <DiscoverableOrganizationsList
+                list={ discoverableOrganizations }
+                onEmptyListPlaceholderActionClick={ () => {
+                    history.push(AppConstants.getPaths().get("ASSIGN_ORGANIZATION_DISCOVERY_DOMAINS"));
+                } }
+                onSearchQueryClear={ handleSearchQueryClear }
+                searchQuery={ searchQuery }
+                data-componentid="organization-list-with-discovery"
+            />
+        </ListLayout>
+    );
+};
+
+/**
+ * Default props for the component.
+ */
+DiscoverableOrganizationsListLayout.defaultProps = {
+    "data-componentid": "discoverable-organizations-list-layout"
+};
+
+export default DiscoverableOrganizationsListLayout;

--- a/features/admin.organization-discovery.v1/constants/organization-discovery-config-constants.ts
+++ b/features/admin.organization-discovery.v1/constants/organization-discovery-config-constants.ts
@@ -25,5 +25,8 @@ export class OrganizationDiscoveryConfigConstants {
      */
     private constructor() {}
 
+    public static readonly EMAIL_DOMAIN_DISCOVERY_PROPERTY_KEY: string = "emailDomain.enable";
+    public static readonly EMAIL_DOMAIN_DISCOVERY_SELF_REG_PROPERTY_KEY: string = "emailDomainBasedSelfSignup.enable";
+
     public static readonly ORGANIZATION_DISCOVERY_DOMAINS_NOT_CONFIGURED_ERROR_CODE: string = "OCM-60002";
 }

--- a/features/admin.organization-discovery.v1/constants/organization-discovery-constants.ts
+++ b/features/admin.organization-discovery.v1/constants/organization-discovery-constants.ts
@@ -59,5 +59,7 @@ export class OrganizationDiscoveryConstants {
         .set("ORGANIZATION_DISCOVERY_CREATE", "organizationDiscovery.create")
         .set("ORGANIZATION_DISCOVERY_UPDATE", "organizationDiscovery.update")
         .set("ORGANIZATION_DISCOVERY_DELETE", "organizationDiscovery.delete")
-        .set("ORGANIZATION_DISCOVERY_READ", "organizationDiscovery.read");
+        .set("ORGANIZATION_DISCOVERY_READ", "organizationDiscovery.read")
+        .set("ORGANIZATION_DISCOVERY_EMAIL_DOMAIN_FOR_SELF_REG",
+            "organizationDiscovery.emailDomainDiscoveryForSelfReg");
 }

--- a/features/admin.organization-discovery.v1/models/organization-discovery.ts
+++ b/features/admin.organization-discovery.v1/models/organization-discovery.ts
@@ -77,7 +77,7 @@ export interface OrganizationAttributesInterface {
 
 export interface OrganizationDiscoveryConfigPropertyInterface {
     key: string;
-    value: boolean;
+    value: string;
 }
 
 export interface OrganizationDiscoveryAttributesInterface {

--- a/features/admin.organization-discovery.v1/models/organization-discovery.ts
+++ b/features/admin.organization-discovery.v1/models/organization-discovery.ts
@@ -37,6 +37,11 @@ export interface OrganizationDiscoveryAttributeDataInterface {
     attributes: OrganizationDiscoveryAttributesInterface[];
 }
 
+export interface OrganizationDiscoveryResponseInterface {
+    isOrganizationDiscoveryEnabled: boolean;
+    isEmailDomainBasedSelfRegistrationEnabled: boolean;
+}
+
 export interface OrganizationLinkInterface {
     href: string;
     rel: string;

--- a/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
+++ b/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
@@ -17,6 +17,7 @@
  */
 
 import Alert from "@oxygen-ui/react/Alert";
+import { useRequiredScopes } from "@wso2is/access-control";
 import {
     AppConstants,
     AppState,
@@ -24,7 +25,6 @@ import {
     UIConstants,
     history
 } from "@wso2is/admin.core.v1";
-import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/form";
@@ -81,17 +81,7 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
     const isEmailDomainDiscoveryForSelfRegFeatureEnabled: boolean = !featureConfig?.organizationDiscovery?.
         disabledFeatures?.includes("organizationDiscovery.emailDomainDiscoveryForSelfReg");
-    const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
-
-    const isReadOnly: boolean = useMemo(
-        () =>
-            !hasRequiredScopes(
-                featureConfig?.organizationDiscovery,
-                featureConfig?.organizationDiscovery?.scopes?.update,
-                allowedScopes
-            ),
-        [ featureConfig, allowedScopes ]
-    );
+    const isReadOnly: boolean = !useRequiredScopes(featureConfig?.organizationDiscovery?.scopes?.update);
 
     const [ searchQuery, setSearchQuery ] = useState<string>("");
     const [ listItemLimit, setListItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);

--- a/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
+++ b/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
@@ -50,7 +50,7 @@ import { ConnectorPropertyInterface } from "../../admin.connections.v1";
 import {
     ServerConfigurationsConstants,
     UpdateGovernanceConnectorConfigPropertyInterface,
-    useGovernanceConnectorDetails
+    useGetGovernanceConnectorById
 } from "../../admin.server-configurations.v1";
 import updateOrganizationDiscoveryConfig from "../api/update-organization-discovery-config";
 import useGetOrganizationDiscovery from "../api/use-get-organization-discovery";
@@ -112,7 +112,7 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
 
     const {
         data: selfRegistrationConnectorDetetails
-    } = useGovernanceConnectorDetails(ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID,
+    } = useGetGovernanceConnectorById(ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID,
         ServerConfigurationsConstants.SELF_SIGN_UP_CONNECTOR_ID);
 
     const { isOrganizationDiscoveryEnabled, isEmailDomainBasedSelfRegistrationEnabled } = organizationDiscoveryConfig;

--- a/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
+++ b/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
@@ -79,6 +79,8 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
     const dispatch: Dispatch = useDispatch();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state?.config?.ui?.features);
+    const isEmailDomainDiscoveryForSelfRegFeatureEnabled: boolean = !featureConfig?.organizationDiscovery?.
+        disabledFeatures?.includes("organizationDiscovery.emailDomainDiscoveryForSelfReg");
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
 
     const isReadOnly: boolean = useMemo(
@@ -396,50 +398,53 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
             <Divider hidden />
             { isOrganizationDiscoveryEnabled && (
                 <>
-                    <EmphasizedSegment
-                        padded={ true }
-                    >
-                        <Form>
-                            <Field.Checkbox
-                                ariaLabel="emailDomainBasedSelfRegistration"
-                                name="emailDomainBasedSelfRegistration"
-                                label={ t("organizationDiscovery:selfRegistration.label") }
-                                listen={ (value: boolean) => handleEmailDomainBasedSelfRegistration(value) }
-                                checked={ isEmailDomainBasedSelfRegistrationEnabled }
-                                disabled={ !isSelfRegEnabled }
-                                width={ 16 }
-                                data-testid={ `${testId}-notify-account-confirmation` }
-                                hint={ isSelfRegEnabled && t("organizationDiscovery:selfRegistration.labelHint") }
-                            />
-                            { !isSelfRegEnabled && (
-                                <Alert severity="info">
-                                    <Trans
-                                        i18nKey={ "organizationDiscovery:selfRegistration.message" }
-                                    >
-                                        Enable
-                                        <Link
-                                            external={ false }
-                                            onClick={ () => {
-                                                history.push(
-                                                    AppConstants.getPaths().get("GOVERNANCE_CONNECTOR_EDIT").replace(
-                                                        ":categoryId",
-                                                        ServerConfigurationsConstants.
-                                                            USER_ONBOARDING_CONNECTOR_ID
-                                                    ).replace(
-                                                        ":connectorId",
-                                                        ServerConfigurationsConstants.
-                                                            SELF_SIGN_UP_CONNECTOR_ID
-                                                    )
-                                                );
-                                            } }
-                                        >self-registration
-                                        </Link>
-                                        to allow domain discovery for self-registration.
-                                    </Trans>
-                                </Alert>
-                            ) }
-                        </Form>
-                    </EmphasizedSegment>
+                    { isEmailDomainDiscoveryForSelfRegFeatureEnabled && (
+                        <EmphasizedSegment
+                            padded={ true }
+                        >
+                            <Form>
+                                <Field.Checkbox
+                                    ariaLabel="emailDomainBasedSelfRegistration"
+                                    name="emailDomainBasedSelfRegistration"
+                                    label={ t("organizationDiscovery:selfRegistration.label") }
+                                    listen={ (value: boolean) => handleEmailDomainBasedSelfRegistration(value) }
+                                    checked={ isEmailDomainBasedSelfRegistrationEnabled }
+                                    disabled={ !isSelfRegEnabled }
+                                    width={ 16 }
+                                    data-testid={ `${testId}-notify-account-confirmation` }
+                                    hint={ isSelfRegEnabled && t("organizationDiscovery:selfRegistration.labelHint") }
+                                />
+                                { !isSelfRegEnabled && (
+                                    <Alert severity="info">
+                                        <Trans
+                                            i18nKey={ "organizationDiscovery:selfRegistration.message" }
+                                        >
+                                            Enable
+                                            <Link
+                                                external={ false }
+                                                onClick={ () => {
+                                                    history.push(
+                                                        AppConstants.getPaths().get(
+                                                            "GOVERNANCE_CONNECTOR_EDIT").replace(
+                                                            ":categoryId",
+                                                            ServerConfigurationsConstants.
+                                                                USER_ONBOARDING_CONNECTOR_ID
+                                                        ).replace(
+                                                            ":connectorId",
+                                                            ServerConfigurationsConstants.
+                                                                SELF_SIGN_UP_CONNECTOR_ID
+                                                        )
+                                                    );
+                                                } }
+                                            >self-registration
+                                            </Link>
+                                            to allow domain discovery for self-registration.
+                                        </Trans>
+                                    </Alert>
+                                ) }
+                            </Form>
+                        </EmphasizedSegment>
+                    ) }
                     <DiscoverableOrganizationsListLayout
                         discoverableOrganizations={ discoverableOrganizations }
                         listItemLimit = { listItemLimit }

--- a/features/admin.server-configurations.v1/api/governance-connectors.ts
+++ b/features/admin.server-configurations.v1/api/governance-connectors.ts
@@ -115,7 +115,7 @@ export const useGovernanceConnectors = <
  * @param connectorId - ID of the connector
  * @returns the governance connector.
  */
-export const useGovernanceConnectorDetails = <
+export const useGetGovernanceConnectorById = <
     Data = GovernanceConnectorInterface,
     Error = RequestErrorInterface
     >(

--- a/features/admin.server-configurations.v1/api/governance-connectors.ts
+++ b/features/admin.server-configurations.v1/api/governance-connectors.ts
@@ -108,6 +108,42 @@ export const useGovernanceConnectors = <
     };
 };
 
+/**
+ * Get details of a governance connector.
+ *
+ * @param categoryId - ID of the connector category
+ * @param connectorId - ID of the connector
+ * @returns the governance connector.
+ */
+export const useGovernanceConnectorDetails = <
+    Data = GovernanceConnectorInterface,
+    Error = RequestErrorInterface
+    >(
+        categoryId: string,
+        connectorId: string,
+        shouldFetch: boolean = true
+    ): RequestResultInterface<Data, Error> => {
+    const requestConfig: RequestConfigInterface = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        url: store.getState().config.endpoints.governanceConnectorCategories + "/"
+            + categoryId + "/connectors/" + connectorId
+    };
+
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(shouldFetch ? requestConfig: null);
+
+    return {
+        data,
+        error: error,
+        isLoading: !error && !data,
+        isValidating,
+        mutate: mutate
+    };
+};
+
 export const getData = (url: string): Promise<any> => {
     const requestConfig: AxiosRequestConfig = {
         headers: {

--- a/modules/i18n/src/models/namespaces/organization-discovery-ns.ts
+++ b/modules/i18n/src/models/namespaces/organization-discovery-ns.ts
@@ -164,6 +164,26 @@ export interface organizationDiscoveryNS {
                 message: string;
             };
         };
+        enableEmailDomainBasedSelfRegistration: {
+            error: {
+                description: string;
+                message: string;
+            };
+            success: {
+                description: string;
+                message: string;
+            };
+        };
+        disableEmailDomainBasedSelfRegistration: {
+            error: {
+                description: string;
+                message: string;
+            };
+            success: {
+                description: string;
+                message: string;
+            };
+        };
     };
     placeholders: {
         emptyList: {
@@ -171,6 +191,11 @@ export interface organizationDiscoveryNS {
             title: string;
             subtitles: string;
         };
+    };
+    selfRegistration: {
+        label: string;
+        labelHint: string;
+        message: string;
     };
     title: string;
 }

--- a/modules/i18n/src/translations/en-US/portals/organization-discovery.ts
+++ b/modules/i18n/src/translations/en-US/portals/organization-discovery.ts
@@ -40,14 +40,16 @@ export const organizationDiscovery: organizationDiscoveryNS = {
         placeholder: "Search by Organization Name"
     },
     assign: {
-        title: "Assign Email Domains",
+        buttons: {
+            assign: "Assign"
+        },
         description: "Assign email domains for organizations.",
         form: {
             fields: {
                 emailDomains: {
+                    hint: "Type and enter email domains to map to the organization. (E.g. gmail.com etc.)",
                     label : "Email Domains",
                     placeholder: "Enter email domains",
-                    hint: "Type and enter email domains to map to the organization. (E.g. gmail.com etc.)",
                     validations: {
                         invalid: {
                             0: "Please enter a valid email domain.",
@@ -56,18 +58,40 @@ export const organizationDiscovery: organizationDiscoveryNS = {
                     }
                 },
                 organizationName: {
-                    label: "Organization Name",
-                    placeholder: "Select an organization",
                     emptyPlaceholder: {
                         0: "There are no organizations available.",
                         1: "All the organizations have assigned domains."
                     },
-                    hint: "Enter the name of the organization you wish to add the domain mapping."
+                    hint: "Enter the name of the organization you wish to add the domain mapping.",
+                    label: "Organization Name",
+                    placeholder: "Select an organization"
                 }
             }
         },
-        buttons: {
-            assign: "Assign"
+        title: "Assign Email Domains"
+    },
+    edit: {
+        back: "Back",
+        description: "Edit Email Domains",
+        form: {
+            fields: {
+                emailDomains: {
+                    hint: "Type and enter email domains to map to the organization. (E.g. gmail.com etc.)",
+                    label : "Email Domains",
+                    placeholder: "Enter email domains",
+                    validations: {
+                        invalid: {
+                            0: "Please enter a valid email domain.",
+                            1: "Provided email domain is already mapped to a different organization."
+                        }
+                    }
+                },
+                organizationName: {
+                    hint: "The name of the organization to which the domain mappings are added.",
+                    label: "Organization Name"
+                }
+            },
+            message: "Changing email domain mappings may result in existing users being unable to log in."
         }
     },
     emailDomains: {
@@ -76,31 +100,8 @@ export const organizationDiscovery: organizationDiscoveryNS = {
             enable: "Enable email domain discovery"
         }
     },
-    edit: {
-        back: "Back",
-        description: "Edit Email Domains",
-        form: {
-            fields: {
-                emailDomains: {
-                    label : "Email Domains",
-                    placeholder: "Enter email domains",
-                    hint: "Type and enter email domains to map to the organization. (E.g. gmail.com etc.)",
-                    validations: {
-                        invalid: {
-                            0: "Please enter a valid email domain.",
-                            1: "Provided email domain is already mapped to a different organization."
-                        }
-                    }
-                },
-                organizationName: {
-                    label: "Organization Name",
-                    hint: "The name of the organization to which the domain mappings are added."
-                }
-            },
-            message: "Changing email domain mappings may result in existing users being unable to log in."
-        }
-    },
-    message: "Email domain discovery feature can only be used when email address is configured as the username.",
+    message: "Email domain discovery feature can only be used when email address is configured as the username."
+        + " When enabled, email domains are validated during user authentication and onboarding to organizations.",
     notifications: {
         addEmailDomains: {
             error: {
@@ -118,6 +119,16 @@ export const organizationDiscovery: organizationDiscoveryNS = {
                 message: "Validating unsuccessful"
             }
         },
+        disableEmailDomainBasedSelfRegistration: {
+            error: {
+                description: "An error occurred while disabling email domain discovery for self-registration.",
+                message: "Disabling unsuccessful"
+            },
+            success: {
+                description: "Successfully disabled email domain discovery for self-registration.",
+                message: "Disabled successfully"
+            }
+        },
         disableEmailDomainDiscovery: {
             error: {
                 description: "An error occurred while disabling email domain discovery.",
@@ -126,6 +137,16 @@ export const organizationDiscovery: organizationDiscoveryNS = {
             success: {
                 description: "Successfully disabled email domain discovery.",
                 message: "Disabled successfully"
+            }
+        },
+        enableEmailDomainBasedSelfRegistration: {
+            error: {
+                description: "An error occurred while enabling email domain discovery for self-registration.",
+                message: "Enabling unsuccessful"
+            },
+            success: {
+                description: "Successfully enabled email domain discovery for self-registration.",
+                message: "Enabled successfully"
             }
         },
         enableEmailDomainDiscovery: {
@@ -174,5 +195,10 @@ export const organizationDiscovery: organizationDiscoveryNS = {
             title: "Assign Email Domain"
         }
     },
-    title: "Email Domain Discovery"
+    selfRegistration: {
+        label: "Email domain discovery for self-registration",
+        labelHint: "when enabled, users will be self-registered in child organizations via shared applications",
+        message: "Enable <1>self-registration</1> to allow domain discovery for self-registration"
+    },
+    title: "Organization Discovery"
 };

--- a/modules/i18n/src/translations/en-US/portals/organization-discovery.ts
+++ b/modules/i18n/src/translations/en-US/portals/organization-discovery.ts
@@ -101,7 +101,8 @@ export const organizationDiscovery: organizationDiscoveryNS = {
         }
     },
     message: "Email domain discovery feature can only be used when email address is configured as the username."
-        + " When enabled, email domains are validated during user authentication and onboarding to organizations.",
+        + " When enabled, email domains are validated during user authentication and when administrators"
+        + " onboard users to organizations.",
     notifications: {
         addEmailDomains: {
             error: {
@@ -197,7 +198,7 @@ export const organizationDiscovery: organizationDiscoveryNS = {
     },
     selfRegistration: {
         label: "Email domain discovery for self-registration",
-        labelHint: "when enabled, users will be self-registered in child organizations via shared applications",
+        labelHint: "When enabled, users will be self-registered in child organizations via shared applications",
         message: "Enable <1>self-registration</1> to allow domain discovery for self-registration"
     },
     title: "Organization Discovery"

--- a/modules/i18n/src/translations/en-US/portals/pages.ts
+++ b/modules/i18n/src/translations/en-US/portals/pages.ts
@@ -38,7 +38,7 @@ export const pages: pagesNS = {
     },
     emailDomainDiscovery: {
         subTitle: "Configure email domain discovery for organizations.",
-        title: "Email Domain Discovery"
+        title: "Organization Discovery"
     },
     emailLocaleAdd: {
         backButton: "Go back to {{name}} template",


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Following improvements will be made to the existing email domain discovery page 
- Generalize the page name to "Organization Discovery"
- Move down the assign email domain button from top right corner to separate email domain discovery related configs from email domain mappings for organizations
- Improve the info message at the top to mention the flows that restricts email domains when email domain discovery is enabled
- Add a checkbox to incorporate the new config: email domain based organization discovery for self-registration

<img width="1483" alt="Screenshot 2024-11-05 at 10 50 23 AM" src="https://github.com/user-attachments/assets/06f54ce6-b7e1-4af7-ab9e-f0dd7e9b815d">

### Related issue
- https://github.com/wso2/product-is/issues/21610