### PR TITLE
[APIM Public] Validate the auth fail massege with the resourceBundle

### DIFF
--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -311,3 +311,4 @@ error.user.not.found.smsotp=User not found in the directory. Cannot proceed furt
 authenticate.button=Authenticate
 please.enter.code=Please enter the code!
 enter.phone.number=Enter Your Mobile Phone Number
+federated.login=Federated Login

--- a/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -271,3 +271,4 @@ error.user.not.found.smsotp=Utilisateur introuvable dans l'annuaire. Impossible 
 authenticate.button=S'uthentifier
 please.enter.code=Veuillez entrer le code !
 enter.phone.number=Entrez votre numÃ©ro de tÃ©lÃ©phone portable
+federated.login=Connexion fédérée

--- a/apps/authentication-portal/src/main/webapp/domain.jsp
+++ b/apps/authentication-portal/src/main/webapp/domain.jsp
@@ -27,14 +27,22 @@
 
 <%
     String domainUnknown = AuthenticationEndpointUtil.i18n(resourceBundle, "domain.unknown");
-    String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.failed");
+    String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "authentication.failed.please.retry");
     boolean loginFailed = false;
     if (Boolean.parseBoolean(request.getParameter("authFailure"))) {
         loginFailed = true;
         if (request.getParameter("authFailureMsg") != null) {
-            errorMessage = request.getParameter("authFailureMsg");
+            String error = Encode.forJava(request.getParameter("authFailureMsg"));
+            /*
+            * Only allowing error messages defined in the resourceBundle.
+            * AuthenticationEndpointUtil.i18n() will return the value of the provided key if the key is found
+            * in the resourceBundle. If the key is not found, it will return the key itself.
+            */
+            if (!error.equalsIgnoreCase(AuthenticationEndpointUtil.i18n(resourceBundle, error))) {
+                errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, error);
+            }
 
-            if (domainUnknown.equalsIgnoreCase(errorMessage)) {
+            if (domainUnknown.equalsIgnoreCase(error)) {
                 errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "domain.cannot.be.identified");
             }
         }


### PR DESCRIPTION
Port: https://github.com/wso2-support/identity-apps/pull/473

### Purpose
This PR adds a validation for the auth failure message with the values defined in the resourceBundle to ensure unwanted values are not displayed on the page.

### Related issues
https://github.com/wso2-enterprise/wso2-apim-internal/issues/8218