### PR TITLE
Fix application edit view breaking in sub organizations

### DIFF
--- a/.changeset/fuzzy-peaches-play.md
+++ b/.changeset/fuzzy-peaches-play.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Fix application edit view breaking in sub organizations

--- a/features/admin.applications.v1/components/forms/general-details-form/general-details-form.tsx
+++ b/features/admin.applications.v1/components/forms/general-details-form/general-details-form.tsx
@@ -267,7 +267,7 @@ export const GeneralDetailsForm: FunctionComponent<GeneralDetailsFormPopsInterfa
     const [ isMcpClientApplication, setIsMcpClientApplication ] = useState<boolean>();
 
     useEffect(() => {
-        if (template["originalTemplateId"] === "mcp-client-application") {
+        if (template?.["originalTemplateId"] === "mcp-client-application") {
             setIsMcpClientApplication(true);
         }
     }, [ template ]);

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -606,7 +606,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
     }, [ template ]);
 
     useEffect(() => {
-        if (template["originalTemplateId"] === "mcp-client-application") {
+        if (template?.["originalTemplateId"] === "mcp-client-application") {
             setIsMcpClientApplication(true);
         }
     }, [ template ]);
@@ -1222,8 +1222,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 }
 
                 if (
-                    template["originalTemplateId"] &&
-                    !applicationConfig.allowedGrantTypes[template["originalTemplateId"]].includes(name)
+                    template?.["originalTemplateId"] &&
+                    !applicationConfig.allowedGrantTypes[template["originalTemplateId"]]?.includes(name)
                 ) {
                     return;
                 }

--- a/features/admin.applications.v1/components/settings/access-configuration.tsx
+++ b/features/admin.applications.v1/components/settings/access-configuration.tsx
@@ -1070,7 +1070,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
         }
 
         if (applicationTemplateId === ApplicationTemplateIdTypes.M2M_APPLICATION ||
-            template["originalTemplateId"] === ApplicationTemplateIdTypes.MCP_CLIENT_APPLICATION
+            template?.["originalTemplateId"] === ApplicationTemplateIdTypes.MCP_CLIENT_APPLICATION
         ) {
             return (
                 <>
@@ -1176,7 +1176,7 @@ export const AccessConfiguration: FunctionComponent<AccessConfigurationPropsInte
                                 protocol: ApplicationManagementUtils
                                     .resolveProtocolDisplayName(
                                         applicationTemplateId === ApplicationTemplateIdTypes.M2M_APPLICATION ||
-                                        template["originalTemplateId"] ===
+                                        template?.["originalTemplateId"] ===
                                             ApplicationTemplateIdTypes.MCP_CLIENT_APPLICATION
                                             ? SupportedAuthProtocolTypes.OAUTH2
                                             : SupportedAuthProtocolTypes.OAUTH2_OIDC


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

Due to missing optional chaining operation, attempting to check `originalTemplateId` property in application template results in an uncaught exception when viewing applications that are not generated from the mcp-client-application template. This PR fixes the issue by adding optional chaining to property access wherever necessary.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
