### PR TITLE
Add support for user's filtering by pending primary email and mobile verification via console

### DIFF
--- a/.changeset/fresh-lies-nail.md
+++ b/.changeset/fresh-lies-nail.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add support for user's filtering by pending primary email and mobile verification via console

--- a/features/admin.users.v1/constants/user-management-constants.ts
+++ b/features/admin.users.v1/constants/user-management-constants.ts
@@ -497,5 +497,15 @@ export const USER_ACCOUNT_STATUS_FILTER_OPTIONS: DropdownChild[] = [
         key: "PENDING_AP",
         text: "users:advancedSearch.accountStatusFilter.options.pendingInitialPasswordSetup",
         value: "urn:scim:wso2:schema:accountState eq PENDING_AP"
+    },
+    {
+        key: "PENDING_PRIMARY_EMAIL",
+        text: "users:advancedSearch.accountStatusFilter.options.pendingPrimaryEmailVerification",
+        value: "urn:scim:wso2:schema:emailVerified ne true"
+    },
+    {
+        key: "PENDING_PRIMARY_MOBILE",
+        text: "users:advancedSearch.accountStatusFilter.options.pendingPrimaryMobileVerification",
+        value: "urn:scim:wso2:schema:phoneVerified ne true"
     }
 ];

--- a/modules/i18n/src/models/namespaces/users-ns.ts
+++ b/modules/i18n/src/models/namespaces/users-ns.ts
@@ -193,6 +193,8 @@ export interface usersNS {
                 locked: string;
                 pendingInitialPasswordSetup: string;
                 pendingPasswordReset: string;
+                pendingPrimaryEmailVerification: string;
+                pendingPrimaryMobileVerification: string;
             };
         };
         form: {

--- a/modules/i18n/src/translations/en-US/portals/users.ts
+++ b/modules/i18n/src/translations/en-US/portals/users.ts
@@ -39,7 +39,9 @@ export const users: usersNS = {
                 disabled: "Disabled",
                 locked: "Locked",
                 pendingInitialPasswordSetup: "Pending initial password setup",
-                pendingPasswordReset: "Pending password reset"
+                pendingPasswordReset: "Pending password reset",
+                pendingPrimaryEmailVerification: "Pending email verification",
+                pendingPrimaryMobileVerification: "Pending mobile verification"
             }
         },
         form: {


### PR DESCRIPTION
### Purpose
- $Subject
<img width="1680" alt="Screenshot 2025-05-30 at 11 48 00" src="https://github.com/user-attachments/assets/e4b2aed6-41b8-462b-b37e-3225c334894b" />


### Related Issues
- https://github.com/wso2/product-is/issues/23991

### To be merged after
- ne operator support for user's filtering

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
