### PR TITLE
Enable Filtering with Custom Tag on the Connections Page

### DIFF
--- a/.changeset/gorgeous-files-cover.md
+++ b/.changeset/gorgeous-files-cover.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Enable Filtering with Custom Tag on the Connections Page

--- a/features/admin.connections.v1/meta/authenticator-meta.ts
+++ b/features/admin.connections.v1/meta/authenticator-meta.ts
@@ -312,7 +312,8 @@ export class AuthenticatorMeta {
             AuthenticatorLabels.SOCIAL,
             AuthenticatorLabels.SAML,
             AuthenticatorLabels.PASSKEY,
-            AuthenticatorLabels.API_AUTHENTICATION
+            AuthenticatorLabels.API_AUTHENTICATION,
+            AuthenticatorLabels.CUSTOM
         ];
     }
 


### PR DESCRIPTION
### Purpose
This PR enables filtering authenticators with the "custom" tag on the connections page.

NOTE: The final filtering functionality depends on a backend change that is currently in progress.

<img width="800" alt="image" src="https://github.com/user-attachments/assets/ca7cdef0-6f18-4637-a653-60c74b1df6dc" />


### Related Issue
- https://github.com/wso2/product-is/issues/22713

