### PR TITLE
Fix apiResourceData.identifier value not shown in UI

### DIFF
--- a/.changeset/fair-hounds-call.md
+++ b/.changeset/fair-hounds-call.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.api-resources.v2": patch
+---
+
+Fix apiResourceData.identifier value.

--- a/features/admin.api-resources.v2/components/api-resource-panes/general-api-resource.tsx
+++ b/features/admin.api-resources.v2/components/api-resource-panes/general-api-resource.tsx
@@ -240,10 +240,8 @@ export const GeneralAPIResource: FunctionComponent<GeneralAPIResourceInterface> 
                                         minLength={ 0 }
                                         width={ 16 }
                                         data-componentid={ `${componentId}-general-form-identifier` }
+                                        value={ apiResourceData.identifier }
                                     >
-                                        <CopyInputField
-                                            value={ apiResourceData.identifier }
-                                        />
                                     </Field.Input>
                                 )
                             }


### PR DESCRIPTION
### Purpose
API resource identifier is not shown in the UI due to the CopyInputField component. In this PR we are adding the value without the copyable field.

Issue : https://github.com/wso2/product-is/issues/23183

<img width="1512" alt="Screenshot 2025-02-20 at 13 42 15" src="https://github.com/user-attachments/assets/3112e809-98a5-4825-835a-3ceed16159e6" />

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
