### PR TITLE
Fix unnecessary line break in groups tab subheading in the roles page.

### DIFF
--- a/.changeset/friendly-planes-burn.md
+++ b/.changeset/friendly-planes-burn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.roles.v2": patch
+---
+
+fix(roles): remove unwanted line break in groups tab subheading

--- a/features/admin.roles.v2/components/edit-role/edit-role-groups.tsx
+++ b/features/admin.roles.v2/components/edit-role/edit-role-groups.tsx
@@ -263,7 +263,7 @@ export const RoleGroupsList: FunctionComponent<RoleGroupsPropsInterface> = (
             <Heading as="h4">
                 { t("roles:edit.groups.heading") }
             </Heading>
-            <Heading subHeading ellipsis as="h6">
+            <Heading subHeading as="h6">
                 { t("roles:edit.groups.subHeading") }
             </Heading>
             <Heading as="h5">


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
$Subject

![Screenshot 2025-06-25 210605](https://github.com/user-attachments/assets/64dc1456-e406-47fb-95a6-ecdf6dcf2bfd)


### Related Issues
https://github.com/wso2/product-is/issues/24309 

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

