### PR TITLE
Prevent implicit verification of primary email/mobile without user verification

### DIFF
--- a/.changeset/twenty-zebras-rush.md
+++ b/.changeset/twenty-zebras-rush.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/myaccount": patch
+"@wso2is/console": patch
+"@wso2is/core": patch
+---
+
+Prevent implicit verification of primary email/mobile without user verification

--- a/apps/myaccount/src/constants/profile-constants.ts
+++ b/apps/myaccount/src/constants/profile-constants.ts
@@ -59,6 +59,7 @@ export class ProfileConstants {
     public static readonly ACCOUNT_STATE: string = "ACCOUNT_STATE";
     public static readonly PREFERRED_CHANNEL: string = "PREFERRED_CHANNEL";
     public static readonly EMAIL_VERIFIED: string = "EMAIL_VERIFIED";
+    public static readonly PHONE_VERIFIED: string = "PHONE_VERIFIED";
 }
 
 /**

--- a/apps/myaccount/src/utils/profile-utils.ts
+++ b/apps/myaccount/src/utils/profile-utils.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2019-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -291,4 +291,18 @@ export const getProfileCompletion = (
     store.dispatch(setProfileCompletion(completion));
 
     return completion;
+};
+
+/**
+ * Checks if the primary claim is verified.
+ *
+ * @param claimKey - Claim key to check.
+ * @param profileInfo - Profile information.
+ * @returns True if the primary claim is verified, false otherwise.
+ */
+export const isPrimaryClaimVerified = (claimKey: string, profileInfo: BasicProfileInterface): boolean => {
+    const systemSchema: string | undefined = SCIMConfigs?.scim?.systemSchema;
+    const claimValue: boolean | string = profileInfo?.[systemSchema]?.[claimKey];
+
+    return claimValue === true || claimValue === "true";
 };

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -119,6 +119,8 @@ const VERIFIED_MOBILE_NUMBERS_ATTRIBUTE: string =
     ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("VERIFIED_MOBILE_NUMBERS");
 const VERIFIED_EMAIL_ADDRESSES_ATTRIBUTE: string =
     ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("VERIFIED_EMAIL_ADDRESSES");
+const EMAIL_VERIFIED_ATTRIBUTE: string = ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("EMAIL_VERIFIED");
+const MOBILE_VERIFIED_ATTRIBUTE: string = ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("MOBILE_VERIFIED");
 
 /**
  * Prop types for the basic details component.
@@ -1915,6 +1917,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         let primaryAttributeSchema: ProfileSchemaInterface;
         let maxAllowedLimit: number = 0;
         let verificationPendingValue: string = "";
+        let primaryVerified: boolean = false;
 
         if (schema.name === EMAIL_ADDRESSES_ATTRIBUTE) {
             attributeValueList = multiValuedAttributeValues[EMAIL_ADDRESSES_ATTRIBUTE] ?? [];
@@ -1926,6 +1929,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                 schema.name === EMAIL_ATTRIBUTE);
             maxAllowedLimit = ProfileConstants.MAX_EMAIL_ADDRESSES_ALLOWED;
             verificationPendingValue = getVerificationPendingAttributeValue(EMAIL_ADDRESSES_ATTRIBUTE);
+            primaryVerified = user[userConfig.userProfileSchema]?.get(EMAIL_VERIFIED_ATTRIBUTE) === true ||
+                user[userConfig.userProfileSchema]?.get(EMAIL_VERIFIED_ATTRIBUTE) === "true";
 
         } else if (schema.name === MOBILE_NUMBERS_ATTRIBUTE) {
             attributeValueList = multiValuedAttributeValues[MOBILE_NUMBERS_ATTRIBUTE] ?? [];
@@ -1937,6 +1942,9 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                 schema.name === MOBILE_ATTRIBUTE);
             maxAllowedLimit = ProfileConstants.MAX_MOBILE_NUMBERS_ALLOWED;
             verificationPendingValue = getVerificationPendingAttributeValue(MOBILE_NUMBERS_ATTRIBUTE);
+            primaryVerified = user[userConfig.userProfileSchema]?.get(MOBILE_VERIFIED_ATTRIBUTE) === true ||
+                user[userConfig.userProfileSchema]?.get(MOBILE_VERIFIED_ATTRIBUTE) === "true";
+
         } else {
             attributeValueList = multiValuedAttributeValues[schema.name] ?? [];
             maxAllowedLimit = ProfileConstants.MAX_MULTI_VALUES_ALLOWED;
@@ -1947,19 +1955,40 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
             || schema.name === MOBILE_NUMBERS_ATTRIBUTE;
 
         const showVerifiedPopup = (value: string): boolean => {
+            const isPrimaryAndVerified: boolean = value === fetchedPrimaryAttributeValue && primaryVerified;
+
             return isEmailOrMobile && verificationEnabled &&
-                (verifiedAttributeValueList.includes(value) || value === fetchedPrimaryAttributeValue);
+                (verifiedAttributeValueList.includes(value) || isPrimaryAndVerified);
         };
 
         const showPrimaryPopup = (value: string): boolean => {
             if (!isEmailOrMobile) {
                 return false;
             }
-            if (verificationEnabled && !verifiedAttributeValueList.includes(value)) {
-                return value === fetchedPrimaryAttributeValue;
+
+            const isFetchedPrimary : boolean = value === fetchedPrimaryAttributeValue;
+            const isCurrentPrimary : boolean = value === primaryAttributeValue;
+            const isVerified : boolean =
+                !verificationEnabled ||                       // verification disabled → treat as verified.
+                verifiedAttributeValueList.includes(value) || // explicitly verified via list.
+                (isFetchedPrimary && primaryVerified);        // legacy single‑value flow
+
+            /* ───────── SINGLE VALUE ─────────
+            * Show the popup if that lone value is either:
+            *   • already stored as primary in the database, OR
+            *   • the user later set as primary while it is verified.
+            */
+            if (attributeValueList.length === 1) {
+                return isFetchedPrimary || (isCurrentPrimary && isVerified);
             }
 
-            return value === primaryAttributeValue;
+            /* ───── MULTIPLE VALUES ─────
+            * Show the popup on exactly one row — the one that is the
+            * current primary *and* meets at least ONE of these:
+            *   • it is verified, OR
+            *   • the database has flagged it as primary.
+            */
+            return isCurrentPrimary && (isVerified || isFetchedPrimary);
         };
 
         const showPendingVerificationPopup = (value: string): boolean => {
@@ -1970,11 +1999,14 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         };
 
         const showMakePrimaryButton = (value: string): boolean => {
+            const isPrimaryAndVerified: boolean = value === fetchedPrimaryAttributeValue && primaryVerified;
+
             if (!isEmailOrMobile) {
                 return false;
             }
             if (verificationEnabled) {
-                return verifiedAttributeValueList.includes(value) && value !== primaryAttributeValue;
+                return (verifiedAttributeValueList.includes(value) || isPrimaryAndVerified)
+                    && value !== primaryAttributeValue;
             }
 
             return value !== primaryAttributeValue;
@@ -1983,7 +2015,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         const showVerifyButton = (value: string): boolean =>
             schema.name === EMAIL_ADDRESSES_ATTRIBUTE
             && verificationEnabled
-            && !(verifiedAttributeValueList.includes(value) || value === primaryAttributeValue);
+            && !(verifiedAttributeValueList.includes(value) ||
+                (value === fetchedPrimaryAttributeValue && primaryVerified));
 
         const resolvedMutabilityValue: string = schema?.profiles?.console?.mutability ?? schema.mutability;
         const resolvedMultiValueAttributeRequiredValue: boolean

--- a/modules/core/src/constants/profile-constants.ts
+++ b/modules/core/src/constants/profile-constants.ts
@@ -103,7 +103,8 @@ export class ProfileConstants {
         .set("LAST_NAME", "name.familyName")
         .set("ACCOUNT_STATE", "accountState")
         .set("PREFERRED_CHANNEL", "preferredChannel")
-        .set("EMAIL_VERIFIED", "emailVerified");
+        .set("EMAIL_VERIFIED", "emailVerified")
+        .set("PHONE_VERIFIED", "phoneVerified");
 
     /**
      * States if the SCIM schema is mutable.


### PR DESCRIPTION
### Purpose
- $Subject
- This PR 
   - Ensures that primary email and mobile values set by an administrator are only marked as verified after the user completes the verification process.
   - Here the verification status is determined by the emailVerified and phoneVerified claims.
   - If these claims are not set to true for the primary email or mobile, the "Verify" button will be displayed to prompt the user to trigger verification.


### Related Issues
- https://github.com/wso2/product-is/issues/23958

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/948
- https://github.com/wso2/carbon-identity-framework/pull/6704

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
