### PR TITLE
Minor bug fix for resolving governance connectors in user profile page

### DIFF
--- a/.changeset/small-timers-wink.md
+++ b/.changeset/small-timers-wink.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.users.v1": patch
+---
+
+Minor bug fix for resolving governance connectors in user profile page

--- a/features/admin.users.v1/components/user-change-password.tsx
+++ b/features/admin.users.v1/components/user-change-password.tsx
@@ -164,7 +164,8 @@ export const ChangePasswordComponent: FunctionComponent<ChangePasswordPropsInter
             return;
         }
 
-        if (governanceConnectorProperties === undefined) {
+        if (governanceConnectorProperties === undefined
+            || governanceConnectorProperties?.length !== connectorProperties?.length) {
             setGovernanceConnectorProperties(connectorProperties);
         }
     }, [ connectorProperties ]);


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

- `connectorProperties` prop get assigned to `governanceConnectorProperties` in user-change-password component.
- But since the connectorProperties are not loaded at once, it will not contain all the connectors in the initial rendering.
- Due to the logic in here[1], `governanceConnectorProperties` will not get updated once `connectorProperties` has a non-empty value.
- Hence added a logic to resolve that

[1] - https://github.com/wso2/identity-apps/blob/54229d3df446d94349dccebde2abf860813451f6/features/admin.users.v1/components/user-change-password.tsx#L167

<img width="1796" alt="Screenshot 2025-03-05 at 10 37 56 AM" src="https://github.com/user-attachments/assets/ce7e3a37-0da3-43ab-b6c6-564671be7560" />


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/23366
