### PR TITLE
Add console role listener

### DIFF
--- a/.changeset/kind-eyes-mix.md
+++ b/.changeset/kind-eyes-mix.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+introduce console listener

--- a/identity-apps-core/components/org.wso2.identity.apps.common/pom.xml
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/pom.xml
@@ -88,6 +88,14 @@
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.application</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.api.resource.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.api.resource.collection.mgt</artifactId>
+        </dependency>
         <!-- To fix travis build -->
         <dependency>
             <groupId>xalan</groupId>
@@ -141,7 +149,8 @@
             org.wso2.carbon.identity.role.v2.mgt.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
             org.wso2.carbon.identity.organization.management.service.*; version="${identity.org.mgt.core.version.range}",
             org.wso2.carbon.identity.organization.management.application.*; version="${identity.org.mgt.application.version.range}",
-            org.wso2.carbon.identity.api.resource.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}"
+            org.wso2.carbon.identity.api.resource.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+            org.wso2.carbon.identity.api.resource.collection.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}"
         </import.package>
         <dsannotations>*</dsannotations>
     </properties>

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonDataHolder.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.identity.apps.common.internal;
 
+import org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionManager;
 import org.wso2.carbon.identity.api.resource.mgt.APIResourceManager;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.oauth.OAuthAdminServiceImpl;
@@ -47,6 +48,7 @@ public class AppsCommonDataHolder {
     private RoleManagementService roleManagementService;
 
     private APIResourceManager apiResourceManager;
+    private APIResourceCollectionManager apiResourceCollectionManager;
 
     private Set<String> systemAppConsumerKeys = new HashSet<>();
 
@@ -220,6 +222,26 @@ public class AppsCommonDataHolder {
     public APIResourceManager getAPIResourceManager() {
 
         return apiResourceManager;
+    }
+
+    /**
+     * Set API resource collection manager.
+     *
+     * @param apiResourceCollectionManager APIResourceCollectionManager.
+     */
+    public void setAPIResourceCollectionManager(APIResourceCollectionManager apiResourceCollectionManager) {
+
+        this.apiResourceCollectionManager = apiResourceCollectionManager;
+    }
+
+    /**
+     * Get API resource collection manager.
+     *
+     * @return apiResourceCollectionManager.
+     */
+    public APIResourceCollectionManager getApiResourceCollectionManager() {
+
+        return apiResourceCollectionManager;
     }
 
 

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.core.ServerStartupObserver;
+import org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionManager;
 import org.wso2.carbon.identity.api.resource.mgt.APIResourceManager;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.InboundAuthenticationRequestConfig;
@@ -48,6 +49,7 @@ import org.wso2.identity.apps.common.listner.AppPortalApplicationMgtListener;
 import org.wso2.identity.apps.common.listner.AppPortalOAuthAppMgtListener;
 import org.wso2.identity.apps.common.listner.AppPortalRoleManagementListener;
 import org.wso2.identity.apps.common.listner.AppPortalTenantMgtListener;
+import org.wso2.identity.apps.common.listner.ConsoleRoleListener;
 import org.wso2.identity.apps.common.util.AppPortalUtils;
 
 import java.util.HashSet;
@@ -109,6 +111,10 @@ public class AppsCommonServiceComponent {
                 RoleManagementListener roleManagementListener = new AppPortalRoleManagementListener(true);
                 bundleContext.registerService(RoleManagementListener.class.getName(), roleManagementListener, null);
                 log.debug("AppPortalRoleManagementListener registered successfully.");
+
+                RoleManagementListener consoleRoleListener = new ConsoleRoleListener();
+                bundleContext.registerService(RoleManagementListener.class.getName(), consoleRoleListener, null);
+                log.debug("ConsoleRoleListener registered successfully.");
             }
 
             if (!CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
@@ -264,6 +270,22 @@ public class AppsCommonServiceComponent {
     protected void unsetAPIResourceManager(APIResourceManager apiResourceManager) {
 
         AppsCommonDataHolder.getInstance().setAPIResourceManager(null);
+    }
+
+    @Reference(
+        name = "api.resource.collection.mgt.service",
+        service = APIResourceCollectionManager.class,
+        cardinality = ReferenceCardinality.MANDATORY,
+        policy = ReferencePolicy.DYNAMIC,
+        unbind = "unsetAPIResourceCollectionManager")
+    protected void setAPIResourceManager(APIResourceCollectionManager apiResourceCollectionManager) {
+
+        AppsCommonDataHolder.getInstance().setAPIResourceCollectionManager(apiResourceCollectionManager);
+    }
+
+    protected void unsetAPIResourceCollectionManager(APIResourceCollectionManager apiResourceCollectionManager) {
+
+        AppsCommonDataHolder.getInstance().setAPIResourceCollectionManager(null);
     }
 
     private boolean skipPortalInitialization() {

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/ConsoleRoleListener.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/ConsoleRoleListener.java
@@ -1,0 +1,284 @@
+package org.wso2.identity.apps.common.listner;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.api.resource.collection.mgt.APIResourceCollectionManagerImpl;
+import org.wso2.carbon.identity.api.resource.collection.mgt.exception.APIResourceCollectionMgtException;
+import org.wso2.carbon.identity.api.resource.collection.mgt.internal.APIResourceCollectionMgtServiceDataHolder;
+import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollection;
+import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollectionSearchResult;
+import org.wso2.carbon.identity.api.resource.mgt.APIResourceMgtException;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
+import org.wso2.carbon.identity.application.common.model.Scope;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.listener.AbstractRoleManagementListener;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.Permission;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
+import org.wso2.identity.apps.common.internal.AppsCommonDataHolder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.wso2.carbon.identity.api.resource.collection.mgt.constant.APIResourceCollectionManagementConstants.APIResourceCollectionConfigBuilderConstants.EDIT_FEATURE_SCOPE_SUFFIX;
+import static org.wso2.carbon.identity.api.resource.collection.mgt.constant.APIResourceCollectionManagementConstants.APIResourceCollectionConfigBuilderConstants.VIEW_FEATURE_SCOPE_SUFFIX;
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.CONSOLE_APP_AUDIENCE_NAME;
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.CONSOLE_ORG_SCOPE_PREFIX;
+import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.CONSOLE_SCOPE_PREFIX;
+
+/**
+ * Console role listener to populate organization console application roles permissions.
+ */
+public class ConsoleRoleListener extends AbstractRoleManagementListener {
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 87;
+    }
+
+    @Override
+    public boolean isEnable() {
+
+        return true;
+    }
+
+    @Override
+    public void preAddRole(String roleName, List<String> userList, List<String> groupList, List<Permission> permissions,
+                           String audience, String audienceId, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        if (isConsoleApp(audience, audienceId, tenantDomain)) {
+            List<Permission> consoleFeaturePermissions = getConsoleFeaturePermissions(permissions);
+            if (consoleFeaturePermissions != null && !consoleFeaturePermissions.isEmpty()) {
+                // If console features are added to the role, then we need to we only need to persist the console
+                // permissions.
+                permissions.retainAll(consoleFeaturePermissions);
+            }
+        }
+    }
+
+    @Override
+    public void postGetRole(Role role, String roleId, String tenantDomain) throws IdentityRoleManagementException {
+
+
+        if (!RoleConstants.ADMINISTRATOR.equals(role.getName()) &&
+            role.getAudienceName().equals(CONSOLE_APP_AUDIENCE_NAME)) {
+            // Get updated console role permissions with newly added read and write scopes from API resource collection.
+            List<Permission> rolePermissions = getUpgradedPermissions(role.getPermissions(), tenantDomain);
+            role.setPermissions(rolePermissions);
+        }
+    }
+
+    @Override
+    public void postGetPermissionListOfRole(List<Permission> permissionListOfRole, String roleId, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        if (isConsoleRole(roleId, tenantDomain)) {
+            List<Permission> rolePermissions = getUpgradedPermissions(permissionListOfRole, tenantDomain);
+            permissionListOfRole.clear();
+            permissionListOfRole.addAll(rolePermissions);
+        }
+    }
+
+    @Override
+    public void postGetPermissionListOfRoles(List<String> permissions, List<String> roleIds, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        boolean isConsolePermissionsContains = isConsolePermissionsContains(permissions);
+        boolean isConsoleFeaturePermissionsContains = isConsoleFeaturePermissionsContains(permissions);
+        if (isConsolePermissionsContains || isConsoleFeaturePermissionsContains) {
+            List<Permission> resolvedRolePermissions = new ArrayList<>();
+            List<Permission> systemPermissions = getSystemPermission(tenantDomain);
+            permissions.forEach(permission -> {
+                Optional<Permission> newPermission = systemPermissions.stream()
+                    .filter(permission1 -> permission1.getName().equals(permission))
+                    .findFirst();
+                newPermission.ifPresent(resolvedRolePermissions::add);
+            });
+            List<Permission> rolePermissions = getUpgradedPermissions(resolvedRolePermissions, tenantDomain);
+            permissions.clear();
+            permissions.addAll(rolePermissions.stream().map(Permission::getName).collect(Collectors.toList()));
+        }
+    }
+
+    @Override
+    public void preUpdatePermissionsForRole(String roleId, List<Permission> addedPermissions,
+                                            List<Permission> deletedPermissions, String audience, String audienceId,
+                                            String tenantDomain) throws IdentityRoleManagementException {
+
+        if (isConsoleApp(audience, audienceId, tenantDomain)) {
+            List<Permission> consoleFeaturePermissions = getConsoleFeaturePermissions(addedPermissions);
+            if (consoleFeaturePermissions != null && !consoleFeaturePermissions.isEmpty()) {
+                // If console features are added to the role, then we need to we only need to persist the console
+                // permissions.
+                addedPermissions.retainAll(consoleFeaturePermissions);
+            }
+        }
+    }
+
+    private List<Permission> getUpgradedPermissions(List<Permission> rolePermissions, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        // Fetch all system scopes to resolve permission details from permission name.
+        List<Permission> systemPermissions = getSystemPermission(tenantDomain);
+        List<APIResourceCollection> apiResourceCollections = getAPIResourceCollections(tenantDomain);
+        List<Permission> consoleFeaturePermissions = getConsoleFeaturePermissions(rolePermissions);
+        if (!consoleFeaturePermissions.isEmpty()) {
+            // This is where we handle the new console roles (console roles created after 7.0.0) permissions.
+            // We check whether the role has the view feature scope or edit feature scope. If the role has the
+            // view feature scope, then we add all the read scopes. If the role has the edit feature scope, then we
+            // add all the write scopes.
+            consoleFeaturePermissions.forEach(permission -> {
+                apiResourceCollections.forEach(apiResourceCollection -> {
+                    // If the role has the edit feature scope, then we add all the write and read scopes.
+                    if (apiResourceCollection.getEditFeatureScope() != null &&
+                        apiResourceCollection.getEditFeatureScope().equals(permission.getName())) {
+                        apiResourceCollection.getWriteScopes().forEach(writeScope -> {
+                            Optional<Permission> newPermission = systemPermissions.stream()
+                                .filter(permission1 -> permission1.getName().equals(writeScope))
+                                .findFirst();
+                            newPermission.ifPresent(rolePermissions::add);
+                        });
+                    }
+                    if (apiResourceCollection.getViewFeatureScope() != null &&
+                        apiResourceCollection.getViewFeatureScope().equals(permission.getName())) {
+                        apiResourceCollection.getReadScopes().forEach(readScope -> {
+                            Optional<Permission> newPermission = systemPermissions.stream()
+                                .filter(permission1 -> permission1.getName().equals(readScope))
+                                .findFirst();
+                            newPermission.ifPresent(rolePermissions::add);
+                        });
+                    }
+                });
+            });
+        } else {
+            // This is where we handle the initial console roles (console roles created in 7.0.0) permissions.
+            // Here we assume these role only contains legacy feature scope not the new feature scopes.
+            List<Permission> consolePermissions = getConsolePermissions(rolePermissions);
+            consolePermissions.forEach(permission -> {
+                apiResourceCollections.forEach(apiResourceCollection -> {
+                    // Match the permission with the collection.
+                    if (apiResourceCollection.getReadScopes().contains(permission.getName())) {
+                        // Add new read scopes since we have the feature scope.
+                        apiResourceCollection.getReadScopes().forEach(newReadScope -> {
+                            Optional<Permission> newPermission = systemPermissions.stream()
+                                .filter(permission1 -> permission1.getName().equals(newReadScope))
+                                .findFirst();
+                            newPermission.ifPresent(rolePermissions::add);
+                        });
+                        List<String> legacyWriteScopes = apiResourceCollection.getLegacyWriteScopes();
+                        // if all the writeScopes are in the role's permission list, then add new write scopes.
+                        if (rolePermissions.stream().anyMatch(rolePermission ->
+                            legacyWriteScopes.contains(rolePermission.getName()))) {
+                            apiResourceCollection.getWriteScopes().forEach(newWriteScope -> {
+                                Optional<Permission> newPermission = systemPermissions.stream()
+                                    .filter(permission1 -> permission1.getName().equals(newWriteScope))
+                                    .findFirst();
+                                newPermission.ifPresent(rolePermissions::add);
+                            });
+                        }
+                    }
+                });
+            });
+        }
+        return rolePermissions;
+    }
+
+    private boolean isConsoleRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
+
+        RoleManagementService roleManagementService = AppsCommonDataHolder.getInstance()
+            .getRoleManagementServiceV2();
+        RoleBasicInfo role = roleManagementService.getRoleBasicInfoById(roleId, tenantDomain);
+        return !RoleConstants.ADMINISTRATOR.equals(role.getName()) &&
+            role.getAudienceName().equals(CONSOLE_APP_AUDIENCE_NAME);
+    }
+
+    private boolean isConsoleApp(String audience, String audienceId, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        if (!RoleConstants.APPLICATION.equals(audience)) {
+            return false;
+        }
+        ApplicationManagementService applicationManagementService = AppsCommonDataHolder.getInstance()
+            .getApplicationManagementService();
+        try {
+            ApplicationBasicInfo applicationBasicInfo = applicationManagementService
+                .getApplicationBasicInfoByResourceId(audienceId, tenantDomain);
+            return applicationBasicInfo != null && CONSOLE_APP_AUDIENCE_NAME
+                .equals(applicationBasicInfo.getApplicationName());
+        } catch (IdentityApplicationManagementException e) {
+            throw new IdentityRoleManagementException("Error while retrieving application basic info for application " +
+                "id : " + audienceId, e);
+        }
+    }
+
+    private List<APIResourceCollection> getAPIResourceCollections(String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        try {
+            List<String> requiredAttributes = new ArrayList<>();
+            requiredAttributes.add("apiResources");
+            APIResourceCollectionSearchResult apiResourceCollectionSearchResult = APIResourceCollectionManagerImpl
+                .getInstance().getAPIResourceCollections("", requiredAttributes, tenantDomain);
+            return apiResourceCollectionSearchResult.getAPIResourceCollections();
+
+        } catch (APIResourceCollectionMgtException e) {
+            throw new IdentityRoleManagementException("Error while retrieving api collection for tenant : " +
+                tenantDomain, e);
+        }
+    }
+
+    private List<Permission> getConsoleFeaturePermissions(List<Permission> rolePermissions) {
+
+        return rolePermissions.stream().filter(permission -> permission != null &&
+                permission.getName() != null && (permission.getName().startsWith(CONSOLE_SCOPE_PREFIX)
+                || permission.getName().startsWith(CONSOLE_ORG_SCOPE_PREFIX)) &&
+                (permission.getName().endsWith(VIEW_FEATURE_SCOPE_SUFFIX) ||
+                    permission.getName().endsWith(EDIT_FEATURE_SCOPE_SUFFIX)))
+            .collect(Collectors.toList());
+    }
+
+    private List<Permission> getConsolePermissions(List<Permission> rolePermissions) {
+
+        return rolePermissions.stream().filter(permission -> permission != null &&
+                permission.getName() != null && (permission.getName().startsWith(CONSOLE_SCOPE_PREFIX)
+                || permission.getName().startsWith(CONSOLE_ORG_SCOPE_PREFIX)) &&
+                !(permission.getName().endsWith(VIEW_FEATURE_SCOPE_SUFFIX) ||
+                    permission.getName().endsWith(EDIT_FEATURE_SCOPE_SUFFIX)))
+            .collect(Collectors.toList());
+    }
+
+    private boolean isConsoleFeaturePermissionsContains(List<String> rolePermissions) {
+
+        return rolePermissions.stream().anyMatch(permission -> StringUtils.isNotBlank(permission) &&
+            (permission.startsWith(CONSOLE_SCOPE_PREFIX) || permission.startsWith(CONSOLE_ORG_SCOPE_PREFIX)) &&
+            (permission.endsWith(VIEW_FEATURE_SCOPE_SUFFIX) || permission.endsWith(EDIT_FEATURE_SCOPE_SUFFIX)));
+    }
+
+    private boolean isConsolePermissionsContains(List<String> rolePermissions) {
+
+        return rolePermissions.stream().anyMatch(permission -> StringUtils.isNotBlank(permission) &&
+            (permission.startsWith(CONSOLE_SCOPE_PREFIX) || permission.startsWith(CONSOLE_ORG_SCOPE_PREFIX)) &&
+            !(permission.endsWith(VIEW_FEATURE_SCOPE_SUFFIX) || permission.endsWith(EDIT_FEATURE_SCOPE_SUFFIX)));
+    }
+
+    private List<Permission> getSystemPermission(String tenantDomain) throws IdentityRoleManagementException {
+        List<Scope> systemScopes;
+        try {
+            systemScopes = APIResourceCollectionMgtServiceDataHolder.getInstance()
+                .getAPIResourceManagementService().getSystemAPIScopes(tenantDomain);
+        } catch (APIResourceMgtException e) {
+            throw new IdentityRoleManagementException("Error while retrieving internal scopes for tenant " +
+                "domain : " + tenantDomain, e);
+        }
+        return systemScopes.stream().map(scope -> new Permission(scope.getName(), scope.getDisplayName(),
+            scope.getApiID())).collect(Collectors.toList());
+    }
+}
+

--- a/identity-apps-core/pom.xml
+++ b/identity-apps-core/pom.xml
@@ -734,7 +734,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>7.7.142-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.176</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.core.service.version>1.0.77
         </identity.organization.management.core.service.version>

--- a/identity-apps-core/pom.xml
+++ b/identity-apps-core/pom.xml
@@ -402,6 +402,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.api.resource.collection.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
                 <artifactId>org.wso2.carbon.identity.captcha</artifactId>
                 <version>${identity.governance.version}</version>
@@ -729,7 +734,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>7.2.30</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.142-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.core.service.version>1.0.77
         </identity.organization.management.core.service.version>


### PR DESCRIPTION
### Proposed changes in this pull request

Previously, newly added scopes to the API resource collection did not reflect in existing console roles. With this PR (https://github.com/wso2/carbon-identity-framework/pull/6372), we have introduced a new collection version and set previous collection as  v0, which includes two feature scopes used for collection viewing and editing. 

Following is sample api resource collection (v0 one and new one) 

```
# API Resource collection for Diagnostic Logs
[[api_resource_collections]]
name = "diagnosticLogs"
displayName = "Diagnostic Logs"
type = "tenant"
version="v0"

[[api_resource_collections.scopes.feature]]
name="console:diagnosticLogs"

[[api_resource_collections.scopes.read]]
name="internal_application_mgt_view"


# Newly Added API Resource collection for Diagnostic Logs
[[api_resource_collections]]
name = "diagnosticLogs"
displayName = "Diagnostic Logs"
type = "tenant"

[[api_resource_collections.scopes.feature]]
name="console:diagnosticLogs"

# New view feature scope
[[api_resource_collections.scopes.feature]]
name="console:diagnosticLogs_view"

# New edit feature scope
[[api_resource_collections.scopes.feature]]
name="console:diagnosticLogs_edit"

[[api_resource_collections.scopes.read]]
name="internal_application_mgt_view"
```

In this PR we have introduce a listener to resolve console role permission at runtime. 

When we fetch a console role, this listener : 

```
## Input: Role Permissions

### Step 1: Retrieve System Data
1. Retrieve system permissions for the given tenant.
2. Retrieve API resource collections for the given tenant.

### Step 2: Extract Console Feature Permissions
- Retrieve console feature permissions from the role’s permissions list.
  - **Console feature permissions** are the ones defined at the new API resource collection with `_view` and `_edit` suffixes.

### Step 3: Check Console Feature Permissions List
#### Case 1: Console Feature Permissions List is **Not Empty**
1. Assume this is a **"new" console role** (created with `_view` and `_edit` feature permissions).
2. Create a new list to hold resolved role permissions.
3. For each console feature permission:
   - For each API resource collection:
     - If the permission matches the **edit feature scope**, add all corresponding **write scopes** of the collection.
     - If the permission matches the **view feature scope**, add all corresponding **read scopes** of the collection.
4. Return the resolved permissions.

#### Case 2: Console Feature Permissions List is **Empty**
1. Assume this is an **"old" console role**.
2. Convert the original role permissions to a set.
3. Retrieve console permissions from the role’s permission list (legacy feature scopes).
4. For each console permission:
   - For each API resource collection:
     - If the permission name is in the **read scopes**, add all new **read scopes** of the collection.
     - Check if the role has **all legacy write scopes** for that collection; if so, add all new **write scopes** of the collection.
5. Return the resolved permissions.
```

When adding or updating role (with permission) now we only persist new feature scope. In get role level we will resolve actual permissions of the role with api collection. This will resolve the original problem

### Related Issues
- https://github.com/wso2/product-is/issues/22071

### Merge After
- https://github.com/wso2/carbon-identity-framework/pull/6372