### PR TITLE
Add rule for pre update profile action

### DIFF
--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -289,8 +289,7 @@
             },
             "actions": {
                 "disabledFeatures": [
-                    "actions.types.list.preRegistration",
-                    "actions.types.list.preUpdateProfile"
+                    "actions.types.list.preRegistration"
                 ],
                 "enabled": true,
                 "featureFlags": [

--- a/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
@@ -24,7 +24,7 @@ import Typography from "@oxygen-ui/react/Typography";
 import { FeatureAccessConfigInterface } from "@wso2is/access-control";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import useGetRulesMeta from "@wso2is/admin.rules.v1/api/use-get-rules-meta";
-import { RuleWithoutIdInterface } from "@wso2is/admin.rules.v1/models/rules";
+import { RuleExecuteCollectionWithoutIdInterface, RuleWithoutIdInterface } from "@wso2is/admin.rules.v1/models/rules";
 import { RulesProvider } from "@wso2is/admin.rules.v1/providers/rules-provider";
 import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
@@ -89,7 +89,7 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
     isReadOnly,
     actionTypeApiPath,
     isCreateFormState,
-    ["data-componentid"]: componentId = "pre-update-password-action-config-form"
+    ["data-componentid"]: componentId = "pre-update-profile-action-config-form"
 }: PreUpdateProfileActionConfigFormInterface): ReactElement => {
 
     const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
@@ -193,6 +193,16 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
         values: PreUpdatePasswordActionConfigFormPropertyInterface,
         changedFields: PreUpdatePasswordActionConfigFormPropertyInterface) => {
 
+        let payloadRule: RuleWithoutIdInterface | RuleExecuteCollectionWithoutIdInterface | Record<string, never>;
+
+        if (isHasRule) {
+            payloadRule = rule;
+        } else {
+            if (!isCreateFormState && !rule) {
+                payloadRule = {};
+            }
+        }
+
         const authProperties: Partial<AuthenticationPropertiesInterface> = {};
 
         if (isAuthenticationUpdateFormState || isCreateFormState) {
@@ -228,7 +238,8 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
                     },
                     uri: values.endpointUri
                 },
-                name: values.name
+                name: values.name,
+                ...(payloadRule !== null && { rule: payloadRule })
             };
 
             setIsSubmitting(true);
@@ -253,7 +264,8 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
                     } : undefined,
                     uri: changedFields?.endpointUri ? values.endpointUri : undefined
                 } : undefined,
-                name: changedFields?.name ? values.name : undefined
+                name: changedFields?.name ? values.name : undefined,
+                ...(payloadRule !== null && { rule: payloadRule })
             };
 
             setIsSubmitting(true);

--- a/features/admin.rules.v1/api/use-get-resource-list-or-resource-details.ts
+++ b/features/admin.rules.v1/api/use-get-resource-list-or-resource-details.ts
@@ -36,7 +36,7 @@ import { HttpMethods } from "@wso2is/core/models";
  */
 const useGetResourceListOrResourceDetails = <Data = any, Error = RequestErrorInterface>(
     endpointPath: string,
-    shouldFetch: boolean = true
+    shouldFetch: boolean
 ): RequestResultInterface<Data, Error> => {
     const requestConfig: RequestConfigInterface = {
         headers: {

--- a/features/admin.rules.v1/components/rule-conditions.tsx
+++ b/features/admin.rules.v1/components/rule-conditions.tsx
@@ -18,7 +18,8 @@
 
 import Alert from "@oxygen-ui/react/Alert";
 import AlertTitle from "@oxygen-ui/react/AlertTitle";
-import Autocomplete, { AutocompleteRenderInputParams } from "@oxygen-ui/react/Autocomplete";
+import Autocomplete, { AutocompleteInputChangeReason,
+    AutocompleteRenderInputParams } from "@oxygen-ui/react/Autocomplete";
 import Box from "@oxygen-ui/react/Box";
 import Button from "@oxygen-ui/react/Button";
 import CircularProgress from "@oxygen-ui/react/CircularProgress";
@@ -32,9 +33,12 @@ import Select, { SelectChangeEvent } from "@oxygen-ui/react/Select";
 import TextField from "@oxygen-ui/react/TextField";
 import { MinusIcon, PlusIcon, TrashIcon } from "@oxygen-ui/react-icons";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { Code } from "@wso2is/react-components";
 import debounce from "lodash-es/debounce";
-import React, { ChangeEvent, Dispatch, Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { ChangeEvent, Dispatch, Fragment, FunctionComponent, HTMLAttributes, ReactElement, useEffect,
+    useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { DropdownProps } from "semantic-ui-react";
 import useGetResourceListOrResourceDetails from "../api/use-get-resource-list-or-resource-details";
 import { useRulesContext } from "../hooks/use-rules-context";
 import {
@@ -43,7 +47,7 @@ import {
     LinkInterface,
     ListDataInterface
 } from "../models/meta";
-import { ResourceInterface } from "../models/resource";
+import { ClaimResourceInterface, ResourceInterface } from "../models/resource";
 import {
     AdjoiningOperatorTypes,
     ConditionExpressionInterface,
@@ -103,6 +107,7 @@ interface ValueInputAutocompleteProps extends ComponentCommonPropsInterface {
     resourceType: string;
     initialResourcesLoadUrl: string;
     filterBaseResourcesUrl: string;
+    shouldFetch: boolean;
 }
 
 /**
@@ -195,7 +200,8 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         filterBaseResourcesUrl,
         ruleId,
         conditionId,
-        expressionId
+        expressionId,
+        shouldFetch
     }: ValueInputAutocompleteProps) => {
 
         const [ inputValue, setInputValue ] = useState<string>(null);
@@ -211,9 +217,9 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
             : initialResourcesLoadUrl;
 
         const { data: initialResources = [], isLoading: isInitialLoading } =
-            useGetResourceListOrResourceDetails(initialResourcesLoadUrl);
+            useGetResourceListOrResourceDetails(initialResourcesLoadUrl, shouldFetch);
         const { data: filteredResources = [], isLoading: isFiltering } =
-            useGetResourceListOrResourceDetails(filterUrl);
+            useGetResourceListOrResourceDetails(filterUrl, shouldFetch);
 
         useEffect(() => {
             if (resourceDetails) {
@@ -383,26 +389,37 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
     }: ResourceListSelectProps) => {
 
         const [ resourceDetails, setResourceDetails ] = useState<ResourceInterface>(null);
-        const valueReferenceAttribute: string = findMetaValuesAgainst?.value?.valueReferenceAttribute || "id";
-        const valueDisplayAttribute: string = findMetaValuesAgainst?.value?.valueDisplayAttribute || "name";
+        const [ inputValue, setInputValue ] = useState("");
+        const [ claimList, setClaimList ] = useState<ValueInputAutocompleteOptionsInterface[]>([]);
+        let valueReferenceAttribute: string = findMetaValuesAgainst?.value?.valueReferenceAttribute || "id";
+        let valueDisplayAttribute: string = findMetaValuesAgainst?.value?.valueDisplayAttribute || "name";
+        const [ selectedValue, setSelectedValue ] = useState<string>(null);
 
         let resourceType: string;
+        let shouldFetch: boolean = false;
 
         // TODO: Handle other resource types once the API is updated with the required data.
         if (expressionField === "application") {
             resourceType = "applications";
+            shouldFetch = true;
+        } else if (expressionField === "claim") {
+            resourceType = "claims";
+            //TODO: these hardcoded values will be removed once the rule metadata api change PR is merged.
+            valueReferenceAttribute = "claimURI";
+            valueDisplayAttribute = "displayName";
+            shouldFetch = false;
         }
 
         const {
             data: fetchedResourcesList,
             isLoading: isResourcesListLoading
-        } = useGetResourceListOrResourceDetails(initialResourcesLoadUrl);
+        } = useGetResourceListOrResourceDetails(initialResourcesLoadUrl, true);
 
         const {
             data: resourcesDetails,
             isLoading: isResourceDetailsLoading,
             error: resourceDetailsError
-        } = useGetResourceListOrResourceDetails(`/${resourceType}/${expressionValue}`);
+        } = useGetResourceListOrResourceDetails(`/${resourceType}/${expressionValue}`, shouldFetch);
 
         useEffect(() => {
             if (!isResourceDetailsLoading) {
@@ -415,7 +432,149 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
             }
         }, [ isResourceDetailsLoading, resourceDetailsError ]);
 
-        if (fetchedResourcesList && !isResourcesListLoading) {
+        useEffect(() => {
+            if (expressionField === "claim" && fetchedResourcesList) {
+                const initialOptions: ValueInputAutocompleteOptionsInterface[] =
+                            fetchedResourcesList?.map((resource: ClaimResourceInterface) => ({
+                                id: resource[valueReferenceAttribute],
+                                label: resource[valueDisplayAttribute]
+                            }));
+
+                const sortedClaims: ValueInputAutocompleteOptionsInterface[] =
+                initialOptions?.sort((a: ValueInputAutocompleteOptionsInterface,
+                    b: ValueInputAutocompleteOptionsInterface) => {
+                    return a.label > b.label ? 1 : -1;
+                });
+
+                /**
+                 * Disables the role claim attribute.
+                 *
+                 * The role attribute is temporarily disabled until the ambiguities
+                 * related to the claim are resolved.
+                 * @param claimsList - List of claims.
+                 * @returns - Filtered claims list.
+                 */
+                const filterOutRoleClaimAttribute = (claimsList: ValueInputAutocompleteOptionsInterface[]):
+                ValueInputAutocompleteOptionsInterface[] => {
+
+                    const excludedClaims: Set<string> = new Set([
+                        "http://wso2.org/claims/roles",
+                        "http://wso2.org/claims/applicationRoles"
+                    ]);
+
+                    return claimsList?.filter((claim: ValueInputAutocompleteOptionsInterface) =>
+                        !excludedClaims.has(claim?.id));
+                };
+
+                const claimList: ValueInputAutocompleteOptionsInterface[] =
+                filterOutRoleClaimAttribute(sortedClaims);
+
+                const matchedClaim = claimList.find(
+                    (claim: ValueInputAutocompleteOptionsInterface) => claim.id === expressionValue
+                );
+
+                setClaimList(claimList);
+                setInputValue(matchedClaim ? matchedClaim.label : "");
+                setSelectedValue(matchedClaim ? matchedClaim.id : null);
+
+            }
+        }, [ fetchedResourcesList ]);
+
+        if (isResourcesListLoading || !fetchedResourcesList) {
+            return;
+        }
+
+        if (expressionField == "claim") {
+
+            return (
+                <Autocomplete
+                    loading={ isResourcesListLoading }
+                    fullWidth
+                    aria-label="Attribute selection"
+                    className="pt-2"
+                    componentsProps={ {
+                        paper: {
+                            elevation: 2
+                        },
+                        popper: {
+                            modifiers: [
+                                {
+                                    enabled: false,
+                                    name: "flip"
+                                },
+                                {
+                                    enabled: false,
+                                    name: "preventOverflow"
+                                }
+                            ]
+                        }
+                    } }
+                    inputValue={ inputValue }
+                    value={ selectedValue ? { id: selectedValue, label: inputValue } : null }
+                    onInputChange={ (event: ChangeEvent, value: string, reason: AutocompleteInputChangeReason) => {
+
+                        if (reason === "reset") {
+                            setInputValue("");
+
+                            return;
+                        } else {
+                            setInputValue(value);
+                        }
+                    } }
+                    onChange={ (e: React.ChangeEvent, value: ValueInputAutocompleteOptionsInterface) => {
+
+                        if (value) {
+                            setSelectedValue(value?.id);
+                            setInputValue(value?.label);
+                            handleExpressionChangeDebounced(
+                                value.id,
+                                ruleId,
+                                conditionId,
+                                expressionId,
+                                ExpressionFieldTypes.Value,
+                                true
+                            );
+                        }
+                    } }
+                    options={ claimList }
+                    getOptionLabel={ (claim: DropdownProps) =>
+                        claim?.label
+                    }
+                    isOptionEqualToValue={
+                        (option: ValueInputAutocompleteOptionsInterface,
+                            value: ValueInputAutocompleteOptionsInterface) =>
+                            value?.id && option.id === value.id
+                    }
+                    renderOption={ (props: HTMLAttributes<HTMLLIElement>,
+                        option: ValueInputAutocompleteOptionsInterface) => (
+                        <li { ...props } key={ option.id }>
+                            <div className="multiline">
+                                <div>{ option?.label }</div>
+                                <div>
+                                    <Code className="description" compact withBackground={ false }>
+                                        { option?.id }
+                                    </Code>
+                                </div>
+                            </div>
+                        </li>
+                    ) }
+                    renderInput={ (params: AutocompleteRenderInputParams) => (
+                        <TextField
+                            { ...params }
+                            variant="outlined"
+                            placeholder={ t("rules:fields.autocomplete.placeholderText") }
+                            value={ inputValue }
+                            InputProps={ {
+                                ...params.InputProps
+                            } }
+                        />
+                    ) }
+                    key="autocompleteSearchWithList"
+                    data-componentid={ `${componentId}-select-attributes` }
+                />
+            );
+
+        } else if (resourceType == "applications") {
             // Set first value of the list if option is empty
             if (expressionValue === "") {
                 handleExpressionChangeDebounced(
@@ -441,6 +600,7 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
                         valueDisplayAttribute={ valueDisplayAttribute }
                         initialResourcesLoadUrl={ initialResourcesLoadUrl }
                         filterBaseResourcesUrl={ filterBaseResourcesUrl }
+                        shouldFetch={ shouldFetch }
                     />
                 );
             }
@@ -549,13 +709,15 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
                 );
             }
 
-            if (metaValue?.links?.length > 1) {
+            if (metaValue?.links?.length >= 1) {
                 const initialResourcesLoadUrl: string = metaValue?.links.find(
                     (link: LinkInterface) => link.rel === "values")?.href;
                 const filterBaseResourcesUrl: string = metaValue?.links.find(
                     (link: LinkInterface) => link.rel === "filter")?.href;
 
-                if (initialResourcesLoadUrl && filterBaseResourcesUrl) {
+                if ((expressionField === "application" && initialResourcesLoadUrl && filterBaseResourcesUrl) ||
+                    (expressionField === "claim" && initialResourcesLoadUrl)) {
+
                     return (
                         <ResourceListSelect
                             ruleId={ ruleId }

--- a/features/admin.rules.v1/models/resource.ts
+++ b/features/admin.rules.v1/models/resource.ts
@@ -26,6 +26,13 @@ export interface ResourceInterface {
     [key: string]: any;
 }
 
+export interface ClaimResourceInterface {
+    claimURI: string;
+    displayName: string;
+    isDisabled?: boolean;
+    [key: string]: any;
+}
+
 /**
  * Interface for the rule feature resource list.
  */

--- a/features/admin.rules.v1/providers/rules-provider.tsx
+++ b/features/admin.rules.v1/providers/rules-provider.tsx
@@ -39,7 +39,7 @@ interface RuleContextRefInterface extends RuleExecuteCollectionInterface {
     isMultipleRules: boolean;
 }
 
-// Refference to hold the latest context value
+// Reference to hold the latest context value
 const RuleContextRef: { ruleInstance: RuleContextRefInterface | undefined } = {
     ruleInstance: undefined
 };


### PR DESCRIPTION
#### Description 
This PR adds the rule support for the pre update profile action
In the pre update profile action , two fields of "flow" and "claim" are getting used where the "flow" field metadata is provided completely through the rule meta data api and the "claim" field metadata is provided through claim metadata api call done in the frontend.

#### Suggested changes

https://github.com/user-attachments/assets/f7e07523-8038-4fda-a03a-2bc0e1e245c6

#### Related issue
- 