### PR TITLE
Fix missing icon in the custom connector creation wizard

### DIFF
--- a/.changeset/tidy-poems-arrive.md
+++ b/.changeset/tidy-poems-arrive.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Fix missing expert icon in the custom connector creation wizard

--- a/features/admin.connections.v1/configs/ui.ts
+++ b/features/admin.connections.v1/configs/ui.ts
@@ -21,6 +21,7 @@ import FIDOIcon from "../../themes/default/assets/images/authenticators/fido-pas
 import SalesforceLogo from "../../themes/default/assets/images/connectors/salesforce.png";
 import SCIMLogo from "../../themes/default/assets/images/connectors/scim.png";
 import SPMLLogo from "../../themes/default/assets/images/connectors/spml.png";
+import ExpertIcon from "../../themes/default/assets/images/identity-providers/expert.svg";
 import FacebookLogo from "../../themes/default/assets/images/identity-providers/facebook-idp-illustration.svg";
 import GithubIdPIcon from "../../themes/default/assets/images/identity-providers/github-idp-illustration.svg";
 import GoogleLogo from "../../themes/default/assets/images/identity-providers/google-idp-illustration.svg";
@@ -89,6 +90,7 @@ export const getConnectionIcons = (): any => {
         "email-otp-authenticator": EmailOTPIcon,
         emailOTP: EmailOTPIcon,
         enterprise: EnterpriseConnectionIcon,
+        expert: ExpertIcon,
         facebook: FacebookLogo,
         fido: FIDOIcon,
         githubAuthenticator: GithubIdPIcon,


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This PR fixes the missing expert icon in the custom connector creation wizard


### Related Issues
- https://github.com/wso2/product-is/issues/21300

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
