### PR TITLE
Fix attribute issue

### DIFF
--- a/.changeset/good-impalas-rest.md
+++ b/.changeset/good-impalas-rest.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/console": patch
+---
+
+Fix attributes view page issue

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -602,6 +602,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
     };
 
     const subAttributeDropdownOptions: DropDownItemInterface[] = useMemo(() => {
+        if (!props.claim) return [];
+
         return fetchedAttributes
             ?.filter((claim: Claim) => {
                 const isSystemClaim: boolean = claim.properties?.some(
@@ -620,8 +622,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
             .sort(
                 (a: { text: string }, b: { text: string }) =>
                     a.text.localeCompare(b.text)
-            );
-    }, [ fetchedAttributes, subAttributes, claim?.claimURI ]);
+            ) ?? [];
+    }, [ fetchedAttributes, subAttributes, props.claim?.claimURI ]);
 
     const onSubmit = (values: Record<string, unknown>) => {
         let data: Claim;


### PR DESCRIPTION
### Purpose
As a fix for the following issue in the Attributes view page, when viewing the attribute after navigating to another attribute.

<img width="498" alt="Screenshot 2025-05-30 at 22 51 00" src="https://github.com/user-attachments/assets/32ea2f8d-8572-43c9-b14b-d3cbd1eee4d2" />
