### PR TITLE
Filter out old application templates in extension API calls

### DIFF
--- a/.changeset/many-donkeys-dance.md
+++ b/.changeset/many-donkeys-dance.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.application-templates.v1": patch
+"@wso2is/console": patch
+---
+
+Filter out old application templates in extension API calls

--- a/features/admin.application-templates.v1/api/use-get-application-template-metadata.ts
+++ b/features/admin.application-templates.v1/api/use-get-application-template-metadata.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/features/admin.application-templates.v1/api/use-get-application-template-metadata.ts
+++ b/features/admin.application-templates.v1/api/use-get-application-template-metadata.ts
@@ -23,6 +23,7 @@ import useRequest, {
 } from "@wso2is/admin.core.v1/hooks/use-request";
 import { store } from "@wso2is/admin.core.v1/store";
 import { HttpMethods } from "@wso2is/core/models";
+import { ApplicationTemplateConstants } from "../constants/templates";
 import { ApplicationTemplateMetadataInterface } from "../models/templates";
 
 /**
@@ -45,7 +46,11 @@ const useGetApplicationTemplateMetadata = <Data = ApplicationTemplateMetadataInt
         url: store?.getState()?.config?.endpoints?.applicationTemplateMetadata?.replace("{{id}}", id)
     };
 
-    const { data, error, isValidating, mutate } = useRequest<Data, Error>(shouldFetch ? requestConfig : null);
+    const isExcludedAppTemplateForExtensionAPI: boolean =
+        ApplicationTemplateConstants.EXCLUDED_APP_TEMPLATES_FOR_EXTENSION_API.includes(id);
+
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(
+        shouldFetch && !isExcludedAppTemplateForExtensionAPI ? requestConfig : null);
 
     return {
         data,

--- a/features/admin.application-templates.v1/api/use-get-application-template.ts
+++ b/features/admin.application-templates.v1/api/use-get-application-template.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/features/admin.application-templates.v1/api/use-get-application-template.ts
+++ b/features/admin.application-templates.v1/api/use-get-application-template.ts
@@ -23,6 +23,7 @@ import useRequest, {
 } from "@wso2is/admin.core.v1/hooks/use-request";
 import { store } from "@wso2is/admin.core.v1/store";
 import { HttpMethods } from "@wso2is/core/models";
+import { ApplicationTemplateConstants } from "../constants/templates";
 import { ApplicationTemplateInterface } from "../models/templates";
 
 /**
@@ -44,7 +45,11 @@ const useGetApplicationTemplate = <Data = ApplicationTemplateInterface, Error = 
         url: store?.getState()?.config?.endpoints?.applicationTemplate?.replace("{{id}}", id)
     };
 
-    const { data, error, isValidating, mutate } = useRequest<Data, Error>(shouldFetch ? requestConfig : null);
+    const isExcludedAppTemplateForExtensionAPI: boolean =
+            ApplicationTemplateConstants.EXCLUDED_APP_TEMPLATES_FOR_EXTENSION_API.includes(id);
+
+    const { data, error, isValidating, mutate } = useRequest<Data, Error>(
+        shouldFetch && !isExcludedAppTemplateForExtensionAPI ? requestConfig : null);
 
     return {
         data,

--- a/features/admin.application-templates.v1/constants/templates.ts
+++ b/features/admin.application-templates.v1/constants/templates.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -53,4 +53,18 @@ export class ApplicationTemplateConstants {
         [ AuthProtocolTypes.WS_FEDERATION ]: "passiveSts",
         [ AuthProtocolTypes.WS_TRUST ]: "wsTrust"
     };
+
+    /**
+     * Excludes old application templates from triggering API calls to fetch
+     * template or metadata JSON files, as they have not been migrated to the
+     * extension API.
+     */
+    public static readonly EXCLUDED_APP_TEMPLATES_FOR_EXTENSION_API: string[] = [
+        "custom-application",
+        "custom-protocol-application",
+        "m2m-application",
+        "mobile-application",
+        "single-page-application",
+        "traditional-web-application"
+    ];
 }

--- a/features/admin.application-templates.v1/constants/templates.ts
+++ b/features/admin.application-templates.v1/constants/templates.ts
@@ -49,10 +49,10 @@ export class ApplicationTemplateConstants {
     public static readonly APPLICATION_INBOUND_PROTOCOL_KEYS: {
         [ AuthProtocolTypes.WS_FEDERATION ]: string;
         [ AuthProtocolTypes.WS_TRUST ]: string;
-    } = {
-        [ AuthProtocolTypes.WS_FEDERATION ]: "passiveSts",
-        [ AuthProtocolTypes.WS_TRUST ]: "wsTrust"
-    };
+        } = {
+            [ AuthProtocolTypes.WS_FEDERATION ]: "passiveSts",
+            [ AuthProtocolTypes.WS_TRUST ]: "wsTrust"
+        };
 
     /**
      * Excludes old application templates from triggering API calls to fetch


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Excludes old application templates from triggering API calls to fetch template or metadata JSON files, as they have not been migrated to the extension API.


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
