### PR TITLE
Decode the encoded url lang input before splitting

### DIFF
--- a/.changeset/fresh-seas-eat.md
+++ b/.changeset/fresh-seas-eat.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Decode the encoded url lang input before splitting.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -135,7 +135,7 @@
         if (localeFromCookie) {
             return localeFromCookie;
         } else if (localeFromUrlParams) {
-            const firstLangFromUrlParams = localeFromUrlParams.split(" ")[0];
+            const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
             return firstLangFromUrlParams;
         } else if (browserLocale) {
             return browserLocale;

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -136,7 +136,7 @@
             return localeFromCookie;
         } else if (localeFromUrlParams) {
             const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
-            return firstLangFromUrlParams;
+            return encodeURIComponent(firstLangFromUrlParams);
         } else if (browserLocale) {
             return browserLocale;
         } else {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -125,7 +125,7 @@
             return localeFromCookie;
         } else if (localeFromUrlParams) {
             const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
-            return firstLangFromUrlParams;
+            return encodeURIComponent(firstLangFromUrlParams);
         } else if (browserLocale) {
             return browserLocale;
         } else {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -124,7 +124,7 @@
         if (localeFromCookie) {
             return localeFromCookie;
         } else if (localeFromUrlParams) {
-            const firstLangFromUrlParams = localeFromUrlParams.split(" ")[0];
+            const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
             return firstLangFromUrlParams;
         } else if (browserLocale) {
             return browserLocale;

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -135,7 +135,7 @@
         if (localeFromCookie) {
             return localeFromCookie;
         } else if (localeFromUrlParams) {
-            const firstLangFromUrlParams = localeFromUrlParams.split(" ")[0];
+            const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
             return firstLangFromUrlParams;
         } else if (browserLocale) {
             return browserLocale;

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -136,7 +136,7 @@
             return localeFromCookie;
         } else if (localeFromUrlParams) {
             const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
-            return firstLangFromUrlParams;
+            return encodeURIComponent(firstLangFromUrlParams);
         } else if (browserLocale) {
             return browserLocale;
         } else {


### PR DESCRIPTION
### Purpose
As issue has occurred when multiple languages are set as the ui_lang query param, the first item doesn't get picked up when setting ui_lang cookie. 

The root cause was we have encoded the url query param before processing it [1].

> With this fix, we decode the encoded query param value before making the split operation.

[1] https://github.com/wso2/identity-apps/pull/4826