### PR TITLE
Add checkbox to configure JIT outbound provisioning when adding a outbound provisioner.

### DIFF
--- a/.changeset/smart-mirrors-sort.md
+++ b/.changeset/smart-mirrors-sort.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.provisioning.v1": patch
+---
+
+Add a checkbox to configure JIT outbound when adding a provisioning connector.

--- a/features/admin.provisioning.v1/components/outbound-provisioning-connector-setup-form.tsx
+++ b/features/admin.provisioning.v1/components/outbound-provisioning-connector-setup-form.tsx
@@ -334,7 +334,6 @@ export const OutboundProvisioningConnectorSetupForm: FunctionComponent<
                         <Field
                             name="jit"
                             required={ false }
-                            requiredErrorMessage=""
                             type="checkbox"
                             children={ [
                                 {

--- a/features/admin.provisioning.v1/components/outbound-provisioning-connector-setup-form.tsx
+++ b/features/admin.provisioning.v1/components/outbound-provisioning-connector-setup-form.tsx
@@ -90,6 +90,7 @@ export const OutboundProvisioningConnectorSetupForm: FunctionComponent<
     const [ selectedIdp, setSelectedIdp ] = useState<string>();
     const [ isBlockingChecked, setIsBlockingChecked ] = useState<boolean>(initialValues?.blocking ?? false);
     const [ isRulesChecked, setIsRulesChecked ] = useState<boolean>(initialValues?.rules ?? false);
+    const [ isJITChecked, setIsJITChecked ] = useState<boolean>(initialValues?.jit);
     const [ connector, setConnector ] = useState<string>(initialValues?.connector);
 
     useEffect(() => {
@@ -187,6 +188,7 @@ export const OutboundProvisioningConnectorSetupForm: FunctionComponent<
             blocking: isBlockingChecked,
             connector: connector,
             idp: idpName,
+            jit: isJITChecked,
             rules: isRulesChecked
         };
     };
@@ -324,6 +326,34 @@ export const OutboundProvisioningConnectorSetupForm: FunctionComponent<
                         <Hint>
                             { t("applications:forms.outboundProvisioning.fields.blocking" +
                                 ".hint") }
+                        </Hint>
+                    </Grid.Column>
+                </Grid.Row>
+                <Grid.Row columns={ 1 }>
+                    <Grid.Column mobile={ 16 } computer={ 10 }>
+                        <Field
+                            name="jit"
+                            required={ false }
+                            requiredErrorMessage=""
+                            type="checkbox"
+                            children={ [
+                                {
+                                    label: t("applications:forms.outboundProvisioning" +
+                                        ".fields.jit.label"),
+                                    value: "jit"
+                                }
+                            ] }
+                            value={ initialValues?.jit ? [ "jit" ] : [] }
+                            listen={
+                                (values: Map<string, FormValue>) => {
+                                    setIsJITChecked(values.get("jit").includes("jit"));
+                                }
+                            }
+                            readOnly={ isReadOnly }
+                            data-testid={ `${ componentId }-jit-checkbox` }
+                        />
+                        <Hint>
+                            { t("applications:forms.outboundProvisioning.fields.jit.hint") }
                         </Hint>
                     </Grid.Column>
                 </Grid.Row>


### PR DESCRIPTION
## Purpose
This PR adds a checkbox to allow enabling JIT outbound when adding an outbound provisioning connector

<img width="737" alt="Screenshot 2024-11-19 at 1 35 15 PM" src="https://github.com/user-attachments/assets/8c743d4d-056c-4d28-adcf-98cf27876f72">

### Related issue
- https://github.com/wso2/product-is/issues/21405