### PR TITLE
Fix show pagination issue in roles page

### DIFF
--- a/.changeset/khaki-apples-juggle.md
+++ b/.changeset/khaki-apples-juggle.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix role pagination issue.

--- a/.changeset/khaki-apples-juggle.md
+++ b/.changeset/khaki-apples-juggle.md
@@ -1,5 +1,5 @@
 ---
-"@wso2is/console": patch
+"@wso2is/admin.roles.v2": patch
 ---
 
 Fix role pagination issue.

--- a/features/admin.roles.v2/pages/role.tsx
+++ b/features/admin.roles.v2/pages/role.tsx
@@ -303,7 +303,7 @@ const RolesPage: FunctionComponent<RolesPagePropsInterface> = (
                         />
                     )
                 }
-                showPagination={ rolesList?.totalResults > 0 }
+                showPagination={ true }
                 totalPages={ Math.ceil(rolesList?.totalResults / listItemLimit) }
                 totalListSize={ rolesList?.totalResults }
                 isLoading={ isRolesListLoading }


### PR DESCRIPTION
Set showPagination prop to true, as the previous logic causes the pagination element to reset when the next button is clicked for the first time as the roleList value being null sometimes.

Related Issues:
- https://github.com/wso2/product-is/issues/21822