### PR TITLE
Drop action ID in Google signup request in new registration portal

### DIFF
--- a/.changeset/strong-boats-join.md
+++ b/.changeset/strong-boats-join.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": minor
+---
+
+Drop action ID in Google signup request

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/self-registration.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/self-registration.jsp
@@ -181,12 +181,11 @@
 
                 useEffect(() => {
                     const savedFlowId = localStorage.getItem("flowId");
-                    const actionTrigger = localStorage.getItem("actionTrigger");
 
                     if (code !== "null" && state !== "null") {
                         setPostBody({
                             flowId: savedFlowId,
-                            actionId: actionTrigger,
+                            actionId: "",
                             inputs: { 
                                 code,
                                 state 


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement, or the change introduced by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

In the request made to the server after getting the code from Google authenticator we need to drop the action ID due to the validation introduced in the backend. 

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
