### PR TITLE
Input format support for the Attributes

### DIFF
--- a/.changeset/clean-bears-study.md
+++ b/.changeset/clean-bears-study.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/core": patch
+---
+
+Input format support for the attributes

--- a/.changeset/sixty-chefs-grow.md
+++ b/.changeset/sixty-chefs-grow.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/i18n": patch
+---
+
+Attribute level input format support

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -906,16 +906,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                 setInputType(multiValued ? ClaimInputFormat.MULTI_SELECT_DROPDOWN : ClaimInputFormat.DROPDOWN);
 
                 break;
-            case ClaimDataType.INTEGER:
-                setInputType(ClaimInputFormat.NUMBER_INPUT);
-
-                break;
             case ClaimDataType.BOOLEAN:
                 setInputType(ClaimInputFormat.CHECKBOX);
-
-                break;
-            case ClaimDataType.DATE_TIME:
-                setInputType(ClaimInputFormat.DATE_PICKER);
 
                 break;
             default:

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -1238,6 +1238,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                     }
                                 } }
                                 data-testid={ `${testId}-form-sub-attributes-dropdown` }
+                                disabled={ isSubOrganization() || isSystemClaim || isReadOnly }
                                 search
                             />
                             <div className="sub-attribute-list">
@@ -1246,21 +1247,23 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                         className="sub-attribute-row"
                                         key={ index }>
                                         <span>{ attribute }</span>
-                                        <IconButton
-                                            className="sub-attribute-delete-btn"
-                                            disabled={ isReadOnly }
-                                            onClick={ () => {
-                                                setSubAttributes(
-                                                    subAttributes.filter(
-                                                        (item: string) => item !== attribute
-                                                    )
-                                                );
-                                            } }
-                                            data-componentid={ `${testId}-delete-sub-attribute-${index}` }
-                                            style={ { marginLeft: "auto" } }
-                                        >
-                                            <TrashIcon />
-                                        </IconButton>
+                                        { !(isSubOrganization() || isSystemClaim || isReadOnly) && (
+                                            <IconButton
+                                                className="sub-attribute-delete-btn"
+                                                disabled={ isReadOnly }
+                                                onClick={ () => {
+                                                    setSubAttributes(
+                                                        subAttributes.filter(
+                                                            (item: string) => item !== attribute
+                                                        )
+                                                    );
+                                                } }
+                                                data-componentid={ `${testId}-delete-sub-attribute-${index}` }
+                                                style={ { marginLeft: "auto" } }
+                                            >
+                                                <TrashIcon />
+                                            </IconButton>
+                                        ) }
                                     </div>
                                 )) }
                             </div>
@@ -1285,7 +1288,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                                         ({ key: item.key, value: item.value })));
                                 } }
                                 data-testid={ `${testId}-form-canonical-values-dynamic-field` }
-                                readOnly={ isReadOnly }
+                                readOnly={ isSubOrganization() || isReadOnly }
                             />
                         </>
                     ) }

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -927,7 +927,8 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
         }
     };
 
-    const getFieldTypeOptions = (dataType: ClaimDataType, multiValued: boolean): DropDownItemInterface[] => {
+    const resolveInputFormatOptions = (dataType: ClaimDataType, multiValued: boolean): DropDownItemInterface[] => {
+
         const base: DropDownItemInterface[] = [
             { text: t("claims:local.forms.inputFormat.options.textInput"), value: ClaimInputFormat.TEXT_INPUT }
         ];
@@ -1324,7 +1325,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             data-testid={ `${testId}-form-input-format-input` }
                             hint={ t("claims:local.forms.inputFormat.hint") }
                             disabled={ isSubOrganization() || isReadOnly }
-                            options={ getFieldTypeOptions(dataType as ClaimDataType, multiValued) }
+                            options={ resolveInputFormatOptions(dataType as ClaimDataType, multiValued) }
                             value={ inputType }
                             onChange={ (
                                 event: React.SyntheticEvent<HTMLElement, Event>,

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -943,7 +943,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                     },
                     {
                         text: t("claims:local.forms.inputFormat.options.checkBoxGroup"),
-                        value: ClaimInputFormat.CHECKBOX
+                        value: ClaimInputFormat.CHECKBOX_GROUP
                     }
                 ];
             }

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -1305,7 +1305,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             label={ t("claims:local.forms.multiValued.label") }
                             required={ false }
                             defaultValue={ claim?.multiValued }
-                            data-testid={ `${testId}-form-multi-valued-input` }
+                            data-componentid={ `${testId}-form-multi-valued-input` }
                             hint={ isSystemClaim
                                 ? t("claims:local.forms.multiValuedSystemClaimHint")
                                 : t("claims:local.forms.multiValuedHint") }
@@ -1321,7 +1321,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
                             ariaLabel={ t("claims:local.forms.inputFormat.label") }
                             name="inputFormat"
                             label={ t("claims:local.forms.inputFormat.label") }
-                            data-testid={ `${testId}-form-input-format-input` }
+                            data-componentid={ `${testId}-form-input-format-input` }
                             hint={ t("claims:local.forms.inputFormat.hint") }
                             disabled={ isSubOrganization() || isReadOnly }
                             options={ resolveInputFormatOptions(dataType as ClaimDataType, multiValued) }

--- a/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-basic-details-local-claims.tsx
@@ -903,11 +903,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
         switch (dataType) {
             case ClaimDataType.OPTIONS:
-                if (multiValued) {
-                    setInputType(ClaimInputFormat.MULTI_SELECT_DROPDOWN);
-                } else {
-                    setInputType(ClaimInputFormat.DROPDOWN);
-                }
+                setInputType(multiValued ? ClaimInputFormat.MULTI_SELECT_DROPDOWN : ClaimInputFormat.DROPDOWN);
 
                 break;
             case ClaimDataType.INTEGER:
@@ -929,13 +925,16 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
     const resolveInputFormatOptions = (dataType: ClaimDataType, multiValued: boolean): DropDownItemInterface[] => {
 
-        const base: DropDownItemInterface[] = [
-            { text: t("claims:local.forms.inputFormat.options.textInput"), value: ClaimInputFormat.TEXT_INPUT }
+        const textInputOption: DropDownItemInterface[] = [
+            {
+                text: t("claims:local.forms.inputFormat.options.textInput"),
+                value: ClaimInputFormat.TEXT_INPUT
+            }
         ];
 
         if (dataType === ClaimDataType.DATE_TIME) {
             return [
-                ...base,
+                ...textInputOption,
                 {
                     text: t("claims:local.forms.inputFormat.options.datePicker"),
                     value: ClaimInputFormat.DATE_PICKER
@@ -971,7 +970,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
 
         if (dataType === ClaimDataType.INTEGER) {
             return [
-                ...base,
+                ...textInputOption,
                 {
                     text: t("claims:local.forms.inputFormat.options.numberInput"),
                     value: ClaimInputFormat.NUMBER_INPUT
@@ -992,7 +991,7 @@ export const EditBasicDetailsLocalClaims: FunctionComponent<EditBasicDetailsLoca
             ];
         }
 
-        return base;
+        return textInputOption;
     };
 
     const resolveAttributeRequiredRow = (): ReactElement => {

--- a/modules/core/src/models/claim.ts
+++ b/modules/core/src/models/claim.ts
@@ -35,6 +35,7 @@ export interface Claim {
     required: boolean;
     supportedByDefault: boolean;
     uniquenessScope?: UniquenessScope;
+    inputFormat?: InputFormat
     sharedProfileValueResolvingMethod?: SharedProfileValueResolvingMethod;
     attributeMapping?: AttributeMapping[];
     properties?: Property[];
@@ -76,6 +77,14 @@ export interface Property{
 export interface LabelValue {
     label: string;
     value: string;
+}
+
+/**
+ * Type of input format for claims in the UI.
+ * This is used to determine how the claim should be rendered in the UI.
+ */
+export interface InputFormat {
+    inputType: string;
 }
 
 /**
@@ -197,4 +206,29 @@ export enum ClaimDataType {
     COMPLEX = "complex",
     OPTIONS = "options",
     TEXT = "text"
+}
+
+/**
+ * Enum representing the input formats for claims in the UI.
+ * - DROPDOWN: A dropdown selection.
+ * - RADIO_GROUP: A group of radio buttons.
+ * - MULTI_SELECT_DROPDOWN: A multi-select dropdown.
+ * - CHECKBOX: A checkbox input.
+ * - TEXT_INPUT: A single-line text input.
+ * - TEXTAREA: A multi-line text input.
+ * - DATE_PICKER: A date picker input.
+ * - NUMBER_INPUT: A numeric input field.
+ * - TOGGLE: A toggle switch input.
+ */
+export enum ClaimInputFormat {
+    DROPDOWN = "dropdown",
+    RADIO_GROUP = "radio_group",
+    CHECKBOX_GROUP = "checkbox_group",
+    MULTI_SELECT_DROPDOWN = "multi_select_dropdown",
+    CHECKBOX = "checkbox",
+    TEXT_INPUT = "text_input",
+    TEXTAREA = "textarea",
+    DATE_PICKER = "date_picker",
+    NUMBER_INPUT = "number_input",
+    TOGGLE = "toggle"
 }

--- a/modules/core/src/models/claim.ts
+++ b/modules/core/src/models/claim.ts
@@ -212,6 +212,7 @@ export enum ClaimDataType {
  * Enum representing the input formats for claims in the UI.
  * - DROPDOWN: A dropdown selection.
  * - RADIO_GROUP: A group of radio buttons.
+ * - CHECKBOX_GROUP: A group of checkboxes.
  * - MULTI_SELECT_DROPDOWN: A multi-select dropdown.
  * - CHECKBOX: A checkbox input.
  * - TEXT_INPUT: A single-line text input.

--- a/modules/i18n/src/models/namespaces/claims-ns.ts
+++ b/modules/i18n/src/models/namespaces/claims-ns.ts
@@ -545,6 +545,22 @@ export interface ClaimsNS {
             required: {
                 label: string;
             };
+            inputFormat: {
+                label: string;
+                hint: string;
+                options: {
+                    textInput: string;
+                    dropdown: string;
+                    multiSelectDropdown: string;
+                    radioGroup: string;
+                    checkBoxGroup: string;
+                    checkbox: string;
+                    datePicker: string;
+                    textArea: string;
+                    toggle: string;
+                    numberInput: string;
+                }
+            }
             requiredHint: string;
             requiredWarning: string;
             readOnly: {

--- a/modules/i18n/src/translations/en-US/portals/claims.ts
+++ b/modules/i18n/src/translations/en-US/portals/claims.ts
@@ -491,6 +491,22 @@ export const claims: ClaimsNS = {
                 disabledConfigInfo: "Please note that below section is disabled as there is no " +
                     "external claim mapping found for this claim attribute."
             },
+            inputFormat: {
+                hint: "The input format of the attribute.",
+                label: "Input Format",
+                options: {
+                    checkBoxGroup: "Checkbox Group",
+                    checkbox: "Checkbox",
+                    datePicker: "Date Picker",
+                    dropdown: "Dropdown",
+                    multiSelectDropdown: "Multi-Select Dropdown",
+                    numberInput: "Number Input",
+                    radioGroup: "Radio Group",
+                    textArea: "Text Area",
+                    textInput: "Text Input",
+                    toggle: "Toggle"
+                }
+            },
             multiValued: {
                 label: "Allow multiple values for this attribute",
                 placeholder: "Select a user attribute"


### PR DESCRIPTION
### Purpose
$subject

### Related Issues
- https://github.com/wso2/product-is/issues/24392

- For the attributes where input formats are not defined, the default input format is `text_input`
- Previously the boolean data types are presented as checkbox, hence if the data type is boolean, the input format 
will be checkbox.
- The input formats can be altered for the system claims (with different data types) and custom claims as shown below.

https://github.com/user-attachments/assets/9c79508d-a351-4143-ad7f-269d8a480950


