### PR TITLE
Encode login_hint parameter before rendering on the login page

### DIFF
--- a/.changeset/ninety-schools-invite.md
+++ b/.changeset/ninety-schools-invite.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Encode login_hint parameter before rendering on the login page

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/basicauth.jsp
@@ -505,7 +505,7 @@
                     aria-required="true"
                 >
                 <i aria-hidden="true" class="user fill icon"></i>
-                <input id="username" name="username" type="hidden" value="<%=username%>">
+                <input id="username" name="username" type="hidden" value="<%=Encode.forHtmlAttribute(username)%>">
             </div>
         </div>
         <div class="mt-1" id="usernameError" style="display: none;">
@@ -515,7 +515,7 @@
             </span>
         </div>
     <% } else { %>
-        <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=username%>">
+        <input id="username" name="username" type="hidden" data-testid="login-page-username-input" value="<%=Encode.forHtmlAttribute(username)%>">
     <% } %>
         <div class="field mt-3 mb-0">
             <label><%=AuthenticationEndpointUtil.i18n(resourceBundle, "password")%></label>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -533,8 +533,8 @@
                             class="ellipsis"
                             data-position="top left"
                             data-variation="inverted"
-                            data-content="<%=sanitizeUserName%>">
-                        <%=sanitizeUserName%>
+                            data-content="<%=Encode.forHtmlAttribute(sanitizeUserName)%>">
+                        <%=Encode.forHtmlContent(sanitizeUserName)%>
                     </span>
                 </div>
                 <% } %>
@@ -1473,7 +1473,7 @@
                 var baseLocation = "<%=commonauthURL%>?idp=" + key + "&authenticator=" + value +
                     "&sessionDataKey=<%=Encode.forUriComponent(request.getParameter("sessionDataKey"))%>";
 
-                if ("<%=username%>" !== "null" && "<%=username%>".length > 0) {
+                if ("<%=Encode.forJavaScript(username)%>" !== "null" && "<%=Encode.forJavaScript(username)%>".length > 0) {
                     document.location = baseLocation + "&username=" + "<%=Encode.forUriComponent(username)%>" + "<%=multiOptionURIParam%>";
                 } else {
                     document.location = baseLocation + "<%=multiOptionURIParam%>";


### PR DESCRIPTION
### Purpose
Ensure that values passed via the `login_hint` or `username` parameters are displayed correctly and safely on the login page by applying proper output encoding based on the rendering context.

### Goals
* Avoid display issues caused by special characters in user-supplied values.
* Maintain correct rendering behavior in HTML body, attribute, and JavaScript contexts.
* Preserve existing backend logic such as login flow and organization resolution.
* Align with best practices for context-aware output handling.

### Approach
This update introduces context-specific encoding for values rendered in the login interface:

* `Encode.forHtmlContent(...)` is used for values displayed inside the HTML body.
* `Encode.forHtmlAttribute(...)` is used for values placed within HTML attributes (e.g., hidden input fields).
* `Encode.forJavaScript(...)` is used for values embedded inside JavaScript code blocks or inline handlers.

The encoding is applied at the **point of rendering** (e.g., inside `login.jsp` and `basicauth.jsp`), allowing the backend to work with raw input while ensuring safe and predictable display on the frontend.

---

### Related Issue

Public issue: https://github.com/wso2/product-is/issues/24243


