### PR TITLE
Enable read-only mode in custom authenticators for users without write permission

### DIFF
--- a/.changeset/slow-bikes-argue.md
+++ b/.changeset/slow-bikes-argue.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Enable read-only mode in custom authenticators for users without write permission

--- a/features/admin.connections.v1/components/edit/connection-edit.tsx
+++ b/features/admin.connections.v1/components/edit/connection-edit.tsx
@@ -269,6 +269,7 @@ export const EditConnection: FunctionComponent<EditConnectionPropsInterface> = (
                 <CustomAuthenticatorSettings
                     isCustomLocalAuthenticator={ isCustomLocalAuthenticator }
                     isLoading={ isLoading }
+                    isReadOnly={ isReadOnly }
                     connector={ identityProvider }
                     onUpdate={ onUpdate }
                     data-componentid={ `${ testId }-authenticator-settings` }

--- a/features/admin.connections.v1/components/edit/forms/custom-authenticator-general-details-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/custom-authenticator-general-details-form.tsx
@@ -245,6 +245,7 @@ CustomAuthenticatorGeneralDetailsFormPopsInterface> = ({
                         maxLength={ 100 }
                         minLength={ 3 }
                         data-componentid={ `${_componentId}-form-wizard-display-name` }
+                        readOnly={ isReadOnly }
                     />
                     <Field.Input
                         name="image"

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -65,6 +65,10 @@ export interface CustomAuthenticatorSettingsPagePropsInterface extends Identifia
      */
     isLoading?: boolean;
     /**
+     * Specifies if the component should only be read-only.
+     */
+    isReadOnly: boolean;
+    /**
      * Connection details.
      */
     connector: CustomAuthConnectionInterface | ConnectionInterface;
@@ -83,6 +87,7 @@ export interface CustomAuthenticatorSettingsPagePropsInterface extends Identifia
 export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettingsPagePropsInterface> = ({
     isCustomLocalAuthenticator,
     isLoading,
+    isReadOnly,
     connector,
     onUpdate,
     ["data-componentid"]: componentId = "custom-authenticator-settings-page"
@@ -294,7 +299,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
                                         setIsEndpointAuthenticationUpdated(isAuthenticationUpdated);
                                     } }
                                 />
-                                { !isLoading && (
+                                { !isLoading && !isReadOnly && (
                                     <Button
                                         size="medium"
                                         variant="contained"


### PR DESCRIPTION
### Purpose
This PR enables the read-only view of custom authenticators for users with only connection read permission.

### Related Issue 
- https://github.com/wso2/product-is/issues/23192