### PR TITLE
Add "mins" label to input fields in session configuration page

### DIFF
--- a/.changeset/nice-sloths-grow.md
+++ b/.changeset/nice-sloths-grow.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/features": patch
+"@wso2is/admin.session-management.v1": patch
+---
+
+Fix input label issue in session configuration

--- a/.changeset/tough-forks-search.md
+++ b/.changeset/tough-forks-search.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/i18n": patch
+---
+
+Fix input label issue in session configuration

--- a/features/admin.session-management.v1/pages/session-management.scss
+++ b/features/admin.session-management.v1/pages/session-management.scss
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.session-mgt-form-container {
+    .ui.grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        column-gap: 50px;
+        padding: 16px;
+        margin-bottom: 10px;
+    }
+}
+
+@media (max-width: 768px) {
+    .session-mgt-form-container {
+        .ui.grid {
+            grid-template-columns: 1fr;
+        }
+    }
+}

--- a/features/admin.session-management.v1/pages/session-management.scss
+++ b/features/admin.session-management.v1/pages/session-management.scss
@@ -21,8 +21,6 @@
         display: grid;
         grid-template-columns: repeat(2, 1fr);
         column-gap: 50px;
-        padding: 16px;
-        margin-bottom: 10px;
     }
 }
 

--- a/features/admin.session-management.v1/pages/session-management.tsx
+++ b/features/admin.session-management.v1/pages/session-management.tsx
@@ -22,13 +22,13 @@ import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
-import { EmphasizedSegment, PageLayout, PrimaryButton } from "@wso2is/react-components";
+import { EmphasizedSegment, PageLayout } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
-import { Divider, Grid, Placeholder, Ref } from "semantic-ui-react";
+import { Divider, Grid, Label, Placeholder, Ref } from "semantic-ui-react";
 import { updateSessionManagmentConfigurations, useSessionManagementConfig } from "../api/session-management";
 import { SessionManagementConstants } from "../constants/session-management";
 import {
@@ -36,6 +36,7 @@ import {
     SessionManagementConfigFormErrorValidationsInterface,
     SessionManagementConfigFormValuesInterface
 } from "../models/session-management";
+import "./session-management.scss";
 
 /**
  * Props for session management settings page.
@@ -263,110 +264,98 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
             data-componentid={ `${ componentId }-form-layout` }
         >
             <Ref innerRef={ pageContextRef }>
-                <Grid className={ "mt-2" } >
-                    <Grid.Row columns={ 1 }>
-                        <Grid.Column width={ 16 }>
-                            <EmphasizedSegment className="form-wrapper" padded={ "very" }>
-                                { isSessionManagementFetchRequestLoading
-                                    ? renderLoadingPlaceholder()
-                                    : (
-                                        <>
-                                            <Form
-                                                id={ FORM_ID }
-                                                uncontrolledForm={ true }
-                                                onSubmit={ handleSubmit }
-                                                initialValues={ sessionManagementConfig }
-                                                enableReinitialize={ true }
-                                                ref={ formRef }
-                                                noValidate={ true }
-                                                validate={ validateForm }
-                                                autoComplete="new-password"
-                                            >
-                                                <Grid>
-                                                    <Grid.Row columns={ 2 } key={ 1 }>
-                                                        <Grid.Column key="idleSessionTimeout">
-                                                            <Field.Input
-                                                                min={ SessionManagementConstants
-                                                                    .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                                                ariaLabel="Idle Session Timeout Field"
-                                                                inputType="number"
-                                                                name="idleSessionTimeout"
-                                                                label={ t("sessionManagement:form." +
-                                                                    "idleSessionTimeout.label") }
-                                                                placeholder={ t("sessionManagement:form." +
-                                                                    "idleSessionTimeout.placeholder") }
-                                                                hint={ t("sessionManagement:form." +
-                                                                    "idleSessionTimeout.hint") }
-                                                                required={ true }
-                                                                value={ sessionManagementConfig?.idleSessionTimeout }
-                                                                readOnly={ isReadOnly }
-                                                                maxLength={ null }
-                                                                minLength={ SessionManagementConstants
-                                                                    .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                                                width={ 16 }
-                                                                data-componentid={
-                                                                    `${componentId}-idle-session-timeout` }
-                                                                autoComplete="new-password"
-                                                            />
-                                                        </Grid.Column>
-                                                        <Grid.Column key="rememberMePeriod">
-                                                            <Field.Input
-                                                                min={ SessionManagementConstants
-                                                                    .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                                                ariaLabel="Remember Me Period Field"
-                                                                inputType="number"
-                                                                name="rememberMePeriod"
-                                                                label={ t("sessionManagement:form." +
-                                                                    "rememberMePeriod.label") }
-                                                                placeholder={ t("sessionManagement:form." +
-                                                                    "rememberMePeriod.placeholder") }
-                                                                hint={ t("sessionManagement:form." +
-                                                                    "rememberMePeriod.hint") }
-                                                                required={ true }
-                                                                value={ sessionManagementConfig?.rememberMePeriod }
-                                                                readOnly={ isReadOnly }
-                                                                maxLength={ null }
-                                                                minLength={ SessionManagementConstants
-                                                                    .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                                                width={ 16 }
-                                                                data-componentid={ `${componentId}-remember-me-period` }
-                                                                autoComplete="new-password"
-                                                            />
-                                                        </Grid.Column>
-                                                    </Grid.Row>
-                                                </Grid>
-                                            </Form>
-                                            {
-                                                !isReadOnly && (
-                                                    <>
-                                                        <Divider hidden />
-                                                        <Grid.Row columns={ 1 } className="mt-6">
-                                                            <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>
-                                                                <PrimaryButton
-                                                                    size="small"
-                                                                    loading={ isSubmitting }
-                                                                    onClick={ () => {
-                                                                        formRef?.current?.triggerSubmit();
-                                                                    } }
-                                                                    ariaLabel="Session management form update button"
-                                                                    data-componentid={
-                                                                        `${ componentId }-update-button`
-                                                                    }
-                                                                >
-                                                                    { t("common:update") }
-                                                                </PrimaryButton>
-                                                            </Grid.Column>
-                                                        </Grid.Row>
-                                                    </>
-                                                )
-                                            }
-                                        </>
-                                    )
-                                }
-                            </EmphasizedSegment>
-                        </Grid.Column>
-                    </Grid.Row>
-                </Grid>
+                <EmphasizedSegment className="form-wrapper" padded={ "very" }>
+                    { isSessionManagementFetchRequestLoading
+                        ? renderLoadingPlaceholder()
+                        : (
+                            <>
+                                <div className="session-mgt-form-container">
+                                    <Form
+                                        id={ FORM_ID }
+                                        uncontrolledForm={ false }
+                                        onSubmit={ handleSubmit }
+                                        initialValues={ sessionManagementConfig }
+                                        enableReinitialize={ true }
+                                        ref={ formRef }
+                                        noValidate={ true }
+                                        validate={ validateForm }
+                                    >
+                                        <Field.Input
+                                            min={ SessionManagementConstants
+                                                .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                            ariaLabel="Idle Session Timeout Field"
+                                            inputType="number"
+                                            name="idleSessionTimeout"
+                                            label={ t("sessionManagement:form." +
+                                                "idleSessionTimeout.label") }
+                                            placeholder={ t("sessionManagement:form." +
+                                                "idleSessionTimeout.placeholder") }
+                                            hint={ t("sessionManagement:form." +
+                                                "idleSessionTimeout.hint") }
+                                            required={ true }
+                                            value={ sessionManagementConfig?.idleSessionTimeout }
+                                            readOnly={ isReadOnly }
+                                            maxLength={ null }
+                                            minLength={ SessionManagementConstants
+                                                .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                            width="100%"
+                                            data-componentid={
+                                                `${componentId}-idle-session-timeout` }
+                                            labelPosition="right"
+                                        >
+                                            <input />
+                                            <Label>mins</Label>
+                                        </Field.Input>
+                                        <Field.Input
+                                            min={ SessionManagementConstants
+                                                .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                            ariaLabel="Remember Me Period Field"
+                                            inputType="number"
+                                            name="rememberMePeriod"
+                                            label={ t("sessionManagement:form." +
+                                                "rememberMePeriod.label") }
+                                            placeholder={ t("sessionManagement:form." +
+                                                "rememberMePeriod.placeholder") }
+                                            hint={ t("sessionManagement:form." +
+                                                "rememberMePeriod.hint") }
+                                            required={ true }
+                                            value={ sessionManagementConfig?.rememberMePeriod }
+                                            readOnly={ isReadOnly }
+                                            maxLength={ null }
+                                            minLength={ SessionManagementConstants
+                                                .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                            width="100%"
+                                            data-componentid={ `${componentId}-remember-me-period` }
+                                            labelPosition="right"
+                                        >
+                                            <input />
+                                            <Label>mins</Label>
+                                        </Field.Input>
+                                        {
+                                            !isReadOnly && (
+                                                <Field.Button
+                                                    form={ FORM_ID }
+                                                    size="small"
+                                                    buttonType="primary_btn"
+                                                    name="update-button"
+                                                    data-componentid={
+                                                        `${ componentId }-update-button`
+                                                    }
+                                                    loading={ isSubmitting }
+                                                    onClick={ () => {
+                                                        formRef?.current?.triggerSubmit();
+                                                    } }
+                                                    ariaLabel="Session management form update button"
+                                                    label={ t("common:update") }
+                                                />
+                                            )
+                                        }
+                                    </Form>
+                                </div>
+                            </>
+                        )
+                    }
+                </EmphasizedSegment>
             </Ref>
         </PageLayout>
     );

--- a/features/admin.session-management.v1/pages/session-management.tsx
+++ b/features/admin.session-management.v1/pages/session-management.tsx
@@ -268,91 +268,89 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
                     { isSessionManagementFetchRequestLoading
                         ? renderLoadingPlaceholder()
                         : (
-                            <>
-                                <div className="session-mgt-form-container">
-                                    <Form
-                                        id={ FORM_ID }
-                                        uncontrolledForm={ false }
-                                        onSubmit={ handleSubmit }
-                                        initialValues={ sessionManagementConfig }
-                                        enableReinitialize={ true }
-                                        ref={ formRef }
-                                        noValidate={ true }
-                                        validate={ validateForm }
-                                    >
-                                        <Field.Input
-                                            min={ SessionManagementConstants
-                                                .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                            ariaLabel="Idle Session Timeout Field"
-                                            inputType="number"
-                                            name="idleSessionTimeout"
-                                            label={ t("sessionManagement:form." +
+                            <div className="session-mgt-form-container">
+                                <Form
+                                    id={ FORM_ID }
+                                    uncontrolledForm={ false }
+                                    onSubmit={ handleSubmit }
+                                    initialValues={ sessionManagementConfig }
+                                    enableReinitialize={ true }
+                                    ref={ formRef }
+                                    noValidate={ true }
+                                    validate={ validateForm }
+                                >
+                                    <Field.Input
+                                        min={ SessionManagementConstants
+                                            .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                        ariaLabel="Idle Session Timeout Field"
+                                        inputType="number"
+                                        name="idleSessionTimeout"
+                                        label={ t("sessionManagement:form." +
                                                 "idleSessionTimeout.label") }
-                                            placeholder={ t("sessionManagement:form." +
+                                        placeholder={ t("sessionManagement:form." +
                                                 "idleSessionTimeout.placeholder") }
-                                            hint={ t("sessionManagement:form." +
+                                        hint={ t("sessionManagement:form." +
                                                 "idleSessionTimeout.hint") }
-                                            required={ true }
-                                            value={ sessionManagementConfig?.idleSessionTimeout }
-                                            readOnly={ isReadOnly }
-                                            maxLength={ null }
-                                            minLength={ SessionManagementConstants
-                                                .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                            width="100%"
-                                            data-componentid={
-                                                `${componentId}-idle-session-timeout` }
-                                            labelPosition="right"
-                                        >
-                                            <input />
-                                            <Label>mins</Label>
-                                        </Field.Input>
-                                        <Field.Input
-                                            min={ SessionManagementConstants
-                                                .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                            ariaLabel="Remember Me Period Field"
-                                            inputType="number"
-                                            name="rememberMePeriod"
-                                            label={ t("sessionManagement:form." +
+                                        required={ true }
+                                        value={ sessionManagementConfig?.idleSessionTimeout }
+                                        readOnly={ isReadOnly }
+                                        maxLength={ null }
+                                        minLength={ SessionManagementConstants
+                                            .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                        width="100%"
+                                        data-componentid={
+                                            `${ componentId }-idle-session-timeout` }
+                                        labelPosition="right"
+                                    >
+                                        <input />
+                                        <Label>{ t("common:minutes") }</Label>
+                                    </Field.Input>
+                                    <Field.Input
+                                        min={ SessionManagementConstants
+                                            .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                        ariaLabel="Remember Me Period Field"
+                                        inputType="number"
+                                        name="rememberMePeriod"
+                                        label={ t("sessionManagement:form." +
                                                 "rememberMePeriod.label") }
-                                            placeholder={ t("sessionManagement:form." +
+                                        placeholder={ t("sessionManagement:form." +
                                                 "rememberMePeriod.placeholder") }
-                                            hint={ t("sessionManagement:form." +
+                                        hint={ t("sessionManagement:form." +
                                                 "rememberMePeriod.hint") }
-                                            required={ true }
-                                            value={ sessionManagementConfig?.rememberMePeriod }
-                                            readOnly={ isReadOnly }
-                                            maxLength={ null }
-                                            minLength={ SessionManagementConstants
-                                                .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                            width="100%"
-                                            data-componentid={ `${componentId}-remember-me-period` }
-                                            labelPosition="right"
-                                        >
-                                            <input />
-                                            <Label>mins</Label>
-                                        </Field.Input>
-                                        {
-                                            !isReadOnly && (
-                                                <Field.Button
-                                                    form={ FORM_ID }
-                                                    size="small"
-                                                    buttonType="primary_btn"
-                                                    name="update-button"
-                                                    data-componentid={
-                                                        `${ componentId }-update-button`
-                                                    }
-                                                    loading={ isSubmitting }
-                                                    onClick={ () => {
-                                                        formRef?.current?.triggerSubmit();
-                                                    } }
-                                                    ariaLabel="Session management form update button"
-                                                    label={ t("common:update") }
-                                                />
-                                            )
-                                        }
-                                    </Form>
-                                </div>
-                            </>
+                                        required={ true }
+                                        value={ sessionManagementConfig?.rememberMePeriod }
+                                        readOnly={ isReadOnly }
+                                        maxLength={ null }
+                                        minLength={ SessionManagementConstants
+                                            .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                        width="100%"
+                                        data-componentid={ `${ componentId }-remember-me-period` }
+                                        labelPosition="right"
+                                    >
+                                        <input />
+                                        <Label>{ t("common:minutes") }</Label>
+                                    </Field.Input>
+                                    {
+                                        !isReadOnly && (
+                                            <Field.Button
+                                                form={ FORM_ID }
+                                                size="small"
+                                                buttonType="primary_btn"
+                                                name="update-button"
+                                                data-componentid={
+                                                    `${ componentId }-update-button`
+                                                }
+                                                loading={ isSubmitting }
+                                                onClick={ () => {
+                                                    formRef?.current?.triggerSubmit();
+                                                } }
+                                                ariaLabel="Session management form update button"
+                                                label={ t("common:update") }
+                                            />
+                                        )
+                                    }
+                                </Form>
+                            </div>
                         )
                     }
                 </EmphasizedSegment>

--- a/features/admin.session-management.v1/pages/session-management.tsx
+++ b/features/admin.session-management.v1/pages/session-management.tsx
@@ -16,15 +16,15 @@
  * under the License.
  */
 
+import { useRequiredScopes } from "@wso2is/access-control";
 import { AppConstants, AppState, FeatureConfigInterface, history } from "@wso2is/admin.core.v1";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
-import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
 import { EmphasizedSegment, PageLayout } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useMemo, useRef, useState } from "react";
+import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
@@ -57,13 +57,7 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
     const formRef: MutableRefObject<FormPropsInterface> = useRef<FormPropsInterface>(null);
 
     const featureConfig : FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
-    const allowedScopes : string = useSelector((state: AppState) => state?.auth?.allowedScopes);
-
-    const isReadOnly : boolean = useMemo(() => !hasRequiredScopes(
-        featureConfig?.governanceConnectors,
-        featureConfig?.governanceConnectors?.scopes?.update,
-        allowedScopes
-    ), [ featureConfig, allowedScopes ]);
+    const hasConnectorUpdatePermission: boolean = useRequiredScopes(featureConfig.governanceConnectors.scopes?.update);
 
     const dispatch : Dispatch<any> = useDispatch();
 
@@ -293,7 +287,7 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
                                                 "idleSessionTimeout.hint") }
                                         required={ true }
                                         value={ sessionManagementConfig?.idleSessionTimeout }
-                                        readOnly={ isReadOnly }
+                                        readOnly={ !hasConnectorUpdatePermission }
                                         maxLength={ null }
                                         minLength={ SessionManagementConstants
                                             .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
@@ -319,7 +313,7 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
                                                 "rememberMePeriod.hint") }
                                         required={ true }
                                         value={ sessionManagementConfig?.rememberMePeriod }
-                                        readOnly={ isReadOnly }
+                                        readOnly={ !hasConnectorUpdatePermission }
                                         maxLength={ null }
                                         minLength={ SessionManagementConstants
                                             .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
@@ -331,7 +325,7 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
                                         <Label>{ t("common:minutes") }</Label>
                                     </Field.Input>
                                     {
-                                        !isReadOnly && (
+                                        hasConnectorUpdatePermission && (
                                             <Field.Button
                                                 form={ FORM_ID }
                                                 size="small"

--- a/modules/i18n/src/models/namespaces/common-ns.ts
+++ b/modules/i18n/src/models/namespaces/common-ns.ts
@@ -107,6 +107,7 @@ export interface CommonNS {
     metaAttributes: string;
     minimize: string;
     minValidation: string;
+    minutes: string;
     more: string;
     myAccount: string;
     name: string;

--- a/modules/i18n/src/translations/de-DE/portals/common.ts
+++ b/modules/i18n/src/translations/de-DE/portals/common.ts
@@ -118,6 +118,7 @@ export const common: CommonNS = {
     "metaAttributes": "Metaattribute",
     "minValidation": "Dieser Wert sollte größer oder gleich {{min}} sein.",
     "minimize": "Minimieren",
+    "minutes": "minuten",
     "more": "Mehr",
     "myAccount": "Mein Konto",
     "name": "Name",

--- a/modules/i18n/src/translations/en-US/portals/common.ts
+++ b/modules/i18n/src/translations/en-US/portals/common.ts
@@ -118,6 +118,7 @@ export const common: CommonNS = {
     metaAttributes: "Meta Attributes",
     minValidation: "This value should be greater than or equal to {{min}}.",
     minimize: "Minimize",
+    minutes: "mins",
     more: "More",
     myAccount: "My Account",
     name: "Name",

--- a/modules/i18n/src/translations/en-US/portals/governance-connectors.ts
+++ b/modules/i18n/src/translations/en-US/portals/governance-connectors.ts
@@ -272,7 +272,7 @@ export const governanceConnectors: governanceConnectorsNS = {
                 },
                 siftConnector: {
                     properties: {
-                        name: "Sift Connector",
+                        name: "Fraud Detection",
                         description: "Integrate Sift to detect and prevent fraudulent account logins.",
                         siftConnectorApiKey: {
                             label: "Sift API Key",

--- a/modules/i18n/src/translations/es-ES/portals/common.ts
+++ b/modules/i18n/src/translations/es-ES/portals/common.ts
@@ -118,6 +118,7 @@ export const common: CommonNS = {
     metaAttributes: "Metaatributos",
     minValidation: "Este valor debe ser mayor o igual a {{min}}.",
     minimize: "Minimizar",
+    minutes: "minutos",
     more: "más",
     myAccount: "Mi cuenta",
     name: "Nombre",

--- a/modules/i18n/src/translations/fr-FR/portals/common.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/common.ts
@@ -119,6 +119,7 @@ export const common: CommonNS = {
     metaAttributes: "Méta-attributs",
     minValidation: "Cette valeur doit être supérieure ou égale à {{min}}.",
     minimize: "Minimiser",
+    minutes: "mins",
     more: "Plus",
     myAccount: "Mon compte",
     name: "Nom",

--- a/modules/i18n/src/translations/ja-JP/portals/common.ts
+++ b/modules/i18n/src/translations/ja-JP/portals/common.ts
@@ -118,6 +118,7 @@ export const common: CommonNS = {
     "metaAttributes": "メタ属性",
     "minValidation": "この値は{{min}}以上である必要があります。",
     "minimize": "最小化します",
+    "minutes": "分",
     "more": "もっと",
     "myAccount": "私のアカウント",
     "name": "名前",

--- a/modules/i18n/src/translations/pt-BR/portals/common.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/common.ts
@@ -118,6 +118,7 @@ export const common: CommonNS = {
     metaAttributes: "Metaatributos",
     minValidation: "Este valor deve ser maior ou igual a {{min}}.",
     minimize: "Minimizar",
+    minutes: "minutos",
     more: "Mais",
     myAccount: "Minha Conta",
     name: "Nome",

--- a/modules/i18n/src/translations/pt-PT/portals/common.ts
+++ b/modules/i18n/src/translations/pt-PT/portals/common.ts
@@ -118,6 +118,7 @@ export const common: CommonNS = {
     metaAttributes: "Metaatributos",
     minValidation: "Este valor deve ser maior ou igual a {{min}}.",
     minimize: "minimizar",
+    minutes: "minutos",
     more: "Mais",
     myAccount: "Minha conta",
     name: "Nome",

--- a/modules/i18n/src/translations/si-LK/portals/common.ts
+++ b/modules/i18n/src/translations/si-LK/portals/common.ts
@@ -118,6 +118,7 @@ export const common: CommonNS = {
     metaAttributes: "අතිරේක ගුණාංග",
     minValidation: "මෙම අගය {{min}} ට වඩා වැඩි හෝ සමාන විය යුතුය.",
     minimize: "අවම කරන්න",
+    minutes: "මිනිත්තු",
     more: "තව",
     myAccount: "පුද්ගලික ගිණුම",
     name: "නම",

--- a/modules/i18n/src/translations/ta-IN/portals/common.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/common.ts
@@ -119,6 +119,7 @@ export const common: CommonNS = {
     metaAttributes: "மெட்டா பண்புக்கூறுகள்",
     minValidation: "இந்த மதிப்பு {{min}} ஐ விட அதிகமாகவோ அல்லது சமமாகவோ இருக்க வேண்டும்.",
     minimize: "குறைத்தல்",
+    minutes: "நிமிடங்கள்",
     more: "மேலும்",
     myAccount: "என் கணக்கு",
     name: "பெயர்",

--- a/modules/i18n/src/translations/zh-CN/portals/common.ts
+++ b/modules/i18n/src/translations/zh-CN/portals/common.ts
@@ -118,6 +118,7 @@ export const common: CommonNS = {
     "metaAttributes": "元属性",
     "minValidation": "该值应大于或等于{{min}}。",
     "minimize": "最小化",
+    "minutes": "分钟",
     "more": "更多的",
     "myAccount": "我的账户",
     "name": "姓名",


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

Add unit of time in the input fields in session configuration page.

![image](https://github.com/user-attachments/assets/51b435d0-3f2f-425d-9bee-d4588dd58a22)

### Related Issues

https://github.com/wso2/product-is/issues/22321

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
