### PR TITLE
Validate HEAD requests when clicking on org invitation link

### DIFF
--- a/.changeset/orange-impalas-drop.md
+++ b/.changeset/orange-impalas-drop.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Validate HEAD requests when clicking on org invitation link

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/accept-invitation.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/accept-invitation.jsp
@@ -16,11 +16,13 @@
   ~ under the License.
 --%>
 
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="java.net.HttpURLConnection, java.net.URL, java.io.BufferedReader, java.io.InputStreamReader" %>
 <%@ page import="java.io.OutputStream" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="java.io.File" %>
+<%@ page import="javax.ws.rs.HttpMethod" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 
@@ -39,6 +41,14 @@
                     "/api/server/v1/guests/invitation/accept", false);
     String confCode = request.getParameter("code");
     String acceptApiResponse = "";
+
+    // Some mail providers initially sends a HEAD request to
+    // check the validity of the link before redirecting users.
+    String httpMethod = request.getMethod();
+    if (StringUtils.equals(httpMethod, HttpMethod.HEAD)) {
+        response.setStatus(response.SC_OK);
+        return;
+    }
 
     try {
         // Create a URL object with the API URL


### PR DESCRIPTION
## Purpose
This PR fixes the issue when a sub-organization invites a parent organization user with a some email servers (ex: outlook), the invitation link becomes invalid immediately after acceptance. 

#### Issue with Outlook
This occurs due to Safe Links protection in Outlook, which sends a HEAD request to the original link before redirecting the user. Since IS processes the HEAD request as a valid request, it completes the invitation flow before the user actually clicks the link. As a result, when the user is redirected, the confirmation code is already invalidated, leading to an "Invitation Expired" error.

### Implementation
When a mail provider sends an initial HEAD request to validate a link before redirecting the user, this PR fixes it to respond with HTTP SC_OK without processing the request. This prevents premature execution of the invitation acceptance logic.

### Related Issue
- https://github.com/wso2/product-is/issues/23426
