### PR TITLE
Add support for plugin extensions in the flow builder core

### DIFF
--- a/.changeset/giant-berries-hear.md
+++ b/.changeset/giant-berries-hear.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.flow-builder-core.v1": patch
+"@wso2is/console": patch
+---
+
+Add support for plugin extensions in the flow builder core

--- a/features/admin.flow-builder-core.v1/components/resources/steps/view/reorderable-element.tsx
+++ b/features/admin.flow-builder-core.v1/components/resources/steps/view/reorderable-element.tsx
@@ -122,7 +122,7 @@ export const ReorderableElement: FunctionComponent<ReorderableComponentPropsInte
         /**
          * Execute plugins for ON_NODE_ELEMENT_DELETE event.
          */
-        await PluginRegistry.getInstance().executePlugins(EventTypes.ON_NODE_ELEMENT_DELETE, stepId, element);
+        await PluginRegistry.getInstance().execute(EventTypes.ON_NODE_ELEMENT_DELETE, stepId, element);
 
         deleteComponent(stepId, element);
         setIsOpenResourcePropertiesPanel(false);

--- a/features/admin.flow-builder-core.v1/components/resources/steps/view/reorderable-element.tsx
+++ b/features/admin.flow-builder-core.v1/components/resources/steps/view/reorderable-element.tsx
@@ -27,6 +27,8 @@ import VisualFlowConstants from "../../../../constants/visual-flow-constants";
 import useAuthenticationFlowBuilderCore from "../../../../hooks/use-authentication-flow-builder-core-context";
 import useComponentDelete from "../../../../hooks/use-component-delete";
 import { Element } from "../../../../models/elements";
+import { EventTypes } from "../../../../models/extension";
+import { executePlugins } from "../../../../plugins/plugin-registry";
 import Handle from "../../../dnd/handle";
 import Sortable, { SortableProps } from "../../../dnd/sortable";
 
@@ -112,6 +114,20 @@ export const ReorderableElement: FunctionComponent<ReorderableComponentPropsInte
         setLastInteractedResource(element);
     };
 
+    /**
+     * Handles the deletion of the element.
+     */
+    const handleElementDelete = async (): Promise<void> => {
+
+        /**
+         * Execute plugins for ON_NODE_ELEMENT_DELETE event.
+         */
+        await executePlugins(EventTypes.ON_NODE_ELEMENT_DELETE, stepId, element);
+
+        deleteComponent(stepId, element);
+        setIsOpenResourcePropertiesPanel(false);
+    };
+
     return (
         <Sortable
             id={ id }
@@ -140,10 +156,7 @@ export const ReorderableElement: FunctionComponent<ReorderableComponentPropsInte
                     </Handle>
                     <Handle
                         label="Delete"
-                        onClick={ () => {
-                            deleteComponent(stepId, element);
-                            setIsOpenResourcePropertiesPanel(false);
-                        } }
+                        onClick={ handleElementDelete }
                     >
                         <TrashIcon />
                     </Handle>

--- a/features/admin.flow-builder-core.v1/components/resources/steps/view/reorderable-element.tsx
+++ b/features/admin.flow-builder-core.v1/components/resources/steps/view/reorderable-element.tsx
@@ -28,7 +28,7 @@ import useAuthenticationFlowBuilderCore from "../../../../hooks/use-authenticati
 import useComponentDelete from "../../../../hooks/use-component-delete";
 import { Element } from "../../../../models/elements";
 import { EventTypes } from "../../../../models/extension";
-import { executePlugins } from "../../../../plugins/plugin-registry";
+import PluginRegistry from "../../../../plugins/plugin-registry";
 import Handle from "../../../dnd/handle";
 import Sortable, { SortableProps } from "../../../dnd/sortable";
 
@@ -122,7 +122,7 @@ export const ReorderableElement: FunctionComponent<ReorderableComponentPropsInte
         /**
          * Execute plugins for ON_NODE_ELEMENT_DELETE event.
          */
-        await executePlugins(EventTypes.ON_NODE_ELEMENT_DELETE, stepId, element);
+        await PluginRegistry.getInstance().executePlugins(EventTypes.ON_NODE_ELEMENT_DELETE, stepId, element);
 
         deleteComponent(stepId, element);
         setIsOpenResourcePropertiesPanel(false);

--- a/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
+++ b/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
@@ -49,7 +49,7 @@ import { Resource, ResourceTypes } from "../../models/resources";
 import { Step } from "../../models/steps";
 import { Template, TemplateTypes } from "../../models/templates";
 import { Widget } from "../../models/widget";
-import { executePlugins } from "../../plugins/plugin-registry";
+import PluginRegistry from "../../plugins/plugin-registry";
 import generateResourceId from "../../utils/generate-resource-id";
 import ResourcePanel from "../resource-panel/resource-panel";
 import ElementPropertiesPanel from "../resource-property-panel/resource-property-panel";
@@ -303,7 +303,7 @@ const DecoratedVisualFlow: FunctionComponent<DecoratedVisualFlowPropsInterface> 
     const onNodesDelete: OnNodesDelete<Node> = useCallback(
         async (deleted: Node[]) => {
             // Execute plugins for ON_NODE_DELETE event.
-            await executePlugins(EventTypes.ON_NODE_DELETE, deleted);
+            await PluginRegistry.getInstance().executePlugins(EventTypes.ON_NODE_DELETE, deleted);
 
             setEdges(
                 deleted?.reduce((acc: Edge[], node: Node) => {
@@ -336,7 +336,7 @@ const DecoratedVisualFlow: FunctionComponent<DecoratedVisualFlowPropsInterface> 
     const onEdgesDelete: (deleted: Edge[]) => void = useCallback(
         async (deleted: Edge[]) => {
             // Execute plugins for ON_EDGE_DELETE event.
-            await executePlugins(EventTypes.ON_EDGE_DELETE, deleted);
+            await PluginRegistry.getInstance().executePlugins(EventTypes.ON_EDGE_DELETE, deleted);
         },
         []
     );

--- a/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
+++ b/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
@@ -303,7 +303,7 @@ const DecoratedVisualFlow: FunctionComponent<DecoratedVisualFlowPropsInterface> 
     const onNodesDelete: OnNodesDelete<Node> = useCallback(
         async (deleted: Node[]) => {
             // Execute plugins for ON_NODE_DELETE event.
-            await PluginRegistry.getInstance().executePlugins(EventTypes.ON_NODE_DELETE, deleted);
+            await PluginRegistry.getInstance().execute(EventTypes.ON_NODE_DELETE, deleted);
 
             setEdges(
                 deleted?.reduce((acc: Edge[], node: Node) => {
@@ -336,7 +336,7 @@ const DecoratedVisualFlow: FunctionComponent<DecoratedVisualFlowPropsInterface> 
     const onEdgesDelete: (deleted: Edge[]) => void = useCallback(
         async (deleted: Edge[]) => {
             // Execute plugins for ON_EDGE_DELETE event.
-            await PluginRegistry.getInstance().executePlugins(EventTypes.ON_EDGE_DELETE, deleted);
+            await PluginRegistry.getInstance().execute(EventTypes.ON_EDGE_DELETE, deleted);
         },
         []
     );

--- a/features/admin.flow-builder-core.v1/components/visual-flow/visual-flow.tsx
+++ b/features/admin.flow-builder-core.v1/components/visual-flow/visual-flow.tsx
@@ -78,7 +78,8 @@ const VisualFlow: FunctionComponent<VisualFlowPropsInterface> = ({
     edges,
     onEdgesChange,
     onConnect,
-    onNodesDelete
+    onNodesDelete,
+    onEdgesDelete
 }: VisualFlowPropsInterface): ReactElement => {
     const edgeTypes: { [key: string]: FC<Edge> } = useMemo(() => {
         return {
@@ -106,6 +107,7 @@ const VisualFlow: FunctionComponent<VisualFlowPropsInterface> = ({
                     edgeTypes={ edgeTypes as any }
                     onConnect={ onConnect }
                     onNodesDelete={ onNodesDelete }
+                    onEdgesDelete={ onEdgesDelete }
                     proOptions={ { hideAttribution: true } }
                     data-componentid={ componentId }
                     onNodesChange={ onNodesChange }

--- a/features/admin.flow-builder-core.v1/hooks/use-delete-redirection-resource.ts
+++ b/features/admin.flow-builder-core.v1/hooks/use-delete-redirection-resource.ts
@@ -32,7 +32,7 @@ import { registerPlugin, unregisterPlugin } from "../plugins/plugin-registry";
  * This hook registers an event listener for node deletion events and ensures that
  * any associated redirection action nodes are also deleted when a redirection node is removed.
  */
-const useDeleteRedirectionResource = () => {
+const useDeleteRedirectionResource = (): void => {
 
     const { setIsOpenResourcePropertiesPanel } = useAuthenticationFlowBuilderCore();
     const { getEdges, getNodes, updateNodeData, setNodes } = useReactFlow();

--- a/features/admin.flow-builder-core.v1/hooks/use-delete-redirection-resource.ts
+++ b/features/admin.flow-builder-core.v1/hooks/use-delete-redirection-resource.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Edge, Node, useReactFlow } from "@xyflow/react";
+import { useEffect } from "react";
+import useAuthenticationFlowBuilderCore from "./use-authentication-flow-builder-core-context";
+import VisualFlowConstants from "../constants/visual-flow-constants";
+import { ActionTypes } from "../models/actions";
+import { Element, ElementCategories } from "../models/elements";
+import { EventTypes } from "../models/extension";
+import { StepTypes } from "../models/steps";
+import { registerPlugin, unregisterPlugin } from "../plugins/plugin-registry";
+
+/**
+ * Custom hook to handle the deletion of redirection resources in the flow builder.
+ *
+ * This hook registers an event listener for node deletion events and ensures that
+ * any associated redirection action nodes are also deleted when a redirection node is removed.
+ */
+const useDeleteRedirectionResource = () => {
+
+    const { setIsOpenResourcePropertiesPanel } = useAuthenticationFlowBuilderCore();
+    const { getEdges, getNodes, updateNodeData, setNodes } = useReactFlow();
+
+    useEffect(() => {
+        registerPlugin(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode);
+        registerPlugin(EventTypes.ON_NODE_ELEMENT_DELETE, deleteRedirectionNode);
+        registerPlugin(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode);
+
+        return () => {
+            unregisterPlugin(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode.name);
+            unregisterPlugin(EventTypes.ON_NODE_ELEMENT_DELETE, deleteRedirectionNode.name);
+            unregisterPlugin(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode.name);
+        };
+    }, []);
+
+    /**
+     * Deletes associated redirection components when redirection nodes are removed.
+     *
+     * This utility function ensures that when a redirection node is deleted from the flow,
+     * any related redirection initiation action components are also removed to maintain consistency.
+     *
+     * @param deleted - An array of nodes that have been deleted from the flow.
+     */
+    const deleteRedirectionActionNode = async (
+        deleted: Node[]
+    ): Promise<boolean> => {
+
+        const nodes: Node[] = getNodes();
+        const edges: Edge[] = getEdges();
+        const actionNodes: Node[] = [];
+        const actionComponentIds: string[] = [];
+
+        deleted.forEach((node: Node) => {
+            if (node?.type === StepTypes.Redirection) {
+                const actionNode: Node[] = nodes?.filter((n: Node) => {
+                    return edges?.some((edge: Edge) => {
+                        if (edge.target === node.id && edge.source === n.id
+                                && edge.sourceHandle.includes(VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX)) {
+                            actionComponentIds.push(edge.sourceHandle.slice(0,
+                                -VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX.length));
+
+                            return true;
+                        }
+
+                        return false;
+                    });
+                });
+
+                if (actionNode?.length > 0) {
+                    actionNodes.push(...actionNode);
+                }
+            }
+        });
+
+        // If no action nodes are found, return true to indicate no further action is needed.
+        if (actionNodes.length === 0) {
+            return true;
+        }
+
+        actionNodes.forEach((actionNode: Node) => {
+            updateNodeData(actionNode.id, (node: Node) => {
+                const components: Element[] = (node.data.components as Element[])?.filter((component: Element) => {
+                    return !actionComponentIds.includes(component.id);
+                });
+
+                return {
+                    components
+                };
+            });
+        });
+        setIsOpenResourcePropertiesPanel(false);
+
+        return true;
+    };
+
+    /**
+     * Deletes the redirection node when a redirection action is removed.
+     *
+     * @param _stepId - The ID of the step from which the element is being deleted.
+     * @param element - The element being deleted, which is expected to be a redirection action.
+     * @returns Returns true if the deletion was successful.
+     */
+    const deleteRedirectionNode = async (
+        _stepId: string,
+        element: Element
+    ): Promise<boolean> => {
+
+        if (element.category === ElementCategories.Action && element?.action?.type === ActionTypes.Next) {
+            setNodes((nodes: Node[]) => nodes?.filter((node: Node) =>
+                node.id !== element?.action?.next || node.type !== StepTypes.Redirection));
+        }
+
+        return true;
+    };
+
+    /**
+     * Deletes the component and node associated with the deleted edges.
+     *
+     * @param deleted - The deleted edges from the flow.
+     * @returns Returns true if the deletion was successful.
+     */
+    const deleteComponentAndNode = async (
+        deleted: Edge[]
+    ): Promise<boolean> => {
+
+        const nodes: Node[] = getNodes();
+        const redirectionNodeIds: string[] = [];
+        const actionNodeIds: string[] = [];
+        const actionComponentIds: string[] = [];
+
+        deleted.forEach((edge: Edge) => {
+            nodes.forEach((node: Node) => {
+                if (node.type === StepTypes.Redirection && edge.target === node.id) {
+                    actionComponentIds.push(edge.sourceHandle.slice(0,
+                        -VisualFlowConstants.FLOW_BUILDER_NEXT_HANDLE_SUFFIX.length));
+                    actionNodeIds.push(edge.source);
+                    redirectionNodeIds.push(edge.target);
+                }
+            });
+        });
+
+        if (redirectionNodeIds.length === 0) {
+            return true;
+        }
+
+        setNodes((nodes: Node[]) => nodes?.filter((node: Node) => !redirectionNodeIds.includes(node.id)));
+
+        actionNodeIds.forEach((actionNodeId: string) => {
+            updateNodeData(actionNodeId, (node: Node) => {
+                const components: Element[] = (node.data.components as Element[])?.filter((component: Element) => {
+                    return !actionComponentIds.includes(component.id);
+                });
+
+                return {
+                    components
+                };
+            });
+        });
+        setIsOpenResourcePropertiesPanel(false);
+
+        return true;
+    };
+};
+
+export default useDeleteRedirectionResource;

--- a/features/admin.flow-builder-core.v1/hooks/use-delete-redirection-resource.ts
+++ b/features/admin.flow-builder-core.v1/hooks/use-delete-redirection-resource.ts
@@ -24,7 +24,7 @@ import { ActionTypes } from "../models/actions";
 import { Element, ElementCategories } from "../models/elements";
 import { EventTypes } from "../models/extension";
 import { StepTypes } from "../models/steps";
-import { registerPlugin, unregisterPlugin } from "../plugins/plugin-registry";
+import PluginRegistry from "../plugins/plugin-registry";
 
 /**
  * Custom hook to handle the deletion of redirection resources in the flow builder.
@@ -38,14 +38,15 @@ const useDeleteRedirectionResource = (): void => {
     const { getEdges, getNodes, updateNodeData, setNodes } = useReactFlow();
 
     useEffect(() => {
-        registerPlugin(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode);
-        registerPlugin(EventTypes.ON_NODE_ELEMENT_DELETE, deleteRedirectionNode);
-        registerPlugin(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode);
+        PluginRegistry.getInstance().registerPlugin(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode);
+        PluginRegistry.getInstance().registerPlugin(EventTypes.ON_NODE_ELEMENT_DELETE, deleteRedirectionNode);
+        PluginRegistry.getInstance().registerPlugin(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode);
 
         return () => {
-            unregisterPlugin(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode.name);
-            unregisterPlugin(EventTypes.ON_NODE_ELEMENT_DELETE, deleteRedirectionNode.name);
-            unregisterPlugin(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode.name);
+            PluginRegistry.getInstance().unregisterPlugin(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode.name);
+            PluginRegistry.getInstance().unregisterPlugin(EventTypes.ON_NODE_ELEMENT_DELETE,
+                deleteRedirectionNode.name);
+            PluginRegistry.getInstance().unregisterPlugin(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode.name);
         };
     }, []);
 

--- a/features/admin.flow-builder-core.v1/hooks/use-delete-redirection-resource.ts
+++ b/features/admin.flow-builder-core.v1/hooks/use-delete-redirection-resource.ts
@@ -38,15 +38,15 @@ const useDeleteRedirectionResource = (): void => {
     const { getEdges, getNodes, updateNodeData, setNodes } = useReactFlow();
 
     useEffect(() => {
-        PluginRegistry.getInstance().registerPlugin(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode);
-        PluginRegistry.getInstance().registerPlugin(EventTypes.ON_NODE_ELEMENT_DELETE, deleteRedirectionNode);
-        PluginRegistry.getInstance().registerPlugin(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode);
+        PluginRegistry.getInstance().register(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode);
+        PluginRegistry.getInstance().register(EventTypes.ON_NODE_ELEMENT_DELETE, deleteRedirectionNode);
+        PluginRegistry.getInstance().register(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode);
 
         return () => {
-            PluginRegistry.getInstance().unregisterPlugin(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode.name);
-            PluginRegistry.getInstance().unregisterPlugin(EventTypes.ON_NODE_ELEMENT_DELETE,
+            PluginRegistry.getInstance().unregister(EventTypes.ON_NODE_DELETE, deleteRedirectionActionNode.name);
+            PluginRegistry.getInstance().unregister(EventTypes.ON_NODE_ELEMENT_DELETE,
                 deleteRedirectionNode.name);
-            PluginRegistry.getInstance().unregisterPlugin(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode.name);
+            PluginRegistry.getInstance().unregister(EventTypes.ON_EDGE_DELETE, deleteComponentAndNode.name);
         };
     }, []);
 

--- a/features/admin.flow-builder-core.v1/models/extension.ts
+++ b/features/admin.flow-builder-core.v1/models/extension.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Enum for event types in the flow builder extension.
+ */
+export enum EventTypes {
+    /**
+     * Event triggered when a node is removed.
+     */
+    ON_NODE_DELETE = "onNodeDelete",
+    /**
+     * Event triggered when an edge is removed.
+     */
+    ON_EDGE_DELETE = "onEdgeDelete",
+    /**
+     * Event triggered when a element of a node is deleted.
+     */
+    ON_NODE_ELEMENT_DELETE = "onNodeElementDelete",
+    /**
+     * Event triggered when a the flow is updated.
+     */
+    ON_FLOW_UPDATE = "onFlowUpdate"
+}

--- a/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
+++ b/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
@@ -27,7 +27,7 @@ class PluginRegistry {
     private plugins: Map<string, Map<string, (...args: any[]) => Promise<boolean>>> = new Map();
 
     private constructor() {
-        // Private constructor to prevent instantiation
+        // Private constructor to prevent instantiation.
     }
 
     public static getInstance(): PluginRegistry {

--- a/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
+++ b/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
@@ -30,6 +30,7 @@ export const registerPlugin = (eventName: string, handler: (...args: any[]) => P
     if (!plugins.has(eventName)) {
         plugins.set(eventName, new Map());
     }
+
     plugins.get(eventName)!.set(handler.name, handler);
 };
 

--- a/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
+++ b/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
@@ -18,81 +18,102 @@
 
 import debounce from "lodash/debounce";
 
-const plugins: Map<string, Map<string, (...args: any[]) => Promise<boolean>>> = new Map();
-
 /**
- * Registers a plugin with the given name and event.
- *
- * @param eventName - The name of the event to register the plugin for.
- * @param handler - The handler function to be called when the event is triggered.
+ * PluginRegistry is a singleton class that manages the registration and execution of plugins.
  */
-export const registerPlugin = (eventName: string, handler: (...args: any[]) => Promise<boolean>): void => {
-    if (!plugins.has(eventName)) {
-        plugins.set(eventName, new Map());
+class PluginRegistry {
+    private static instance: PluginRegistry;
+
+    private plugins: Map<string, Map<string, (...args: any[]) => Promise<boolean>>> = new Map();
+
+    private constructor() {
+        // Private constructor to prevent instantiation
     }
 
-    plugins.get(eventName)!.set(handler.name, handler);
-};
+    public static getInstance(): PluginRegistry {
+        if (!PluginRegistry.instance) {
+            PluginRegistry.instance = new PluginRegistry();
+        }
 
-/**
- * Unregister a plugin with the given name and event.
- *
- * @param eventName - The name of the event to unregister the plugin from.
- * @param handlerName - The name of the handler function to be removed.
- */
-export const unregisterPlugin = (eventName: string, handlerName: string): void => {
-    if (plugins.has(eventName)) {
-        const handlers = plugins.get(eventName);
-        if (handlers && handlers.has(handlerName)) {
-            handlers.delete(handlerName);
-            if (handlers.size === 0) {
-                plugins.delete(eventName); // Remove the event if no handlers are left.
+        return PluginRegistry.instance;
+    }
+
+    /**
+     * Registers a plugin with the given name and event.
+     *
+     * @param eventName - The name of the event to register the plugin for.
+     * @param handler - The handler function to be called when the event is triggered.
+     */
+    registerPlugin(eventName: string, handler: (...args: any[]) => Promise<boolean>): void {
+        if (!this.plugins.has(eventName)) {
+            this.plugins.set(eventName, new Map());
+        }
+
+        this.plugins.get(eventName)!.set(handler.name, handler);
+    };
+
+    /**
+     * Unregister a plugin with the given name and event.
+     *
+     * @param eventName - The name of the event to unregister the plugin from.
+     * @param handlerName - The name of the handler function to be removed.
+     */
+    unregisterPlugin(eventName: string, handlerName: string): void {
+        if (this.plugins.has(eventName)) {
+            const handlers = this.plugins.get(eventName);
+            if (handlers && handlers.has(handlerName)) {
+                handlers.delete(handlerName);
+                if (handlers.size === 0) {
+                    this.plugins.delete(eventName); // Remove the event if no handlers are left.
+                }
             }
         }
-    }
-};
+    };
 
-/**
- * Executes all registered plugins for the given event with the provided arguments (Debounce).
- *
- * @param eventName - The name of the event to execute plugins for.
- * @param args - The arguments to pass to the plugin handlers.
- * @returns True if all plugins returned true, false otherwise.
- */
-export const executePluginsWithDebounce = (eventName: string, ...args: any[]): Promise<boolean> => {
-   return debounce(() => {
-        return execute(eventName, ...args);
-    }, 500)(); // Debounce execution to avoid rapid calls.
-}
-
-/**
- * Executes all registered plugins for the given event with the provided arguments.
- *
- * @param eventName - The name of the event to execute plugins for.
- * @param args - The arguments to pass to the plugin handlers.
- * @returns True if all plugins returned true, false otherwise.
- */
-export const executePlugins = (eventName: string, ...args: any[]): Promise<boolean> => {
-    return execute(eventName, ...args);
-}
-
-/**
- * Executes all registered plugins for the given event with the provided arguments.
- *
- * @param eventName - The name of the event to execute plugins for.
- * @param args - The arguments to pass to the plugin handlers.
- * @returns True if all plugins returned true, false otherwise.
- */
-const execute = async (eventName: string, ...args: any[]): Promise<boolean> => {
-    const handlers = plugins.get(eventName)?.values();
-    if (!handlers) {
-        return true; // No plugins registered, consider it a success.
+    /**
+     * Executes all registered plugins for the given event with the provided arguments (Debounce).
+     *
+     * @param eventName - The name of the event to execute plugins for.
+     * @param args - The arguments to pass to the plugin handlers.
+     * @returns True if all plugins returned true, false otherwise.
+     */
+    executePluginsWithDebounce (eventName: string, ...args: any[]): Promise<boolean> {
+        return debounce(() => {
+            return this.execute(eventName, ...args);
+        }, 500)(); // Debounce execution to avoid rapid calls.
     }
 
-    for (const handler of handlers) {
-        if (!(await handler(...args))) {
-            return false; // If any plugin returns false, stop execution and return false.
+    /**
+     * Executes all registered plugins for the given event with the provided arguments.
+     *
+     * @param eventName - The name of the event to execute plugins for.
+     * @param args - The arguments to pass to the plugin handlers.
+     * @returns True if all plugins returned true, false otherwise.
+     */
+    executePlugins = (eventName: string, ...args: any[]): Promise<boolean> => {
+        return this.execute(eventName, ...args);
+    }
+
+    /**
+     * Executes all registered plugins for the given event with the provided arguments.
+     *
+     * @param eventName - The name of the event to execute plugins for.
+     * @param args - The arguments to pass to the plugin handlers.
+     * @returns True if all plugins returned true, false otherwise.
+     */
+    async execute(eventName: string, ...args: any[]): Promise<boolean> {
+        const handlers = this.plugins.get(eventName)?.values();
+        if (!handlers) {
+            return true; // No plugins registered, consider it a success.
         }
+
+        for (const handler of handlers) {
+            if (!(await handler(...args))) {
+                return false; // If any plugin returns false, stop execution and return false.
+            }
+        }
+        return true; // All plugins executed successfully.
     }
-    return true; // All plugins executed successfully.
 }
+
+export default PluginRegistry;

--- a/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
+++ b/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import debounce from "lodash/debounce";
+
+const plugins: Map<string, Map<string, (...args: any[]) => Promise<boolean>>> = new Map();
+
+/**
+ * Registers a plugin with the given name and event.
+ *
+ * @param eventName - The name of the event to register the plugin for.
+ * @param handler - The handler function to be called when the event is triggered.
+ */
+export const registerPlugin = (eventName: string, handler: (...args: any[]) => Promise<boolean>): void => {
+    if (!plugins.has(eventName)) {
+        plugins.set(eventName, new Map());
+    }
+    plugins.get(eventName)!.set(handler.name, handler);
+};
+
+/**
+ * Unregister a plugin with the given name and event.
+ *
+ * @param eventName - The name of the event to unregister the plugin from.
+ * @param handlerName - The name of the handler function to be removed.
+ */
+export const unregisterPlugin = (eventName: string, handlerName: string): void => {
+    if (plugins.has(eventName)) {
+        const handlers = plugins.get(eventName);
+        if (handlers && handlers.has(handlerName)) {
+            handlers.delete(handlerName);
+            if (handlers.size === 0) {
+                plugins.delete(eventName); // Remove the event if no handlers are left.
+            }
+        }
+    }
+};
+
+/**
+ * Executes all registered plugins for the given event with the provided arguments (Debounce).
+ *
+ * @param eventName - The name of the event to execute plugins for.
+ * @param args - The arguments to pass to the plugin handlers.
+ * @returns True if all plugins returned true, false otherwise.
+ */
+export const executePluginsWithDebounce = (eventName: string, ...args: any[]): Promise<boolean> => {
+   return debounce(() => {
+        return execute(eventName, ...args);
+    }, 500)(); // Debounce execution to avoid rapid calls.
+}
+
+/**
+ * Executes all registered plugins for the given event with the provided arguments.
+ *
+ * @param eventName - The name of the event to execute plugins for.
+ * @param args - The arguments to pass to the plugin handlers.
+ * @returns True if all plugins returned true, false otherwise.
+ */
+export const executePlugins = (eventName: string, ...args: any[]): Promise<boolean> => {
+    return execute(eventName, ...args);
+}
+
+/**
+ * Executes all registered plugins for the given event with the provided arguments.
+ *
+ * @param eventName - The name of the event to execute plugins for.
+ * @param args - The arguments to pass to the plugin handlers.
+ * @returns True if all plugins returned true, false otherwise.
+ */
+const execute = async (eventName: string, ...args: any[]): Promise<boolean> => {
+    const handlers = plugins.get(eventName)?.values();
+    if (!handlers) {
+        return true; // No plugins registered, consider it a success.
+    }
+
+    for (const handler of handlers) {
+        if (!(await handler(...args))) {
+            return false; // If any plugin returns false, stop execution and return false.
+        }
+    }
+    return true; // All plugins executed successfully.
+}

--- a/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
+++ b/features/admin.flow-builder-core.v1/plugins/plugin-registry.ts
@@ -44,7 +44,7 @@ class PluginRegistry {
      * @param eventName - The name of the event to register the plugin for.
      * @param handler - The handler function to be called when the event is triggered.
      */
-    registerPlugin(eventName: string, handler: (...args: any[]) => Promise<boolean>): void {
+    public registerPlugin(eventName: string, handler: (...args: any[]) => Promise<boolean>): void {
         if (!this.plugins.has(eventName)) {
             this.plugins.set(eventName, new Map());
         }
@@ -58,7 +58,7 @@ class PluginRegistry {
      * @param eventName - The name of the event to unregister the plugin from.
      * @param handlerName - The name of the handler function to be removed.
      */
-    unregisterPlugin(eventName: string, handlerName: string): void {
+    public unregisterPlugin(eventName: string, handlerName: string): void {
         if (this.plugins.has(eventName)) {
             const handlers = this.plugins.get(eventName);
             if (handlers && handlers.has(handlerName)) {
@@ -77,7 +77,7 @@ class PluginRegistry {
      * @param args - The arguments to pass to the plugin handlers.
      * @returns True if all plugins returned true, false otherwise.
      */
-    executePluginsWithDebounce (eventName: string, ...args: any[]): Promise<boolean> {
+    public executePluginsWithDebounce (eventName: string, ...args: any[]): Promise<boolean> {
         return debounce(() => {
             return this.execute(eventName, ...args);
         }, 500)(); // Debounce execution to avoid rapid calls.
@@ -90,7 +90,7 @@ class PluginRegistry {
      * @param args - The arguments to pass to the plugin handlers.
      * @returns True if all plugins returned true, false otherwise.
      */
-    executePlugins = (eventName: string, ...args: any[]): Promise<boolean> => {
+    public executePlugins = (eventName: string, ...args: any[]): Promise<boolean> => {
         return this.execute(eventName, ...args);
     }
 
@@ -101,7 +101,7 @@ class PluginRegistry {
      * @param args - The arguments to pass to the plugin handlers.
      * @returns True if all plugins returned true, false otherwise.
      */
-    async execute(eventName: string, ...args: any[]): Promise<boolean> {
+    public async execute(eventName: string, ...args: any[]): Promise<boolean> {
         const handlers = this.plugins.get(eventName)?.values();
         if (!handlers) {
             return true; // No plugins registered, consider it a success.


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This update introduces plugin extension support for the Flow Builder core, enabling logic extensions based on event types.
It allows developers to easily implement custom hooks and plug them into the core logic to modify behavior in an efficient and modular way.

As an example, the included sample demonstrates how to handle the deletion of nodes or edges in a redirection flow. Previously, deleting a redirection node would leave the associated action button behind, and vice versa. This was not ideal, as these components are provided only as widgets and are not configurable at a granular level.

With this enhancement, the following behaviors are now automated:

* Automatically delete the redirection node if the redirection action button is deleted.
* Automatically delete the redirection action button if the redirection node is deleted.
* If the edge connecting the redirection action button and redirection node is deleted, both elements will be removed.

This improves consistency and provides a cleaner experience for users interacting with redirection flows.



### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/24541
