### PR TITLE
Add js and data sanitization to backToUrl in self-registration-username-request.jsp

### DIFF
--- a/.changeset/curly-bags-relate.md
+++ b/.changeset/curly-bags-relate.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add sanitation to self registration callback

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -740,6 +740,8 @@
                             if (!StringUtils.equalsIgnoreCase(backToUrl, "null") &&
                                 !StringUtils.isBlank(backToUrl) &&
                                 !backToUrl.toLowerCase().contains("javascript:") &&
+                                !backToUrl.toLowerCase().contains("file:") &&
+                                !backToUrl.toLowerCase().contains("ftp:") &&
                                 !backToUrl.toLowerCase().contains("data:")) {
                         %>
                         <div class="buttons mt-2">
@@ -1302,6 +1304,8 @@
                             if (!StringUtils.equalsIgnoreCase(backToUrl, "null") &&
                                 !StringUtils.isBlank(backToUrl) &&
                                 !backToUrl.toLowerCase().contains("javascript:") &&
+                                !backToUrl.toLowerCase().contains("file:") &&
+                                !backToUrl.toLowerCase().contains("ftp:") &&
                                 !backToUrl.toLowerCase().contains("data:")) {
                         %>
                         <div class="buttons mt-2">

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -737,13 +737,16 @@
 
                         <div class="ui divider hidden"></div>
                         <%
-                            if (!StringUtils.equalsIgnoreCase(backToUrl,"null") && !StringUtils.isBlank(backToUrl)) {
+                            if (!StringUtils.equalsIgnoreCase(backToUrl, "null") &&
+                                !StringUtils.isBlank(backToUrl) &&
+                                !backToUrl.toLowerCase().contains("javascript:") &&
+                                !backToUrl.toLowerCase().contains("data:")) {
                         %>
                         <div class="buttons mt-2">
                             <div class="field external-link-container text-small">
                                 <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                                         "Already.have.an.account")%>
-                                <a href="<%= StringEscapeUtils.escapeHtml4(backToUrl) %>">
+                                <a href="<%=backToUrl%>">
                                     <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Sign.in")%>
                                 </a>
                             </div>
@@ -1296,13 +1299,16 @@
                         </div>
                         <div class="ui divider hidden"></div>
                         <%
-                            if (!StringUtils.equalsIgnoreCase(backToUrl,"null") && !StringUtils.isBlank(backToUrl)) {
+                            if (!StringUtils.equalsIgnoreCase(backToUrl, "null") &&
+                                !StringUtils.isBlank(backToUrl) &&
+                                !backToUrl.toLowerCase().contains("javascript:") &&
+                                !backToUrl.toLowerCase().contains("data:")) {
                         %>
                         <div class="buttons mt-2">
                             <div class="field external-link-container text-small">
                                 <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                                         "Already.have.an.account")%>
-                                <a href="<%= StringEscapeUtils.escapeHtml4(backToUrl) %>">
+                                <a href="<%=backToUrl%>">
                                     <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Sign.in")%>
                                 </a>
                             </div>


### PR DESCRIPTION
### Purpose
This pull request includes changes to improve security by adding sanitation to self-registration callbacks in the `identity-apps-core` module. The most important changes include the addition of sanitation checks to prevent potential security vulnerabilities in the `self-registration-username-request.jsp` file.

### Behaviour after the fix

If the callback query parameter contains "javascript:" or "data:", the sign-in button will not be rendered. A similar fix has been applied [here](https://github.com/wso2/identity-apps/blob/53caa9f40d668ba3652aa97e6dba38a61e0b3ed3/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/branding-preferences.jsp#L622).
<img width="1795" alt="Screenshot 2025-01-23 at 11 03 21 AM" src="https://github.com/user-attachments/assets/5df94a3c-cd26-4306-b39c-eab908907944" />
