### PR TITLE
Improve attribute mappings logic to handle deleted user store mappings

### DIFF
--- a/.changeset/chilled-vans-jam.md
+++ b/.changeset/chilled-vans-jam.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/admin.users.v1": patch
+"@wso2is/myaccount": patch
+---
+
+Improve attribut mappings logic to remove deleted user store mappings

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -340,7 +340,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                 }
 
                 const excludedUserStores: string[] =
-                    schema?.excludedUserStores?.split(",")?.map((store: string) => store.trim().toUpperCase()) || [];
+                    schema?.excludedUserStores?.split(",")?.map((store: string) => store?.trim().toUpperCase()) || [];
 
                 return !excludedUserStores.includes(userStoreDomain);
             });

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -29,7 +29,6 @@ import { AlertLevels, AttributeMapping, Claim, IdentifiableComponentInterface, P
 import { addAlert } from "@wso2is/core/store";
 import { Field, FormValue, Forms, useTrigger } from "@wso2is/forms";
 import { EmphasizedSegment, PrimaryButton } from "@wso2is/react-components";
-import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -324,7 +324,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                 }
 
                 const excludedUserStores: string[] =
-                    schema?.excludedUserStores?.split(",")?.map((store: string) => store.trim().toUpperCase()) || [];
+                    schema?.excludedUserStores?.split(",")?.map((store: string) => store?.trim().toUpperCase()) || [];
 
                 return !excludedUserStores.includes(userStoreDomain);
             });


### PR DESCRIPTION
### Purpose
Improve attribute mappings logic to handle deleted user store mappings

- When submitting code now filters the excludedUserStores list to include only those user stores that exist. This prevents any deleted user stores from being included in the EXCLUDED_USER_STORES_CLAIM_PROPERTY.

- The existingMappings array filters out mappings associated with deleted user stores, ensuring that only valid mappings are preserved.

### Related Issues
- https://github.com/wso2/product-is/issues/19991

### Related PRs
- https://github.com/wso2/identity-apps/pull/7124
- https://github.com/wso2/identity-apps/pull/7145

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
