### PR TITLE
Remove shared applications from the role creation wizard in sub org level

### DIFF
--- a/.changeset/breezy-sheep-sort.md
+++ b/.changeset/breezy-sheep-sort.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.roles.v2": patch
+---
+
+Remove shared apps from the role creation wizard

--- a/features/admin.roles.v2/components/wizard-updated/__tests__/role-basics.test.tsx
+++ b/features/admin.roles.v2/components/wizard-updated/__tests__/role-basics.test.tsx
@@ -26,6 +26,9 @@ jest.mock("@wso2is/admin.applications.v1/api/application", () => ({
             applications: [
                 {
                     "access": "WRITE",
+                    "advancedConfigurations": {
+                        "fragment": false
+                    },
                     "associatedRoles": {
                         "allowedAudience": "ORGANIZATION"
                     },

--- a/features/admin.roles.v2/components/wizard-updated/role-basics.tsx
+++ b/features/admin.roles.v2/components/wizard-updated/role-basics.tsx
@@ -104,7 +104,8 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
         isLoading: isApplicationListFetchRequestLoading,
         error: applicationListFetchRequestError,
         mutate: mutateApplicationListFetchRequest
-    } = useApplicationList("clientId,associatedRoles.allowedAudience", null, null, applicationSearchQuery);
+    } = useApplicationList("clientId,associatedRoles.allowedAudience,advancedConfigurations", null, null,
+        applicationSearchQuery);
 
     const {
         data: rolesList,
@@ -146,36 +147,38 @@ export const RoleBasics: FunctionComponent<RoleBasicProps> = (props: RoleBasicPr
 
         applicationList?.applications?.map((application: ApplicationListItemInterface) => {
             if (!RoleConstants.READONLY_APPLICATIONS_CLIENT_IDS.includes(application?.clientId)) {
-                options.push({
-                    content: (
-                        <ListItemText
-                            primary={ application.name }
-                            secondary={
-                                application?.associatedRoles?.allowedAudience === RoleAudienceTypes.ORGANIZATION
-                                    ? (
-                                        <>
-                                            { t("roles:addRoleWizard.forms.roleBasicDetails." +
-                                                "assignedApplication.applicationSubTitle.organization") }
-                                            <Link
-                                                data-componentid={ `${componentId}-link-navigate-roles` }
-                                                onClick={ () => navigateToApplicationEdit(application?.id) }
-                                                external={ false }
-                                            >
-                                                { t("roles:addRoleWizard.forms." +
-                                                    "roleBasicDetails.assignedApplication.applicationSubTitle." +
-                                                    "changeAudience") }
-                                            </Link>
-                                        </>
-                                    ) : t("roles:addRoleWizard.forms.roleBasicDetails." +
-                                        "assignedApplication.applicationSubTitle.application")
-                            }
-                        />
-                    ),
-                    disabled: application?.associatedRoles?.allowedAudience === RoleAudienceTypes.ORGANIZATION,
-                    key: application.id,
-                    text: application.name,
-                    value: application.id
-                });
+                if (application?.advancedConfigurations?.fragment === false) {
+                    options.push({
+                        content: (
+                            <ListItemText
+                                primary={ application.name }
+                                secondary={
+                                    application?.associatedRoles?.allowedAudience === RoleAudienceTypes.ORGANIZATION
+                                        ? (
+                                            <>
+                                                { t("roles:addRoleWizard.forms.roleBasicDetails." +
+                                                    "assignedApplication.applicationSubTitle.organization") }
+                                                <Link
+                                                    data-componentid={ `${componentId}-link-navigate-roles` }
+                                                    onClick={ () => navigateToApplicationEdit(application?.id) }
+                                                    external={ false }
+                                                >
+                                                    { t("roles:addRoleWizard.forms." +
+                                                        "roleBasicDetails.assignedApplication.applicationSubTitle." +
+                                                        "changeAudience") }
+                                                </Link>
+                                            </>
+                                        ) : t("roles:addRoleWizard.forms.roleBasicDetails." +
+                                            "assignedApplication.applicationSubTitle.application")
+                                }
+                            />
+                        ),
+                        disabled: application?.associatedRoles?.allowedAudience === RoleAudienceTypes.ORGANIZATION,
+                        key: application.id,
+                        text: application.name,
+                        value: application.id
+                    });
+                }
             }
         });
 


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
- $subject
- Part of the implementation : https://github.com/wso2/product-is/issues/21208
- When creating the application audience roles in the sub organizations, those roles should only be associated with the applications which are created directly in the sub organization. This fix will enforce that in the role creation wizard.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/21208

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/identity-apps/pull/7240