### PR TITLE
Fix issue with push check status endpoint

### DIFF
--- a/.changeset/lucky-ladybugs-yawn.md
+++ b/.changeset/lucky-ladybugs-yawn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix push status check endpoint issue with tenanted users.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/pushAuth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/pushAuth.jsp
@@ -314,14 +314,12 @@
 
                 pollingInterval = setInterval(() => {
                     $.ajax({
-                        url: STATUS_URL,
+                        url: "<%= Encode.forJavaScriptBlock(identityServerEndpointContextParam)%>" + STATUS_URL,
                         type: "GET",
                         contentType: "application/json",
                         success: function (response) {
                             if (response.status === "COMPLETED") {
                                 clearInterval(pollingInterval);
-                                document.getElementById("instruction-div").style.display = "none";
-                                $("#responseReceived").transition("fade");
                                 setTimeout(() => {
                                     document.getElementById("scenario").value = "PROCEED_PUSH_AUTHENTICATION";
                                     $("#submitForm").submit();


### PR DESCRIPTION
This will fix the issue of the status check polling endpoint of push auth status for tenanted users