### PR TITLE
Conditionally display heading text based on push provider feature flag

### DIFF
--- a/.changeset/odd-nails-impress.md
+++ b/.changeset/odd-nails-impress.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.email-providers.v1": patch
+"@wso2is/admin.email-and-sms.v1": patch
+"@wso2is/admin.sms-providers.v1": patch
+"@wso2is/console": patch
+---
+
+Conditionally display heading text based on push provider feature flag

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -1633,6 +1633,12 @@ export interface Extensions {
                 }
             };
         };
+        emailAndSms: {
+            heading: string;
+            title: string;
+            description: string;
+            goBack: string;
+        };
         notificationChannel: {
             heading: string;
             title: string;

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -1737,6 +1737,12 @@ export const extensions: Extensions = {
                 }
             }
         },
+        emailAndSms: {
+            heading: "SMS / Email Providers",
+            title: "SMS / Email Providers",
+            description: "Configure the SMS and Email providers for your organization.",
+            goBack: "Go back to Email & SMS"
+        },
         notificationChannel: {
             heading: "Notification Channels",
             title: "Notification Channels",

--- a/features/admin.email-and-sms.v1/pages/email-and-sms.tsx
+++ b/features/admin.email-and-sms.v1/pages/email-and-sms.tsx
@@ -54,6 +54,8 @@ export const EmailAndSMSPage: FunctionComponent<EmailAndSMSPageInterface> = (
 
     const featureConfig : FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
+    const isPushProviderFeatureEnabled: boolean = featureConfig?.pushProviders?.enabled;
+
     /**
      * Handle connector advance setting selection.
      */
@@ -71,9 +73,21 @@ export const EmailAndSMSPage: FunctionComponent<EmailAndSMSPageInterface> = (
 
     return (
         <PageLayout
-            pageTitle={ t("extensions:develop.notificationChannel.heading") }
-            title={ t("extensions:develop.notificationChannel.title") }
-            description={ t("extensions:develop.notificationChannel.description") }
+            pageTitle={
+                isPushProviderFeatureEnabled
+                    ? t("extensions:develop.notificationChannel.heading")
+                    : t("extensions:develop.emailAndSms.heading")
+            }
+            title={
+                isPushProviderFeatureEnabled
+                    ? t("extensions:develop.notificationChannel.title")
+                    : t("extensions:develop.emailAndSms.title")
+            }
+            description={
+                isPushProviderFeatureEnabled
+                    ? t("extensions:develop.notificationChannel.description")
+                    : t("extensions:develop.emailAndSms.description")
+            }
             data-testid={ `${componentid}-page-layout` }
         >
             <Grid container rowSpacing={ 3 } columnSpacing={ 3 }>

--- a/features/admin.email-providers.v1/pages/email-providers.tsx
+++ b/features/admin.email-providers.v1/pages/email-providers.tsx
@@ -442,7 +442,9 @@ const EmailProvidersPage: FunctionComponent<EmailProvidersPageInterface> = (
             pageHeaderMaxWidth={ true }
             backButton={ {
                 onClick: handleBackButtonClick,
-                text: t("extensions:develop.emailProviders.goBack")
+                text: isPushProviderFeatureEnabled
+                    ? t("extensions:develop.emailProviders.goBack")
+                    : t("extensions:develop.emailAndSms.goBack")
             } }
             action={
                 featureConfig.emailProviders?.enabled &&

--- a/features/admin.sms-providers.v1/pages/sms-providers.tsx
+++ b/features/admin.sms-providers.v1/pages/sms-providers.tsx
@@ -523,7 +523,9 @@ const SMSProviders: FunctionComponent<SMSProviderPageInterface> = (
             pageHeaderMaxWidth={ true }
             backButton={ {
                 onClick: handleBackButtonClick,
-                text: t("smsProviders:goBack")
+                text: isPushProviderFeatureEnabled
+                    ? t("smsProviders:goBack")
+                    : t("extensions:develop.emailAndSms.goBack")
             } }
             data-componentid={ `${componentId}-form-layout` }
         >


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pr adds the support to switch between `notification channel` and `email and sms` related headings and sub headings based on whether push provider feature is enabled.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
