### PR TITLE
Fix org list display inconsistencies after creating a new sub org or deleting an existing sub org

### DIFF
--- a/.changeset/forty-kings-dance.md
+++ b/.changeset/forty-kings-dance.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.organizations.v1": patch
+---
+
+Fix org list display inconsistencies after creating a new sub org or deleting an existing sub org

--- a/features/admin.organizations.v1/pages/organizations.tsx
+++ b/features/admin.organizations.v1/pages/organizations.tsx
@@ -386,6 +386,8 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
      */
     const handleOrganizationDelete = (): void => {
         getOrganizationLists(listItemLimit, filterQuery, "", "");
+        setAuthorizedListPrevCursor("");
+        setAuthorizedListNextCursor("");
     };
 
     /**

--- a/features/admin.organizations.v1/pages/organizations.tsx
+++ b/features/admin.organizations.v1/pages/organizations.tsx
@@ -385,14 +385,14 @@ const OrganizationsPage: FunctionComponent<OrganizationsPageInterface> = (
      * Handles organization delete action.
      */
     const handleOrganizationDelete = (): void => {
-        getOrganizationLists(listItemLimit, filterQuery, after, before);
+        getOrganizationLists(listItemLimit, filterQuery, "", "");
     };
 
     /**
      * Handles organization list update action.
      */
     const handleOrganizationListUpdate = (): void => {
-        getOrganizationLists(listItemLimit, filterQuery, after, before);
+        getOrganizationLists(listItemLimit, filterQuery, "", "");
         updateAuthorizedList();
     };
 


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

With this fix, when an organization is deleted or a new one is created, the most recently added organizations will be displayed.

https://github.com/user-attachments/assets/c968523d-19e9-40db-9bca-672c4d16a62f

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- fixes https://github.com/wso2/product-is/issues/20990

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
