### PR TITLE
Config support for error page for authentication endpoint and account recovery endpoint

### DIFF
--- a/.changeset/empty-moles-train.md
+++ b/.changeset/empty-moles-train.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add config support to have custom error page in webapps

--- a/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.authentication.portal.server.feature/resources/web.xml.j2
@@ -399,59 +399,77 @@
       {% endif %}
     {% endfor %}
 
+    <!-- *************** Custom Error Page Configurations ********************** -->
+    {% set all_error_pages = [] %}
+    {# --- Add custom error pages first --- #}
+    {% for error_page in authenticationendpoint.error_pages %}
     <error-page>
-        <exception-type>java.lang.Throwable</exception-type>
-        <location>/generic-exception-response.jsp</location>
+        {% if error_page['exception-type'] is defined %}
+            <exception-type>{{ error_page['exception-type'] }}</exception-type>
+            <location>{{ error_page.location }}</location>
+        {% elif error_page.code is defined %}
+            <error-code>{{ error_page.code }}</error-code>
+            <location>{{ error_page.location }}</location>
+        {% else %}
+            <location>{{ error_page.location }}</location>
+        {% endif %}
     </error-page>
+    {% endfor %}
+    <!-- *************** End of Custom Error Page Configurations ********************** -->
 
-    <!-- custom error pages -->
+    {# --- Now add defaults, only if not already handled --- #}
+    {% set handled_codes = [] %}
+    {% for error_page in authenticationendpoint.error_pages %}
+        {% if error_page.code is defined %}
+            {% set _ = handled_codes.append(error_page.code) %}
+        {% elif error_page['exception-type'] is defined %}
+            {% set _ = handled_codes.append(error_page['exception-type']) %}
+        {% else %}
+            {% set _ = handled_codes.append('default') %}
+        {% endif %}
+    {% endfor %}
+
+    {% set default_error_pages = [
+        {"exception-type": "java.lang.Throwable", "location": "/error.jsp"},
+        {"code": 400, "location": "/errors/error_400.jsp"},
+        {"code": 401, "location": "/errors/error_401.jsp"},
+        {"code": 403, "location": "/errors/error_403.jsp"},
+        {"code": 404, "location": "/errors/error_404.jsp"},
+        {"code": 405, "location": "/errors/error_405.jsp"},
+        {"code": 408, "location": "/errors/error_408.jsp"},
+        {"code": 410, "location": "/errors/error_410.jsp"},
+        {"code": 500, "location": "/errors/error_500.jsp"},
+        {"code": 502, "location": "/errors/error_502.jsp"},
+        {"code": 503, "location": "/errors/error_503.jsp"},
+        {"code": 504, "location": "/errors/error_504.jsp"},
+        {"location": "/errors/error.jsp"}
+    ] %}
+
+    <!-- *************** Default Error Page Configurations ********************** -->
+    {% for error_page in default_error_pages %}
+        {% if error_page.code is defined %}
+            {% set code_name = error_page.code %}
+        {% elif error_page['exception-type'] is defined %}
+            {% set code_name = error_page['exception-type'] %}
+        {% else %}
+            {% set code_name = 'default' %}
+        {% endif %}
+
+    {% if code_name not in handled_codes %}
     <error-page>
-        <error-code>400</error-code>
-        <location>/errors/error_400.jsp</location>
+        {% if error_page['exception-type'] is defined %}
+            <exception-type>{{ error_page['exception-type'] }}</exception-type>
+            <location>{{ error_page.location }}</location>
+        {% elif error_page.code is defined %}
+            <error-code>{{ error_page.code }}</error-code>
+            <location>{{ error_page.location }}</location>
+        {% else %}
+            <location>{{ error_page.location }}</location>
+        {% endif %}
     </error-page>
-    <error-page>
-        <error-code>401</error-code>
-        <location>/errors/error_401.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>403</error-code>
-        <location>/errors/error_403.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>404</error-code>
-        <location>/errors/error_404.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>405</error-code>
-        <location>/errors/error_405.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>408</error-code>
-        <location>/errors/error_408.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>410</error-code>
-        <location>/errors/error_410.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>500</error-code>
-        <location>/errors/error_500.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>502</error-code>
-        <location>/errors/error_502.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>503</error-code>
-        <location>/errors/error_503.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>504</error-code>
-        <location>/errors/error_504.jsp</location>
-    </error-page>
-    <error-page>
-        <location>/errors/error.jsp</location>
-    </error-page>
+    {% endif %}
+    {% endfor %}
+    <!-- *************** End of Default Error Page Configurations ********************** -->
 
     <session-config>
         <cookie-config>

--- a/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
+++ b/identity-apps-core/features/org.wso2.identity.apps.recovery.portal.server.feature/resources/web.xml.j2
@@ -245,59 +245,77 @@
         {% endif %}
     {% endfor %}
 
+    <!-- *************** Custom Error Page Configurations ********************** -->
+    {% set all_error_pages = [] %}
+    {# --- Add custom error pages first --- #}
+    {% for error_page in accountrecoveryendpoint.error_pages %}
     <error-page>
-        <exception-type>java.lang.Throwable</exception-type>
-        <location>/error.jsp</location>
+        {% if error_page['exception-type'] is defined %}
+            <exception-type>{{ error_page['exception-type'] }}</exception-type>
+            <location>{{ error_page.location }}</location>
+        {% elif error_page.code is defined %}
+            <error-code>{{ error_page.code }}</error-code>
+            <location>{{ error_page.location }}</location>
+        {% else %}
+            <location>{{ error_page.location }}</location>
+        {% endif %}
     </error-page>
+    {% endfor %}
+    <!-- *************** End of Custom Error Page Configurations ********************** -->
 
-    <!-- custom error pages -->
+    {# --- Now add defaults, only if not already handled --- #}
+    {% set handled_codes = [] %}
+    {% for error_page in accountrecoveryendpoint.error_pages %}
+        {% if error_page.code is defined %}
+            {% set _ = handled_codes.append(error_page.code) %}
+        {% elif error_page['exception-type'] is defined %}
+            {% set _ = handled_codes.append(error_page['exception-type']) %}
+        {% else %}
+            {% set _ = handled_codes.append('default') %}
+        {% endif %}
+    {% endfor %}
+
+    {% set default_error_pages = [
+        {"exception-type": "java.lang.Throwable", "location": "/error.jsp"},
+        {"code": 400, "location": "/errors/error_400.jsp"},
+        {"code": 401, "location": "/errors/error_401.jsp"},
+        {"code": 403, "location": "/errors/error_403.jsp"},
+        {"code": 404, "location": "/errors/error_404.jsp"},
+        {"code": 405, "location": "/errors/error_405.jsp"},
+        {"code": 408, "location": "/errors/error_408.jsp"},
+        {"code": 410, "location": "/errors/error_410.jsp"},
+        {"code": 500, "location": "/errors/error_500.jsp"},
+        {"code": 502, "location": "/errors/error_502.jsp"},
+        {"code": 503, "location": "/errors/error_503.jsp"},
+        {"code": 504, "location": "/errors/error_504.jsp"},
+        {"location": "/errors/error.jsp"}
+    ] %}
+
+    <!-- *************** Default Error Page Configurations ********************** -->
+    {% for error_page in default_error_pages %}
+        {% if error_page.code is defined %}
+            {% set code_name = error_page.code %}
+        {% elif error_page['exception-type'] is defined %}
+            {% set code_name = error_page['exception-type'] %}
+        {% else %}
+            {% set code_name = 'default' %}
+        {% endif %}
+
+    {% if code_name not in handled_codes %}
     <error-page>
-        <error-code>400</error-code>
-        <location>/errors/error_400.jsp</location>
+        {% if error_page['exception-type'] is defined %}
+            <exception-type>{{ error_page['exception-type'] }}</exception-type>
+            <location>{{ error_page.location }}</location>
+        {% elif error_page.code is defined %}
+            <error-code>{{ error_page.code }}</error-code>
+            <location>{{ error_page.location }}</location>
+        {% else %}
+            <location>{{ error_page.location }}</location>
+        {% endif %}
     </error-page>
-    <error-page>
-        <error-code>401</error-code>
-        <location>/errors/error_401.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>403</error-code>
-        <location>/errors/error_403.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>404</error-code>
-        <location>/errors/error_404.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>405</error-code>
-        <location>/errors/error_405.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>408</error-code>
-        <location>/errors/error_408.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>410</error-code>
-        <location>/errors/error_410.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>500</error-code>
-        <location>/errors/error_500.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>502</error-code>
-        <location>/errors/error_502.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>503</error-code>
-        <location>/errors/error_503.jsp</location>
-    </error-page>
-    <error-page>
-        <error-code>504</error-code>
-        <location>/errors/error_504.jsp</location>
-    </error-page>
-    <error-page>
-        <location>/errors/error.jsp</location>
-    </error-page>
+    {% endif %}
+    {% endfor %}
+    <!-- *************** End of Default Error Page Configurations ********************** -->
 
     <session-config>
         <cookie-config>


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

- Custom error pages from TOML are now printed **before** default error pages for both authentication and account recovery endpoint.
- Default error pages are rendered **only if** they are not overridden by a custom entry.
- Prevents duplicate `<error-page>` entries for the same `error-code` or `exception-type`.
- Maintains fallback `<error-page>` for unmatched errors.
---

### Key Improvements:

- Custom error pages have full priority.
- Default error pages are cleanly appended without conflict.
- No duplication or override issues.
- Template is now simpler, cleaner, and compliant with servlet container behavior.

---

### Testing:

- Custom and default error pages render correctly.
- Specific errors (e.g., 400, 504) map to custom pages if configured.



### Related Issues
https://github.com/wso2/product-is/issues/23834

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
