### PR TITLE
Add SAML2 Outbound Request Attribute ProviderName UI

### DIFF
--- a/.changeset/nasty-peaches-breathe.md
+++ b/.changeset/nasty-peaches-breathe.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.connections.v1": minor
+"@wso2is/i18n": minor
+---
+
+Add authentication request provider name config to set the ProviderName in SAML2 outbound requests

--- a/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -249,6 +249,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
             AuthRedirectUrl: findPropVal<string>({ defaultValue: authorizedRedirectURL, key: "AuthRedirectUrl" }),
             AuthnContextClassRef: findPropVal<string>({ defaultValue: "", key: "AuthnContextClassRef" }),
             AuthnContextComparisonLevel: findPropVal<string>({ defaultValue: "", key: "AuthnContextComparisonLevel" }),
+            AuthnReqProviderName: findPropVal<string>({ defaultValue: "", key: "authnReqProviderName" }),
             CustomAuthnContextClassRef: findPropVal<string>({ defaultValue: "", key: "CustomAuthnContextClassRef" }),
             DigestAlgorithm: findPropVal<string>({ defaultValue: "SHA256", key: "DigestAlgorithm" }),
             ForceAuthentication: findPropVal<string>({ defaultValue: "string", key: "ForceAuthentication" }),
@@ -298,8 +299,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
             /**
              * https://github.com/wso2/product-is/issues/17004
              */
-            isAssertionSigned: findPropVal<boolean>({ defaultValue: false, key: "isAssertionSigned" }),
-            AuthnReqProviderName: findPropVal<string>({defaultValue: "", key: "authnReqProviderName"})
+            isAssertionSigned: findPropVal<boolean>({ defaultValue: false, key: "isAssertionSigned" })
 
         } as SamlPropertiesInterface;
 

--- a/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -115,6 +115,7 @@ export interface SamlPropertiesInterface {
     IncludeCert?: boolean;
     IncludeNameIDPolicy?:boolean;
     AuthnContextClassRef?: string;
+    AuthnReqProviderName?: string;
 }
 
 const FORM_ID: string = "saml-authenticator-form";
@@ -297,7 +298,8 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
             /**
              * https://github.com/wso2/product-is/issues/17004
              */
-            isAssertionSigned: findPropVal<boolean>({ defaultValue: false, key: "isAssertionSigned" })
+            isAssertionSigned: findPropVal<boolean>({ defaultValue: false, key: "isAssertionSigned" }),
+            AuthnReqProviderName: findPropVal<string>({defaultValue: "", key: "authnReqProviderName"})
 
         } as SamlPropertiesInterface;
 
@@ -956,6 +958,25 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                             label={ t(`${ I18N_TARGET_KEY }.commonAuthQueryParams.label`) }
                             ariaLabel={ t(`${ I18N_TARGET_KEY }.commonAuthQueryParams.ariaLabel`) }
                             name="commonAuthQueryParams"
+                            readOnly={ readOnly }
+                        />
+                    </SectionRow>
+                    <SectionRow>
+                        <Field.Input
+                            name="authnReqProviderName"
+                            value={ formValues?.AuthnReqProviderName }
+                            inputType="default"
+                            placeholder={ t(`${ I18N_TARGET_KEY }.authnReqProviderName.placeholder`) }
+                            ariaLabel={ t(`${ I18N_TARGET_KEY }.authnReqProviderName.ariaLabel`) }
+                            data-testid={ `${ testId }-authnReqProviderName-field` }
+                            label={ (
+                                <FormInputLabel htmlFor="authnReqProviderName">
+                                    { t(`${ I18N_TARGET_KEY }.authnReqProviderName.label`) }
+                                </FormInputLabel>
+                            ) }
+                            maxLength={ 100 }
+                            minLength={ 0 }
+                            hint={ t(`${ I18N_TARGET_KEY }.authnReqProviderName.hint`) }
                             readOnly={ readOnly }
                         />
                     </SectionRow>

--- a/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -39,6 +39,7 @@ import {
 import {
     DEFAULT_NAME_ID_FORMAT,
     DEFAULT_PROTOCOL_BINDING,
+    IDENTITY_PROVIDER_AUTHENTICATION_REQUEST_PROVIDER_NAME_LENGTH,
     IDENTITY_PROVIDER_AUTHORIZED_REDIRECT_URL_LENGTH,
     IDENTITY_PROVIDER_ENTITY_ID_LENGTH,
     LOGOUT_URL_LENGTH,
@@ -249,7 +250,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
             AuthRedirectUrl: findPropVal<string>({ defaultValue: authorizedRedirectURL, key: "AuthRedirectUrl" }),
             AuthnContextClassRef: findPropVal<string>({ defaultValue: "", key: "AuthnContextClassRef" }),
             AuthnContextComparisonLevel: findPropVal<string>({ defaultValue: "", key: "AuthnContextComparisonLevel" }),
-            AuthnReqProviderName: findPropVal<string>({ defaultValue: "", key: "authnReqProviderName" }),
+            AuthnReqProviderName: findPropVal<string>({ defaultValue: "", key: "AuthnReqProviderName" }),
             CustomAuthnContextClassRef: findPropVal<string>({ defaultValue: "", key: "CustomAuthnContextClassRef" }),
             DigestAlgorithm: findPropVal<string>({ defaultValue: "SHA256", key: "DigestAlgorithm" }),
             ForceAuthentication: findPropVal<string>({ defaultValue: "string", key: "ForceAuthentication" }),
@@ -963,19 +964,19 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                     </SectionRow>
                     <SectionRow>
                         <Field.Input
-                            name="authnReqProviderName"
+                            name="AuthnReqProviderName"
                             value={ formValues?.AuthnReqProviderName }
                             inputType="default"
                             placeholder={ t(`${ I18N_TARGET_KEY }.authnReqProviderName.placeholder`) }
                             ariaLabel={ t(`${ I18N_TARGET_KEY }.authnReqProviderName.ariaLabel`) }
                             data-testid={ `${ testId }-authnReqProviderName-field` }
                             label={ (
-                                <FormInputLabel htmlFor="authnReqProviderName">
+                                <FormInputLabel htmlFor="AuthnReqProviderName">
                                     { t(`${ I18N_TARGET_KEY }.authnReqProviderName.label`) }
                                 </FormInputLabel>
                             ) }
-                            maxLength={ 100 }
-                            minLength={ 0 }
+                            maxLength={ IDENTITY_PROVIDER_AUTHENTICATION_REQUEST_PROVIDER_NAME_LENGTH.max }
+                            minLength={ IDENTITY_PROVIDER_AUTHENTICATION_REQUEST_PROVIDER_NAME_LENGTH.min }
                             hint={ t(`${ I18N_TARGET_KEY }.authnReqProviderName.hint`) }
                             readOnly={ readOnly }
                         />

--- a/features/admin.connections.v1/utils/saml-idp-utils.ts
+++ b/features/admin.connections.v1/utils/saml-idp-utils.ts
@@ -289,6 +289,7 @@ export const LOGOUT_URL_LENGTH: MinMaxLength = { max: 2048, min: 10 };
 export const IDENTITY_PROVIDER_ENTITY_ID_LENGTH: MinMaxLength = { max: 2048, min: 5 };
 export const IDENTITY_PROVIDER_NAME_LENGTH: MinMaxLength = { max: 120, min: 3 };
 export const IDENTITY_PROVIDER_AUTHORIZED_REDIRECT_URL_LENGTH: MinMaxLength = { max: 2048, min: 10 };
+export const IDENTITY_PROVIDER_AUTHENTICATION_REQUEST_PROVIDER_NAME_LENGTH: MinMaxLength = { max: 240, min: 0 };
 
 /**
  * Given a {@link FormErrors} object, it will check whether

--- a/modules/i18n/src/models/namespaces/authentication-provider-ns.ts
+++ b/modules/i18n/src/models/namespaces/authentication-provider-ns.ts
@@ -812,6 +812,12 @@ export interface AuthenticationProviderNS {
                     placeholder: string;
                     ariaLabel: string;
                 };
+                authnReqProviderName: {
+                    hint: string;
+                    label: string;
+                    placeholder: string;
+                    ariaLabel: string;
+                };
             };
         };
         outboundConnectorAccordion: {

--- a/modules/i18n/src/translations/en-US/portals/authentication-provider.ts
+++ b/modules/i18n/src/translations/en-US/portals/authentication-provider.ts
@@ -800,6 +800,12 @@ export const authenticationProvider:AuthenticationProviderNS = {
                     ariaLabel: "Enable assertion encryption",
                     hint: "Specify if SAMLAssertion element is encrypted",
                     label: "Enable assertion encryption"
+                },
+                authnReqProviderName: {
+                    hint: "The human-readable name of the requester.",
+                    label: "Authentication Request Provider Name",
+                    placeholder: "Enter authentication request provider name",
+                    ariaLabel: "Authentication Request Provider Name"
                 }
             },
             smsOTP: {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

Adds the UI for the SAML2 Outbound Request attribute ProviderName.

<img width="755" alt="Screenshot 2024-12-19 at 13 07 31" src="https://github.com/user-attachments/assets/cadcee49-1426-4a6b-9cf8-f64741293ca5" />

This supports getting the ProviderName via the `Authentication Request Provider Name` configuration in the SAML Connection.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/21536

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/182

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
