### PR TITLE
Hide attribute mappings section when no remote user stores are plugged in

### DIFF
--- a/.changeset/five-chicken-carry.md
+++ b/.changeset/five-chicken-carry.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.userstores.v1": patch
+"@wso2is/admin.claims.v1": patch
+---
+
+Hide attribute mappings when no remote users stores

--- a/features/admin.userstores.v1/models/user-stores.ts
+++ b/features/admin.userstores.v1/models/user-stores.ts
@@ -39,6 +39,15 @@ export interface UserStoreListItem {
 }
 
 /**
+ * User store basic details object.
+ */
+export interface UserStoreBasicData {
+    id: string;
+    name: string;
+    enabled?: boolean;
+}
+
+/**
  * Type of userstore list item passed as options to dropdown fields.
  */
 export interface UserStoreDropdownItem {


### PR DESCRIPTION
### Purpose
Hide attribute mappings section when no remote user stores are plugged in.

<img width="953" alt="image" src="https://github.com/user-attachments/assets/f323b7b9-df9a-4ec8-8848-4dc0b8608064">

### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Related PRs
- https://github.com/wso2/identity-apps/pull/7124

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
