### PR TITLE
Fix NPE while accessing oauth2_error.jsp page with missing parameters

### DIFF
--- a/.changeset/honest-donuts-joke.md
+++ b/.changeset/honest-donuts-joke.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix NPE issue when accessing oauth2_error.jsp with missing parameters

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/oauth2_error.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/oauth2_error.jsp
@@ -11,6 +11,7 @@
 
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
+<%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
 <%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
@@ -30,10 +31,12 @@
     String regex = "application=";
     String errorMsgContext = errorMsg;
     String errorMsgApp = "";
-    String[] error = errorMsg.split(regex);
-    if (error.length > 1) {
-        errorMsgContext = errorMsg.split(regex)[0] + regex;
-        errorMsgApp = errorMsg.split(regex)[1];
+    if (StringUtils.isNotBlank(errorMsg)) {
+        String[] error = errorMsg.split(regex);
+        if (error.length > 1) {
+            errorMsgContext = errorMsg.split(regex)[0] + regex;
+            errorMsgApp = errorMsg.split(regex)[1];
+        }
     }
 %>
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/oauth2_error.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/oauth2_error.jsp
@@ -34,8 +34,8 @@
     if (StringUtils.isNotBlank(errorMsg)) {
         String[] error = errorMsg.split(regex);
         if (error.length > 1) {
-            errorMsgContext = errorMsg.split(regex)[0] + regex;
-            errorMsgApp = errorMsg.split(regex)[1];
+            errorMsgContext = error[0] + regex;
+            errorMsgApp = error[1];
         }
     }
 %>


### PR DESCRIPTION
When oauth2_error.jsp page is accessed without the oauthErrorMsg parameter, a null pointer exception is thrown. This PR contains the fix for it.

Related issue:
- https://github.com/wso2/product-is/issues/23785

Previous behaviour:
A null pointer exception was logged in the server logs and the below message is shown in the UI.
<img width="746" alt="Screenshot 2025-04-19 at 15 55 01" src="https://github.com/user-attachments/assets/f3e11efb-f1ff-42d6-92f1-222ec7f28909" />

After this fix:
No error message in server logs and the below message is shown in the UI.
<img width="746" alt="Screenshot 2025-04-19 at 15 53 43" src="https://github.com/user-attachments/assets/c692bc92-683b-49a2-9f97-96ade0e40449" />
