### PR TITLE
Fix navigating to Console issue in Root Organizations

### DIFF
--- a/.changeset/mighty-shirts-agree.md
+++ b/.changeset/mighty-shirts-agree.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.tenants.v1": patch
+"@wso2is/i18n": patch
+---
+
+When using the `Go to Console` link in Root Organizations listing page, there are issues due to how session is handles specially in `carbon.super`.

--- a/features/admin.tenants.v1/components/tenant-card.tsx
+++ b/features/admin.tenants.v1/components/tenant-card.tsx
@@ -68,20 +68,16 @@ export interface TenantCardProps extends LoadableComponentInterface {
  * @param props - Props injected to the component.
  * @returns Tenant Card component.
  */
-const TenantCard: FunctionComponent<TenantCardProps> = ({
-    isLoading,
-    tenant
-}: TenantCardProps): ReactElement => {
+const TenantCard: FunctionComponent<TenantCardProps> = ({ isLoading, tenant }: TenantCardProps): ReactElement => {
     const { t } = useTranslation();
 
-    const clientHost: string = useSelector((state: AppState) => state.config?.deployment?.clientHost);
     const isTenantDeletionEnabled: boolean = useSelector((state: AppState) => {
         return !state?.config?.ui?.features?.tenants?.disabledFeatures?.includes(
             TenantConstants.FEATURE_DICTIONARY.TENANT_DELETION
         );
     });
 
-    const { deleteTenant, disableTenant, enableTenant } = useTenants();
+    const { deleteTenant, disableTenant, enableTenant, navigateToTenantConsole } = useTenants();
 
     const [ anchorEl, setAnchorEl ] = useState<null | HTMLElement>(null);
 
@@ -93,16 +89,6 @@ const TenantCard: FunctionComponent<TenantCardProps> = ({
 
     const handleClose = (): void => {
         setAnchorEl(null);
-    };
-
-    /**
-     * Builds a Console URL for the passed in tenant domain by replacing the tenant domain in the client host URL.
-     *
-     * @param tenantDomain - Tenant domain.
-     * @returns Built tenant console URL.
-     */
-    const buildTenantConsoleURL = (tenantDomain: string): string => {
-        return clientHost.replace(/\/t\/[^/]+\//, `/t/${tenantDomain}/`);
     };
 
     if (isLoading) {
@@ -218,9 +204,10 @@ const TenantCard: FunctionComponent<TenantCardProps> = ({
                         >
                             <MenuItem
                                 className="tenant-card-footer-dropdown-item"
-                                onClick={ () =>
-                                    window.open(buildTenantConsoleURL(tenant.domain), "_blank", "noopener noreferrer")
-                                }
+                                onClick={ () => {
+                                    navigateToTenantConsole(tenant);
+                                    handleClose();
+                                } }
                             >
                                 <ListItemIcon>
                                     <ArrowUpRightFromSquareIcon />

--- a/features/admin.tenants.v1/context/tenant-context.tsx
+++ b/features/admin.tenants.v1/context/tenant-context.tsx
@@ -52,6 +52,11 @@ export interface TenantContextProps {
      */
     mutateTenantList: () => void;
     /**
+     * Navigate to the tenant console.
+     * @param tenant  - Tenant to navigate to.
+     */
+    navigateToTenantConsole: (tenant: Tenant) => void;
+    /**
      * The search query.
      */
     searchQuery: string;
@@ -91,6 +96,7 @@ const TenantContext: Context<TenantContextProps> = createContext<null | TenantCo
     isInitialRenderingComplete: false,
     isTenantListLoading: false,
     mutateTenantList: () => null,
+    navigateToTenantConsole: () => null,
     searchQuery: "",
     searchQueryClearTrigger: false,
     setSearchQuery: () => null,

--- a/modules/i18n/src/models/namespaces/tenants-ns.ts
+++ b/modules/i18n/src/models/namespaces/tenants-ns.ts
@@ -163,6 +163,14 @@ export interface TenantsNS {
             primaryAction: string;
             secondaryAction: string;
         };
+        navigatingToTenantConsole: {
+            assertionHint: string;
+            content: string;
+            header: string;
+            message: string;
+            primaryAction: string;
+            secondaryAction: string;
+        };
     },
     edit: {
         backButton: string;

--- a/modules/i18n/src/translations/en-US/portals/tenants.ts
+++ b/modules/i18n/src/translations/en-US/portals/tenants.ts
@@ -166,6 +166,14 @@ export const tenants: TenantsNS = {
             message: "This action will temporarily disable the organization.",
             primaryAction: "Confirm",
             secondaryAction: "Cancel"
+        },
+        navigatingToTenantConsole: {
+            assertionHint: "Please confirm your action.",
+            content: "If you continue navigating to the <1>{{domain}}</1> Console, you will be logged out from the current session.",
+            header: "Confirmation",
+            message: "Navigating to the Console will require you to re-login.",
+            primaryAction: "Logout & Go to Console",
+            secondaryAction: "Cancel"
         }
     },
     edit: {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

When using the `Go to Console` link in Root Organizations listing page, there are issues due to how session is handles specially in `carbon.super`.

This pull request introduces a new feature to navigate to the tenant console and refactors related components for improved functionality and readability. The most important changes include adding the `navigateToTenantConsole` function, updating the `TenantProvider` and `TenantCard` components, and modifying the i18n translations to support the new confirmation modal.

### New Feature: Navigate to Tenant Console
* [`features/admin.tenants.v1/context/tenant-context.tsx`](diffhunk://#diff-9eaeb64cce469b0ce5721213cd8a90b5857fbfbd882be50d2cf7cebedafd5e4eR54-R58): Added `navigateToTenantConsole` function to the `TenantContextProps` interface. [[1]](diffhunk://#diff-9eaeb64cce469b0ce5721213cd8a90b5857fbfbd882be50d2cf7cebedafd5e4eR54-R58) [[2]](diffhunk://#diff-9eaeb64cce469b0ce5721213cd8a90b5857fbfbd882be50d2cf7cebedafd5e4eR99)
* [`features/admin.tenants.v1/providers/tenant-provider.tsx`](diffhunk://#diff-2c7554124d11ba06a2d3c673537ba9e73051129cd948fb0fcd1be836f96fc780R218-R233): Implemented `handleTenantConsoleNavigation` function to handle navigation to the tenant console and added a confirmation modal for this action. [[1]](diffhunk://#diff-2c7554124d11ba06a2d3c673537ba9e73051129cd948fb0fcd1be836f96fc780R218-R233) [[2]](diffhunk://#diff-2c7554124d11ba06a2d3c673537ba9e73051129cd948fb0fcd1be836f96fc780R251-R254) [[3]](diffhunk://#diff-2c7554124d11ba06a2d3c673537ba9e73051129cd948fb0fcd1be836f96fc780L276-R307)

### Component Updates
* [`features/admin.tenants.v1/components/tenant-card.tsx`](diffhunk://#diff-c521e82c47305026b5cd86b403268bf5287cdde069a2f70869d52d377a4ac564L71-R80): Refactored the `TenantCard` component to use the `navigateToTenantConsole` function instead of the `buildTenantConsoleURL` function. [[1]](diffhunk://#diff-c521e82c47305026b5cd86b403268bf5287cdde069a2f70869d52d377a4ac564L71-R80) [[2]](diffhunk://#diff-c521e82c47305026b5cd86b403268bf5287cdde069a2f70869d52d377a4ac564L98-L107) [[3]](diffhunk://#diff-c521e82c47305026b5cd86b403268bf5287cdde069a2f70869d52d377a4ac564L221-R210)

### i18n Translations
* [`modules/i18n/src/models/namespaces/tenants-ns.ts`](diffhunk://#diff-1db7e536e99236f39503565e907abc24be835035da4312462f6d3509516766efR166-R173): Added new translation keys for the tenant console navigation confirmation modal.
* [`modules/i18n/src/translations/en-US/portals/tenants.ts`](diffhunk://#diff-5fbcaefaa3c31f84caf5f0a09fd0b67c48dc72e51a23dcb965fc45e3b338740cR169-R176): Provided English translations for the new confirmation modal.

These changes collectively enhance the user experience by providing a clear and confirmed way to navigate to the tenant console, ensuring users are aware of the session implications.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- Fixes https://github.com/wso2/product-is/issues/22225

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
