### PR TITLE
Policy administration feature - Encode policy ID in URL

### DIFF
--- a/.changeset/afraid-ways-film.md
+++ b/.changeset/afraid-ways-film.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.policy-administration.v1": patch
+"@wso2is/console": patch
+---
+
+Add encoding for policy ID

--- a/features/admin.policy-administration.v1/components/policy-list-draggable-node.tsx
+++ b/features/admin.policy-administration.v1/components/policy-list-draggable-node.tsx
@@ -24,7 +24,6 @@ import { EllipsisVerticalIcon }  from "@oxygen-ui/react-icons";
 import { AppConstants, history } from "@wso2is/admin.core.v1";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import kebabCase from "lodash-es/kebabCase";
 import React, { FunctionComponent, HTMLAttributes, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -67,7 +66,7 @@ const PolicyListDraggableNode: FunctionComponent<PolicyListDraggableNodePropsInt
     const dispatch: Dispatch = useDispatch();
 
     const handleEdit = (policyId: string) => {
-        history.push(`${AppConstants.getPaths().get("EDIT_POLICY").replace(":id", kebabCase(policyId))}`);
+        history.push(`${AppConstants.getPaths().get("EDIT_POLICY").replace(":id", btoa(policyId))}`);
     };
 
     const handleDelete = async (): Promise<void> => {
@@ -79,7 +78,7 @@ const PolicyListDraggableNode: FunctionComponent<PolicyListDraggableNodePropsInt
                 policyIds: [ `${policy.policyId}` ],
                 subscriberIds: [ "PDP Subscriber" ]
             });
-            await deletePolicy(policy.policyId);
+            await deletePolicy(btoa(policy.policyId));
 
             dispatch(addAlert({
                 description: t("policyAdministration:alerts.deleteSuccess.description"),

--- a/features/admin.policy-administration.v1/components/policy-list-node.tsx
+++ b/features/admin.policy-administration.v1/components/policy-list-node.tsx
@@ -22,7 +22,6 @@ import Typography from "@oxygen-ui/react/Typography";
 import { AppConstants, history } from "@wso2is/admin.core.v1";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import kebabCase from "lodash-es/kebabCase";
 import React, { FunctionComponent, HTMLAttributes, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
@@ -66,12 +65,12 @@ const PolicyListNode: FunctionComponent<PolicyListDraggableNodePropsInterface> =
     const dispatch: Dispatch = useDispatch();
 
     const handleEdit = (policyId: string) => {
-        history.push(`${AppConstants.getPaths().get("EDIT_POLICY").replace(":id", kebabCase(policyId))}`);
+        history.push(`${AppConstants.getPaths().get("EDIT_POLICY").replace(":id", btoa(policyId))}`);
     };
 
     const handleDelete = async (): Promise<void> => {
         try {
-            await deletePolicy(policy.policyId);
+            await deletePolicy(btoa(policy.policyId));
 
             setPageInactive(0);
             setHasMoreInactivePolicies(true);

--- a/features/admin.policy-administration.v1/pages/edit-policy.tsx
+++ b/features/admin.policy-administration.v1/pages/edit-policy.tsx
@@ -58,19 +58,10 @@ const EditPolicyPage: FunctionComponent<EditPolicyPageProps> = ({
     const shouldFetchPolicy: boolean = !isEmpty(policyId);
     const [ updatedPolicyScript, setUpdatedPolicyScript ] = useState<string | undefined>();
 
-    /**
-     * Converts kebab-case to snake_case.
-     *
-     * @param kebab - Kebab case string.
-     * @returns Snake case string.
-     */
-    const kebabToSnakeCase = (kebab: string): string => {
-        return kebab.replace(/-/g, "_");
-    };
 
     // Fetch the policy using the useGetPolicy hook
     const { data: policy, isLoading, error } = useGetPolicy(
-        kebabToSnakeCase(policyId || ""),
+        policyId || "",
         shouldFetchPolicy
     );
 


### PR DESCRIPTION
Since policy ID is a string, it will be encoded and used in paths and api calls.

Feature : https://github.com/wso2/product-is/issues/22334