### PR TITLE
Fix issues in user creation when email is not required

### DIFF
--- a/features/admin.users.v1/components/wizard/add-user-wizard.tsx
+++ b/features/admin.users.v1/components/wizard/add-user-wizard.tsx
@@ -503,7 +503,7 @@ export const AddUserWizard: FunctionComponent<AddUserWizardPropsInterface> = (
             }, "passwordOption", "newPassword", "userType", "domain", "firstName", "lastName");
 
             // If email value is not present, use the emails value.
-            if (isEmpty(userInfo?.email) && userInfo?.emails.length > 0) {
+            if (isEmpty(userInfo?.email) && userInfo?.emails?.length > 0) {
                 delete combinedUserDetails.email;
 
                 // Primary will be the string value in the emails array.

--- a/features/admin.users.v1/components/wizard/steps/add-user-basic.tsx
+++ b/features/admin.users.v1/components/wizard/steps/add-user-basic.tsx
@@ -480,6 +480,17 @@ export const AddUserUpdated: React.FunctionComponent<AddUserProps> = (
         mapMultiValuedAttributeValues(profileInfo);
     }, [ profileInfo ]);
 
+    /**
+     * This will set the ask password option as OFFLINE if email verification is not enabled or email is not required.
+     */
+    useEffect(() => {
+        if (!emailVerificationEnabled || !isEmailRequired) {
+            setAskPasswordOption(AskPasswordOptionTypes.OFFLINE);
+        } else {
+            setAskPasswordOption(userConfig.defautlAskPasswordOption);
+        }
+    }, [ isEmailRequired ]);
+
     const resolveNamefieldAttributes = () => {
         const hiddenAttributes: (HiddenFieldNames)[] = [];
         const nameSchema: ProfileSchemaInterface = profileSchemas
@@ -936,7 +947,7 @@ export const AddUserUpdated: React.FunctionComponent<AddUserProps> = (
                     className="mb-4"
                 >
                     {
-                        !emailVerificationEnabled? (
+                        (!emailVerificationEnabled || (!isEmailRequired && !isValidEmail)) ? (
                             <Popup
                                 basic
                                 inverted


### PR DESCRIPTION

### Purpose
This PR addresses two issues in the user creation flow when the email attribute is set as not required.
1. A null pointer exception occurs when the email is left blank and the form is submitted. 
2. Currently, if the email field is left blank, the "Invite via Email" option is shown as enabled and selected by default. 

####  Fixes done
1. A null check is added to fix the null pointer exception.
2. If the email verification is disabled or if the email is not required, the "Invite Offline" option is selected by default.
3. If the email is not required and the email field is blank, the "Invite via Email" option is disabled. Once a valid email is entered, the 'Invite via Email" option will be dynamically enabled.

### Related Issues
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
