### PR TITLE
Display User Given Icon in the Login Editor for Custom Local Authenticators

### DIFF
--- a/.changeset/cyan-frogs-fail.md
+++ b/.changeset/cyan-frogs-fail.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.identity-providers.v1": patch
+---
+
+Display User Given Icon in the Login Editor for Custom Local Authenticators

--- a/features/admin.identity-providers.v1/meta/authenticator-meta.ts
+++ b/features/admin.identity-providers.v1/meta/authenticator-meta.ts
@@ -24,7 +24,7 @@ import { AuthenticatorLabels } from "@wso2is/admin.connections.v1/models/authent
 import get from "lodash-es/get";
 import { ReactNode } from "react";
 import { getAuthenticatorIcons } from "../configs/ui";
-import { AuthenticatorCategories } from "../models";
+import { AuthenticatorCategories, LocalAuthenticatorInterface } from "../models";
 
 export class AuthenticatorMeta {
 
@@ -165,10 +165,16 @@ export class AuthenticatorMeta {
      * Currently authenticator id is being used to fetch the respective authenticator icon.
      * Existing function could not be used since the id and the name of
      * custom authenticators are not pre defined.
+     * For custom local authenticators, it returns the authenticator's own image URI if available,
+     * or falls back to a default custom authenticator icon.
      *
      * @returns Custom Authenticator Icon.
      */
-    public static getCustomAuthenticatorIcon(): string {
+    public static getCustomAuthenticatorIcon(authenticator: LocalAuthenticatorInterface): string {
+        if (authenticator?.image) {
+            return authenticator.image;
+        }
+
         return getAuthenticatorIcons()?.customAuthenticator;
     }
 

--- a/features/admin.identity-providers.v1/models/identity-provider.ts
+++ b/features/admin.identity-providers.v1/models/identity-provider.ts
@@ -440,10 +440,15 @@ export interface LocalAuthenticatorInterface extends CommonPluggableComponentInt
      */
     displayName?: string;
     /**
-     * Description for the local authenticator.
+     * Description of the local authenticator.
      * This property is used only with custom local authenticators.
      */
     description?: string;
+    /**
+     * Image URI of the local authenticator.
+     * This property is used only with custom local authenticators.
+     */
+    image?: string;
     /**
      * Is authenticator enabled.
      */
@@ -452,7 +457,7 @@ export interface LocalAuthenticatorInterface extends CommonPluggableComponentInt
      * Authenticator Type.
      * @example [ LOCAL, REQUEST_PATH ]
      */
-    type?:  string;
+    type?: string;
     /**
      * Details endpoint.
      */

--- a/features/admin.identity-providers.v1/utils/identity-provider-management-utils.ts
+++ b/features/admin.identity-providers.v1/utils/identity-provider-management-utils.ts
@@ -136,6 +136,29 @@ export class IdentityProviderManagementUtils {
             return authenticator?.tags?.includes("Custom");
         };
 
+        /**
+         * Resolves the image of the local authenticator.
+         *
+         * For system defined user authenticators, the function retrieves the default icon.
+         * For custom local authenticators, it returns the authenticator's own image URI if available,
+         * or falls back to a default custom authenticator icon.
+         *
+         * @param authenticator - Authenticator.
+         * @returns image URI of the authenticator.
+         */
+        const resolveLocalAuthenticatorImage = (authenticator: LocalAuthenticatorInterface): string => {
+            if (!isCustomLocalAuthenticator(authenticator)) {
+                AuthenticatorMeta.getAuthenticatorIcon(authenticator.id);
+            }
+
+            // Resolve image URI of custom local authenticators.
+            if (authenticator?.image) {
+                return authenticator.image;
+            } else {
+                AuthenticatorMeta.getCustomAuthenticatorIcon();
+            }
+        };
+
         return axios.all(getPromises())
             .then(axios.spread((local: LocalAuthenticatorInterface[],
                 federated: IdentityProviderListResponseInterface) => {
@@ -169,9 +192,7 @@ export class IdentityProviderManagementUtils {
                         displayName: authenticator.displayName,
                         id: authenticator.id,
                         idp: LocalAuthenticatorConstants.LOCAL_IDP_IDENTIFIER,
-                        image: isCustomLocalAuthenticator(authenticator) ?
-                            AuthenticatorMeta.getCustomAuthenticatorIcon() :
-                            AuthenticatorMeta.getAuthenticatorIcon(authenticator.id),
+                        image: resolveLocalAuthenticatorImage(authenticator),
                         isEnabled: authenticator.isEnabled,
                         name: authenticator.name
                     });

--- a/features/admin.identity-providers.v1/utils/identity-provider-management-utils.ts
+++ b/features/admin.identity-providers.v1/utils/identity-provider-management-utils.ts
@@ -143,12 +143,11 @@ export class IdentityProviderManagementUtils {
          * @returns image URI of the authenticator.
          */
         const resolveLocalAuthenticatorImage = (authenticator: LocalAuthenticatorInterface): string => {
-            if (!isCustomLocalAuthenticator(authenticator)) {
-                return AuthenticatorMeta.getAuthenticatorIcon(authenticator.id);
+            if (isCustomLocalAuthenticator(authenticator)) {
+                return AuthenticatorMeta.getCustomAuthenticatorIcon(authenticator);
             }
 
-            // Resolve image URI of custom local authenticators.
-            return AuthenticatorMeta.getCustomAuthenticatorIcon(authenticator);
+            return AuthenticatorMeta.getAuthenticatorIcon(authenticator.id);
         };
 
         return axios.all(getPromises())

--- a/features/admin.identity-providers.v1/utils/identity-provider-management-utils.ts
+++ b/features/admin.identity-providers.v1/utils/identity-provider-management-utils.ts
@@ -137,26 +137,18 @@ export class IdentityProviderManagementUtils {
         };
 
         /**
-         * Resolves the image of the local authenticator.
-         *
-         * For system defined user authenticators, the function retrieves the default icon.
-         * For custom local authenticators, it returns the authenticator's own image URI if available,
-         * or falls back to a default custom authenticator icon.
+         * Resolves the image of both system defined local authenticators and custom local authenticators.
          *
          * @param authenticator - Authenticator.
          * @returns image URI of the authenticator.
          */
         const resolveLocalAuthenticatorImage = (authenticator: LocalAuthenticatorInterface): string => {
             if (!isCustomLocalAuthenticator(authenticator)) {
-                AuthenticatorMeta.getAuthenticatorIcon(authenticator.id);
+                return AuthenticatorMeta.getAuthenticatorIcon(authenticator.id);
             }
 
             // Resolve image URI of custom local authenticators.
-            if (authenticator?.image) {
-                return authenticator.image;
-            } else {
-                AuthenticatorMeta.getCustomAuthenticatorIcon();
-            }
+            return AuthenticatorMeta.getCustomAuthenticatorIcon(authenticator);
         };
 
         return axios.all(getPromises())


### PR DESCRIPTION
### Purpose
This PR enables the login flow editor on the application's edit page to display user-defined icons for custom local authenticators.

Connector:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/86c54ac3-925b-4ee5-99b3-a84d8074782b" />

---

Login flow editor:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f404c529-91c8-4c03-bf16-4a18cda962d6" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/0f46939d-5e41-429d-a08d-ee5b56a7b570" />




### Related Issues
- https://github.com/wso2/product-is/issues/22756

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
