### PR TITLE
Fix the group last modified time in group list view

### DIFF
--- a/.changeset/perfect-geese-attend.md
+++ b/.changeset/perfect-geese-attend.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.groups.v1": patch
+---
+
+Fix the issue of displaying group created time for the last modified in the group list view

--- a/features/admin.groups.v1/components/group-list.tsx
+++ b/features/admin.groups.v1/components/group-list.tsx
@@ -315,7 +315,10 @@ export const GroupList: React.FunctionComponent<GroupListProps> = (props: GroupL
                 key: "lastModified",
                 render: (group: GroupsInterface): ReactNode => {
                     const now: Moment = moment(new Date());
-                    const receivedDate: Moment = moment(group.meta.created);
+                    const receivedDate: Moment = moment(group.meta.lastModified ?
+                        group.meta.lastModified :
+                        group.meta.created
+                    );
 
                     return t("console:common.dateTime.humanizedDateString", {
                         date: moment.duration(now.diff(receivedDate)).humanize()


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Group last modified time is set to group created time in the group list view. This PR fixes the issue by showing the group modified time when it is present in the SCIM response.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/19244

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
