### PR TITLE
Fix central deployment refresh issue and change guest user deletion endpoint

### DIFF
--- a/.changeset/olive-carpets-wave.md
+++ b/.changeset/olive-carpets-wave.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.console-settings.v1": patch
+"@wso2is/console": patch
+---
+
+Fix central server refreshing issue and add guest delete

--- a/apps/console/src/auth.html
+++ b/apps/console/src/auth.html
@@ -214,6 +214,7 @@
 
                     function getApiPath(path) {
                         var tenantDomain = getTenantName();
+
                         if (!tenantDomain || isCentralDeploymentEnabled) {
                             if (startupConfig.superTenantProxy) {
                                 tenantDomain = startupConfig.superTenantProxy;
@@ -454,7 +455,7 @@
                     if(isSilentSignInDisabled) {
 
                         if(isTenantSwitchPath) {
-                            if (isCentralDeploymentEnabled && userTenant && userTenant !== startupConfig.superTenant) {
+                            if (isCentralDeploymentEnabled && userTenant !== startupConfig.superTenant) {
                                 var regionalAuthConfig = getRegionalAuthConfig(userTenant);
                                 auth.initialize(regionalAuthConfig);
                             } else {
@@ -465,7 +466,7 @@
                             window.location = applicationDomain + '/<%= htmlWebpackPlugin.options.basename %>?disable_silent_sign_in=true&invite_user=true';
                         }
                     } else {
-                        if (isCentralDeploymentEnabled && userTenant && userTenant !== startupConfig.superTenant) {
+                        if (isCentralDeploymentEnabled && userTenant !== startupConfig.superTenant) {
                             var regionalAuthConfig = getRegionalAuthConfig(userTenant);
                             auth.initialize(regionalAuthConfig)
                         } else {

--- a/apps/console/src/auth.html
+++ b/apps/console/src/auth.html
@@ -214,8 +214,7 @@
 
                     function getApiPath(path) {
                         var tenantDomain = getTenantName();
-
-                        if (!tenantDomain) {
+                        if (!tenantDomain || isCentralDeploymentEnabled) {
                             if (startupConfig.superTenantProxy) {
                                 tenantDomain = startupConfig.superTenantProxy;
                             } else {
@@ -383,6 +382,31 @@
                         startupConfig.superTenant;
                     }
 
+                    function getRegionalAuthConfig(tenantDomain) {
+                        return regionalAuthConfig = {
+                            signInRedirectURL: deploymentUnitSignInRedirectURL(tenantDomain),
+                            signOutRedirectURL: getSignOutRedirectURL(),
+                            clientID: "<%= htmlWebpackPlugin.options.clientID %>",
+                            baseUrl: getDeploymentUnitApiPath(tenantDomain),
+                            responseMode: "query",
+                            scope: ["openid SYSTEM profile email"],
+                            storage: "webWorker",
+                            disableTrySignInSilently: false,
+                            enableOIDCSessionManagement: false,
+                            endpoints: {
+                                authorizationEndpoint: getDeploymentUnitApiPath("/oauth2/authorize", tenantDomain),
+                                clockTolerance: 300,
+                                jwksEndpointURL: getDeploymentUnitApiPath("/oauth2/jwks", tenantDomain),
+                                logoutEndpointURL: getDeploymentUnitApiPath("/oidc/logout", tenantDomain),
+                                oidcSessionIFrameEndpointURL: getDeploymentUnitApiPath("/oidc/checksession", tenantDomain),
+                                tokenEndpointURL: getDeploymentUnitApiPath("/oauth2/token", tenantDomain),
+                                tokenRevocationEndpointURL: getDeploymentUnitApiPath("/oauth2/revoke", tenantDomain),
+                                issuer: getDeploymentUnitApiPath("/oauth2/token", tenantDomain)
+                            },
+                            enablePKCE: true
+                        }
+                    }
+
                     var auth = AsgardeoAuth.AsgardeoSPAClient.getInstance();
                     if (isCentralDeploymentEnabled) {
                         auth = AsgardeoAuth.AsgardeoSPAClient.getInstance("primary");
@@ -430,13 +454,23 @@
                     if(isSilentSignInDisabled) {
 
                         if(isTenantSwitchPath) {
-                            auth.initialize(authConfig);
+                            if (isCentralDeploymentEnabled && userTenant && userTenant !== startupConfig.superTenant) {
+                                var regionalAuthConfig = getRegionalAuthConfig(userTenant);
+                                auth.initialize(regionalAuthConfig);
+                            } else {
+                                auth.initialize(authConfig);
+                            }
                             auth.signIn(getAuthParams({}));
                         } else {
                             window.location = applicationDomain + '/<%= htmlWebpackPlugin.options.basename %>?disable_silent_sign_in=true&invite_user=true';
                         }
                     } else {
-                        auth.initialize(authConfig);
+                        if (isCentralDeploymentEnabled && userTenant && userTenant !== startupConfig.superTenant) {
+                            var regionalAuthConfig = getRegionalAuthConfig(userTenant);
+                            auth.initialize(regionalAuthConfig)
+                        } else {
+                            auth.initialize(authConfig);
+                        }
 
                         if (window.top === window.self) {
                             var authCallbackUrl = window.location.pathname + window.location.hash;
@@ -475,28 +509,7 @@
                                                 loginTenant = superTenantGlobal;
                                             }
                                             
-                                            var regionalAuthConfig = {
-                                                signInRedirectURL: deploymentUnitSignInRedirectURL(loginTenant),
-                                                signOutRedirectURL: getSignOutRedirectURL(),
-                                                clientID: "<%= htmlWebpackPlugin.options.clientID %>",
-                                                baseUrl: getDeploymentUnitApiPath(loginTenant),
-                                                responseMode: "query",
-                                                scope: ["openid SYSTEM profile email"],
-                                                storage: "webWorker",
-                                                disableTrySignInSilently: false,
-                                                enableOIDCSessionManagement: false,
-                                                endpoints: {
-                                                    authorizationEndpoint: getDeploymentUnitApiPath("/oauth2/authorize", loginTenant),
-                                                    clockTolerance: 300,
-                                                    jwksEndpointURL: getDeploymentUnitApiPath("/oauth2/jwks", loginTenant),
-                                                    logoutEndpointURL: getDeploymentUnitApiPath("/oidc/logout", loginTenant),
-                                                    oidcSessionIFrameEndpointURL: getDeploymentUnitApiPath("/oidc/checksession", loginTenant),
-                                                    tokenEndpointURL: getDeploymentUnitApiPath("/oauth2/token", loginTenant),
-                                                    tokenRevocationEndpointURL: getDeploymentUnitApiPath("/oauth2/revoke", loginTenant),
-                                                    issuer: getDeploymentUnitApiPath("/oauth2/token", loginTenant)
-                                                },
-                                                enablePKCE: true
-                                            }
+                                            var regionalAuthConfig = getRegionalAuthConfig(loginTenant);
                                             var authSecondary = AsgardeoAuth.AsgardeoSPAClient.getInstance("secondary");
 
                                             authSecondary.initialize(regionalAuthConfig);


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
- With central deployment, we need to call guest user deletion endpoint to delete guest admin users. For existing architecture, we will use the existing role deletion endpoint. For new architecture, we will use guest user deletion endpoint
- With central deployment, we can observe few issues with refreshing the browser. This PR will fix them