### PR TITLE
Disable multi valued property for system claims

### DIFF
--- a/.changeset/wild-parents-battle.md
+++ b/.changeset/wild-parents-battle.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Disable the multi valued check box for the system claims

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -964,7 +964,9 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         required={ false }
                         defaultValue={ claim?.multiValued }
                         data-testid={ `${testId}-form-multi-valued-input` }
-                        hint={ !isSystemClaim && t("claims:local.forms.multiValuedHint") }
+                        hint={ isSystemClaim
+                            ? t("claims:local.forms.multiValuedDisabledHint")
+                            : t("claims:local.forms.multiValuedHint") }
                         readOnly={ isSubOrganization() || isSystemClaim || isReadOnly }
                     />
                     { !attributeConfig.localAttributes.createWizard.showRegularExpression && !hideSpecialClaims

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -964,8 +964,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                         required={ false }
                         defaultValue={ claim?.multiValued }
                         data-testid={ `${testId}-form-multi-valued-input` }
-                        hint={ t("claims:local.forms.multiValuedHint") }
-                        readOnly={ isReadOnly }
+                        hint={ !isSystemClaim && t("claims:local.forms.multiValuedHint") }
+                        readOnly={ isSubOrganization() || isSystemClaim || isReadOnly }
                     />
                     { !attributeConfig.localAttributes.createWizard.showRegularExpression && !hideSpecialClaims
                         && (

--- a/modules/i18n/src/models/namespaces/claims-ns.ts
+++ b/modules/i18n/src/models/namespaces/claims-ns.ts
@@ -512,6 +512,7 @@ export interface ClaimsNS {
                 placeholder: string;
             };
             multiValuedHint: string;
+            multiValuedDisabledHint: string;
             displayOrderHint: string;
             required: {
                 label: string;

--- a/modules/i18n/src/translations/en-US/portals/claims.ts
+++ b/modules/i18n/src/translations/en-US/portals/claims.ts
@@ -473,6 +473,7 @@ export const claims: ClaimsNS = {
                 label: "Allow multiple values for this attribute",
                 placeholder: "Select a user attribute"
             },
+            multiValuedDisabledHint: "This setting cannot be modified for system claims.",
             multiValuedHint: "Select this option if the attribute can have multiple values.",
             name: {
                 label: "Attribute Display Name",


### PR DESCRIPTION
### Purpose

Only the custom claims should be able to configure whether it should be multi valued or not.
The system claims should shown its state whether multi valued or not, but should not allow to update. As updating the claim data type or the structure can harm the system operations.

> 1. For custom claims.
<img width="1103" alt="Screenshot 2025-04-23 at 19 19 33" src="https://github.com/user-attachments/assets/d7934d4b-6a7f-4240-9bad-3210eafd5c07" />


> 2. For system claims

I have updated the hint which guide the users to check the checkbox as for the system claim, the checkbox is not check or uncheck.

2.1  For Single valued claims.

<img width="913" alt="Screenshot 2025-04-23 at 20 29 01" src="https://github.com/user-attachments/assets/54eb7774-48c0-4b13-96ef-47566e947925" />


2.2 For multi valued claims.
<img width="878" alt="Screenshot 2025-04-23 at 20 30 13" src="https://github.com/user-attachments/assets/a48a4fe3-e3f9-4f7a-aaba-a43c27a9bd44" />


### Related Issues
- https://github.com/wso2/product-is/issues/23547
