### PR TITLE
Revert action cache version to v2

### DIFF
--- a/.changeset/orange-comics-matter.md
+++ b/.changeset/orange-comics-matter.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/i18n": patch
+---
+
+Add changeset for Update action rule config form info message

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -90,7 +90,7 @@ jobs:
                   echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
 
             - name: 🔆 Cache pnpm modules
-              uses: actions/cache@v3
+              uses: actions/cache@v2
               id: pnpm-cache
               with:
                   path: ${{ steps.get-pnpm-cache-dir.outputs.pnpm_cache_dir }}
@@ -154,7 +154,7 @@ jobs:
 
             - name: 💾 Cache local Maven repository
               id: cache-maven-m2
-              uses: actions/cache@v3
+              uses: actions/cache@v2
               with:
                   path: ~/.m2/repository
                   key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
### Purpose
This PR reverts the GitHub action cache version to v2 due to continuous failures in console releases.