### PR TITLE
Fix incorrect placement of mandatory indicator in username recovery page

### DIFF
--- a/.changeset/twelve-kids-wash.md
+++ b/.changeset/twelve-kids-wash.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix incorrect placement of mandatory indicator in username recovery page

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -297,7 +297,7 @@ jobs:
 
       - name: 💾 Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -200,24 +200,27 @@
                 <div class="segment-form">
                     <form class="ui large form" method="post" action="verify.do" id="recoverDetailsForm">
                         <% if (isFirstNameInClaims || isLastNameInClaims) { %>
-                        <div class="field">
-                            <label><%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "name")%></label>
-                            <div class="two fields">
-                                <% if (isFirstNameInClaims) { %>
-                                <div class="required field">
-                                    <input id="first-name" type="text" required name="http://wso2.org/claims/givenname"
-                                        placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                                            "First.name")%>*" />
-                                </div>
-                                <% } %>
-                                <% if (isLastNameInClaims) { %>
-                                <div class="field">
-                                    <input id="last-name" type="text" name="http://wso2.org/claims/lastname"
-                                        placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                                            "Last.name")%>" />
-                                </div>
-                                <% } %>
+                        <div class="two fields">
+                            <% if (isFirstNameInClaims) { %>
+                            <div class="required field">
+                                <label>
+                                    <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "First.name")%>
+                                </label>
+                                <input id="first-name" type="text" required name="http://wso2.org/claims/givenname"
+                                    placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
+                                        "First.name")%>" />
                             </div>
+                            <% } %>
+                            <% if (isLastNameInClaims) { %>
+                            <div class="field">
+                                <label>
+                                    <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Last.name")%>
+                                </label>
+                                <input id="last-name" type="text" name="http://wso2.org/claims/lastname"
+                                    placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
+                                        "Last.name")%>" />
+                            </div>
+                            <% } %>
                         </div>
                         <% } %>
 
@@ -245,7 +248,7 @@
                             <label for="contact" class="control-label"><%=i18n(recoveryResourceBundle, customText,
                                     "contact")%></label>
                             <input id="contact" type="text" name="contact" 
-                                placeholder="<%=i18n(recoveryResourceBundle, customText, "contact")%>*" 
+                                placeholder="<%=i18n(recoveryResourceBundle, customText, "contact")%>" 
                                     required class="form-control" />
                         </div>
                         <% } %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -90,6 +90,7 @@
     boolean isLastNameInClaims = false;
     boolean isEmailInClaims = false;
     boolean isMobileInClaims = false;
+    boolean isFirstNameRequired = false;
     List<Claim> claims;
     UsernameRecoveryApi usernameRecoveryApi = new UsernameRecoveryApi();
     try {
@@ -118,6 +119,7 @@
         if (StringUtils.equals(claim.getUri(),
                 IdentityManagementEndpointConstants.ClaimURIs.FIRST_NAME_CLAIM)) {
             isFirstNameInClaims = true;
+            isFirstNameRequired = claim.getRequired();
         }
         if (StringUtils.equals(claim.getUri(), IdentityManagementEndpointConstants.ClaimURIs.LAST_NAME_CLAIM)) {
             isLastNameInClaims = true;
@@ -202,23 +204,23 @@
                         <% if (isFirstNameInClaims || isLastNameInClaims) { %>
                         <div class="two fields">
                             <% if (isFirstNameInClaims) { %>
-                            <div class="required field">
+                            <div class="<%= isFirstNameRequired ? "required field" : "field" %>">
                                 <label>
-                                    <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "First.name")%>
+                                    <%=i18n(recoveryResourceBundle, customText, "First.name")%>
                                 </label>
-                                <input id="first-name" type="text" required name="http://wso2.org/claims/givenname"
-                                    placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                                        "First.name")%>" />
+                                <input id="first-name" type="text" 
+                                    <%= isFirstNameRequired ? "required" : "" %> 
+                                    name="http://wso2.org/claims/givenname"
+                                    placeholder="<%=i18n(recoveryResourceBundle, customText, "First.name")%>" />
                             </div>
                             <% } %>
                             <% if (isLastNameInClaims) { %>
                             <div class="field">
                                 <label>
-                                    <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Last.name")%>
+                                    <%=i18n(recoveryResourceBundle, customText, "Last.name")%>
                                 </label>
                                 <input id="last-name" type="text" name="http://wso2.org/claims/lastname"
-                                    placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
-                                        "Last.name")%>" />
+                                    placeholder="<%=i18n(recoveryResourceBundle, customText, "Last.name")%>" />
                             </div>
                             <% } %>
                         </div>
@@ -383,11 +385,11 @@
                 const errorMessage = $("#error-msg");
                 errorMessage.hide();
 
-                <% if (isFirstNameInClaims){ %>
+                <% if (isFirstNameInClaims && isFirstNameRequired) { %>
                     const firstName = $("#first-name").val();
 
                     if (firstName === "") {
-                        errorMessage.text("<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "fill.the.first.name")%>");
+                        errorMessage.text("<%=i18n(recoveryResourceBundle, customText, "fill.the.first.name")%>");
                         errorMessage.show();
                         $("html, body").animate({scrollTop: errorMessage.offset().top}, "slow");
                         submitButton.removeClass("loading").attr("disabled", false);


### PR DESCRIPTION
### Purpose
- $Subject
- Resolves https://github.com/wso2/product-is/issues/22364
- Resolves https://github.com/wso2/product-is/issues/21016

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers) - N/A
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation. - Had an offline discussion with @DonOmalVindula
- [ ] Documentation provided. (Add links if there are any) - N/A
- [ ] Relevant backend changes deployed and verified - N/A
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any) - N/A
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any) - N/A

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
