### PR TITLE
Rename Auto Login Flows

### DIFF
--- a/.changeset/beige-owls-burn.md
+++ b/.changeset/beige-owls-burn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Rename login flows

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -66,7 +66,7 @@
     String ERROR_CODE = "errorCode";
     String PASSWORD_RESET_PAGE = "password-reset.jsp";
     String AUTO_LOGIN_COOKIE_NAME = "ALOR";
-    String AUTO_LOGIN_FLOW_TYPE = "RECOVERY";
+    String AUTO_LOGIN_FLOW_TYPE = "ACCOUNT_RECOVERY";
     String AUTO_LOGIN_COOKIE_DOMAIN = "AutoLoginCookieDomain";
     String USERSTORE_DOMAIN = "userstoredomain";
     String RECOVERY_TYPE_INVITE = "invite";

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -75,7 +75,7 @@
     String usernameAlreadyExistsErrorCode = "20030";
     String AUTO_LOGIN_COOKIE_NAME = "ALOR";
     String AUTO_LOGIN_COOKIE_DOMAIN = "AutoLoginCookieDomain";
-    String AUTO_LOGIN_FLOW_TYPE = "SIGNUP";
+    String AUTO_LOGIN_FLOW_TYPE = "SELF_SIGNUP";
     PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
     Boolean isAutoLoginEnable = preferenceRetrievalClient.checkAutoLoginAfterSelfRegistrationEnabled(tenantDomain);
     Boolean isSelfRegistrationLockOnCreationEnabled = preferenceRetrievalClient.checkSelfRegistrationLockOnCreation(tenantDomain);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
@@ -54,7 +54,7 @@
     String errorMsg = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorMsg"));
     String AUTO_LOGIN_COOKIE_NAME = "ALOR";
     String AUTO_LOGIN_COOKIE_DOMAIN = "AutoLoginCookieDomain";
-    String AUTO_LOGIN_FLOW_TYPE = "SIGNUP";
+    String AUTO_LOGIN_FLOW_TYPE = "SELF_SIGNUP";
     String username = null;
     String applicationAccessUrl = "";
 


### PR DESCRIPTION
## Purpose 
Auto login feature login flows use different names compared in prior product versions. To keep the changes consistent update the auto login flow names.

## Related Issue 
- https://github.com/wso2/product-is/issues/23119

## Related PR/s
- https://github.com/wso2-extensions/identity-local-auth-basicauth/pull/221