### PR TITLE
Fix the issue of UI persisting stale data in authenticator connected apps list

### DIFF
--- a/.changeset/short-moose-warn.md
+++ b/.changeset/short-moose-warn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Fix the issue of UI persisting stale data in authenticator connected apps list

--- a/features/admin.connections.v1/api/connections.ts
+++ b/features/admin.connections.v1/api/connections.ts
@@ -860,6 +860,40 @@ export const getConnectedApps = (idpId: string): Promise<any> => {
 };
 
 /**
+ * Get connected apps of the authenticator.
+ *
+ * Currently, connected apps can be added only to custom local authenticators and federated authenticators.
+ *
+ * @param idpId - ID of the authenticator.
+ * @returns  A promise containing the response.
+ */
+export const getConnectedAppsOfAuthenticator = (authenticatorId: string): Promise<any> => {
+
+    const requestConfig: RequestConfigInterface = {
+        headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        url: store.getState().config.endpoints.authenticators + "/" + authenticatorId + "/connected-apps/"
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 200) {
+                return Promise.reject(
+                    new Error("Failed to get connected apps for the authenticator: " + authenticatorId)
+                );
+            }
+
+            return Promise.resolve(response.data as ConnectedAppsInterface);
+        }).catch((error: AxiosError) => {
+            return Promise.reject(error);
+        });
+};
+
+
+/**
  * Update identity provider details.
  *
  * @param connection - Connection.

--- a/features/admin.connections.v1/api/connections.ts
+++ b/features/admin.connections.v1/api/connections.ts
@@ -864,7 +864,7 @@ export const getConnectedApps = (idpId: string): Promise<any> => {
  *
  * Currently, connected apps can be added only to custom local authenticators and federated authenticators.
  *
- * @param idpId - ID of the authenticator.
+ * @param authenticatorId - ID of the authenticator.
  * @returns  A promise containing the response.
  */
 export const getConnectedAppsOfAuthenticator = (authenticatorId: string): Promise<any> => {

--- a/features/admin.connections.v1/components/authenticator-grid.tsx
+++ b/features/admin.connections.v1/components/authenticator-grid.tsx
@@ -343,7 +343,8 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                 if (response.count === 0) {
                     setDeletingIDP(
                         authenticators.find(
-                            (idp: ConnectionInterface | AuthenticatorInterface) => idp.id === authenticatorId
+                            (authenticator: ConnectionInterface | AuthenticatorInterface) =>
+                                authenticator.id === authenticatorId
                         )
                     );
                     setShowDeleteConfirmationModal(true);

--- a/features/admin.connections.v1/components/authenticator-grid.tsx
+++ b/features/admin.connections.v1/components/authenticator-grid.tsx
@@ -62,9 +62,9 @@ import { Dispatch } from "redux";
 import {
     deleteConnection,
     deleteCustomAuthenticator,
-    getConnectedApps
+    getConnectedApps,
+    getConnectedAppsOfAuthenticator
 } from "../api/connections";
-import { useGetAuthenticatorConnectedApps } from "../api/use-get-authenticator-connected-apps";
 import { getConnectionIcons } from "../configs/ui";
 import { AuthenticatorMeta } from "../meta/authenticator-meta";
 import {
@@ -170,7 +170,6 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
         (ConnectionInterface | AuthenticatorInterface)[]>([]);
     const [ showDeleteConfirmationModal, setShowDeleteConfirmationModal ] = useState<boolean>(false);
     const [ deletingIDP, setDeletingIDP ] = useState<ConnectionInterface>(undefined);
-    const [ deletingAuthenticatorId, setDeletingAuthenticatorId ] = useState<string>(undefined);
     const [ isDeletionloading, setIsDeletionLoading ] = useState(false);
     const [ connectedApps, setConnectedApps ] = useState<string[]>(undefined);
     const [
@@ -178,8 +177,6 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
         setShowDeleteErrorDueToConnectedAppsModal
     ] = useState<boolean>(false);
     const [ isConnectedAppsLoading, setIsConnectedAppsLoading ] = useState<boolean>(true);
-    const [ shouldFetchLocalAuthenticatorConnectedApps, setShouldFetchLocalAuthenticatorConnectedApps ] =
-        useState<boolean>(false);
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const productName: string = useSelector((state: AppState) => state?.config?.ui?.productName);
@@ -192,11 +189,6 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
 
     const connectionResourcesUrl: string = UIConfig?.connectionResourcesUrl;
 
-    const {
-        data: connectedAppsOfLocalAuthenticator,
-        isLoading: isLoadingConnectedAppsOfLocalAuthenticator
-    } = useGetAuthenticatorConnectedApps(deletingAuthenticatorId, shouldFetchLocalAuthenticatorConnectedApps);
-
     useEffect(() => {
         const shownAuthenticatorList: (ConnectionInterface | AuthenticatorInterface)[] =
             authenticators.filter((authenticator:ConnectionInterface | AuthenticatorInterface)  => {
@@ -205,17 +197,6 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
 
         setDisplayingAuthenticators(shownAuthenticatorList);
     }, [ authenticators ]);
-
-    /**
-     * This use effect initiates custom local authenticator delete action.
-     *
-     * This ensures that the deletion is initiated only after the connected apps are fetched.
-     * Initializing the delete process before the connected apps are fetched will result in unintended behavior.
-     */
-    useEffect(() => {
-        connectedAppsOfLocalAuthenticator &&
-            handleLocalAuthenticatorDelete(deletingAuthenticatorId);
-    }, [ connectedAppsOfLocalAuthenticator, deletingAuthenticatorId ]);
 
     /**
      * Redirects to the authenticator edit page when the edit button is clicked.
@@ -274,10 +255,8 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
             return;
         }
 
-        // If the connection is a custom local authenticator, then check for connected apps through a custom hook.
         if (isCustomLocalAuthenticator) {
-            setDeletingAuthenticatorId(idpId);
-            setShouldFetchLocalAuthenticatorConnectedApps(true);
+            handleLocalAuthenticatorDelete(idpId);
 
             return;
         }
@@ -357,26 +336,34 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
      * System defined authenticators cannot be deleted.
      */
     const handleLocalAuthenticatorDelete = async (authenticatorId: string): Promise<void> => {
-        connectedAppsOfLocalAuthenticator ? setIsConnectedAppsLoading(false) : setIsConnectedAppsLoading(true);
+        setIsConnectedAppsLoading(true);
 
-        if (isLoadingConnectedAppsOfLocalAuthenticator || !connectedAppsOfLocalAuthenticator) {
-            return;
-        }
-
-        if (connectedAppsOfLocalAuthenticator?.count === 0) {
-            setDeletingIDP(
-                authenticators.find((idp: ConnectionInterface | AuthenticatorInterface) => idp.id === authenticatorId)
-            );
-            setShowDeleteConfirmationModal(true);
-        } else {
-            setIsConnectedAppsLoading(true);
-
-            setShowDeleteErrorDueToConnectedAppsModal(true);
-            loadConnectedAppDetails(connectedAppsOfLocalAuthenticator);
-
-            setIsConnectedAppsLoading(false);
-            setShouldFetchLocalAuthenticatorConnectedApps(false);
-        };
+        getConnectedAppsOfAuthenticator(authenticatorId)
+            .then(async (response: ConnectedAppsInterface) => {
+                if (response.count === 0) {
+                    setDeletingIDP(
+                        authenticators.find(
+                            (idp: ConnectionInterface | AuthenticatorInterface) => idp.id === authenticatorId
+                        )
+                    );
+                    setShowDeleteConfirmationModal(true);
+                } else {
+                    setShowDeleteErrorDueToConnectedAppsModal(true);
+                    loadConnectedAppDetails(response);
+                }
+            })
+            .catch((error: AxiosError & { description: string; message: string }) => {
+                dispatch(
+                    addAlert({
+                        description: error?.description || t("idp:connectedApps.genericError.description"),
+                        level: AlertLevels.ERROR,
+                        message: error?.message || t("idp:connectedApps.genericError.message")
+                    })
+                );
+            })
+            .finally(() => {
+                setIsConnectedAppsLoading(false);
+            });
     };
 
     /**


### PR DESCRIPTION
### Purpose
This PR fixes the issue of UI persisting stale data in the authenticator connected apps list by using Axios instead of SWR when fetching connected apps of a custom local authenticator before trying to delete the authenticator from the bottom right corner delete button authenticator card in the connections list page grid layout.

https://github.com/user-attachments/assets/6196d45f-c23e-4893-a409-61649c1cd393

### Related Issue
- https://github.com/wso2/product-is/issues/23187