### PR TITLE
Enable API Resources UI in sub organization from View only capability

### DIFF
--- a/.changeset/blue-tigers-live.md
+++ b/.changeset/blue-tigers-live.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.api-resources.v2": patch
+"@wso2is/admin.core.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add API Resource View capability in sub orgs

--- a/.changeset/blue-tigers-live.md
+++ b/.changeset/blue-tigers-live.md
@@ -2,7 +2,6 @@
 "@wso2is/admin.api-resources.v2": patch
 "@wso2is/admin.core.v1": patch
 "@wso2is/console": patch
-"@wso2is/i18n": patch
 ---
 
 Add API Resource View capability in sub orgs

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -327,6 +327,7 @@ export interface Extensions {
         apiResource: {
             pageHeader: {
                 description: string;
+                subOrgDescription: string;
                 title: string;
             };
             empty: string;

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -473,6 +473,7 @@ export const extensions: Extensions = {
         apiResource: {
             pageHeader: {
                 description: "Create and manage the APIs used to define the API scopes/permissions that can be consumed by your applications.",
+                subOrgDescription: "View the APIs that define scopes and permissions for your applications.",
                 title: "API Resources"
             },
             empty: "There are no API resources available at the moment.",

--- a/features/admin.api-resources.v2/package.json
+++ b/features/admin.api-resources.v2/package.json
@@ -22,6 +22,7 @@
         "@wso2is/forms": "^2.3.6",
         "@wso2is/react-components": "^2.8.11",
         "@wso2is/admin.core.v1": "^2.35.1",
+        "@wso2is/admin.organizations.v1": "^2.26.62",
         "axios": "^0.19.2",
         "i18next": "^21.9.1",
         "node-forge": "^0.10.0",

--- a/features/admin.api-resources.v2/pages/api-resources.tsx
+++ b/features/admin.api-resources.v2/pages/api-resources.tsx
@@ -25,6 +25,8 @@ import {
     getEmptyPlaceholderIllustrations,
     history
 } from "@wso2is/admin.core.v1";
+import { OrganizationType } from "@wso2is/admin.organizations.v1/constants";
+import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertInterface, AlertLevels, IdentifiableComponentInterface, LinkInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
@@ -88,6 +90,7 @@ const APIResourcesPage: FunctionComponent<APIResourcesPageInterface> = (
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
+    const { organizationType } = useGetCurrentOrganizationType();
 
     const {
         data: apiResourcesListData,
@@ -252,9 +255,18 @@ const APIResourcesPage: FunctionComponent<APIResourcesPageInterface> = (
             }
             pageTitle={ t("extensions:develop.apiResource.pageHeader.title") }
             title={ t("extensions:develop.apiResource.pageHeader.title") }
-            description={ (
+            description={ organizationType !== OrganizationType.SUBORGANIZATION ? (
                 <>
                     { t("extensions:develop.apiResource.pageHeader.description") }
+                    <DocumentationLink
+                        link={ getLink("develop.apiResources.learnMore") }
+                    >
+                        { t("extensions:common.learnMore") }
+                    </DocumentationLink>
+                </>
+            ) : (
+                <>
+                    { t("extensions:develop.apiResource.pageHeader.subOrgDescription") }
                     <DocumentationLink
                         link={ getLink("develop.apiResources.learnMore") }
                     >
@@ -267,48 +279,53 @@ const APIResourcesPage: FunctionComponent<APIResourcesPageInterface> = (
             headingColumnWidth="11"
             actionColumnWidth="5"
         >
-            <EmphasizedSegment
-                onClick={ () => {
-                    history.push(APIResourcesConstants.getPaths().get("API_RESOURCES_CATEGORY")
-                        .replace(":categoryId", APIResourceType.MANAGEMENT));
-                } }
-                className="clickable"
-                data-componentid={ `${ componentId }-management-api-container` }
-            >
-                <List>
-                    <List.Item>
-                        <Grid container direction="row" xs={ 12 } alignItems="center">
-                            <Grid xs={ 10 } alignContent="center">
-                                <GenericIcon
-                                    verticalAlign="middle"
-                                    fill="primary"
-                                    transparent
-                                    icon={ <BuildingGearIcon size="medium" /> }
-                                    spaced="right"
-                                    floated="left"
-                                    className="mt-1"
-                                />
-                                <List.Header>
-                                    { t("extensions:develop.apiResource.managementAPI.header") }
-                                </List.Header>
-                                <List.Description>
-                                    { t("extensions:develop.apiResource.managementAPI.description") }
-                                </List.Description>
-                            </Grid>
-                            <Grid xs={ 2 }>
-                                <GenericIcon
-                                    verticalAlign="middle"
-                                    fill="primary"
-                                    transparent
-                                    icon={ <ChevronRightIcon /> }
-                                    spaced="right"
-                                    floated="right"
-                                />
-                            </Grid>
-                        </Grid>
-                    </List.Item>
-                </List>
-            </EmphasizedSegment>
+            {
+                organizationType !== OrganizationType.SUBORGANIZATION &&
+                (
+                    <EmphasizedSegment
+                        onClick={ () => {
+                            history.push(APIResourcesConstants.getPaths().get("API_RESOURCES_CATEGORY")
+                                .replace(":categoryId", APIResourceType.MANAGEMENT));
+                        } }
+                        className="clickable"
+                        data-componentid={ `${ componentId }-management-api-container` }
+                    >
+                        <List>
+                            <List.Item>
+                                <Grid container direction="row" xs={ 12 } alignItems="center">
+                                    <Grid xs={ 10 } alignContent="center">
+                                        <GenericIcon
+                                            verticalAlign="middle"
+                                            fill="primary"
+                                            transparent
+                                            icon={ <BuildingGearIcon size="medium" /> }
+                                            spaced="right"
+                                            floated="left"
+                                            className="mt-1"
+                                        />
+                                        <List.Header>
+                                            { t("extensions:develop.apiResource.managementAPI.header") }
+                                        </List.Header>
+                                        <List.Description>
+                                            { t("extensions:develop.apiResource.managementAPI.description") }
+                                        </List.Description>
+                                    </Grid>
+                                    <Grid xs={ 2 }>
+                                        <GenericIcon
+                                            verticalAlign="middle"
+                                            fill="primary"
+                                            transparent
+                                            icon={ <ChevronRightIcon /> }
+                                            spaced="right"
+                                            floated="right"
+                                        />
+                                    </Grid>
+                                </Grid>
+                            </List.Item>
+                        </List>
+                    </EmphasizedSegment>
+                )
+            }
             <EmphasizedSegment
                 onClick={ () => {
                     history.push(APIResourcesConstants.getPaths().get("API_RESOURCES_CATEGORY")

--- a/features/admin.core.v1/constants/app-constants.ts
+++ b/features/admin.core.v1/constants/app-constants.ts
@@ -481,7 +481,8 @@ export class AppConstants {
         "smsTemplates",
         "governanceConnectors",
         "branding",
-        "consoleSettings"
+        "consoleSettings",
+        "apiResources"
     ];
 
     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2265,6 +2265,9 @@ importers:
       '@wso2is/admin.core.v1':
         specifier: ^2.35.1
         version: link:../admin.core.v1
+      '@wso2is/admin.organizations.v1':
+        specifier: ^2.26.62
+        version: link:../admin.organizations.v1
       '@wso2is/core':
         specifier: ^2.5.2
         version: link:../../modules/core


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
- $subject
- This will enable the UI component to view the sub organization level API Resources which are getting from the implementations of [1].

[1] https://github.com/wso2/carbon-identity-framework/pull/6002

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- Sub task of https://github.com/wso2/product-is/issues/21208

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/carbon-identity-framework/pull/6002

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
