### PR TITLE
Use getRoleBasicInfoById when checking Administrator role

### DIFF
--- a/.changeset/seven-snakes-speak.md
+++ b/.changeset/seven-snakes-speak.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Use getRoleBasicInfoById when checking Administrator role

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/AppPortalRoleManagementListener.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/AppPortalRoleManagementListener.java
@@ -25,7 +25,7 @@ import org.wso2.carbon.identity.organization.management.service.util.Organizatio
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.listener.AbstractRoleManagementListener;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Permission;
-import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
@@ -150,7 +150,8 @@ public class AppPortalRoleManagementListener extends AbstractRoleManagementListe
 
     private boolean isAdministratorRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
 
-        Role role = AppsCommonDataHolder.getInstance().getRoleManagementServiceV2().getRole(roleId, tenantDomain);
+        RoleBasicInfo role = AppsCommonDataHolder.getInstance().getRoleManagementServiceV2().getRoleBasicInfoById(
+            roleId, tenantDomain);
 
         return role != null && StringUtils.equalsIgnoreCase(ADMINISTRATOR, role.getName())
             && StringUtils.equalsIgnoreCase(APPLICATION, role.getAudience())

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/test/java/org/wso2/identity/apps/common/listener/AppPortalRoleManagementListenerTest.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/test/java/org/wso2/identity/apps/common/listener/AppPortalRoleManagementListenerTest.java
@@ -29,7 +29,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
-import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.config.RealmConfiguration;
@@ -81,7 +81,7 @@ public class AppPortalRoleManagementListenerTest {
     private RoleManagementService roleManagementService;
 
     @Mock
-    private Role role;
+    private RoleBasicInfo role;
 
     @BeforeMethod
     public void setUp() {
@@ -140,7 +140,7 @@ public class AppPortalRoleManagementListenerTest {
         when(mockUserRealm.getUserStoreManager()).thenReturn(mockUserStoreManager);
         when(mockUserStoreManager.getUserIDFromUserName(anyString())).thenReturn(adminUserId);
         mockAppsCommonDataHolder(appsCommonDataHolder);
-        when(roleManagementService.getRole(roleId, tenantDomain)).thenReturn(role);
+        when(roleManagementService.getRoleBasicInfoById(roleId, tenantDomain)).thenReturn(role);
         setRoleAttributes(isAdminRole);
 
         // Call the method.


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Use getRoleBasicInfoById instead of getRole method when checking Administrator role to avoid unnecessary DB calls.


### Related Issues
https://github.com/wso2/product-is/issues/21496