### PR TITLE
Add a loader to custom federated authenticator settings tab

### DIFF
--- a/.changeset/pretty-starfishes-attend.md
+++ b/.changeset/pretty-starfishes-attend.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Add a loader to custom federated authenticator settings tab

--- a/features/admin.connections.v1/components/edit/connection-edit.tsx
+++ b/features/admin.connections.v1/components/edit/connection-edit.tsx
@@ -272,6 +272,7 @@ export const EditConnection: FunctionComponent<EditConnectionPropsInterface> = (
                     isReadOnly={ isReadOnly }
                     connector={ identityProvider }
                     onUpdate={ onUpdate }
+                    loader={ Loader }
                     data-componentid={ `${ testId }-authenticator-settings` }
                 />
             </ResourceTab.Pane>

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -76,6 +76,10 @@ export interface CustomAuthenticatorSettingsPagePropsInterface extends Identifia
      * Callback to update the connector details.
      */
     onUpdate: (id: string, tabName?: string) => void;
+    /**
+     * Loading Component.
+     */
+    loader: () => ReactElement;
 }
 
 /**
@@ -90,6 +94,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
     isReadOnly,
     connector,
     onUpdate,
+    loader: Loader,
     ["data-componentid"]: componentId = "custom-authenticator-settings-page"
 }: CustomAuthenticatorSettingsPagePropsInterface): ReactElement => {
     const dispatch: Dispatch = useDispatch();
@@ -98,6 +103,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
     const [ initialValues, setInitialValues ] = useState<EndpointConfigFormPropertyInterface>(null);
     const [ endpointAuthenticationType, setEndpointAuthenticationType ] = useState<AuthenticationType>(null);
     const [ isEndpointAuthenticationUpdated, setIsEndpointAuthenticationUpdated ] = useState<boolean>(false);
+    const [ isEndpointDetailsLoading, setIsEndpointDetailsLoading ] = useState<boolean>(false);
 
     useEffect(() => {
         if (isCustomLocalAuthenticator) {
@@ -123,6 +129,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
      * @param customFederatedAuthenticatorId - Custom federated authenticator id.
      */
     const getCustomFederatedAuthenticatorInitialValues = (customFederatedAuthenticatorId: string) => {
+        setIsEndpointDetailsLoading(true);
         getFederatedAuthenticatorDetails(connector?.id, customFederatedAuthenticatorId)
             .then((data: FederatedAuthenticatorListItemInterface) => {
                 const endpointAuth: EndpointConfigFormPropertyInterface = {
@@ -134,6 +141,8 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
             })
             .catch((error: AxiosError) => {
                 handleGetCustomAuthenticatorError(error);
+            }).finally(() => {
+                setIsEndpointDetailsLoading(false);
             });
     };
 
@@ -273,6 +282,10 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
             handleUpdateCustomFederatedAuthenticator(values, authProperties);
         }
     };
+
+    if (isLoading || isEndpointDetailsLoading) {
+        return <Loader />;
+    }
 
     return (
         <div className="custom-authenticator-settings-tab">


### PR DESCRIPTION
### Purpose
This PR adds a loader to be displayed in the settings tab of the custom federated authenticators, when the fetching is delayed, similar to the behaviour in the settings tab of IDPs such as Google.

https://github.com/user-attachments/assets/2090e382-4fd5-474b-95b0-60b37b258b0f


### Related Issue
- https://github.com/wso2/product-is/issues/23202