### PR TITLE
encode the ui_locales url param using the Encode.forHtmlAttribute method

### DIFF
--- a/.changeset/wise-crabs-repair.md
+++ b/.changeset/wise-crabs-repair.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Change the encode method of the ui_locales param

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -23,6 +23,7 @@
 <%@ page import="java.io.File" %>
 <%@ page import="java.io.BufferedReader" %>
 <%@ page import="java.io.FileReader" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%-- Localization --%>
 <jsp:directive.include file="localize.jsp" />
@@ -43,7 +44,7 @@
         const localeFromCookie = getCookie("ui_lang");
         var localeFromUrlParams = null;
         if (urlParams.has('ui_locales')) {
-            localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
+            localeFromUrlParams = "<%= Encode.forHtmlAttribute(request.getParameter("ui_locales")) %>";
         }
         const browserLocale = "<%= userLocale %>"
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
@@ -115,8 +116,8 @@
         if (localeFromCookie) {
             return localeFromCookie;
         } else if (localeFromUrlParams) {
-            const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
-            return encodeURIComponent(firstLangFromUrlParams);
+            const firstLangFromUrlParams = localeFromUrlParams.split(" ")[0];
+            return firstLangFromUrlParams;
         } else if (browserLocale) {
             return browserLocale;
         } else {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -23,6 +23,7 @@
 <%@ page import="java.io.File" %>
 <%@ page import="java.io.BufferedReader" %>
 <%@ page import="java.io.FileReader" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%-- Localization --%>
 <jsp:directive.include file="localize.jsp" />
@@ -43,7 +44,7 @@
         const localeFromCookie = getCookie("ui_lang");
         var localeFromUrlParams = null;
         if (urlParams.has('ui_locales')) {
-            localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
+            localeFromUrlParams = "<%= Encode.forHtmlAttribute(request.getParameter("ui_locales")) %>";
         }
         const browserLocale = "<%= userLocale %>"
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
@@ -102,8 +103,8 @@
         if (localeFromCookie) {
             return localeFromCookie;
         } else if (localeFromUrlParams) {
-            const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
-            return encodeURIComponent(firstLangFromUrlParams);
+            const firstLangFromUrlParams = localeFromUrlParams.split(" ")[0];
+            return firstLangFromUrlParams;
         } else if (browserLocale) {
             return browserLocale;
         } else {

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -23,6 +23,7 @@
 <%@ page import="java.io.File" %>
 <%@ page import="java.io.BufferedReader" %>
 <%@ page import="java.io.FileReader" %>
+<%@ page import="org.owasp.encoder.Encode" %>
 
 <%-- Localization --%>
 <jsp:directive.include file="localize.jsp" />
@@ -43,7 +44,7 @@
         const localeFromCookie = getCookie("ui_lang");
         var localeFromUrlParams = null;
         if (urlParams.has('ui_locales')) {
-            localeFromUrlParams = encodeURIComponent(urlParams.get('ui_locales'));
+            localeFromUrlParams ="<%= Encode.forHtmlAttribute(request.getParameter("ui_locales")) %>";
         }
         const browserLocale = "<%= userLocale %>"
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);
@@ -115,8 +116,8 @@
         if (localeFromCookie) {
             return localeFromCookie;
         } else if (localeFromUrlParams) {
-            const firstLangFromUrlParams = decodeURIComponent(localeFromUrlParams).split(" ")[0];
-            return encodeURIComponent(firstLangFromUrlParams);
+            const firstLangFromUrlParams = localeFromUrlParams.split(" ")[0];
+            return firstLangFromUrlParams;
         } else if (browserLocale) {
             return browserLocale;
         } else {


### PR DESCRIPTION
### Purpose
- Use OWASP Encode.forHtmlAttribute to encode the ui_locales param instead of using encodeURIComponent.
- Remove the decode part from the compute locale method, becuase it is not needed with Encode.forHtmlAttribute 

### Related issue
https://github.com/wso2/product-is/issues/22932