### PR TITLE
Fix Settings of created Custom Authenticator (Service-based) in sub organizations are not modifiable

### DIFF
--- a/.changeset/witty-bikes-collect.md
+++ b/.changeset/witty-bikes-collect.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.connections.v1": patch
+"@wso2is/admin.actions.v1": patch
+---
+
+Fix Settings of created Custom Authenticator (Service-based) in sub organizations are not modifiable

--- a/features/admin.actions.v1/components/action-endpoint-config-form.tsx
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.tsx
@@ -51,6 +51,10 @@ interface ActionEndpointConfigFormInterface extends IdentifiableComponentInterfa
      */
     isCreateFormState: boolean;
     /**
+     * Specifies whether to skip permission checks
+     */
+    isSkipPermission?: boolean;
+    /**
      * Callback function triggered when the authentication type is changed.
      *
      * @param updatedValue - The new authentication type selected.
@@ -62,6 +66,7 @@ interface ActionEndpointConfigFormInterface extends IdentifiableComponentInterfa
 const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterface> = ({
     initialValues,
     isCreateFormState,
+    isSkipPermission,
     onAuthenticationTypeChange,
     [ "data-componentid" ]: _componentId = "action-endpoint-config-form"
 }: ActionEndpointConfigFormInterface): ReactElement => {
@@ -79,6 +84,15 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
     const { t } = useTranslation();
 
     const getFieldDisabledStatus = (): boolean => {
+        /**
+         * When isSkipPermission flag is set to true, all the fields are enabled.
+         * This is currently being used with custom authenticators to enable/disable
+         * form update based on connection specific permissions.
+         */
+        if (isSkipPermission) {
+            return hasActionUpdatePermissions;
+        }
+
         if (isCreateFormState) {
             return !hasActionCreatePermissions;
         } else {

--- a/features/admin.actions.v1/components/action-endpoint-config-form.tsx
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.tsx
@@ -51,9 +51,9 @@ interface ActionEndpointConfigFormInterface extends IdentifiableComponentInterfa
      */
     isCreateFormState: boolean;
     /**
-     * Specifies whether to skip permission checks
+     * Specifies whether to skip update permission checks
      */
-    isSkipPermission?: boolean;
+    skipUpdatePermission?: boolean;
     /**
      * Callback function triggered when the authentication type is changed.
      *
@@ -66,7 +66,7 @@ interface ActionEndpointConfigFormInterface extends IdentifiableComponentInterfa
 const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterface> = ({
     initialValues,
     isCreateFormState,
-    isSkipPermission,
+    skipUpdatePermission,
     onAuthenticationTypeChange,
     [ "data-componentid" ]: _componentId = "action-endpoint-config-form"
 }: ActionEndpointConfigFormInterface): ReactElement => {
@@ -85,11 +85,11 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
 
     const getFieldDisabledStatus = (): boolean => {
         /**
-         * When isSkipPermission flag is set to true, all the fields are enabled.
+         * When skipUpdatePermission flag is set to true, all the fields are enabled.
          * This is currently being used with custom authenticators to enable/disable
          * form update based on connection specific permissions.
          */
-        if (isSkipPermission) {
+        if (skipUpdatePermission) {
             return hasActionUpdatePermissions;
         }
 

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -104,6 +104,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
     const [ endpointAuthenticationType, setEndpointAuthenticationType ] = useState<AuthenticationType>(null);
     const [ isEndpointAuthenticationUpdated, setIsEndpointAuthenticationUpdated ] = useState<boolean>(false);
     const [ isEndpointDetailsLoading, setIsEndpointDetailsLoading ] = useState<boolean>(false);
+    const [ isSkipPermission, setIsSkipPermission ] = useState<boolean>(false);
 
     useEffect(() => {
         if (isCustomLocalAuthenticator) {
@@ -118,6 +119,15 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
             getCustomFederatedAuthenticatorInitialValues(customAuthenticatorId);
         }
     }, []);
+
+    /**
+     * When the user has connection edit permission, skip inherent permission check in the action configuration form.
+     */
+    useEffect(() => {
+        if (!isReadOnly) {
+            setIsSkipPermission(true);
+        }
+    }, [ isReadOnly ]);
 
     /**
      * This function is utilized only for custom federated authenticators since endpoint details are not
@@ -304,6 +314,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
                                 <ActionEndpointConfigForm
                                     initialValues={ initialValues }
                                     isCreateFormState={ false }
+                                    isSkipPermission={ isSkipPermission }
                                     onAuthenticationTypeChange={ (
                                         authenticationType: AuthenticationType,
                                         isAuthenticationUpdated: boolean

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -104,7 +104,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
     const [ endpointAuthenticationType, setEndpointAuthenticationType ] = useState<AuthenticationType>(null);
     const [ isEndpointAuthenticationUpdated, setIsEndpointAuthenticationUpdated ] = useState<boolean>(false);
     const [ isEndpointDetailsLoading, setIsEndpointDetailsLoading ] = useState<boolean>(false);
-    const [ isSkipPermission, setIsSkipPermission ] = useState<boolean>(false);
+    const [ skipActionUpdatePermission, setSkipActionUpdatePermission ] = useState<boolean>(false);
 
     useEffect(() => {
         if (isCustomLocalAuthenticator) {
@@ -124,9 +124,11 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
      * When the user has connection edit permission, skip inherent permission check in the action configuration form.
      */
     useEffect(() => {
-        if (!isReadOnly) {
-            setIsSkipPermission(true);
+        if (isReadOnly) {
+            return;
         }
+
+        setSkipActionUpdatePermission(true);
     }, [ isReadOnly ]);
 
     /**
@@ -314,7 +316,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
                                 <ActionEndpointConfigForm
                                     initialValues={ initialValues }
                                     isCreateFormState={ false }
-                                    isSkipPermission={ isSkipPermission }
+                                    skipUpdatePermission={ skipActionUpdatePermission }
                                     onAuthenticationTypeChange={ (
                                         authenticationType: AuthenticationType,
                                         isAuthenticationUpdated: boolean


### PR DESCRIPTION
### Purpose
> $Subject

The following scenarios were tested against the new update:
1. Attempt to update a custom authenticator in a sub-organization (With default permissions)
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/b4e06ca2-0f60-484e-b390-8722ba0b137d" />

2. Attempt to update a custom authenticator in a sub organization (With connection view permission)

### Related Issue
- https://github.com/wso2/product-is/issues/23233