### PR TITLE
Remove Access Token attributes from M2M

### DIFF
--- a/.changeset/new-tomatoes-decide.md
+++ b/.changeset/new-tomatoes-decide.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+remove AT attributes from M2m

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -2730,7 +2730,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                                 readOnly={ readOnly }
                                 data-testid={ `${ testId }-access-token-type-radio-group` }
                             />
-                            { isJWTAccessTokenTypeSelected &&
+                            { isJWTAccessTokenTypeSelected && !isM2MApplication &&
                                 isFeatureEnabled(applicationFeatureConfig, "applications.accessTokenAttributes") ? (
                                     <Grid.Row>
                                         <Grid.Column width={ 8 }>


### PR DESCRIPTION
### Purpose
Access token attributes section is enabled for M2M app but it shouldn't

https://github.com/user-attachments/assets/fc6511b1-35d6-4b60-8fce-f6179d287950


### Related Issues
https://github.com/wso2/product-is/issues/23257

### Checklist


- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
