### PR TITLE
[bug-fix] Disable read-only user store users' profile image updating via console

### DIFF
--- a/.changeset/tough-months-wink.md
+++ b/.changeset/tough-months-wink.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.console-settings.v1": patch
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Disable profile image updating of administrators

--- a/features/admin.console-settings.v1/pages/console-administrator-edit-page.tsx
+++ b/features/admin.console-settings.v1/pages/console-administrator-edit-page.tsx
@@ -16,11 +16,14 @@
  * under the License.
  */
 
+import { useRequiredScopes } from "@wso2is/access-control";
 import { getProfileInformation } from "@wso2is/admin.authentication.v1/store";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import { AppState } from "@wso2is/admin.core.v1/store";
+import { SCIMConfigs } from "@wso2is/admin.extensions.v1/configs/scim";
+import { userstoresConfig } from "@wso2is/admin.extensions.v1/configs/userstores";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import { getGovernanceConnectors } from "@wso2is/admin.server-configurations.v1/api";
 import { ServerConfigurationsConstants } from "@wso2is/admin.server-configurations.v1/constants";
@@ -28,9 +31,11 @@ import { ConnectorPropertyInterface, GovernanceConnectorInterface }
     from "@wso2is/admin.server-configurations.v1/models";
 import { getUserDetails, updateUserInfo } from "@wso2is/admin.users.v1/api/users";
 import { EditUser } from "@wso2is/admin.users.v1/components/edit-user";
+import { UserManagementConstants } from "@wso2is/admin.users.v1/constants/user-management-constants";
 import UserManagementProvider from "@wso2is/admin.users.v1/providers/user-management-provider";
 import { UserManagementUtils } from "@wso2is/admin.users.v1/utils/user-management-utils";
-import { hasRequiredScopes, resolveUserDisplayName, resolveUserEmails } from "@wso2is/core/helpers";
+import useUserStores from "@wso2is/admin.userstores.v1/hooks/use-user-stores";
+import { isFeatureEnabled, resolveUserDisplayName, resolveUserEmails } from "@wso2is/core/helpers";
 import {
     AlertInterface,
     AlertLevels,
@@ -41,7 +46,7 @@ import {
 }from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { EditAvatarModal, Popup, TabPageLayout, UserAvatar } from "@wso2is/react-components";
-import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, MouseEvent, ReactElement, useEffect, useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
@@ -63,23 +68,49 @@ const ConsoleAdministratorsEditPage: FunctionComponent<ConsoleAdministratorsEdit
     props: ConsoleAdministratorsEditPageInterface
 ): ReactElement => {
 
-    const { "data-componentid": componentId } = props;
+    const { "data-componentid": componentId = "console-administrators-edit-page" } = props;
 
     const { t } = useTranslation();
 
     const dispatch: Dispatch<any> = useDispatch();
 
     const { isSuperOrganization } = useGetCurrentOrganizationType();
+    const { isUserStoreReadOnly, readOnlyUserStoreNamesList } = useUserStores();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
-    const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
     const profileInfo: ProfileInfoInterface = useSelector((state: AppState) => state.profile.profileInfo);
+    const hasUsersUpdatePermissions: boolean = useRequiredScopes(featureConfig?.users?.scopes?.update);
+    const isUserUpdateFeatureEnabled: boolean = isFeatureEnabled(
+        featureConfig?.users, UserManagementConstants.FEATURE_DICTIONARY.get("USER_UPDATE"));
+    const isUpdatingSharedProfilesFeatureEnabled: boolean = isFeatureEnabled(
+        featureConfig?.users, UserManagementConstants.FEATURE_DICTIONARY.get("USER_SHARED_PROFILES"));
 
     const [ user, setUserProfile ] = useState<ProfileInfoInterface>(emptyProfileInfo);
     const [ isUserDetailsRequestLoading, setIsUserDetailsRequestLoading ] = useState<boolean>(false);
     const [ showEditAvatarModal, setShowEditAvatarModal ] = useState<boolean>(false);
     const [ connectorProperties, setConnectorProperties ] = useState<ConnectorPropertyInterface[]>(undefined);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+
+    /**
+     * Checks if the user store is read only.
+     */
+    const isReadOnlyUserStore: boolean = useMemo(() => {
+        const userStoreName: string = user?.userName?.split("/").length > 1
+            ? user?.userName?.split("/")[0]
+            : userstoresConfig.primaryUserstoreName;
+
+        return isUserStoreReadOnly(userStoreName);
+    }, [ user, readOnlyUserStoreNamesList ]);
+
+    /**
+     * Checks if the UI should be in read-only mode.
+     */
+    const isReadOnly: boolean = !isUserUpdateFeatureEnabled
+        || !hasUsersUpdatePermissions
+        || isReadOnlyUserStore
+        || user[ SCIMConfigs.scim.systemSchema ]?.userSourceId
+        || user[ SCIMConfigs.scim.systemSchema ]?.isReadOnlyUser === "true"
+        || (user[ SCIMConfigs.scim.systemSchema ]?.managedOrg && !isUpdatingSharedProfilesFeatureEnabled);
 
     useEffect(() => {
         if (isSuperOrganization) {
@@ -298,16 +329,12 @@ const ConsoleAdministratorsEditPage: FunctionComponent<ConsoleAdministratorsEdit
                     user.userName) }
                 image={ (
                     <UserAvatar
-                        editable={
-                            hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
-                        }
+                        editable={ !isReadOnly }
+                        hoverable={ false }
                         name={ resolveUserDisplayName(user) }
                         size="tiny"
                         image={ user?.profileUrl }
-                        onClick={ () =>
-                            hasRequiredScopes(featureConfig?.users, featureConfig?.users?.scopes?.update, allowedScopes)
-                            && setShowEditAvatarModal(true)
-                        }
+                        onClick={ () => !isReadOnly && setShowEditAvatarModal(true) }
                     />
                 ) }
                 loadingStateOptions={ {
@@ -324,11 +351,12 @@ const ConsoleAdministratorsEditPage: FunctionComponent<ConsoleAdministratorsEdit
                 data-componentid={ componentId }
             >
                 <EditUser
-                    featureConfig={ featureConfig }
                     user={ user }
                     handleUserUpdate={ handleUserUpdate }
                     connectorProperties={ connectorProperties }
                     isLoading={ isUserDetailsRequestLoading }
+                    isReadOnly={ isReadOnly }
+                    isReadOnlyUserStore={ isReadOnlyUserStore }
                 />
                 {
                     showEditAvatarModal && (
@@ -416,10 +444,6 @@ const ConsoleAdministratorsEditPage: FunctionComponent<ConsoleAdministratorsEdit
             </TabPageLayout>
         </UserManagementProvider>
     );
-};
-
-ConsoleAdministratorsEditPage.defaultProps = {
-    "data-componentid": "console-administrators-edit-page"
 };
 
 export default ConsoleAdministratorsEditPage;

--- a/features/admin.console-settings.v1/pages/console-administrator-edit-page.tsx
+++ b/features/admin.console-settings.v1/pages/console-administrator-edit-page.tsx
@@ -330,7 +330,7 @@ const ConsoleAdministratorsEditPage: FunctionComponent<ConsoleAdministratorsEdit
                 image={ (
                     <UserAvatar
                         editable={ !isReadOnly }
-                        hoverable={ false }
+                        hoverable={ !isReadOnly }
                         name={ resolveUserDisplayName(user) }
                         size="tiny"
                         image={ user?.profileUrl }


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
$subject

Before:

https://github.com/user-attachments/assets/e93a723b-9f2e-4889-82d4-8a2415481aeb

Now:

https://github.com/user-attachments/assets/76e96fb6-4235-4c0d-9341-83d98a2cb8e9


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
