### PR TITLE
Remove search option of language switcher from recovery-portal, authentication portal and x509-cert-auth-portal.

### DIFF
--- a/.changeset/flat-cameras-lie.md
+++ b/.changeset/flat-cameras-lie.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Remove search from language switcher

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -163,7 +163,7 @@
     }
 %>
 
-<div id="language-selector-dropdown" class="ui fluid search selection dropdown language-selector-dropdown" data-testid="language-selector-dropdown">
+<div id="language-selector-dropdown" class="ui fluid selection dropdown language-selector-dropdown" data-testid="language-selector-dropdown">
     <input type="hidden" id="language-selector-input" onChange="onLangChange()" name="language-select" />
     <i class="dropdown icon"></i>
     <div id="language-selector-selected-text" class="default text">

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -150,7 +150,7 @@
     }
 %>
 
-<div id="language-selector-dropdown" class="ui fluid search selection dropdown language-selector-dropdown" data-testid="language-selector-dropdown">
+<div id="language-selector-dropdown" class="ui fluid selection dropdown language-selector-dropdown" data-testid="language-selector-dropdown">
     <input type="hidden" id="language-selector-input" onChange="onLangChange()" name="language-select" />
     <i class="dropdown icon"></i>
     <div id="language-selector-selected-text" class="default text">

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -163,7 +163,7 @@
     }
 %>
 
-<div id="language-selector-dropdown" class="ui fluid search selection dropdown language-selector-dropdown" data-testid="language-selector-dropdown">
+<div id="language-selector-dropdown" class="ui fluid selection dropdown language-selector-dropdown" data-testid="language-selector-dropdown">
     <input type="hidden" id="language-selector-input" onChange="onLangChange()" name="language-select" />
     <i class="dropdown icon"></i>
     <div id="language-selector-selected-text" class="default text">


### PR DESCRIPTION
This pull request includes changes to remove the `search` class from the language selector dropdown in multiple files. This change simplifies the dropdown by removing the search functionality.

Changes to language selector dropdowns:

* [`identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp`](diffhunk://#diff-e0e69cd22ed58f3880b435eff43b0b5da3186781364bcfdf5edb9bd174d97117L166-R166): Removed the `search` class from the `language-selector-dropdown` div.
* [`identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp`](diffhunk://#diff-cfaa9970bd999170585b2f2f8543d28d2e111cd5765f27d2bd26dd7ac48b301eL153-R153): Removed the `search` class from the `language-selector-dropdown` div.
* [`identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/language-switcher.jsp`](diffhunk://#diff-6ba3309feb092d5987a4a3a3cd7a49bd010503f57ca92512e0ef149a1b243fd9L166-R166): Removed the `search` class from the `language-selector-dropdown` div.

### Related Issue/s 
- https://github.com/wso2/product-is/issues/23745
