### PR TITLE
Fix issue of Image and Description fields of custom local authenticator getting cleared when the authenticator is enabled/disabled

### DIFF
--- a/.changeset/heavy-windows-swim.md
+++ b/.changeset/heavy-windows-swim.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Fix issue of Image and Description fields of custom local authenticator getting cleared when the authenticator is enabled/disabled

--- a/features/admin.connections.v1/components/edit/settings/general-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/general-settings.tsx
@@ -380,6 +380,7 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
         setIsSubmitting(true);
 
         updateCustomAuthenticator(editingIDP.id, {
+            description: (editingIDP as CustomAuthConnectionInterface)?.description,
             displayName: (editingIDP as CustomAuthConnectionInterface)?.displayName,
             endpoint: {
                 authentication: {
@@ -387,6 +388,7 @@ export const GeneralSettings: FunctionComponent<GeneralSettingsInterface> = (
                 },
                 uri: (editingIDP as CustomAuthConnectionInterface).endpoint?.uri
             },
+            image: (editingIDP as CustomAuthConnectionInterface)?.image,
             ...(updatedDetails as CustomAuthConnectionInterface)
         })
             .then(() => {

--- a/features/admin.connections.v1/pages/authenticator-edit.tsx
+++ b/features/admin.connections.v1/pages/authenticator-edit.tsx
@@ -179,7 +179,7 @@ export const AuthenticatorEditPage: FunctionComponent<AuthenticatorEditPageProps
                                 description: error.response.data.description
                             }),
                             level: AlertLevels.ERROR,
-                            message: t("authenticationProvider:" + "notifications.getIDP.error.message")
+                            message: t("authenticationProvider:notifications.getIDP.error.message")
                         })
                     );
 
@@ -188,9 +188,9 @@ export const AuthenticatorEditPage: FunctionComponent<AuthenticatorEditPageProps
 
                 dispatch(
                     addAlert({
-                        description: t("authenticationProvider:" + "notifications.getIDP.genericError.description"),
+                        description: t("authenticationProvider:notifications.getIDP.genericError.description"),
                         level: AlertLevels.ERROR,
-                        message: t("authenticationProvider:" + "notifications.getIDP.genericError.message")
+                        message: t("authenticationProvider:notifications.getIDP.genericError.message")
                     })
                 );
             })
@@ -254,15 +254,15 @@ export const AuthenticatorEditPage: FunctionComponent<AuthenticatorEditPageProps
             return (
                 <LabelWithPopup
                     popupHeader={ t("authenticationProvider:popups.appStatus.enabled.header") }
-                    popupSubHeader={ t("authenticationProvider:popups.appStatus." + "enabled.content") }
+                    popupSubHeader={ t("authenticationProvider:popups.appStatus.enabled.content") }
                     labelColor="green"
                 />
             );
         } else {
             return (
                 <LabelWithPopup
-                    popupHeader={ t("authenticationProvider:popups.appStatus." + "disabled.header") }
-                    popupSubHeader={ t("authenticationProvider:popups.appStatus." + "disabled.content") }
+                    popupHeader={ t("authenticationProvider:popups.appStatus.disabled.header") }
+                    popupSubHeader={ t("authenticationProvider:popups.appStatus.disabled.content") }
                     labelColor="grey"
                 />
             );


### PR DESCRIPTION
### Purpose
$Subject

https://github.com/user-attachments/assets/0d7bebdb-d1bc-4bbd-80ca-bdb81620007a

### Related Issue
- https://github.com/wso2/product-is/issues/23070