### PR TITLE
Improve session refresh logic

### DIFF
--- a/.changeset/three-hounds-fry.md
+++ b/.changeset/three-hounds-fry.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Improve session refresh logic

--- a/apps/console/src/init/init.ts
+++ b/apps/console/src/init/init.ts
@@ -112,14 +112,29 @@ if (
 let _idleSecondsCounter: number = 0;
 let _sessionAgeCounter: number = 0;
 
-document.onclick = function() {
+/**
+ * This function is called when the user interacts with the page.
+ */
+const onUserInteraction = (): void => {
+    // If the user has been inactive for SESSION_REFRESH_TIMEOUT seconds,
+    // and the idle session warning is not yet displayed,
+    // refresh the session when the user starts interact with the page.
+    if (_idleSecondsCounter >= SESSION_REFRESH_TIMEOUT && _idleSecondsCounter < IDLE_WARNING_TIMEOUT) {
+        dispatchEvent(new MessageEvent(CommonConstants.SESSION_REFRESH_EVENT));
+    }
+
+    // Reset the idle seconds counter.
     _idleSecondsCounter = 0;
+};
+
+document.onclick = function() {
+    onUserInteraction();
 };
 document.onmousemove = function() {
-    _idleSecondsCounter = 0;
+    onUserInteraction();
 };
 document.onkeypress = function() {
-    _idleSecondsCounter = 0;
+    onUserInteraction();
 };
 
 // Run the timer in main thread if the browser doesn't support worker threads.


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
- Improve logic to check the session validity when the user starts interacting with the console after a period of inactivity.
- This will not fire when the idle session warning banner is popped up. 


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/23973

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
