### PR TITLE
Add support for opening the property panel on double-clicking an element

### DIFF
--- a/.changeset/early-starfishes-sniff.md
+++ b/.changeset/early-starfishes-sniff.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.flow-builder-core.v1": patch
+"@wso2is/console": patch
+---
+
+Add support for opening the property panel on double-clicking an element

--- a/features/admin.flow-builder-core.v1/components/resources/steps/view/reorderable-element.tsx
+++ b/features/admin.flow-builder-core.v1/components/resources/steps/view/reorderable-element.tsx
@@ -79,6 +79,18 @@ export const ReorderableElement: FunctionComponent<ReorderableComponentPropsInte
         setIsOpenResourcePropertiesPanel
     } = useAuthenticationFlowBuilderCore();
 
+    /**
+     * Handles the opening of the property panel for the resource.
+     *
+     * @param event - MouseEvent triggered on element interaction.
+     */
+    const handlePropertyPanelOpen = (event: MouseEvent): void => {
+
+        event.stopPropagation();
+        setLastInteractedStepId(stepId);
+        setLastInteractedResource(element);
+    };
+
     return (
         <Sortable
             id={ id }
@@ -93,6 +105,7 @@ export const ReorderableElement: FunctionComponent<ReorderableComponentPropsInte
                 alignItems="center"
                 className={ classNames("reorderable-component", className) }
                 data-componentid={ `${componentId}-${element.type}` }
+                onDoubleClick={ handlePropertyPanelOpen }
             >
                 <Box className="flow-builder-dnd-actions">
                     <Handle label="Drag" cursor="grab" ref={ handleRef }>
@@ -100,11 +113,7 @@ export const ReorderableElement: FunctionComponent<ReorderableComponentPropsInte
                     </Handle>
                     <Handle
                         label="Edit"
-                        onClick={ (event: MouseEvent) => {
-                            event.stopPropagation();
-                            setLastInteractedStepId(stepId);
-                            setLastInteractedResource(element);
-                        } }
+                        onClick={ handlePropertyPanelOpen }
                     >
                         <PencilIcon />
                     </Handle>


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
> $subject


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/24492

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
