### PR TITLE
Conditionally enable impersonation for users in primary user store

### DIFF
--- a/.changeset/tricky-buttons-rescue.md
+++ b/.changeset/tricky-buttons-rescue.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add impersonation UX improvements.

--- a/features/admin.extensions.v1/configs/models/user.ts
+++ b/features/admin.extensions.v1/configs/models/user.ts
@@ -20,6 +20,7 @@ import { AskPasswordOptionTypes, PasswordOptionTypes } from "@wso2is/admin.users
 import { ProfileInfoInterface } from "@wso2is/core/models";
 
 export interface User {
+    allowImpersonationForPrimaryUserStore: boolean;
     bulkUserImportLimit: {
         fileSize: number;
         inviteEmails: number;

--- a/features/admin.extensions.v1/configs/user.ts
+++ b/features/admin.extensions.v1/configs/user.ts
@@ -23,6 +23,7 @@ import { ProfileInfoInterface } from "@wso2is/core/models";
 import { User } from "./models";
 
 export const userConfig: User = {
+    allowImpersonationForPrimaryUserStore: true,
     bulkUserImportLimit: {
         fileSize: 500,
         inviteEmails: 50,

--- a/features/admin.users.v1/components/user-impersonation-action.tsx
+++ b/features/admin.users.v1/components/user-impersonation-action.tsx
@@ -171,6 +171,12 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
         }
     }, [ idToken, subjectToken ]);
 
+    /**
+     * Timeout to handle unexpected errors occurs in the impersonation iframe.
+     * Currently, there's no way to detect such errors from within the iframe,
+     * as the iframe itself is unaware of the errors occured in different
+     * hosts—such as the authentication portal.
+     */
     useEffect(() => {
         if (impersonationInProgress) {
             setTimeout(() => {
@@ -244,7 +250,7 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
                 // Set if my account is enabled.
                 setMyAccountStatus(myAccountApplication?.applicationEnabled);
 
-                // Set if my account login Steps is one and the BasicAuthenticator is included.
+                // Set if my account have only one login step and the BasicAuthenticator is included.
                 if (myAccountApplication?.authenticationSequence?.steps?.length === 1) {
                     const step: any = myAccountApplication?.authenticationSequence?.steps[0];
 

--- a/features/admin.users.v1/components/user-impersonation-action.tsx
+++ b/features/admin.users.v1/components/user-impersonation-action.tsx
@@ -171,6 +171,25 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
         }
     }, [ idToken, subjectToken ]);
 
+    useEffect(() => {
+        if (impersonationInProgress) {
+            setTimeout(() => {
+                if (impersonationInProgress && idToken == undefined && subjectToken == undefined) {
+                    setImpersonationInProgress(false);
+                    dispatch(addAlert({
+                        description: t(
+                            "users:notifications.impersonateUser.error.description"
+                        ),
+                        level: AlertLevels.ERROR,
+                        message: t(
+                            "users:notifications.impersonateUser.error.message"
+                        )
+                    }));
+                }
+            }, 5000);
+        }
+    }, [ impersonationInProgress ]);
+
     const handleInitImpersonateIframeMessage = (event: CompositionEvent) => {
         if (event.data === "impersonation-authorize-request-complete"
                 && sessionStorage.getItem(IMPERSONATION_ARTIFACTS) != null) {
@@ -398,20 +417,6 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
         setCodeVerifier(codeVerifier);
         setCodeChallenge(codeChallenge);
         setImpersonationInProgress(true);
-        setTimeout(() => {
-            if (impersonationInProgress && idToken == undefined && subjectToken == undefined) {
-                setImpersonationInProgress(false);
-                dispatch(addAlert({
-                    description: t(
-                        "users:notifications.impersonateUser.error.description"
-                    ),
-                    level: AlertLevels.ERROR,
-                    message: t(
-                        "users:notifications.impersonateUser.error.message"
-                    )
-                }));
-            }
-        }, 5000);
     };
 
     /**

--- a/features/admin.users.v1/constants/user-management-constants.ts
+++ b/features/admin.users.v1/constants/user-management-constants.ts
@@ -183,6 +183,9 @@ export class UserManagementConstants {
     public static readonly ID_TOKEN: string = "id_token";
     public static readonly SUBJECT_TOKEN: string = "subject_token";
 
+    // Name of the Asgardeo userstore.
+    public static readonly ASGARDEO_USERSTORE: string = "ASGARDEO-USER";
+
     // Feature flags.
     public static readonly ATTRIBUTE_PROFILES_FOR_USER_CREATION_FEATURE_FLAG: string
         = "users.user.creation.attribute.profile";

--- a/modules/i18n/src/models/namespaces/user-ns.ts
+++ b/modules/i18n/src/models/namespaces/user-ns.ts
@@ -94,6 +94,7 @@ export interface userNS {
                 buttonDisableHints: {
                     insufficientPermissions: string;
                     myAccountDisabled: string;
+                    myAccountLoginFlowIncompatible: string;
                     userAccountDisabled: string;
                     userAccountLocked: string;
                 };

--- a/modules/i18n/src/translations/en-US/portals/user.ts
+++ b/modules/i18n/src/translations/en-US/portals/user.ts
@@ -100,6 +100,7 @@ export const user: userNS = {
                 buttonDisableHints: {
                     insufficientPermissions: "Logged in user should be assigned with Impersonator My Account application role.",
                     myAccountDisabled: "My account application should be enabled to impersonate the user.",
+                    myAccountLoginFlowIncompatible: "My account Login Flow is incompatible.",
                     userAccountDisabled: "User account should be enabled to impersonate the user.",
                     userAccountLocked: "User account should be unlocked to impersonate the user."
                 },


### PR DESCRIPTION
### Purpose
The below improvements were added.

1.  Handle impersonation for asgardeo users - Asgardeo users should not be able to see impersonate action, as the action is not allowed. For other users in other userstore should be able to see.
2. Disable impersonation for login flow incompatibility - My Account login flow should be compatible with console login flow.
3. Fix timeout not working issues
    - As we are using a different iframe to sso impersonated user, when an unexpected error occurs there's no way to identify an error occurred in that iframe (error occurs in the authentication portal cannot be detected in the iframe). Because of this limitation, we added a timeout to fail the impersonation.

### Related Issues
- https://github.com/wso2/product-is/issues/23462