### PR TITLE
Add info modal for unavailable email templates

### DIFF
--- a/.changeset/rotten-months-shout.md
+++ b/.changeset/rotten-months-shout.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.email-management.v1": patch
+"@wso2is/console": patch
+---
+
+Add info modal for unavailable loacle for suborgs.

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -2678,6 +2678,11 @@ export interface Extensions {
                 replicateContent: {
                     header: string;
                     message: string;
+                },
+                updateFromRootOrg: {
+                    header: string,
+                    message: string,
+                    content: string
                 }
             },
             dangerZone: {

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -2967,6 +2967,11 @@ export const extensions: Extensions = {
                 replicateContent: {
                     header: "Replicate content?",
                     message: "Seems like you don't have any content for this locale. Do you need to populate the previous locale's content here as a quick start?"
+                },
+                updateFromRootOrg: {
+                    header: "Template not available",
+                    message: "Template is not available for selected locale.",
+                    content: "The selected locale is not available for the selected template currently. Please contact admins for more infomation."
                 }
             },
             dangerZone: {

--- a/features/admin.email-management.v1/pages/email-customization.tsx
+++ b/features/admin.email-management.v1/pages/email-customization.tsx
@@ -75,6 +75,7 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
     const [ selectedEmailTemplate, setSelectedEmailTemplate ] = useState<EmailTemplate>();
     const [ currentEmailTemplate, setCurrentEmailTemplate ] = useState<EmailTemplate>();
     const [ showReplicatePreviousTemplateModal, setShowReplicatePreviousTemplateModal ] = useState(false);
+    const [ showUpdateTemplateFromRootOrgModal, setShowUpdateTemplateFromRootOrgModal ] = useState(false);
     const [ isTemplateNotAvailable, setIsTemplateNotAvailable ] = useState(false);
 
     const emailTemplates: Record<string, string>[] = useSelector(
@@ -206,6 +207,9 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
             } else {
                 setCurrentEmailTemplate(undefined);
             }
+            setShowUpdateTemplateFromRootOrgModal(true);
+
+            return;
         }
 
         if (emailTemplateError.response.data.description) {
@@ -345,6 +349,10 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
         setShowReplicatePreviousTemplateModal(false);
     };
 
+    const alertUpdateTemplateFromRootOrg = () => {
+        setShowUpdateTemplateFromRootOrgModal(false);
+    };
+
     const resolveTabPanes = ():  TabProps[ "panes" ] => {
         const panes: TabProps [ "panes" ] = [];
 
@@ -462,6 +470,33 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
                     >
                         { t("extensions:develop.emailTemplates.modal.replicateContent.message") }
                     </ConfirmationModal.Message>
+                </ConfirmationModal>
+
+                <ConfirmationModal
+                    type="info"
+                    open={ showUpdateTemplateFromRootOrgModal }
+                    primaryAction={ t("common:okay") }
+                    onPrimaryActionClick={ (): void => alertUpdateTemplateFromRootOrg() }
+                    data-componentid={ `${ componentId }-update-template-from-root-org-modal` }
+                    closeOnDimmerClick={ true }
+                >
+                    <ConfirmationModal.Header
+                        data-componentid={ `${ componentId }-update-template-from-root-org-modal-header` }
+                    >
+                        { t("extensions:develop.emailTemplates.modal.updateFromRootOrg.header") }
+                    </ConfirmationModal.Header>
+                    <ConfirmationModal.Message
+                        attached
+                        info
+                        data-componentid={ `${ componentId }-update-template-from-root-org-modal-message` }
+                    >
+                        { t("extensions:develop.emailTemplates.modal.updateFromRootOrg.message") }
+                    </ConfirmationModal.Message>
+                    <ConfirmationModal.Content
+                        data-testid={ `${ componentId }-update-template-from-root-org-modal-content` }
+                    >
+                        { t("extensions:develop.emailTemplates.modal.updateFromRootOrg.content") }
+                    </ConfirmationModal.Content>
                 </ConfirmationModal>
             </PageLayout>
         </BrandingPreferenceProvider>

--- a/features/admin.email-management.v1/pages/email-customization.tsx
+++ b/features/admin.email-management.v1/pages/email-customization.tsx
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-import { Show } from "@wso2is/access-control";
+import { Show, useRequiredScopes } from "@wso2is/access-control";
 import BrandingPreferenceProvider from "@wso2is/admin.branding.v1/providers/branding-preference-provider";
 import { AppState, FeatureConfigInterface, I18nConstants } from "@wso2is/admin.core.v1";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
-import { hasRequiredScopes, isFeatureEnabled } from "@wso2is/core/helpers";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
 import {
     AlertInterface,
     AlertLevels,
@@ -91,26 +91,26 @@ const EmailCustomizationPage: FunctionComponent<EmailCustomizationPageInterface>
     const { t } = useTranslation();
     const { getLink } = useDocumentation();
 
+    const hasUsersUpdateEmailTemplatesPermissions: boolean = useRequiredScopes(
+        emailTemplatesFeatureConfig?.scopes?.update
+    );
+
+    const hasUsersCreateEmailTemplatesPermissions: boolean = useRequiredScopes(
+        emailTemplatesFeatureConfig?.scopes?.create
+    );
+
     const isReadOnly: boolean = useMemo(() => {
         return !isFeatureEnabled(
             emailTemplatesFeatureConfig,
             EmailManagementConstants.FEATURE_DICTIONARY.get("EMAIL_TEMPLATES_UPDATE")
-        ) || !hasRequiredScopes(
-            emailTemplatesFeatureConfig,
-            emailTemplatesFeatureConfig?.scopes?.update,
-            allowedScopes
-        );
+        ) || hasUsersUpdateEmailTemplatesPermissions;
     }, [ emailTemplatesFeatureConfig, allowedScopes ]);
 
     const hasEmailTemplateCreatePermissions: boolean = useMemo(() => {
         return isFeatureEnabled(
             emailTemplatesFeatureConfig,
             EmailManagementConstants.FEATURE_DICTIONARY.get("EMAIL_TEMPLATES_CREATE")
-        ) && hasRequiredScopes(
-            emailTemplatesFeatureConfig,
-            emailTemplatesFeatureConfig?.scopes?.create,
-            allowedScopes
-        );
+        ) && hasUsersCreateEmailTemplatesPermissions;
     }, [ emailTemplatesFeatureConfig, allowedScopes ]);
 
     const {


### PR DESCRIPTION
Add info message to alert when selected locale of an email template from sub-org which is not available.

Design : 
<img width="1512" alt="Screenshot 2024-12-16 at 10 21 29" src="https://github.com/user-attachments/assets/5fa1c05c-98e8-4f8b-a0f5-aea7bffc8820" />
