### PR TITLE
Deprecate configs in Connections

### DIFF
--- a/.changeset/violet-bats-explain.md
+++ b/.changeset/violet-bats-explain.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.connections.v1": patch
+"@wso2is/admin.extensions.v1": patch
 "@wso2is/console": patch
 "@wso2is/i18n": patch
 ---

--- a/.changeset/violet-bats-explain.md
+++ b/.changeset/violet-bats-explain.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.connections.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Deprecate configs in Connections.

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -812,7 +812,11 @@
                 "scopes": {}
             },
             "identityProviders": {
-                "disabledFeatures": [],
+                "disabledFeatures": [
+                    "connections.federationHub",
+                    "connections.saml.artifactBinding",
+                    "connections.saml.attributeConsumingServiceIndex"
+                ],
                 "enabled": true,
                 "featureFlags": [],
                 "scopes": {

--- a/features/admin.connections.v1/components/edit/forms/advanced-configurations-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/advanced-configurations-form.tsx
@@ -19,6 +19,7 @@
 import { Show } from "@wso2is/access-control";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import { AppState } from "@wso2is/admin.core.v1/store";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, FormValue, Forms } from "@wso2is/forms";
 import { Hint } from "@wso2is/react-components";
@@ -26,6 +27,10 @@ import React, { FunctionComponent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Button, Grid } from "semantic-ui-react";
+import {
+    CommonAuthenticatorConstants,
+    ConnectionsFeatureDictionaryKeys
+} from "../../../constants/common-authenticator-constants";
 import { ConnectionAdvanceInterface } from "../../../models/connection";
 
 /**
@@ -73,6 +78,11 @@ export const AdvanceConfigurationsForm: FunctionComponent<AdvanceConfigurationsF
     const { t } = useTranslation();
     const featureConfig : FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
+    const isFederationHubEnabled: boolean = isFeatureEnabled(
+        featureConfig.identityProviders,
+        CommonAuthenticatorConstants.FEATURE_DICTIONARY.get(ConnectionsFeatureDictionaryKeys.FederationHub)
+    );
+
     /**
      * Prepare form values for submitting.
      *
@@ -90,33 +100,38 @@ export const AdvanceConfigurationsForm: FunctionComponent<AdvanceConfigurationsF
     return (
         <Forms onSubmit={ (values: Map<string, FormValue>) => onSubmit(updateConfiguration(values)) }>
             <Grid>
-                <Grid.Row columns={ 1 }>
-                    <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
-                        <Field
-                            name="federationHub"
-                            label=""
-                            required={ false }
-                            requiredErrorMessage={ t("authenticationProvider:forms.common." +
-                                "requiredErrorMessage") }
-                            value={ config?.isFederationHub ? [ "federationHub" ] : [] }
-                            type="checkbox"
-                            children={ [
-                                {
-                                    label: t("authenticationProvider:forms.advancedConfigs." +
+                { isFederationHubEnabled && (
+                    <Grid.Row columns={ 1 }>
+                        <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
+                            <Field
+                                name="federationHub"
+                                label=""
+                                required={ false }
+                                requiredErrorMessage={ t("authenticationProvider:forms.common." +
+                                    "requiredErrorMessage") }
+                                value={ config?.isFederationHub ? [ "federationHub" ] : [] }
+                                type="checkbox"
+                                children={ [
+                                    {
+                                        label: t("authenticationProvider:forms.advancedConfigs." +
                                         "federationHub.label"),
-                                    value: "federationHub"
-                                }
-                            ] }
-                            toggle
-                            data-testid={ `${ testId }-federation-hub` }
-                            readOnly={ isReadOnly }
-                        />
-                        <Hint>
-                            { t("authenticationProvider:forms." +
-                                "advancedConfigs.federationHub.hint") }
-                        </Hint>
-                    </Grid.Column>
-                </Grid.Row>
+                                        value: "federationHub"
+                                    }
+                                ] }
+                                toggle
+                                data-testid={ `${ testId }-federation-hub` }
+                                readOnly={ isReadOnly }
+                            />
+                            <Hint>
+                                { t("authenticationProvider:forms." +
+                                    "advancedConfigs.federationHub.hint") }
+                            </Hint>
+                            <Hint warning>
+                                { t("common:deprecated") }
+                            </Hint>
+                        </Grid.Column>
+                    </Grid.Row>
+                ) }
                 <Grid.Row columns={ 1 }>
                     <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 8 }>
                         <Field

--- a/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -19,16 +19,21 @@
 import Autocomplete, { AutocompleteRenderInputParams } from "@oxygen-ui/react/Autocomplete";
 import TextField from "@oxygen-ui/react/TextField";
 import Typography from "@oxygen-ui/react/Typography";
-import { AppState } from "@wso2is/admin.core.v1/store";
 import { ConfigReducerStateInterface } from "@wso2is/admin.core.v1/models/reducer-state";
+import { AppState } from "@wso2is/admin.core.v1/store";
 import { identityProviderConfig } from "@wso2is/admin.extensions.v1";
-import { TestableComponentInterface } from "@wso2is/core/models";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
+import { FeatureAccessConfigInterface, TestableComponentInterface } from "@wso2is/core/models";
 import { DropdownChild, Field, Form, composeValidators } from "@wso2is/form";
-import { Code, FormInputLabel, FormSection } from "@wso2is/react-components";
+import { Code, FormInputLabel, FormSection, Hint } from "@wso2is/react-components";
 import React, { FunctionComponent, PropsWithChildren, ReactElement, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { Divider, Grid, SemanticWIDTHS } from "semantic-ui-react";
+import {
+    CommonAuthenticatorConstants,
+    ConnectionsFeatureDictionaryKeys
+} from "../../../../constants/common-authenticator-constants";
 import {
     AuthenticatorSettingsFormModes,
     CommonAuthenticatorFormInitialValuesInterface
@@ -142,6 +147,21 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
 
     const disabledFeatures: string[] = useSelector((state: AppState) =>
         state.config.ui.features?.identityProviders?.disabledFeatures);
+
+    const featureConfig: FeatureAccessConfigInterface = useSelector((state: AppState) =>
+        state.config.ui.features?.identityProviders);
+
+    const isArtifactBindingFeatureEnabled: boolean = isFeatureEnabled(
+        featureConfig,
+        CommonAuthenticatorConstants.FEATURE_DICTIONARY.get(ConnectionsFeatureDictionaryKeys.SAMLArtifactBinding)
+    );
+
+    const isAttributeConsumingServiceIndexEnabled: boolean = isFeatureEnabled(
+        featureConfig,
+        CommonAuthenticatorConstants.FEATURE_DICTIONARY.get(
+            ConnectionsFeatureDictionaryKeys.SAMLAttributeConsumingServiceIndex
+        )
+    );
 
     const config: ConfigReducerStateInterface = useSelector((state: AppState) => state.config);
     const { t } = useTranslation();
@@ -883,7 +903,10 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                         </SectionRow>
                     ) }
 
-                    { identityProviderConfig.extendedSamlConfig.attributeConsumingServiceIndexEnabled && (
+                    { (
+                        identityProviderConfig.extendedSamlConfig.attributeConsumingServiceIndexEnabled &&
+                        isAttributeConsumingServiceIndexEnabled
+                    ) && (
                         <SectionRow>
                             <Field.Input
                                 name="AttributeConsumingServiceIndex"
@@ -902,6 +925,9 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                                 hint={ t(`${ I18N_TARGET_KEY }.attributeConsumingServiceIndex.hint`) }
                                 readOnly={ readOnly }
                             />
+                            <Hint warning>
+                                { t("common:deprecated") }
+                            </Hint>
                         </SectionRow>
                     ) }
 
@@ -988,9 +1014,15 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                 <Divider hidden/>
             </FormSection>
 
-            { identityProviderConfig.extendedSamlConfig.isArtifactBindingEnabled && (
+            { (
+                identityProviderConfig.extendedSamlConfig.isArtifactBindingEnabled &&
+                isArtifactBindingFeatureEnabled
+            ) && (
                 <FormSection heading="Artifact Binding">
                     <Grid>
+                        <Hint warning>
+                            { t("common:deprecated") }
+                        </Hint>
                         <SectionRow>
                             <Field.Checkbox
                                 required={ false }

--- a/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/authenticators/saml-authenticator-form.tsx
@@ -903,10 +903,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                         </SectionRow>
                     ) }
 
-                    { (
-                        identityProviderConfig.extendedSamlConfig.attributeConsumingServiceIndexEnabled &&
-                        isAttributeConsumingServiceIndexEnabled
-                    ) && (
+                    { isAttributeConsumingServiceIndexEnabled && (
                         <SectionRow>
                             <Field.Input
                                 name="AttributeConsumingServiceIndex"
@@ -1014,10 +1011,7 @@ export const SamlAuthenticatorSettingsForm: FunctionComponent<SamlSettingsFormPr
                 <Divider hidden/>
             </FormSection>
 
-            { (
-                identityProviderConfig.extendedSamlConfig.isArtifactBindingEnabled &&
-                isArtifactBindingFeatureEnabled
-            ) && (
+            { isArtifactBindingFeatureEnabled && (
                 <FormSection heading="Artifact Binding">
                     <Grid>
                         <Hint warning>

--- a/features/admin.connections.v1/constants/common-authenticator-constants.ts
+++ b/features/admin.connections.v1/constants/common-authenticator-constants.ts
@@ -17,6 +17,15 @@
  */
 
 /**
+ * Keys used in feature dictionary.
+ */
+export enum ConnectionsFeatureDictionaryKeys {
+    FederationHub = "CONNECTIONS_FEDERATION_HUB",
+    SAMLArtifactBinding = "CONNECTIONS_SAML_ARTIFACT_BINDING",
+    SAMLAttributeConsumingServiceIndex = "CONNECTIONS_SAML_ATTRIBUTE_CONSUMING_SERVICE_INDEX",
+}
+
+/**
  * This class contains the constants for the Common for Authenticators.
  */
 export class CommonAuthenticatorConstants {
@@ -100,4 +109,14 @@ export class CommonAuthenticatorConstants {
     public static readonly DISPLAY_NAME_REGEX: RegExp = /^.{3,}$/;
 
     public static readonly TEMPLATE_ID_FIELD: string = "templateId";
+
+    /**
+     * Set of keys used to enable/disable sub-features.
+     */
+    public static readonly FEATURE_DICTIONARY: Map<string, string> = new Map<string, string>([
+        [ ConnectionsFeatureDictionaryKeys.FederationHub, "connections.federationHub" ],
+        [ ConnectionsFeatureDictionaryKeys.SAMLArtifactBinding, "connections.saml.artifactBinding" ],
+        [ ConnectionsFeatureDictionaryKeys.SAMLAttributeConsumingServiceIndex,
+            "connections.saml.attributeConsumingServiceIndex" ]
+    ]);
 }

--- a/features/admin.extensions.v1/configs/identity-provider.tsx
+++ b/features/admin.extensions.v1/configs/identity-provider.tsx
@@ -187,14 +187,12 @@ export const identityProviderConfig: IdentityProviderConfig = {
         showOutboundProvisioning: true
     },
     extendedSamlConfig: {
-        attributeConsumingServiceIndexEnabled: true,
         authContextComparisonLevelEnabled: true,
         enableAssertionSigningEnabled: true,
         forceAuthenticationEnabled: true,
         includeAuthenticationContextEnabled: true,
         includeNameIDPolicyEnabled: true,
         includePublicCertEnabled: true,
-        isArtifactBindingEnabled: true,
         isAssertionEncryptionEnabled: true,
         responseAuthenticationContextClassEnabled: true,
         saml2WebSSOUserIdLocationEnabled: true

--- a/features/admin.extensions.v1/configs/models/identity-providers.ts
+++ b/features/admin.extensions.v1/configs/models/identity-providers.ts
@@ -21,8 +21,6 @@ import { ResourceTabPaneInterface } from "@wso2is/react-components";
 import { ReactElement, ReactNode } from "react";
 
 export interface ExtendedSamlConfigInterface {
-    isArtifactBindingEnabled: boolean;
-    attributeConsumingServiceIndexEnabled: boolean;
     saml2WebSSOUserIdLocationEnabled: boolean;
     authContextComparisonLevelEnabled: boolean;
     responseAuthenticationContextClassEnabled: boolean;

--- a/modules/i18n/src/models/namespaces/common-ns.ts
+++ b/modules/i18n/src/models/namespaces/common-ns.ts
@@ -65,6 +65,7 @@ export interface CommonNS {
     dangerZone: string;
     darkMode: string;
     delete: string;
+    deprecated: string;
     description: string;
     deviceModel: string;
     docs: string;

--- a/modules/i18n/src/translations/de-DE/portals/common.ts
+++ b/modules/i18n/src/translations/de-DE/portals/common.ts
@@ -69,6 +69,7 @@ export const common: CommonNS = {
     "dangerZone": "Gefahrenzone",
     "darkMode": "Dunkler Modus",
     "delete": "Löschen",
+    "deprecated": "Diese Konfiguration ist veraltet und wird in einer zukünftigen Version entfernt.",
     "description": "Beschreibung",
     "deviceModel": "Gerätemodell",
     "disable": "Deaktivieren",

--- a/modules/i18n/src/translations/en-US/portals/common.ts
+++ b/modules/i18n/src/translations/en-US/portals/common.ts
@@ -69,6 +69,7 @@ export const common: CommonNS = {
     dangerZone: "Danger Zone",
     darkMode: "Dark mode",
     delete: "Delete",
+    deprecated: "This configuration is deprecated and will be removed in a future release.",
     description: "Description",
     deviceModel: "Device model",
     disable: "Disable",

--- a/modules/i18n/src/translations/es-ES/portals/common.ts
+++ b/modules/i18n/src/translations/es-ES/portals/common.ts
@@ -69,6 +69,7 @@ export const common: CommonNS = {
     dangerZone: "Zona peligrosa",
     darkMode: "Modo oscuro",
     delete: "Borrar",
+    deprecated: "Esta configuración está obsoleta y se eliminará en una versión futura.",
     description: "Descripción",
     deviceModel: "Modelo de dispositivo",
     disable: "Desactivar",

--- a/modules/i18n/src/translations/fr-FR/portals/common.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/common.ts
@@ -70,6 +70,7 @@ export const common: CommonNS = {
     dangerZone: "Zone de danger",
     darkMode: "Mode sombre",
     delete: "Supprimer",
+    deprecated: "Cette configuration est obsolète et sera supprimée dans une version future.",
     description: "Description",
     deviceModel: "Modèle d'appareil",
     disable: "désactiver",

--- a/modules/i18n/src/translations/ja-JP/portals/common.ts
+++ b/modules/i18n/src/translations/ja-JP/portals/common.ts
@@ -69,6 +69,7 @@ export const common: CommonNS = {
     "dangerZone": "危険区域",
     "darkMode": "ダークモード",
     "delete": "消去",
+    "deprecated": "この構成は非推奨であり、今後のリリースで削除される予定です。",
     "description": "説明",
     "deviceModel": "デバイスモデル",
     "disable": "無効にします",

--- a/modules/i18n/src/translations/pt-BR/portals/common.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/common.ts
@@ -69,6 +69,7 @@ export const common: CommonNS = {
     dangerZone: "Zona de Perigo",
     darkMode: "Modo Escuro",
     delete: "Deletar",
+    deprecated: "Esta configuração foi descontinuada e será removida em uma versão futura.",
     description: "Descrição",
     deviceModel: "Modelo do dispositivo",
     disable: "Desabilitar",

--- a/modules/i18n/src/translations/pt-PT/portals/common.ts
+++ b/modules/i18n/src/translations/pt-PT/portals/common.ts
@@ -69,6 +69,7 @@ export const common: CommonNS = {
     dangerZone: "Zona de perigo",
     darkMode: "Modo escuro",
     delete: "Excluir",
+    deprecated: "Esta configuração foi descontinuada e será removida em uma versão futura.",
     description: "Descrição",
     deviceModel: "Modelo do dispositivo",
     disable: "Desabilitar",

--- a/modules/i18n/src/translations/si-LK/portals/common.ts
+++ b/modules/i18n/src/translations/si-LK/portals/common.ts
@@ -69,6 +69,7 @@ export const common: CommonNS = {
     dangerZone: "අන්තරා කලාපය",
     darkMode: "අඳුරු තේමාව",
     delete: "මකන්න",
+    deprecated: "මෙම වින්‍යාසය අහෝසි කර ඇති අතර අනාගත නිකුතුවකින් ඉවත් කෙරෙනු ඇත.",
     description: "විස්තරය",
     deviceModel: "උපාංග ආකෘතිය",
     disable: "අක්‍රීය",

--- a/modules/i18n/src/translations/ta-IN/portals/common.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/common.ts
@@ -70,6 +70,7 @@ export const common: CommonNS = {
     dangerZone: "ஆபத்து மண்டலம்",
     darkMode: "இருண்ட தீம்",
     delete: "அழி",
+    deprecated: "இந்த கட்டமைப்பு பழமையானது மற்றும் எதிர்கால வெளியீட்டில் நீக்கப்படும்.",
     description: "விபரம்",
     deviceModel: "கருவி மாதிரி",
     disable: "முடக்கப்பட்டது",

--- a/modules/i18n/src/translations/zh-CN/portals/common.ts
+++ b/modules/i18n/src/translations/zh-CN/portals/common.ts
@@ -69,6 +69,7 @@ export const common: CommonNS = {
     "dangerZone": "危险区",
     "darkMode": "黑暗模式",
     "delete": "删除",
+    "deprecated": "此配置已弃用，并将在未来的版本中删除。",
     "description": "描述",
     "deviceModel": "设备型号",
     "disable": "禁用",


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Deprecate the following configs in connections
- Federation hub
- Artifact Binding in SAML
- Attribute consuming service index in SAML

If enabled, they will show the deprecated message.

<img width="495" alt="Screenshot 2025-04-24 at 11 26 09" src="https://github.com/user-attachments/assets/aaf87383-c3c6-4333-a982-1a316195b91b" />

<img width="502" alt="Screenshot 2025-04-24 at 11 26 03" src="https://github.com/user-attachments/assets/456c48da-37e3-473d-927a-681bab604fda" />

<img width="519" alt="Screenshot 2025-04-24 at 11 24 05" src="https://github.com/user-attachments/assets/6623964e-6acf-4713-bb38-2c9054706453" />

### Related Issues
- https://github.com/wso2/product-is/issues/23841

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
