### PR TITLE
Make 'Identity Apps Commons' component activation log level to debug

### DIFF
--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceStartupObserver.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceStartupObserver.java
@@ -44,7 +44,7 @@ public class AppsCommonServiceStartupObserver implements ServerStartupObserver {
             log.info(appPortal.getName() + " URL : " + IdentityUtil
                 .getServerURL(appPortal.getEndpoint(), true, true));
         }
-        log.info("Identity apps common service component activated successfully.");
+        log.debug("Identity apps common service component activated successfully.");
     }
 
 }


### PR DESCRIPTION
### Proposed changes in this pull request

$subject to avoid unnecessary logs to be printed during the product startup.

Related to,
- https://github.com/wso2/product-is/issues/20778