### PR TITLE
Resolve server origin when tenant qualified URLs are disabled

### DIFF
--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -63,6 +63,7 @@ export class Config {
             serverOrigin: window["AppUtils"]?.getConfig()?.serverOrigin,
             superTenant: window["AppUtils"]?.getConfig()?.superTenant,
             tenant: window["AppUtils"]?.getConfig()?.tenant,
+            tenantContext: window["AppUtils"]?.getConfig()?.tenantContext,
             tenantPath: window["AppUtils"]?.getConfig()?.tenantPath,
             tenantPrefix: window["AppUtils"]?.getConfig()?.tenantPrefix
         };

--- a/features/admin.core.v1/configs/app.ts
+++ b/features/admin.core.v1/configs/app.ts
@@ -82,6 +82,11 @@ export class Config {
      * @returns Server host.
      */
     public static resolveServerHost(enforceOrgPath?: boolean, skipAuthzRuntimePath?: boolean): string {
+        // If tenant qualified URLs are disabled, return the server origin.
+        if (!this.isTenantQualifiedURLsEnabled()) {
+            return this.getDeploymentConfig()?.serverOrigin;
+        }
+
         const serverOriginWithTenant: string = window[ "AppUtils" ]?.getConfig()?.serverOriginWithTenant;
 
         if (skipAuthzRuntimePath && serverOriginWithTenant?.slice(-2) === "/o") {
@@ -107,6 +112,29 @@ export class Config {
                 window[ "AppUtils" ]?.getConfig()?.serverOrigin }/t/${ store.getState().organization.organization.id
             }`;
         }
+    }
+
+    /**
+     * This method directly returns the server host read from the deployment config.
+     *
+     * @returns server host.
+     */
+    public static resolveServerHostFromConfig() {
+        if (this.isTenantQualifiedURLsEnabled()) {
+            return this.getDeploymentConfig()?.serverOrigin;
+        } else {
+            return this.getDeploymentConfig()?.serverHost;
+        }
+    }
+
+
+    /**
+     * This method checks if tenant qualified URLs are enabled.
+     *
+     * @returns true if tenant qualified URLs are enabled.
+     */
+    private static isTenantQualifiedURLsEnabled() {
+        return this.getDeploymentConfig()?.tenantContext?.enableTenantQualifiedUrls;
     }
 
     /**
@@ -141,6 +169,7 @@ export class Config {
             serverOrigin: window[ "AppUtils" ]?.getConfig()?.serverOrigin,
             superTenant: window[ "AppUtils" ]?.getConfig()?.superTenant,
             tenant: window[ "AppUtils" ]?.getConfig()?.tenant,
+            tenantContext: window[ "AppUtils" ]?.getConfig()?.tenantContext,
             tenantPath: window[ "AppUtils" ]?.getConfig()?.tenantPath,
             tenantPrefix: window[ "AppUtils" ]?.getConfig()?.tenantPrefix
         };
@@ -264,27 +293,27 @@ export class Config {
             ...getAPIResourceEndpoints(this.resolveServerHost()),
             ...getAdministratorsResourceEndpoints(this.resolveServerHost()),
             ...getApplicationsResourceEndpoints(this.resolveServerHost()),
-            ...getApprovalsResourceEndpoints(this.getDeploymentConfig()?.serverHost),
+            ...getApprovalsResourceEndpoints(this.resolveServerHostFromConfig()),
             ...getBrandingResourceEndpoints(this.resolveServerHost()),
-            ...getClaimResourceEndpoints(this.getDeploymentConfig()?.serverHost, this.resolveServerHost()),
-            ...getCertificatesResourceEndpoints(this.getDeploymentConfig()?.serverHost),
+            ...getClaimResourceEndpoints(this.resolveServerHostFromConfig(), this.resolveServerHost()),
+            ...getCertificatesResourceEndpoints(this.resolveServerHostFromConfig()),
             ...getIDVPResourceEndpoints(this.resolveServerHost()),
             ...getEmailTemplatesResourceEndpoints(this.resolveServerHost()),
             ...getConnectionResourceEndpoints(this.resolveServerHost()),
-            ...getRolesResourceEndpoints(this.resolveServerHost(), this.getDeploymentConfig().serverHost),
+            ...getRolesResourceEndpoints(this.resolveServerHost(), this.resolveServerHostFromConfig()),
             ...getServerConfigurationsResourceEndpoints(this.resolveServerHost()),
             ...getUsersResourceEndpoints(this.resolveServerHost()),
             ...getUserstoreResourceEndpoints(this.resolveServerHost()),
-            ...getScopesResourceEndpoints(this.getDeploymentConfig()?.serverHost),
+            ...getScopesResourceEndpoints(this.resolveServerHostFromConfig()),
             ...getGroupsResourceEndpoints(this.resolveServerHost()),
             ...getValidationServiceEndpoints(this.resolveServerHost()),
-            ...getRemoteFetchConfigResourceEndpoints(this.getDeploymentConfig()?.serverHost),
-            ...getSecretsManagementEndpoints(this.getDeploymentConfig()?.serverHost),
+            ...getRemoteFetchConfigResourceEndpoints(this.resolveServerHostFromConfig()),
+            ...getSecretsManagementEndpoints(this.resolveServerHostFromConfig()),
             ...getExtendedFeatureResourceEndpoints(this.resolveServerHost(), this.getDeploymentConfig()),
-            ...getOrganizationsResourceEndpoints(this.resolveServerHost(true), this.getDeploymentConfig().serverHost),
+            ...getOrganizationsResourceEndpoints(this.resolveServerHost(true), this.resolveServerHostFromConfig()),
             ...getTenantResourceEndpoints(this.getDeploymentConfig().serverOrigin),
             ...getFeatureGateResourceEndpoints(this.resolveServerHostforFG(false)),
-            ...getInsightsResourceEndpoints(this.getDeploymentConfig()?.serverHost),
+            ...getInsightsResourceEndpoints(this.resolveServerHostFromConfig()),
             ...getExtensionTemplatesEndpoints(this.resolveServerHost()),
             ...getApplicationTemplatesResourcesEndpoints(this.resolveServerHost()),
             ...getActionsResourceEndpoints(this.resolveServerHost()),
@@ -295,7 +324,7 @@ export class Config {
             ...getPushProviderTemplateEndpoints(this.resolveServerHost()),
             ...getRemoteLoggingEndpoints(this.resolveServerHost()),
             ...getRegistrationFlowBuilderResourceEndpoints(this.resolveServerHost()),
-            CORSOrigins: `${ this.getDeploymentConfig()?.serverHost }/api/server/v1/cors/origins`,
+            CORSOrigins: `${ this.resolveServerHostFromConfig() }/api/server/v1/cors/origins`,
             asyncStatus: `${ this.resolveServerHost(false, true) }/api/server/v1/async-operations`,
             // TODO: Remove this endpoint and use ID token to get the details
             me: `${ this.getDeploymentConfig()?.serverHost }/scim2/Me`,

--- a/features/admin.core.v1/store/reducers/config.ts
+++ b/features/admin.core.v1/store/reducers/config.ts
@@ -78,6 +78,7 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
             serverOrigin: "",
             superTenant: "",
             tenant: "",
+            tenantContext: null,
             tenantPath: "",
             tenantPrefix: ""
         },

--- a/modules/core/src/models/config.ts
+++ b/modules/core/src/models/config.ts
@@ -146,6 +146,11 @@ export interface CommonDeploymentConfigInterface<T = Record<string, unknown>, S 
      */
     tenant: string;
     /**
+     * Tenant context information.
+     * ex: `enableTenantQualifiedUrls`
+     */
+    tenantContext: TenantContextInterface;
+    /**
      * Tenant path.
      * ex: `/t/wso2.com`
      */
@@ -155,6 +160,24 @@ export interface CommonDeploymentConfigInterface<T = Record<string, unknown>, S 
      * ex: `t`
      */
     tenantPrefix: string;
+}
+
+/**
+ * Tenant context interface.
+ */
+export interface TenantContextInterface {
+    /**
+     * Enable tenant qualified URLs.
+     */
+    enableTenantQualifiedUrls: boolean;
+    /**
+     * Require super tenant in app URLs.
+     */
+    requireSuperTenantInAppUrls: boolean;
+    /**
+     * Require super tenant in URLs.
+     */
+    requireSuperTenantInUrls: boolean;
 }
 
 /**


### PR DESCRIPTION
### Purpose
This PR updates the resolution logic for server origin based on the deployment.toml configuration that controls tenant-qualified URL support. With this update [1], we've introduced backward compatibility to support deployments that use non-tenant-qualified URLs.

To disable tenant-qualified URLs, the following server configuration can be used:

```
[tenant_context]
enable_tenant_qualified_urls = false
enable_tenanted_sessions = false
```

When the above configs are set to false, the server origin will always resolve as non-tenant-qualified. 

