### PR TITLE
Set ui_lang cookie if ui_locale in url param exists

### DIFF
--- a/.changeset/six-toys-destroy.md
+++ b/.changeset/six-toys-destroy.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Set ui_lang cookie if ui_locale in url param exists.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -49,6 +49,7 @@
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
 
         languageSelectionInput.val(computedLocale);
+        setCookieFromUrlParamUiLocale(computedLocale);
 
         const dataOption = $( "div[data-value='" + computedLocale + "']" );
         dataOption.addClass("active selected")
@@ -109,6 +110,15 @@
             expires = "; expires=" + date.toUTCString();
         }
         document.cookie = name + "=" + (value || "")  + expires + domain + "; path=/";
+    }
+
+    /**
+     * Handles language change by setting the `ui_locale` cookie from the url params ui_locale.
+     */
+     function setCookieFromUrlParamUiLocale(computedLocale) {
+        const EXPIRY_DAYS = 30;
+
+        setCookie('ui_lang', computedLocale, EXPIRY_DAYS);
     }
 
     /**

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -49,7 +49,7 @@
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
 
         languageSelectionInput.val(computedLocale);
-        setCookieFromUrlParamUiLocale(computedLocale);
+        setUILocaleCookie(computedLocale);
 
         const dataOption = $( "div[data-value='" + computedLocale + "']" );
         dataOption.addClass("active selected")
@@ -113,12 +113,11 @@
     }
 
     /**
-     * Handles language change by setting the `ui_locale` cookie from the url params ui_locale.
+     * Handles language change by setting the `ui_locale` cookie.
      */
-     function setCookieFromUrlParamUiLocale(computedLocale) {
-        const EXPIRY_DAYS = 30;
-
-        setCookie('ui_lang', computedLocale, EXPIRY_DAYS);
+    function setUILocaleCookie(language) {
+        var EXPIRY_DAYS = 30;
+        setCookie('ui_lang', language, EXPIRY_DAYS);
     }
 
     /**
@@ -127,9 +126,8 @@
     function onLangChange() {
         const langSwitchForm = document.getElementById("language-selector-input");
         const language = langSwitchForm.value;
-        const EXPIRY_DAYS = 30;
+        setUILocaleCookie(language);
 
-        setCookie('ui_lang', language, EXPIRY_DAYS);
         window.location.reload();
     }
 

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -49,7 +49,7 @@
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
 
         languageSelectionInput.val(computedLocale);
-        setCookieFromUrlParamUiLocale(computeLocale);
+        setUILocaleCookie(computeLocale);
 
         const dataOption = $( "div[data-value='" + computedLocale + "']" );
         dataOption.addClass("active selected")
@@ -102,12 +102,11 @@
     }
 
     /**
-     * Handles language change by setting the `ui_locale` cookie from the url params ui_locale.
+     * Handles language change by setting the `ui_locale` cookie.
      */
-     function setCookieFromUrlParamUiLocale(computedLocale) {
-        const EXPIRY_DAYS = 30;
-
-        setCookie('ui_lang', computedLocale, EXPIRY_DAYS);
+    function setUILocaleCookie(language) {
+        var EXPIRY_DAYS = 30;
+        setCookie('ui_lang', language, EXPIRY_DAYS);
     }
 
     /**
@@ -116,9 +115,8 @@
     function onLangChange() {
         const langSwitchForm = document.getElementById("language-selector-input");
         const language = langSwitchForm.value;
-        const EXPIRY_DAYS = 30;
+        setUILocaleCookie(language);
 
-        setCookie('ui_lang', language, EXPIRY_DAYS);
         window.location.reload();
     }
 

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -49,6 +49,7 @@
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
 
         languageSelectionInput.val(computedLocale);
+        setCookieFromUrlParamUiLocale(computeLocale);
 
         const dataOption = $( "div[data-value='" + computedLocale + "']" );
         dataOption.addClass("active selected")
@@ -98,6 +99,15 @@
             expires = "; expires=" + date.toUTCString();
         }
         document.cookie = name + "=" + (value || "")  + expires + domain + "; path=/";
+    }
+
+    /**
+     * Handles language change by setting the `ui_locale` cookie from the url params ui_locale.
+     */
+     function setCookieFromUrlParamUiLocale(computedLocale) {
+        const EXPIRY_DAYS = 30;
+
+        setCookie('ui_lang', computedLocale, EXPIRY_DAYS);
     }
 
     /**

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -49,7 +49,7 @@
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
 
         languageSelectionInput.val(computedLocale);
-        setCookieFromUrlParamUiLocale(computedLocale);
+        setUILocaleCookie(computedLocale);
 
         const dataOption = $( "div[data-value='" + computedLocale + "']" );
         dataOption.addClass("active selected")
@@ -113,12 +113,11 @@
     }
 
     /**
-     * Handles language change by setting the `ui_locale` cookie from the url params ui_locale.
+     * Handles language change by setting the `ui_locale` cookie.
      */
-     function setCookieFromUrlParamUiLocale(computedLocale) {
-        const EXPIRY_DAYS = 30;
-
-        setCookie('ui_lang', computedLocale, EXPIRY_DAYS);
+     function setUILocaleCookie(language) {
+        var EXPIRY_DAYS = 30;
+        setCookie('ui_lang', language, EXPIRY_DAYS);
     }
 
     /**
@@ -127,9 +126,8 @@
     function onLangChange() {
         const langSwitchForm = document.getElementById("language-selector-input");
         const language = langSwitchForm.value;
-        const EXPIRY_DAYS = 30;
+        setUILocaleCookie(language);
 
-        setCookie('ui_lang', language, EXPIRY_DAYS);
         window.location.reload();
     }
 

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -49,6 +49,7 @@
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
 
         languageSelectionInput.val(computedLocale);
+        setCookieFromUrlParamUiLocale(computedLocale);
 
         const dataOption = $( "div[data-value='" + computedLocale + "']" );
         dataOption.addClass("active selected")
@@ -109,6 +110,15 @@
             expires = "; expires=" + date.toUTCString();
         }
         document.cookie = name + "=" + (value || "")  + expires + domain + "; path=/";
+    }
+
+    /**
+     * Handles language change by setting the `ui_locale` cookie from the url params ui_locale.
+     */
+     function setCookieFromUrlParamUiLocale(computedLocale) {
+        const EXPIRY_DAYS = 30;
+
+        setCookie('ui_lang', computedLocale, EXPIRY_DAYS);
     }
 
     /**


### PR DESCRIPTION
### Purpose
> When setting a preferred language for the IS pages through the ui_locales parameter the language selection gets lost for the account recovery flows (username / password). Nonetheless the self registration flow works as expected.

The root cause was the `ui_locale` from the query param is only being processed in the current jsp page. It's not getting passed down. Furthermore we have found that the ui_locale cookie is not getting updated by the url param `ui_locale` value.

This PR sets the `ui_locale` passed from the query param in the cookie.

Pending:
- Validation for the url param value

### Related Issues
- https://github.com/wso2/product-is/issues/22362

Related PRs:
- https://github.com/wso2/identity-apps/pull/7380