### PR TITLE
Change wording to imply admin data separation implemented

### DIFF
--- a/.changeset/eighty-papayas-join.md
+++ b/.changeset/eighty-papayas-join.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/console": patch
+---
+
+Change wording to imply admin data separation implemented

--- a/features/admin.extensions.v1/configs/components/admin-data-separation-notice/admin-data-separation-notice.tsx
+++ b/features/admin.extensions.v1/configs/components/admin-data-separation-notice/admin-data-separation-notice.tsx
@@ -173,7 +173,7 @@ const AdminDataSeparationNotice: FunctionComponent<AdminDataSeparationNoticeProp
             <Typography variant="body1" sx={ { mt: 1 } }>
                 <Trans>
                     As of <strong>June 27, 2025</strong>, we have
-                    implemented <strong>region-based separation of admin user data</strong> in { productName } to
+                    introduced <strong>region-based separation of admin user data</strong> in { productName } to
                     meet compliance and data residency requirements.
                 </Trans>
             </Typography>

--- a/features/admin.extensions.v1/configs/components/admin-data-separation-notice/admin-data-separation-notice.tsx
+++ b/features/admin.extensions.v1/configs/components/admin-data-separation-notice/admin-data-separation-notice.tsx
@@ -172,8 +172,8 @@ const AdminDataSeparationNotice: FunctionComponent<AdminDataSeparationNoticeProp
 
             <Typography variant="body1" sx={ { mt: 1 } }>
                 <Trans>
-                    Effective from <strong>June 27, 2025</strong>, we are
-                    introducing <strong>region-based separation of admin user data</strong> in { productName } to
+                    As of <strong>June 27, 2025</strong>, we have
+                    implemented <strong>region-based separation of admin user data</strong> in { productName } to
                     meet compliance and data residency requirements.
                 </Trans>
             </Typography>


### PR DESCRIPTION
### Purpose
Update the wording in admin data separation banner to imply the data separation is in place now instead of we are introducing since the said date is passed