### PR TITLE
Add Error Messages for Generic and Pending Verification Scenarios In JIT flow. 

### DIFF
--- a/.changeset/smooth-onions-dance.md
+++ b/.changeset/smooth-onions-dance.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add Error Messages for Generic and Pending Verification Scenarios In JIT flow

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -76,6 +76,7 @@ enter.your.email=Enter your email
 enter.your.username=Enter your username
 enter.your.password=Enter your password
 login.fail.message=Login failed! Please check your username and password and try again.
+login.failed.generic=Login failed. If the issue persists please contact your administrator.
 emailusername.fail.message=Invalid username! Username should be an email address.
 username.fail.message=Could not find any account with this user name! Please recheck the username and try again.
 password.fail.message=Login failed! Please recheck the password and try again.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/retry.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/retry.jsp
@@ -154,7 +154,17 @@
         <layout:component componentName="MainSection">
             <div class="ui orange attached segment mt-3">
                 <%
-                    if (StringUtils.equals(errorCode, IdentityCoreConstants.USER_ACCOUNT_LOCKED_ERROR_CODE) &&
+                    if (IdentityCoreConstants.LOGIN_FAILED_GENERIC_ERROR_CODE.equals(errorCode)) {
+                %>
+                    <h3 class="ui header text-center slogan-message mt-3 mb-6">
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "unable.to.proceed")%>
+                    </h3>
+
+                    <p class="portal-tagline-description">
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "login.failed.generic")%>
+                    </p>
+                <%
+                    } else if (StringUtils.equals(errorCode, IdentityCoreConstants.USER_ACCOUNT_LOCKED_ERROR_CODE) &&
                             StringUtils.isBlank(remainingAttempts)) {
                 %>
                     <h3 class="ui header text-center slogan-message mt-3 mb-6">
@@ -166,6 +176,16 @@
                         <a href="mailto:<%= StringEscapeUtils.escapeHtml4(supportEmail) %>" target="_blank">
                             <span class="orange-text-color button"><%= StringEscapeUtils.escapeHtml4(supportEmail) %></span>
                         </a> <%=AuthenticationEndpointUtil.i18n(resourceBundle, "for.assistance")%>
+                    </p>
+                <%
+                    } else if (IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE.equals(errorCode)) {
+                %>
+                    <h3 class="ui header text-center slogan-message mt-3 mb-6">
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "unable.to.proceed")%>
+                    </h3>
+
+                    <p class="portal-tagline-description">
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "account.confirmation.pending")%>
                     </p>
                 <%
                     } else if (IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE.equals(errorCode)) {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/retry.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/retry.jsp
@@ -157,11 +157,11 @@
                     if (IdentityCoreConstants.LOGIN_FAILED_GENERIC_ERROR_CODE.equals(errorCode)) {
                 %>
                     <h3 class="ui header text-center slogan-message mt-3 mb-6">
-                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "unable.to.proceed")%>
+                        <%=i18n(resourceBundle, customText, "unable.to.proceed")%>
                     </h3>
 
                     <p class="portal-tagline-description">
-                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "login.failed.generic")%>
+                        <%=i18n(resourceBundle, customText, "login.failed.generic")%>
                     </p>
                 <%
                     } else if (StringUtils.equals(errorCode, IdentityCoreConstants.USER_ACCOUNT_LOCKED_ERROR_CODE) &&
@@ -181,11 +181,11 @@
                     } else if (IdentityCoreConstants.USER_ACCOUNT_NOT_CONFIRMED_ERROR_CODE.equals(errorCode)) {
                 %>
                     <h3 class="ui header text-center slogan-message mt-3 mb-6">
-                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "unable.to.proceed")%>
+                        <%=i18n(resourceBundle, customText, "unable.to.proceed")%>
                     </h3>
 
                     <p class="portal-tagline-description">
-                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "account.confirmation.pending")%>
+                        <%=i18n(resourceBundle, customText, "account.confirmation.pending")%>
                     </p>
                 <%
                     } else if (IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE.equals(errorCode)) {


### PR DESCRIPTION
### Purpose 

The related PR introduces `authentication.jit_provisioning.show_failure_reason` config. Along this there are two new error codes introduced for following scenarios.

1. Generic error 
2. Pending verification 

This PR introduces the improvements to handle the error codes in the front end. 

### Related PR/s
- https://github.com/wso2/carbon-identity-framework/pull/6512

### Related Issue 
- https://github.com/wso2/product-is/issues/21711

### Demo 
- https://github.com/wso2/product-is/issues/21711#issuecomment-2664042439