### PR TITLE
Ingore regex pattern matching for inbound OAuth apps

### DIFF
--- a/.changeset/cold-doors-brush.md
+++ b/.changeset/cold-doors-brush.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/react-components": patch
+"@wso2is/core": patch
+---
+
+Ingore regex pattern matching for inbound OAuth apps

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -1962,7 +1962,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                             return false;
                                         }
                                         if (URLUtils.isURLValid(value)) {
-                                            if (URLUtils.isHttpUrl(value) || URLUtils.isHttpsUrl(value)) {
+                                            if (URLUtils.isHttpUrl(value, false) || URLUtils.isHttpsUrl(value, false)) {
                                                 setCallbackURLsErrorLabel(null);
 
                                                 return true;

--- a/features/admin.applications.v1/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/features/admin.applications.v1/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -21,7 +21,6 @@ import { TestableComponentInterface } from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
 import { Field, FormValue, Forms } from "@wso2is/forms";
 import { ContentLoader, Hint, LinkButton, Message, URLInput } from "@wso2is/react-components";
-import { FormValidation } from "@wso2is/validation";
 import intersection from "lodash-es/intersection";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";

--- a/features/admin.applications.v1/components/wizard/oauth-protocol-settings-wizard-form.tsx
+++ b/features/admin.applications.v1/components/wizard/oauth-protocol-settings-wizard-form.tsx
@@ -543,14 +543,8 @@ export const OauthProtocolSettingsWizardForm: FunctionComponent<OAuthProtocolSet
                                             }
 
                                             if (URLUtils.isURLValid(value)) {
-                                                if (FormValidation.url(value, {
-                                                    domain: {
-                                                        allowUnicode: true,
-                                                        minDomainSegments: 1,
-                                                        tlds: false
-                                                    },
-                                                    scheme: [ "http", "https" ]
-                                                })) {
+                                                if (URLUtils.isHttpUrl(value, false) ||
+                                                URLUtils.isHttpsUrl(value, false)) {
                                                     setCallbackURLsErrorLabel(null);
 
                                                     return true;

--- a/modules/core/src/utils/url-utils.ts
+++ b/modules/core/src/utils/url-utils.ts
@@ -34,33 +34,35 @@ export class URLUtils {
     private constructor() { }
 
     /**
-     * Checks if the passed in url is a valid Http URL.
+     * Checks if the passed-in URL is a valid HTTP URL.
+     * If `forceRegexValidation` is false, it only checks if the URL starts with "http://".
      *
      * @param url - URL to evaluate.
-     *
-     * @returns True if the url is a http url.
+     * @param forceRegexValidation - Flag to use regex pattern validation (default: true).
+     * @returns True if the URL is a valid HTTP URL.
      */
-    public static isHttpUrl(url: string): boolean {
-        if (url.startsWith("http://")) {
-            return !!url.trim().match(PatternConstants.HTTP_URL_REGEX_PATTERN);
+    public static isHttpUrl(url: string, forceRegexValidation: boolean = true): boolean {
+        if (!forceRegexValidation) {
+            return url.trim().startsWith("http://");
         }
 
-        return false;
+        return !!url.trim().match(PatternConstants.HTTP_URL_REGEX_PATTERN);
     }
 
     /**
-     * Checks if the passed in url is a valid Https URL.
+     * Checks if the passed-in URL is a valid HTTPS URL.
+     * If `forceRegexValidation` is false, it only checks if the URL starts with "https://".
      *
      * @param url - URL to evaluate.
-     *
-     * @returns True if the url is a https url.
+     * @param forceRegexValidation - Flag to use regex pattern validation (default: true).
+     * @returns True if the URL is a valid HTTPS URL.
      */
-    public static isHttpsUrl(url: string): boolean {
-        if (url.startsWith("https://")) {
-            return !!url.trim().match(PatternConstants.HTTPS_URL_REGEX_PATTERN);
+    public static isHttpsUrl(url: string, forceRegexValidation: boolean = true): boolean {
+        if (!forceRegexValidation) {
+            return url.trim().startsWith("https://");
         }
 
-        return false;
+        return !!url.trim().match(PatternConstants.HTTPS_URL_REGEX_PATTERN);
     }
 
     /**

--- a/modules/react-components/src/components/input/url-input.tsx
+++ b/modules/react-components/src/components/input/url-input.tsx
@@ -513,8 +513,8 @@ export const URLInput: FunctionComponent<URLInputPropsInterface> = (
     const resolveCORSStatusLabel = (url: string) => {
         const { origin, href } = URLUtils.urlComponents(url);
         const positive: boolean = isOriginIsKnownAndAllowed(url);
-        const isValid: boolean = (URLUtils.isURLValid(url, true) && (URLUtils.isHttpUrl(url) ||
-            URLUtils.isHttpsUrl(url)));
+        const isValid: boolean = (URLUtils.isURLValid(url, true) && (URLUtils.isHttpUrl(url, false) ||
+            URLUtils.isHttpsUrl(url, false)));
 
         /**
          * TODO : React Components should not depend on the product


### PR DESCRIPTION
### Purpose
$subject
To properly fix this, we have initially tried to do the regex pattern validation asynchronously with a webworker and kill the asyc task within a one second period if the regex pattern validation didn't complete. This is the best approach to do this. But when we try that we came up with several blockers where we couldn't use the async function inside the `url-input` component due to the way it was written. So we couldn't go with the above approach we mentioned. Therefore as a fix to this we are going to just ignore the regex pattern validation for inbound-oauth apps. 
Create this https://github.com/wso2/product-is/issues/21706 issue here to support the async validation for URLInput component.

### Related Issues
- https://github.com/wso2/product-is/issues/21375
