### PR TITLE
Fix password input validation UI for old password policy connector

### DIFF
--- a/.changeset/hip-gifts-stare.md
+++ b/.changeset/hip-gifts-stare.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.validation.v1": patch
+"@wso2is/console": patch
+---
+
+Fix password input validation UI

--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -2998,7 +2998,15 @@ export interface Extensions {
                 label: string;
                 timeFormat: string;
             };
-            passwordValidationHeading: string;
+            passwordValidation: {
+                heading: string;
+                passwordValidationRegexLabel: string;
+                passwordValidationRegexHint: string;
+                passwordValidationRegexPlaceholder: string;
+                passwordValidationErrorLabel: string;
+                passwordValidationErrorHint: string;
+                passwordValidationErrorPlaceholder: string;
+            };
             userOnboarding: {
                 heading: string;
                 subHeading: string;

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -3596,7 +3596,15 @@ export const extensions: Extensions = {
                 label: "Password expires in ",
                 timeFormat: "days"
             },
-            passwordValidationHeading: "Password Input Validation",
+            passwordValidation: {
+                heading: "Password Input Validation",
+                passwordValidationRegexLabel: "Password pattern regex",
+                passwordValidationRegexHint: "Provide a valid regular expression for the password pattern. The regex must be between 3 and 255 characters.",
+                passwordValidationRegexPlaceholder: "Enter password pattern regex",
+                passwordValidationErrorLabel: "Error message on pattern violation",
+                passwordValidationErrorHint: "This error message will be displayed when a pattern violation is detected.",
+                passwordValidationErrorPlaceholder: "Enter the error message"
+            },
             userOnboarding: {
                 backButton: "Go back to Self Registration",
                 heading: "Self Registration",

--- a/features/admin.validation.v1/pages/validation-config-edit.tsx
+++ b/features/admin.validation.v1/pages/validation-config-edit.tsx
@@ -705,7 +705,11 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
 
     const resolveLegacyPasswordValidation: () => ReactElement = (): ReactElement => {
         return (
-            <>
+            <div className="validation-configurations-form">
+                <Divider className="heading-divider" />
+                <Heading as="h4">
+                    { t("extensions:manage.serverConfigurations.passwordValidation.heading") }
+                </Heading>
                 <Field.Checkbox
                     className="toggle mb-4"
                     ariaLabel="passwordPolicy.enable"
@@ -787,7 +791,7 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
                         />
                         <label>and</label>
                         <Field.Input
-                            ariaLabel="Minimum length of the password"
+                            ariaLabel="Maximum length of the password"
                             inputType="number"
                             name={
                                 GovernanceConnectorUtils.encodeConnectorPropertyName("passwordPolicy.max.length")
@@ -857,10 +861,12 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
                     type="text"
                     width={ 12 }
                     required
-                    placeholder={ "Enter password pattern regex" }
+                    placeholder={ t(
+                        "extensions:manage.serverConfigurations.passwordValidation.passwordValidationRegexPlaceholder"
+                    ) }
                     labelPosition="top"
                     minLength={ 3 }
-                    maxLength={ 100 }
+                    maxLength={ 255 }
                     readOnly={ isReadOnly }
                     listen={ (
                         value: string
@@ -878,7 +884,8 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
                         GovernanceConnectorUtils.resolveFieldLabel(
                             "Password Validation",
                             "passwordPolicy.pattern",
-                            "Password pattern regex")
+                            t("extensions:manage.serverConfigurations.passwordValidation.passwordValidationRegexLabel")
+                        )
                     }
                     disabled={ !isLegacyPasswordPolicyEnabled }
                 />
@@ -887,9 +894,7 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
                         GovernanceConnectorUtils.resolveFieldHint(
                             "Password Validation",
                             "passwordPolicy.pattern",
-                            "Length of the OTP for SMS and" +
-                            " e-mail verifications. OTP length" +
-                            " must be 4-10."
+                            t("extensions:manage.serverConfigurations.passwordValidation.passwordValidationRegexHint")
                         )
                     }
                 </Hint>
@@ -902,10 +907,13 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
                     type="text"
                     width={ 12 }
                     required
-                    placeholder={ "Enter password pattern regex" }
+                    placeholder={ t(
+                        "extensions:manage.serverConfigurations.passwordValidation." +
+                        "passwordValidationErrorPlaceholder"
+                    ) }
                     labelPosition="top"
                     minLength={ 3 }
-                    maxLength={ 100 }
+                    maxLength={ 255 }
                     readOnly={ isReadOnly }
                     listen={ (
                         value: string
@@ -923,7 +931,7 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
                         GovernanceConnectorUtils.resolveFieldLabel(
                             "Password Validation",
                             "passwordPolicy.errorMsg",
-                            "Error message on pattern violation")
+                            t("extensions:manage.serverConfigurations.passwordValidation.passwordValidationErrorLabel"))
                     }
                     disabled={ !isLegacyPasswordPolicyEnabled }
                 />
@@ -932,12 +940,11 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
                         GovernanceConnectorUtils.resolveFieldHint(
                             "Password Validation",
                             "passwordPolicy.errorMsg",
-                            "This error message will be displayed" +
-                            " when a pattern violation is detected."
+                            t("extensions:manage.serverConfigurations.passwordValidation.passwordValidationErrorHint")
                         )
                     }
                 </Hint>
-            </>
+            </div>
         );
     };
 
@@ -985,7 +992,7 @@ export const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPa
             <div className="validation-configurations-form">
                 <Divider className="heading-divider" />
                 <Heading as="h4">
-                    { t("extensions:manage.serverConfigurations.passwordValidationHeading") }
+                    { t("extensions:manage.serverConfigurations.passwordValidation.heading") }
                 </Heading>
                 <div className="criteria">
                     <label>


### PR DESCRIPTION
### Purpose

When the old password policy connector is enabled,

- Render a dedicated heading and divider for the password-validation block
- Use the new translation keys for labels, placeholders and hints
- Correct the aria-label for the “maximum length” field
- Increase the regex-pattern and error-message maxlength from 100 to 255

<img width="957" alt="Image" src="https://github.com/user-attachments/assets/45397ef1-9ef1-434b-8b84-9d1ce17b35cc" />

### Related Issues
- https://github.com/wso2/product-is/issues/23941