### PR TITLE
Fix Callback URL Validation for Offline Onboarding Flow

### DIFF
--- a/.changeset/lucky-penguins-knock.md
+++ b/.changeset/lucky-penguins-knock.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix Callback URL Validation for Offline Onboarding Flow

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -117,7 +117,7 @@
     } else {
             if (StringUtils.isNotBlank(spId)) {
             try {
-                if (spId.equals(MY_ACCOUNT_APP_ID)) {
+                if (spId.equals(MY_ACCOUNT_APP_ID) || isUserPortalUrl(callback, tenantDomain, application)) {
                     applicationName = MY_ACCOUNT_APP_NAME;
                 } else {
                     applicationName = applicationDataRetrieval.getApplicationName(tenantDomain,spId);


### PR DESCRIPTION
### Purpose

To ensure the `isAccessUrlAvailable` property is properly set during the offline user onboarding flow, even when the `userStoreDomain` is not available.

### Goals

* Correctly identify the MyAccount application when the service provider ID matches or the callback matches the MyAccount access URL.
* Prevent callback URL validation failures during password submission in offline onboarding scenarios.

### Approach

* Enhanced the fallback logic to infer the correct application name when `userStoreDomain` is missing.
* Reused the existing `isUserPortalUrl` utility to handle cases where the access URL points to the MyAccount application.
* Ensured consistent behavior for setting the `isAccessUrlAvailable` property across all onboarding flows.

## Related Issues

public issue: https://github.com/wso2/product-is/issues/24086

> **Note:**
> _This is not reproducible in Asgardeo: [Click here to view 🔗](https://drive.google.com/file/d/15bQZWt_Zy80xFO5P7duGirpg1lwN8Z-H/view?usp=sharing)_