### PR TITLE
Update flow composer to support configurable flow types

### DIFF
--- a/.changeset/tame-timers-warn.md
+++ b/.changeset/tame-timers-warn.md
@@ -1,5 +1,5 @@
 ---
-"@wso2is/admin.registration-flow-builder.v1": patch
+"@wso2is/admin.registration-flow-builder.v1": minor
 ---
 
 Update flow composer to support configurable flow types

--- a/.changeset/tame-timers-warn.md
+++ b/.changeset/tame-timers-warn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.registration-flow-builder.v1": patch
+---
+
+Update flow composer to support configurable flow types

--- a/features/admin.registration-flow-builder.v1/api/use-get-registration-flow.ts
+++ b/features/admin.registration-flow-builder.v1/api/use-get-registration-flow.ts
@@ -23,6 +23,7 @@ import useRequest, {
 } from "@wso2is/admin.core.v1/hooks/use-request";
 import { store } from "@wso2is/admin.core.v1/store";
 import { HttpMethods } from "@wso2is/core/models";
+import { FlowTypes } from "../components/registration-flow-builder-core";
 
 /**
  * Hook to get the configured registration flow.
@@ -44,7 +45,7 @@ const useGetRegistrationFlow = <Data = any, Error = RequestErrorInterface>(
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: store.getState().config.endpoints.registrationFlow
+        url: `${store.getState().config.endpoints.registrationFlow}?flowType=${FlowTypes.REGISTRATION}`
     };
 
     const { data, error, isLoading, isValidating, mutate } = useRequest<Data, Error>(

--- a/features/admin.registration-flow-builder.v1/api/use-get-registration-flow.ts
+++ b/features/admin.registration-flow-builder.v1/api/use-get-registration-flow.ts
@@ -23,7 +23,7 @@ import useRequest, {
 } from "@wso2is/admin.core.v1/hooks/use-request";
 import { store } from "@wso2is/admin.core.v1/store";
 import { HttpMethods } from "@wso2is/core/models";
-import { FlowTypes } from "../components/registration-flow-builder-core";
+import RegistrationFlowConstants from "../constants/registration-flow-constants";
 
 /**
  * Hook to get the configured registration flow.
@@ -45,7 +45,7 @@ const useGetRegistrationFlow = <Data = any, Error = RequestErrorInterface>(
             "Content-Type": "application/json"
         },
         method: HttpMethods.GET,
-        url: `${store.getState().config.endpoints.registrationFlow}?flowType=${FlowTypes.REGISTRATION}`
+        url: `${store.getState().config.endpoints.registrationFlow}?flowType=${RegistrationFlowConstants.REGISTRATION_FLOW_TYPE}`
     };
 
     const { data, error, isLoading, isValidating, mutate } = useRequest<Data, Error>(

--- a/features/admin.registration-flow-builder.v1/components/registration-flow-builder-core.tsx
+++ b/features/admin.registration-flow-builder.v1/components/registration-flow-builder-core.tsx
@@ -75,24 +75,6 @@ import useGenerateRegistrationFlow, {
 } from "../hooks/use-generate-registration-flow";
 
 /**
- * Enum for flow types
- */
-export enum FlowTypes {
-    /**
-     * Registration flow type
-     */
-    REGISTRATION = "REGISTRATION",
-    /**
-     * Ask password flow type
-     */
-    ASK_PASSWORD = "ASK_PASSWORD",
-    /**
-     * Password recovery flow type
-     */
-    PASSWORD_RECOVERY = "PASSWORD_RECOVERY"
-}
-
-/**
  * Props interface of {@link RegistrationFlowBuilderCore}
  */
 export type RegistrationFlowBuilderCorePropsInterface = IdentifiableComponentInterface;

--- a/features/admin.registration-flow-builder.v1/components/registration-flow-builder-core.tsx
+++ b/features/admin.registration-flow-builder.v1/components/registration-flow-builder-core.tsx
@@ -75,6 +75,24 @@ import useGenerateRegistrationFlow, {
 } from "../hooks/use-generate-registration-flow";
 
 /**
+ * Enum for flow types
+ */
+export enum FlowTypes {
+    /**
+     * Registration flow type
+     */
+    REGISTRATION = "REGISTRATION",
+    /**
+     * Ask password flow type
+     */
+    ASK_PASSWORD = "ASK_PASSWORD",
+    /**
+     * Password recovery flow type
+     */
+    PASSWORD_RECOVERY = "PASSWORD_RECOVERY"
+}
+
+/**
  * Props interface of {@link RegistrationFlowBuilderCore}
  */
 export type RegistrationFlowBuilderCorePropsInterface = IdentifiableComponentInterface;

--- a/features/admin.registration-flow-builder.v1/config/endpoints.ts
+++ b/features/admin.registration-flow-builder.v1/config/endpoints.ts
@@ -27,6 +27,6 @@ export const getRegistrationFlowBuilderResourceEndpoints = (
     serverOrigin: string
 ): RegistrationFlowBuilderResourceEndpointsInterface => {
     return {
-        registrationFlow: `${ serverOrigin }/api/server/v1/registration-flow`
+        registrationFlow: `${ serverOrigin }/api/server/v1/flow`
     };
 };

--- a/features/admin.registration-flow-builder.v1/constants/registration-flow-constants.ts
+++ b/features/admin.registration-flow-builder.v1/constants/registration-flow-constants.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Constants related to the tenant management operations.
+ *
+ * @remarks
+ * This class is not meant to be instantiated. It only provides static constants.
+ *
+ * @example
+ * ```typescript
+ * const errorMessage = TenantConstants.TENANT_ACTIVATION_UPDATE_ERROR;
+ * ```
+ */
+class RegistrationFlowConstants {
+    /**
+     * Private constructor to avoid object instantiation from outside the class.
+     */
+    private constructor() {}
+
+    public static readonly REGISTRATION_FLOW_TYPE: string = "REGISTRATION";
+
+}
+
+export default RegistrationFlowConstants;

--- a/features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx
+++ b/features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx
@@ -30,6 +30,7 @@ import ResourceProperties from "../components/resource-property-panel/resource-p
 import ElementFactory from "../components/resources/elements/element-factory";
 import RegistrationFlowBuilderContext from "../context/registration-flow-builder-context";
 import { Attribute } from "../models/attributes";
+import { FlowTypes } from "../components/registration-flow-builder-core";
 import transformFlow from "../utils/transform-flow";
 
 /**
@@ -93,7 +94,10 @@ const FlowContextWrapper: FC<RegistrationFlowBuilderProviderProps> = ({
         }
 
         try {
-            await configureRegistrationFlow(transformFlow(flow) as any);
+            const registrationFlow = transformFlow(flow) as any;
+            registrationFlow.flowType = FlowTypes.REGISTRATION;
+
+            await configureRegistrationFlow(registrationFlow);
 
             dispatch(
                 addAlert({

--- a/features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx
+++ b/features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx
@@ -30,7 +30,7 @@ import ResourceProperties from "../components/resource-property-panel/resource-p
 import ElementFactory from "../components/resources/elements/element-factory";
 import RegistrationFlowBuilderContext from "../context/registration-flow-builder-context";
 import { Attribute } from "../models/attributes";
-import { FlowTypes } from "../components/registration-flow-builder-core";
+import RegistrationFlowConstants from "../constants/registration-flow-constants";
 import transformFlow from "../utils/transform-flow";
 
 /**
@@ -95,7 +95,7 @@ const FlowContextWrapper: FC<RegistrationFlowBuilderProviderProps> = ({
 
         try {
             const registrationFlow = transformFlow(flow) as any;
-            registrationFlow.flowType = FlowTypes.REGISTRATION;
+            registrationFlow.flowType = RegistrationFlowConstants.REGISTRATION_FLOW_TYPE;
 
             await configureRegistrationFlow(registrationFlow);
 


### PR DESCRIPTION
This pull request introduces changes to enhance the registration flow builder functionality by adding support for flow types and updating related configurations. The primary focus is on introducing a `FlowTypes` enum to manage different flow types, updating API endpoints, and ensuring the flow type is included in API requests and transformations.

### Enhancements to flow type management:

* [`features/admin.registration-flow-builder.v1/components/registration-flow-builder-core.tsx`](diffhunk://#diff-4d7d519fba0419abc495a40e34b099190f8ac3b04605c791d2c05b14222e68bcR77-R94): Added a `FlowTypes` enum to define constants for different flow types, including `REGISTRATION`, `ASK_PASSWORD`, and `PASSWORD_RECOVERY`. This provides a centralized and consistent way to reference flow types.

* [`features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx`](diffhunk://#diff-a3c86a87fa2469fddd991e2ed5ffd17d32ceb730cf6c9c8b9e298346f17f32f9L96-R100): Updated the `FlowContextWrapper` to include the `flowType` property (set to `FlowTypes.REGISTRATION`) when configuring the registration flow. This ensures the flow type is explicitly defined during transformations.

### Updates to API and configuration:

* [`features/admin.registration-flow-builder.v1/api/use-get-registration-flow.ts`](diffhunk://#diff-d0419fdd9e89867c2e38747ee90e56ed158795f7498d1eca6c1e386baa4fe53bL47-R48): Updated the API call to append the `flowType` query parameter (set to `FlowTypes.REGISTRATION`) to the registration flow endpoint. This ensures the correct flow type is retrieved.

* [`features/admin.registration-flow-builder.v1/config/endpoints.ts`](diffhunk://#diff-65fd45c8522e67532fdadf50ca141b434d80c47694f1523104195d107328a8bdL30-R30): Modified the `registrationFlow` endpoint to use a more generic base path (`/flow` instead of `/registration-flow`), aligning with the introduction of multiple flow types.

### Code refactoring:

* `features/admin.registration-flow-builder.v1/api/use-get-registration-flow.ts` and `features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx`: Imported the new `FlowTypes` enum where needed to replace hardcoded flow type values, improving code readability and maintainability. [[1]](diffhunk://#diff-d0419fdd9e89867c2e38747ee90e56ed158795f7498d1eca6c1e386baa4fe53bR26) [[2]](diffhunk://#diff-a3c86a87fa2469fddd991e2ed5ffd17d32ceb730cf6c9c8b9e298346f17f32f9R33)