### PR TITLE
Make Attribute Mappings section visible when remote user stores are configured

### DIFF
--- a/.changeset/funny-cherries-visit.md
+++ b/.changeset/funny-cherries-visit.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.claims.v1": patch
+---
+
+Show attribute mappings section for remote user stores

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -143,15 +143,20 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                                 delete claimData.id;
                                 delete claimData.dialectURI;
 
+                                const updatedMappings: AttributeMapping[] = Array.from(values)?.map(
+                                    ([ userstore, attribute ]: [string, FormValue]) => ({
+                                        mappedAttribute: attribute?.toString(),
+                                        userstore: userstore?.toString()
+                                    })
+                                );
+
+                                const existingMappings: AttributeMapping[] = claim?.attributeMapping?.filter(
+                                    (mapping: AttributeMapping) => !values.has(mapping?.userstore)
+                                ) || [];
+
                                 const submitData: Claim = {
                                     ...claimData,
-                                    attributeMapping: Array.from(values).map(
-                                        ([ userstore, attribute ]: [ string, FormValue ]) => {
-                                            return {
-                                                mappedAttribute: attribute.toString(),
-                                                userstore: userstore.toString()
-                                            };
-                                        }),
+                                    attributeMapping: [ ...updatedMappings, ...existingMappings ],
                                     properties: [
                                         ...(claimData.properties?.filter((prop: Property) =>
                                             prop.key.toLowerCase() !==

--- a/features/admin.claims.v1/pages/local-claims-edit.tsx
+++ b/features/admin.claims.v1/pages/local-claims-edit.tsx
@@ -180,6 +180,40 @@ const LocalClaimsEditPage: FunctionComponent<LocalClaimsEditPageInterface> = (
     ];
 
     /**
+     * Contains the data of the basic panes.
+     */
+    const basicPanes: {
+        menuItem: string;
+        render: () => JSX.Element;
+    }[] = [
+        {
+            menuItem: t("claims:local.pageLayout.edit.tabs.general"),
+            render: () => (
+                <ResourceTab.Pane controlledSegmentation>
+                    <EditBasicDetailsLocalClaims
+                        claim={ claim }
+                        update={ getClaim }
+                        data-testid="local-claims-basic-details-edit"
+                    />
+                </ResourceTab.Pane>
+            )
+        },
+        {
+            menuItem: t("claims:local.pageLayout.edit.tabs.mappedAttributes"),
+            render: () => (
+                <ResourceTab.Pane controlledSegmentation>
+                    <EditMappedAttributesLocalClaims
+                        claim={ claim }
+                        update={ getClaim }
+                        userStores={ userStores }
+                        data-componentid={ `${ testId }-edit-local-claims-mapped-attributes` }
+                    />
+                </ResourceTab.Pane>
+            )
+        }
+    ];
+
+    /**
      * This generates the first letter of a claim.
      * @param name - Name of the claim.
      * @returns The first letter of a claim.
@@ -227,11 +261,17 @@ const LocalClaimsEditPage: FunctionComponent<LocalClaimsEditPageInterface> = (
                             isLoading={ isLocalClaimDetailsRequestLoading }
                             panes={  panes }
                             data-testid={ `${testId}-tabs` } />)
-                    : (
-                        <EditBasicDetailsLocalClaims
-                            claim={ claim }
-                            update={ getClaim }
-                            data-testid="local-claims-basic-details-edit"/>)
+                    : userStores?.length >= 1
+                        ? (
+                            <ResourceTab
+                                isLoading={ isLocalClaimDetailsRequestLoading }
+                                panes={ basicPanes }
+                                data-testid={ `${testId}-tabs` } />)
+                        : (
+                            <EditBasicDetailsLocalClaims
+                                claim={ claim }
+                                update={ getClaim }
+                                data-testid="local-claims-basic-details-edit"/>)
             }
 
         </TabPageLayout>


### PR DESCRIPTION
### Purpose
- Make Attribute Mappings section visible when remote user stores are configured

### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Related PRs
- https://github.com/wso2/identity-apps/pull/7135
- https://github.com/wso2/identity-apps/pull/7139

### Checklist

- [] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [x] Documentation provided. (Add links if there are any) - 
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
