### PR TITLE
Fix attribute sorting in user profiles

### DIFF
--- a/.changeset/empty-moons-juggle.md
+++ b/.changeset/empty-moons-juggle.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/myaccount": patch
+---
+
+Fix attribute sorting in user profiles

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -370,12 +370,14 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
     useEffect(() => {
 
         const getDisplayOrder = (schema: ProfileSchema): number => {
+            if (schema.name === ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("USERNAME")) return 0;
             if (schema.name === EMAIL_ADDRESSES_ATTRIBUTE
                 && (!schema.displayOrder || schema.displayOrder == "0")) return 6;
             if (schema.name === MOBILE_NUMBERS_ATTRIBUTE
                 && (!schema.displayOrder || schema.displayOrder == "0")) return 7;
+            if (!schema.displayOrder || schema.displayOrder == "0") return Number.MAX_SAFE_INTEGER;
 
-            return schema.displayOrder ? parseInt(schema.displayOrder, 10) : -1;
+            return schema.displayOrder ? parseInt(schema.displayOrder, 10) : Number.MAX_SAFE_INTEGER;;
         };
 
         const sortedSchemas: ProfileSchemaInterface[] = ProfileUtils.flattenSchemas(
@@ -383,16 +385,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
         ).filter((item: ProfileSchemaInterface) =>
             item.name !== ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("META_VERSION")
         ).sort((a: ProfileSchema, b: ProfileSchema) => {
-            const orderA: number = getDisplayOrder(a);
-            const orderB: number = getDisplayOrder(b);
-
-            if (orderA === -1) {
-                return -1;
-            } else if (orderB === -1) {
-                return 1;
-            } else {
-                return orderA - orderB;
-            }
+            return getDisplayOrder(a) - getDisplayOrder(b);
         });
 
         setProfileSchema(sortedSchemas);

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -304,28 +304,21 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
     useEffect(() => {
 
         const getDisplayOrder = (schema: ProfileSchemaInterface): number => {
+            if (schema.name === ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("USERNAME")) return 0;
             if (schema.name === EMAIL_ADDRESSES_ATTRIBUTE
                 && (!schema.displayOrder || schema.displayOrder == "0")) return 6;
             if (schema.name === MOBILE_NUMBERS_ATTRIBUTE
                 && (!schema.displayOrder || schema.displayOrder == "0")) return 7;
+            if (!schema.displayOrder || schema.displayOrder == "0") return Number.MAX_SAFE_INTEGER;
 
-            return schema.displayOrder ? parseInt(schema.displayOrder, 10) : -1;
+            return schema.displayOrder ? parseInt(schema.displayOrder, 10) : Number.MAX_SAFE_INTEGER;
         };
 
         const sortedSchemas: ProfileSchemaInterface[] = ProfileUtils.flattenSchemas([ ...profileSchemas ])
             .filter((item: ProfileSchemaInterface) =>
                 item.name !== ProfileConstants?.SCIM2_SCHEMA_DICTIONARY.get("META_VERSION"))
             .sort((a: ProfileSchemaInterface, b: ProfileSchemaInterface) => {
-                const orderA: number = getDisplayOrder(a);
-                const orderB: number = getDisplayOrder(b);
-
-                if (orderA === -1) {
-                    return -1;
-                } else if (orderB === -1) {
-                    return 1;
-                } else {
-                    return orderA - orderB;
-                }
+                return getDisplayOrder(a) - getDisplayOrder(b);
             });
 
         setProfileSchema(sortedSchemas);


### PR DESCRIPTION
This PR fixes an issue where attributes without a defined displayOrder were appearing at the beginning of the user profile. With this update, any attribute missing a displayOrder will now be shown at the end of the profile.

Eg: sharedType doesn't have a displayOrder.

<img width="742" alt="image" src="https://github.com/user-attachments/assets/92fab90e-d24b-4d49-b639-b623ca57d0af" />


With this change if schema doesn't have order Id it will be shown at the end of the user profile
![image](https://github.com/user-attachments/assets/8f789a46-4987-4851-b605-4dcc598090f0)

