### PR TITLE
Fix custom internal user authenticator is categorized under 2fa in the classic login editor 

### DIFF
--- a/.changeset/strong-plums-relax.md
+++ b/.changeset/strong-plums-relax.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix custom internal user authenticator is categorized under 2fa in the classic login editor

--- a/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
+++ b/features/admin.applications.v1/components/settings/sign-on-methods/step-based-flow/step-based-flow.tsx
@@ -186,7 +186,7 @@ export const StepBasedFlow: FunctionComponent<AuthenticationFlowPropsInterface> 
             } else if (ApplicationManagementConstants.SECOND_FACTOR_AUTHENTICATORS.includes(authenticator.id)) {
                 secondFactorAuth.push(authenticator);
             } else if (SignInMethodUtils.isCustomAuthenticator(authenticator)) {
-                if (SignInMethodUtils.isSecondFactorAuthenticator) {
+                if (SignInMethodUtils.isSecondFactorAuthenticator(authenticator)) {
                     customTwoFactorAuthentication.push(authenticator);
                 } else {
                     customInternalUserAuthentication.push(authenticator);


### PR DESCRIPTION
### Purpose 
This PR fixes the internal user authenticator being categorized under a fault category in the classic editor.

### Related Issue
- https://github.com/wso2/product-is/issues/23212