### PR TITLE
Fix the issue in the self-registration flow when the email address is configured as a unique value

### DIFF
--- a/.changeset/swift-humans-bow.md
+++ b/.changeset/swift-humans-bow.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix the issue in the self-registration flow when the email address is configured as a unique value

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -153,6 +153,7 @@
     } catch (Exception e) {
         usernameConfig = null;
     }
+
     Boolean isAlphanumericUsernameEnabled = false;
     if (usernameConfig.has("alphanumericFormatValidator")) {
         isAlphanumericUsernameEnabled = (Boolean) usernameConfig.get("alphanumericFormatValidator");


### PR DESCRIPTION
## Purpose
This PR resolves issues in the self-registration flow when the email address is configured as a unique value. Previously, if a user entered an already registered email, they were redirected to an error page without an option to enter a different email and continue the registration process. This PR addresses that by including the email field on the error page. Additionally, it fixes an issue where, even with a valid email, the password fields would trigger an 'empty password' error. These issues are now resolved with this PR.

## Related Issue
- https://github.com/wso2/product-is/issues/21567
- https://github.com/wso2/product-is/issues/21579
- https://github.com/wso2/product-is/issues/21565