### PR TITLE
Hide m2m applications in application selection modal in IDP quickstart

### DIFF
--- a/.changeset/itchy-readers-fly.md
+++ b/.changeset/itchy-readers-fly.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Hide m2m applications in application selection modal in IDP quickstart

--- a/features/admin.applications.v1/components/application-selection-modal.tsx
+++ b/features/admin.applications.v1/components/application-selection-modal.tsx
@@ -29,10 +29,10 @@ import { Dispatch } from "redux";
 import { DropdownProps, Grid, Modal, ModalProps, PaginationProps } from "semantic-ui-react";
 import { useApplicationList } from "../api/application";
 import { ApplicationList } from "../components/application-list";
-import { ApplicationManagementConstants } from "../constants/application-management";
 import {
     ApplicationListInterface,
-    ApplicationListItemInterface
+    ApplicationListItemInterface,
+    ApplicationTemplateIdTypes
 } from "../models/application";
 
 /**
@@ -82,7 +82,7 @@ const ApplicationSelectionModal: FunctionComponent<ApplicationSelectionModalInte
         data: applicationList,
         isLoading: isApplicationListFetchRequestLoading,
         error: applicationListFetchRequestError
-    } = useApplicationList("clientId", listItemLimit, listOffset, null);
+    } = useApplicationList("clientId,templateId", listItemLimit, listOffset, null, true, true);
 
     /**
      * Handles the application list fetch request error.
@@ -93,9 +93,7 @@ const ApplicationSelectionModal: FunctionComponent<ApplicationSelectionModalInte
             return;
         }
 
-        if (applicationListFetchRequestError?.response
-                && applicationListFetchRequestError?.response?.data
-                && applicationListFetchRequestError?.response?.data?.description) {
+        if (applicationListFetchRequestError?.response?.data?.description) {
             dispatch(addAlert({
                 description: applicationListFetchRequestError.response.data.description,
                 level: AlertLevels.ERROR,
@@ -147,9 +145,7 @@ const ApplicationSelectionModal: FunctionComponent<ApplicationSelectionModalInte
             // Remove the system apps from the application list.
             if (!UIConfig?.legacyMode?.applicationListSystemApps) {
                 appList.applications = appList.applications.filter((item: ApplicationListItemInterface) =>
-                    !ApplicationManagementConstants.SYSTEM_APPS.includes(item.name)
-                        && !ApplicationManagementConstants.DEFAULT_APPS.includes(item.name)
-                );
+                    item.templateId !== ApplicationTemplateIdTypes.M2M_APPLICATION);
                 appList.count = appList.count - (applicationList.applications.length - appList.applications.length);
                 appList.totalResults = appList.totalResults -
                         (applicationList.applications.length - appList.applications.length);


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

current `filteredApplicationsList` logic filters the system apps on the frontend before displaying the eligible application list in the application select wizard in IDP quickstart. However, this is now not necessary as there is BE support to retrieve the apps excluding system apps[1].

This PR modifies the frontend logic to filter out m2m applications as there is no BE support to filter apps based on the template type and utilizes the BE support to exclude system apps.

[1] https://github.com/wso2/identity-apps/pull/7002

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
