### PR TITLE
Add content type as application/json for json files

### DIFF
--- a/.changeset/big-insects-clap.md
+++ b/.changeset/big-insects-clap.md
@@ -1,4 +1,5 @@
 ---
+"@wso2is/myaccount": patch
 "@wso2is/console": patch
 ---
 

--- a/.changeset/khaki-melons-whisper.md
+++ b/.changeset/khaki-melons-whisper.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add content type as application/json for json files

--- a/apps/console/src/public/WEB-INF/web.xml
+++ b/apps/console/src/public/WEB-INF/web.xml
@@ -19,6 +19,11 @@
 
     <display-name>console</display-name>
 
+    <mime-mapping>
+        <extension>json</extension>
+        <mime-type>application/json</mime-type>
+    </mime-mapping>
+
     <error-page>
         <error-code>404</error-code>
         <location>/index.jsp</location>

--- a/apps/myaccount/src/public/WEB-INF/web.xml
+++ b/apps/myaccount/src/public/WEB-INF/web.xml
@@ -19,6 +19,11 @@
 
     <display-name>myaccount</display-name>
 
+    <mime-mapping>
+        <extension>json</extension>
+        <mime-type>application/json</mime-type>
+    </mime-mapping>
+
     <error-page>
         <error-code>404</error-code>
         <location>/index.jsp</location>


### PR DESCRIPTION
### Purpose
- Add content type as json for json files
- Use the mime type to set application/json to set th content type

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
