### PR TITLE
Add AppPortalRoleManagementV3Listener and ConsoleRoleV3Listener

### DIFF
--- a/identity-apps-core/components/org.wso2.identity.apps.common/pom.xml
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>org.wso2.carbon.identity.role.v2.mgt.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.role.v3.mgt.core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
             <artifactId>org.wso2.carbon.identity.oauth</artifactId>
         </dependency>
@@ -147,6 +151,7 @@
             org.wso2.carbon.identity.application.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",
             org.wso2.carbon.identity.application.common.*; version="${carbon.identity.framework.imp.pkg.version.range}",
             org.wso2.carbon.identity.role.v2.mgt.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
+            org.wso2.carbon.identity.role.v3.mgt.core.*; version="${carbon.identity.framework.imp.pkg.version.range}",
             org.wso2.carbon.identity.organization.management.service.*; version="${identity.org.mgt.core.version.range}",
             org.wso2.carbon.identity.organization.management.application.*; version="${identity.org.mgt.application.version.range}",
             org.wso2.carbon.identity.api.resource.mgt.*; version="${carbon.identity.framework.imp.pkg.version.range}",

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonDataHolder.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonDataHolder.java
@@ -46,6 +46,7 @@ public class AppsCommonDataHolder {
     private RealmService realmService;
 
     private RoleManagementService roleManagementService;
+    private org.wso2.carbon.identity.role.v3.mgt.core.RoleManagementService roleManagementServiceV3;
 
     private APIResourceManager apiResourceManager;
     private APIResourceCollectionManager apiResourceCollectionManager;
@@ -202,6 +203,26 @@ public class AppsCommonDataHolder {
     public RoleManagementService getRoleManagementServiceV2() {
 
         return roleManagementService;
+    }
+
+    /**
+     * Set role management service v3.
+     *
+     * @param roleManagementServiceV3 RoleManagementServiceV3.
+     */
+    public void setRoleManagementServiceV3(org.wso2.carbon.identity.role.v3.mgt.core.RoleManagementService
+                                               roleManagementServiceV3) {
+
+        this.roleManagementServiceV3 = roleManagementServiceV3;
+    }
+
+    /**
+     * Get role management service v3.
+     * @return RoleManagementServiceV3.
+     */
+    public org.wso2.carbon.identity.role.v3.mgt.core.RoleManagementService getRoleManagementServiceV3() {
+
+        return roleManagementServiceV3;
     }
 
     /**

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
@@ -130,7 +130,6 @@ public class AppsCommonServiceComponent {
                     org.wso2.carbon.identity.role.v3.mgt.core.listener.RoleManagementListener.class.getName(),
                     consoleRoleListenerV3, null);
                 log.debug("ConsoleRoleListenerV3 registered successfully.");
-
             }
 
             if (!CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/internal/AppsCommonServiceComponent.java
@@ -48,8 +48,10 @@ import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.identity.apps.common.listner.AppPortalApplicationMgtListener;
 import org.wso2.identity.apps.common.listner.AppPortalOAuthAppMgtListener;
 import org.wso2.identity.apps.common.listner.AppPortalRoleManagementListener;
+import org.wso2.identity.apps.common.listner.AppPortalRoleManagementV3Listener;
 import org.wso2.identity.apps.common.listner.AppPortalTenantMgtListener;
 import org.wso2.identity.apps.common.listner.ConsoleRoleListener;
+import org.wso2.identity.apps.common.listner.ConsoleRoleV3Listener;
 import org.wso2.identity.apps.common.util.AppPortalUtils;
 
 import java.util.HashSet;
@@ -115,6 +117,20 @@ public class AppsCommonServiceComponent {
                 RoleManagementListener consoleRoleListener = new ConsoleRoleListener();
                 bundleContext.registerService(RoleManagementListener.class.getName(), consoleRoleListener, null);
                 log.debug("ConsoleRoleListener registered successfully.");
+
+                org.wso2.carbon.identity.role.v3.mgt.core.listener.RoleManagementListener roleManagementListenerV3 =
+                        new AppPortalRoleManagementV3Listener(true);
+                bundleContext.registerService(org.wso2.carbon.identity.role.v3.mgt.core.listener.
+                        RoleManagementListener.class.getName(), roleManagementListenerV3, null);
+                log.debug("AppPortalRoleManagementV3Listener registered successfully.");
+
+                org.wso2.carbon.identity.role.v3.mgt.core.listener.RoleManagementListener consoleRoleListenerV3 =
+                        new ConsoleRoleV3Listener();
+                bundleContext.registerService(
+                    org.wso2.carbon.identity.role.v3.mgt.core.listener.RoleManagementListener.class.getName(),
+                    consoleRoleListenerV3, null);
+                log.debug("ConsoleRoleListenerV3 registered successfully.");
+
             }
 
             if (!CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
@@ -254,6 +270,24 @@ public class AppsCommonServiceComponent {
     protected void unsetRoleManagementServiceV2(RoleManagementService roleManagementService) {
 
         AppsCommonDataHolder.getInstance().setRoleManagementServiceV2(null);
+    }
+
+    @Reference(
+        name = "role.management.service.v3",
+        service = org.wso2.carbon.identity.role.v3.mgt.core.RoleManagementService.class,
+        cardinality = ReferenceCardinality.MANDATORY,
+        policy = ReferencePolicy.DYNAMIC,
+        unbind = "unsetRoleManagementServiceV3")
+    protected void setRoleManagementServiceV3(org.wso2.carbon.identity.role.v3.mgt.core.RoleManagementService
+                                                      roleManagementService) {
+
+        AppsCommonDataHolder.getInstance().setRoleManagementServiceV3(roleManagementService);
+    }
+
+    protected void unsetRoleManagementServiceV3(org.wso2.carbon.identity.role.v3.mgt.core.RoleManagementService
+                                                    roleManagementService) {
+
+        AppsCommonDataHolder.getInstance().setRoleManagementServiceV3(null);
     }
 
     @Reference(

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/AppPortalRoleManagementV3Listener.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/AppPortalRoleManagementV3Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/AppPortalRoleManagementV3Listener.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/AppPortalRoleManagementV3Listener.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.apps.common.listner;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.role.v3.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v3.mgt.core.listener.AbstractRoleManagementListener;
+import org.wso2.carbon.identity.role.v3.mgt.core.model.Permission;
+import org.wso2.carbon.identity.role.v3.mgt.core.model.RoleBasicInfo;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.identity.apps.common.internal.AppsCommonDataHolder;
+
+import java.util.List;
+
+import static org.wso2.carbon.identity.role.v3.mgt.core.RoleConstants.ADMINISTRATOR;
+import static org.wso2.carbon.identity.role.v3.mgt.core.RoleConstants.APPLICATION;
+import static org.wso2.carbon.identity.role.v3.mgt.core.RoleConstants.Error.INVALID_REQUEST;
+import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+import static org.wso2.identity.apps.common.util.AppPortalConstants.CONSOLE_APP;
+
+/**
+ * App portal role management listener for SCIM2 Role API V3.
+ */
+public class AppPortalRoleManagementV3Listener extends AbstractRoleManagementListener {
+
+    private boolean isEnable;
+
+    /**
+     * Constructor for app portal role management listener with enable flag.
+     *
+     * @param isEnable Enable flag.
+     */
+    public AppPortalRoleManagementV3Listener(boolean isEnable) {
+
+        this.isEnable = isEnable;
+    }
+
+    @Override
+    public int getExecutionOrderId() {
+
+        return 50;
+    }
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 50;
+    }
+
+    @Override
+    public boolean isEnable() {
+
+        return this.isEnable;
+    }
+
+    @Override
+    public void preUpdateRoleName(String roleId, String newRoleName, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        if (isAdministratorRole(roleId, tenantDomain)) {
+            throw new IdentityRoleManagementException(INVALID_REQUEST.getCode(),
+                "Updating name of the 'Administrator' role belongs to the 'Console' application is not allowed.");
+        }
+    }
+
+    @Override
+    public void preDeleteRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
+
+        if (isAdministratorRole(roleId, tenantDomain)) {
+            throw new IdentityRoleManagementException(INVALID_REQUEST.getCode(),
+                "Deleting the 'Administrator' role belongs to the 'Console' application is not allowed.");
+        }
+    }
+
+    @Override
+    public void preUpdateUserListOfRole(String roleId, List<String> newUserIDList, List<String> deletedUserIDList,
+                                        String tenantDomain) throws IdentityRoleManagementException {
+
+        if (deletedUserIDList == null || !isAdministratorRole(roleId, tenantDomain)) {
+            return;
+        }
+
+        try {
+            if (OrganizationManagementUtil.isOrganization(tenantDomain)) {
+                return;
+            }
+        } catch (OrganizationManagementException e) {
+            throw new IdentityRoleManagementException("Failed to determine if the tenant is a sub-organization for " +
+                "tenant domain: " + tenantDomain, e);
+        }
+
+        String adminUserId;
+        try {
+            UserRealm userRealm =
+                (UserRealm) PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserRealm();
+            String adminUsername = userRealm.getRealmConfiguration().getAdminUserName();
+
+            UserStoreManager userStoreManager = userRealm.getUserStoreManager();
+            adminUserId = ((AbstractUserStoreManager) userStoreManager).getUserIDFromUserName(adminUsername);
+        } catch (UserStoreException e) {
+            throw new IdentityRoleManagementException("Failed to retrieve user id of the tenant admin.", e);
+        }
+
+        if (deletedUserIDList.contains(adminUserId)) {
+            throw new IdentityRoleManagementException(INVALID_REQUEST.getCode(),
+                "Deleting the tenant admin from 'Administrator' role belongs to the 'Console' application is " +
+                    "not allowed.");
+        }
+    }
+
+    @Override
+    public void preUpdatePermissionsForRole(String roleId, List<Permission> addedPermissions,
+                                            List<Permission> deletedPermissions, String audience, String audienceId,
+                                            String tenantDomain) throws IdentityRoleManagementException {
+
+        // Pre update permission check for the administrator role is not required when tenant creation.
+        String requestInitiatedTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        if (SUPER_TENANT_DOMAIN_NAME.equals(requestInitiatedTenantDomain) &&
+            !StringUtils.equals(tenantDomain, requestInitiatedTenantDomain)) {
+            return;
+        }
+        if (isAdministratorRole(roleId, tenantDomain)) {
+            throw new IdentityRoleManagementException(INVALID_REQUEST.getCode(),
+                "Updating permissions of the 'Administrator' role belongs to the 'Console' application is not " +
+                    "allowed.");
+        }
+    }
+
+    private boolean isAdministratorRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
+
+        RoleBasicInfo role = AppsCommonDataHolder.getInstance().getRoleManagementServiceV3().getRoleBasicInfoById(
+            roleId, tenantDomain);
+
+        return role != null && StringUtils.equalsIgnoreCase(ADMINISTRATOR, role.getName())
+            && StringUtils.equalsIgnoreCase(APPLICATION, role.getAudience())
+            && StringUtils.equalsIgnoreCase(CONSOLE_APP, role.getAudienceName());
+    }
+}

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/ConsoleRoleV3Listener.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/listner/ConsoleRoleV3Listener.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.identity.apps.common.listner;
+
+import org.wso2.carbon.identity.api.resource.collection.mgt.exception.APIResourceCollectionMgtException;
+import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollection;
+import org.wso2.carbon.identity.api.resource.collection.mgt.model.APIResourceCollectionSearchResult;
+import org.wso2.carbon.identity.api.resource.mgt.APIResourceMgtException;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ApplicationBasicInfo;
+import org.wso2.carbon.identity.application.common.model.Scope;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.role.v3.mgt.core.RoleConstants;
+import org.wso2.carbon.identity.role.v3.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v3.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v3.mgt.core.listener.AbstractRoleManagementListener;
+import org.wso2.carbon.identity.role.v3.mgt.core.model.Permission;
+import org.wso2.carbon.identity.role.v3.mgt.core.model.Role;
+import org.wso2.carbon.identity.role.v3.mgt.core.model.RoleBasicInfo;
+import org.wso2.identity.apps.common.internal.AppsCommonDataHolder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.wso2.carbon.identity.api.resource.collection.mgt.constant.APIResourceCollectionManagementConstants.APIResourceCollectionConfigBuilderConstants.EDIT_FEATURE_SCOPE_SUFFIX;
+import static org.wso2.carbon.identity.api.resource.collection.mgt.constant.APIResourceCollectionManagementConstants.APIResourceCollectionConfigBuilderConstants.VIEW_FEATURE_SCOPE_SUFFIX;
+import static org.wso2.carbon.identity.role.v3.mgt.core.RoleConstants.CONSOLE_APP_AUDIENCE_NAME;
+import static org.wso2.carbon.identity.role.v3.mgt.core.RoleConstants.CONSOLE_ORG_SCOPE_PREFIX;
+import static org.wso2.carbon.identity.role.v3.mgt.core.RoleConstants.CONSOLE_SCOPE_PREFIX;
+
+/**
+ * Console role listener for SCIM2 Role API V3 to populate organization console application roles permissions.
+ */
+public class ConsoleRoleV3Listener extends AbstractRoleManagementListener {
+
+    @Override
+    public int getDefaultOrderId() {
+
+        return 87;
+    }
+
+    @Override
+    public boolean isEnable() {
+
+        return true;
+    }
+
+    @Override
+    public void preAddRole(String roleName, List<Permission> permissions,
+                           String audience, String audienceId, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        if (isConsoleApp(audience, audienceId, tenantDomain) && !RoleConstants.ADMINISTRATOR.equals(roleName)) {
+            List<Permission> consoleFeaturePermissions = getConsoleFeaturePermissions(permissions);
+            if (consoleFeaturePermissions != null && !consoleFeaturePermissions.isEmpty()) {
+                // If console features are added to the role, then we need to we only need to persist the console
+                // permissions.
+                permissions.retainAll(consoleFeaturePermissions);
+            }
+        }
+    }
+
+    @Override
+    public void postGetRole(Role role, String roleId, String tenantDomain) throws IdentityRoleManagementException {
+
+        if (!RoleConstants.ADMINISTRATOR.equals(role.getName()) &&
+            role.getAudienceName().equals(CONSOLE_APP_AUDIENCE_NAME)) {
+            // Get updated console role permissions with newly added read and write scopes from API resource collection.
+            List<Permission> rolePermissions = getUpgradedPermissions(role.getPermissions(), tenantDomain);
+            role.setPermissions(rolePermissions);
+        }
+    }
+
+    @Override
+    public void postGetPermissionListOfRole(List<Permission> permissionListOfRole, String roleId, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        if (isConsoleRole(roleId, tenantDomain)) {
+            List<Permission> rolePermissions = getUpgradedPermissions(permissionListOfRole, tenantDomain);
+            permissionListOfRole.clear();
+            permissionListOfRole.addAll(rolePermissions);
+        }
+    }
+
+    @Override
+    public void postGetPermissionListOfRoles(List<String> permissions, List<String> roleIds, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        boolean isConsoleRole = false;
+        for (String roleId : roleIds) {
+            if (isConsoleRole(roleId, tenantDomain)) {
+                isConsoleRole = true;
+                break;
+            }
+        }
+        if (isConsoleRole) {
+            List<Permission> resolvedRolePermissions = new ArrayList<>();
+            List<Permission> systemPermissions = getSystemPermission(tenantDomain);
+            permissions.forEach(permission -> {
+                Optional<Permission> newPermission = systemPermissions.stream()
+                    .filter(permission1 -> permission1.getName().equals(permission))
+                    .findFirst();
+                newPermission.ifPresent(resolvedRolePermissions::add);
+            });
+            List<Permission> rolePermissions = getUpgradedPermissions(resolvedRolePermissions, tenantDomain);
+            permissions.clear();
+            permissions.addAll(rolePermissions.stream().map(Permission::getName).collect(Collectors.toList()));
+        }
+    }
+
+    @Override
+    public void preUpdatePermissionsForRole(String roleId, List<Permission> addedPermissions,
+                                            List<Permission> deletedPermissions, String audience, String audienceId,
+                                            String tenantDomain) throws IdentityRoleManagementException {
+
+        if (isConsoleRole(roleId, tenantDomain)) {
+            List<Permission> consoleFeaturePermissions = getConsoleFeaturePermissions(addedPermissions);
+            if (consoleFeaturePermissions != null && !consoleFeaturePermissions.isEmpty()) {
+                // If console features are added to the role, then we need to we only need to persist the console
+                // permissions.
+                addedPermissions.retainAll(consoleFeaturePermissions);
+            }
+        }
+    }
+
+    /**
+     * This method resolves the new permissions for the console roles. In this method, we resolve two type of console
+     * roles. 1. Console roles created after 7.0.0. 2. Console roles created in 7.0.0.
+     *
+     * @param rolePermissions List of permissions of the role.
+     * @param tenantDomain    Tenant domain.
+     * @return List of resolved permissions.
+     * @throws IdentityRoleManagementException If an error occurs while resolving the permissions.
+     */
+    private List<Permission> getUpgradedPermissions(List<Permission> rolePermissions, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        // Fetch all system scopes to resolve permission details from permission name.
+        List<Permission> systemPermissions = getSystemPermission(tenantDomain);
+        List<APIResourceCollection> apiResourceCollections = getAPIResourceCollections(tenantDomain);
+        List<Permission> consoleFeaturePermissions = getConsoleFeaturePermissions(rolePermissions);
+        if (!consoleFeaturePermissions.isEmpty()) {
+            // This is where we handle the new console roles (console roles created after 7.0.0) permissions.
+            // We check whether the role has the view feature scope or edit feature scope. If the role has the
+            // view feature scope, then we add all the read scopes. If the role has the edit feature scope, then we
+            // add all the write scopes.
+            List<Permission> resolvedRolePermissions = new ArrayList<>();
+            consoleFeaturePermissions.forEach(permission -> {
+                apiResourceCollections.forEach(apiResourceCollection -> {
+                    // If the role has the edit feature scope, then we add all the write and read scopes.
+                    if (apiResourceCollection.getEditFeatureScope() != null &&
+                        apiResourceCollection.getEditFeatureScope().equals(permission.getName())) {
+                        apiResourceCollection.getWriteScopes().forEach(writeScope -> {
+                            Optional<Permission> newPermission = systemPermissions.stream()
+                                .filter(permission1 -> permission1.getName().equals(writeScope))
+                                .findFirst();
+                            newPermission.ifPresent(resolvedRolePermissions::add);
+                        });
+                    }
+                    if (apiResourceCollection.getViewFeatureScope() != null &&
+                        apiResourceCollection.getViewFeatureScope().equals(permission.getName())) {
+                        apiResourceCollection.getReadScopes().forEach(readScope -> {
+                            Optional<Permission> newPermission = systemPermissions.stream()
+                                .filter(permission1 -> permission1.getName().equals(readScope))
+                                .findFirst();
+                            newPermission.ifPresent(resolvedRolePermissions::add);
+                        });
+                    }
+                });
+            });
+            return resolvedRolePermissions;
+        } else {
+            // This is where we handle the initial console roles (console roles created in 7.0.0) permissions.
+            // Here we assume these role only contains legacy feature scope not the new feature scopes.
+            Set<Permission> resolvedRolePermissions = new HashSet<>(new ArrayList<>(rolePermissions));
+            List<Permission> consolePermissions = getConsolePermissions(rolePermissions);
+            consolePermissions.forEach(permission -> {
+                apiResourceCollections.forEach(apiResourceCollection -> {
+                    // Match the permission with the collection.
+                    if (apiResourceCollection.getReadScopes().contains(permission.getName())) {
+                        // Add new read scopes since we have the feature scope.
+                        apiResourceCollection.getReadScopes().forEach(newReadScope -> {
+                            Optional<Permission> newPermission = systemPermissions.stream()
+                                .filter(permission1 -> permission1.getName().equals(newReadScope))
+                                .findFirst();
+                            newPermission.ifPresent(resolvedRolePermissions::add);
+                        });
+                        List<String> legacyWriteScopes = apiResourceCollection.getLegacyWriteScopes();
+                        // if all the writeScopes are in the role's permission list, then add new write scopes.
+                        if (rolePermissions.stream().anyMatch(rolePermission ->
+                            legacyWriteScopes.contains(rolePermission.getName()))) {
+                            apiResourceCollection.getWriteScopes().forEach(newWriteScope -> {
+                                Optional<Permission> newPermission = systemPermissions.stream()
+                                    .filter(permission1 -> permission1.getName().equals(newWriteScope))
+                                    .findFirst();
+                                newPermission.ifPresent(resolvedRolePermissions::add);
+                            });
+                        }
+                    }
+                });
+            });
+            return new ArrayList<>(resolvedRolePermissions);
+        }
+    }
+
+    /**
+     * Check whether the role is a console role. We consider all the console roles except the administrator role.
+     *
+     * @param roleId       Role id.
+     * @param tenantDomain Tenant domain.
+     * @return True if the role is a console role.
+     * @throws IdentityRoleManagementException If an error occurs while checking the role.
+     */
+    private boolean isConsoleRole(String roleId, String tenantDomain) throws IdentityRoleManagementException {
+
+        RoleManagementService roleManagementService = AppsCommonDataHolder.getInstance()
+            .getRoleManagementServiceV3();
+        RoleBasicInfo role = roleManagementService.getRoleBasicInfoById(roleId, tenantDomain);
+        return !RoleConstants.ADMINISTRATOR.equals(role.getName()) &&
+            role.getAudienceName().equals(CONSOLE_APP_AUDIENCE_NAME);
+    }
+
+    /**
+     * Check whether the app is a console application based in audience.
+     *
+     * @param audience     Audience.
+     * @param audienceId   Audience id.
+     * @param tenantDomain Tenant domain.
+     * @return True if the app is a console application.
+     * @throws IdentityRoleManagementException If an error occurs while checking the app.
+     */
+    private boolean isConsoleApp(String audience, String audienceId, String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        if (!RoleConstants.APPLICATION.equalsIgnoreCase(audience)) {
+            return false;
+        }
+        ApplicationManagementService applicationManagementService = AppsCommonDataHolder.getInstance()
+            .getApplicationManagementService();
+        try {
+            ApplicationBasicInfo applicationBasicInfo = applicationManagementService
+                .getApplicationBasicInfoByResourceId(audienceId, tenantDomain);
+            return applicationBasicInfo != null && CONSOLE_APP_AUDIENCE_NAME
+                .equals(applicationBasicInfo.getApplicationName());
+        } catch (IdentityApplicationManagementException e) {
+            throw new IdentityRoleManagementException("Error while retrieving application basic info for application " +
+                "id : " + audienceId, e);
+        }
+    }
+
+    /**
+     * Get API resource collections for the tenant. This will return all the tenant and organization specific API
+     * collections.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return List of API resource collections.
+     * @throws IdentityRoleManagementException If an error occurs while retrieving the API resource collections.
+     */
+    private List<APIResourceCollection> getAPIResourceCollections(String tenantDomain)
+        throws IdentityRoleManagementException {
+
+        try {
+            List<String> requiredAttributes = new ArrayList<>();
+            requiredAttributes.add("apiResources");
+            APIResourceCollectionSearchResult apiResourceCollectionSearchResult = AppsCommonDataHolder
+                .getInstance().getApiResourceCollectionManager()
+                .getAPIResourceCollections("", requiredAttributes, tenantDomain);
+            return apiResourceCollectionSearchResult.getAPIResourceCollections();
+
+        } catch (APIResourceCollectionMgtException e) {
+            throw new IdentityRoleManagementException("Error while retrieving api collection for tenant : " +
+                tenantDomain, e);
+        }
+    }
+
+    /**
+     * Get console feature permissions from the role permissions.
+     *
+     * @param rolePermissions Role permissions.
+     * @return List of console feature permissions.
+     */
+    private List<Permission> getConsoleFeaturePermissions(List<Permission> rolePermissions) {
+
+        return rolePermissions.stream().filter(permission -> permission != null &&
+                permission.getName() != null && (permission.getName().startsWith(CONSOLE_SCOPE_PREFIX)
+                || permission.getName().startsWith(CONSOLE_ORG_SCOPE_PREFIX)) &&
+                (permission.getName().endsWith(VIEW_FEATURE_SCOPE_SUFFIX) ||
+                    permission.getName().endsWith(EDIT_FEATURE_SCOPE_SUFFIX)))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Get console permissions (old ones) from the role permissions.
+     *
+     * @param rolePermissions Role permissions.
+     * @return List of console permissions.
+     */
+    private List<Permission> getConsolePermissions(List<Permission> rolePermissions) {
+
+        return rolePermissions.stream().filter(permission -> permission != null &&
+                permission.getName() != null && (permission.getName().startsWith(CONSOLE_SCOPE_PREFIX)
+                || permission.getName().startsWith(CONSOLE_ORG_SCOPE_PREFIX)) &&
+                !(permission.getName().endsWith(VIEW_FEATURE_SCOPE_SUFFIX) ||
+                    permission.getName().endsWith(EDIT_FEATURE_SCOPE_SUFFIX)))
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Get system permissions for the tenant.
+     *
+     * @param tenantDomain Tenant domain.
+     * @return List of system permissions.
+     * @throws IdentityRoleManagementException If an error occurs while retrieving the system permissions.
+     */
+    private List<Permission> getSystemPermission(String tenantDomain) throws IdentityRoleManagementException {
+        List<Scope> systemScopes;
+
+        try {
+            systemScopes = AppsCommonDataHolder.getInstance()
+                .getAPIResourceManager().getSystemAPIScopes(tenantDomain);
+        } catch (APIResourceMgtException e) {
+            throw new IdentityRoleManagementException("Error while retrieving internal scopes for tenant " +
+                "domain : " + tenantDomain, e);
+        }
+        return systemScopes.stream().map(scope -> new Permission(scope.getName(), scope.getDisplayName(),
+            scope.getApiID())).collect(Collectors.toList());
+    }
+}
+

--- a/identity-apps-core/pom.xml
+++ b/identity-apps-core/pom.xml
@@ -337,6 +337,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.role.v3.mgt.core</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.core</artifactId>
                 <version>${carbon.kernel.version}</version>
@@ -734,7 +739,7 @@
         <carbon.extension.identity.authenticator.version>3.0.0</carbon.extension.identity.authenticator.version>
         <org.wso2.carbon.identity.association.account>5.1.5</org.wso2.carbon.identity.association.account>
         <identity.extension.utils>1.0.8</identity.extension.utils>
-        <carbon.identity.framework.version>7.7.176</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.146-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.0.0, 8.0.0)</carbon.identity.framework.imp.pkg.version.range>
         <identity.organization.management.core.service.version>1.0.77
         </identity.organization.management.core.service.version>


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Add the AppPortalRoleManagementV3Listener and ConsoleRoleV3Listener which uses the SCIM2 Role API V3.

Merge this PR soon after merging the following PRs:
- https://github.com/wso2/carbon-identity-framework/pull/6732
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/639
- https://github.com/wso2/charon/pull/431

### Related Issues
- https://github.com/wso2/product-is/issues/21686

### Related PRs
- https://github.com/wso2/charon/pull/431
- https://github.com/wso2/carbon-identity-framework/pull/6732
- https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/639

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
