### PR TITLE
Remove duplicate api resource endpoint URL resolution

### DIFF
--- a/.changeset/dull-roses-jog.md
+++ b/.changeset/dull-roses-jog.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.roles.v2": patch
+"@wso2is/admin.core.v1": patch
+---
+
+Remove duplicate api resource endpoint URL resolution

--- a/.changeset/small-ladybugs-cry.md
+++ b/.changeset/small-ladybugs-cry.md
@@ -1,6 +1,7 @@
 ---
 "@wso2is/admin.roles.v2": patch
 "@wso2is/admin.core.v1": patch
+"@wso2is/console": patch
 ---
 
 Remove duplicate api resource endpoint URL resolution

--- a/features/admin.core.v1/configs/app.ts
+++ b/features/admin.core.v1/configs/app.ts
@@ -120,7 +120,7 @@ export class Config {
      * @returns server host.
      */
     public static resolveServerHostFromConfig() {
-        if (this.isTenantQualifiedURLsEnabled()) {
+        if (!this.isTenantQualifiedURLsEnabled()) {
             return this.getDeploymentConfig()?.serverOrigin;
         } else {
             return this.getDeploymentConfig()?.serverHost;

--- a/features/admin.roles.v2/configs/endpoints.ts
+++ b/features/admin.roles.v2/configs/endpoints.ts
@@ -30,8 +30,6 @@ export const getRolesResourceEndpoints = (
     serverHost: string
 ): RolesResourceEndpointsInterface => {
     return {
-        // TODO: This need to be removed once this endpoint is moved to the API resources feature.
-        apiResources: `${serverHost}/api/server/v1/api-resources`,
         permission: `${serverHostWithOrgPath}/api/server/v1/permission-management/permissions`,
         roles: `${serverHostWithOrgPath}/scim2/Roles`,
         rolesV2: `${serverHostWithOrgPath}/scim2/v2/Roles`,

--- a/features/admin.roles.v2/models/endpoints.ts
+++ b/features/admin.roles.v2/models/endpoints.ts
@@ -20,8 +20,6 @@
  * Interface for the Role Management feature resource endpoints.
  */
 export interface RolesResourceEndpointsInterface {
-    // TODO: This need to be removed once this endpoint is moved to the API resources feature.
-    apiResources?: string;
     roles: string;
     // TODO: This need to be removed once the Role V2 endpoint is enabled.
     rolesV2: string;


### PR DESCRIPTION
### Purpose 
This PR fixes the issue of api resource endpoint URL being overridden from the admin.roles.v2 component.

### Related Issue
- https://github.com/wso2/product-is/issues/24170