### PR TITLE
Fix change password failure for suborg users via myaccount

### DIFF
--- a/.changeset/real-keys-move.md
+++ b/.changeset/real-keys-move.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Fix change password failure for suborg users via myaccount

--- a/apps/myaccount/src/api/change-password.ts
+++ b/apps/myaccount/src/api/change-password.ts
@@ -36,7 +36,8 @@ import { store } from "../store";
  * @param newPassword - newly assigned password.
  * @returns axiosResponse - a promise containing the response.
  */
-export const updatePassword = (currentPassword: string, newPassword: string, isSubOrgUser: boolean = false, userOrganizationId: string = null): Promise<AxiosResponse> => {
+export const updatePassword = (currentPassword: string, newPassword: string,
+    isSubOrgUser: boolean = false, userOrganizationId: string = null): Promise<AxiosResponse> => {
 
     // If the `httpRequest` method from SDK is used for the request, it causes the 401 to be handled by
     // the callbacks set fot the application which will log the user out. Hence, axios will be used
@@ -45,7 +46,8 @@ export const updatePassword = (currentPassword: string, newPassword: string, isS
     // See https://github.com/asgardio/asgardio-js-oidc-sdk/issues/45 for progress.
     // httpRequest.disableHandler();
 
-    const tenantDomain = isSubOrgUser ? userOrganizationId : store.getState().authenticationInformation.tenantDomain;
+    const tenantDomain: string = isSubOrgUser ? userOrganizationId :
+        store.getState().authenticationInformation.tenantDomain;
     const username: string = [
         store.getState().authenticationInformation?.profileInfo.userName,
         "@",
@@ -55,9 +57,10 @@ export const updatePassword = (currentPassword: string, newPassword: string, isS
     const encoder: TextEncoder = new TextEncoder();
     const encodedPassword: string = String.fromCharCode(...encoder.encode(currentPassword));
     const url: string = store.getState().config.endpoints.me;
-    let updatedUrl = url;
+    let updatedUrl: string = url;
+
     if (isSubOrgUser) {
-        updatedUrl = url.replace(/\/t\/[^/]+\//, `/t/${userOrganizationId}/`)
+        updatedUrl = url.replace(/\/t\/[^/]+\//, `/t/${userOrganizationId}/`);
     }
 
     const requestConfig: AxiosRequestConfig = {

--- a/apps/myaccount/src/api/change-password.ts
+++ b/apps/myaccount/src/api/change-password.ts
@@ -36,7 +36,7 @@ import { store } from "../store";
  * @param newPassword - newly assigned password.
  * @returns axiosResponse - a promise containing the response.
  */
-export const updatePassword = (currentPassword: string, newPassword: string): Promise<AxiosResponse> => {
+export const updatePassword = (currentPassword: string, newPassword: string, isSubOrgUser: boolean = false, userOrganizationId: string = null): Promise<AxiosResponse> => {
 
     // If the `httpRequest` method from SDK is used for the request, it causes the 401 to be handled by
     // the callbacks set fot the application which will log the user out. Hence, axios will be used
@@ -45,14 +45,20 @@ export const updatePassword = (currentPassword: string, newPassword: string): Pr
     // See https://github.com/asgardio/asgardio-js-oidc-sdk/issues/45 for progress.
     // httpRequest.disableHandler();
 
+    const tenantDomain = isSubOrgUser ? userOrganizationId : store.getState().authenticationInformation.tenantDomain;
     const username: string = [
         store.getState().authenticationInformation?.profileInfo.userName,
         "@",
-        store.getState().authenticationInformation.tenantDomain
+        tenantDomain
     ].join("");
     // In case the password contains non-ascii characters, converting to valid ascii format.
     const encoder: TextEncoder = new TextEncoder();
     const encodedPassword: string = String.fromCharCode(...encoder.encode(currentPassword));
+    const url: string = store.getState().config.endpoints.me;
+    let updatedUrl = url;
+    if (isSubOrgUser) {
+        updatedUrl = url.replace(/\/t\/[^/]+\//, `/t/${userOrganizationId}/`)
+    }
 
     const requestConfig: AxiosRequestConfig = {
         data: {
@@ -71,7 +77,7 @@ export const updatePassword = (currentPassword: string, newPassword: string): Pr
             "Content-Type": "application/json"
         },
         method: HttpMethods.PATCH,
-        url: store.getState().config.endpoints.me,
+        url: updatedUrl,
         withCredentials: true
     };
 

--- a/apps/myaccount/src/components/change-password/change-password.tsx
+++ b/apps/myaccount/src/components/change-password/change-password.tsx
@@ -19,6 +19,7 @@
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms, useTrigger } from "@wso2is/forms";
 import { PasswordValidation, ValidationStatusInterface } from "@wso2is/react-components";
+import { OrganizationType } from "@wso2is/admin.organizations.v1/constants";
 import React, { Dispatch, FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -81,6 +82,10 @@ export const ChangePassword: FunctionComponent<ChangePasswordProps> = (props: Ch
         state?.config?.ui?.isPasswordInputValidationEnabled);
 
     const endUserSession: () => Promise<boolean> = useEndUserSession();
+
+    const userOrganizationId: string = useSelector((state: AppState) => state?.organization?.userOrganizationId);
+    const organizationType: string = useSelector((state: AppState) => state?.organization?.organizationType);
+    const isSubOrgUser: boolean = (organizationType === OrganizationType.SUBORGANIZATION);
 
     /**
      * Get the configurations.
@@ -177,7 +182,7 @@ export const ChangePassword: FunctionComponent<ChangePasswordProps> = (props: Ch
      */
     const changePassword = () => {
 
-        updatePassword(currentPassword, newPassword)
+        updatePassword(currentPassword, newPassword, isSubOrgUser, userOrganizationId)
             .then((response: any) => {
                 if (response.status && response.status === 200) {
                     // reset the form.

--- a/apps/myaccount/src/components/change-password/change-password.tsx
+++ b/apps/myaccount/src/components/change-password/change-password.tsx
@@ -16,10 +16,10 @@
  * under the License.
  */
 
+import { OrganizationType } from "@wso2is/admin.organizations.v1/constants";
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms, useTrigger } from "@wso2is/forms";
 import { PasswordValidation, ValidationStatusInterface } from "@wso2is/react-components";
-import { OrganizationType } from "@wso2is/admin.organizations.v1/constants";
 import React, { Dispatch, FunctionComponent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This PR fixes change password failure for suborg users via myaccount. This is previously failed due to calling the `scim2/Me` endpoint in `/t/carbon.super/` path and using username as `<username>@carbon.super` for basic auth for sub org users.

In order to fix this issue, this call initiated with the `/t/<tenant-domain>/` path of the sub org. (Currently tenant domain of sub org equals to org ID.) Also, username given for the basic auth is also changed to `<username>@<tenant-domain>` for sub org users.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/22018

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
