### PR TITLE
Hide new remote user stores in administrators listing

### DIFF
--- a/.changeset/lazy-eggs-talk.md
+++ b/.changeset/lazy-eggs-talk.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.console-settings.v1": patch
+---
+
+Hide new remote user stores in administrators listing

--- a/features/admin.console-settings.v1/components/console-administrators/console-administrators.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/console-administrators.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -27,6 +27,7 @@ import { userstoresConfig } from "@wso2is/admin.extensions.v1";
 import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import { useUserStores } from "@wso2is/admin.userstores.v1/api";
+import { RemoteUserStoreManagerType } from "@wso2is/admin.userstores.v1/constants/user-store-constants";
 import { UserStoreDropdownItem, UserStoreListItem, UserStorePostData } from "@wso2is/admin.userstores.v1/models";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, {
@@ -118,6 +119,11 @@ const ConsoleAdministrators: FunctionComponent<ConsoleAdministratorsInterface> =
             };
 
             userStoreList?.forEach((store: UserStoreListItem, index: number) => {
+                // Skip the remote user store in administrators listing as it is not supporting user listing.
+                if (store?.typeName === RemoteUserStoreManagerType.RemoteUserStoreManager) {
+                    return;
+                }
+
                 if (store?.name?.toUpperCase() !== userstoresConfig?.primaryUserstoreName) {
                     getAUserStore(store.id).then((response: UserStorePostData) => {
                         const isDisabled: boolean = response.properties.find(


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
$subject since the new remote user stores implementation does not support user listing yet.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/identity-apps/pull/7099

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
