### PR TITLE
Fix Sign-In Link Encoding in Self-Registration Page for Sub Organizations

### DIFF
--- a/.changeset/curly-toes-brake.md
+++ b/.changeset/curly-toes-brake.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix Sign-In Link Encoding in Self-Registration Page for Sub Organizations

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -110,7 +110,7 @@
     PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
     boolean isSelfRegistrationLockOnCreationEnabled = preferenceRetrievalClient.checkSelfRegistrationLockOnCreation(tenantDomain);
     String callback = Encode.forHtmlAttribute(request.getParameter("callback"));
-    String backToUrl = callback;
+    String backToUrl = Encode.forHtmlAttribute(IdentityManagementEndpointUtil.encodeURL(request.getParameter("callback")));
     String sp = Encode.forHtmlAttribute(request.getParameter("sp"));
     String previousStep = Encode.forHtmlAttribute(request.getParameter("previous_step"));
     String username = request.getParameter("username");


### PR DESCRIPTION
### Purpose

Fix redirect failures from the self-registration page back to the login page caused by unencoded or improperly decoded callback URLs.

### Goals

* Ensure the "Already have an account? Sign in" link redirects correctly across redirection hops.
* Avoid malformed URL issues and 400 errors during login redirection.
* Align frontend behavior with backend URL encoding expectations.

### Approach

* Used proper encoding on the callback URL to ensure redirection works reliably after returning from the self-registration page.

### Related PRs

* https://github.com/wso2-extensions/identity-auth-organization-login/pull/60

## Related Issue

public-issue: https://github.com/wso2/product-is/issues/23963