### PR TITLE
Fix branding issue in dismiss button of the timeout modal

### DIFF
--- a/.changeset/fast-suits-promise.md
+++ b/.changeset/fast-suits-promise.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Reflect branding in dismiss button of the timeout modal

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/util/modal.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/util/modal.jsp
@@ -48,7 +48,7 @@
         </div>
     </div>
     <div class="actions">
-        <div class="ui deny button" id="asg-modal-0-dismiss-button">
+        <div class="ui secondary deny button" id="asg-modal-0-dismiss-button">
             ${param.cancel_button_text}
         </div>
         <c:if test="${not empty param.action_button_text}">

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/util/modal.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/util/modal.jsp
@@ -48,7 +48,7 @@
         </div>
     </div>
     <div class="actions">
-        <div class="ui deny button" id="asg-modal-0-dismiss-button">
+        <div class="ui secondary deny button" id="asg-modal-0-dismiss-button">
             ${param.cancel_button_text}
         </div>
         <c:if test="${not empty param.action_button_text}">


### PR DESCRIPTION
## Purpose
- https://github.com/wso2/product-is/issues/21756

Applied for both authentication portal and account recovery portal timeout modals.

Default UI

<img width="717" alt="image" src="https://github.com/user-attachments/assets/725a6c6a-42c7-47e3-996b-5d52967aa4ec">


Added the `secondary` CSS class to apply the dismiss button branding.

<img width="720" alt="image" src="https://github.com/user-attachments/assets/5efa0116-3a71-4911-beb2-fb7b86b2b168">

This pull request includes changes to reflect branding in the dismiss button of the timeout modal across different web applications. The most important changes are:

UI updates:

* [`identity-apps-core/apps/authentication-portal/src/main/webapp/util/modal.jsp`](diffhunk://#diff-43937527ebe2ee06a27a18846366d5e4ffce47381d2d72d6692b4efa8589953eL51-R51): Updated the dismiss button to use the `secondary` class for branding consistency.
* [`identity-apps-core/apps/recovery-portal/src/main/webapp/util/modal.jsp`](diffhunk://#diff-dd40315313c4024b49babc9ec85c8f2c199ed12e0d0f38283df1598f047b2a8cL51-R51): Updated the dismiss button to use the `secondary` class for branding consistency.