### PR TITLE
Fix left aligned footer when branding applied.

### DIFF
--- a/.changeset/fifty-teachers-hope.md
+++ b/.changeset/fifty-teachers-hope.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix left aligned footer after branding.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/css/product-footer.css
@@ -1,6 +1,5 @@
-.ida-flex {
+.centered-flex-wrap {
     display: flex;
-}
-.ida-flex-wrap {
     flex-wrap: wrap;
+    justify-content: center;
 }

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -73,7 +73,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu ida-flex ida-flex-wrap">
+            <div class="right menu centered-flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/css/product-footer.css
@@ -1,6 +1,5 @@
-.ida-flex {
+.centered-flex-wrap {
     display: flex;
-}
-.ida-flex-wrap {
     flex-wrap: wrap;
+    justify-content: center;
 }

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
@@ -68,7 +68,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu ida-flex ida-flex-wrap">
+            <div class="right menu centered-flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/css/product-footer.css
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/css/product-footer.css
@@ -1,6 +1,5 @@
-.ida-flex {
+.centered-flex-wrap {
     display: flex;
-}
-.ida-flex-wrap {
     flex-wrap: wrap;
+    justify-content: center;
 }

--- a/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/x509-certificate-authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -72,7 +72,7 @@
                     <% } %>
                 </a>
             </div>
-            <div class="right menu ida-flex ida-flex-wrap">
+            <div class="right menu centered-flex-wrap">
             <%
                 if (!StringUtils.isBlank(privacyPolicyURL)) {
             %>


### PR DESCRIPTION
### Purpose 
With the changes introduced with https://github.com/wso2/identity-apps/pull/8063 to fix the issue of language switcher panning outside screen, it introduced another issue where the footer's right panel is left aligned in the mobile veiw. 
This PR fixes that issue and also improves the naming of the CSS classes introduced in the original PR. 

## Related Issue/s 
- https://github.com/wso2/product-is/issues/23670 

### Before Fix 
https://github.com/user-attachments/assets/1c362c90-4fc4-44a8-83f2-16e54642ae21

### After Fix 

https://github.com/user-attachments/assets/20ebaa0d-08d7-4841-a04c-ce4fd09a6e21

