### PR TITLE
Add show missing password button to create root organization UI

### DIFF
--- a/.changeset/tricky-needles-film.md
+++ b/.changeset/tricky-needles-film.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.tenants.v1": patch
+---
+
+Fix missing show password button in the create root organization ui

--- a/features/admin.tenants.v1/components/add-tenant/add-tenant-form.scss
+++ b/features/admin.tenants.v1/components/add-tenant/add-tenant-form.scss
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -30,5 +30,9 @@
     .add-tenant-form-sub-title {
         margin-bottom: var(--oxygen-spacing-2);
         margin-top: var(--oxygen-spacing-3);
+    }
+
+    .password-input-btn {
+        height: 90px;
     }
 }

--- a/features/admin.tenants.v1/components/add-tenant/add-tenant-form.tsx
+++ b/features/admin.tenants.v1/components/add-tenant/add-tenant-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -522,7 +522,7 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
                                 direction={ { sm: "row", xs: "column" } }
                                 alignItems="center"
                             >
-                                <div className="inline-flex-field" style={ { height: "90px" } }>
+                                <div className="inline-flex-field password-input-btn">
                                     <FinalFormField
                                         key="password"
                                         width={ 16 }

--- a/features/admin.tenants.v1/components/add-tenant/add-tenant-form.tsx
+++ b/features/admin.tenants.v1/components/add-tenant/add-tenant-form.tsx
@@ -45,6 +45,7 @@ import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, ReactElement, useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
+import { Icon } from "semantic-ui-react";
 import getTenantDomainAvailability from "../../api/get-tenant-domain-availability";
 import TenantConstants from "../../constants/tenant-constants";
 import { AddTenantRequestPayload, Tenant, TenantOwner, TenantStatus } from "../../models/tenants";
@@ -83,6 +84,7 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
     const enableEmailDomain: boolean = useSelector((state: AppState) => state.config?.ui?.enableEmailDomain);
 
     const [ isPasswordValid, setIsPasswordValid ] = useState<boolean>(false);
+    const [ isPasswordVisible, setIsPasswordVisible ] = useState(false);
 
     const userNameValidationConfig: ValidationFormInterface = useMemo((): ValidationFormInterface => {
         return getUsernameConfiguration(validationData);
@@ -373,6 +375,20 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
         </FormSpy>
     );
 
+    const renderInputAdornmentOfSecret = (showSecret: boolean, onClick: () => void): ReactElement => (
+        <InputAdornment position="end">
+            <Icon
+                link={ true }
+                className="list-icon reset-field-to-default-adornment"
+                size="small"
+                color="grey"
+                name={ !showSecret ? "eye" : "eye slash" }
+                data-componentid={ `${ componentId }-password-view-button` }
+                onClick={ onClick }
+            />
+        </InputAdornment>
+    );
+
     return (
         <FinalForm
             initialValues={ {} }
@@ -504,9 +520,9 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
                             <Stack
                                 spacing={ { sm: 2, xs: 1 } }
                                 direction={ { sm: "row", xs: "column" } }
-                                alignItems="flex-end"
+                                alignItems="center"
                             >
-                                <div className="inline-flex-field">
+                                <div className="inline-flex-field" style={ { height: "90px" } }>
                                     <FinalFormField
                                         key="password"
                                         width={ 16 }
@@ -515,7 +531,12 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
                                         required={ true }
                                         data-componentid={ `${componentId}-password` }
                                         name="password"
-                                        type="password"
+                                        type={ isPasswordVisible ? "text" : "password" }
+                                        InputProps={ {
+                                            endAdornment: renderInputAdornmentOfSecret(
+                                                isPasswordVisible,
+                                                () => setIsPasswordVisible(!isPasswordVisible))
+                                        } }
                                         label={ t("tenants:common.form.fields.password.label") }
                                         placeholder={ t("tenants:common.form.fields.password.placeholder") }
                                         component={ TextFieldAdapter }


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This PR adds a show missing password button to the text field and also fixes a minor alignment issue of the generate password button.

<img width="1440" alt="Screenshot 2025-01-19 at 02 57 10" src="https://github.com/user-attachments/assets/fac73561-4eef-4ce0-adf9-f61918f8f7e3" />



### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/22134


### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
