### PR TITLE
Fix privilege check to include secondary user stores

### DIFF
--- a/.changeset/flat-jars-warn.md
+++ b/.changeset/flat-jars-warn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.authentication.v1": patch
+---
+
+Fix privilege check to include secondary user stores

--- a/features/admin.authentication.v1/hooks/use-sign-in.ts
+++ b/features/admin.authentication.v1/hooks/use-sign-in.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -255,7 +255,7 @@ const useSignIn = (): UseSignInInterface => {
         } = window["AppUtils"].getConfig()?.__experimental__platformIdP;
 
         if (__experimental__platformIdP?.enabled) {
-            isPrivilegedUser = idToken?.sub?.startsWith(`${ CONSUMER_USERSTORE }/`);
+            isPrivilegedUser = /^.+\//.test(idToken?.sub);
 
             if (idToken?.default_tenant && idToken.default_tenant !== "carbon.super") {
                 const redirectUrl: URL = new URL(

--- a/features/admin.authentication.v1/hooks/use-sign-in.ts
+++ b/features/admin.authentication.v1/hooks/use-sign-in.ts
@@ -41,7 +41,6 @@ import {
 import { OrganizationType } from "@wso2is/admin.organizations.v1/constants";
 import useOrganizationSwitch from "@wso2is/admin.organizations.v1/hooks/use-organization-switch";
 import useOrganizations from "@wso2is/admin.organizations.v1/hooks/use-organizations";
-import { CONSUMER_USERSTORE } from "@wso2is/admin.userstores.v1/constants/user-store-constants";
 import {
     AppConstants as CommonAppConstants,
     CommonConstants as CommonConstantsCore


### PR DESCRIPTION
### Purpose
$subject

Currently, the isPrivilegedUser check only detected privileged users from "DEFAULT" user store. With this fix, it will check if there's any prefix in the idToken subject and assigned that user as a privileged user.

### Approach
The regular expression ^.+\/ checks if the string starts with any sequence of characters (^.+) followed by a /`.

- ^ asserts the position at the start of the string.
- .+ matches any sequence of one or more characters.
- \/ matches the literal / character (escaped with a backslash).

**IMPORTANT**: This works as the domain part of an email address doesn't allow (/) slashes according to the standard email format rules defined by RFC 5322.

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
