### PR TITLE
Update image and description when custom local authenticator settings are being updated

### DIFF
--- a/.changeset/great-bobcats-love.md
+++ b/.changeset/great-bobcats-love.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Update image and description when custom local authenticator settings are being updated

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -183,6 +183,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
         authProperties: Partial<AuthenticationPropertiesInterface>
     ) => {
         const updatingValues: EndpointAuthenticationUpdateInterface = {
+            description: connector.description,
             displayName: resolveDisplayName(),
             endpoint: {
                 authentication: {
@@ -191,6 +192,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
                 },
                 uri: values?.endpointUri
             },
+            image: connector.image,
             isEnabled: connector.isEnabled,
             isPrimary: connector.isPrimary
         };


### PR DESCRIPTION
### Purpose
This PR sends the image and description of the custom local authenticator when the settings are updated. 
This is required since a PUT request is triggered when settings are updated in custom local authenticators.

https://github.com/user-attachments/assets/31d05c69-7958-4a97-8336-e78f13ab4dd3

### Related Issue
- https://github.com/wso2/product-is/issues/23061