### PR TITLE
Improve user profiles to add existing primary to verified list when attribute verification enabled

### DIFF
--- a/.changeset/neat-spies-ring.md
+++ b/.changeset/neat-spies-ring.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/myaccount": patch
+---
+
+Improve my account and console user profiles to add existing primary to verified list, when verification enabled

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -1005,6 +1005,23 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                     }
                 });
             }
+
+            if (isEmailVerificationEnabled) {
+                const existingVerifiedEmails: string[] =
+                    profileInfo.get(VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE)?.split(",") || [];
+
+                if (existingPrimaryEmail && !existingVerifiedEmails.includes(existingPrimaryEmail)) {
+                    existingVerifiedEmails.push(existingPrimaryEmail);
+                    data.Operations.push({
+                        op: "replace",
+                        value: {
+                            [schema.schemaId]: {
+                                [VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE]: existingVerifiedEmails
+                            }
+                        }
+                    });
+                }
+            }
         } else if (schema.name === MOBILE_NUMBERS_ATTRIBUTE) {
 
             const filteredSubAttributes: MultiValue[] = extractSubAttributes(
@@ -1034,6 +1051,23 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                         }
                     }
                 });
+            }
+
+            if (isMobileVerificationEnabled) {
+                const existingVerifiedMobiles: string[] =
+                    profileInfo.get(VERIFIED_MOBILE_NUMBERS_ATTRIBUTE)?.split(",") || [];
+
+                if (existingPrimaryMobile && !existingVerifiedMobiles.includes(existingPrimaryMobile)) {
+                    existingVerifiedMobiles.push(existingPrimaryMobile);
+                    data.Operations.push({
+                        op: "replace",
+                        value: {
+                            [schema.schemaId]: {
+                                [VERIFIED_MOBILE_NUMBERS_ATTRIBUTE]: existingVerifiedMobiles
+                            }
+                        }
+                    });
+                }
             }
         }
         updateProfileInfo(data as unknown as Record<string, unknown>).then((response: AxiosResponse) => {

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -638,8 +638,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                 let verifiedValues: string[] = [];
 
                 if (schema.name === EMAIL_ADDRESSES_ATTRIBUTE) {
-                    primaryValue = profileDetails.profileInfo?.emails?.find(
-                        (subAttribute: string) => typeof subAttribute === "string");
+                    primaryValue = getExistingPrimaryEmail();
                     isVerificationEnabled = isEmailVerificationEnabled;
                     verifiedAttributeName = VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE;
                     verifiedValues = profileInfo.get(VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE)?.split(",") || [];
@@ -2473,7 +2472,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
      */
     const getSchemaFromName = (schemaName: string): ProfileSchema => {
 
-        return profileSchema.find((schema: ProfileSchema) => schema.name === schemaName);
+        return profileSchema?.find((schema: ProfileSchema) => schema.name === schemaName);
     };
 
     /**

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -1161,10 +1161,33 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                     }
                 });
             }
+
+            if (isEmailVerificationEnabled) {
+                const verifiedEmailList: string[]
+                    = profileInfo?.get(VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE)?.split(",") || [];
+                const updatedVerifiedEmailList: string[] =
+                    verifiedEmailList.filter((email: string) => email !== attributeValue);
+
+                data.Operations.push({
+                    op: "replace",
+                    value: {
+                        [schema.schemaId] : {
+                            [EMAIL_ADDRESSES_ATTRIBUTE]: updatedEmailList,
+                            [VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE]: updatedVerifiedEmailList
+                        }
+                    }
+                });
+            }
         } else if (schema.name === MOBILE_NUMBERS_ATTRIBUTE) {
             const mobileList: string[] = profileInfo?.get(MOBILE_NUMBERS_ATTRIBUTE)?.split(",") || [];
             const updatedMobileList: string[] = mobileList.filter((mobile: string) => mobile !== attributeValue);
             const primaryMobile: string = profileInfo.get(MOBILE_ATTRIBUTE);
+
+            data.Operations[0].value = {
+                [schema.schemaId]: {
+                    [MOBILE_NUMBERS_ATTRIBUTE]: updatedMobileList
+                }
+            };
 
             if (attributeValue === primaryMobile) {
                 const filteredSubAttributes: MultiValue[] = extractSubAttributes(
@@ -1185,11 +1208,21 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                 });
             }
 
-            data.Operations[0].value = {
-                [schema.schemaId]: {
-                    [MOBILE_NUMBERS_ATTRIBUTE]: updatedMobileList
-                }
-            };
+            if (isMobileVerificationEnabled) {
+                const verifiedMobileList: string[] =
+                    profileInfo?.get(VERIFIED_MOBILE_NUMBERS_ATTRIBUTE)?.split(",") || [];
+                const verifiedUpdatedMobileList: string[] =
+                    verifiedMobileList.filter((mobile: string) => mobile !== attributeValue);
+
+                data.Operations.push({
+                    op: "replace",
+                    value: {
+                        [schema.schemaId] : {
+                            [VERIFIED_MOBILE_NUMBERS_ATTRIBUTE]: verifiedUpdatedMobileList
+                        }
+                    }
+                });
+            }
         }
         updateProfileInfo(data as unknown as Record<string, unknown>).then((response: AxiosResponse) => {
             if (response.status === 200) {

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -701,8 +701,8 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
             } else if (schemaNames.length === 1) {
                 // List of sub attributes.
                 const subValue: string[] = profileDetails.profileInfo[schemaNames[0]]
-                    && profileDetails.profileInfo[schemaNames[0]]
-                        .filter((subAttribute: string) => typeof subAttribute === "object");
+                    && profileDetails.profileInfo[schemaNames[0]]?.filter(
+                        (subAttribute: string) => typeof subAttribute === "object");
 
                 if (subValue && subValue.length > 0) {
                     subValue.map((value: string) => {
@@ -732,10 +732,10 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
 
                 // The primary value of the email attribute.
                 if (schemaNames[0] === "emails" && profileDetails?.profileInfo[schemaNames[0]]) {
-                    primaryValue = profileDetails.profileInfo[schemaNames[0]]
-                        && profileDetails.profileInfo[schemaNames[0]]
-                            .find((subAttribute: string) => typeof subAttribute === "string");
-                    attributeValues.push(primaryValue);
+                    primaryValue = getExistingPrimaryEmail();
+                    if (primaryValue) {
+                        attributeValues.push(primaryValue);
+                    }
                 }
 
                 // List of sub attributes.

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -1006,8 +1006,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                 ]
             };
 
-            const existingPrimaryEmail: string = profileDetails.profileInfo?.emails?.find(
-                (subAttribute: string) => typeof subAttribute === "string");
+            const existingPrimaryEmail: string = getExistingPrimaryEmail();
             const existingEmailList: string[] = profileInfo?.get(EMAIL_ADDRESSES_ATTRIBUTE)?.split(",") || [];
 
             if (existingPrimaryEmail && !existingEmailList.includes(existingPrimaryEmail)) {
@@ -1138,8 +1137,7 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
         if (schema.name === EMAIL_ADDRESSES_ATTRIBUTE) {
             const emailList: string[] = profileInfo?.get(EMAIL_ADDRESSES_ATTRIBUTE)?.split(",") || [];
             const updatedEmailList: string[] = emailList.filter((email: string) => email !== attributeValue);
-            const primaryEmail: string = profileDetails?.profileInfo?.emails?.find(
-                (subAttribute: string) => typeof subAttribute === "string");
+            const primaryEmail: string = getExistingPrimaryEmail();
 
             data.Operations[0].value = {
                 [schema.schemaId] : {
@@ -1595,8 +1593,9 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
     };
 
     const getExistingPrimaryEmail = (): string => {
-        return profileDetails.profileInfo[EMAIL_ATTRIBUTE] &&
-            profileDetails.profileInfo[EMAIL_ATTRIBUTE]
+        return profileDetails.profileInfo[EMAIL_ATTRIBUTE]
+            && Array.isArray(profileDetails.profileInfo[EMAIL_ATTRIBUTE])
+            && profileDetails.profileInfo[EMAIL_ATTRIBUTE]
                 .find((subAttribute: string) => typeof subAttribute === "string");
     };
 

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -1172,7 +1172,6 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
                     op: "replace",
                     value: {
                         [schema.schemaId] : {
-                            [EMAIL_ADDRESSES_ATTRIBUTE]: updatedEmailList,
                             [VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE]: updatedVerifiedEmailList
                         }
                     }
@@ -1211,14 +1210,14 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
             if (isMobileVerificationEnabled) {
                 const verifiedMobileList: string[] =
                     profileInfo?.get(VERIFIED_MOBILE_NUMBERS_ATTRIBUTE)?.split(",") || [];
-                const verifiedUpdatedMobileList: string[] =
+                const updatedVerifiedMobileList: string[] =
                     verifiedMobileList.filter((mobile: string) => mobile !== attributeValue);
 
                 data.Operations.push({
                     op: "replace",
                     value: {
                         [schema.schemaId] : {
-                            [VERIFIED_MOBILE_NUMBERS_ATTRIBUTE]: verifiedUpdatedMobileList
+                            [VERIFIED_MOBILE_NUMBERS_ATTRIBUTE]: updatedVerifiedMobileList
                         }
                     }
                 });

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -911,7 +911,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
 
     const handleVerifiedMobileNumbers = (data: PatchRoleDataInterface): void => {
         const verifiedAttributeSchema: ProfileSchemaInterface | undefined = profileSchema.find(
-            (schema: ProfileSchemaInterface) => schema.name === VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE
+            (schema: ProfileSchemaInterface) => schema.name === VERIFIED_MOBILE_NUMBERS_ATTRIBUTE
         );
 
         if (!isMultipleEmailAndMobileNumberEnabled

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -1711,6 +1711,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         let attributeValueList: string[] = [];
         let verifiedAttributeValueList: string[] = [];
         let primaryAttributeValue: string = "";
+        let fetchedPrimaryAttributeValue: string = "";
         let verificationEnabled: boolean = false;
         let primaryAttributeSchema: ProfileSchemaInterface;
         let maxAllowedLimit: number = 0;
@@ -1719,6 +1720,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             attributeValueList = multiValuedAttributeValues[EMAIL_ADDRESSES_ATTRIBUTE] ?? [];
             verifiedAttributeValueList = profileInfo?.get(VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE)?.split(",") ?? [];
             primaryAttributeValue = primaryValues[EMAIL_ATTRIBUTE];
+            fetchedPrimaryAttributeValue = profileInfo?.get(EMAIL_ATTRIBUTE);
             verificationEnabled = configSettings?.isEmailVerificationEnabled === "true";
             primaryAttributeSchema = profileSchema.find((schema: ProfileSchemaInterface) =>
                 schema.name === EMAIL_ATTRIBUTE);
@@ -1728,6 +1730,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             attributeValueList = multiValuedAttributeValues[MOBILE_NUMBERS_ATTRIBUTE] ?? [];
             verifiedAttributeValueList = profileInfo?.get(VERIFIED_MOBILE_NUMBERS_ATTRIBUTE)?.split(",") ?? [];
             primaryAttributeValue = primaryValues[MOBILE_ATTRIBUTE];
+            fetchedPrimaryAttributeValue = profileInfo?.get(MOBILE_ATTRIBUTE);
             verificationEnabled = configSettings?.isMobileVerificationEnabled === "true"
                 || configSettings?.isMobileVerificationByPrivilegeUserEnabled === "true";
             primaryAttributeSchema = profileSchema.find((schema: ProfileSchemaInterface) =>
@@ -1739,7 +1742,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
 
         const showVerifiedPopup = (value: string): boolean => {
             return verificationEnabled &&
-                (verifiedAttributeValueList.includes(value) || value === primaryAttributeValue);
+                (verifiedAttributeValueList.includes(value) || value === fetchedPrimaryAttributeValue);
         };
 
         const showPrimaryPopup = (value: string): boolean => {

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -1746,6 +1746,10 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         };
 
         const showPrimaryPopup = (value: string): boolean => {
+            if (verificationEnabled && !verifiedAttributeValueList.includes(value)) {
+                return value === fetchedPrimaryAttributeValue;
+            }
+
             return value === primaryAttributeValue;
         };
 

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -97,6 +97,7 @@ import {
 import "./user-profile.scss";
 import {
     constructPatchOpValueForMultiValuedAttribute,
+    constructPatchOperationForMultiValuedVerifiedAttribute,
     getDisplayOrder,
     isMultipleEmailsAndMobileNumbersEnabled
 } from "../utils/user-management-utils";
@@ -871,6 +872,38 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         }
     };
 
+    const handleVerifiedEmailAddresses = (data: PatchRoleDataInterface): void => {
+        if (!isMultipleEmailAndMobileNumberEnabled || configSettings?.isEmailVerificationEnabled !== "true") return;
+
+        const verifiedAttributeValueList: string[]
+            = profileInfo?.get(VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE)?.split(",") ?? [];
+        const operation: ScimOperationsInterface = constructPatchOperationForMultiValuedVerifiedAttribute({
+            primaryValue: profileInfo?.get(EMAIL_ATTRIBUTE),
+            profileSchema,
+            valueList: multiValuedAttributeValues[EMAIL_ADDRESSES_ATTRIBUTE],
+            verifiedAttrSchemaName: VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE,
+            verifiedValueList: verifiedAttributeValueList
+        });
+
+        data.Operations.push(operation);
+    };
+
+    const handleVerifiedMobileNumbers = (data: PatchRoleDataInterface): void => {
+        if (!isMultipleEmailAndMobileNumberEnabled || configSettings?.isMobileVerificationEnabled !== "true") return;
+
+        const verifiedAttributeValueList: string[]
+            = profileInfo?.get(VERIFIED_MOBILE_NUMBERS_ATTRIBUTE)?.split(",") ?? [];
+        const operation: ScimOperationsInterface = constructPatchOperationForMultiValuedVerifiedAttribute({
+            primaryValue: profileInfo?.get(MOBILE_ATTRIBUTE),
+            profileSchema,
+            valueList: multiValuedAttributeValues[MOBILE_NUMBERS_ATTRIBUTE],
+            verifiedAttrSchemaName: VERIFIED_MOBILE_NUMBERS_ATTRIBUTE,
+            verifiedValueList: verifiedAttributeValueList
+        });
+
+        data.Operations.push(operation);
+    };
+
     /**
      * The following method handles the `onSubmit` event of forms.
      *
@@ -890,6 +923,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
 
         if (isMultipleEmailAndMobileNumberEnabled) {
             handlePrimaryEmailAndMobile(values);
+            handleVerifiedEmailAddresses(data);
+            handleVerifiedMobileNumbers(data);
         }
 
         if (adminUserType === AdminAccountTypes.INTERNAL) {

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -885,6 +885,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             verifiedValueList: verifiedAttributeValueList
         });
 
+        if (!operation) return;
         data.Operations.push(operation);
     };
 
@@ -901,6 +902,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             verifiedValueList: verifiedAttributeValueList
         });
 
+        if (!operation) return;
         data.Operations.push(operation);
     };
 

--- a/features/admin.users.v1/utils/user-management-utils.ts
+++ b/features/admin.users.v1/utils/user-management-utils.ts
@@ -357,13 +357,9 @@ export const constructPatchOperationForMultiValuedVerifiedAttribute = ({
     }): ScimOperationsInterface => {
     const modifiedVerifiedList: string[] = cloneDeep(verifiedValueList);
 
-    if (
-        !isEmpty(primaryValue) &&
-      !verifiedValueList.includes(primaryValue) &&
-      valueList?.includes(primaryValue)
-    ) {
-        modifiedVerifiedList.push(primaryValue);
-    }
+    if (isEmpty(primaryValue) || verifiedValueList.includes(primaryValue) || !valueList?.includes(primaryValue)) return;
+
+    modifiedVerifiedList.push(primaryValue);
 
     const verifiedSchema: ProfileSchemaInterface | undefined = profileSchema.find(
         (schema: ProfileSchemaInterface) => schema.name === verifiedAttrSchemaName


### PR DESCRIPTION
### Purpose
- Add existing primary value to verified values when a new value is added or when the primary changes.

### Checklist

- [x] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [x] Documentation provided. (Add links if there are any)
- [x] Relevant backend changes deployed and verified
- [x] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [x] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
