### PR TITLE
Allow "." in claim uri from UI

### DIFF
--- a/.changeset/five-bulldogs-smile.md
+++ b/.changeset/five-bulldogs-smile.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/console": patch
+---
+
+Allow "." in claim uri from UI

--- a/features/admin.claims.v1/components/wizard/local-claim/basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/wizard/local-claim/basic-details-local-claims.tsx
@@ -221,8 +221,8 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                         loading={ validateMapping }
                                         listen={ (values: Map<string, FormValue>) => {
                                             setClaimID(values.get("claimURI").toString());
-                                            setOidcMapping(values.get("claimURI").toString().replace(/\./g,""));
-                                            setScimMapping(values.get("claimURI").toString().replace(/\./g,""));
+                                            setOidcMapping(values.get("claimURI").toString());
+                                            setScimMapping(values.get("claimURI").toString());
                                             setIsScimMappingRemoved(false);
                                         } }
                                         onMouseOver={ () => {
@@ -241,7 +241,7 @@ export const BasicDetailsLocalClaims = (props: BasicDetailsLocalClaimsPropsInter
                                             let isAttributeValid: boolean = true;
 
                                             // TODO : Discuss on max characters for attribute name
-                                            if (!value.match(/^\w+$/) || value.length > 30) {
+                                            if (!value.match(/^\w+(\.\w+)?$/) || value.length > 30) {
                                                 isAttributeValid = false;
                                             }
 


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
1. This PR will allow `.` in claim uri in the claim creation wizard.
2. `.` is normally used when creating complex attributes. Hence this improvement done to support that particular case. 

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/23612