### PR TITLE
Proper encoding of ui_locales param in language-switcher.jsp

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/language-switcher.jsp
@@ -44,7 +44,7 @@
         const localeFromCookie = getCookie("ui_lang");
         var localeFromUrlParams = null;
         if (urlParams.has('ui_locales')) {
-            localeFromUrlParams = "<%= Encode.forHtmlAttribute(request.getParameter("ui_locales")) %>";
+            localeFromUrlParams = "<%= Encode.forJavaScript(request.getParameter("ui_locales")) %>";
         }
         const browserLocale = "<%= userLocale %>"
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/language-switcher.jsp
@@ -44,7 +44,7 @@
         const localeFromCookie = getCookie("ui_lang");
         var localeFromUrlParams = null;
         if (urlParams.has('ui_locales')) {
-            localeFromUrlParams = "<%= Encode.forHtmlAttribute(request.getParameter("ui_locales")) %>";
+            localeFromUrlParams = "<%= Encode.forJavaScript(request.getParameter("ui_locales")) %>";
         }
         const browserLocale = "<%= userLocale %>"
         const computedLocale = computeLocale(localeFromCookie, localeFromUrlParams, browserLocale);


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
$subject, as the localeFromUrlParams parameter has been used in JS functions.


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
