### PR TITLE
Fix policy edit view expanding not persisting changes done already in Policy Administration feature

### DIFF
--- a/.changeset/famous-kiwis-fry.md
+++ b/.changeset/famous-kiwis-fry.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.policy-administration.v1": patch
+---
+
+Fix policy edit view expanding not persisting changes done already

--- a/features/admin.policy-administration.v1/pages/edit-policy.tsx
+++ b/features/admin.policy-administration.v1/pages/edit-policy.tsx
@@ -20,8 +20,8 @@ import Alert from "@oxygen-ui/react/Alert";
 import Box from "@oxygen-ui/react/Box";
 import Button from "@oxygen-ui/react/Button";
 import CircularProgress from "@oxygen-ui/react/CircularProgress";
-import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
+import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { PageLayout } from "@wso2is/react-components";
@@ -36,6 +36,7 @@ import { updatePolicy } from "../api/entitlement-policies";
 import { useGetPolicy } from "../api/use-get-policy";
 import PolicyEditor from "../components/policy-editor/policy-editor";
 import { PolicyInterface } from "../models/policies";
+import { unformatXML } from "../utils/utils";
 
 
 
@@ -82,7 +83,7 @@ const EditPolicyPage: FunctionComponent<EditPolicyPageProps> = ({
         const updatedPolicy: Partial<PolicyInterface> = {
             active: policy.active,
             attributeDTOs: [],
-            policy: updatedPolicyScript,
+            policy: unformatXML(updatedPolicyScript),
             policyEditorData: policy.policyEditorData,
             policyId: policy.policyId,
             policyIdReferences: policy.policyIdReferences,
@@ -141,7 +142,7 @@ const EditPolicyPage: FunctionComponent<EditPolicyPageProps> = ({
             { !isLoading && !error && policy && (
                 <Box className="script-editor">
                     <PolicyEditor
-                        policyScript ={ policy.policy }
+                        policyScript ={ updatedPolicyScript || policy.policy }
                         data-componentid={ `${componentId}-policy-editor` }
                         onScriptChange={ (updatedScript: string) => setUpdatedPolicyScript(updatedScript) }
                     />


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This fixes policy edit view expanding not persisting changes done already.


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/22315

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
