### PR TITLE
Add webhooks template to configs

### DIFF
--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -314,6 +314,36 @@
                 }
             },
             {% endif %}
+            {% if console.webhooks is defined %}
+            "webhooks": {
+                "disabledFeatures": [
+                    {% if console.webhooks.disabled_features is defined %}
+                    {% for feature in console.webhooks.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {% if console.webhooks.enabled is defined %} {{ console.webhooks.enabled }},
+                {% else %} true,
+                {% endif %}
+                "scopes": {
+                    {% if console.webhooks.scopes is defined %}
+                    {% for operation, scopes in console.webhooks.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "read": [],
+                        "update": [],
+                        "delete": []
+                    {% endif %}
+                }
+            },
+            {% endif %}
             {% if console.internal_notification_sending is defined %}
             "internalNotificationSending": {
                 "disabledFeatures": [


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

This pull request introduces a new configuration section for managing webhooks in the `deployment.config.json.j2` file. The changes allow for the customization of webhook features, including enabling/disabling features and specifying scopes for different operations.

### Added Webhooks Configuration:

* Introduced a new `webhooks` section in the configuration file to manage webhook-related settings. This includes:
  - [`disabledFeatures`](diffhunk://#diff-32e42abd8b916a47ebe88ca9c28978dc3936409b2fed27f6ef32a0f90ba21635R317-R346): A list of features that can be disabled if specified (`console.webhooks.disabled_features`).
  - [`enabled`](diffhunk://#diff-32e42abd8b916a47ebe88ca9c28978dc3936409b2fed27f6ef32a0f90ba21635R317-R346): A flag to enable or disable webhooks, defaulting to `true` if not explicitly defined (`console.webhooks.enabled`).
  - [`scopes`](diffhunk://#diff-32e42abd8b916a47ebe88ca9c28978dc3936409b2fed27f6ef32a0f90ba21635R317-R346): A mapping of operations (e.g., `create`, `read`, `update`, `delete`) to their respective scopes, with default empty arrays if not specified (`console.webhooks.scopes`).