### PR TITLE
Fix generic error shown during JDBC user store edit connection test

### DIFF
--- a/.changeset/poor-countries-fetch.md
+++ b/.changeset/poor-countries-fetch.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.userstores.v1": patch
+"@wso2is/console": patch
+---
+
+Add console to the changeset

--- a/.changeset/pretty-dingos-decide.md
+++ b/.changeset/pretty-dingos-decide.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.userstores.v1": patch
+---
+
+Fix generic error shown during JDBC user store edit connection test

--- a/.changeset/pretty-dingos-decide.md
+++ b/.changeset/pretty-dingos-decide.md
@@ -1,5 +1,0 @@
----
-"@wso2is/admin.userstores.v1": patch
----
-
-Fix generic error shown during JDBC user store edit connection test

--- a/features/admin.userstores.v1/components/edit/edit-connection-details-user-store.tsx
+++ b/features/admin.userstores.v1/components/edit/edit-connection-details-user-store.tsx
@@ -26,7 +26,7 @@ import React, { FunctionComponent, ReactElement, useEffect, useState } from "rea
 import { useTranslation } from "react-i18next";
 import { useDispatch } from "react-redux";
 import { Dispatch } from "redux";
-import { Button, Grid, Icon } from "semantic-ui-react";
+import { Button, Grid, Header, Icon } from "semantic-ui-react";
 import { SqlEditor } from "..";
 import { patchUserStore, testConnection } from "../../api";
 import { JDBC } from "../../constants";
@@ -480,15 +480,6 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
                                                         setConnectionFailed(false);
                                                         setConnectionSuccessful(true);
                                                     } else {
-                                                        dispatch(addAlert({
-                                                            description: t("userstores:" +
-                                                                "notifications.testConnection.genericError" +
-                                                                ".description"),
-                                                            level: AlertLevels.ERROR,
-                                                            message: t(
-                                                                "userstores:notifications.testConnection.genericError" +
-                                                                ".message")
-                                                        }));
                                                         setConnectionSuccessful(false);
                                                         setConnectionFailed(true);
                                                     }
@@ -526,6 +517,11 @@ export const EditConnectionDetails: FunctionComponent<EditConnectionDetailsProps
                                     />
                                     { t("userstores:forms.connection.testButton") }
                                 </Button>
+                                { connectionFailed && (
+                                    <Header as="h6" color="red">
+                                        { t("userstores:forms.connection.connectionErrorMessage") }
+                                    </Header>
+                                ) }
                             </Grid.Column>
                         </Grid.Row>
                     ) }


### PR DESCRIPTION
### Purpose
When editing a secondary JDBC user store and clicking **Test Connection** with invalid connection parameters, the Console previously showed a generic error alert ("Something went wrong."). This behavior was inconsistent with the initial user store creation flow, which displays more descriptive feedback. The goal of this PR is to improve the user experience during connection testing in the edit flow.

### Goals
* Remove misleading generic alert shown when `connection: false` is returned.
* Ensure error messages from backend exceptions are shown via the existing `.catch()` handler.
* Provide a fallback UI error message below the **Test Connection** button when connection fails with no backend exception.
* Align the connection test behavior in the edit view with the behavior in the user store creation wizard.


### Approach
* Removed the alert dispatch block from the `else` condition inside the `.then()` block of the `testConnection()` response.
* Allowed all failed connections to fall into the `.catch()` block for proper backend error message handling.
* Added a fallback UI message using `<Header>` under the **Test Connection** button, shown only when `connectionFailed === true`.
* Used the translation key: `userstores:forms.connection.connectionErrorMessage` for localized fallback message content.

---

## Related Issues
public issue: https://github.com/wso2/product-is/issues/24515