### PR TITLE
Add access control to the branding link in application edit page

### DIFF
--- a/.changeset/fast-shoes-exercise.md
+++ b/.changeset/fast-shoes-exercise.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.branding.v1": patch
+"@wso2is/console": patch
+---
+
+Add access control for branding link in application edit page

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -490,7 +490,8 @@
             },
             "branding": {
                 "disabledFeatures": [
-                    "branding.hostnameUrlBranding"
+                    "branding.hostnameUrlBranding",
+                    "branding.stylesAndText.application.text"
                 ],
                 "enabled": true,
                 "featureFlags": [

--- a/features/admin.applications.v1/components/edit-application.tsx
+++ b/features/admin.applications.v1/components/edit-application.tsx
@@ -172,6 +172,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
     } = useApplicationTemplateMetadata();
     // Check if the user has the required scopes to update the application.
     const hasApplicationUpdatePermissions: boolean = useRequiredScopes(featureConfig?.applications?.scopes?.update);
+    const hasBrandingViewPermissions: boolean = useRequiredScopes(featureConfig?.branding?.scopes?.read);
 
     const availableInboundProtocols: AuthProtocolMetaListItemInterface[] =
         useSelector((state: AppState) => state.application.meta.inboundProtocols);
@@ -544,7 +545,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
                 featureConfig={ featureConfig }
                 template={ template }
                 isBrandingSectionHidden={ brandingDisabledFeatures.includes(BrandingPreferencesConstants.
-                    APP_WISE_BRANDING_FEATURE_TAG) }
+                    APP_WISE_BRANDING_FEATURE_TAG) || !hasBrandingViewPermissions }
                 readOnly={ readOnly || applicationConfig.editApplication.getTabPanelReadOnlyStatus(
                     "APPLICATION_EDIT_GENERAL_SETTINGS", application) }
                 data-componentid={ `${ componentId }-general-settings` }

--- a/features/admin.branding.v1/components/branding-preference-tabs.tsx
+++ b/features/admin.branding.v1/components/branding-preference-tabs.tsx
@@ -29,7 +29,11 @@ import {
     PreviewScreenType,
     PreviewScreenVariationType
 } from "@wso2is/common.branding.v1/models";
-import { FeatureAccessConfigInterface, FeatureFlagsInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
+import {
+    FeatureAccessConfigInterface,
+    FeatureFlagsInterface,
+    IdentifiableComponentInterface
+} from "@wso2is/core/models";
 import { FormPropsInterface } from "@wso2is/form";
 import { Heading, Link, ResourceTab, ResourceTabPaneInterface } from "@wso2is/react-components";
 import cloneDeep from "lodash-es/cloneDeep";

--- a/features/admin.branding.v1/components/branding-preference-tabs.tsx
+++ b/features/admin.branding.v1/components/branding-preference-tabs.tsx
@@ -29,7 +29,7 @@ import {
     PreviewScreenType,
     PreviewScreenVariationType
 } from "@wso2is/common.branding.v1/models";
-import { FeatureFlagsInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { FeatureAccessConfigInterface, FeatureFlagsInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { FormPropsInterface } from "@wso2is/form";
 import { Heading, Link, ResourceTab, ResourceTabPaneInterface } from "@wso2is/react-components";
 import cloneDeep from "lodash-es/cloneDeep";
@@ -164,8 +164,10 @@ export const BrandingPreferenceTabs: FunctionComponent<BrandingPreferenceTabsInt
     const systemTheme: string = useSelector((state: AppState) => state.config.ui.theme?.name);
     const supportEmail: string = useSelector((state: AppState) =>
         state.config.deployment.extensions?.supportEmail as string);
+    const brandingFeatureConfig: FeatureAccessConfigInterface = useSelector(
+        (state: AppState) => state.config.ui.features?.branding);
     const brandingFeatureFlags: FeatureFlagsInterface[] = useSelector(
-        (state: AppState) => state.config.ui.features?.branding?.featureFlags);
+        () => brandingFeatureConfig?.featureFlags);
 
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(isUpdating);
     const [
@@ -458,24 +460,14 @@ export const BrandingPreferenceTabs: FunctionComponent<BrandingPreferenceTabsInt
             render: AdvancePreferenceTabPane
         });
 
-        panes.push({
-            "data-tabid": BrandingPreferencesConstants.TABS.TEXT_TAB_ID,
-            menuItem: (
-                <Menu.Item
-                    key="text"
-                    disabled={ brandingMode === BrandingModes.APPLICATION }
-                >
-                    { t("branding:tabs.text.label") }
-                    {   brandingMode === BrandingModes.APPLICATION && (
-                        <FeatureFlagLabel
-                            featureFlags={ brandingFeatureFlags }
-                            featureKey={
-                                FeatureFlagConstants.FEATURE_FLAG_KEY_MAP.APPLICATION_BRANDING_TEXT
-                            }
-                            type="chip"
-                        />
-                    ) }
-                    {   brandingMode !== BrandingModes.APPLICATION && (
+        if (brandingMode === BrandingModes.ORGANIZATION) {
+            panes.push({
+                "data-tabid": BrandingPreferencesConstants.TABS.TEXT_TAB_ID,
+                menuItem: (
+                    <Menu.Item
+                        key="text"
+                    >
+                        { t("branding:tabs.text.label") }
                         <FeatureFlagLabel
                             featureFlags={ brandingFeatureFlags }
                             featureKey={
@@ -483,11 +475,36 @@ export const BrandingPreferenceTabs: FunctionComponent<BrandingPreferenceTabsInt
                             }
                             type="chip"
                         />
-                    ) }
-                </Menu.Item>
-            ),
-            render: TextPreferenceTabPane
-        });
+                    </Menu.Item>
+                ),
+                render: TextPreferenceTabPane
+            });
+        }
+
+        if (brandingMode === BrandingModes.APPLICATION &&
+            !brandingFeatureConfig?.disabledFeatures?.includes(FeatureFlagConstants
+                .FEATURE_FLAG_KEY_MAP.APPLICATION_BRANDING_TEXT)) {
+
+            panes.push({
+                "data-tabid": BrandingPreferencesConstants.TABS.TEXT_TAB_ID,
+                menuItem: (
+                    <Menu.Item
+                        key="text"
+                        disabled={ true }
+                    >
+                        { t("branding:tabs.text.label") }
+                        <FeatureFlagLabel
+                            featureFlags={ brandingFeatureFlags }
+                            featureKey={
+                                FeatureFlagConstants.FEATURE_FLAG_KEY_MAP.APPLICATION_BRANDING_TEXT
+                            }
+                            type="chip"
+                        />
+                    </Menu.Item>
+                ),
+                render: TextPreferenceTabPane
+            });
+        }
 
         if (!isSplitView) {
             panes.push({


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

This PR introduces access control to the branding link in application edit page and removes text customization tab in application branding page.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/22631

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
