### PR TITLE
Set readOnly state to few fields in Pre Update Password Action UI

### DIFF
--- a/.changeset/shaggy-penguins-tie.md
+++ b/.changeset/shaggy-penguins-tie.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.actions.v1": patch
+---
+
+Fix disabled state of few fields in pre update password action ui

--- a/features/admin.actions.v1/components/certificate/action-certificate-list.tsx
+++ b/features/admin.actions.v1/components/certificate/action-certificate-list.tsx
@@ -71,6 +71,10 @@ interface ActionCertificatesPropsListInterface extends IdentifiableComponentInte
      * The ID of the action.
      */
     actionId: string;
+    /**
+     * Indicates if the form is in read only mode.
+     */
+    readOnly?: boolean;
 }
 
 /**
@@ -87,6 +91,7 @@ export const ActionCertificatesListComponent: FunctionComponent<ActionCertificat
     isCreateFormState,
     actionTypeApiPath,
     actionId,
+    readOnly,
     [ "data-componentid" ]: _componentId = "action-certificate-list"
 }: ActionCertificatesPropsListInterface ): ReactElement => {
 
@@ -328,6 +333,7 @@ export const ActionCertificatesListComponent: FunctionComponent<ActionCertificat
                                                     {
                                                         "data-componentid": `${ _componentId }-edit-cert-${ index }
                                                         -button`,
+                                                        disabled: readOnly,
                                                         icon: "pencil",
                                                         onClick: () => setShowWizard(true),
                                                         popupText: t("actions:fields.passwordSharing.certificate"+
@@ -348,6 +354,7 @@ export const ActionCertificatesListComponent: FunctionComponent<ActionCertificat
                                                     {
                                                         "data-componentid": `${ _componentId }-delete-cert-${ index }
                                                         -button`,
+                                                        disabled: readOnly,
                                                         icon: "trash alternate",
                                                         onClick: handleDeleteCertificate,
                                                         popupText: t("actions:fields.passwordSharing.certificate"+
@@ -402,6 +409,7 @@ export const ActionCertificatesListComponent: FunctionComponent<ActionCertificat
                                 variant="outlined"
                                 size="small"
                                 className={ "secondary-button" }
+                                disabled={ readOnly }
                             >
                                 { t("actions:buttons.addCertificate") }
                             </Button>

--- a/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
@@ -330,6 +330,7 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
                         ]
                     }
                     clearable={ true }
+                    disabled={ getFieldDisabledStatus() }
                 />
                 <FormLabel className="certificate-label" >
                     { t("actions:fields.passwordSharing.certificate.label") }
@@ -345,6 +346,7 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
                     certificate={ PEMValue }
                     actionTypeApiPath={ actionTypeApiPath }
                     actionId={ initialValues?.id }
+                    readOnly={ getFieldDisabledStatus() }
                 />
                 { RuleExpressionsMetaData && showRuleComponent && (
                     <RuleConfigForm

--- a/features/admin.actions.v1/components/rule-config-form.tsx
+++ b/features/admin.actions.v1/components/rule-config-form.tsx
@@ -98,19 +98,18 @@ const RuleConfigForm: FunctionComponent<RuleConfigFormInterface> = ({
                             <Code key="refresh_token">refresh_token</Code>
                         ] }
                     />
-                    { !readonly && (
-                        <div>
-                            <Button
-                                onClick={ () => setIsHasRule(true) }
-                                variant="outlined"
-                                size="small"
-                                className={ "secondary-button" }
-                                data-componentid={ `${ _componentId }-configure-rule-button` }
-                            >
-                                { t("actions:fields.rules.button") }
-                            </Button>
-                        </div>
-                    ) }
+                    <div>
+                        <Button
+                            onClick={ () => setIsHasRule(true) }
+                            variant="outlined"
+                            size="small"
+                            className={ "secondary-button" }
+                            data-componentid={ `${ _componentId }-configure-rule-button` }
+                            disabled={ readonly }
+                        >
+                            { t("actions:fields.rules.button") }
+                        </Button>
+                    </div>
                 </Alert>
             ) }
         </>


### PR DESCRIPTION
### Purpose
> $subject

Previous behaviour for user with view permission
<img width="1799" alt="image" src="https://github.com/user-attachments/assets/4041aa3e-b83b-4b11-91d9-98ff0841dfae" />

New behaviour for user with view permission
<img width="1800" alt="image" src="https://github.com/user-attachments/assets/c04c5fbc-05ad-4ecf-9ed7-b7c62b629937" />

