### PR TITLE
Disable policy edit button in the active policy list in Policy Administration page

### DIFF
--- a/.changeset/silver-years-tie.md
+++ b/.changeset/silver-years-tie.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.policy-administration.v1": patch
+"@wso2is/i18n": patch
+---
+
+Disable policy edit button in the active policy list in Policy Administration page and change tooltip text

--- a/features/admin.policy-administration.v1/components/policy-list-draggable-node.tsx
+++ b/features/admin.policy-administration.v1/components/policy-list-draggable-node.tsx
@@ -20,8 +20,6 @@ import Card from "@oxygen-ui/react/Card";
 import CardContent from "@oxygen-ui/react/CardContent";
 import Stack from "@oxygen-ui/react/Stack";
 import Typography from "@oxygen-ui/react/Typography";
-import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
-import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import React, { FunctionComponent, HTMLAttributes, ReactElement } from "react";
@@ -66,10 +64,6 @@ const PolicyListDraggableNode: FunctionComponent<PolicyListDraggableNodePropsInt
 }: PolicyListDraggableNodePropsInterface): ReactElement => {
     const { t } = useTranslation();
     const dispatch: Dispatch = useDispatch();
-
-    const handleEdit = (policyId: string) => {
-        history.push(`${AppConstants.getPaths().get("EDIT_POLICY").replace(":id", btoa(policyId))}`);
-    };
 
     const handleDelete = async (): Promise<void> => {
         try {
@@ -135,17 +129,17 @@ const PolicyListDraggableNode: FunctionComponent<PolicyListDraggableNodePropsInt
                         <Popup
                             trigger={ (
                                 <Icon
-                                    link={ true }
-                                    onClick={ () => handleEdit(policy.policyId) }
+                                    link={ false }
                                     data-componentid={ `${componentId}-edit-button` }
                                     className="list-icon"
                                     size="small"
                                     color="grey"
                                     name="pencil alternate"
+                                    disabled={ true }
                                 />
                             ) }
                             position="top center"
-                            content={ t("common:edit") }
+                            content={ t("Deactivate Policy to Edit") }
                             inverted
                         />
                         <Popup

--- a/features/admin.policy-administration.v1/components/policy-list-draggable-node.tsx
+++ b/features/admin.policy-administration.v1/components/policy-list-draggable-node.tsx
@@ -139,7 +139,7 @@ const PolicyListDraggableNode: FunctionComponent<PolicyListDraggableNodePropsInt
                                 />
                             ) }
                             position="top center"
-                            content={ t("Deactivate Policy to Edit") }
+                            content={ t("policyAdministration:editPolicy.disabledBtnTooltip") }
                             inverted
                         />
                         <Popup

--- a/modules/i18n/src/models/namespaces/policy-administration-ns.ts
+++ b/modules/i18n/src/models/namespaces/policy-administration-ns.ts
@@ -25,6 +25,7 @@ export interface policyAdministrationNS {
    };
     editPolicy: {
         backBtn: string;
+        disabledBtnTooltip: string;
     };
     createPolicy: {
         title: string;

--- a/modules/i18n/src/translations/en-US/portals/policy-administration.ts
+++ b/modules/i18n/src/translations/en-US/portals/policy-administration.ts
@@ -86,7 +86,7 @@ export const policyAdministration: policyAdministrationNS = {
     },
     editPolicy: {
         backBtn: "Go back to Policy Administration ",
-        disabledBtnTooltip: "Deactivate to Edit"
+        disabledBtnTooltip: "You need to deactivate this policy to enable editing."
     },
     inactivePoliciesPlaceholder: {
         subtitle: "There are currently no inactive policies to display.",

--- a/modules/i18n/src/translations/en-US/portals/policy-administration.ts
+++ b/modules/i18n/src/translations/en-US/portals/policy-administration.ts
@@ -85,7 +85,8 @@ export const policyAdministration: policyAdministrationNS = {
         title: "Create Policy"
     },
     editPolicy: {
-        backBtn: "Go back to Policy Administration "
+        backBtn: "Go back to Policy Administration ",
+        disabledBtnTooltip: "Deactivate to Edit"
     },
     inactivePoliciesPlaceholder: {
         subtitle: "There are currently no inactive policies to display.",


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This PR disables the policy edit button in the active policy list in Policy Administration page


<img width="1440" alt="Screenshot 2025-03-03 at 16 06 05" src="https://github.com/user-attachments/assets/7d0cc5d0-5cb6-4d93-9c0e-46582806ca69" />

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/23337

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
