### PR TITLE
Remove base64 encoding for push discovery data in QR code

### DIFF
--- a/.changeset/famous-vans-wait.md
+++ b/.changeset/famous-vans-wait.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Remove base64 encoding for push discovery data in QR code

--- a/apps/myaccount/src/hooks/use-push-authenticator.ts
+++ b/apps/myaccount/src/hooks/use-push-authenticator.ts
@@ -67,7 +67,7 @@ const usePushAuthenticator = () => {
 
         initPushAuthenticatorQRCode()
             .then((response: any) => {
-                const qrCode: string = window.btoa(JSON.stringify(response?.data));
+                const qrCode: string = JSON.stringify(response?.data);
 
                 setIsConfigPushAuthenticatorModalOpen(true);
                 setQrCode(qrCode);


### PR DESCRIPTION
With this PR, we will remove the behaviour of encoding and showing the push diacovery data in the QR code.

Related issue:
- https://github.com/wso2/product-is/issues/23863