### PR TITLE
Few improvements to action forms

### DIFF
--- a/.changeset/heavy-onions-move.md
+++ b/.changeset/heavy-onions-move.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.connections.v1": patch
+"@wso2is/admin.actions.v1": patch
+---
+
+Refactor action forms

--- a/features/admin.actions.v1/components/action-endpoint-config-form.tsx
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.tsx
@@ -24,14 +24,11 @@ import Divider from "@oxygen-ui/react/Divider";
 import InputAdornment from "@oxygen-ui/react/InputAdornment";
 import { SelectChangeEvent } from "@oxygen-ui/react/Select";
 import Typography from "@oxygen-ui/react/Typography";
-import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
-import { AppState } from "@wso2is/admin.core.v1/store";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { FinalFormField, FormSpy, SelectFieldAdapter, TextFieldAdapter } from "@wso2is/form/src";
 import { Hint } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { useSelector } from "react-redux";
 import { Icon } from "semantic-ui-react";
 import { ActionsConstants } from "../constants/actions-constants";
 import {
@@ -51,9 +48,9 @@ interface ActionEndpointConfigFormInterface extends IdentifiableComponentInterfa
      */
     isCreateFormState: boolean;
     /**
-     * Specifies whether to skip update permission checks
+     * Specifies whether the form is read-only.
      */
-    skipUpdatePermission?: boolean;
+    isReadOnly: boolean;
     /**
      * Callback function triggered when the authentication type is changed.
      *
@@ -66,39 +63,18 @@ interface ActionEndpointConfigFormInterface extends IdentifiableComponentInterfa
 const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterface> = ({
     initialValues,
     isCreateFormState,
-    skipUpdatePermission,
+    isReadOnly,
     onAuthenticationTypeChange,
     [ "data-componentid" ]: _componentId = "action-endpoint-config-form"
 }: ActionEndpointConfigFormInterface): ReactElement => {
 
-    const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
-        (state: AppState) => state.config.ui.features.actions);
     const [ authenticationType, setAuthenticationType ] = useState<AuthenticationType>(null);
     const [ isAuthenticationUpdateFormState, setIsAuthenticationUpdateFormState ] = useState<boolean>(false);
     const [ isShowSecret1, setIsShowSecret1 ] = useState<boolean>(false);
     const [ isShowSecret2, setIsShowSecret2 ] = useState<boolean>(false);
-    const hasActionUpdatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.update);
-    const hasActionCreatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.create);
     const [ isHttpEndpointUri, setIsHttpEndpointUri ] = useState<boolean>(false);
 
     const { t } = useTranslation();
-
-    const getFieldDisabledStatus = (): boolean => {
-        /**
-         * When skipUpdatePermission flag is set to true, all the fields are enabled.
-         * This is currently being used with custom authenticators to enable/disable
-         * form update based on connection specific permissions.
-         */
-        if (skipUpdatePermission) {
-            return false;
-        }
-
-        if (isCreateFormState) {
-            return !hasActionCreatePermissions;
-        } else {
-            return !hasActionUpdatePermissions;
-        }
-    };
 
     /**
      * The following useEffect is used to set the current Action Authentication Type.
@@ -183,7 +159,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                             size="small"
                             className={ "secondary-button" }
                             data-componentid={ `${_componentId}-change-authentication-button` }
-                            disabled={ getFieldDisabledStatus() }
+                            disabled={ isReadOnly }
                         >
                             { t("actions:buttons.changeAuthentication") }
                         </Button>
@@ -236,7 +212,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                         component={ TextFieldAdapter }
                                         maxLength={ 100 }
                                         minLength={ 0 }
-                                        disabled={ getFieldDisabledStatus() }
+                                        disabled={ isReadOnly }
                                     />
                                     <FinalFormField
                                         key="password"
@@ -262,7 +238,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                         component={ TextFieldAdapter }
                                         maxLength={ 100 }
                                         minLength={ 0 }
-                                        disabled={ getFieldDisabledStatus() }
+                                        disabled={ isReadOnly }
                                     />
                                 </>
                             );
@@ -294,7 +270,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                         component={ TextFieldAdapter }
                                         maxLength={ 100 }
                                         minLength={ 0 }
-                                        disabled={ getFieldDisabledStatus() }
+                                        disabled={ isReadOnly }
                                     />
                                 </>
                             );
@@ -327,7 +303,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                         component={ TextFieldAdapter }
                                         maxLength={ 100 }
                                         minLength={ 0 }
-                                        disabled={ getFieldDisabledStatus() }
+                                        disabled={ isReadOnly }
                                     />
                                     <FinalFormField
                                         key="value"
@@ -353,7 +329,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                         component={ TextFieldAdapter }
                                         maxLength={ 100 }
                                         minLength={ 0 }
-                                        disabled={ getFieldDisabledStatus() }
+                                        disabled={ isReadOnly }
                                     />
                                 </>
                             );
@@ -421,7 +397,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                 ]
                             }
                             onChange={ handleAuthTypeChange }
-                            disabled={ getFieldDisabledStatus() }
+                            disabled={ isReadOnly }
                         />
                         { renderAuthenticationPropertyFields() }
                     </>
@@ -476,7 +452,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                 component={ TextFieldAdapter }
                 maxLength={ 100 }
                 minLength={ 0 }
-                disabled={ getFieldDisabledStatus() }
+                disabled={ isReadOnly }
             />
             { isHttpEndpointUri && (
                 <Alert

--- a/features/admin.actions.v1/components/action-endpoint-config-form.tsx
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.tsx
@@ -478,15 +478,6 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                 minLength={ 0 }
                 disabled={ getFieldDisabledStatus() }
             />
-            <FormSpy
-                onChange={ ({ values }: { values: EndpointConfigFormPropertyInterface }) => {
-                    if (values?.endpointUri?.startsWith("http://")) {
-                        setIsHttpEndpointUri(true);
-                    } else {
-                        setIsHttpEndpointUri(false);
-                    }
-                } }
-            />
             { isHttpEndpointUri && (
                 <Alert
                     severity="warning"
@@ -505,6 +496,58 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                 { t("actions:fields.authentication.label") }
             </Typography>
             { renderAuthenticationSection() }
+            <FormSpy
+                onChange={ ({ values }: { values: EndpointConfigFormPropertyInterface }) => {
+                    if (values?.endpointUri?.startsWith("http://")) {
+                        setIsHttpEndpointUri(true);
+                    } else {
+                        setIsHttpEndpointUri(false);
+                    }
+
+                    if (isAuthenticationUpdateFormState) {
+                        // Clear inputs of property field values of other authentication types.
+                        switch (authenticationType) {
+                            case AuthenticationType.BASIC:
+                                delete values.accessTokenAuthProperty;
+                                delete values.headerAuthProperty;
+                                delete values.valueAuthProperty;
+
+                                break;
+                            case AuthenticationType.BEARER:
+                                delete values.usernameAuthProperty;
+                                delete values.passwordAuthProperty;
+                                delete values.headerAuthProperty;
+                                delete values.valueAuthProperty;
+
+                                break;
+                            case AuthenticationType.API_KEY:
+                                delete values.usernameAuthProperty;
+                                delete values.passwordAuthProperty;
+                                delete values.accessTokenAuthProperty;
+
+                                break;
+                            case AuthenticationType.NONE:
+                                delete values.usernameAuthProperty;
+                                delete values.passwordAuthProperty;
+                                delete values.headerAuthProperty;
+                                delete values.valueAuthProperty;
+                                delete values.accessTokenAuthProperty;
+
+                                break;
+                            default:
+                                break;
+                        }
+                    } else {
+                        // Clear inputs of all property field values.
+                        values.authenticationType = initialValues?.authenticationType;
+                        delete values.usernameAuthProperty;
+                        delete values.passwordAuthProperty;
+                        delete values.headerAuthProperty;
+                        delete values.valueAuthProperty;
+                        delete values.accessTokenAuthProperty;
+                    }
+                } }
+            />
         </>
     );
 };

--- a/features/admin.actions.v1/components/common-action-config-form.tsx
+++ b/features/admin.actions.v1/components/common-action-config-form.tsx
@@ -16,14 +16,11 @@
  * under the License.
  */
 
-import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
-import { AppState } from "@wso2is/admin.core.v1/store";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { FinalFormField, TextFieldAdapter } from "@wso2is/form/src";
 import { Hint } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
-import { useSelector } from "react-redux";
 import ActionEndpointConfigForm from "./action-endpoint-config-form";
 import {
     ActionConfigFormPropertyInterface,
@@ -40,6 +37,10 @@ interface CommonActionConfigFormInterface extends IdentifiableComponentInterface
      */
     isCreateFormState: boolean;
     /**
+     * Specifies whether the form is read-only.
+     */
+    isReadOnly: boolean;
+    /**
      * Callback function triggered when the authentication type is changed.
      *
      * @param updatedValue - The new authentication type selected.
@@ -51,24 +52,12 @@ interface CommonActionConfigFormInterface extends IdentifiableComponentInterface
 const CommonActionConfigForm: FunctionComponent<CommonActionConfigFormInterface> = ({
     initialValues,
     isCreateFormState,
+    isReadOnly,
     onAuthenticationTypeChange,
     [ "data-componentid" ]: _componentId = "common-action-config-form"
 }: CommonActionConfigFormInterface): ReactElement => {
 
-    const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
-        (state: AppState) => state.config.ui.features.actions);
-    const hasActionUpdatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.update);
-    const hasActionCreatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.create);
-
     const { t } = useTranslation();
-
-    const getFieldDisabledStatus = (): boolean => {
-        if (isCreateFormState) {
-            return !hasActionCreatePermissions;
-        } else {
-            return !hasActionUpdatePermissions;
-        }
-    };
 
     return (
         <>
@@ -94,12 +83,13 @@ const CommonActionConfigForm: FunctionComponent<CommonActionConfigFormInterface>
                 component={ TextFieldAdapter }
                 maxLength={ 100 }
                 minLength={ 0 }
-                disabled={ getFieldDisabledStatus() }
+                disabled={ isReadOnly }
             />
             <ActionEndpointConfigForm
                 initialValues={ initialValues }
                 isCreateFormState={ isCreateFormState }
                 onAuthenticationTypeChange={ onAuthenticationTypeChange }
+                isReadOnly={ isReadOnly }
             />
         </>
     );

--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -26,7 +26,7 @@ import { RuleExecuteCollectionWithoutIdInterface, RuleWithoutIdInterface } from 
 import { RulesProvider } from "@wso2is/admin.rules.v1/providers/rules-provider";
 import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
-import { FinalForm, FormRenderProps, FormSpy } from "@wso2is/form";
+import { FinalForm, FormRenderProps } from "@wso2is/form";
 import { EmphasizedSegment } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
@@ -298,99 +298,33 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                         }
                         validate={ validateForm }
                         initialValues={ initialValues }
-                        render={ ({ handleSubmit, form }: FormRenderProps) => (
-                            <form onSubmit={ handleSubmit }>
-                                <EmphasizedSegment
-                                    className="form-wrapper"
-                                    padded="very"
-                                    data-componentid={ `${ _componentId }-section` }
-                                >
-                                    <div className="form-container with-max-width">
-                                        { renderFormFields() }
-                                        { !isLoading && (
-                                            <Button
-                                                size="medium"
-                                                variant="contained"
-                                                onClick={ handleSubmit }
-                                                className={ "button-container" }
-                                                data-componentid={ `${ _componentId }-primary-button` }
-                                                loading={ isSubmitting }
-                                                disabled={ getFieldDisabledStatus() }
-                                            >
-                                                {
-                                                    isCreateFormState
-                                                        ? t("actions:buttons.create")
-                                                        : t("actions:buttons.update")
-                                                }
-                                            </Button>
-                                        ) }
-                                    </div>
-                                </EmphasizedSegment>
-                                <FormSpy
-                                    subscription={ { values: true } }
-                                >
-                                    { ({ values }: { values: ActionConfigFormPropertyInterface }) => {
-                                        if (!isAuthenticationUpdateFormState) {
-                                            form.change("authenticationType",
-                                                initialValues?.authenticationType);
-                                            switch (authenticationType) {
-                                                case AuthenticationType.BASIC:
-                                                    delete values.usernameAuthProperty;
-                                                    delete values.passwordAuthProperty;
-
-                                                    break;
-                                                case AuthenticationType.BEARER:
-                                                    delete values.accessTokenAuthProperty;
-
-                                                    break;
-                                                case AuthenticationType.API_KEY:
-                                                    delete values.headerAuthProperty;
-                                                    delete values.valueAuthProperty;
-
-                                                    break;
-                                                default:
-                                                    break;
+                        render={ ({ handleSubmit }: FormRenderProps) => (
+                            <EmphasizedSegment
+                                className="form-wrapper"
+                                padded="very"
+                                data-componentid={ `${ _componentId }-section` }
+                            >
+                                <div className="form-container with-max-width">
+                                    { renderFormFields() }
+                                    { !isLoading && (
+                                        <Button
+                                            size="medium"
+                                            variant="contained"
+                                            onClick={ handleSubmit }
+                                            className={ "button-container" }
+                                            data-componentid={ `${ _componentId }-primary-button` }
+                                            loading={ isSubmitting }
+                                            disabled={ getFieldDisabledStatus() }
+                                        >
+                                            {
+                                                isCreateFormState
+                                                    ? t("actions:buttons.create")
+                                                    : t("actions:buttons.update")
                                             }
-                                        }
-
-                                        // Clear inputs of property field values of other authentication types.
-                                        switch (authenticationType) {
-                                            case AuthenticationType.BASIC:
-                                                delete values.accessTokenAuthProperty;
-                                                delete values.headerAuthProperty;
-                                                delete values.valueAuthProperty;
-
-                                                break;
-                                            case AuthenticationType.BEARER:
-                                                delete values.usernameAuthProperty;
-                                                delete values.passwordAuthProperty;
-                                                delete values.headerAuthProperty;
-                                                delete values.valueAuthProperty;
-
-                                                break;
-                                            case AuthenticationType.API_KEY:
-                                                delete values.usernameAuthProperty;
-                                                delete values.passwordAuthProperty;
-                                                delete values.accessTokenAuthProperty;
-
-                                                break;
-                                            case AuthenticationType.NONE:
-                                                delete values.usernameAuthProperty;
-                                                delete values.passwordAuthProperty;
-                                                delete values.headerAuthProperty;
-                                                delete values.valueAuthProperty;
-                                                delete values.accessTokenAuthProperty;
-
-                                                break;
-                                            default:
-
-                                                break;
-                                        }
-
-                                        return null;
-                                    } }
-                                </FormSpy>
-                            </form>
+                                        </Button>
+                                    ) }
+                                </div>
+                            </EmphasizedSegment>
                         ) }
                     >
                     </FinalForm>

--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -19,7 +19,7 @@
 import Box from "@oxygen-ui/react/Box";
 import Button from "@oxygen-ui/react/Button";
 import Skeleton from "@oxygen-ui/react/Skeleton";
-import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
+import { FeatureAccessConfigInterface } from "@wso2is/access-control";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import useGetRulesMeta from "@wso2is/admin.rules.v1/api/use-get-rules-meta";
 import { RuleExecuteCollectionWithoutIdInterface, RuleWithoutIdInterface } from "@wso2is/admin.rules.v1/models/rules";
@@ -63,6 +63,10 @@ interface PreIssueAccessTokenActionConfigFormInterface extends IdentifiableCompo
      */
     isLoading?: boolean;
     /**
+     * Specifies whether the form is read-only.
+     */
+    isReadOnly: boolean;
+    /**
      * Action Type of the Action.
      */
     actionTypeApiPath: string;
@@ -75,6 +79,7 @@ interface PreIssueAccessTokenActionConfigFormInterface extends IdentifiableCompo
 const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessTokenActionConfigFormInterface> = ({
     initialValues,
     isLoading,
+    isReadOnly,
     actionTypeApiPath,
     isCreateFormState,
     [ "data-componentid" ]: _componentId = "action-config-form"
@@ -92,9 +97,6 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
 
     const handleSuccess: (operation: string) => void = useHandleSuccess();
     const handleError: (error: AxiosError, operation: string) => void = useHandleError();
-
-    const hasActionUpdatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.update);
-    const hasActionCreatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.create);
 
     const {
         mutate: mutateActions
@@ -141,14 +143,6 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
             <Skeleton variant="rectangular" height={ 7 } />
         </Box>
     );
-
-    const getFieldDisabledStatus = (): boolean => {
-        if (isCreateFormState) {
-            return !hasActionCreatePermissions;
-        } else {
-            return !hasActionUpdatePermissions;
-        }
-    };
 
     const validateForm = (values: ActionConfigFormPropertyInterface):
         Partial<ActionConfigFormPropertyInterface> => {
@@ -266,13 +260,14 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                 <CommonActionConfigForm
                     initialValues={ initialValues }
                     isCreateFormState={ isCreateFormState }
+                    isReadOnly={ isReadOnly }
                     onAuthenticationTypeChange={ (updatedValue: AuthenticationType, change: boolean) => {
                         setAuthenticationType(updatedValue);
                         setIsAuthenticationUpdateFormState(change);
                     } }/>
                 { (RuleExpressionsMetaData && showRuleComponent) && (
                     <RuleConfigForm
-                        readonly={ getFieldDisabledStatus() }
+                        readonly={ isReadOnly }
                         rule={ rule }
                         ruleActionType={ actionTypeApiPath }
                         setRule={ setRule }
@@ -314,7 +309,7 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                                             className={ "button-container" }
                                             data-componentid={ `${ _componentId }-primary-button` }
                                             loading={ isSubmitting }
-                                            disabled={ getFieldDisabledStatus() }
+                                            disabled={ isReadOnly }
                                         >
                                             {
                                                 isCreateFormState

--- a/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
@@ -22,7 +22,7 @@ import Divider from "@oxygen-ui/react/Divider";
 import FormLabel from "@oxygen-ui/react/FormLabel";
 import Skeleton from "@oxygen-ui/react/Skeleton";
 import Typography from "@oxygen-ui/react/Typography";
-import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
+import { FeatureAccessConfigInterface } from "@wso2is/access-control";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import useGetRulesMeta from "@wso2is/admin.rules.v1/api/use-get-rules-meta";
 import { RuleExecuteCollectionWithoutIdInterface, RuleWithoutIdInterface } from "@wso2is/admin.rules.v1/models/rules";
@@ -73,6 +73,10 @@ interface PreUpdatePasswordActionConfigFormInterface extends IdentifiableCompone
      */
     isLoading?: boolean;
     /**
+     * Specifies whether the form is read-only.
+     */
+    isReadOnly: boolean;
+    /**
      * Action Type of the Action.
      */
     actionTypeApiPath: string;
@@ -85,6 +89,7 @@ interface PreUpdatePasswordActionConfigFormInterface extends IdentifiableCompone
 const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActionConfigFormInterface> = ({
     initialValues,
     isLoading,
+    isReadOnly,
     actionTypeApiPath,
     isCreateFormState,
     ["data-componentid"]: _componentId = "pre-update-password-action-config-form"
@@ -103,9 +108,6 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
 
     const handleSuccess: (operation: string) => void = useHandleSuccess();
     const handleError: (error: AxiosError, operation: string) => void = useHandleError();
-
-    const hasActionUpdatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.update);
-    const hasActionCreatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.create);
 
     const {
         mutate: mutateActions
@@ -155,14 +157,6 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
             <Skeleton variant="rectangular" height={ 7 } />
         </Box>
     );
-
-    const getFieldDisabledStatus = (): boolean => {
-        if (isCreateFormState) {
-            return !hasActionCreatePermissions;
-        } else {
-            return !hasActionUpdatePermissions;
-        }
-    };
 
     const validateForm = (values: PreUpdatePasswordActionConfigFormPropertyInterface):
         Partial<PreUpdatePasswordActionConfigFormPropertyInterface> => {
@@ -294,6 +288,7 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
                 <CommonActionConfigForm
                     initialValues={ initialValues }
                     isCreateFormState={ isCreateFormState }
+                    isReadOnly={ isReadOnly }
                     onAuthenticationTypeChange={ (updatedValue: AuthenticationType, change: boolean) => {
                         setAuthenticationType(updatedValue);
                         setIsAuthenticationUpdateFormState(change);
@@ -329,7 +324,7 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
                         ]
                     }
                     clearable={ true }
-                    disabled={ getFieldDisabledStatus() }
+                    disabled={ isReadOnly }
                 />
                 <FormLabel className="certificate-label" >
                     { t("actions:fields.passwordSharing.certificate.label") }
@@ -345,12 +340,12 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
                     certificate={ PEMValue }
                     actionTypeApiPath={ actionTypeApiPath }
                     actionId={ initialValues?.id }
-                    readOnly={ getFieldDisabledStatus() }
+                    readOnly={ isReadOnly }
                     data-componentid={ `${ _componentId }-certificate` }
                 />
                 { RuleExpressionsMetaData && showRuleComponent && (
                     <RuleConfigForm
-                        readonly={ getFieldDisabledStatus() }
+                        readonly={ isReadOnly }
                         rule={ rule }
                         ruleActionType={ actionTypeApiPath }
                         setRule={ setRule }
@@ -392,7 +387,7 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
                                             className={ "button-container" }
                                             data-componentid={ `${_componentId}-primary-button` }
                                             loading={ isSubmitting }
-                                            disabled={ getFieldDisabledStatus() }
+                                            disabled={ isReadOnly }
                                         >
                                             {
                                                 isCreateFormState

--- a/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
@@ -33,7 +33,6 @@ import {
     FinalForm,
     FinalFormField,
     FormRenderProps,
-    FormSpy,
     SelectFieldAdapter
 } from "@wso2is/form";
 import { DropdownChild } from "@wso2is/forms";
@@ -374,103 +373,36 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
                     <FinalForm
                         onSubmit={ (values: PreUpdatePasswordActionConfigFormPropertyInterface, form: any) => {
                             handleSubmit(values, form.getState().dirtyFields);
-                        }
-                        }
+                        } }
                         validate={ validateForm }
                         initialValues={ initialValues }
-                        render={ ({ handleSubmit, form }: FormRenderProps) => (
-                            <form onSubmit={ handleSubmit }>
-                                <EmphasizedSegment
-                                    className="form-wrapper"
-                                    padded={ "very" }
-                                    data-componentid={ `${_componentId}-section` }
-                                >
-                                    <div className="form-container with-max-width">
-                                        { renderFormFields() }
-                                        { !isLoading && (
-                                            <Button
-                                                size="medium"
-                                                variant="contained"
-                                                onClick={ handleSubmit }
-                                                className={ "button-container" }
-                                                data-componentid={ `${_componentId}-primary-button` }
-                                                loading={ isSubmitting }
-                                                disabled={ getFieldDisabledStatus() }
-                                            >
-                                                {
-                                                    isCreateFormState
-                                                        ? t("actions:buttons.create")
-                                                        : t("actions:buttons.update")
-                                                }
-                                            </Button>
-                                        ) }
-                                    </div>
-                                </EmphasizedSegment>
-                                <FormSpy
-                                    subscription={ { values: true } }
-                                >
-                                    { ({ values }: { values: ActionConfigFormPropertyInterface }) => {
-                                        if (!isAuthenticationUpdateFormState) {
-                                            form.change("authenticationType",
-                                                initialValues?.authenticationType);
-                                            switch (authenticationType) {
-                                                case AuthenticationType.BASIC:
-                                                    delete values.usernameAuthProperty;
-                                                    delete values.passwordAuthProperty;
-
-                                                    break;
-                                                case AuthenticationType.BEARER:
-                                                    delete values.accessTokenAuthProperty;
-
-                                                    break;
-                                                case AuthenticationType.API_KEY:
-                                                    delete values.headerAuthProperty;
-                                                    delete values.valueAuthProperty;
-
-                                                    break;
-                                                default:
-                                                    break;
+                        render={ ({ handleSubmit }: FormRenderProps) => (
+                            <EmphasizedSegment
+                                className="form-wrapper"
+                                padded={ "very" }
+                                data-componentid={ `${_componentId}-section` }
+                            >
+                                <div className="form-container with-max-width">
+                                    { renderFormFields() }
+                                    { !isLoading && (
+                                        <Button
+                                            size="medium"
+                                            variant="contained"
+                                            onClick={ handleSubmit }
+                                            className={ "button-container" }
+                                            data-componentid={ `${_componentId}-primary-button` }
+                                            loading={ isSubmitting }
+                                            disabled={ getFieldDisabledStatus() }
+                                        >
+                                            {
+                                                isCreateFormState
+                                                    ? t("actions:buttons.create")
+                                                    : t("actions:buttons.update")
                                             }
-                                        }
-
-                                        // Clear inputs of property field values of other authentication types.
-                                        switch (authenticationType) {
-                                            case AuthenticationType.BASIC:
-                                                delete values.accessTokenAuthProperty;
-                                                delete values.headerAuthProperty;
-                                                delete values.valueAuthProperty;
-
-                                                break;
-                                            case AuthenticationType.BEARER:
-                                                delete values.usernameAuthProperty;
-                                                delete values.passwordAuthProperty;
-                                                delete values.headerAuthProperty;
-                                                delete values.valueAuthProperty;
-
-                                                break;
-                                            case AuthenticationType.API_KEY:
-                                                delete values.usernameAuthProperty;
-                                                delete values.passwordAuthProperty;
-                                                delete values.accessTokenAuthProperty;
-
-                                                break;
-                                            case AuthenticationType.NONE:
-                                                delete values.usernameAuthProperty;
-                                                delete values.passwordAuthProperty;
-                                                delete values.headerAuthProperty;
-                                                delete values.valueAuthProperty;
-                                                delete values.accessTokenAuthProperty;
-
-                                                break;
-                                            default:
-
-                                                break;
-                                        }
-
-                                        return null;
-                                    } }
-                                </FormSpy>
-                            </form>
+                                        </Button>
+                                    ) }
+                                </div>
+                            </EmphasizedSegment>
                         ) }
                     >
                     </FinalForm>

--- a/features/admin.actions.v1/pages/action-configuration-page.tsx
+++ b/features/admin.actions.v1/pages/action-configuration-page.tsx
@@ -83,6 +83,7 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
     const handleError: (error: AxiosError, operation: string) => void = useHandleError();
 
     const hasActionUpdatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.update);
+    const hasActionCreatePermissions: boolean = useRequiredScopes(actionsFeatureConfig?.scopes?.create);
 
     const actionTypeApiPath: string = useMemo(() => {
         const path: string[] = history.location.pathname.split("/");
@@ -214,6 +215,17 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
             );
         }
     }, [ isActionLoading, actionFetchRequestError ]);
+
+    /**
+     * This function resolves whether the form is read-only or not.
+     */
+    const isReadOnly = (): boolean => {
+        if (showCreateForm) {
+            return !hasActionCreatePermissions;
+        } else {
+            return !hasActionUpdatePermissions;
+        }
+    };
 
     /**
      * Handles the back button click event.
@@ -386,6 +398,7 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
                                 <PreIssueAccessTokenActionConfigForm
                                     initialValues={ actionCommonInitialValues }
                                     isLoading={ isLoading }
+                                    isReadOnly={ isReadOnly() }
                                     actionTypeApiPath={ actionTypeApiPath }
                                     isCreateFormState={ showCreateForm }
                                 />
@@ -395,6 +408,7 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
                                 <PreUpdatePasswordActionConfigForm
                                     initialValues={ preUpdatePasswordActionInitialValues }
                                     isLoading={ isLoading }
+                                    isReadOnly={ isReadOnly() }
                                     actionTypeApiPath={ actionTypeApiPath }
                                     isCreateFormState={ showCreateForm }
                                 />

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -104,7 +104,6 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
     const [ endpointAuthenticationType, setEndpointAuthenticationType ] = useState<AuthenticationType>(null);
     const [ isEndpointAuthenticationUpdated, setIsEndpointAuthenticationUpdated ] = useState<boolean>(false);
     const [ isEndpointDetailsLoading, setIsEndpointDetailsLoading ] = useState<boolean>(false);
-    const [ skipActionUpdatePermission, setSkipActionUpdatePermission ] = useState<boolean>(false);
 
     useEffect(() => {
         if (isCustomLocalAuthenticator) {
@@ -119,17 +118,6 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
             getCustomFederatedAuthenticatorInitialValues(customAuthenticatorId);
         }
     }, []);
-
-    /**
-     * When the user has connection edit permission, skip inherent permission check in the action configuration form.
-     */
-    useEffect(() => {
-        if (isReadOnly) {
-            return;
-        }
-
-        setSkipActionUpdatePermission(true);
-    }, [ isReadOnly ]);
 
     /**
      * This function is utilized only for custom federated authenticators since endpoint details are not
@@ -315,7 +303,7 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
                             <ActionEndpointConfigForm
                                 initialValues={ initialValues }
                                 isCreateFormState={ false }
-                                skipUpdatePermission={ skipActionUpdatePermission }
+                                isReadOnly={ isReadOnly }
                                 onAuthenticationTypeChange={ (
                                     authenticationType: AuthenticationType,
                                     isAuthenticationUpdated: boolean

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -26,7 +26,7 @@ import {
 } from "@wso2is/admin.identity-providers.v1/models";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
-import { FinalForm, FormRenderProps, FormSpy } from "@wso2is/form";
+import { FinalForm, FormRenderProps } from "@wso2is/form";
 import { EmphasizedSegment } from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
@@ -305,100 +305,38 @@ export const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorS
                 onSubmit={ handleSubmit }
                 initialValues={ initialValues }
                 validate={ validateForm }
-                render={ ({ handleSubmit, form }: FormRenderProps) => (
-                    <form onSubmit={ handleSubmit }>
-                        <EmphasizedSegment
-                            className="endpoint-settings-container"
-                            padded={ "very" }
-                            data-componentid={ `${componentId}-section` }
-                        >
-                            <div className="form-container with-max-width">
-                                <ActionEndpointConfigForm
-                                    initialValues={ initialValues }
-                                    isCreateFormState={ false }
-                                    skipUpdatePermission={ skipActionUpdatePermission }
-                                    onAuthenticationTypeChange={ (
-                                        authenticationType: AuthenticationType,
-                                        isAuthenticationUpdated: boolean
-                                    ) => {
-                                        setEndpointAuthenticationType(authenticationType);
-                                        setIsEndpointAuthenticationUpdated(isAuthenticationUpdated);
-                                    } }
-                                />
-                                { !isLoading && !isReadOnly && (
-                                    <Button
-                                        size="medium"
-                                        variant="contained"
-                                        onClick={ handleSubmit }
-                                        className={ "button-container" }
-                                        data-componentid={ `${componentId}-update-button` }
-                                    >
-                                        { t("actions:buttons.update") }
-                                    </Button>
-                                ) }
-                            </div>
-                        </EmphasizedSegment>
-                        <FormSpy subscription={ { values: true } }>
-                            { ({ values }: { values: EndpointConfigFormPropertyInterface }) => {
-                                if (!isEndpointAuthenticationUpdated) {
-                                    form.change("authenticationType", values?.authenticationType);
-                                    switch (values?.authenticationType) {
-                                        case AuthenticationType.BASIC:
-                                            delete values.usernameAuthProperty;
-                                            delete values.passwordAuthProperty;
-
-                                            break;
-                                        case AuthenticationType.BEARER:
-                                            delete values.accessTokenAuthProperty;
-
-                                            break;
-                                        case AuthenticationType.API_KEY:
-                                            delete values.headerAuthProperty;
-                                            delete values.valueAuthProperty;
-
-                                            break;
-                                        default:
-                                            break;
-                                    }
-                                }
-
-                                // Clear inputs of property field values of other authentication types.
-                                switch (values?.authenticationType) {
-                                    case AuthenticationType.BASIC:
-                                        delete values.accessTokenAuthProperty;
-                                        delete values.headerAuthProperty;
-                                        delete values.valueAuthProperty;
-
-                                        break;
-                                    case AuthenticationType.BEARER:
-                                        delete values.usernameAuthProperty;
-                                        delete values.passwordAuthProperty;
-                                        delete values.headerAuthProperty;
-                                        delete values.valueAuthProperty;
-
-                                        break;
-                                    case AuthenticationType.API_KEY:
-                                        delete values.usernameAuthProperty;
-                                        delete values.passwordAuthProperty;
-                                        delete values.accessTokenAuthProperty;
-
-                                        break;
-                                    case AuthenticationType.NONE:
-                                        delete values.usernameAuthProperty;
-                                        delete values.passwordAuthProperty;
-                                        delete values.headerAuthProperty;
-                                        delete values.valueAuthProperty;
-                                        delete values.accessTokenAuthProperty;
-
-                                        break;
-                                    default:
-                                        break;
-                                }
-
-                                return null;
-                            } }
-                        </FormSpy>
-                    </form>
+                render={ ({ handleSubmit }: FormRenderProps) => (
+                    <EmphasizedSegment
+                        className="endpoint-settings-container"
+                        padded={ "very" }
+                        data-componentid={ `${componentId}-section` }
+                    >
+                        <div className="form-container with-max-width">
+                            <ActionEndpointConfigForm
+                                initialValues={ initialValues }
+                                isCreateFormState={ false }
+                                skipUpdatePermission={ skipActionUpdatePermission }
+                                onAuthenticationTypeChange={ (
+                                    authenticationType: AuthenticationType,
+                                    isAuthenticationUpdated: boolean
+                                ) => {
+                                    setEndpointAuthenticationType(authenticationType);
+                                    setIsEndpointAuthenticationUpdated(isAuthenticationUpdated);
+                                } }
+                            />
+                            { !isLoading && !isReadOnly && (
+                                <Button
+                                    size="medium"
+                                    variant="contained"
+                                    onClick={ handleSubmit }
+                                    className={ "button-container" }
+                                    data-componentid={ `${componentId}-update-button` }
+                                >
+                                    { t("actions:buttons.update") }
+                                </Button>
+                            ) }
+                        </div>
+                    </EmphasizedSegment>
                 ) }
             ></FinalForm>
         </div>


### PR DESCRIPTION
### Purpose

1. Move FormSpy used to clear authentication properties related fields to action-endpoint-config-form
2. Make forms to utilize one parameter to decide the readOnly state, where top most component should pass the respective readOnly state to the dependent components

### Related Issue
- 