### PR TITLE
Show/hide cookie consent banner globally and in authentication and recovery portals

### DIFF
--- a/.changeset/wise-coats-serve.md
+++ b/.changeset/wise-coats-serve.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/identity-apps-core": patch
+"@wso2is/myaccount": patch
+"@wso2is/console": patch
+---
+
+Add global configuration and support configurations in authentication and recovery portals to show/hide cookie consent banner

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -474,7 +474,7 @@
                 "enabled": {% if console.ai.enabled is defined %} {{ console.ai.enabled }},
                     {% else %}
                         {% if ai_services.key is defined and ai_services.key|length > 0 %} true,
-                        {% else %} false,                     
+                        {% else %} false,
                         {% endif %}
                 {% endif %}
                 "scopes": {
@@ -2022,8 +2022,10 @@
         {% if console.ui.is_feature_gate_enabled is defined %}
         "isFeatureGateEnabled": {{ console.ui.is_feature_gate_enabled }},
         {% endif %}
-        {% if console.ui.is_cookie_consent_banner_enabled is defined %}
-        "isCookieConsentBannerEnabled": {{ console.ui.is_cookie_consent_banner_enabled }},
+        {% set cookie_consent = console.ui.is_cookie_consent_banner_enabled if console.ui.is_cookie_consent_banner_enabled is defined
+            else ui.is_cookie_consent_banner_enabled %}
+        {% if cookie_consent is defined %}
+        "isCookieConsentBannerEnabled": {{ cookie_consent }},
         {% endif %}
         {% if console.ui.cookie_policy_url is defined %}
         "cookiePolicyUrl": "{{ console.ui.cookie_policy_url }}",

--- a/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
+++ b/apps/myaccount/java/org.wso2.identity.apps.myaccount.server.feature/resources/deployment.config.json.j2
@@ -355,8 +355,10 @@
                 }
             }
         },
-        {% if myaccount.ui.is_cookie_consent_banner_enabled is defined %}
-        "isCookieConsentBannerEnabled": {{ myaccount.ui.is_cookie_consent_banner_enabled }},
+        {% set cookie_consent = myaccount.ui.is_cookie_consent_banner_enabled if myaccount.ui.is_cookie_consent_banner_enabled is defined
+            else ui.is_cookie_consent_banner_enabled %}
+        {% if cookie_consent is defined %}
+        "isCookieConsentBannerEnabled": {{ cookie_consent }},
         {% endif %}
         {% if myaccount.ui.cookie_policy_url is defined %}
         "cookiePolicyUrl": "{{ myaccount.ui.cookie_policy_url }}",

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/cookie-consent-banner.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/cookie-consent-banner.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2021-2023, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2021-2025, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -30,7 +30,8 @@
 <jsp:directive.include file="./branding-preferences.jsp"/>
 
 <%
-    if (!StringUtils.isBlank(cookiePolicyURL)) {
+    boolean isCookieConsentBannerEnabled = Boolean.parseBoolean(application.getInitParameter("isCookieConsentBannerEnabled"));
+    if (!StringUtils.isBlank(cookiePolicyURL) && isCookieConsentBannerEnabled) {
 %>
 <div id="cookie-consent-banner" data-testid="cookie-consent-banner" class="ui segment cookie-consent-banner inverted aligned-right hidden transition">
     <div class="banner-image" data-testid="cookie-consent-banner-image">

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/cookie-consent-banner.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/cookie-consent-banner.jsp
@@ -1,5 +1,5 @@
 <%--
-  ~ Copyright (c) 2021-2023, WSO2 LLC. (https://www.wso2.com).
+  ~ Copyright (c) 2021-2025, WSO2 LLC. (https://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -30,7 +30,8 @@
 <jsp:directive.include file="./branding-preferences.jsp"/>
 
 <%
-    if (!StringUtils.isBlank(cookiePolicyURL)) {
+    boolean isCookieConsentBannerEnabled = Boolean.parseBoolean(application.getInitParameter("isCookieConsentBannerEnabled"));
+    if (!StringUtils.isBlank(cookiePolicyURL) && isCookieConsentBannerEnabled) {
 %>
 <div id="cookie-consent-banner" data-testid="cookie-consent-banner" class="ui segment cookie-consent-banner inverted aligned-right hidden transition">
     <div class="banner-image" data-testid="cookie-consent-banner-image">

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
   ~
-  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~    http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing,
   ~ software distributed under the License is distributed on an
@@ -46,6 +46,14 @@
         <context-param>
             <param-name>isDowntimeBannerEnabled</param-name>
             <param-value>{{ downtime_banner.enabled }}</param-value>
+        </context-param>
+    {% endif %}
+    {% set cookie_consent = authenticationendpoint.ui.is_cookie_consent_banner_enabled
+        if authenticationendpoint.ui.is_cookie_consent_banner_enabled is defined else ui.is_cookie_consent_banner_enabled %}
+    {% if cookie_consent is defined %}
+        <context-param>
+            <param-name>isCookieConsentBannerEnabled</param-name>
+            <param-value>{{ cookie_consent }}</param-value>
         </context-param>
     {% endif %}
     {% if event.default_listener.validation.enable is defined %}

--- a/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (c) 2021-2024, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~ Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
   ~
-  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
   ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~    http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing,
   ~ software distributed under the License is distributed on an
@@ -64,6 +64,14 @@
         <context-param>
             <param-name>isDowntimeBannerEnabled</param-name>
             <param-value>{{ downtime_banner.enabled }}</param-value>
+        </context-param>
+    {% endif %}
+    {% set cookie_consent = accountrecoveryendpoint.ui.is_cookie_consent_banner_enabled
+        if accountrecoveryendpoint.ui.is_cookie_consent_banner_enabled is defined else ui.is_cookie_consent_banner_enabled %}
+    {% if cookie_consent is defined %}
+        <context-param>
+            <param-name>isCookieConsentBannerEnabled</param-name>
+            <param-value>{{ cookie_consent }}</param-value>
         </context-param>
     {% endif %}
     {% if identity_mgt.user_self_registration.enable_detailed_api_response is defined %}


### PR DESCRIPTION
## Purpose
Currently, the is_cookie_consent_banner_enabled configuration is available only for myaccount and console React applications and it can not show/hide cookie consent banner in authentication and recovery portals. This PR fixes this issue by introducing three new configurations to show/hide cookie consent banner in authentication and recovery portals and globally across all the applications.

## Implementation

A new global configuration as below is introduced to show/hide cookie consent banner in console, my account, authentication and recovery portals. The default value of the configuration will be set to true preserving the existing and expected behaviour. 

```
[ui]
is_cookie_consent_banner_enabled=true
```

Additionally this PR introduces two additional configurations to control the visibility of the cookie consent banner in authentication and recovery portals as below.

Authentication Endpoint
```
[authenticationendpoint.ui]
is_cookie_consent_banner_enabled=false
```
Account Recovery Endpoint
```
[accountrecoveryendpoint.ui]
is_cookie_consent_banner_enabled=false
```

In this implementation, application-level configurations will take precedence over the global configuration. If an application-level configuration is defined, the cookie consent banner will follow that setting; otherwise, it will adhere to the global configuration.

### Related Issue
- https://github.com/wso2/product-is/issues/23432

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/6640