### PR TITLE
Set isDefault Property of the Custom Federated Authenticator when updating Endpoint Details

### DIFF
--- a/.changeset/pink-jars-shake.md
+++ b/.changeset/pink-jars-shake.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Set isDefault Property of the Custom Federated Authenticator when updating Endpoint Details #7510

--- a/features/admin.connections.v1/components/edit/connection-edit.tsx
+++ b/features/admin.connections.v1/components/edit/connection-edit.tsx
@@ -467,7 +467,6 @@ export const EditConnection: FunctionComponent<EditConnectionPropsInterface> = (
                         },
                         uri: changedFields?.endpointUri ? values.endpointUri : undefined
                     },
-                    isDefault: true,
                     isEnabled: identityProvider.isEnabled,
                     isPrimary: identityProvider.isPrimary
                 };
@@ -502,6 +501,7 @@ export const EditConnection: FunctionComponent<EditConnectionPropsInterface> = (
                         },
                         uri: values.endpointUri
                     },
+                    isDefault: true,
                     isEnabled: identityProvider.isEnabled
                 };
 

--- a/features/admin.connections.v1/components/edit/connection-edit.tsx
+++ b/features/admin.connections.v1/components/edit/connection-edit.tsx
@@ -467,6 +467,7 @@ export const EditConnection: FunctionComponent<EditConnectionPropsInterface> = (
                         },
                         uri: changedFields?.endpointUri ? values.endpointUri : undefined
                     },
+                    isDefault: true,
                     isEnabled: identityProvider.isEnabled,
                     isPrimary: identityProvider.isPrimary
                 };

--- a/features/admin.connections.v1/models/connection.ts
+++ b/features/admin.connections.v1/models/connection.ts
@@ -753,7 +753,7 @@ export interface CustomAuthGeneralDetailsFormValuesInterface {
     /**
      * Display name of the connection
      */
-    displayName?: string
+    displayName?: string;
     /**
      * Description of the connection
      */
@@ -770,6 +770,10 @@ export interface CustomAuthGeneralDetailsFormValuesInterface {
      * Set is enabled connection
      */
     isEnabled?: boolean;
+    /**
+     * Set is default authenticator
+     */
+    isDefault?: boolean;
 }
 
 export interface OutboundProvisioningConnectorMetaDataInterface {

--- a/features/admin.connections.v1/models/connection.ts
+++ b/features/admin.connections.v1/models/connection.ts
@@ -770,10 +770,6 @@ export interface CustomAuthGeneralDetailsFormValuesInterface {
      * Set is enabled connection
      */
     isEnabled?: boolean;
-    /**
-     * Set is default authenticator
-     */
-    isDefault?: boolean;
 }
 
 export interface OutboundProvisioningConnectorMetaDataInterface {
@@ -854,45 +850,9 @@ export interface CustomAuthenticationCreateWizardGeneralFormValuesInterface {
  */
 export interface EndpointAuthenticationUpdateInterface extends CustomAuthGeneralDetailsFormValuesInterface {
     /**
-     * Name of the Action.
-     */
-    name?: string;
-    /**
-     * Description of the Action.
-     */
-    description?: string;
-    /**
      * Endpoint configuration of the Action.
      */
-    endpoint?: Partial<EndpointInterface>;
-}
-
-/**
- *  Endpoint configuration.
- */
-export interface EndpointInterface {
-    /**
-     * External endpoint.
-     */
-    uri: string;
-    /**
-     * Authentication configurations of the Action.
-     */
-    authentication: AuthenticationInterface;
-}
-
-/**
- *  Endpoint authentication configuration.
- */
-interface AuthenticationInterface {
-    /**
-     * Authentication Type.
-     */
-    type: EndpointAuthenticationType;
-    /**
-     * Authentication properties.
-     */
-    properties: Partial<EndpointConfigFormPropertyInterface>;
+    endpoint?: Partial<ExternalEndpoint>;
 }
 
 /**

--- a/features/admin.connections.v1/models/connection.ts
+++ b/features/admin.connections.v1/models/connection.ts
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import { EndpointConfigFormPropertyInterface } from "@wso2is/admin.actions.v1/models/actions";
 import { IdentifiableComponentInterface, LinkInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { GenericIconProps } from "@wso2is/react-components";
 import { ComponentType, LazyExoticComponent, ReactElement } from "react";


### PR DESCRIPTION
### Purpose
This PR ensures that the isDefault property is explicitly set when updating the endpoint details of custom federated authenticators. Since a PUT operation is used for this update, failing to set isDefault would result in the authenticator not being recognized as the default for the Identity Provider (IDP), which would, in turn, remove the defaultAuthenticatorID from the IDP.

Since custom federated authenticators support only a single authenticator within the IDP object, we are setting isDefault to true by default.

### Related Issue
- https://github.com/wso2/product-is/issues/22789