### PR TITLE
Remove invalid regex used for email validation.

### DIFF
--- a/features/admin.users.v1/components/wizard/steps/add-user-basic.tsx
+++ b/features/admin.users.v1/components/wizard/steps/add-user-basic.tsx
@@ -964,11 +964,7 @@ export const AddUserUpdated: React.FunctionComponent<AddUserProps> = (
                         validation={ async (value: string, validation: Validation) => {
                             setBasicDetailsLoading(true);
 
-                            // Check username validity against userstore regex.
-                            if (value && (
-                                !SharedUserStoreUtils.validateInputAgainstRegEx(
-                                    value, userStoreUsernameRegEx))
-                                    || !FormValidation.email(value)) {
+                            if (value && !FormValidation.email(value)) {
                                 validation.isValid = false;
                                 validation.errorMessages.push(USERNAME_REGEX_VIOLATION_ERROR_MESSAGE);
                                 scrollToInValidField("email");


### PR DESCRIPTION
This pull request includes a change to the `AddUserBasic` component in the `admin.users.v1` feature. The change simplifies the username validation logic by removing the check against the user store regex and retaining only the email validation.

Validation logic update:

* [`features/admin.users.v1/components/wizard/steps/add-user-basic.tsx`](diffhunk://#diff-570e187a8837eb9a1d4af80e2defb067cb7d3d66a54e6fcfb913e717db4732d1L967-R967): Removed the username validation against the user store regex (`SharedUserStoreUtils.validateInputAgainstRegEx`) and retained only the email validation using `FormValidation.email`. This simplifies the validation logic.

### Related Issues
- https://github.com/wso2/product-is/issues/23753
- https://github.com/wso2/product-is/issues/23764