### PR TITLE
Show SCIM2 custom schema tab by default

### DIFF
--- a/.changeset/violet-spiders-change.md
+++ b/.changeset/violet-spiders-change.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.claims.v1": patch
+---
+
+Show SCIM2 custom schema tab by default

--- a/features/admin.claims.v1/components/edit/external-dialect/edit-external-claims.tsx
+++ b/features/admin.claims.v1/components/edit/external-dialect/edit-external-claims.tsx
@@ -294,10 +294,10 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
         setFilteredClaims(claims);
     };
 
-    const handleAttributesSubmit = async (claims: AddExternalClaim[]): Promise<void> => {
+    const handleAttributesSubmit = (claims: AddExternalClaim[]): void => {
 
         setIsSubmitting(true);
-        const dialectPromise: Promise<string> = dialectID
+        const resolvedDialectIDPromise: Promise<string> = dialectID
             ? Promise.resolve(dialectID)
             : addDialect(attributeUri)
                 .then(() => {
@@ -317,7 +317,7 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
                     return currentDialect.id;
                 });
 
-        dialectPromise.then((resolvedDialectID: string) => {
+        resolvedDialectIDPromise.then((resolvedDialectID: string) => {
             const addAttributesRequests: Promise<AddExternalClaim>[] = claims.map((claim: AddExternalClaim) => {
                 return addExternalClaim(resolvedDialectID, {
                     claimURI: claim.claimURI,
@@ -325,7 +325,7 @@ export const EditExternalClaims: FunctionComponent<EditExternalClaimsPropsInterf
                 });
             });
 
-            return Promise.all(addAttributesRequests);
+            Promise.all(addAttributesRequests);
         }).then(() => {
             dispatch(addAlert(
                 {

--- a/features/admin.claims.v1/pages/attribute-mappings.tsx
+++ b/features/admin.claims.v1/pages/attribute-mappings.tsx
@@ -83,10 +83,12 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
         const [ dialects, setDialects ] = useState<ClaimDialect[]>(null);
         const [ mappedLocalclaims, setMappedLocalClaims ] = useState<string[]>([]);
         const [ triggerFetchMappedClaims, setTriggerFetchMappedClaims ] = useState<boolean>(true);
+        const [ triigerFetchDialects, setTriggerFetchDialects ] = useState<boolean>(true);
 
         useEffect(() => {
             getDialect();
-        }, []);
+            setTriggerFetchDialects(false);
+        }, [ triigerFetchDialects ]);
 
         useEffect(() => {
             if ( dialects && dialects.length > 0 && triggerFetchMappedClaims ) {
@@ -424,6 +426,7 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                             attributeType={ type }
                                             mappedLocalClaims={ mappedLocalclaims }
                                             updateMappedClaims={ setTriggerFetchMappedClaims }
+                                            updateDialects={ setTriggerFetchDialects }
                                             isAttributeButtonEnabled={ tab.isAttributeButtonEnabled }
                                             attributeButtonText= { t(tab.attributeButtonText) }
                                         />
@@ -438,25 +441,24 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                         dialect.dialectURI === userSchemaURI
                     );
 
-                    if (dialect) {
-                        panes.push({
-                            menuItem: "Custom Schema",
-                            render: () => (
-                                <ResourceTab.Pane controlledSegmentation attached={ false }>
-                                    <ExternalDialectEditPage
-                                        id={ dialect.id }
-                                        attributeType={ type }
-                                        attributeUri={ dialect.dialectURI }
-                                        mappedLocalClaims={ mappedLocalclaims }
-                                        updateMappedClaims={ setTriggerFetchMappedClaims }
-                                        isAttributeButtonEnabled={ true }
-                                        attributeButtonText=
-                                            { t("claims:external.pageLayout.edit.attributePrimaryAction") }
-                                    />
-                                </ResourceTab.Pane>
-                            )
-                        });
-                    }
+                    panes.push({
+                        menuItem: "Custom Schema",
+                        render: () => (
+                            <ResourceTab.Pane controlledSegmentation attached={ false }>
+                                <ExternalDialectEditPage
+                                    id={ dialect?.id }
+                                    attributeType={ type }
+                                    attributeUri={ userSchemaURI }
+                                    mappedLocalClaims={ mappedLocalclaims }
+                                    updateMappedClaims={ setTriggerFetchMappedClaims }
+                                    updateDialects={ setTriggerFetchDialects }
+                                    isAttributeButtonEnabled={ true }
+                                    attributeButtonText=
+                                        { t("claims:external.pageLayout.edit.attributePrimaryAction") }
+                                />
+                            </ResourceTab.Pane>
+                        )
+                    });
                 }
 
                 return panes;
@@ -486,6 +488,7 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                         attributeType={ type }
                                         mappedLocalClaims={ mappedLocalclaims }
                                         updateMappedClaims={ setTriggerFetchMappedClaims }
+                                        updateDialects={ setTriggerFetchDialects }
                                         isAttributeButtonEnabled={ tab.isAttributeButtonEnabled }
                                         attributeButtonText= { tab.attributeButtonText }
                                     />
@@ -509,6 +512,7 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                                 attributeUri={ dialect.dialectURI }
                                 mappedLocalClaims={ mappedLocalclaims }
                                 updateMappedClaims={ setTriggerFetchMappedClaims }
+                                updateDialects={ setTriggerFetchDialects }
                                 isAttributeButtonEnabled={ true }
                                 attributeButtonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
                             />
@@ -542,6 +546,7 @@ export const AttributeMappings: FunctionComponent<RouteChildrenProps<AttributeMa
                         attributeUri={ dialects &&  dialects[ 0 ]?.dialectURI }
                         mappedLocalClaims={ mappedLocalclaims }
                         updateMappedClaims={ setTriggerFetchMappedClaims }
+                        updateDialects={ setTriggerFetchDialects }
                         isAttributeButtonEnabled={ true }
                         attributeButtonText= { t("claims:external.pageLayout.edit.attributePrimaryAction") }
                     />

--- a/features/admin.claims.v1/pages/external-dialect-edit.tsx
+++ b/features/admin.claims.v1/pages/external-dialect-edit.tsx
@@ -188,15 +188,6 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
             });
     };
 
-    useEffect(() => {
-        if (!dialectId) {
-            setDialect(null);
-
-            return;
-        }
-        getDialect();
-    }, [ dialectId ]);
-
     /**
      * Fetch external claims.
      *
@@ -251,10 +242,12 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
 
     useEffect(() => {
         if (!dialectId) {
+            setDialect(null);
             setClaims(undefined);
 
             return;
         }
+        getDialect();
         getExternalClaims();
     }, [ dialectId ]);
 

--- a/features/admin.claims.v1/pages/external-dialect-edit.tsx
+++ b/features/admin.claims.v1/pages/external-dialect-edit.tsx
@@ -76,6 +76,10 @@ interface ExternalDialectEditPageInterface extends TestableComponentInterface {
      * Update mapped claims on delete or edit
      */
     updateMappedClaims?: ReactDispatch<SetStateAction<boolean>>;
+    /**
+     * Update dialects on add
+     */
+    updateDialects?: ReactDispatch<SetStateAction<boolean>>;
 }
 
 /**
@@ -94,6 +98,7 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
         isAttributeButtonEnabled,
         attributeButtonText,
         updateMappedClaims,
+        updateDialects,
         [ "data-testid" ]: testId,
         id: dialectId
     } = props;
@@ -184,7 +189,12 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
     };
 
     useEffect(() => {
-        dialectId && getDialect();
+        if (!dialectId) {
+            setDialect(null);
+
+            return;
+        }
+        getDialect();
     }, [ dialectId ]);
 
     /**
@@ -240,6 +250,11 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
     };
 
     useEffect(() => {
+        if (!dialectId) {
+            setClaims(undefined);
+
+            return;
+        }
         getExternalClaims();
     }, [ dialectId ]);
 
@@ -347,6 +362,7 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
                 attributeUri={ attributeUri }
                 mappedLocalClaims={ mappedLocalClaims }
                 updateMappedClaims={ updateMappedClaims }
+                updateDialects={ updateDialects }
                 isAttributeButtonEnabled={ isAttributeButtonEnabled }
                 attributeButtonText={ attributeButtonText }
             />
@@ -355,6 +371,7 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
 
             {
                 attributeConfig.attributeMappings.showDangerZone
+                && dialect?.id
                 && !ClaimManagementConstants.SYSTEM_DIALECTS.includes(dialect?.id)
                 && (
                     <Grid>


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Shows the Custom Schema tab in SCIM 2 view by default, even if the custom dialect is not created. This provides the option to create a custom SCIM attribute without having to add a local attribute.

Before

https://github.com/user-attachments/assets/b765cb5d-6ab8-40b9-bb0d-579547f17c70


After

https://github.com/user-attachments/assets/530b5432-4b35-4817-8598-b6d067dcad53



### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/23273

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
