### PR TITLE
Fix footer not being stacked on mobile view

### DIFF
--- a/.changeset/thin-pianos-wait.md
+++ b/.changeset/thin-pianos-wait.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix footer not being stacked on mobile view

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -22,7 +22,7 @@
 copyright=© {{currentYear}} WSO2 LLC.
 site.title=WSO2 Identity Server
 powered.by=Bereitgestellt von
-privacy.policy=Datenschutz-Bestimmungen gelesen und verstanden
+privacy.policy=Datenschutzerklärung
 terms.of.service=Nutzungsbedingungen
 # <!-- End of Common Translations -->
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/css/product-footer.css
@@ -1,0 +1,4 @@
+.flex-wrap {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/css/product-footer.css
@@ -1,4 +1,6 @@
-.flex-wrap {
+.ida-flex {
     display: flex;
+}
+.ida-flex-wrap {
     flex-wrap: wrap;
 }

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -73,7 +73,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu flex-wrap">
+            <div class="right menu ida-flex ida-flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -45,6 +45,9 @@
     }
 %>
 
+<%-- Custom styles --%>
+<link href="css/product-footer.css" rel="stylesheet">
+
 <%-- footer --%>
 <footer class="footer">
     <div class="ui container fluid">
@@ -70,7 +73,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu">
+            <div class="right menu flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
@@ -21,7 +21,7 @@
 copyright=© {{currentYear}} WSO2 LLC.
 site.title=WSO2 Identity Server
 powered.by=Bereitgestellt von
-privacy.policy=Datenschutz-Bestimmungen gelesen und verstanden
+privacy.policy=Datenschutzerklärung
 terms.of.service=Nutzungsbedingungen
 # <!-- End of Common Translations -->
 

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/css/product-footer.css
@@ -1,0 +1,4 @@
+.flex-wrap {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/css/product-footer.css
@@ -1,4 +1,6 @@
-.flex-wrap {
+.ida-flex {
     display: flex;
+}
+.ida-flex-wrap {
     flex-wrap: wrap;
 }

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
@@ -68,7 +68,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu flex-wrap">
+            <div class="right menu ida-flex ida-flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
@@ -44,6 +44,9 @@
     }
 %>
 
+<%-- Custom styles --%>
+<link href="css/product-footer.css" rel="stylesheet">
+
 <%-- footer --%>
 <footer class="footer">
     <div class="ui container fluid">
@@ -65,7 +68,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu">
+            <div class="right menu flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -20,7 +20,7 @@
 copyright=© {{currentYear}} WSO2 LLC.
 site.title=WSO2 Identity Server
 powered.by=Bereitgestellt von
-privacy.policy=Datenschutz-Bestimmungen gelesen und verstanden
+privacy.policy=Datenschutzerklärung
 terms.of.service=Nutzungsbedingungen
 # <!-- End of Common Translations -->
 

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/css/product-footer.css
@@ -1,0 +1,4 @@
+.flex-wrap {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/css/product-footer.css
@@ -1,4 +1,6 @@
-.flex-wrap {
+.ida-flex {
     display: flex;
+}
+.ida-flex-wrap {
     flex-wrap: wrap;
 }

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -44,6 +44,9 @@
     }
 %>
 
+<%-- Custom styles --%>
+<link href="css/product-footer.css" rel="stylesheet">
+
 <%-- footer --%>
 <footer class="footer">
     <div class="ui container fluid">
@@ -69,7 +72,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu">
+            <div class="right menu flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -72,7 +72,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu flex-wrap">
+            <div class="right menu ida-flex ida-flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>


### PR DESCRIPTION
This pull request introduces a new `flex-wrap` CSS class to improve the responsiveness of the footer layout across multiple portals (`authentication-portal`, `recovery-portal`, and `x509-certificate-authentication-portal`). The changes ensure that footer items wrap properly on smaller screens. The updates include adding the new CSS class, linking the corresponding stylesheet, and applying the class to the footer's HTML structure.

### CSS Enhancements:
* Added a new `.flex-wrap` class in `product-footer.css` for all three portals to enable flexible wrapping of elements. (`[identity-apps-core/apps/authentication-portal/src/main/webapp/css/product-footer.cssR1-R4](diffhunk://#diff-8e8923e5407fb85d377acaccfbe803a61381d55e0c46e2e7f78161ee64055ddaR1-R4)`)

### HTML Updates:
* Included the `product-footer.css` stylesheet in the `product-footer.jsp` file for all three portals to apply the new styles. (`[[1]](diffhunk://#diff-e299c974343d2ad4ca2b0340192594ea6ef76c4699543a4f20dae7f0781f42d0R48-R50)`, `[[2]](diffhunk://#diff-910f1f233b66bec0066b5b7ee85c5cb5ff751f263009bfda5958fe5d1f2f1ab2R47-R49)`, `[[3]](diffhunk://#diff-6411a023c1281c84ea3be40545f8f7d65c69a2873664e5a78a78e7edd109df65R47-R49)`)
* Updated the `<div class="right menu">` element in the footer to include the `flex-wrap` class, ensuring proper wrapping of footer items. (`[[1]](diffhunk://#diff-e299c974343d2ad4ca2b0340192594ea6ef76c4699543a4f20dae7f0781f42d0L73-R76)`, `[[2]](diffhunk://#diff-910f1f233b66bec0066b5b7ee85c5cb5ff751f263009bfda5958fe5d1f2f1ab2L68-R71)`, `[[3]](diffhunk://#diff-6411a023c1281c84ea3be40545f8f7d65c69a2873664e5a78a78e7edd109df65L72-R75)`)

### Related Issues 
- https://github.com/wso2/product-is/issues/23670

### Fix demo 

https://github.com/user-attachments/assets/deb81407-2693-4d4b-af5c-85673ca8a176

