### PR TITLE
Show only the email field in the regsitration field when the email as username is enabled

### DIFF
--- a/.changeset/lemon-baboons-collect.md
+++ b/.changeset/lemon-baboons-collect.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Hide username filed with deployment.toml change

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -114,6 +114,9 @@
     String errorMsg = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorMsg"));
     String consentPurposeGroupName = "SELF-SIGNUP";
     String consentPurposeGroupType = "SYSTEM";
+    boolean isEmailUsernameEnabled = MultitenantUtils.isEmailUserName();
+    boolean hideUsernameFieldWhenEmailAsUsernameIsEnabled = Boolean.parseBoolean(config.getServletContext().getInitParameter(
+        "HideUsernameWhenEmailAsUsernameEnabled"));
 
     String[] missingClaimList = new String[0];
     String[] missingClaimDisplayName = new String[0];

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -1602,6 +1602,10 @@
                         var error_msg = $("#error-msg");
                         var server_error_msg = $("#server-error-msg");
 
+                        if (<%=isEmailUsernameEnabled%> && <%=hideUsernameFieldWhenEmailAsUsernameIsEnabled%>) {
+                            alphanumericUsernameUserInput.value = usernameUserInput.value;
+                        }
+
                         if (!<%=isUsernameValidationEnabled%>) {
                             if (showUsernameRegexValidationStatus()) {
                                 userName.value = alphanumericUsernameUserInput.value.trim();
@@ -1711,6 +1715,10 @@
                 var elements = document.getElementsByTagName("input");
                 var error_msg = $("#error-msg");
                 var server_error_msg = $("#server-error-msg");
+
+                if (<%=isEmailUsernameEnabled%> && <%=hideUsernameFieldWhenEmailAsUsernameIsEnabled%>) {
+                    alphanumericUsernameUserInput.value = usernameUserInput.value;
+                }
 
                 // Username validation.
                 if (!<%=isUsernameValidationEnabled%>) {

--- a/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -48,6 +48,12 @@
                 <param-value>{{ accountrecoveryendpoint.auto_login_cookie_domain }}</param-value>
         </context-param>
     {% endif %}
+    {% if accountrecoveryendpoint.hide_username_when_email_as_username_enabled is defined %}
+        <context-param>
+           <param-name>HideUsernameWhenEmailAsUsernameEnabled</param-name>
+           <param-value>{{ accountrecoveryendpoint.hide_username_when_email_as_username_enabled }}</param-value>
+       </context-param>
+    {% endif %}
     {% if event.default_listener.validation.enable is defined %}
         <context-param>
             <param-name>isPasswordInputValidationEnabled</param-name>


### PR DESCRIPTION
## Purpose
$subject
The UI will look as below when the email as the username is enabled and the following configuration is set to true in the deployment.toml
```
[accountrecoveryendpoint]
hide_username_when_email_as_username_enabled = true
```

Enabled
<img width="493" alt="Screenshot 2024-10-30 at 12 30 00 PM" src="https://github.com/user-attachments/assets/b6bdea27-8e1a-42a7-880e-eb29885383b2">

Disable
<img width="521" alt="Screenshot 2024-11-02 at 4 39 26 PM" src="https://github.com/user-attachments/assets/431ee6c0-b05b-4b3a-ba15-0a732c43167c">


### Related Issue(s)
- https://github.com/wso2/product-is/issues/21411