### PR TITLE
Enable Group Tab for Custom Federated Authenticators

### DIFF
--- a/.changeset/kind-pans-joke.md
+++ b/.changeset/kind-pans-joke.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Enable Group Tab for Custom Federated Authenticators

--- a/features/admin.connections.v1/components/edit/connection-edit.tsx
+++ b/features/admin.connections.v1/components/edit/connection-edit.tsx
@@ -475,7 +475,7 @@ export const EditConnection: FunctionComponent<EditConnectionPropsInterface> = (
             shouldShowTab(type, ConnectionTabTypes.IDENTITY_PROVIDER_GROUPS) &&
             featureConfig?.identityProviderGroups?.enabled &&
             !isOrganizationEnterpriseAuthenticator &&
-            !isCustomAuthenticator
+            !isCustomLocalAuthenticator
         ) {
             panes.push({
                 "data-tabid": ConnectionUIConstants.TabIds.IDENTITY_PROVIDER_GROUPS,

--- a/features/admin.connections.v1/components/edit/settings/identity-provider-groups/identity-provider-groups.tsx
+++ b/features/admin.connections.v1/components/edit/settings/identity-provider-groups/identity-provider-groups.tsx
@@ -17,9 +17,9 @@
  */
 
 import { ClaimManagementConstants } from "@wso2is/admin.claims.v1/constants";
-import { AppState } from "@wso2is/admin.core.v1/store";
-import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import useUIConfig from "@wso2is/admin.core.v1/hooks/use-ui-configs";
+import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
+import { AppState } from "@wso2is/admin.core.v1/store";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
@@ -231,7 +231,7 @@ export const IdentityProviderGroupsTab: FunctionComponent<IdentityProviderGroups
         );
 
         // Hide the info message if the connection is a custom federated authenticator.
-        if(ConnectionsManagementUtils.IsCustomAuthenticator(editingIDP)) {
+        if(ConnectionsManagementUtils.IsCustomAuthenticator(editingIDP.federatedAuthenticators?.authenticators[0])) {
             return;
         }
 

--- a/features/admin.connections.v1/components/edit/settings/identity-provider-groups/identity-provider-groups.tsx
+++ b/features/admin.connections.v1/components/edit/settings/identity-provider-groups/identity-provider-groups.tsx
@@ -43,6 +43,7 @@ import {
     ConnectionClaimMappingInterface,
     ConnectionInterface
 } from "../../../../models/connection";
+import { ConnectionsManagementUtils } from "../../../../utils/connection-utils";
 
 const FORM_ID: string = "idp-group-attributes-form";
 
@@ -228,6 +229,11 @@ export const IdentityProviderGroupsTab: FunctionComponent<IdentityProviderGroups
                 info
             />
         );
+
+        // Hide the info message if the connection is a custom federated authenticator.
+        if(ConnectionsManagementUtils.IsCustomAuthenticator(editingIDP)) {
+            return;
+        }
 
         /**
          * If the claim mappings are empty,


### PR DESCRIPTION
### Purpose
This PR enables the `Group` tab for custom federated authenticators.
<img width="800" alt="image" src="https://github.com/user-attachments/assets/2a3823cd-7a38-4e15-af0b-966d5059b256" />


### Related Issues
- https://github.com/wso2/product-is/issues/22900

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
