### PR TITLE
Fix: Disabled secondary userstores are visibile in the mapped attribute menu of a local claim

### DIFF
--- a/.changeset/red-apples-relax.md
+++ b/.changeset/red-apples-relax.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/console": patch
+---
+
+Hide disabled userstores from mapped attribute menu

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -218,69 +218,73 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                             } }
                         >
                             { userStores.map((store: UserStoreBasicData, index: number) => {
-                                return (
-                                    <Accordion
-                                        defaultExpanded
-                                        expanded={ true }
-                                        key={ index }
-                                        data-componentid={ `${componentId}-form-accordion-${store.name}` }
-                                    >
-                                        <AccordionSummary>
-                                            <Typography variant="h6"> { store.name } </Typography>
-                                        </AccordionSummary>
-                                        <AccordionDetails>
-                                            <Grid>
-                                                <Grid.Row columns={ 2 } key={ index } verticalAlign="middle">
-                                                    <Grid.Column width={ 6 }>
-                                                        <p> {
-                                                            t("claims:local.mappedAttributes.mappedAttributeName")
-                                                        }</p>
-                                                    </Grid.Column>
-                                                    <Grid.Column width={ 6 }>
-                                                        <Field
-                                                            type="text"
-                                                            name={ store.name }
-                                                            placeholder={ t("claims:local.forms.attribute." +
-                                                                "placeholder") }
-                                                            required={ true }
-                                                            requiredErrorMessage={
-                                                                t("claims:local.forms." +
-                                                                    "attribute.requiredErrorMessage")
-                                                            }
-                                                            value={ getMappedAttributeForUserStore(store.name) }
-                                                            data-componentid={
-                                                                `${componentId}-form-attribute-name-input-
-                                                                    ${store.name}` }
-                                                            readOnly={ isReadOnly }
-                                                        />
-                                                    </Grid.Column>
-                                                </Grid.Row>
-                                                { ClaimManagementConstants.USER_STORE_CONFIG_SUPPORTED_CLAIMS
-                                                    .includes(claim.claimURI) && (
+                                if (store.enabled || store.id.toUpperCase() === PRIMARY_USERSTORE.toUpperCase()) {
+                                    return (
+                                        <Accordion
+                                            defaultExpanded
+                                            expanded={ true }
+                                            key={ index }
+                                            data-componentid={ `${componentId}-form-accordion-${store.name}` }
+                                        >
+                                            <AccordionSummary>
+                                                <Typography variant="h6"> { store.name } </Typography>
+                                            </AccordionSummary>
+                                            <AccordionDetails>
+                                                <Grid>
                                                     <Grid.Row columns={ 2 } key={ index } verticalAlign="middle">
                                                         <Grid.Column width={ 6 }>
-                                                            <p>{ t("claims:local.mappedAttributes." +
-                                                                    "enableForUserStore") }</p>
+                                                            <p> {
+                                                                t("claims:local.mappedAttributes.mappedAttributeName")
+                                                            }</p>
                                                         </Grid.Column>
                                                         <Grid.Column width={ 6 }>
-                                                            <Checkbox
-                                                                checked={ !excludedUserStores.includes(store.name) }
-                                                                onChange={ (e: React.ChangeEvent<HTMLInputElement>) =>
-                                                                    handleEnableForUserStore(
-                                                                        store.name, e.target.checked
-                                                                    ) }
-                                                                disabled={ isReadOnly }
+                                                            <Field
+                                                                type="text"
+                                                                name={ store.name }
+                                                                placeholder={ t("claims:local.forms.attribute." +
+                                                                    "placeholder") }
+                                                                required={ true }
+                                                                requiredErrorMessage={
+                                                                    t("claims:local.forms." +
+                                                                        "attribute.requiredErrorMessage")
+                                                                }
+                                                                value={ getMappedAttributeForUserStore(store.name) }
                                                                 data-componentid={
-                                                                    `${componentId}-form-userstore-support-checkbox` +
-                                                                        `-${store.name}` }
+                                                                    `${componentId}-form-attribute-name-input-
+                                                                        ${store.name}` }
+                                                                readOnly={ isReadOnly }
                                                             />
                                                         </Grid.Column>
                                                     </Grid.Row>
-                                                ) }
-                                            </Grid>
-                                        </AccordionDetails>
-                                    </Accordion>
-                                );
+                                                    { ClaimManagementConstants.USER_STORE_CONFIG_SUPPORTED_CLAIMS
+                                                        .includes(claim.claimURI) && (
+                                                        <Grid.Row columns={ 2 } key={ index } verticalAlign="middle">
+                                                            <Grid.Column width={ 6 }>
+                                                                <p>{ t("claims:local.mappedAttributes." +
+                                                                        "enableForUserStore") }</p>
+                                                            </Grid.Column>
+                                                            <Grid.Column width={ 6 }>
+                                                                <Checkbox
+                                                                    checked={ !excludedUserStores.includes(store.name) }
+                                                                    onChange={ 
+                                                                        (e: React.ChangeEvent<HTMLInputElement>) =>
+                                                                            handleEnableForUserStore(
+                                                                                store.name, e.target.checked
+                                                                            ) }
+                                                                    disabled={ isReadOnly }
+                                                                    data-componentid={
+                                                                        `${componentId}` +
+                                                                        "-form-userstore-support-checkbox" +
+                                                                        `-${store.name}` }
+                                                                />
+                                                            </Grid.Column>
+                                                        </Grid.Row>
+                                                    ) }
+                                                </Grid>
+                                            </AccordionDetails>
+                                        </Accordion>
+                                    );
+                                }
                             }) }
                         </Forms>
                     </Grid.Column>

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -266,7 +266,7 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
                                                             <Grid.Column width={ 6 }>
                                                                 <Checkbox
                                                                     checked={ !excludedUserStores.includes(store.name) }
-                                                                    onChange={ 
+                                                                    onChange={
                                                                         (e: React.ChangeEvent<HTMLInputElement>) =>
                                                                             handleEnableForUserStore(
                                                                                 store.name, e.target.checked


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This PR will hide disabled userstores from the mapped attribute menu of a local claim

### Related Issues
- https://github.com/wso2/product-is/issues/19208

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
