### PR TITLE
Fix Id token signing info

### DIFF
--- a/.changeset/breezy-boats-cry.md
+++ b/.changeset/breezy-boats-cry.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix id_token signing info

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -3665,11 +3665,11 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 <Trans
                                     i18nKey={
                                         "applications:forms.inboundOIDC.sections.idToken" +
-                                        ".fields.algorithm.hint"
+                                        ".fields.signing.hint"
                                     }
                                 >
                                     The dropdown contains the supported <Code withBackground>id_token</Code>
-                                    encryption algorithms.
+                                    signing algorithms.
                                 </Trans>
                             </Hint>
                         </Grid.Column>


### PR DESCRIPTION
### Purpose
Current info in Id_token signing area is wrong,  the description states:

"The dropdown contains the supported ID token encryption algorithms."

However, this is incorrect, as the dropdown actually lists the supported ID token signing algorithms, not encryption algorithms.

Before
<img width="953" alt="Image" src="https://github.com/user-attachments/assets/657b024e-5a35-41af-8a6a-9c38996b4084" />

After
<img width="953" alt="Screenshot 2025-02-19 at 11 18 32" src="https://github.com/user-attachments/assets/33270d10-b6e1-4f85-88c4-894ee61d43ab" />


### Related Issues
https://github.com/wso2/product-is/issues/23147


### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
