### PR TITLE
Remove server port when building the callback url when the server is starting at default https port

### DIFF
--- a/.changeset/khaki-deers-clean.md
+++ b/.changeset/khaki-deers-clean.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Remove server port when building the callback url when the server is starting at default https port

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -16,6 +16,8 @@
   ~ under the License.
 --%>
 
+<%@ page import="org.apache.commons.httpclient.HttpURL" %>
+<%@ page import="org.apache.commons.httpclient.HttpsURL" %>
 <%@ page import="org.apache.cxf.jaxrs.client.JAXRSClientFactory" %>
 <%@ page import="org.apache.cxf.jaxrs.provider.json.JSONProvider" %>
 <%@ page import="org.apache.cxf.jaxrs.client.WebClient" %>
@@ -577,7 +579,11 @@
                 int serverPort = request.getServerPort();
                 String uri = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_REQUEST_URI);
                 String prmstr = URLDecoder.decode(((String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING)), UTF_8);
-                urlWithoutEncoding = scheme + "://" +serverName + ":" + serverPort + uri + "?" + prmstr;
+                if ((scheme == "http" && serverPort == HttpURL.DEFAULT_PORT) || (scheme == "https" && serverPort == HttpsURL.DEFAULT_PORT)) {
+                    urlWithoutEncoding = scheme + "://" + serverName + uri + "?" + prmstr;
+                } else {
+                    urlWithoutEncoding = scheme + "://" + serverName + ":" + serverPort + uri + "?" + prmstr;
+                }
             }
             urlWithoutEncoding = IdentityManagementEndpointUtil.replaceUserTenantHintPlaceholder(
                     urlWithoutEncoding, userTenantDomain);

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -18,6 +18,8 @@
 
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <%@ page import="org.apache.commons.collections.CollectionUtils" %>
+<%@ page import="org.apache.commons.httpclient.HttpURL" %>
+<%@ page import="org.apache.commons.httpclient.HttpsURL" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.EndpointConfigManager" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthContextAPIClient" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.Constants" %>
@@ -1234,6 +1236,9 @@
                                     String uri = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_REQUEST_URI);
                                     String prmstr = (String) request.getAttribute(JAVAX_SERVLET_FORWARD_QUERY_STRING);
                                     String urlWithoutEncoding = scheme + "://" +serverName + ":" + serverPort + uri + "?" + prmstr;
+                                    if ((scheme == "http" && serverPort == HttpURL.DEFAULT_PORT) || (scheme == "https" && serverPort == HttpsURL.DEFAULT_PORT)) {
+                                        urlWithoutEncoding = scheme + "://" + serverName + uri + "?" + prmstr;
+                                    }
                                     urlEncodedURL = URLEncoder.encode(urlWithoutEncoding, UTF_8);
                                     urlParameters = prmstr;
                                 } else {


### PR DESCRIPTION
## Purpose
With this PR,
- https://github.com/wso2-extensions/identity-governance/pull/927
We improved the regex validations to correctly validate the callback urls when the server port is set to the deafult http/https port.

- But since the url is built from the jsp in password recovery scenario, now it's failing to validate against the new regex.
- So this PR will resolve that issue.

### Other PRs related to callback regex validation improvement
- https://github.com/wso2/carbon-identity-framework/pull/6600
- https://github.com/wso2-extensions/identity-governance/pull/927

## Related Issue
- https://github.com/wso2/product-is/issues/23566