### PR TITLE
Process ui_locales in recovery pages

### DIFF
--- a/.changeset/spicy-apples-tan.md
+++ b/.changeset/spicy-apples-tan.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Process ui_locales in recovery pages

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-tenant-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-tenant-request.jsp
@@ -95,6 +95,14 @@ if (IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
                 <div class="segment-form">
                     <form class="ui large form" method="post" action="password-recovery-with-claims.jsp"
                         id="tenantBasedRecovery">
+                        <%
+                            String ui_locales = request.getParameter("ui_locales");
+                            if (StringUtils.isNotBlank(ui_locales)) {
+                        %>
+                                <input id="ui_locales" name="ui_locales" type="hidden" value="<%=Encode.forHtmlAttribute(ui_locales)%>"/>
+                        <%
+                            }
+                        %>
                         <input id="tenant-domain" type="text" name="tenantDomain" class="form-control align-center" 
                                 placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Tenant.domain")%>">
                         <%

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-username-request.jsp
@@ -132,6 +132,14 @@
                     <div class="segment-form">
                         <form class="ui large form" action="recoverpassword.do" method="post" id="tenantBasedRecovery">
                             <div class="field">
+                                <%
+                                    String ui_locales = request.getParameter("ui_locales");
+                                    if (StringUtils.isNotBlank(ui_locales)) {
+                                %>
+                                        <input id="ui_locales" name="ui_locales" type="hidden" value="<%=Encode.forHtmlAttribute(ui_locales)%>"/>
+                                <%
+                                    }
+                                %>
                                 <% if (isMultiAttributeLoginEnabledInTenant) { %>
                                     <label><%=usernameLabel %></label>
                                 <% } else { %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-with-claims-options.jsp
@@ -228,6 +228,14 @@
                 <div class="ui divider hidden"></div>
                 <div class="segment-form">
                     <form class="ui large form" method="post" action="verify.do" id="recoverDetailsForm">
+                        <%
+                            String ui_locales = request.getParameter("ui_locales");
+                            if (StringUtils.isNotBlank(ui_locales)) {
+                        %>
+                                <input id="ui_locales" name="ui_locales" type="hidden" value="<%=Encode.forHtmlAttribute(ui_locales)%>"/>
+                        <%
+                            }
+                        %>
                         <div class="segment" style="text-align: left;">
                         <% if (isNotificationBasedRecoveryEnabled) { %>
                         <% if (isEmailEnabled) { %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-with-claims.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-with-claims.jsp
@@ -190,6 +190,14 @@
 
                 <div class="segment-form">
                     <form class="ui large form" method="post" action="password-recovery-with-claims-options.jsp" id="recoverDetailsForm">
+                        <%
+                            String ui_locales = request.getParameter("ui_locales");
+                            if (StringUtils.isNotBlank(ui_locales)) {
+                        %>
+                            <   input id="ui_locales" name="ui_locales" type="hidden" value="<%=Encode.forHtmlAttribute(ui_locales)%>"/>
+                        <%
+                            }
+                        %>
                         <div class="field">
                             <label class="control-label"><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                                     "Username")%></label>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -248,6 +248,14 @@
                 <div class="segment-form">
                     <form class="ui large form" method="post" action="verify.do" id="recoverDetailsForm">
                         <%
+                        String ui_locales = request.getParameter("ui_locales");
+                        if (StringUtils.isNotBlank(ui_locales)) {
+                        %>
+                            <input id="ui_locales" name="ui_locales" type="hidden" value="<%=Encode.forHtmlAttribute(ui_locales)%>"/>
+                        <%
+                        }
+                        %>
+                        <%
                         if (StringUtils.isNotBlank(sp)) {
                         %>
                             <input id="sp" name="sp" type="hidden" value="<%=Encode.forHtmlAttribute(sp)%>"/>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery-tenant-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery-tenant-request.jsp
@@ -89,6 +89,14 @@
                 <div class="segment-form">
                     <form class="ui large form" method="post" action="recoverusername.do" id="tenantBasedRecovery">
                         <%
+                            String ui_locales = request.getParameter("ui_locales");
+                            if (StringUtils.isNotBlank(ui_locales)) {
+                        %>
+                                <input id="ui_locales" name="ui_locales" type="hidden" value="<%=Encode.forHtmlAttribute(ui_locales)%>"/>
+                        <%
+                            }
+                        %>
+                        <%
                             if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
                         %>
                         <input id="tenant-domain" type="text" name="tenantDomain"

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -199,6 +199,14 @@
 
                 <div class="segment-form">
                     <form class="ui large form" method="post" action="verify.do" id="recoverDetailsForm">
+                        <%
+                            String ui_locales = request.getParameter("ui_locales");
+                            if (StringUtils.isNotBlank(ui_locales)) {
+                        %>
+                                <input id="ui_locales" name="ui_locales" type="hidden" value="<%=Encode.forHtmlAttribute(ui_locales)%>"/>
+                        <%
+                            }
+                        %>
                         <% if (isFirstNameInClaims || isLastNameInClaims) { %>
                         <div class="field">
                             <label><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "name")%></label>


### PR DESCRIPTION
## Purpose
> $subject

- All the jsp pages mentioned in the issue are updated with the ui_locale processing logic.
- However please note that the below pages are deprecated.
    - username-recovery-tenant-request.jsp
    - password-recovery-tenant-request.jsp
    - password-recovery-username-request.jsp

### Tested flows:
- Password recovery  - `password-recovery.jsp`
- Username recovery - `username-recovery.jsp`
- Password recovery with claims - `password-recovery-with-claims.jsp`

### Related Issues:
- https://github.com/wso2/product-is/issues/22362

