### PR TITLE
Fix SCIM2 claim migration issue in user profiles

### DIFF
--- a/.changeset/angry-ears-relax.md
+++ b/.changeset/angry-ears-relax.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/myaccount": patch
+"@wso2is/core": patch
+---
+
+Fix SCIM2 claim migration issue with user profiles

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -27,6 +27,7 @@ import Chip from "@oxygen-ui/react/Chip";
 import IconButton from "@oxygen-ui/react/IconButton";
 import Paper from "@oxygen-ui/react/Paper";
 import { Show, useRequiredScopes } from "@wso2is/access-control";
+import { getAllExternalClaims } from "@wso2is/admin.claims.v1/api";
 import { ClaimManagementConstants } from "@wso2is/admin.claims.v1/constants/claim-management-constants";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
@@ -50,6 +51,7 @@ import { getUserNameWithoutDomain, resolveUserstore } from "@wso2is/core/helpers
 import {
     AlertInterface,
     AlertLevels,
+    ExternalClaim,
     MultiValueAttributeInterface,
     PatchOperationRequest,
     ProfileInfoInterface,
@@ -278,6 +280,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         return isMultipleEmailsAndMobileNumbersEnabled(profileInfo, profileSchema);
     }, [ profileSchema, profileInfo ]);
 
+    const [ duplicatedUserClaims, setDuplicatedUserClaims ] = useState<ExternalClaim[]>([]);
+
     useEffect(() => {
         if (connectorProperties && Array.isArray(connectorProperties) && connectorProperties?.length > 0) {
 
@@ -342,6 +346,54 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
     useEffect(() => {
         mapUserToSchema(profileSchema, user);
     }, [ profileSchema, user ]);
+
+    /**
+     * This useEffect identifies external claims that are mapped to the same local claim
+     * between the Enterprise schema and the WSO2 System schema.
+     *
+     * These dual mappings occur only in migrated environments due to the SCIM2 schema restructuring
+     * introduced in https://github.com/wso2/product-is/issues/20850.
+     *
+     * The effect fetches both sets of external claims and detects overlaps by comparing their
+     * mappedLocalClaimURI values.
+     * Identified Enterprise claims are then excluded from the user profile UI to avoid redundancy.
+     */
+    useEffect(() => {
+        const fetchAllClaims = async () => {
+            try {
+                const [ enterpriseClaims, systemClaims ] = await Promise.all([
+                    getAllExternalClaims(
+                        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM2_SCHEMAS_EXT_ENT_USER"),
+                        null
+                    ),
+                    getAllExternalClaims(
+                        ClaimManagementConstants.ATTRIBUTE_DIALECT_IDS.get("SCIM2_SCHEMAS_EXT_SYSTEM"),
+                        null
+                    )
+                ]);
+
+                const systemMappedClaimURIs: Set<string> = new Set(
+                    systemClaims.map((claim: ExternalClaim) => claim.mappedLocalClaimURI).filter(Boolean)
+                );
+                const duplicates: ExternalClaim[] = enterpriseClaims.filter(
+                    (claim: ExternalClaim) =>
+                        claim.mappedLocalClaimURI &&
+                        systemMappedClaimURIs.has(claim.mappedLocalClaimURI)
+                );
+
+                setDuplicatedUserClaims(duplicates);
+
+            } catch (error) {
+                dispatch(addAlert({
+                    description: t("claims:external.notifications.fetchExternalClaims.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("claims:external.notifications.fetchExternalClaims.genericError.message")
+                }));
+            }
+        };
+
+        fetchAllClaims();
+    }, []);
 
     /**
      * This will add role attribute to countries search input to prevent autofill suggestions.
@@ -2609,6 +2661,12 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
         if (schema.name === EMAIL_ADDRESSES_ATTRIBUTE || schema.name === MOBILE_NUMBERS_ATTRIBUTE) {
             return !isEmpty(multiValuedAttributeValues[schema.name])
                 || (!isReadOnly && resolvedMutabilityValue !== ProfileConstants.READONLY_SCHEMA);
+        }
+
+        const schemaClaimURI: string = `${schema.schemaId}:${schema.name}`;
+
+        if (duplicatedUserClaims?.some((claim: ExternalClaim) => claim.claimURI === schemaClaimURI)) {
+            return false;
         }
 
         return (!isEmpty(profileInfo.get(schema.name)) ||

--- a/modules/core/src/constants/profile-constants.ts
+++ b/modules/core/src/constants/profile-constants.ts
@@ -132,4 +132,16 @@ export class ProfileConstants {
     // Self sign up
     public static readonly SELF_SIGN_UP_CONNECTOR: string = "self-sign-up";
     public static readonly SELF_SIGN_UP_ENABLE_SEND_OTP_IN_EMAIL: string = "SelfRegistration.OTP.SendOTPInEmail";
+
+    public static readonly MIGRATED_ENTERPRISE_SCIM_ATTRIBUTES: string[] = [
+        "askPassword", "verifyEmail", "pendingEmails.value", "accountLocked", "accountState",
+        "emailOTPDisabled", "emailVerified", "failedEmailOTPAttempts", "failedLoginAttempts",
+        "failedLoginAttemptsBeforeSuccess", "failedLoginLockoutCount", "failedPasswordRecoveryAttempts",
+        "failedSMSOTPAttempts", "failedTOTPAttempts", "isLiteUser", "lastLoginTime", "lastLogonTime",
+        "lastPasswordUpdateTime", "lockedReason", "phoneVerified", "preferredChannel", "smsOTPDisabled",
+        "tenantAdminAskPassword", "unlockTime", "accountDisabled", "dateOfBirth", "isReadOnlyUser",
+        "pendingMobileNumber", "forcePasswordReset", "oneTimePassword", "verifyMobile", "country",
+        "userSourceId", "totpEnabled", "backupCodeEnabled", "failedBackupCodeAttempts", "managedOrg",
+        "preferredMFAOption"
+    ];
 }


### PR DESCRIPTION
### Purpose

This PR resolves a claim display conflict in the Console user profile UI caused by SCIM2 schema restructuring. It prevents the rendering of Enterprise schema claims that are duplicated in the System (WSO2) schema.

In migrated environments, due to changes introduced via [wso2/product-is#20850](https://github.com/wso2/product-is/issues/20850), both the Enterprise and System schemas may define external claims that point to the same local claim (e.g., country). This leads to the same claim being displayed twice in the User Profile UI.

### Approach

In Console,
* Fetches external claims for:
    - Enterprise schema (urn:ietf:params:scim:schemas:extension:enterprise:2.0:User)
    - System schema (urn:scim:wso2:schema)
* Identifies Enterprise schema claims whose mappedLocalClaimURI also exists in the System schema.
* Filters these claims out from the profile field rendering logic using their claimURI.

In MyAccount,
* Maintains a list of known SCIM attributes that were duplicated across schemas during migration in the codebase.
* For each such attribute:
    - Checks whether both schema versions exist in the SCIM2 user response.
    - Compares their values.
* If both values are present and equal, the Enterprise schema version of the claim is hidden from the profile UI.

### Related Issue
- https://github.com/wso2/product-is/issues/24083