### PR TITLE
Change readonly user store checking logic in bulk user import wizard

### DIFF
--- a/.changeset/olive-cats-float.md
+++ b/.changeset/olive-cats-float.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.userstores.v1": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Update readonly user store checking logic in bulk user import wizard

--- a/features/admin.users.v1/components/wizard/bulk-import-user-wizard.tsx
+++ b/features/admin.users.v1/components/wizard/bulk-import-user-wizard.tsx
@@ -265,7 +265,8 @@ export const BulkImportUserWizard: FunctionComponent<BulkImportUserInterface> = 
         const params: Record<string, string> = {
             requiredAttributes: [
                 UserStoreManagementConstants.USER_STORE_PROPERTY_READ_ONLY,
-                UserStoreManagementConstants.USER_STORE_PROPERTY_BULK_IMPORT_SUPPORTED
+                UserStoreManagementConstants.USER_STORE_PROPERTY_BULK_IMPORT_SUPPORTED,
+                UserStoreManagementConstants.USER_STORE_PROPERTY_IS_BULK_IMPORT_SUPPORTED
             ].join(",")
         };
 
@@ -320,10 +321,13 @@ export const BulkImportUserWizard: FunctionComponent<BulkImportUserInterface> = 
      */
     const isBulkImportSupportedUserStore = (userStore: UserStoreDetails): boolean => {
         const isReadWriteUserStore: boolean = !isUserStoreReadOnly(userStore?.name);
-        const isBulkImportSupported: boolean =  !userStore.properties?.some(
+        const isBulkImportSupported: boolean = !userStore.properties?.some(
             (property: UserStoreProperty) =>
-                property.name === UserStoreManagementConstants.USER_STORE_PROPERTY_BULK_IMPORT_SUPPORTED &&
-                property.value === "false"
+                [
+                    UserStoreManagementConstants.USER_STORE_PROPERTY_BULK_IMPORT_SUPPORTED.toLowerCase(),
+                    UserStoreManagementConstants.USER_STORE_PROPERTY_IS_BULK_IMPORT_SUPPORTED.toLowerCase()
+                ].includes(property?.name?.toLowerCase()) &&
+                property?.value?.toLowerCase() === "false"
         );
 
         return isReadWriteUserStore && isBulkImportSupported;

--- a/features/admin.userstores.v1/constants/user-store-constants.ts
+++ b/features/admin.userstores.v1/constants/user-store-constants.ts
@@ -49,6 +49,7 @@ export class UserStoreManagementConstants {
     // Name of the readonly DEFAULT userstore property.
     public static readonly USER_STORE_PROPERTY_READ_ONLY: string = "ReadOnly";
     public static readonly USER_STORE_PROPERTY_BULK_IMPORT_SUPPORTED: string = "BulkImportSupported";
+    public static readonly USER_STORE_PROPERTY_IS_BULK_IMPORT_SUPPORTED: string = "IsBulkImportSupported";
 
     /**
      * Set of keys used to enable/disable features.


### PR DESCRIPTION
- Change readonly user store checking logic in bulk user import wizard
- Check BulkImportSupported or IsBulkImportSupported property, since in JDBC user stores `IsBulkImportSupported` is used.


https://github.com/user-attachments/assets/e99ab81a-732d-4be2-9dbe-44ea4804d826

