### PR TITLE
Impersonate CB URL fix

### DIFF
--- a/.changeset/tricky-points-chew.md
+++ b/.changeset/tricky-points-chew.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add impersonate cb url fix.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ read_only_apps = []
 callback_url = "regexp=(https://localhost:9443/console|https://localhost:9443/t/(.*)/console|https://localhost:9443/console/login|https://localhost:9443/t/(.*)/console/login|https://localhost:9001/console|https://localhost:9001/t/(.*)/console|https://localhost:9001/console/login|https://localhost:9001/t/(.*)/console/login|https://localhost:9443/o/(.*)/console|https://localhost:9001/o/(.*)/console|https://localhost:9001/o/(.*)/console/login)"
 
 [myaccount]
-callback_url = "regexp=(https://localhost:9443/myaccount|https://localhost:9443/t/(.*)/myaccount|https://localhost:9443/myaccount/login|https://localhost:9443/t/(.*)/myaccount/login|https://localhost:9000/myaccount|https://localhost:9000/t/(.*)/myaccount|https://localhost:9000/myaccount/login|https://localhost:9000/t/(.*)/myaccount/login|https://localhost:9443/console/resources/users/init-impersonate.html|https://llocalhost:9001/console/resources/users/init-impersonate.html)"
+callback_url = "regexp=(https://localhost:9443/myaccount|https://localhost:9443/t/(.*)/myaccount|https://localhost:9443/myaccount/login|https://localhost:9443/t/(.*)/myaccount/login|https://localhost:9000/myaccount|https://localhost:9000/t/(.*)/myaccount|https://localhost:9000/myaccount/login|https://localhost:9000/t/(.*)/myaccount/login|https://localhost:9443/console/resources/users/init-impersonate.html|https://localhost:9001/console/resources/users/init-impersonate.html)"
 ```
 
 #### Start the Identity Server

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ read_only_apps = []
 callback_url = "regexp=(https://localhost:9443/console|https://localhost:9443/t/(.*)/console|https://localhost:9443/console/login|https://localhost:9443/t/(.*)/console/login|https://localhost:9001/console|https://localhost:9001/t/(.*)/console|https://localhost:9001/console/login|https://localhost:9001/t/(.*)/console/login|https://localhost:9443/o/(.*)/console|https://localhost:9001/o/(.*)/console|https://localhost:9001/o/(.*)/console/login)"
 
 [myaccount]
-callback_url = "regexp=(https://localhost:9443/myaccount|https://localhost:9443/t/(.*)/myaccount|https://localhost:9443/myaccount/login|https://localhost:9443/t/(.*)/myaccount/login|https://localhost:9000/myaccount|https://localhost:9000/t/(.*)/myaccount|https://localhost:9000/myaccount/login|https://localhost:9000/t/(.*)/myaccount/login)"
+callback_url = "regexp=(https://localhost:9443/myaccount|https://localhost:9443/t/(.*)/myaccount|https://localhost:9443/myaccount/login|https://localhost:9443/t/(.*)/myaccount/login|https://localhost:9000/myaccount|https://localhost:9000/t/(.*)/myaccount|https://localhost:9000/myaccount/login|https://localhost:9000/t/(.*)/myaccount/login|https://localhost:9443/console/resources/users/init-impersonate.html|https://llocalhost:9001/console/resources/users/init-impersonate.html)"
 ```
 
 #### Start the Identity Server

--- a/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
+++ b/identity-apps-core/components/org.wso2.identity.apps.common/src/main/java/org/wso2/identity/apps/common/util/AppPortalUtils.java
@@ -163,7 +163,7 @@ public class AppPortalUtils {
                 consoleCallbackUrl = ApplicationMgtUtil.resolveOriginUrlFromPlaceholders(consoleCallbackUrl,
                     CONSOLE_APP);
                 appendedConsoleCallBackURLRegex = "|" + consoleCallbackUrl.replace(
-                    consolePortalPath, portalPath + "/resources/users/init-impersonate.html");
+                    consolePortalPath, consolePortalPath + "/resources/users/init-impersonate.html");
             }
         } catch (URLBuilderException e) {
             throw new IdentityOAuthAdminException("Server encountered an error while building callback URL with " +


### PR DESCRIPTION
### Purpose
For default IS setup, impersonate doesn't work without adding the cb url to deployment toml manually. The CB url generated had to be fixed as in the PR.

### Related Issues
- N/A
