### PR TITLE
Resolve diacritical marks not being resolved in oauth_response.jsp page

### DIFF
--- a/.changeset/green-ladybugs-beam.md
+++ b/.changeset/green-ladybugs-beam.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add JSP directive for UTF-8 encoding

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/oauth_response.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/oauth_response.jsp
@@ -11,6 +11,7 @@
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="org.wso2.carbon.identity.core.ServiceURLBuilder" %>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%
     request.setAttribute("ut", request.getAttribute("userTenantDomain"));


### PR DESCRIPTION
## Purpose
Ensure proper rendering of diacritical marks in localized languages on the `oauth_response.jsp` page by setting the encoding to UTF-8 in WSO2 Identity Server v7.0.0.

## Implementaiton
This PR includes a small change to the `identity-apps-core/apps/authentication-portal/src/main/webapp/oauth_response.jsp` file. The change sets the language to Java and specifies the content type and page encoding for the JSP page.

### Previous Behaviour
<img width="500" alt="Screenshot 2025-02-18 at 2 54 39 PM" src="https://github.com/user-attachments/assets/cc9077a8-7044-48bc-8baa-f88e92b0cb18" />

### Fixed Behaviour
<img width="500" alt="Screenshot 2025-02-18 at 3 02 30 PM" src="https://github.com/user-attachments/assets/6bd09d41-ab9e-4bd4-b08c-3cf409d849ac" />

## Related Issues
- https://github.com/wso2/product-is/issues/22899