### PR TITLE
Change dynamic connector route order id

### DIFF
--- a/.changeset/new-pillows-stare.md
+++ b/.changeset/new-pillows-stare.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change dynamicConnector route order id

--- a/apps/console/src/configs/routes.tsx
+++ b/apps/console/src/configs/routes.tsx
@@ -1142,7 +1142,7 @@ export const getAppViewRoutes = (): RouteInterface[] => {
             },
             id: "dynamicConnector",
             name: "Dynamic Connector",
-            order: 24,
+            order: 998,
             path: AppConstants.getPaths()
                 .get("GOVERNANCE_CONNECTOR_EDIT"),
             protected: true,


### PR DESCRIPTION
### Purpose

- `dynamicConnector` route is disabled in the side panel
- Hence changing its order to a value where it doesnt affect other feature routes in scenarios like in the related issue


### Related Issue
- https://github.com/wso2/product-is/issues/23281