### PR TITLE
Add support for showing public client checkbox based on the publicClientAllowed configuration on selected grant types.

### DIFF
--- a/.changeset/happy-jokes-obey.md
+++ b/.changeset/happy-jokes-obey.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
+---
+
+Add support for showing public client checkbox based on the publicClientAllowed configuration on selected grant types.

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -1903,11 +1903,13 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         && !isMobileApplication
         && !isFAPIApplication
         && (
-            selectedGrantTypes?.includes(
-                ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT)
-            || selectedGrantTypes?.includes(ApplicationManagementConstants.DEVICE_GRANT)
-            || selectedGrantTypes?.includes(
-                ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE)
+            selectedGrantTypes?.some((grantType: string) => {
+                const grantTypeOption: GrantTypeInterface = metadata?.allowedGrantTypes?.options?.find(
+                    (option: GrantTypeInterface) => option.name === grantType
+                );
+
+                return grantTypeOption?.publicClientAllowed === true;
+            })
         )
         && !isSystemApplication
         && !isDefaultApplication;

--- a/features/admin.applications.v1/models/application-inbound.ts
+++ b/features/admin.applications.v1/models/application-inbound.ts
@@ -38,6 +38,7 @@ export interface MetadataPropertyInterface {
 export interface GrantTypeInterface {
     name?: string;
     displayName?: string;
+    publicClientAllowed?: boolean;
 }
 
 export interface GrantTypeMetaDataInterface {


### PR DESCRIPTION
### Purpose
Previously, the logic for displaying the "Public Client" checkbox under the protocol section of an application was hardcoded to only show it when the selected grant types included `authorization_code`, `device_code`, or `token_exchange`. This limitation was due the lack of information in the `applications/meta/inbound-protocols/oidc` response regarding the "allow public client" configuration for each grant type.

With recent API enhancements, the frontend logic has been updated to dynamically display the checkbox whenever any of the selected grant types have the "allow public client" configuration set to true.

### Related prs
Should be merged after the following changes are added to the product
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2806
- https://github.com/wso2/identity-api-server/pull/903

### Related issue
- https://github.com/wso2/product-is/issues/23972