### PR TITLE
Fix read only field display logic in user profile in console and my account

### DIFF
--- a/.changeset/cold-taxis-brake.md
+++ b/.changeset/cold-taxis-brake.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/myaccount": patch
+---
+
+Fix read only field displaying logic in user profiles

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -2634,6 +2634,22 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                 : schema.name === MOBILE_ATTRIBUTE
         );
 
+    /**
+     * Check whether the value is empty or not.
+     * @param schema - Profile schema
+     * @returns boolean - Whether value is empty or not.
+     */
+    const isValueEmpty = (schema: ProfileSchema): boolean => {
+
+        if (schema.name === EMAIL_ADDRESSES_ATTRIBUTE) {
+            return isEmpty(profileInfo.get(schema.name)) && isEmpty(profileInfo.get(EMAIL_ATTRIBUTE));
+        } else if (schema.name === MOBILE_NUMBERS_ATTRIBUTE) {
+            return isEmpty(profileInfo.get(schema.name)) && isEmpty(profileInfo.get(MOBILE_ATTRIBUTE));
+        }
+
+        return isEmpty(profileInfo.get(schema.name));
+    };
+
     return (
         <>
             <SettingsSection
@@ -2715,11 +2731,13 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                                                             : null
                                                     }
                                                     {
-                                                        !isEmpty(profileInfo.get(schema.name)) ||
-                                        (!CommonUtils.isProfileReadOnly(isReadOnlyUser)
-                                            && (resolvedMutabilityValue !== ProfileConstants.READONLY_SCHEMA)
-                                            && hasRequiredScopes(featureConfig?.personalInfo,
-                                                featureConfig?.personalInfo?.scopes?.update, allowedScopes))
+                                                        !isValueEmpty(schema)
+                                                            || (!CommonUtils.isProfileReadOnly(isReadOnlyUser)
+                                                            && (resolvedMutabilityValue
+                                                                !== ProfileConstants.READONLY_SCHEMA)
+                                                                && hasRequiredScopes(featureConfig?.personalInfo,
+                                                                    featureConfig?.personalInfo?.scopes?.update,
+                                                                    allowedScopes))
                                                             ? generateSchemaForm(schema, index)
                                                             : null
                                                     }

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -2276,6 +2276,11 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             }
         }
 
+        if (schema.name === EMAIL_ADDRESSES_ATTRIBUTE || schema.name === MOBILE_NUMBERS_ATTRIBUTE) {
+            return !isEmpty(multiValuedAttributeValues[schema.name])
+                || (!isReadOnly && resolvedMutabilityValue !== ProfileConstants.READONLY_SCHEMA);
+        }
+
         return (!isEmpty(profileInfo.get(schema.name)) ||
             (!isReadOnly && (resolvedMutabilityValue !== ProfileConstants.READONLY_SCHEMA)));
     };

--- a/features/admin.users.v1/components/wizard/bulk-import-user-wizard.tsx
+++ b/features/admin.users.v1/components/wizard/bulk-import-user-wizard.tsx
@@ -271,7 +271,7 @@ export const BulkImportUserWizard: FunctionComponent<BulkImportUserInterface> = 
             .then((response: UserStoreDetails[]) => {
                 response?.forEach(async (item: UserStoreDetails, index: number) => {
                     // Filter read/write enabled and bulk import supported user stores.
-                    if (await isBulkImportSupportedUserStore(item)) {
+                    if (isBulkImportSupportedUserStore(item)) {
                         userStoreArray.push({
                             key: index,
                             text: item.name.toUpperCase(),
@@ -317,15 +317,17 @@ export const BulkImportUserWizard: FunctionComponent<BulkImportUserInterface> = 
      * @returns If the given userstore is read only or not and bulk import is supported.
      */
     const isBulkImportSupportedUserStore = (userStore: UserStoreDetails): boolean => {
-        let isReadWriteUserStore: boolean = false;
-        let isBulkImportSupported: boolean = false;
+        let isReadWriteUserStore: boolean = true;
+        let isBulkImportSupported: boolean = true;
 
         userStore?.properties?.forEach((property: UserStoreProperty) => {
-            if (property.name === UserStoreManagementConstants.USER_STORE_PROPERTY_READ_ONLY) {
-                isReadWriteUserStore = property.value === "false";
+            if (property.name === UserStoreManagementConstants.USER_STORE_PROPERTY_READ_ONLY
+                && property.value === "true") {
+                isReadWriteUserStore = false;
             }
-            if (property.name === UserStoreManagementConstants.USER_STORE_PROPERTY_BULK_IMPORT_SUPPORTED) {
-                isBulkImportSupported = property.value === "true";
+            if (property.name === UserStoreManagementConstants.USER_STORE_PROPERTY_BULK_IMPORT_SUPPORTED
+                && property.value === "false") {
+                isBulkImportSupported = false;
             }
         });
 


### PR DESCRIPTION
### Purpose
- Fix read only field display logic in console and my account.
- Improve bulk user import default logic when user store proeprties are not defined.

### Checklist

- [x] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
