### PR TITLE
Fix isAccessUrlAvailable Property Setting for Admin-Initiated Password Reset

### DIFF
--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -106,11 +106,12 @@
 
     if (StringUtils.isNotBlank(callback) &&
         StringUtils.isNotBlank(userStoreDomain)) {
-        if (StringUtils.isNotBlank(sp)) {
+        if (StringUtils.isNotBlank(sp) && !StringUtils.equalsIgnoreCase(sp, "null")) {
             applicationName = sp;
         } else if (callback.contains(CONSOLE_APP_NAME.toLowerCase())) {
             applicationName = CONSOLE_APP_NAME;
-        } else if (callback.contains(MY_ACCOUNT_APP_NAME.toLowerCase().replaceAll("\\s+", ""))) {
+        } else if (callback.contains(MY_ACCOUNT_APP_NAME.toLowerCase().replaceAll("\\s+", "")) || 
+                isUserPortalUrl(callback, tenantDomain, application)) {
             applicationName = MY_ACCOUNT_APP_NAME;
         }
     } else {
@@ -284,6 +285,16 @@
 	}
 
     session.invalidate();
+%>
+
+<%! 
+    private boolean isUserPortalUrl(String callback, String tenantDomain, ServletContext application) {
+        
+        String userPortalUrl = IdentityManagementEndpointUtil.getUserPortalUrl(
+                application.getInitParameter(IdentityManagementEndpointConstants.ConfigConstants.USER_PORTAL_URL),
+                tenantDomain);
+        return StringUtils.equals(callback, userPortalUrl);
+    }
 %>
 
 <%-- Data for the layout from the page --%>


### PR DESCRIPTION
### **Purpose:**

To ensure the `isAccessUrlAvailable` property is correctly set during the admin-initiated password reset flow, preventing callback URL validation failures when the MyAccount application is configured with an access URL, even when the `sp` parameter is missing or incorrectly set to `"null"`.

### **Goals:**

* Ensure the `isAccessUrlAvailable` property correctly reflects the availability of an application access URL.
* Prevent callback URL validation errors during password reset, including cases where the sp parameter is missing or incorrectly set to "null".
* Ensure consistent behavior for MyAccount password reset flows, regardless of the presence of the `sp` parameter.
*Simplify the logic for identifying the target application to improve maintainability and reduce potential edge cases.

**Approach:**

  * Default the application name to `"My Account"` if the `sp` parameter is empty or set to `"null"`, ensuring the correct application access URL is resolved.
  * Use a helper method to correctly identify My Account URLs, reducing false positives and improving readability.
  * Retain the existing logic for retrieving application access URLs and handling tenant placeholders to avoid breaking changes.
  * Ensure the `isAccessUrlAvailable` property is consistently set based on the final resolved application name, avoiding unexpected behavior in the password reset flow.

## Related Issues

product-is issue: https://github.com/wso2/product-is/issues/23934