### PR TITLE
Add a new input field adapter for custom authenticator text with adornment

### DIFF
--- a/.changeset/flat-dodos-beam.md
+++ b/.changeset/flat-dodos-beam.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.connections.v1": patch
+"@wso2is/form": patch
+---
+
+Add a new input field adapter for custom authenticator text with adornment

--- a/features/admin.connections.v1/components/create/custom-authenticator-create-wizard.tsx
+++ b/features/admin.connections.v1/components/create/custom-authenticator-create-wizard.tsx
@@ -897,7 +897,7 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
             <Field.Input
                 className="identifier-field"
                 ariaLabel="identifier"
-                inputType="text"
+                inputType="text_with_adornment"
                 name="identifier"
                 label={ t("customAuthenticator:fields.createWizard.generalSettingsStep.identifier.label") }
                 placeholder={ t("customAuthenticator:fields.createWizard.generalSettingsStep.identifier.placeholder") }

--- a/modules/form/src/components/adapters/__DEPRECATED__adapters.tsx
+++ b/modules/form/src/components/adapters/__DEPRECATED__adapters.tsx
@@ -148,6 +148,102 @@ export const __DEPRECATED__TextFieldAdapter = (props:FieldRenderProps<any> ): Re
                     : (): void => { return; }
             }
             iconPosition={ childFieldProps?.iconPosition }
+        />
+    );
+};
+
+/**
+ * Deprecated Semantic UI Text Field adapter.
+ *
+ * @param props - Props injected to the component.
+ * @returns Text Field Adapter.
+ */
+export const TextFieldWithAdornmentAdapter = (props:FieldRenderProps<any> ): ReactElement => {
+
+    const { childFieldProps, input, meta, parentFormProps } = props;
+
+    return (
+        <Form.Input
+            aria-label={ childFieldProps?.ariaLabel }
+            key={ childFieldProps?.testId }
+            required={ childFieldProps?.required }
+            data-testid={ childFieldProps?.testId }
+            label={ childFieldProps?.label !== "" ? childFieldProps?.label : null }
+            onKeyPress={ (event: React.KeyboardEvent, data: any) => {
+                event.key === ENTER_KEY && input.onBlur(data?.name);
+            } }
+            onChange={ (_event: React.ChangeEvent<HTMLInputElement>, data: InputOnChangeData) => {
+                if (childFieldProps?.listen && typeof childFieldProps?.listen === "function") {
+                    childFieldProps?.listen(data?.value);
+                }
+
+                input.onChange(data?.value);
+            } }
+            onBlur={ (event: any) => input.onBlur(event) }
+            control={ Input }
+            autoFocus={ childFieldProps?.autoFocus || false }
+            value={ meta.modified
+                ? input.value
+                : (childFieldProps?.value
+                    ? childFieldProps?.value
+                    : (parentFormProps?.values[ childFieldProps?.name ]
+                        ? parentFormProps?.values[ childFieldProps?.name ]
+                        : "")) }
+            { ...omit(childFieldProps, [ "value", "listen" ]) }
+            type={
+                childFieldProps?.inputType === "number"
+                    ? "number"
+                    : "text"
+            }
+            error={ ((meta.error || meta.submitError) && meta.touched)
+                ? {
+                    content: ((meta.error || meta.submitError) && meta.touched)
+                        ? meta.error || meta.submitError
+                        : null,
+                    "data-componentid": `${childFieldProps["data-componentid"]}-error`
+                }
+                : false
+            }
+            onKeyDown={
+                // Restrict typing non-numeric characters in the "number" input fields.
+                // Setting `type=number` is not sufficient to support firefox & IE.
+                // Port fix from https://github.com/wso2/identity-apps/pull/2035
+                childFieldProps?.inputType === "number"
+                    ? ((event: KeyboardEvent) => {
+                        const isNumber: boolean = /^[0-9]$/i.test(event.key);
+                        const isAllowed: boolean = (
+                            (event.key === "a"
+                                || event.key === "v"
+                                || event.key === "c"
+                                || event.key === "x")
+                            && (event.ctrlKey === true
+                                || event.metaKey === true)
+                        )
+                            || (
+                                event.key === "ArrowRight"
+                                || event.key == "ArrowLeft")
+                            || (
+                                event.key === "Delete"
+                                || event.key === "Backspace");
+
+                        !isNumber && !isAllowed && event.preventDefault();
+                    })
+                    : (): void => { return; }
+            }
+            onPaste={
+                // Restrict pasting non-numeric characters in the "number" input fields
+                // Setting `type=number` is not sufficient to support firefox & IE.
+                // Port fix from https://github.com/wso2/identity-apps/pull/2035
+                childFieldProps?.inputType === "number"
+                    ? ((event: ClipboardEvent) => {
+                        const data: string = event.clipboardData.getData("Text") ;
+                        const isNumber: boolean = /^[0-9]+$/i.test(data);
+
+                        !isNumber && event.preventDefault();
+                    })
+                    : (): void => { return; }
+            }
+            iconPosition={ childFieldProps?.iconPosition }
         >
             <input />
             { childFieldProps?.adornment && <Icon>{ childFieldProps.adornment }</Icon> }

--- a/modules/form/src/components/field-input.tsx
+++ b/modules/form/src/components/field-input.tsx
@@ -23,6 +23,7 @@ import { Field as FinalFormField } from "react-final-form";
 import {
     CopyFieldAdapter,
     PasswordFieldAdapter,
+    TextFieldWithAdornmentAdapter,
     __DEPRECATED__TextFieldAdapter
 } from "./adapters/__DEPRECATED__adapters";
 import { FormFieldPropsInterface } from "./field";
@@ -46,7 +47,8 @@ export interface FieldInputPropsInterface extends FormFieldPropsInterface {
         | "copy_input"
         | "password"
         | "phoneNumber"
-        | "roleName";
+        | "roleName"
+        | "text_with_adornment";
     /**
      * Hint of the form field.
      */
@@ -129,7 +131,22 @@ export const FieldInput = (props: FieldInputPropsInterface): ReactElement => {
                     { ...rest }
                 />
             );
-        } else {
+        } else if (inputType == FieldInputTypes.INPUT_TEXT_WITH_ADORNMENT) {
+            return (
+                <FinalFormField
+                    key={ testId }
+                    type="text"
+                    name={ props.name }
+                    parse={ (value: any) => value }
+                    component={ TextFieldWithAdornmentAdapter }
+                    validate={ (value: any, allValues: Record<string, unknown>, meta: FieldState<any>) =>
+                        getValidation(value, allValues, meta, "text", props.required, inputType, validation)
+                    }
+                    { ...props }
+                />
+            );
+        }
+        else {
             return (
                 <FinalFormField
                     key={ testId }

--- a/modules/form/src/models/fields.ts
+++ b/modules/form/src/models/fields.ts
@@ -28,7 +28,8 @@ export enum FieldInputTypes {
     INPUT_EMAIL = "email",
     INPUT_URL = "url",
     INPUT_COPY = "copy_input",
-    INPUT_PASSWORD = "password"
+    INPUT_PASSWORD = "password",
+    INPUT_TEXT_WITH_ADORNMENT = "text_with_adornment",
 }
 
 export enum FieldButtonTypes {


### PR DESCRIPTION
### Purpose
This PR introduces a new text field adapter to be used with text fields with adornments. This is currently being used in custom authenticators.

Changes to the deprecated text adapter are also being reverted from this PR. This will fix the unintentional behaviour caused by the changes to the deprecated adapter.

### Related Issue
-  https://github.com/wso2/product-is/issues/23183