### PR TITLE
Update the regex to permit role names to start with a number

### DIFF
--- a/.changeset/mighty-terms-hug.md
+++ b/.changeset/mighty-terms-hug.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/validation": patch
+---
+
+Update the regex to permit role names to start with a number

--- a/modules/validation/src/validation.ts
+++ b/modules/validation/src/validation.ts
@@ -346,7 +346,7 @@ export const isValidResourceKey = (value: string): boolean => {
 export const isValidRoleName = (value: string): boolean => {
     try {
         const result: ValidationResult = Joi.string()
-            .regex(new RegExp("^[a-zA-Z0-9][a-zA-Z0-9-_. ]+$"))
+            .regex(new RegExp("^[-a-zA-Z0-9][a-zA-Z0-9-_. ]+$"))
             .min(3)
             .max(255)
             .validate(value);

--- a/modules/validation/src/validation.ts
+++ b/modules/validation/src/validation.ts
@@ -346,7 +346,7 @@ export const isValidResourceKey = (value: string): boolean => {
 export const isValidRoleName = (value: string): boolean => {
     try {
         const result: ValidationResult = Joi.string()
-            .regex(new RegExp("^[a-zA-Z][a-zA-Z0-9-_. ]+$"))
+            .regex(new RegExp("^[a-zA-Z0-9][a-zA-Z0-9-_. ]+$"))
             .min(3)
             .max(255)
             .validate(value);


### PR DESCRIPTION
## Purpose
Update the frontend validation logic for role names to support more flexible naming conventions. Previously, role names starting with a digit were considered invalid due to a restrictive regular expression. This update allows role names to start with a digit.

## Implementation
- Updated the regular expression in the `isValidRoleName` function to allow role names to start with a digit.

## Resolved Behaviour
https://github.com/user-attachments/assets/93e1c73a-588e-4b34-8b3c-108a8f89381e

## Related Issue
- https://github.com/wso2/product-is/issues/23265