### PR TITLE
Remove "Admin Advisory" and "Remote Log Publishing" cards from Server section

### DIFF
--- a/.changeset/lovely-bottles-hope.md
+++ b/.changeset/lovely-bottles-hope.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.server.v1": patch
+---
+
+Remove admin advisory and remote log publishing from server configs

--- a/features/admin.server.v1/pages/server.tsx
+++ b/features/admin.server.v1/pages/server.tsx
@@ -21,11 +21,7 @@ import Avatar from "@oxygen-ui/react/Avatar";
 import Card from "@oxygen-ui/react/Card";
 import Grid from "@oxygen-ui/react/Grid";
 import Typography from "@oxygen-ui/react/Typography";
-import {
-    ArrowLoopRightUserIcon,
-    UserBannerIcon,
-    UserIcon
-} from "@oxygen-ui/react-icons";
+import { ArrowLoopRightUserIcon } from "@oxygen-ui/react-icons";
 import { AppConstants, history } from "@wso2is/admin.core.v1";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { GenericIcon, PageLayout } from "@wso2is/react-components";
@@ -63,84 +59,6 @@ export const ServerSettingsListingPage: FunctionComponent<ServerSettingsListingP
         >
             <Ref innerRef={ pageContextRef }>
                 <Grid container rowSpacing={ 3 } columnSpacing={ 3 }>
-                    <Grid xs={ 12 } md={ 6 } lg={ 4 }>
-                        <Card
-                            key="admin-advisory-page-section"
-                            className="server-configuration"
-                            data-componentid="admin-advisory-page-section"
-                            onClick={ () => history.push(AppConstants.getPaths().get("ADMIN_ADVISORY_BANNER_EDIT")) }
-                        >
-                            <CardContent className="server-configuration-header">
-                                <div>
-                                    <GenericIcon
-                                        size="micro"
-                                        icon={ (
-                                            <Avatar
-                                                variant="square"
-                                                randomBackgroundColor
-                                                backgroundColorRandomizer="admin-advisory-banner"
-                                                className="server-configuration-icon-container"
-                                            >
-                                                <UserBannerIcon className="icon" />
-                                            </Avatar>
-                                        ) }
-                                        inline
-                                        transparent
-                                        shape="square"
-                                    />
-                                </div>
-                                <Typography variant="h6">
-                                    { t("console:manage.features.serverConfigs.adminAdvisory." +
-                                        "configurationSection.heading") }
-                                </Typography>
-                            </CardContent>
-                            <CardContent>
-                                <Typography variant="body2" color="text.secondary">
-                                    {  t("console:manage.features.serverConfigs.adminAdvisory." +
-                                        "configurationSection.description") }
-                                </Typography>
-                            </CardContent>
-                        </Card>
-                    </Grid>
-                    <Grid xs={ 12 } md={ 6 } lg={ 4 }>
-                        <Card
-                            key="remote-logging-page-section"
-                            data-componentid="remote-logging-page-section"
-                            className="server-configuration"
-                            onClick={ () => history.push(AppConstants.getPaths().get("REMOTE_LOGGING")) }
-                        >
-                            <CardContent className="server-configuration-header">
-                                <div>
-                                    <GenericIcon
-                                        size="micro"
-                                        icon={ (
-                                            <Avatar
-                                                variant="square"
-                                                randomBackgroundColor
-                                                backgroundColorRandomizer="remote-logging"
-                                                className="server-configuration-icon-container"
-                                            >
-                                                <UserIcon className="icon" />
-                                            </Avatar>
-                                        ) }
-                                        inline
-                                        transparent
-                                        shape="square"
-                                    />
-                                </div>
-                                <Typography variant="h6">
-                                    { t("console:manage.features.serverConfigs.remoteLogPublishing" +
-                                        ".title")  }
-                                </Typography>
-                            </CardContent>
-                            <CardContent>
-                                <Typography variant="body2" color="text.secondary">
-                                    { t("console:manage.features.serverConfigs.remoteLogPublishing" +
-                                        ".description")  }
-                                </Typography>
-                            </CardContent>
-                        </Card>
-                    </Grid>
                     <Grid xs={ 12 } md={ 6 } lg={ 4 }>
                         <Card
                             key="manage-notifications-sending-page-section"

--- a/features/admin.server.v1/public-api.ts
+++ b/features/admin.server.v1/public-api.ts
@@ -16,7 +16,5 @@
  * under the License.
  */
 
-export { default as AdminSessionAdvisoryBannerEditPage } from "./pages/admin-session-advisory-banner-page";
 export { default as InternalNotificationSendingPage } from "./pages/internal-notification-sending-page";
-export { default as RemoteLoggingPage } from "./pages/remote-logging-page";
 export { default as ServerSettingsListingPage } from "./pages/server";


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
`Admin Advisory Banner` and `Remote Log Publishing` sections are moved to `Manage Root Organization > Configure System Settings` under the tenant picker with the multi tenancy onboarding effort. This PR removes these two cards from the server section.

### Related Issues
- https://github.com/wso2/product-is/issues/22000

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
