### PR TITLE
Show username instead of email in lock account notification message

### DIFF
--- a/.changeset/cyan-months-eat.md
+++ b/.changeset/cyan-months-eat.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.users.v1": patch
+---
+
+Change account lock notification user email to username.

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -48,7 +48,6 @@ import { getAssociationType } from "@wso2is/admin.tenants.v1/utils/tenants";
 import { PRIMARY_USERSTORE } from "@wso2is/admin.userstores.v1/constants";
 import { ProfileConstants } from "@wso2is/core/constants";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
-import { resolveUserEmails } from "@wso2is/core/helpers";
 import {
     AlertInterface,
     AlertLevels,

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -1318,19 +1318,15 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                             ? (
                                 attributeValue
                                     ? t("user:profile.notifications.lockUserAccount." +
-                                        "success.message", { name: user.emails && user.emails !== undefined ?
-                                        resolveUserEmails(user?.emails) : resolveUsernameOrDefaultEmail(user, true) })
+                                        "success.message", { name: resolveUsernameOrDefaultEmail(user, true) })
                                     : t("user:profile.notifications.unlockUserAccount." +
-                                        "success.message", { name: user.emails && user.emails !== undefined ?
-                                        resolveUserEmails(user?.emails) : resolveUsernameOrDefaultEmail(user, true) })
+                                        "success.message", { name: resolveUsernameOrDefaultEmail(user, true) })
                             ) : (
                                 attributeValue
                                     ? t("user:profile.notifications.disableUserAccount." +
-                                        "success.message", { name: user.emails && user.emails !== undefined ?
-                                        resolveUserEmails(user?.emails) : resolveUsernameOrDefaultEmail(user, false) })
+                                        "success.message", { name: resolveUsernameOrDefaultEmail(user, true) })
                                     : t("user:profile.notifications.enableUserAccount." +
-                                        "success.message", { name: user.emails && user.emails !== undefined ?
-                                        resolveUserEmails(user?.emails) : resolveUsernameOrDefaultEmail(user, false) })
+                                        "success.message", { name: resolveUsernameOrDefaultEmail(user, true) })
                             )
                 });
                 setShowLockDisableConfirmationModal(false);


### PR DESCRIPTION
$subject

https://github.com/user-attachments/assets/34b3f4f5-b49f-4776-9961-fb72fb423656


### Related Issues
- https://github.com/wso2/product-is/issues/22587
