### PR TITLE
Add self-signup URL input in branding for sub-organizations

### DIFF
--- a/.changeset/quick-deers-double.md
+++ b/.changeset/quick-deers-double.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.branding.v1": minor
+---
+
+Add self-signup URL input in branding for sub-organizations

--- a/features/admin.branding.v1/components/advanced/advance-form.tsx
+++ b/features/admin.branding.v1/components/advanced/advance-form.tsx
@@ -17,7 +17,6 @@
  */
 
 import Code from "@oxygen-ui/react/Code";
-import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import { BrandingPreferenceInterface } from "@wso2is/common.branding.v1/models";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { URLUtils } from "@wso2is/core/utils";
@@ -93,8 +92,6 @@ export const AdvanceForm: FunctionComponent<AdvanceFormPropsInterface> = forward
     } = props;
 
     const { t } = useTranslation();
-
-    const { isFirstLevelOrganization, isSuperOrganization  } = useGetCurrentOrganizationType();
 
     const [ privacyPolicyURL, setPrivacyPolicyURL ] = useState<string>(initialValues.urls.privacyPolicyURL);
     const [ termsOfUseURL, setTermsOfUseURL ] = useState<string>(initialValues.urls.termsOfUseURL);
@@ -264,40 +261,38 @@ export const AdvanceForm: FunctionComponent<AdvanceFormPropsInterface> = forward
                 data-testid={ `${ componentId }-cookie-policy-url` }
                 validation={ validateTemplatableURLs }
             />
-            { (isFirstLevelOrganization() || isSuperOrganization()) && (
-                <Field.Input
-                    ariaLabel="Branding preference self signup URL"
-                    inputType="url"
-                    name="urls.selfSignUpURL"
-                    label={ t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.label") }
-                    placeholder={
-                        t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.placeholder")
-                    }
-                    hint={ (
-                        <Trans
-                            i18nKey="extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.hint"
-                        >
-                        Link to your organization&apos;s Self Signup webpage. You can use placeholders like
-                            <Code>&#123;&#123;lang&#125;&#125;</Code>, <Code>&#123;&#123;country&#125;&#125;</Code>,
-                        or <Code>&#123;&#123;locale&#125;&#125;</Code> to customize the URL for different
-                        regions or languages.
-                        </Trans>
-                    ) }
-                    required={ false }
-                    value={ initialValues.urls.selfSignUpURL }
-                    readOnly={ readOnly }
-                    maxLength={
-                        BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MAX_LENGTH
-                    }
-                    minLength={
-                        BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MIN_LENGTH
-                    }
-                    listen={ (value: string) =>  setSelfSignUpURL(value) }
-                    width={ 16 }
-                    data-testid={ `${ componentId }-self-signup-url` }
-                    validation={ validateTemplatableURLs }
-                />
-            ) }
+            <Field.Input
+                ariaLabel="Branding preference self signup URL"
+                inputType="url"
+                name="urls.selfSignUpURL"
+                label={ t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.label") }
+                placeholder={
+                    t("extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.placeholder")
+                }
+                hint={ (
+                    <Trans
+                        i18nKey="extensions:develop.branding.forms.advance.links.fields.selfSignUpURL.hint"
+                    >
+                    Link to your organization&apos;s Self Signup webpage. You can use placeholders like
+                        <Code>&#123;&#123;lang&#125;&#125;</Code>, <Code>&#123;&#123;country&#125;&#125;</Code>,
+                    or <Code>&#123;&#123;locale&#125;&#125;</Code> to customize the URL for different
+                    regions or languages.
+                    </Trans>
+                ) }
+                required={ false }
+                value={ initialValues.urls.selfSignUpURL }
+                readOnly={ readOnly }
+                maxLength={
+                    BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MAX_LENGTH
+                }
+                minLength={
+                    BrandingPreferencesConstants.ADVANCE_FORM_FIELD_CONSTRAINTS.COOKIE_POLICY_URL_MIN_LENGTH
+                }
+                listen={ (value: string) =>  setSelfSignUpURL(value) }
+                width={ 16 }
+                data-testid={ `${ componentId }-self-signup-url` }
+                validation={ validateTemplatableURLs }
+            />
         </Form>
     );
 });


### PR DESCRIPTION
### Purpose

- Add the self-signup URL input in branding for sub-organizations.

<img width="1493" alt="Screenshot 2025-04-07 at 11 12 02" src="https://github.com/user-attachments/assets/aad3fdf5-574e-4df8-9253-621c640c89b0" />
