### PR TITLE
Fix last name and first name identified as required attributes though it has been disabled as required attributes

### DIFF
--- a/.changeset/poor-bikes-give.md
+++ b/.changeset/poor-bikes-give.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix last name and first name identitied as unique attributes though it has been disbaled as unique attributes

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -234,9 +234,6 @@
     if (hasPurposes) {
         defaultPurposeCatId = selfRegistrationMgtClient.getDefaultPurposeId(user.getTenantDomain());
         uniquePIIs = IdentityManagementEndpointUtil.getUniquePIIs(purposes);
-        if (MapUtils.isNotEmpty(uniquePIIs)) {
-            piisConfigured = true;
-        }
     }
 
     List<Claim> claimsList;
@@ -244,8 +241,9 @@
     try {
         claimsList = usernameRecoveryApi.claimsGet(user.getTenantDomain(), false);
         uniquePIIs = IdentityManagementEndpointUtil.fillPiisWithClaimInfo(uniquePIIs, claimsList);
-        if (uniquePIIs != null) {
+        if (MapUtils.isNotEmpty(uniquePIIs)) {
             claims = uniquePIIs.values().toArray(new Claim[0]);
+            piisConfigured = true;
         }
         IdentityManagementEndpointUtil.addReCaptchaHeaders(request, usernameRecoveryApi.getApiClient().getResponseHeaders());
 
@@ -2094,8 +2092,8 @@
             var firstNameUserInput = document.getElementById("firstNameUserInput");
             var lastNameUserInput = document.getElementById("lastNameUserInput");
 
-            if ( (!!firstNameUserInput &&  firstNameUserInput.value.trim() == "")
-                || ( !!lastNameUserInput && lastNameUserInput.value.trim() == ""))  {
+            if ( (!!firstNameUserInput &&  firstNameUserInput.value.trim() == "" && firstNameUserInput.required)
+                || ( !!lastNameUserInput && lastNameUserInput.value.trim() == "" && lastNameUserInput.required)) {
                 return false;
             }
 


### PR DESCRIPTION
### Purpose

The `hasPurpose` variable at here [1] is false in the product. Hence the variable `piisConfigured` [2] remain as false. Anyway we are overriding the `uniquePIIs` variable [3] at this place. Hence looks [4] code lines are obsolete. 

Due to these concerns, moved the logic to this place [5], which let `piisConfigured ` variable to be properly set.

Properly resolving the variable helped to this place [6].
<img width="983" alt="Screenshot 2025-01-22 at 12 15 09" src="https://github.com/user-attachments/assets/c6d94309-d5d9-4375-971e-9ad920c441f7" />


The submit button is not visible until firstname and lastname is properly set. But it should validated on either claim marked as required. If not keeping as empty string is fine.

[1] - https://github.com/wso2/identity-apps/blob/master/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp#L234
[2] - https://github.com/wso2/identity-apps/blob/master/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp#L89
[3] - https://github.com/wso2/identity-apps/blob/master/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp#L246
[4] - https://github.com/wso2/identity-apps/blob/master/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp#L234~L240
[5] - https://github.com/wso2/identity-apps/pull/7356/files#diff-7071b0a35259cdd1d9926db8765b698d673d63d470717bfa8addfa5bfd4446d3R244-R247
[6] - https://github.com/wso2/identity-apps/blob/master/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp#L426

### Related Issues
- https://github.com/wso2/product-is/issues/22249
