### PR TITLE
Add isPasswordInputValidationEnabled param to authentication endpoint  webapp and add password reset related resources

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -309,6 +309,28 @@ login.reinitiate.message=Browser change detected. We've restarted the login proc
 authenticated.subject.identifier.null=Something went wrong during the authentication process. Authenticated subject identifier is null.
 authenticated.user.id.null=Something went wrong during the authentication process. Authenticated user id is null.
 
+# Password validation
+must.be.between=Must be between
+at.least=At least
+more.than.8.chars=More than 8 characters
+lowercase.and.uppercase.letter=At least one uppercase and lowercase letter
+at.least.one.number=At least one number
+at.least.one.special.char=At least one special character
+at.least.one.unique.char=At least one unique character
+no.more.than.one.repeated.char=No more than one repeated character
+and=and
+characters=characters
+numbers=number(s)
+uppercase=uppercase
+lowercase=lowercase
+character.s=character(s)
+special.characters=special character(s)
+unique.characters=unique character(s)
+no.more.than=No more than
+repeated.characters=repeated character(s)
+passwords.should.match=Both passwords should match
+Password.cannot.be.empty=Password cannot be empty.
+
 # TOTP authentication
 totp.authenticator=Sign in with TOTP
 error.fail=Authentication Failed!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -300,6 +300,28 @@ login.reinitiate.message=Browseränderung erkannt. Wir haben den Anmeldevorgang 
 authenticated.subject.identifier.null=Beim Authentifizierungsvorgang ist ein Fehler aufgetreten. Die authentifizierte Betreff-ID ist null.
 authenticated.user.id.null=Beim Authentifizierungsvorgang ist ein Fehler aufgetreten. Die authentifizierte Benutzer-ID ist null.
 
+# Password validation
+must.be.between=Debe estar entre
+at.least=mindestens
+more.than.8.chars=Mehr als 8 Zeichen
+lowercase.and.uppercase.letter=Mindestens ein Groß- und ein Kleinbuchstabe
+at.least.one.number=Mindestens eine Zahl
+at.least.one.special.char=Mindestens ein Sonderzeichen
+at.least.one.unique.char=Mindestens ein einzigartiges Zeichen
+no.more.than.one.repeated.char=Nicht mehr als ein wiederholtes Zeichen
+and=und
+characters=Zeichen
+numbers=Zahl(en)
+uppercase=Großschrift
+lowercase=Kleinschrift
+character.s=Zeichen
+special.characters=Sonderzeichen
+unique.characters=einzigartiges Zeichen
+no.more.than=nicht mehr als
+repeated.characters=wiederholtes Zeichen
+passwords.should.match=Beide Passwörter sollten übereinstimmen
+Password.cannot.be.empty=Passwort darf nicht leer sein.
+
 # TOTP authentication
 totp.authenticator=Anmeldung mit TOTP
 error.fail=Authentifizierung fehlgeschlagen!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -300,6 +300,28 @@ login.reinitiate.message=Cambio de navegador detectado. Hemos reiniciado el proc
 authenticated.subject.identifier.null=Algo salió mal durante el proceso de autenticación. El identificador de sujeto autenticado es nulo.
 authenticated.user.id.null=Algo salió mal durante el proceso de autenticación. El ID de usuario autenticado es nulo.
 
+# Password validation
+must.be.between=Debe estar entre
+at.least=Al menos
+more.than.8.chars=Más de 8 caracteres
+lowercase.and.uppercase.letter=Al menos una letra mayúscula y minúscula
+at.least.one.number=Al menos un número
+at.least.one.special.char=Al menos un personaje especial
+at.least.one.unique.char=Al menos un personaje único
+no.more.than.one.repeated.char=No más de un personaje repetido
+and=y
+characters=caracteres
+numbers=números)
+uppercase=mayúscula
+lowercase=minúscula
+character.s=caracteres)
+special.characters=caracteres especiales)
+unique.characters=personajes únicos
+no.more.than=No más que
+repeated.characters=personajes repetidos
+passwords.should.match=Ambas contraseñas deberían coincidir
+Password.cannot.be.empty=La contraseña no puede estar vacía.
+
 # TOTP authentication
 totp.authenticator=Iniciar sesión con TOTP
 error.fail=¡La autenticación falló!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -301,6 +301,28 @@ login.reinitiate.message=Changement de navigateur détecté. Nous avons redémar
 authenticated.subject.identifier.null=Quelque chose s'est mal passé pendant le processus d'authentification. L'identifiant de sujet authentifié est nul.
 authenticated.user.id.null=Quelque chose s'est mal passé pendant le processus d'authentification. L'ID utilisateur authentifié est nul.
 
+# Password validation
+must.be.between=Doit être entre
+at.least=Au moins
+more.than.8.chars=Plus de 8 caractères
+lowercase.and.uppercase.letter=Au moins une lettre majuscule et minuscule
+at.least.one.number=Au moins un numéro
+at.least.one.special.char=Au moins un personnage spécial
+at.least.one.unique.char=Au moins un personnage unique
+no.more.than.one.repeated.char=Pas plus d'un personnage répété
+and=et
+characters=personnages
+numbers=Nombres
+uppercase=majuscule
+lowercase=minuscule
+character.s=personnages
+special.characters=caractères spéciaux
+unique.characters=Caractère (s) unique
+no.more.than=Pas plus que
+repeated.characters=caractère répété (s)
+passwords.should.match=Les deux mots de passe doivent correspondre
+Password.cannot.be.empty=Le mot de passe ne peut pas être vide.
+
 # TOTP authentication
 totp.authenticator=Connectez-vous avec TOTP
 error.fail=Echec de l'authentification !

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -299,6 +299,28 @@ login.reinitiate.message=検出されたブラウザの変更。アカウント�
 authenticated.subject.identifier.null=認証プロセス中に何かがうまくいかなかった。認証されたサブジェクト識別子はヌルです。
 authenticated.user.id.null=認証プロセス中に何かがうまくいかなかった。認証されたユーザーIDはnullです。
 
+# Password validation
+must.be.between=次の間でなければならない：
+at.least=少なくとも
+more.than.8.chars=8文字以上
+lowercase.and.uppercase.letter=少なくとも1つの大文字と小文字
+at.least.one.number=少なくとも1つの数字
+at.least.one.special.char=少なくとも1つの特殊文字
+at.least.one.unique.char=少なくとも1つのユニークな文字
+no.more.than.one.repeated.char=繰り返しは1文字まで
+and=そして
+characters=文字を含む
+numbers=数字
+uppercase=大文字
+lowercase=小文字
+character.s=文字
+special.characters=特殊文字
+unique.characters=ユニークな文字
+no.more.than=次を超えない：
+repeated.characters=繰り返し文字
+passwords.should.match=両方のパスワードが一致する必要があります
+Password.cannot.be.empty=パスワードは入力必須です。
+
 ## TOTP authentication
 totp.authenticator=TOTPでサインイン
 error.fail=認証に失敗しました！

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -297,6 +297,28 @@ login.reinitiate.message=Alteração de navegador detectada. Reiniciamos o proce
 authenticated.subject.identifier.null=Algo deu errado durante o processo de autenticação. O identificador de indivíduo autenticado é nulo.
 authenticated.user.id.null=Algo deu errado durante o processo de autenticação. O ID do usuário autenticado é nulo.
 
+# Password validation
+must.be.between=Deve estar entre
+at.least=Pelo menos
+more.than.8.chars=Mais de 8 caracteres
+lowercase.and.uppercase.letter=Pelo menos uma letra maiúscula e uma minúscula
+at.least.one.number=Pelo menos um número
+at.least.one.special.char=Pelo menos um caracter especial
+at.least.one.unique.char=Pelo menos um caracter único
+no.more.than.one.repeated.char=Não mais do que um caracter repetido
+and=e
+characters=caracteres
+numbers=número(s)
+uppercase=maiúscula
+lowercase=minúsculo
+character.s=caractere(s)
+special.characters=caractere(s) especial(is)
+unique.characters=caractere(s) único(s)
+no.more.than=Não mais que
+repeated.characters=caractere(s) repetido(s)
+passwords.should.match=Ambas as senhas devem coincidir
+Password.cannot.be.empty=A senha não pode estar vazia.
+
 # TOTP authentication
 totp.authenticator=Faça login com TOTP
 error.fail=Autenticação falhou!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -300,6 +300,28 @@ login.reinitiate.message=Alteração do navegador detectada. Reiniciamos o proce
 authenticated.subject.identifier.null=Algo deu errado durante o processo de autenticação. O identificador de assunto autenticado é nulo.
 authenticated.user.id.null=Algo deu errado durante o processo de autenticação. O ID do usuário autenticado é nulo.
 
+# Password validation
+must.be.between=Deve estar entre
+at.least=Pelo menos
+more.than.8.chars=Mais de 8 caracteres
+lowercase.and.uppercase.letter=Pelo menos uma letra maiúscula e uma minúscula
+at.least.one.number=Pelo menos um número
+at.least.one.special.char=Pelo menos um caracter especial
+at.least.one.unique.char=Pelo menos um caracter único
+no.more.than.one.repeated.char=Não mais do que um caracter repetido
+and=e
+characters=personagens
+numbers=número(s)
+uppercase=maiúscula
+lowercase=minúsculo
+character.s=personagem(ns)
+special.characters=caracter(es) especial(is)
+unique.characters=caracter(es) único(s)
+no.more.than=Não mais que
+repeated.characters=caracter(es) repetido(s)
+passwords.should.match=Ambas as senhas devem corresponder
+Password.cannot.be.empty=A senha não pode estar vazia.
+
 # TOTP authentication
 totp.authenticator=Faça login com TOTP
 error.fail=Autenticação falhou!

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -299,6 +299,28 @@ login.reinitiate.message=检测到浏览器更改。我们已经重新启动登�
 authenticated.subject.identifier.null=在身份验证过程中出现了问题。身份验证的主题标识符为null。
 authenticated.user.id.null=在身份验证过程中出现了问题。身份验证的用户ID为null。
 
+# Password validation
+must.be.between=必须介于两者之间
+at.least=至少
+more.than.8.chars=超过8个字符
+lowercase.and.uppercase.letter=至少一个大写和小写字母
+at.least.one.number=至少一个数字
+at.least.one.special.char=至少一个特殊角色
+at.least.one.unique.char=至少一个独特的角色
+no.more.than.one.repeated.char=不超过一个重复的角色
+and=和
+characters=人物
+numbers=数字
+uppercase=大写
+lowercase=小写
+character.s=人物）
+special.characters=特殊的角色）
+unique.characters=独特的角色
+no.more.than=不多于
+repeated.characters=重复的字符
+passwords.should.match=两个密码都应匹配
+Password.cannot.be.empty=密码不能为空。
+
 ## TOTP authentication
 totp.authenticator=与TOTP登录
 error.fail=身份验证失败！

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -48,6 +48,12 @@
             <param-value>{{ downtime_banner.enabled }}</param-value>
         </context-param>
     {% endif %}
+    % if event.default_listener.validation.enable is defined %}
+        <context-param>
+            <param-name>isPasswordInputValidationEnabled</param-name>
+            <param-value>{{ event.default_listener.validation.enable }}</param-value>
+        </context-param>
+    {% endif %}
     <!-- **************** End of Application specific configurations ************************* -->
 
     <!-- *************** Global configurations ********************** -->


### PR DESCRIPTION
### Purpose
$subject

### Changes from the PR
- Add the isPasswordInputValidationEnabled config value to the authentication web app web xml to check that whether the password is validated through input validation listener by default or using password policy validation handler.
- The default value of this configuration is true.
- If the configuration is true, the password reset page of the password policy connector shows the password validation rules in the UI and validate against the input validation rules.
- Added some password reset related localization resources as well from this PR

### Related issue
https://github.com/wso2/product-is/issues/21890