### PR TITLE
Fix display of identity claims based on config

### DIFF
--- a/.changeset/strange-mice-wait.md
+++ b/.changeset/strange-mice-wait.md
@@ -1,0 +1,11 @@
+---
+"@wso2is/admin.actions.v1": patch
+"@wso2is/admin.alternative-login-identifier.v1": patch
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.claims.v1": patch
+"@wso2is/admin.login-flow.ai.v1": patch
+"@wso2is/admin.registration-flow-builder.v1": patch
+"@wso2is/core": patch
+---
+
+Fix identity claims display based on config

--- a/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
+++ b/features/admin.actions.v1/components/user-attributes/user-attribute-list.tsx
@@ -97,7 +97,7 @@ const UserAttributeList: FunctionComponent<UserAttributeListPropsInterface> = ({
     useEffect(() => {
 
         const params: ClaimsGetParams = {
-            "exclude-identity-claims": false,
+            "exclude-hidden-claims": false,
             filter: null,
             limit: null,
             offset: null,

--- a/features/admin.alternative-login-identifier.v1/pages/alternative-login-identifier-page.tsx
+++ b/features/admin.alternative-login-identifier.v1/pages/alternative-login-identifier-page.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -30,7 +30,6 @@ import { getAllLocalClaims, updateAClaim } from "@wso2is/admin.claims.v1/api/cla
 import { ClaimManagementConstants } from "@wso2is/admin.claims.v1/constants";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
-import { AppState } from "@wso2is/admin.core.v1/store";
 import { getConnectorDetails, updateGovernanceConnector } from "@wso2is/admin.server-configurations.v1/api";
 import { ServerConfigurationsConstants } from "@wso2is/admin.server-configurations.v1/constants";
 import {
@@ -55,7 +54,7 @@ import { AxiosError } from "axios";
 import isEmpty from "lodash-es/isEmpty";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { Icon } from "semantic-ui-react";
 import { AlternativeLoginIdentifierFormInterface } from "../models/alternative-login-identifier-validation";
@@ -80,9 +79,6 @@ const AlternativeLoginIdentifierInterface: FunctionComponent<AlternativeLoginIde
     const { ["data-componentid"]: componentId } = props;
     const { t } = useTranslation();
     const dispatch: Dispatch = useDispatch();
-
-    const enableIdentityClaims: boolean = useSelector(
-        (state: AppState) => state?.config?.ui?.enableIdentityClaims);
 
     const categoryId: string = ServerConfigurationsConstants.ACCOUNT_MANAGEMENT_CATEGORY_ID;
     const connectorId: string = ServerConfigurationsConstants.MULTI_ATTRIBUTE_LOGIN_CONNECTOR_ID;
@@ -167,7 +163,7 @@ const AlternativeLoginIdentifierInterface: FunctionComponent<AlternativeLoginIde
     const getClaims = () => {
 
         const params: ClaimsGetParams = {
-            "exclude-identity-claims": !enableIdentityClaims,
+            "exclude-hidden-claims": true,
             filter: null,
             limit: null,
             offset: null,

--- a/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
+++ b/features/admin.applications.v1/components/settings/attribute-management/attribute-settings.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,7 +19,6 @@
 import { Show, useRequiredScopes } from "@wso2is/access-control";
 import { getAllExternalClaims, getAllLocalClaims, getDialects } from "@wso2is/admin.claims.v1/api";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
-import { AppState } from "@wso2is/admin.core.v1/store";
 import { EventPublisher } from "@wso2is/admin.core.v1/utils/event-publisher";
 import { applicationConfig } from "@wso2is/admin.extensions.v1";
 import { SubjectAttributeListItem } from "@wso2is/admin.identity-providers.v1/components/settings";
@@ -44,7 +43,7 @@ import isEmpty from "lodash-es/isEmpty";
 import sortBy from "lodash-es/sortBy";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { Button, Divider, Grid } from "semantic-ui-react";
 import { AdvanceAttributeSettings } from "./advance-attribute-settings";
@@ -182,9 +181,6 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
     const dispatch: Dispatch = useDispatch();
 
     const hasApplicationUpdatePermissions: boolean = useRequiredScopes(featureConfig?.applications?.scopes?.update);
-
-    const enableIdentityClaims: boolean = useSelector(
-        (state: AppState) => state?.config?.ui?.enableIdentityClaims);
 
     const [ localDialectURI, setLocalDialectURI ] = useState("");
 
@@ -443,7 +439,7 @@ export const AttributeSettings: FunctionComponent<AttributeSettingsPropsInterfac
     const getClaims = () => {
         setIsClaimLoading(true);
         const params: ClaimsGetParams = {
-            "exclude-identity-claims": !enableIdentityClaims,
+            "exclude-hidden-claims": true,
             filter: null,
             limit: null,
             offset: null,

--- a/features/admin.claims.v1/components/add/add-external-claim.tsx
+++ b/features/admin.claims.v1/components/add/add-external-claim.tsx
@@ -123,8 +123,6 @@ export const AddExternalClaims: FunctionComponent<AddExternalClaimsPropsInterfac
 
     const dispatch: Dispatch = useDispatch();
 
-    const enableIdentityClaims: boolean = useSelector(
-        (state: AppState) => state?.config?.ui?.enableIdentityClaims);
     const userSchemaURI: string = useSelector(
         (state: AppState) => state?.config?.ui?.userSchemaURI);
 
@@ -224,7 +222,7 @@ export const AddExternalClaims: FunctionComponent<AddExternalClaimsPropsInterfac
      */
     useEffect(() => {
         const params: ClaimsGetParams = {
-            "exclude-identity-claims": !enableIdentityClaims,
+            "exclude-hidden-claims": true,
             filter: null,
             limit: null,
             offset: null,

--- a/features/admin.claims.v1/components/edit/external-dialect/edit-external-claim.tsx
+++ b/features/admin.claims.v1/components/edit/external-dialect/edit-external-claim.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,7 +17,6 @@
  */
 
 import { getAllLocalClaims } from "@wso2is/admin.claims.v1/api";
-import { AppState } from "@wso2is/admin.core.v1/store";
 import { sortList } from "@wso2is/admin.core.v1/utils/sort-list";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, Claim, ClaimsGetParams, ExternalClaim, TestableComponentInterface } from "@wso2is/core/models";
@@ -26,7 +25,7 @@ import { Field, FormValue, Forms, Validation } from "@wso2is/forms";
 import { Code } from "@wso2is/react-components";
 import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
 import { Grid } from "semantic-ui-react";
 import { getAnExternalClaim, updateAnExternalClaim } from "../../../api";
@@ -112,15 +111,12 @@ export const EditExternalClaim: FunctionComponent<EditExternalClaimsPropsInterfa
 
     const dispatch: Dispatch = useDispatch();
 
-    const enableIdentityClaims: boolean = useSelector(
-        (state: AppState) => state?.config?.ui?.enableIdentityClaims);
-
     const { t } = useTranslation();
 
     useEffect(() => {
         setIsClaimsLoading(true);
         const params: ClaimsGetParams = {
-            "exclude-identity-claims": !enableIdentityClaims,
+            "exclude-hidden-claims": true,
             filter: null,
             limit: null,
             offset: null,

--- a/features/admin.claims.v1/pages/local-claims.tsx
+++ b/features/admin.claims.v1/pages/local-claims.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2020-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -85,8 +85,6 @@ const LocalClaimsPage: FunctionComponent<LocalClaimsPageInterface> = (
     ];
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
-    const enableIdentityClaims: boolean = useSelector(
-        (state: AppState) => state?.config?.ui?.enableIdentityClaims);
 
     const [ claims, setClaims ] = useState<Claim[]>(null);
     const [ offset, setOffset ] = useState(0);
@@ -115,11 +113,10 @@ const LocalClaimsPage: FunctionComponent<LocalClaimsPageInterface> = (
  * @param sort - Sort Order.
  * @param filter - Search Filter.
  */
-    const getLocalClaims = (limit?: number, sort?: string, offset?: number, filter?: string,
-        excludeIdentity: boolean = !enableIdentityClaims) => {
+    const getLocalClaims = (limit?: number, sort?: string, offset?: number, filter?: string) => {
         setIsLoading(true);
         const params: ClaimsGetParams = {
-            "exclude-identity-claims": excludeIdentity,
+            "exclude-hidden-claims": true,
             filter: filter || null,
             limit: limit || null,
             offset: offset || null,
@@ -153,7 +150,7 @@ const LocalClaimsPage: FunctionComponent<LocalClaimsPageInterface> = (
     }, [ sortBy, sortOrder ]);
 
     useEffect(() => {
-        getLocalClaims(null, null, null, null, !enableIdentityClaims);
+        getLocalClaims(null, null, null, null);
         getADialect("local").then((response: any) => {
             setClaimURIBase(response.dialectURI);
         }).catch((error: IdentityAppsError) => {

--- a/features/admin.login-flow.ai.v1/api/use-user-claims.ts
+++ b/features/admin.login-flow.ai.v1/api/use-user-claims.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -33,7 +33,7 @@ const useUserClaims = (): {
 
     useEffect(() => {
         const params: ClaimsGetParams = {
-            "exclude-identity-claims": false,
+            "exclude-hidden-claims": true,
             filter: null,
             limit: null,
             offset: null,

--- a/features/admin.registration-flow-builder.v1/api/use-get-supported-profile-attributes.ts
+++ b/features/admin.registration-flow-builder.v1/api/use-get-supported-profile-attributes.ts
@@ -48,7 +48,7 @@ const useGetSupportedProfileAttributes = <Data = Attribute[], Error = RequestErr
         },
         method: HttpMethods.GET,
         params: {
-            "exclude-identity-claims": true
+            "exclude-hidden-claims": true
         },
         url: store.getState().config.endpoints.localClaims
     };

--- a/modules/core/src/models/claim.ts
+++ b/modules/core/src/models/claim.ts
@@ -106,6 +106,7 @@ export interface ClaimsGetParams {
     sort: string;
     attributes?: string;
     "exclude-identity-claims"?: boolean;
+    "exclude-hidden-claims"?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This PR updates the frontend to handle the new configuration for hiding selected identity claims from UI listings, using the `exclude-hidden-claims` query parameter instead of the existing `exclude-identity-claims` flag (which hides all identity claims).

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/23902

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/identity-api-server/pull/872

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
