### PR TITLE
Update git actions cache version to v3

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -154,7 +154,7 @@ jobs:
 
             - name: 💾 Cache local Maven repository
               id: cache-maven-m2
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                   path: ~/.m2/repository
                   key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
### Purpose
This PR updates the actions cache version to v3 since the previous v2 is now being deprecated [1].

[1] - https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down