### PR TITLE
Filter out applicationRole from the configurable list

### DIFF
--- a/.changeset/curvy-houses-roll.md
+++ b/.changeset/curvy-houses-roll.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.actions.v1": patch
+---
+
+Filter out applicationRole from the configurable list

--- a/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
@@ -155,7 +155,7 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
      *
      * The final user attribute list is updated only if the user has made changes to the initial list.
      * @param hasChanged - Flag to indicate whether the user has made changes to the initial list.
-     * @param finalAttributeList - Updated attribute list.
+     * @param changedAttributes - Updated attribute list.
      */
     const handleUserAttributeChange = (hasChanged: boolean, changedAttributes: string[]) => {
 

--- a/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
@@ -154,6 +154,7 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
      * Callback to be triggered when the user attribute list is updated.
      *
      * The final user attribute list is updated only if the user has made changes to the initial list.
+     * @param hasChanged - Flag to indicate whether the user has made changes to the initial list.
      * @param finalAttributeList - Updated attribute list.
      */
     const handleUserAttributeChange = (hasChanged: boolean, changedAttributes: string[]) => {

--- a/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
+++ b/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
@@ -242,10 +242,12 @@ const UserAttributeList: FunctionComponent<UserAttributeListPropsInterface> = ({
      */
     const filterOutRoleClaimAttribute = (claimsList: Claim[]): Claim[] => {
 
-        return claimsList?.filter((claim: Claim) =>
-            claim.claimURI !== "http://wso2.org/claims/roles" &&
-            claim.claimURI !== "http://wso2.org/claims/applicationRoles"
-        );
+        const excludedClaims: Set<string> = new Set([
+            "http://wso2.org/claims/roles",
+            "http://wso2.org/claims/applicationRoles"
+        ]);
+
+        return claimsList?.filter((claim: Claim) => !excludedClaims.has(claim.claimURI));
     };
     /**
      * Handles the selection of an attribute from the autocomplete dropdown.

--- a/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
+++ b/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
@@ -242,7 +242,10 @@ const UserAttributeList: FunctionComponent<UserAttributeListPropsInterface> = ({
      */
     const filterOutRoleClaimAttribute = (claimsList: Claim[]): Claim[] => {
 
-        return claimsList?.filter((claim: Claim) => claim.claimURI !== "http://wso2.org/claims/roles");
+        return claimsList?.filter((claim: Claim) =>
+            claim.claimURI !== "http://wso2.org/claims/roles" &&
+            claim.claimURI !== "http://wso2.org/claims/applicationRoles"
+        );
     };
     /**
      * Handles the selection of an attribute from the autocomplete dropdown.

--- a/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
+++ b/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
@@ -81,7 +81,7 @@ const UserAttributeList: FunctionComponent<UserAttributeListPropsInterface> = ({
     "data-componentid": componentId = "autocomplete-search-list"
 }: UserAttributeListPropsInterface): ReactElement => {
 
-    const [ allAttributesList, setAllAttributesList ] = useState<Claim[]>();
+    const [ allAttributesList, setAllAttributesList ] = useState<Claim[]>([]);
     const [ selectedAttributeList, setSelectedAttributeList ] = useState<Claim[]>([]);
     const [ isGetAllLocalClaimsLoading, setIsGetAllLocalClaimsLoading ] = useState<boolean>(false);
     const [ isAttributeLimitReached, setIsAttributeLimitReached ] = useState<boolean>(false);
@@ -362,6 +362,7 @@ const UserAttributeList: FunctionComponent<UserAttributeListPropsInterface> = ({
         <>
             <Hint>{ t("actions:fields.userAttributes.hint") }</Hint>
             <Autocomplete
+                loading={ isGetAllLocalClaimsLoading }
                 fullWidth
                 aria-label="Attribute selection"
                 className="pt-2"
@@ -400,7 +401,7 @@ const UserAttributeList: FunctionComponent<UserAttributeListPropsInterface> = ({
                     event: SyntheticEvent<HTMLElement>,
                     data: DropdownProps
                 ) => handleAttributeSelect(data) }
-                options={ allAttributesList || [] }
+                options={ allAttributesList }
                 getOptionLabel={ (claim: DropdownProps) =>
                     claim?.displayName
                 }

--- a/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
+++ b/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
@@ -400,7 +400,7 @@ const UserAttributeList: FunctionComponent<UserAttributeListPropsInterface> = ({
                     event: SyntheticEvent<HTMLElement>,
                     data: DropdownProps
                 ) => handleAttributeSelect(data) }
-                options={ allAttributesList }
+                options={ allAttributesList || [] }
                 getOptionLabel={ (claim: DropdownProps) =>
                     claim?.displayName
                 }


### PR DESCRIPTION
### Purpose
`applicationRole` is removed from the configurable list of attributes until the ambiguities associated with the claim are resolved.

### Related Issues
- https://github.com/wso2/product-is/issues/23511

**Search results for `role` or `applicationRole`:**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/02d48e6c-fcab-48d8-92f2-236c28a9bf76" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/b8bf973c-44a8-4b04-be03-dfce4d771fb3" />

**Updated loading state:**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/932e8d0e-3325-4e6c-bc0d-5376b12503c7" />


