### PR TITLE
Fix organization identifier not setting correctly from token response

### DIFF
--- a/.changeset/happy-parrots-film.md
+++ b/.changeset/happy-parrots-film.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.feature-gate.v1": patch
+"@wso2is/console": patch
+---
+
+Fix organization identifier not setting correctly from token response

--- a/features/admin.feature-gate.v1/api/use-get-all-features.ts
+++ b/features/admin.feature-gate.v1/api/use-get-all-features.ts
@@ -59,7 +59,7 @@ const useGetAllFeatures = <
     useEffect(() => {
         getDecodedIDToken().then((response: DecodedIDTokenPayload) => {
             // Set tenant domain as organization identifier.
-            setOrgIdentifier(response.orgHandle);
+            setOrgIdentifier(response.org_handle);
         });
     }, [ organizationType ]);
 


### PR DESCRIPTION
### Purpose
$subject

This change was introduced via: https://github.com/wso2/identity-apps/pull/8336/files

However the correct response attribute was not passed. This is now fixed to pass "org_handle"