### PR TITLE
Introduce enable for user store config in attribute mapping section

### DIFF
--- a/.changeset/old-turkeys-talk.md
+++ b/.changeset/old-turkeys-talk.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/i18n": patch
+---
+
+Introduce enable for user store config in attribute mappings

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attribute-local-claims.scss
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attribute-local-claims.scss
@@ -1,3 +1,0 @@
-.userstore-acordion {
-    margin: 2 0 2 0;
-}

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attribute-local-claims.scss
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attribute-local-claims.scss
@@ -1,0 +1,3 @@
+.userstore-acordion {
+    margin: 2 0 2 0;
+}

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -70,7 +70,7 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
     const {
         claim,
         update,
-        [ "data-componentid" ]: componentId
+        [ "data-componentid" ]: componentId = "edit-local-claims-mapped-attributes"
     } = props;
 
     const dispatch: Dispatch = useDispatch();

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -15,11 +15,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+import { AccordionDetails } from "@mui/material";
+import Accordion from "@oxygen-ui/react/Accordion";
+import AccordionSummary from "@oxygen-ui/react/AccordionSummary";
+import Checkbox from "@oxygen-ui/react/Checkbox";
+import Typography from "@oxygen-ui/react/Typography";
+import { ChevronDownIcon } from "@oxygen-ui/react-icons";
 import { Show } from "@wso2is/access-control";
 import { AppState, FeatureConfigInterface } from "@wso2is/admin.core.v1";
 import { getUserStoreList } from "@wso2is/admin.userstores.v1/api";
 import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-stores";
-import { hasRequiredScopes } from "@wso2is/core/helpers";
+// import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, AttributeMapping, Claim, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms, useTrigger } from "@wso2is/forms";
@@ -31,6 +37,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { Divider, Grid } from "semantic-ui-react";
 import { updateAClaim } from "../../../api";
+// import "./edit-mapped-attributes-local-claims.scss";
 
 /**
  * Prop types of `EditMappedAttributesLocalClaims` component
@@ -97,15 +104,16 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
     }, []);
 
     const isReadOnly: boolean = useMemo(() => (
-        !hasRequiredScopes(
-            featureConfig?.attributeDialects, featureConfig?.attributeDialects?.scopes?.update, allowedScopes)
+        // !hasRequiredScopes(
+        //     featureConfig?.attributeDialects, featureConfig?.attributeDialects?.scopes?.update, allowedScopes)
+        false
     ), [ featureConfig, allowedScopes ]);
 
     return (
         <EmphasizedSegment padded="very">
             <Grid data-testid={ testId }>
                 <Grid.Row columns={ 1 }>
-                    <Grid.Column tablet={ 16 } computer={ 12 } largeScreen={ 9 } widescreen={ 6 } mobile={ 16 }>
+                    <Grid.Column tablet={ 16 } computer={ 12 } largeScreen={ 12 } widescreen={ 9 } mobile={ 16 }>
                         <p>
                             { t("claims:local.mappedAttributes.hint") }
                         </p>
@@ -162,37 +170,60 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                                     });
                             } }
                         >
-                            <Grid>
-                                { userStore.map((store: UserStoreListItem, index: number) => {
-                                    return (
-                                        <Grid.Row columns={ 2 } key={ index }>
-                                            <Grid.Column width={ 4 }>
-                                                { store.name }
-                                            </Grid.Column>
-                                            <Grid.Column width={ 12 }>
-                                                <Field
-                                                    type="text"
-                                                    name={ store.name }
-                                                    placeholder={ t("claims:local.forms." +
-                                                        "attribute.placeholder") }
-                                                    required={ true }
-                                                    requiredErrorMessage={
-                                                        t("claims:local.forms." +
-                                                        "attribute.requiredErrorMessage")
-                                                    }
-                                                    value={ claim?.attributeMapping?.find(
-                                                        (attribute: AttributeMapping) => {
-                                                            return attribute.userstore
-                                                                .toLowerCase() === store.name.toLowerCase();
-                                                        })?.mappedAttribute }
-                                                    data-testid={ `${ testId }-form-store-name-input` }
-                                                    readOnly={ isReadOnly }
-                                                />
-                                            </Grid.Column>
-                                        </Grid.Row>
-                                    );
-                                }) }
-                            </Grid>
+                            { userStore.map((store: UserStoreListItem, index: number) => {
+                                return (
+                                    <>
+                                        <Accordion
+                                            className="userstore-acordion"
+                                            defaultExpanded
+                                            expanded={ true }
+                                        >
+                                            <AccordionSummary
+                                                // expandIcon={ <ChevronDownIcon /> }
+                                            >
+                                                <Typography variant="h6"> { store.name } </Typography>
+                                            </AccordionSummary>
+                                            <AccordionDetails>
+                                                <Grid>
+                                                    <Grid.Row columns={ 2 } key={ index }>
+                                                        <Grid.Column width={ 6 }>
+                                                            Mapped attribute name
+                                                        </Grid.Column>
+                                                        <Grid.Column width={ 6 }>
+                                                            <Field
+                                                                type="text"
+                                                                name={ store.name }
+                                                                placeholder={ t("claims:local.forms." +
+                                                                     "attribute.placeholder") }
+                                                                required={ true }
+                                                                requiredErrorMessage={
+                                                                    t("claims:local.forms." +
+                                                                    "attribute.requiredErrorMessage")
+                                                                }
+                                                                value={ claim?.attributeMapping?.find(
+                                                                    (attribute: AttributeMapping) => {
+                                                                        return attribute.userstore
+                                                                            .toLowerCase() === store.name.toLowerCase();
+                                                                    })?.mappedAttribute }
+                                                                data-testid={ `${ testId }-form-store-name-input` }
+                                                                readOnly={ isReadOnly }
+                                                            />
+                                                        </Grid.Column>
+                                                    </Grid.Row>
+                                                    <Grid.Row columns={ 2 } key={ index }>
+                                                        <Grid.Column width={ 6 }>
+                                                            Supported by user store
+                                                        </Grid.Column>
+                                                        <Grid.Column width={ 6 }>
+                                                            <Checkbox />
+                                                        </Grid.Column>
+                                                    </Grid.Row>
+                                                </Grid>
+                                            </AccordionDetails>
+                                        </Accordion>
+                                    </>
+                                );
+                            }) }
                         </Forms>
 
                     </Grid.Column>

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -20,13 +20,13 @@ import Accordion from "@oxygen-ui/react/Accordion";
 import AccordionSummary from "@oxygen-ui/react/AccordionSummary";
 import Checkbox from "@oxygen-ui/react/Checkbox";
 import Typography from "@oxygen-ui/react/Typography";
-import { ChevronDownIcon } from "@oxygen-ui/react-icons";
-import { Show } from "@wso2is/access-control";
+import { Show, useRequiredScopes } from "@wso2is/access-control";
 import { AppState, FeatureConfigInterface } from "@wso2is/admin.core.v1";
+import { userstoresConfig } from "@wso2is/admin.extensions.v1";
 import { getUserStoreList } from "@wso2is/admin.userstores.v1/api";
+import { PRIMARY_USERSTORE } from "@wso2is/admin.userstores.v1/constants";
 import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-stores";
-// import { hasRequiredScopes } from "@wso2is/core/helpers";
-import { AlertLevels, AttributeMapping, Claim, TestableComponentInterface } from "@wso2is/core/models";
+import { AlertLevels, AttributeMapping, Claim, IdentifiableComponentInterface, Property } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms, useTrigger } from "@wso2is/forms";
 import { EmphasizedSegment, PrimaryButton } from "@wso2is/react-components";
@@ -37,12 +37,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { Divider, Grid } from "semantic-ui-react";
 import { updateAClaim } from "../../../api";
-// import "./edit-mapped-attributes-local-claims.scss";
+import { ClaimManagementConstants } from "../../../constants";
 
 /**
  * Prop types of `EditMappedAttributesLocalClaims` component
  */
-interface EditMappedAttributesLocalClaimsPropsInterface extends TestableComponentInterface {
+interface EditMappedAttributesLocalClaimsPropsInterface extends IdentifiableComponentInterface {
     /**
      * Claim to be edited
      */
@@ -52,6 +52,13 @@ interface EditMappedAttributesLocalClaimsPropsInterface extends TestableComponen
      */
     update: () => void;
 }
+
+const USER_STORE_CONFIG_SUPPORTED_CLAIMS: string[] = [
+    ClaimManagementConstants.EMAIL_ADDRESSES_CLAIM_URI,
+    ClaimManagementConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM_URI,
+    ClaimManagementConstants.MOBILE_NUMBERS_CLAIM_URI,
+    ClaimManagementConstants.VERIFIED_MOBILE_NUMBERS_CLAIM_URI
+];
 
 /**
  * This component renders the Mapped Attribute pane of
@@ -68,7 +75,7 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
     const {
         claim,
         update,
-        [ "data-testid" ]: testId
+        [ "data-componentid" ]: componentId
     } = props;
 
     const dispatch: Dispatch = useDispatch();
@@ -80,22 +87,48 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
 
     const { t } = useTranslation();
 
-    const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const hiddenUserStores: string[] = useSelector((state: AppState) => state.config.ui.hiddenUserStores);
+
+    const isReadOnly: boolean = !useRequiredScopes(
+        featureConfig?.attributeDialects?.scopes?.update
+    );
+
+    const getExcludedStoresFromClaim = (claim: Claim): string[] => {
+        const property: Property = claim?.properties?.find(
+            (prop: Property) => prop?.key?.toLowerCase()
+                === ClaimManagementConstants.EXCLUDED_USER_STORES_CLAIM_PROPERTY.toLowerCase()
+        );
+
+        return property?.value?.split(",") || [];
+    };
+    const [ excludedUserStores, setExcludedUserStores ] = useState<string[]>(
+        getExcludedStoresFromClaim(claim)
+    );
 
     useEffect(() => {
         //TODO: [Type Fix] Cannot use `UserStoreListItem[]` here
         // because in line 74 some attributes are missing.
         const userstore: any[] = [];
 
-        userstore.push({
-            id: "PRIMARY",
-            name: "PRIMARY"
-        });
+        if (userstoresConfig?.primaryUserstoreName === PRIMARY_USERSTORE) {
+            userstore.push({
+                id: PRIMARY_USERSTORE,
+                name: PRIMARY_USERSTORE
+            });
+        }
 
         getUserStoreList()
             .then((response: AxiosResponse) => {
-                userstore.push(...response.data);
+                if (hiddenUserStores && hiddenUserStores.length > 0) {
+                    response.data.map((store: UserStoreListItem) => {
+                        if (!hiddenUserStores.includes(store?.name)) {
+                            userstore.push(store);
+                        }
+                    });
+                } else {
+                    userstore.push(...response.data);
+                }
                 setUserStore(userstore);
             })
             .catch(() => {
@@ -103,15 +136,26 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
             });
     }, []);
 
-    const isReadOnly: boolean = useMemo(() => (
-        // !hasRequiredScopes(
-        //     featureConfig?.attributeDialects, featureConfig?.attributeDialects?.scopes?.update, allowedScopes)
-        false
-    ), [ featureConfig, allowedScopes ]);
+    const getMappedAttributeForUserStore = (userStore: string): string | undefined => {
+        const mappingForGivenUserStore: string = claim?.attributeMapping?.find(
+            (attribute: AttributeMapping) =>
+                attribute.userstore.toLowerCase() === userStore.toLowerCase()
+        )?.mappedAttribute;
+
+        // If no specific mapping found, use PRIMARY userstore mapping.
+        if (!mappingForGivenUserStore && userStore !== PRIMARY_USERSTORE) {
+            return claim?.attributeMapping?.find(
+                (attribute: AttributeMapping) =>
+                    attribute.userstore.toLowerCase() === PRIMARY_USERSTORE.toLowerCase()
+            )?.mappedAttribute;
+        }
+
+        return mappingForGivenUserStore;
+    };
 
     return (
         <EmphasizedSegment padded="very">
-            <Grid data-testid={ testId }>
+            <Grid data-componentid={ componentId }>
                 <Grid.Row columns={ 1 }>
                     <Grid.Column tablet={ 16 } computer={ 12 } largeScreen={ 12 } widescreen={ 9 } mobile={ 16 }>
                         <p>
@@ -134,7 +178,18 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                                                 mappedAttribute: attribute.toString(),
                                                 userstore: userstore.toString()
                                             };
-                                        })
+                                        }),
+                                    properties: [
+                                        ...(claimData.properties?.filter((prop: Property) =>
+                                            prop.key.toLowerCase() !==
+                                            ClaimManagementConstants.EXCLUDED_USER_STORES_CLAIM_PROPERTY
+                                                .toLowerCase()
+                                        ) || []),
+                                        {
+                                            key: ClaimManagementConstants.EXCLUDED_USER_STORES_CLAIM_PROPERTY,
+                                            value: excludedUserStores.join(",")
+                                        }
+                                    ]
                                 };
 
                                 setIsSubmitting(true);
@@ -174,20 +229,19 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                                 return (
                                     <>
                                         <Accordion
-                                            className="userstore-acordion"
                                             defaultExpanded
                                             expanded={ true }
                                         >
-                                            <AccordionSummary
-                                                // expandIcon={ <ChevronDownIcon /> }
-                                            >
+                                            <AccordionSummary>
                                                 <Typography variant="h6"> { store.name } </Typography>
                                             </AccordionSummary>
                                             <AccordionDetails>
                                                 <Grid>
-                                                    <Grid.Row columns={ 2 } key={ index }>
+                                                    <Grid.Row columns={ 2 } key={ index } verticalAlign="middle">
                                                         <Grid.Column width={ 6 }>
-                                                            Mapped attribute name
+                                                            <p> {
+                                                                t("claims:local.mappedAttributes.mappedAttributeName")
+                                                            }</p>
                                                         </Grid.Column>
                                                         <Grid.Column width={ 6 }>
                                                             <Field
@@ -200,24 +254,43 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                                                                     t("claims:local.forms." +
                                                                     "attribute.requiredErrorMessage")
                                                                 }
-                                                                value={ claim?.attributeMapping?.find(
-                                                                    (attribute: AttributeMapping) => {
-                                                                        return attribute.userstore
-                                                                            .toLowerCase() === store.name.toLowerCase();
-                                                                    })?.mappedAttribute }
-                                                                data-testid={ `${ testId }-form-store-name-input` }
+                                                                value={ getMappedAttributeForUserStore(store.name) }
+                                                                data-componentid={
+                                                                    `${componentId}-form-attribute-name-input-
+                                                                    ${store.name}` }
                                                                 readOnly={ isReadOnly }
                                                             />
                                                         </Grid.Column>
                                                     </Grid.Row>
-                                                    <Grid.Row columns={ 2 } key={ index }>
-                                                        <Grid.Column width={ 6 }>
-                                                            Supported by user store
-                                                        </Grid.Column>
-                                                        <Grid.Column width={ 6 }>
-                                                            <Checkbox />
-                                                        </Grid.Column>
-                                                    </Grid.Row>
+                                                    { USER_STORE_CONFIG_SUPPORTED_CLAIMS.includes(claim.claimURI) && (
+                                                        <Grid.Row columns={ 2 } key={ index } verticalAlign="middle">
+                                                            <Grid.Column width={ 6 }>
+                                                                <p>{ t("claims:local.mappedAttributes." +
+                                                                    "enableForUserStore") }</p>
+                                                            </Grid.Column>
+                                                            <Grid.Column width={ 6 }>
+                                                                <Checkbox
+                                                                    checked={ !excludedUserStores.includes(store.name) }
+                                                                    onChange={
+                                                                        (e: React.ChangeEvent<HTMLInputElement>) => {
+                                                                            const newExcludedStores: string[]
+                                                                                = e.target.checked
+                                                                                    ? excludedUserStores.filter(
+                                                                                        (name: string) =>
+                                                                                            name !== store.name)
+                                                                                    : [ ...excludedUserStores,
+                                                                                        store.name ];
+
+                                                                            setExcludedUserStores(newExcludedStores);
+                                                                        } }
+                                                                    disabled={ isReadOnly }
+                                                                    data-componentid={
+                                                                        `${componentId}-form-userstore-support-checkbox-
+                                                                        ${store.name}` }
+                                                                />
+                                                            </Grid.Column>
+                                                        </Grid.Row>
+                                                    ) }
                                                 </Grid>
                                             </AccordionDetails>
                                         </Accordion>
@@ -225,7 +298,6 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                                 );
                             }) }
                         </Forms>
-
                     </Grid.Column>
                 </Grid.Row>
                 <Grid.Row columns={ 1 }>
@@ -237,7 +309,7 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                                 onClick={ () => {
                                     setSubmit();
                                 } }
-                                data-testid={ `${ testId }-form-submit-button` }
+                                data-componentid={ `${ componentId }-form-submit-button` }
                                 loading={ isSubmitting }
                                 disabled={ isSubmitting }
                             >
@@ -255,5 +327,5 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
  * Default props for the component.
  */
 EditMappedAttributesLocalClaims.defaultProps = {
-    "data-testid": "edit-local-claims-mapped-attributes"
+    "data-componentid": "edit-local-claims-mapped-attributes"
 };

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -31,7 +31,7 @@ import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms, useTrigger } from "@wso2is/forms";
 import { EmphasizedSegment, PrimaryButton } from "@wso2is/react-components";
 import { AxiosResponse } from "axios";
-import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";

--- a/features/admin.claims.v1/constants/claim-management-constants.ts
+++ b/features/admin.claims.v1/constants/claim-management-constants.ts
@@ -108,7 +108,7 @@ export class ClaimManagementConstants {
         ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM2_SCHEMAS_CORE_USER"),
         ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM2_SCHEMAS_EXT_ENT_USER"),
         ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM_SCHEMAS_CORE")
-    ]
+    ];
 
     public static readonly CUSTOM_MAPPING: string = SCIMConfigs.custom;
 
@@ -130,39 +130,39 @@ export class ClaimManagementConstants {
         isAttributeButtonEnabled: boolean;
         attributeButtonText: string;
     }[] = [
-        {
-            attributeButtonText: "",
-            isAttributeButtonEnabled: false,
-            name: "Core Schema",
-            uri: "urn:ietf:params:scim:schemas:core:2.0"
-        },
-        {
-            attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction",
-            isAttributeButtonEnabled: true,
-            name: "User Schema",
-            uri: "urn:ietf:params:scim:schemas:core:2.0:User"
-        },
-        {
-            attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction" ,
-            isAttributeButtonEnabled: true,
-            name: "Enterprise Schema",
-            uri: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
-        },
-        {
-            attributeButtonText: "",
-            isAttributeButtonEnabled: true,
-            name: "Core 1.0 Schema",
-            uri: "urn:scim:schemas:core:1.0"
-        }
-    ];
+            {
+                attributeButtonText: "",
+                isAttributeButtonEnabled: false,
+                name: "Core Schema",
+                uri: "urn:ietf:params:scim:schemas:core:2.0"
+            },
+            {
+                attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction",
+                isAttributeButtonEnabled: true,
+                name: "User Schema",
+                uri: "urn:ietf:params:scim:schemas:core:2.0:User"
+            },
+            {
+                attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction" ,
+                isAttributeButtonEnabled: true,
+                name: "Enterprise Schema",
+                uri: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+            },
+            {
+                attributeButtonText: "",
+                isAttributeButtonEnabled: true,
+                name: "Core 1.0 Schema",
+                uri: "urn:scim:schemas:core:1.0"
+            }
+        ];
 
     public static readonly EIDAS_TABS: {
         name: string;
         uri: string;
     }[] = [
-        { name: "eIDAS/Legal Person", uri: "http://eidas.europa.eu/attributes/legalperson" },
-        { name: "eIDAS/Natural Person", uri: "http://eidas.europa.eu/attributes/naturalperson" }
-    ];
+            { name: "eIDAS/Legal Person", uri: "http://eidas.europa.eu/attributes/legalperson" },
+            { name: "eIDAS/Natural Person", uri: "http://eidas.europa.eu/attributes/naturalperson" }
+        ];
 
     /**
      * Display names of User Id & Username to
@@ -175,22 +175,27 @@ export class ClaimManagementConstants {
     public static readonly APPLICATION_ROLES_CLAIM_URI: string = "http://wso2.org/claims/applicationRoles";
     public static readonly LOCATION_CLAIM_URI: string = "http://wso2.org/claims/location";
     public static readonly EMAIL_CLAIM_URI: string = "http://wso2.org/claims/emailaddress";
+    public static readonly EMAIL_ADDRESSES_CLAIM_URI: string = "http://wso2.org/claims/emailAddresses";
+    public static readonly VERIFIED_EMAIL_ADDRESSES_CLAIM_URI: string = "http://wso2.org/claims/verifiedEmailAddresses";
     public static readonly MOBILE_CLAIM_URI: string = "http://wso2.org/claims/mobile";
+    public static readonly MOBILE_NUMBERS_CLAIM_URI: string = "http://wso2.org/claims/mobileNumbers";
+    public static readonly VERIFIED_MOBILE_NUMBERS_CLAIM_URI: string = "http://wso2.org/claims/verifiedMobileNumbers";
 
     public static readonly GROUPS_CLAIM_NAME: string = "groups";
     public static readonly ROLES_CLAIM_NAME: string = "roles";
     public static readonly APPLICATION_ROLES_CLAIM_NAME: string = "application_roles";
 
     public static readonly EMPTY_STRING: string = "";
+    public static readonly EXCLUDED_USER_STORES_CLAIM_PROPERTY: string = "ExcludedUserStores";
 
     /**
      * The error code that is returned when there is no item in the list
      */
-     public static readonly RESOURCE_NOT_FOUND_ERROR_CODE: string = "CMT-50017";
+    public static readonly RESOURCE_NOT_FOUND_ERROR_CODE: string = "CMT-50017";
 
-     /**
+    /**
      * The character length of the regex field.
      */
-     public static readonly REGEX_FIELD_MAX_LENGTH: number = 255;
-     public static readonly REGEX_FIELD_MIN_LENGTH: number = 3;
+    public static readonly REGEX_FIELD_MAX_LENGTH: number = 255;
+    public static readonly REGEX_FIELD_MIN_LENGTH: number = 3;
 }

--- a/features/admin.claims.v1/constants/claim-management-constants.ts
+++ b/features/admin.claims.v1/constants/claim-management-constants.ts
@@ -188,6 +188,13 @@ export class ClaimManagementConstants {
     public static readonly EMPTY_STRING: string = "";
     public static readonly EXCLUDED_USER_STORES_CLAIM_PROPERTY: string = "ExcludedUserStores";
 
+    public static readonly USER_STORE_CONFIG_SUPPORTED_CLAIMS: string[] = [
+        ClaimManagementConstants.EMAIL_ADDRESSES_CLAIM_URI,
+        ClaimManagementConstants.VERIFIED_EMAIL_ADDRESSES_CLAIM_URI,
+        ClaimManagementConstants.MOBILE_NUMBERS_CLAIM_URI,
+        ClaimManagementConstants.VERIFIED_MOBILE_NUMBERS_CLAIM_URI
+    ];
+
     /**
      * The error code that is returned when there is no item in the list
      */

--- a/features/admin.claims.v1/constants/claim-management-constants.ts
+++ b/features/admin.claims.v1/constants/claim-management-constants.ts
@@ -130,39 +130,39 @@ export class ClaimManagementConstants {
         isAttributeButtonEnabled: boolean;
         attributeButtonText: string;
     }[] = [
-            {
-                attributeButtonText: "",
-                isAttributeButtonEnabled: false,
-                name: "Core Schema",
-                uri: "urn:ietf:params:scim:schemas:core:2.0"
-            },
-            {
-                attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction",
-                isAttributeButtonEnabled: true,
-                name: "User Schema",
-                uri: "urn:ietf:params:scim:schemas:core:2.0:User"
-            },
-            {
-                attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction" ,
-                isAttributeButtonEnabled: true,
-                name: "Enterprise Schema",
-                uri: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
-            },
-            {
-                attributeButtonText: "",
-                isAttributeButtonEnabled: true,
-                name: "Core 1.0 Schema",
-                uri: "urn:scim:schemas:core:1.0"
-            }
-        ];
+        {
+            attributeButtonText: "",
+            isAttributeButtonEnabled: false,
+            name: "Core Schema",
+            uri: "urn:ietf:params:scim:schemas:core:2.0"
+        },
+        {
+            attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction",
+            isAttributeButtonEnabled: true,
+            name: "User Schema",
+            uri: "urn:ietf:params:scim:schemas:core:2.0:User"
+        },
+        {
+            attributeButtonText: "claims:external.pageLayout.edit.attributeMappingPrimaryAction" ,
+            isAttributeButtonEnabled: true,
+            name: "Enterprise Schema",
+            uri: "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+        },
+        {
+            attributeButtonText: "",
+            isAttributeButtonEnabled: true,
+            name: "Core 1.0 Schema",
+            uri: "urn:scim:schemas:core:1.0"
+        }
+    ];
 
     public static readonly EIDAS_TABS: {
         name: string;
         uri: string;
     }[] = [
-            { name: "eIDAS/Legal Person", uri: "http://eidas.europa.eu/attributes/legalperson" },
-            { name: "eIDAS/Natural Person", uri: "http://eidas.europa.eu/attributes/naturalperson" }
-        ];
+        { name: "eIDAS/Legal Person", uri: "http://eidas.europa.eu/attributes/legalperson" },
+        { name: "eIDAS/Natural Person", uri: "http://eidas.europa.eu/attributes/naturalperson" }
+    ];
 
     /**
      * Display names of User Id & Username to

--- a/features/admin.claims.v1/pages/local-claims-edit.tsx
+++ b/features/admin.claims.v1/pages/local-claims-edit.tsx
@@ -126,7 +126,7 @@ const LocalClaimsEditPage: FunctionComponent<LocalClaimsEditPageInterface> = (
                     <EditMappedAttributesLocalClaims
                         claim={ claim }
                         update={ getClaim }
-                        data-testid={ `${ testId }-edit-local-claims-mapped-attributes` }
+                        data-componentid={ `${ testId }-edit-local-claims-mapped-attributes` }
                     />
                 </ResourceTab.Pane>
             )

--- a/features/admin.claims.v1/pages/local-claims-edit.tsx
+++ b/features/admin.claims.v1/pages/local-claims-edit.tsx
@@ -219,19 +219,11 @@ const LocalClaimsEditPage: FunctionComponent<LocalClaimsEditPageInterface> = (
             bottomMargin={ false }
             data-testid={ `${ testId }-page-layout` }
         >
-            { attributeConfig.attributes.showEditTabs
-                ? (
-                    <ResourceTab
-                        isLoading={ isLocalClaimDetailsRequestLoading }
-                        panes={ panes }
-                        data-testid={ `${ testId }-tabs` } />
-                ) : (
-                    <ResourceTab
-                        isLoading={ isLocalClaimDetailsRequestLoading }
-                        panes={ basicPanes }
-                        data-testid={ `${ testId }-tabs` } />
-                )
-            }
+            <ResourceTab
+                isLoading={ isLocalClaimDetailsRequestLoading }
+                panes={  attributeConfig?.attributes?.showEditTabs ? panes : basicPanes }
+                data-testid={ `${testId}-tabs` }
+            />
         </TabPageLayout>
     );
 };

--- a/features/admin.claims.v1/pages/local-claims-edit.tsx
+++ b/features/admin.claims.v1/pages/local-claims-edit.tsx
@@ -146,6 +146,39 @@ const LocalClaimsEditPage: FunctionComponent<LocalClaimsEditPageInterface> = (
     ];
 
     /**
+     * Contains the data of the basic panes.
+     */
+    const basicPanes: {
+        menuItem: string;
+        render: () => JSX.Element;
+    }[] = [
+        {
+            menuItem: t("claims:local.pageLayout.edit.tabs.general"),
+            render: () => (
+                <ResourceTab.Pane controlledSegmentation>
+                    <EditBasicDetailsLocalClaims
+                        claim={ claim }
+                        update={ getClaim }
+                        data-testid="local-claims-basic-details-edit"
+                    />
+                </ResourceTab.Pane>
+            )
+        },
+        {
+            menuItem: t("claims:local.pageLayout.edit.tabs.mappedAttributes"),
+            render: () => (
+                <ResourceTab.Pane controlledSegmentation>
+                    <EditMappedAttributesLocalClaims
+                        claim={ claim }
+                        update={ getClaim }
+                        data-componentid={ `${ testId }-edit-local-claims-mapped-attributes` }
+                    />
+                </ResourceTab.Pane>
+            )
+        }
+    ];
+
+    /**
      * This generates the first letter of a claim.
      * @param name - Name of the claim.
      * @returns The first letter of a claim.
@@ -193,11 +226,10 @@ const LocalClaimsEditPage: FunctionComponent<LocalClaimsEditPageInterface> = (
                         panes={ panes }
                         data-testid={ `${ testId }-tabs` } />
                 ) : (
-                    <EditBasicDetailsLocalClaims
-                        claim={ claim }
-                        update={ getClaim }
-                        data-testid="local-claims-basic-details-edit"
-                    />
+                    <ResourceTab
+                        isLoading={ isLocalClaimDetailsRequestLoading }
+                        panes={ basicPanes }
+                        data-testid={ `${ testId }-tabs` } />
                 )
             }
         </TabPageLayout>

--- a/modules/i18n/src/models/namespaces/claims-ns.ts
+++ b/modules/i18n/src/models/namespaces/claims-ns.ts
@@ -511,6 +511,8 @@ export interface ClaimsNS {
         };
         mappedAttributes: {
             hint: string;
+            mappedAttributeName: string;
+            enableForUserStore: string;
         };
     };
     list: {

--- a/modules/i18n/src/translations/en-US/portals/claims.ts
+++ b/modules/i18n/src/translations/en-US/portals/claims.ts
@@ -497,7 +497,9 @@ export const claims: ClaimsNS = {
             }
         },
         mappedAttributes: {
-            hint: "Enter the attribute from each user store that you want to map to this attribute."
+            enableForUserStore: "Enable for this user store",
+            hint: "Enter the attribute from the respective user stores that will be mapped to this attribute.",
+            mappedAttributeName: "Mapped Attribute Name"
         },
         notifications: {
             addLocalClaim: {
@@ -571,7 +573,7 @@ export const claims: ClaimsNS = {
                 tabs: {
                     additionalProperties: "Additional Properties",
                     general: "General",
-                    mappedAttributes: "Mapped Attributes"
+                    mappedAttributes: "Attribute Mappings"
                 }
             },
             local: {


### PR DESCRIPTION
### Purpose
- Introduce enable for user store config in attribute mapping section for multi emails and multi mobile related local claims.
- Make "Attribute Mappings" section visible in cloud environment.

<img width="678" alt="Screenshot 2024-11-14 at 20 44 06" src="https://github.com/user-attachments/assets/04b5a6ae-8e12-4f49-9a9f-09a8ac5f5af1">

<img width="690" alt="Screenshot 2024-11-14 at 20 43 36" src="https://github.com/user-attachments/assets/84fc36b2-8b69-4e70-9b7a-204ec6ad923d">


### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Related PRs
- https://github.com/wso2/identity-apps/pull/6563
- https://github.com/wso2/identity-apps/pull/6583

### Checklist

- [x] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [x] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets