### PR TITLE
Hide my account switch for sub-organization users when my account is not shared.

### DIFF
--- a/.changeset/wise-pants-add.md
+++ b/.changeset/wise-pants-add.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.core.v1": patch
+---
+
+Hide my account switch for sub-organization users when my account is not shared.

--- a/features/admin.core.v1/components/header.tsx
+++ b/features/admin.core.v1/components/header.tsx
@@ -128,8 +128,8 @@ const Header: FunctionComponent<HeaderPropsInterface> = ({
 
     const {
         data: myAccountApplicationData,
-        isLoading: isMyAccountApplicationDataFetchRequestLoading
-    } = useMyAccountApplicationData();
+        isLoading: isMyAccountAppDataLoading
+    } = useMyAccountApplicationData(null, showAppSwitchButton);
 
     useEffect(() => {
         if (saasFeatureStatus === FeatureStatus.DISABLED) {
@@ -321,8 +321,11 @@ const Header: FunctionComponent<HeaderPropsInterface> = ({
             return false;
         }
 
-        return (!userOrganizationID || userOrganizationID === window["AppUtils"].getConfig().organizationName) &&
-            (!isMyAccountApplicationDataFetchRequestLoading && myAccountApplicationData?.applications?.length !== 0);
+        if (isMyAccountAppDataLoading || myAccountApplicationData?.applications?.length === 0) {
+            return false;
+        }
+
+        return !userOrganizationID || userOrganizationID === window["AppUtils"].getConfig().organizationName;
     };
 
     /**

--- a/features/admin.core.v1/components/header.tsx
+++ b/features/admin.core.v1/components/header.tsx
@@ -30,6 +30,7 @@ import MenuItem from "@oxygen-ui/react/MenuItem";
 import Typography from "@oxygen-ui/react/Typography";
 import { DiamondIcon, DiscordIcon, StackOverflowIcon, TalkingHeadsetIcon } from "@oxygen-ui/react-icons";
 import { FeatureStatus, Show, useCheckFeatureStatus, useRequiredScopes } from "@wso2is/access-control";
+import { useMyAccountApplicationData } from "@wso2is/admin.applications.v1/api/application";
 import { organizationConfigs } from "@wso2is/admin.extensions.v1";
 import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
 import { FeatureStatusLabel } from "@wso2is/admin.feature-gate.v1/models/feature-status";
@@ -124,6 +125,11 @@ const Header: FunctionComponent<HeaderPropsInterface> = ({
     const [ upgradeButtonURL, setUpgradeButtonURL ] = useState<string>(undefined);
     const { isOrganizationManagementEnabled } = useGlobalVariables();
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
+
+    const {
+        data: myAccountApplicationData,
+        isLoading: isMyAccountApplicationDataFetchRequestLoading
+    } = useMyAccountApplicationData();
 
     useEffect(() => {
         if (saasFeatureStatus === FeatureStatus.DISABLED) {
@@ -303,12 +309,20 @@ const Header: FunctionComponent<HeaderPropsInterface> = ({
         )
     ];
 
+    /**
+     * Check if the my account switch button should be shown.
+     * Will be shown if the user is logged into their resident org and
+     * my account application is available in that organization.
+     *
+     * @returns If the app switch button should be shown.
+     */
     const isShowAppSwitchButton = (): boolean => {
         if (!showAppSwitchButton) {
             return false;
         }
 
-        return !userOrganizationID || userOrganizationID === window["AppUtils"].getConfig().organizationName;
+        return (!userOrganizationID || userOrganizationID === window["AppUtils"].getConfig().organizationName) &&
+            (!isMyAccountApplicationDataFetchRequestLoading && myAccountApplicationData?.applications?.length !== 0);
     };
 
     /**


### PR DESCRIPTION
### Purpose

My Account switch button in the console header will be shown only if the user is logged into their resident organization and my account is shared with that organization

Fixes
- https://github.com/wso2/product-is/issues/22989