### PR TITLE
Add sign-in assertion profile

### DIFF
--- a/.changeset/bright-terms-pay.md
+++ b/.changeset/bright-terms-pay.md
@@ -1,0 +1,9 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.claims.v1": patch
+"@wso2is/myaccount": patch
+"@wso2is/core": patch
+"@wso2is/i18n": patch
+---
+
+Add sign-in assertion profile

--- a/apps/myaccount/src/models/profile.ts
+++ b/apps/myaccount/src/models/profile.ts
@@ -141,6 +141,10 @@ export interface ProfileSchema {
          * Attribute profile for self registration
          */
         selfRegister?: ProfileAttributeInterface;
+        /**
+         * Attribute profile for sign in assertion
+         */
+        signInAssertion?: ProfileAttributeInterface;
     }
 }
 

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -606,6 +606,11 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         supportedByDefault: values?.selfRegistrationSupportedByDefault !== undefined ?
                             (isSelfRegistrationRequired || !!values.selfRegistrationSupportedByDefault)
                             : claim?.profiles?.selfRegistration?.supportedByDefault
+                    },
+                    signInAssertion: {
+                        supportedByDefault: values?.signInAssertionSupportedByDefault !== undefined ?
+                            !!values.signInAssertionSupportedByDefault
+                            : false
                     }
                 },
                 properties: claim?.properties,
@@ -734,6 +739,15 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         }
                     />
                 </TableCell>
+                <TableCell align="center">
+                    <Field.Checkbox
+                        ariaLabel="Display by default in sign-in assertion"
+                        name="signInAssertionSupportedByDefault"
+                        defaultValue={ claim?.profiles?.signInAssertion?.supportedByDefault ?? true }
+                        data-componentid={ `${testId}-form-sign-in-assertion-supported-by-default-checkbox` }
+                        readOnly={ isSupportedByDefaultCheckboxDisabled }
+                    />
+                </TableCell>
             </TableRow>
         );
     };
@@ -815,6 +829,23 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         }
                     />
                 </TableCell>
+                <TableCell align="center">
+                    <Tooltip
+                        trigger={ (
+                            <Field.Checkbox
+                                ariaLabel="Required in sign-in assertion"
+                                name="signInAssertionRequired"
+                                defaultValue={ claim?.profiles?.signInAssertion?.required ?? false }
+                                data-componentid={ `${testId}-form-sign-in-assertion-required-checkbox` }
+                                readOnly
+                            />
+                        ) }
+                        content={
+                            t("claims:local.forms.profiles.signInAssertionRequiredHint")
+                        }
+                        compact
+                    />
+                </TableCell>
             </TableRow>
         );
     };
@@ -876,6 +907,23 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         ) }
                         content={
                             t("claims:local.forms.profiles.selfRegistrationReadOnlyHint")
+                        }
+                        compact
+                    />
+                </TableCell>
+                <TableCell align="center">
+                    <Tooltip
+                        trigger={ (
+                            <Field.Checkbox
+                                ariaLabel="Read-only in sign-in assertion"
+                                name="signInAssertionReadOnly"
+                                defaultValue={ claim?.profiles?.signInAssertion?.readOnly ?? false }
+                                data-componentid={ `${testId}-form-sign-in-assertion-readOnly-checkbox` }
+                                readOnly
+                            />
+                        ) }
+                        content={
+                            t("claims:local.forms.profiles.signInAssertionReadOnlyHint")
                         }
                         compact
                     />
@@ -1219,6 +1267,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                                 </TableCell>
                                                 <TableCell align="center">
                                                     { t("claims:local.forms.profiles.selfRegistration") }
+                                                </TableCell>
+                                                <TableCell align="center">
+                                                    { t("claims:local.forms.profiles.signInAssertion") }
                                                 </TableCell>
                                             </TableRow>
                                         </TableHead>

--- a/modules/core/src/models/claim.ts
+++ b/modules/core/src/models/claim.ts
@@ -38,6 +38,7 @@ export interface Claim {
         console?: AttributeProfileConfig;
         endUser?: AttributeProfileConfig;
         selfRegistration?: AttributeProfileConfig;
+        signInAssertion?: AttributeProfileConfig;
     }
 }
 

--- a/modules/core/src/models/profile.ts
+++ b/modules/core/src/models/profile.ts
@@ -234,6 +234,10 @@ export interface ProfileSchemaInterface {
          * Attribute profile for self registration
          */
         selfRegistration?: ProfileAttributeInterface;
+        /**
+         * Attribute profile for sign in assertion
+         */
+        signInAssertion?: ProfileAttributeInterface;
     }
 }
 

--- a/modules/i18n/src/models/namespaces/claims-ns.ts
+++ b/modules/i18n/src/models/namespaces/claims-ns.ts
@@ -540,6 +540,9 @@ export interface ClaimsNS {
                 readonly: string;
                 readonlyHint: string;
                 selfRegistrationReadOnlyHint: string;
+                signInAssertionReadOnlyHint: string;
+                signInAssertionRequiredHint: string;
+                signInAssertion: string;
             };
         };
         dangerZone: {

--- a/modules/i18n/src/translations/en-US/portals/claims.ts
+++ b/modules/i18n/src/translations/en-US/portals/claims.ts
@@ -494,7 +494,10 @@ export const claims: ClaimsNS = {
                 required: "Required",
                 requiredHint: "If selected, the user must specify a value for this attribute in the profile. Read-only attributes cannot be marked as required.",
                 selfRegistration: "Self-Registration",
-                selfRegistrationReadOnlyHint: "Read-only configuration is not applicable in the self-registration profile."
+                selfRegistrationReadOnlyHint: "Read-only configuration is not applicable in the self-registration profile.",
+                signInAssertion: "Sign-in Assertion",
+                signInAssertionReadOnlyHint: "Read-only configuration is not applicable in the sign-in assertion profile.",
+                signInAssertionRequiredHint: "Required configuration is not applicable in the sign-in assertion profile."
             },
             readOnly: {
                 label: "Make this attribute read-only on the user's profile"


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

New profile support added for Sign-In Assertion
- UI changes in claim editing view to allow toggling display property under the new profile
- Filtering logic implemented in the SP attribute selection UIs to only display claims supported by the sign-in assertion profile.

<img width="696" alt="Screenshot 2025-04-18 at 10 02 17" src="https://github.com/user-attachments/assets/06f564d1-1b4e-4902-b6c8-4353962b4357" />

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2-enterprise/asgardeo-product/issues/29873

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
