### PR TITLE
Fix issues in the UI where signature validation with certificate alias is enabled

### DIFF
--- a/.changeset/silver-berries-pay.md
+++ b/.changeset/silver-berries-pay.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix an issue where enable signature validation is not updated when certificate alias is enabled

--- a/features/admin.applications.v1/components/forms/inbound-saml-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-saml-form.tsx
@@ -236,7 +236,9 @@ export const InboundSAMLForm: FunctionComponent<InboundSAMLFormPropsInterface> =
                     idpEntityIdAlias: values.get("idpEntityIdAlias"),
                     issuer: values.get("issuer") || initialValues?.issuer,
                     requestValidation: {
-                        enableSignatureValidation: isCertAvailableForEncrypt && values.get("requestSignatureValidation")
+                        enableSignatureValidation: (isCertAvailableForEncrypt
+                            || isSignatureValidationCertificateAliasEnabled)
+                        && values.get("requestSignatureValidation")
                             .includes("enableSignatureValidation"),
                         signatureValidationCertAlias: values.get("signatureValidationCertAlias")
                     },
@@ -1932,8 +1934,9 @@ export const InboundSAMLForm: FunctionComponent<InboundSAMLFormPropsInterface> =
                                     <ApplicationCertificateWrapper
                                         protocol={ SupportedAuthProtocolTypes.SAML }
                                         deleteAllowed={ !(
-                                            initialValues?.requestValidation?.enableSignatureValidation ||
-                                            initialValues?.singleSignOnProfile?.assertion?.encryption?.enabled
+                                            (initialValues?.requestValidation?.enableSignatureValidation
+                                                && !isSignatureValidationCertificateAliasEnabled)
+                                            || initialValues?.singleSignOnProfile?.assertion?.encryption?.enabled
                                         ) }
                                         reasonInsideTooltipWhyDeleteIsNotAllowed={
                                             t("applications:forms." +


### PR DESCRIPTION
### Purpose
This change fixes the following bugs
- `enableSignatureValidation ` is not updated to `true` even when the checkbox is enabled and signature validation with certificate alias enabled
- Certificate not being allowed to be deleted even when signature validation does not depend on the uploaded certificate (signature validation with certificate alias is enabled)

### Related Issue
- https://github.com/wso2/product-is/issues/22113