### PR TITLE
Allow old console roles to update discovery configurations after migrating to IS 7.1

### DIFF
--- a/.changeset/tricky-socks-pretend.md
+++ b/.changeset/tricky-socks-pretend.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.organization-discovery.v1": patch
+"@wso2is/console": patch
+---
+
+Allow old console roles to update discovery configurations after migrating to IS 7.1

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -841,6 +841,7 @@
                         "internal_organization_view"
                     ],
                     "update": [
+                        "internal_organization_config_update",
                         "internal_organization_discovery_update"
                     ]
                 }

--- a/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
+++ b/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
@@ -52,6 +52,8 @@ import {
     UpdateGovernanceConnectorConfigPropertyInterface,
     useGetGovernanceConnectorById
 } from "../../admin.server-configurations.v1";
+import addOrganizationDiscoveryConfig from "../api/add-organization-discovery-config";
+import deleteOrganizationDiscoveryConfig from "../api/delete-organization-discovery-config";
 import updateOrganizationDiscoveryConfig from "../api/update-organization-discovery-config";
 import useGetOrganizationDiscovery from "../api/use-get-organization-discovery";
 import useGetOrganizationDiscoveryConfig from "../api/use-get-organization-discovery-config";
@@ -84,7 +86,11 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
     const isEmailDomainDiscoveryForSelfRegFeatureEnabled: boolean = isFeatureEnabled(
         featureConfig?.organizationDiscovery,
         OrganizationDiscoveryConstants.FEATURE_DICTIONARY.get("ORGANIZATION_DISCOVERY_EMAIL_DOMAIN_FOR_SELF_REG"));
-    const isReadOnly: boolean = !useRequiredScopes(featureConfig?.organizationDiscovery?.scopes?.update);
+    const hasUpdateScopes: boolean = useRequiredScopes(featureConfig?.organizationDiscovery?.scopes?.update);
+    const hasCreateScopes: boolean = useRequiredScopes(featureConfig?.organizationDiscovery?.scopes?.create);
+    const hasDeleteScopes: boolean = useRequiredScopes(featureConfig?.organizationDiscovery?.scopes?.delete);
+    // To preserve backward compatibility with old console roles.
+    const isReadOnly: boolean = !hasUpdateScopes && !(hasCreateScopes && hasDeleteScopes);
 
     const [ searchQuery, setSearchQuery ] = useState<string>("");
     const [ listItemLimit, setListItemLimit ] = useState<number>(UIConstants.DEFAULT_RESOURCE_LIST_ITEM_LIMIT);
@@ -267,50 +273,123 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
             });
         }
 
-        updateOrganizationDiscoveryConfig(updateData)
-            .then(() => {
-                dispatch(
-                    addAlert({
-                        description: data.checked ? t(
-                            "organizationDiscovery:notifications." +
-                            "enableEmailDomainDiscovery.success.description"
-                        ) : t(
-                            "organizationDiscovery:notifications." +
-                            "disableEmailDomainDiscovery.success.description"),
-                        level: AlertLevels.SUCCESS,
-                        message: data.checked ? t(
-                            "organizationDiscovery:notifications." +
-                            "enableEmailDomainDiscovery.success.message"
-                        ) : t(
-                            "organizationDiscovery:notifications." +
-                            "disableEmailDomainDiscovery.success.message"
-                        )
-                    })
-                );
+        // To preserve backward compatibility with old console roles.
+        if (hasUpdateScopes) {
+            updateOrganizationDiscoveryConfig(updateData)
+                .then(() => {
+                    dispatch(
+                        addAlert({
+                            description: data.checked ? t(
+                                "organizationDiscovery:notifications." +
+                                "enableEmailDomainDiscovery.success.description"
+                            ) : t(
+                                "organizationDiscovery:notifications." +
+                                "disableEmailDomainDiscovery.success.description"),
+                            level: AlertLevels.SUCCESS,
+                            message: data.checked ? t(
+                                "organizationDiscovery:notifications." +
+                                "enableEmailDomainDiscovery.success.message"
+                            ) : t(
+                                "organizationDiscovery:notifications." +
+                                "disableEmailDomainDiscovery.success.message"
+                            )
+                        })
+                    );
 
-                mutateOrganizationDiscoveryConfigFetchRequest();
-            })
-            .catch(() => {
-                dispatch(
-                    addAlert({
-                        description: data.checked ? t(
-                            "organizationDiscovery:notifications." +
-                            "enableEmailDomainDiscovery.error.description"
-                        ) : t(
-                            "organizationDiscovery:notifications." +
-                            "disableEmailDomainDiscovery.error.description"
-                        ),
-                        level: AlertLevels.ERROR,
-                        message: data.checked ? t(
-                            "organizationDiscovery:notifications." +
-                            "enableEmailDomainDiscovery.error.message"
-                        ) : t(
-                            "organizationDiscovery:notifications." +
-                            "disableEmailDomainDiscovery.error.message"
-                        )
+                    mutateOrganizationDiscoveryConfigFetchRequest();
+                })
+                .catch(() => {
+                    dispatch(
+                        addAlert({
+                            description: data.checked ? t(
+                                "organizationDiscovery:notifications." +
+                                "enableEmailDomainDiscovery.error.description"
+                            ) : t(
+                                "organizationDiscovery:notifications." +
+                                "disableEmailDomainDiscovery.error.description"
+                            ),
+                            level: AlertLevels.ERROR,
+                            message: data.checked ? t(
+                                "organizationDiscovery:notifications." +
+                                "enableEmailDomainDiscovery.error.message"
+                            ) : t(
+                                "organizationDiscovery:notifications." +
+                                "disableEmailDomainDiscovery.error.message"
+                            )
+                        })
+                    );
+                });
+        } else if (hasCreateScopes && hasDeleteScopes) {
+            if (data.checked) {
+                addOrganizationDiscoveryConfig(updateData)
+                    .then(() => {
+                        dispatch(
+                            addAlert({
+                                description: t(
+                                    "organizationDiscovery:notifications." +
+                                    "enableEmailDomainDiscovery.success.description"
+                                ),
+                                level: AlertLevels.SUCCESS,
+                                message: t(
+                                    "organizationDiscovery:notifications." +
+                                    "enableEmailDomainDiscovery.success.message"
+                                )
+                            })
+                        );
+
+                        mutateOrganizationDiscoveryConfigFetchRequest();
                     })
-                );
-            });
+                    .catch(() => {
+                        dispatch(
+                            addAlert({
+                                description: t(
+                                    "organizationDiscovery:notifications." +
+                                    "enableEmailDomainDiscovery.error.description"
+                                ),
+                                level: AlertLevels.ERROR,
+                                message: t(
+                                    "organizationDiscovery:notifications." +
+                                    "enableEmailDomainDiscovery.error.message"
+                                )
+                            })
+                        );
+                    });
+            } else {
+                deleteOrganizationDiscoveryConfig()
+                    .then(() => {
+                        dispatch(
+                            addAlert({
+                                description: t(
+                                    "organizationDiscovery:notifications." +
+                                    "disableEmailDomainDiscovery.success.description"
+                                ),
+                                level: AlertLevels.SUCCESS,
+                                message: t(
+                                    "organizationDiscovery:notifications." +
+                                    "disableEmailDomainDiscovery.success.message"
+                                )
+                            })
+                        );
+
+                        mutateOrganizationDiscoveryConfigFetchRequest();
+                    })
+                    .catch(() => {
+                        dispatch(
+                            addAlert({
+                                description: t(
+                                    "organizationDiscovery:notifications." +
+                                    "disableEmailDomainDiscovery.error.description"
+                                ),
+                                level: AlertLevels.ERROR,
+                                message: t(
+                                    "organizationDiscovery:notifications." +
+                                    "disableEmailDomainDiscovery.error.message"
+                                )
+                            })
+                        );
+                    });
+            }
+        }
     };
 
     /**
@@ -368,7 +447,7 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
                                     label={ t("organizationDiscovery:selfRegistration.label") }
                                     listen={ (value: boolean) => handleEmailDomainBasedSelfRegistration(value) }
                                     checked={ isEmailDomainBasedSelfRegistrationEnabled }
-                                    disabled={ !isSelfRegEnabled }
+                                    disabled={ !isSelfRegEnabled || !hasUpdateScopes }
                                     width={ 16 }
                                     data-testid={ `${testId}-notify-account-confirmation` }
                                     hint={ isSelfRegEnabled && t("organizationDiscovery:selfRegistration.labelHint") }


### PR DESCRIPTION
This pr fixes the following migration issue
- https://github.com/wso2/product-is/issues/21752

Previously created console roles with the organization discovery permissions will have the `internal_organization_config_create` and `internal_organization_config_delete` scopes. This pr ensures that even such old roles will function as expected if they are migrated to IS 7.1

### Related pr
- https://github.com/wso2/carbon-identity-framework/pull/6299