### PR TITLE
Hide impersonation for users in different tenants

### DIFF
--- a/.changeset/popular-crews-explode.md
+++ b/.changeset/popular-crews-explode.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Hide impersonation if authenticated user belong to different tenant.

--- a/features/admin.users.v1/components/user-impersonation-action.tsx
+++ b/features/admin.users.v1/components/user-impersonation-action.tsx
@@ -108,6 +108,8 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
         state.config.ui.features?.users);
     const accountAppClientID: string = useSelector((state: AppState) =>
         state.config.deployment.accountApp.clientID);
+    const authenticatedUserTenanted: string = useSelector((state: AppState) => state?.auth?.username);
+    const loggedInTenantDomain: string = useSelector((state: AppState) => state?.auth?.tenantDomain);
     const getUserId = (userId: string): string => {
         const tenantAwareUserId: string = userId.split("@").length > 1 ? userId.split("@")[0] : userId;
         const userDomainAwareUserId: string = tenantAwareUserId.split("/").length > 1 ?
@@ -340,6 +342,17 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
     };
 
     /**
+     * This function checks whether the authenticated user's (impersonator) tenant is the logged tenant.
+     */
+    const isAuthenticatedUserBelongToTheLoggedInTenant = (): boolean => {
+
+        const authenticatedUserTenantDomain: string = authenticatedUserTenanted.split("@").length > 1
+            ? authenticatedUserTenanted.split("@")[1] : "";
+
+        return authenticatedUserTenantDomain === loggedInTenantDomain;
+    };
+
+    /**
      * This function returns if the impersonation action is enabled for the current user.
      *  1. My Account is enabled.
      *  2. The user is authorized to impersonate.
@@ -442,7 +455,7 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
     const resolveUserActions = (): ReactElement => {
 
         return (
-            !isSubOrgUser && !isUserCurrentLoggedInUser
+            !isSubOrgUser && !isUserCurrentLoggedInUser && isAuthenticatedUserBelongToTheLoggedInTenant()
                 && isFeatureEnabled(userFeatureConfig,
                     UserManagementConstants.FEATURE_DICTIONARY.get("USER_IMPERSONATION")) ?
                 (


### PR DESCRIPTION
### Purpose
> As impersonation is not supported for users in different tenant compared to the impersonator's tenant, we should be hiding the option for the users in different tenant.

### Related issues:
- https://github.com/wso2/product-is/issues/23462