### PR TITLE
Fix missing display of success alert in application sharing.

### DIFF
--- a/.changeset/twelve-eggs-shave.md
+++ b/.changeset/twelve-eggs-shave.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Update missing display of success alert.

--- a/features/admin.applications.v1/components/forms/share-application-form.tsx
+++ b/features/admin.applications.v1/components/forms/share-application-form.tsx
@@ -431,6 +431,23 @@ export const ApplicationShareForm: FunctionComponent<ApplicationShareFormPropsIn
                 application.id,
                 shareAppData
             )
+                .then(() => {
+                    if (!isApplicationShareOperationStatusEnabled) {
+                        dispatch(
+                            addAlert({
+                                description: t(
+                                    "applications:edit.sections.shareApplication" +
+                                    ".addSharingNotification.success.description"
+                                ),
+                                level: AlertLevels.SUCCESS,
+                                message: t(
+                                    "applications:edit.sections.shareApplication" +
+                                    ".addSharingNotification.success.message"
+                                )
+                            })
+                        );
+                    }
+                })
                 .catch((error: AxiosError) => {
                     if (error.response.data.message) {
                         dispatch(


### PR DESCRIPTION
### Purpose
$subject

### Related Issue:
- https://github.com/wso2/product-is/issues/23903
### Related PRs:
- https://github.com/wso2/identity-apps/pull/8138