### PR TITLE
Fix search bar being rendered in empty organizations page 

### DIFF
--- a/.changeset/nice-tools-wash.md
+++ b/.changeset/nice-tools-wash.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.organizations.v1": patch
+---
+
+Fix search bar not being hidden when there are no organizations

--- a/features/admin.organizations.v1/pages/organizations.tsx
+++ b/features/admin.organizations.v1/pages/organizations.tsx
@@ -34,6 +34,7 @@ import { DocumentationLink, ListLayout, PageLayout, PrimaryButton, useDocumentat
 import { AxiosError } from "axios";
 import find from "lodash-es/find";
 import isEmpty from "lodash-es/isEmpty";
+import trim from "lodash-es/trim";
 import React, {
     FunctionComponent,
     MouseEvent,
@@ -592,7 +593,9 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
                     onSortStrategyChange={ handleListSortingStrategyOnChange }
                     showPagination={ true }
                     showTopActionPanel={
-                        !isOrganizationListRequestLoading && organizationList?.organizations?.length > 0
+                        isOrganizationListRequestLoading
+                        || ((searchQuery || "").trim().length > 0)
+                        || (organizationList?.organizations?.length > 0)
                     }
                     sortOptions={ ORGANIZATIONS_LIST_SORTING_OPTIONS }
                     sortStrategy={ listSortingStrategy }

--- a/features/admin.organizations.v1/pages/organizations.tsx
+++ b/features/admin.organizations.v1/pages/organizations.tsx
@@ -592,8 +592,7 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
                     onSortStrategyChange={ handleListSortingStrategyOnChange }
                     showPagination={ true }
                     showTopActionPanel={
-                        isOrganizationListRequestLoading ||
-                                !(!searchQuery && organizationList?.organizations?.length <= 0)
+                        !isOrganizationListRequestLoading && organizationList?.organizations?.length > 0
                     }
                     sortOptions={ ORGANIZATIONS_LIST_SORTING_OPTIONS }
                     sortStrategy={ listSortingStrategy }

--- a/features/admin.organizations.v1/pages/organizations.tsx
+++ b/features/admin.organizations.v1/pages/organizations.tsx
@@ -34,7 +34,6 @@ import { DocumentationLink, ListLayout, PageLayout, PrimaryButton, useDocumentat
 import { AxiosError } from "axios";
 import find from "lodash-es/find";
 import isEmpty from "lodash-es/isEmpty";
-import trim from "lodash-es/trim";
 import React, {
     FunctionComponent,
     MouseEvent,


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This PR hides the search bar from the ui when there are no organizations.
<img width="1440" alt="Screenshot 2025-01-27 at 23 32 49" src="https://github.com/user-attachments/assets/436ecc67-9ed6-4a59-841a-2c0138805988" />



### Related Issues
- https://github.com/wso2/product-is/issues/22496

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
