### PR TITLE
Fix adornment icon missing when `type` is set to `password` in `TextFieldAdapter`

### DIFF
--- a/.changeset/little-buses-smoke.md
+++ b/.changeset/little-buses-smoke.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.tenants.v1": patch
+"@wso2is/form": patch
+---
+
+Fix password adornment icon not rendering

--- a/features/admin.tenants.v1/components/add-tenant/add-tenant-form.tsx
+++ b/features/admin.tenants.v1/components/add-tenant/add-tenant-form.tsx
@@ -45,7 +45,6 @@ import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, ReactElement, useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Icon } from "semantic-ui-react";
 import getTenantDomainAvailability from "../../api/get-tenant-domain-availability";
 import TenantConstants from "../../constants/tenant-constants";
 import { AddTenantRequestPayload, Tenant, TenantOwner, TenantStatus } from "../../models/tenants";
@@ -93,7 +92,6 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
     );
 
     const [ isPasswordValid, setIsPasswordValid ] = useState<boolean>(false);
-    const [ isPasswordVisible, setIsPasswordVisible ] = useState(false);
 
     const userNameValidationConfig: ValidationFormInterface = useMemo((): ValidationFormInterface => {
         return getUsernameConfiguration(validationData);
@@ -418,20 +416,6 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
         </FormSpy>
     );
 
-    const renderInputAdornmentOfSecret = (showSecret: boolean, onClick: () => void): ReactElement => (
-        <InputAdornment position="end">
-            <Icon
-                link={ true }
-                className="list-icon reset-field-to-default-adornment"
-                size="small"
-                color="grey"
-                name={ !showSecret ? "eye" : "eye slash" }
-                data-componentid={ `${ componentId }-password-view-button` }
-                onClick={ onClick }
-            />
-        </InputAdornment>
-    );
-
     return (
         <FinalForm
             initialValues={ {} }
@@ -574,12 +558,7 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
                                         required={ true }
                                         data-componentid={ `${componentId}-password` }
                                         name="password"
-                                        type={ isPasswordVisible ? "text" : "password" }
-                                        InputProps={ {
-                                            endAdornment: renderInputAdornmentOfSecret(
-                                                isPasswordVisible,
-                                                () => setIsPasswordVisible(!isPasswordVisible))
-                                        } }
+                                        type="password"
                                         label={ t("tenants:common.form.fields.password.label") }
                                         placeholder={ t("tenants:common.form.fields.password.placeholder") }
                                         component={ TextFieldAdapter }

--- a/modules/form/src/components/adapters/text-field-adapter.tsx
+++ b/modules/form/src/components/adapters/text-field-adapter.tsx
@@ -78,10 +78,15 @@ const TextFieldAdapter: FunctionComponent<TextFieldAdapterPropsInterface> = (
                 InputLabelProps={ {
                     required
                 } }
-                InputProps={ {
-                    endAdornment,
-                    readOnly
-                } }
+                { ...(endAdornment || readOnly
+                    ? {
+                        InputProps: {
+                            ...(endAdornment && { endAdornment }),
+                            ...(readOnly && { readOnly })
+                        }
+                    }
+                    : {})
+                }
                 inputProps={ {
                     style: { textTransform: uppercase ? "uppercase" : "none" }
                 } }


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This PR addresses the issue where the adornment icon is missing when the `type` is set to `password` in the `TextFieldAdapter` component. The root cause of this issue is the `InputProps` overriding the password visibility toggle logic defined in Oxygen UI.

The solution ensures that the `InputProps` property is conditionally applied to avoid breaking any existing components.

Additionally, this PR includes the reversal of changes made in the following PR to align with this fix:
- https://github.com/wso2/identity-apps/pull/7331

### Related Issues
- https://github.com/wso2/product-is/issues/22134
- https://github.com/wso2/product-is/issues/22337


### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
