### PR TITLE
Add UI to support inheriting login & registration configs.

### DIFF
--- a/apps/console/src/extensions/i18n/models/extensions.ts
+++ b/apps/console/src/extensions/i18n/models/extensions.ts
@@ -2440,6 +2440,16 @@ export interface Extensions {
     manage: {
         accountLogin: {
             notifications: {
+                revert: {
+                    error: {
+                        description: string;
+                        message: string;
+                    },
+                    success: {
+                        description: string;
+                        message: string;
+                    }
+                };
                 success: {
                     description: string;
                     message: string;

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -2590,6 +2590,16 @@ export const extensions: Extensions = {
     manage: {
         accountLogin: {
             notifications: {
+                revert: {
+                    error: {
+                        description: "An error occurred while reverting the username validation configuration.",
+                        message: "Revert error"
+                    },
+                    success: {
+                        description: "Successfully reverted username validation configuration.",
+                        message: "Revert successful"
+                    }
+                },
                 success: {
                     description: "Successfully updated username validation configuration.",
                     message: "Update successful"

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -1687,6 +1687,8 @@
         },
         "routes": {
             "organizationEnabledRoutes": [
+                "accountSecurity",
+                "admin-forced-password-reset",
                 "apiResources",
                 "applications",
                 "attributeDialects",
@@ -1697,11 +1699,16 @@
                 "governanceConnectors",
                 "groups",
                 "identityProviders",
+                "loginAndRegistration",
                 "organizations",
+                "password-recovery",
                 "roles",
+                "self-registration-connector",
                 "smsTemplates",
+                "user-email-verification",
                 "userRoles",
                 "userStores",
+                "username-recovery",
                 "users"
             ]
         },

--- a/features/admin.connections.v1/components/authenticators/sms-otp/sms-otp-authenticator.tsx
+++ b/features/admin.connections.v1/components/authenticators/sms-otp/sms-otp-authenticator.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -81,7 +81,7 @@ export const SmsOTPAuthenticator: FunctionComponent<SmsOTPAuthenticatorInterface
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config?.ui?.features);
     const allowedScopes: string = useSelector((state: AppState) => state?.auth?.allowedScopes);
-    const { isSubOrganization, organizationType } = useGetCurrentOrganizationType();
+    const { organizationType } = useGetCurrentOrganizationType();
 
     const isReadOnly: boolean =
         !hasRequiredScopes(
@@ -89,8 +89,7 @@ export const SmsOTPAuthenticator: FunctionComponent<SmsOTPAuthenticatorInterface
             featureConfig?.identityProviders?.scopes?.update,
             allowedScopes,
             organizationType
-        )
-        || isSubOrganization();
+        );
 
     return (
         <>

--- a/features/admin.identity-providers.v1/components/forms/authenticators/email-otp-authenticator-form.tsx
+++ b/features/admin.identity-providers.v1/components/forms/authenticators/email-otp-authenticator-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2021-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,7 +18,6 @@
 
 import { ConnectionUIConstants } from "@wso2is/admin.connections.v1/constants/connection-ui-constants";
 import { LocalAuthenticatorConstants } from "@wso2is/admin.connections.v1/constants/local-authenticator-constants";
-import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { Field, Form } from "@wso2is/form";
 import { Code } from "@wso2is/react-components";
@@ -160,12 +159,10 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
     } = props;
 
     const { t } = useTranslation();
-    const { isSubOrganization } = useGetCurrentOrganizationType();
 
     // This can be used when `meta` support is there.
     const [ , setFormFields ] = useState<EmailOTPAuthenticatorFormFieldsInterface>(undefined);
     const [ initialValues, setInitialValues ] = useState<EmailOTPAuthenticatorFormInitialValuesInterface>(undefined);
-    const [ isReadOnly ] = useState<boolean>(isSubOrganization() || readOnly);
 
     // SMS OTP length unit is set to digits or characters according to the state of this variable
     const [ isOTPAlphanumeric, setIsOTPAlphanumeric ] = useState<boolean>();
@@ -358,7 +355,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                     </Trans>)
                 }
                 required={ true }
-                readOnly={ isReadOnly }
+                readOnly={ readOnly }
                 min={
                     ConnectionUIConstants
                         .EMAIL_OTP_AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS.EXPIRY_TIME_MIN_VALUE
@@ -400,7 +397,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                         characters will be used.
                     </Trans>)
                 }
-                readOnly={ isReadOnly }
+                readOnly={ readOnly }
                 width={ 12 }
                 data-testid={ `${ testId }-otp-regex-use-numeric` }
                 listen={ (e:boolean) => {setIsOTPAlphanumeric(e);} }
@@ -430,7 +427,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                     </Trans>)
                 }
                 required={ true }
-                readOnly={ isReadOnly }
+                readOnly={ readOnly }
                 maxLength={
                     ConnectionUIConstants
                         .EMAIL_OTP_AUTHENTICATOR_SETTINGS_FORM_FIELD_CONSTRAINTS.OTP_LENGTH_MAX_LENGTH
@@ -460,7 +457,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                 disabled={ isSubmitting }
                 loading={ isSubmitting }
                 label={ t("common:update") }
-                hidden={ isReadOnly }
+                hidden={ readOnly }
             />
         </Form>
     );

--- a/features/admin.saml2-configuration.v1/api/saml2-configuration.ts
+++ b/features/admin.saml2-configuration.v1/api/saml2-configuration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -59,6 +59,44 @@ export const useSaml2Config = <
         isValidating,
         mutate: mutate
     };
+};
+
+/**
+ * Revert saml2 configurations.
+ *
+ * @returns a promise to revert the saml2 configurations.
+ */
+export const revertSaml2Configurations = (): Promise<void> => {
+    const requestConfig: AxiosRequestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.DELETE,
+        url: Config.getServiceResourceEndpoints().saml2Configurations
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 204) {
+                throw new IdentityAppsApiException(
+                    Saml2ConfigurationConstants.ErrorMessages
+                        .SAML2_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE.getErrorMessage(),
+                    null,
+                    response.status,
+                    response.request,
+                    response,
+                    response.config);
+            }
+
+            return Promise.resolve();
+        }).catch((error: AxiosError) => {
+            const errorMessage: string = Saml2ConfigurationConstants.ErrorMessages
+                .SAML2_CONFIG_REVERT_ERROR_CODE.getErrorMessage();
+
+            throw new IdentityAppsApiException(errorMessage, error.stack, error.response?.data?.code, error.request,
+                error.response, error.config);
+        });
 };
 
 /**

--- a/features/admin.saml2-configuration.v1/constants/saml2-configuration.ts
+++ b/features/admin.saml2-configuration.v1/constants/saml2-configuration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,34 +22,50 @@ export class Saml2ConfigurationConstants {
 
     private constructor() { }
 
-	public static readonly SAML2_CONFIG_FETCH_ERROR_CODE: string = "SMC-00001";
+    public static readonly SAML2_CONFIG_FETCH_ERROR_CODE: string = "SMC-00001";
     public static readonly SAML2_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: string = "SMC-00002";
-	public static readonly SAML2_CONFIG_UPDATE_ERROR_CODE: string = "SMC-00003";
+    public static readonly SAML2_CONFIG_UPDATE_ERROR_CODE: string = "SMC-00003";
+    public static readonly SAML2_CONFIG_REVERT_ERROR_CODE: string = "SMC-00004";
+    public static readonly SAML2_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE: string = "SMC-00005";
 
     public static readonly SAML2_CONFIG_FIELD_MIN_LENGTH: number = 0;
 
-	public static ErrorMessages: {
+    public static ErrorMessages: {
         SAML2_CONFIG_FETCH_ERROR_CODE: IdentityAppsError;
         SAML2_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: IdentityAppsError;
         SAML2_CONFIG_UPDATE_ERROR_CODE: IdentityAppsError;
+        SAML2_CONFIG_REVERT_ERROR_CODE: IdentityAppsError;
+        SAML2_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE: IdentityAppsError;
     } = {
-        SAML2_CONFIG_FETCH_ERROR_CODE: new IdentityAppsError(
-            Saml2ConfigurationConstants.SAML2_CONFIG_FETCH_ERROR_CODE,
-            "An error occurred while fetching the saml2 configurations.",
-            "Error while fetching the saml2 configurations",
-            null
-        ),
-        SAML2_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: new IdentityAppsError(
-            Saml2ConfigurationConstants.SAML2_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE,
-            "Received an invalid status code while fetching the saml2 configurations.",
-            "Invalid Status Code while fetching the saml2 configurations",
-            null
-        ),
-        SAML2_CONFIG_UPDATE_ERROR_CODE: new IdentityAppsError(
-            Saml2ConfigurationConstants.SAML2_CONFIG_UPDATE_ERROR_CODE,
-            "An error occurred while updating the saml2 configurations.",
-            "Error while updating the saml2 configurations",
-            null
-        )
-    };
+            SAML2_CONFIG_FETCH_ERROR_CODE: new IdentityAppsError(
+                Saml2ConfigurationConstants.SAML2_CONFIG_FETCH_ERROR_CODE,
+                "An error occurred while fetching the saml2 configurations.",
+                "Error while fetching the saml2 configurations",
+                null
+            ),
+            SAML2_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: new IdentityAppsError(
+                Saml2ConfigurationConstants.SAML2_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE,
+                "Received an invalid status code while fetching the saml2 configurations.",
+                "Invalid Status Code while fetching the saml2 configurations",
+                null
+            ),
+            SAML2_CONFIG_REVERT_ERROR_CODE: new IdentityAppsError(
+                Saml2ConfigurationConstants.SAML2_CONFIG_REVERT_ERROR_CODE,
+                "An error occurred while reverting the saml2 configurations.",
+                "Error while reverting the saml2 configurations",
+                null
+            ),
+            SAML2_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE: new IdentityAppsError(
+                Saml2ConfigurationConstants.SAML2_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE,
+                "Received an invalid status code while reverting the saml2 configurations.",
+                "Invalid Status Code while reverting the saml2 configurations",
+                null
+            ),
+            SAML2_CONFIG_UPDATE_ERROR_CODE: new IdentityAppsError(
+                Saml2ConfigurationConstants.SAML2_CONFIG_UPDATE_ERROR_CODE,
+                "An error occurred while updating the saml2 configurations.",
+                "Error while updating the saml2 configurations",
+                null
+            )
+        };
 }

--- a/features/admin.saml2-configuration.v1/pages/saml2-configuration.tsx
+++ b/features/admin.saml2-configuration.v1/pages/saml2-configuration.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -31,14 +31,21 @@ import {
 import { addAlert } from "@wso2is/core/store";
 import { URLUtils } from "@wso2is/core/utils";
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
-import { EmphasizedSegment, PageLayout, PrimaryButton, URLInput } from "@wso2is/react-components";
+import {
+    DangerZone,
+    DangerZoneGroup,
+    EmphasizedSegment,
+    PageLayout,
+    PrimaryButton,
+    URLInput
+} from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { Divider, Grid, Placeholder, Ref } from "semantic-ui-react";
-import { updateSaml2Configurations, useSaml2Config } from "../api/saml2-configuration";
+import { revertSaml2Configurations, updateSaml2Configurations, useSaml2Config } from "../api/saml2-configuration";
 import { Saml2ConfigurationConstants } from "../constants/saml2-configuration";
 import {
     Saml2ConfigAPIResponseInterface,
@@ -146,6 +153,21 @@ export const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInt
     };
 
     /**
+     * Displays the sucess banner when saml2 configuration configurations are reverted.
+     */
+    const handleRevertSuccess = () => {
+        dispatch(
+            addAlert({
+                description: t("saml2Config:notifications." +
+                    "revertConfiguration.success.description"),
+                level: AlertLevels.SUCCESS,
+                message: t("saml2Config:notifications." +
+                    "revertConfiguration.success.message")
+            })
+        );
+    };
+
+    /**
      * Displays the error banner when unable to update saml2 configuration configurations.
      */
     const handleUpdateError = () => {
@@ -156,6 +178,21 @@ export const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInt
                 level: AlertLevels.ERROR,
                 message: t("saml2Config:notifications." +
                 "updateConfiguration.error.message")
+            })
+        );
+    };
+
+    /**
+     * Displays the error banner when unable to revert saml2 configuration configurations.
+     */
+    const handlerevertError = () => {
+        dispatch(
+            addAlert({
+                description: t("saml2Config:notifications." +
+                    "revertConfiguration.error.description"),
+                level: AlertLevels.ERROR,
+                message: t("saml2Config:notifications." +
+                    "revertConfiguration.error.message")
             })
         );
     };
@@ -210,6 +247,23 @@ export const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInt
             setIsSubmitting(false);
             mutateSaml2Config();
         });
+    };
+
+    /**
+     * Handle saml2 configuration revert.
+     */
+    const onConfigRevert = (): void => {
+        setIsSubmitting(true);
+
+        revertSaml2Configurations()
+            .then(() => {
+                handleRevertSuccess();
+            }).catch(() => {
+                handlerevertError();
+            }).finally(() => {
+                setIsSubmitting(false);
+                mutateSaml2Config();
+            });
     };
 
     const onBackButtonClick = (): void => {
@@ -276,6 +330,7 @@ export const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInt
                                     : (
                                         <>
                                             <Form
+                                                key={ JSON.stringify(saml2Config) || "empty" }
                                                 id={ FORM_ID }
                                                 uncontrolledForm={ true }
                                                 onSubmit={ handleSubmit }
@@ -402,6 +457,21 @@ export const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInt
                             </EmphasizedSegment>
                         </Grid.Column>
                     </Grid.Row>
+                    { !isReadOnly && (
+                        <Grid.Row columns={ 1 } className="mt-6">
+                            <Grid.Column width={ 16 }>
+                                <DangerZoneGroup sectionHeader={ t("common:dangerZone") }>
+                                    <DangerZone
+                                        actionTitle= { t("governanceConnectors:dangerZone.actionTitle") }
+                                        header= { t("governanceConnectors:dangerZone.heading") }
+                                        subheader= { t("governanceConnectors:dangerZone.subHeading") }
+                                        onActionClick={ () => onConfigRevert() }
+                                        data-testid={ `${ componentId }-danger-zone` }
+                                    />
+                                </DangerZoneGroup>
+                            </Grid.Column>
+                        </Grid.Row>
+                    ) }
                 </Grid>
             </Ref>
         </PageLayout>

--- a/features/admin.server-configurations.v1/api/governance-connectors.ts
+++ b/features/admin.server-configurations.v1/api/governance-connectors.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,12 +17,12 @@
  */
 
 import { AsgardeoSPAClient, HttpClientInstance } from "@asgardeo/auth-react";
-import { store } from "@wso2is/admin.core.v1/store";
 import useRequest, {
     RequestConfigInterface,
     RequestErrorInterface,
     RequestResultInterface
 } from "@wso2is/admin.core.v1/hooks/use-request";
+import { store } from "@wso2is/admin.core.v1/store";
 import { LocalAuthenticatorInterface } from "@wso2is/admin.identity-providers.v1/models/identity-provider";
 import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { HttpMethods } from "@wso2is/core/models";
@@ -32,6 +32,7 @@ import {
     GovernanceCategoryForOrgsInterface,
     GovernanceConnectorInterface,
     RealmConfigInterface,
+    RevertGovernanceConnectorConfigInterface,
     UpdateGovernanceConnectorConfigInterface
 } from "../models";
 
@@ -247,6 +248,60 @@ export const updateGovernanceConnector = (data: UpdateGovernanceConnectorConfigI
         "/" + categoryId + "/connectors/" + connectorId;
 
     return updateConfigurations(data, url);
+};
+
+/**
+ * Revert governance connector configurations.
+ *
+ * @param categoryId - ID of the connector category
+ * @param connectorId - ID of the connector
+ * @param requestBody - request payload
+ * @returns a promise containing the response.
+ */
+export const revertGovernanceConnectorProperties = (
+    categoryId: string,
+    connectorId: string,
+    requestBody: RevertGovernanceConnectorConfigInterface
+): Promise<any> => {
+    const url: string = store.getState().config.endpoints.governanceConnectorCategories +
+        "/" + categoryId + "/connectors/revert";
+
+    const requestConfig: AxiosRequestConfig = {
+        data: requestBody,
+        headers: {
+            "Access-Control-Allow-Origin": store.getState().config.deployment.clientHost,
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.POST,
+        params: {
+            connectorId: connectorId
+        },
+        url: url
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 200) {
+                throw new IdentityAppsApiException(
+                    ServerConfigurationsConstants.CONFIGS_REVERT_REQUEST_INVALID_STATUS_CODE_ERROR,
+                    null,
+                    response.status,
+                    response.request,
+                    response,
+                    response.config);
+            }
+
+            return Promise.resolve(response.data);
+        })
+        .catch((error: AxiosError) => {
+            throw new IdentityAppsApiException(
+                ServerConfigurationsConstants.CONFIGS_REVERT_REQUEST_ERROR,
+                error.stack,
+                error.code,
+                error.request,
+                error.response,
+                error.config);
+        });
 };
 
 /**

--- a/features/admin.server-configurations.v1/constants/server-configurations-constants.ts
+++ b/features/admin.server-configurations.v1/constants/server-configurations-constants.ts
@@ -359,8 +359,14 @@ export class ServerConfigurationsConstants {
     public static readonly CONFIGS_UPDATE_REQUEST_INVALID_STATUS_CODE_ERROR: string = "Received an invalid status " +
 		"code while updating the configurations.";
 
+    public static readonly CONFIGS_REVERT_REQUEST_INVALID_STATUS_CODE_ERROR: string = "Received an invalid status " +
+        "code while reverting the configurations to default.";
+
     public static readonly CONFIGS_UPDATE_REQUEST_ERROR: string = "An error occurred while updating the " +
 		"configurations.";
+
+    public static readonly CONFIGS_REVERT_REQUEST_ERROR: string = "An error occurred while reverting the " +
+        "configurations to default.";
 
     public static readonly ADMIN_ADVISORY_BANNER_CONFIGS_UPDATE_REQUEST_ERROR: string = "An error occurred " +
         "while updating the admin advisory banner configurations.";

--- a/features/admin.server-configurations.v1/models/governance-connectors.ts
+++ b/features/admin.server-configurations.v1/models/governance-connectors.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2022-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -75,6 +75,10 @@ export interface UpdateGovernanceConnectorConfigPropertyInterface {
 export interface UpdateGovernanceConnectorConfigInterface {
 	operation: string;
 	properties: UpdateGovernanceConnectorConfigPropertyInterface[];
+}
+
+export interface RevertGovernanceConnectorConfigInterface {
+	properties: string[];
 }
 
 export interface UpdateMultipleGovernanceConnectorsInterface {

--- a/features/admin.session-management.v1/constants/session-management.ts
+++ b/features/admin.session-management.v1/constants/session-management.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -21,40 +21,41 @@ import { IdentityAppsError } from "@wso2is/core/errors";
 export class SessionManagementConstants {
 
     private constructor() { }
-    
+
     public static readonly IDLE_SESSION_TIMEOUT_PATH: string = "/idleSessionTimeoutPeriod";
     public static readonly REMEMBER_ME_PERIOD_PATH: string = "/rememberMePeriod";
     public static readonly REPLACE_OPERATION: string = "REPLACE";
+    public static readonly REMOVE_OPERATION: string = "REMOVE";
 
-	public static readonly SESSION_MANAGEMENT_CONFIG_FETCH_ERROR_CODE: string = "SMC-00001";
+    public static readonly SESSION_MANAGEMENT_CONFIG_FETCH_ERROR_CODE: string = "SMC-00001";
     public static readonly SESSION_MANAGEMENT_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: string = "SMC-00002";
-	public static readonly SESSION_MANAGEMENT_CONFIG_UPDATE_ERROR_CODE: string = "SMC-00003";
+    public static readonly SESSION_MANAGEMENT_CONFIG_UPDATE_ERROR_CODE: string = "SMC-00003";
 
     public static readonly SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH: number = 0;
     public static readonly SESSION_MANAGEMENT_CONFIG_FIELD_MAX_LENGTH: number = 100;
 
-	public static ErrorMessages: {
+    public static ErrorMessages: {
         SESSION_MANAGEMENT_CONFIG_FETCH_ERROR_CODE: IdentityAppsError;
         SESSION_MANAGEMENT_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: IdentityAppsError;
         SESSION_MANAGEMENT_CONFIG_UPDATE_ERROR_CODE: IdentityAppsError;
     } = {
-        SESSION_MANAGEMENT_CONFIG_FETCH_ERROR_CODE: new IdentityAppsError(
-            SessionManagementConstants.SESSION_MANAGEMENT_CONFIG_FETCH_ERROR_CODE,
-            "An error occurred while fetching the session management configurations.",
-            "Error while fetching the session management configurations",
-            null
-        ),
-        SESSION_MANAGEMENT_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: new IdentityAppsError(
-            SessionManagementConstants.SESSION_MANAGEMENT_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE,
-            "Received an invalid status code while fetching the session management configurations.",
-            "Invalid Status Code while fetching the session management configurations",
-            null
-        ),
-        SESSION_MANAGEMENT_CONFIG_UPDATE_ERROR_CODE: new IdentityAppsError(
-            SessionManagementConstants.SESSION_MANAGEMENT_CONFIG_UPDATE_ERROR_CODE,
-            "An error occurred while updating the session management configurations.",
-            "Error while updating the session management configurations",
-            null
-        )
-    };
+            SESSION_MANAGEMENT_CONFIG_FETCH_ERROR_CODE: new IdentityAppsError(
+                SessionManagementConstants.SESSION_MANAGEMENT_CONFIG_FETCH_ERROR_CODE,
+                "An error occurred while fetching the session management configurations.",
+                "Error while fetching the session management configurations",
+                null
+            ),
+            SESSION_MANAGEMENT_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: new IdentityAppsError(
+                SessionManagementConstants.SESSION_MANAGEMENT_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE,
+                "Received an invalid status code while fetching the session management configurations.",
+                "Invalid Status Code while fetching the session management configurations",
+                null
+            ),
+            SESSION_MANAGEMENT_CONFIG_UPDATE_ERROR_CODE: new IdentityAppsError(
+                SessionManagementConstants.SESSION_MANAGEMENT_CONFIG_UPDATE_ERROR_CODE,
+                "An error occurred while updating the session management configurations.",
+                "Error while updating the session management configurations",
+                null
+            )
+        };
 }

--- a/features/admin.session-management.v1/models/session-management.ts
+++ b/features/admin.session-management.v1/models/session-management.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -47,5 +47,5 @@ export interface SessionManagementConfigAPIResponseInterface {
 export interface PatchData {
     operation: string;
     path: string;
-    value: string;
+    value?: string;
 }

--- a/features/admin.session-management.v1/pages/session-management.tsx
+++ b/features/admin.session-management.v1/pages/session-management.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,7 +25,7 @@ import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
-import { EmphasizedSegment, PageLayout } from "@wso2is/react-components";
+import { DangerZone, DangerZoneGroup, EmphasizedSegment, PageLayout } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -144,6 +144,30 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
         );
     };
 
+    const handleRevertSuccess = () => {
+        dispatch(
+            addAlert({
+                description: t("sessionManagement:notifications." +
+                "revertConfiguration.success.description"),
+                level: AlertLevels.SUCCESS,
+                message: t("sessionManagement:notifications." +
+                "revertConfiguration.success.message")
+            })
+        );
+    };
+
+    const handleRevertError = () => {
+        dispatch(
+            addAlert({
+                description: t("sessionManagement:notifications." +
+                "revertConfiguration.error.description"),
+                level: AlertLevels.ERROR,
+                message: t("sessionManagement:notifications." +
+                "revertConfiguration.error.message")
+            })
+        );
+    };
+
     /**
      * Validate input data.
      *
@@ -206,6 +230,32 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
             });
     };
 
+    const onConfigRevert = (): void => {
+        setIsSubmitting(true);
+
+        const updateValues: PatchData[] = [
+            {
+                "operation": SessionManagementConstants.REMOVE_OPERATION,
+                "path": SessionManagementConstants.IDLE_SESSION_TIMEOUT_PATH
+            },
+            {
+                "operation": SessionManagementConstants.REMOVE_OPERATION,
+                "path": SessionManagementConstants.REMEMBER_ME_PERIOD_PATH
+            }
+        ];
+
+        updateSessionManagmentConfigurations(updateValues)
+            .then(() => {
+                handleRevertSuccess();
+                mutateSessionManagementConfig();
+            })
+            .catch(() => {
+                handleRevertError();
+            }).finally(() => {
+                setIsSubmitting(false);
+            });
+    };
+
     const onBackButtonClick = (): void => {
         history.push(AppConstants.getPaths().get("LOGIN_AND_REGISTRATION"));
     };
@@ -261,96 +311,115 @@ export const SessionManagementSettingsPage: FunctionComponent<SessionManagementS
             data-componentid={ `${ componentId }-form-layout` }
         >
             <Ref innerRef={ pageContextRef }>
-                <EmphasizedSegment className="form-wrapper" padded={ "very" }>
-                    { isSessionManagementFetchRequestLoading
-                        ? renderLoadingPlaceholder()
-                        : (
-                            <div className="session-mgt-form-container">
-                                <Form
-                                    id={ FORM_ID }
-                                    uncontrolledForm={ false }
-                                    onSubmit={ handleSubmit }
-                                    initialValues={ sessionManagementConfig }
-                                    enableReinitialize={ true }
-                                    ref={ formRef }
-                                    noValidate={ true }
-                                    validate={ validateForm }
-                                >
-                                    <Field.Input
-                                        min={ SessionManagementConstants
-                                            .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                        ariaLabel="Idle Session Timeout Field"
-                                        inputType="number"
-                                        name="idleSessionTimeout"
-                                        label={ t("sessionManagement:form." +
+                <Grid className={ "mt-3" }>
+                    <Grid.Row columns={ 1 }>
+                        <Grid.Column width={ 16 }>
+                            <EmphasizedSegment className="form-wrapper" padded={ "very" }>
+                                { isSessionManagementFetchRequestLoading
+                                    ? renderLoadingPlaceholder()
+                                    : (
+                                        <div className="session-mgt-form-container">
+                                            <Form
+                                                id={ FORM_ID }
+                                                uncontrolledForm={ false }
+                                                onSubmit={ handleSubmit }
+                                                initialValues={ sessionManagementConfig }
+                                                enableReinitialize={ true }
+                                                ref={ formRef }
+                                                noValidate={ true }
+                                                validate={ validateForm }
+                                            >
+                                                <Field.Input
+                                                    min={ SessionManagementConstants
+                                                        .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                                    ariaLabel="Idle Session Timeout Field"
+                                                    inputType="number"
+                                                    name="idleSessionTimeout"
+                                                    label={ t("sessionManagement:form." +
                                                 "idleSessionTimeout.label") }
-                                        placeholder={ t("sessionManagement:form." +
+                                                    placeholder={ t("sessionManagement:form." +
                                                 "idleSessionTimeout.placeholder") }
-                                        hint={ t("sessionManagement:form." +
+                                                    hint={ t("sessionManagement:form." +
                                                 "idleSessionTimeout.hint") }
-                                        required={ true }
-                                        value={ sessionManagementConfig?.idleSessionTimeout }
-                                        readOnly={ !hasConnectorUpdatePermission }
-                                        maxLength={ null }
-                                        minLength={ SessionManagementConstants
-                                            .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                        width="100%"
-                                        data-componentid={
-                                            `${ componentId }-idle-session-timeout` }
-                                        labelPosition="right"
-                                    >
-                                        <input />
-                                        <Label>{ t("common:minutes") }</Label>
-                                    </Field.Input>
-                                    <Field.Input
-                                        min={ SessionManagementConstants
-                                            .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                        ariaLabel="Remember Me Period Field"
-                                        inputType="number"
-                                        name="rememberMePeriod"
-                                        label={ t("sessionManagement:form." +
+                                                    required={ true }
+                                                    value={ sessionManagementConfig?.idleSessionTimeout }
+                                                    readOnly={ !hasConnectorUpdatePermission }
+                                                    maxLength={ null }
+                                                    minLength={ SessionManagementConstants
+                                                        .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                                    width="100%"
+                                                    data-componentid={
+                                                        `${ componentId }-idle-session-timeout` }
+                                                    labelPosition="right"
+                                                >
+                                                    <input />
+                                                    <Label>{ t("common:minutes") }</Label>
+                                                </Field.Input>
+                                                <Field.Input
+                                                    min={ SessionManagementConstants
+                                                        .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                                    ariaLabel="Remember Me Period Field"
+                                                    inputType="number"
+                                                    name="rememberMePeriod"
+                                                    label={ t("sessionManagement:form." +
                                                 "rememberMePeriod.label") }
-                                        placeholder={ t("sessionManagement:form." +
+                                                    placeholder={ t("sessionManagement:form." +
                                                 "rememberMePeriod.placeholder") }
-                                        hint={ t("sessionManagement:form." +
+                                                    hint={ t("sessionManagement:form." +
                                                 "rememberMePeriod.hint") }
-                                        required={ true }
-                                        value={ sessionManagementConfig?.rememberMePeriod }
-                                        readOnly={ !hasConnectorUpdatePermission }
-                                        maxLength={ null }
-                                        minLength={ SessionManagementConstants
-                                            .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
-                                        width="100%"
-                                        data-componentid={ `${ componentId }-remember-me-period` }
-                                        labelPosition="right"
-                                    >
-                                        <input />
-                                        <Label>{ t("common:minutes") }</Label>
-                                    </Field.Input>
-                                    {
-                                        hasConnectorUpdatePermission && (
-                                            <Field.Button
-                                                form={ FORM_ID }
-                                                size="small"
-                                                buttonType="primary_btn"
-                                                name="update-button"
-                                                data-componentid={
-                                                    `${ componentId }-update-button`
+                                                    required={ true }
+                                                    value={ sessionManagementConfig?.rememberMePeriod }
+                                                    readOnly={ !hasConnectorUpdatePermission }
+                                                    maxLength={ null }
+                                                    minLength={ SessionManagementConstants
+                                                        .SESSION_MANAGEMENT_CONFIG_FIELD_MIN_LENGTH }
+                                                    width="100%"
+                                                    data-componentid={ `${ componentId }-remember-me-period` }
+                                                    labelPosition="right"
+                                                >
+                                                    <input />
+                                                    <Label>{ t("common:minutes") }</Label>
+                                                </Field.Input>
+                                                {
+                                                    hasConnectorUpdatePermission && (
+                                                        <Field.Button
+                                                            form={ FORM_ID }
+                                                            size="small"
+                                                            buttonType="primary_btn"
+                                                            name="update-button"
+                                                            data-componentid={
+                                                                `${ componentId }-update-button`
+                                                            }
+                                                            loading={ isSubmitting }
+                                                            onClick={ () => {
+                                                                formRef?.current?.triggerSubmit();
+                                                            } }
+                                                            ariaLabel="Session management form update button"
+                                                            label={ t("common:update") }
+                                                        />
+                                                    )
                                                 }
-                                                loading={ isSubmitting }
-                                                onClick={ () => {
-                                                    formRef?.current?.triggerSubmit();
-                                                } }
-                                                ariaLabel="Session management form update button"
-                                                label={ t("common:update") }
-                                            />
-                                        )
-                                    }
-                                </Form>
-                            </div>
-                        )
-                    }
-                </EmphasizedSegment>
+                                            </Form>
+                                        </div>
+                                    )
+                                }
+                            </EmphasizedSegment>
+                        </Grid.Column>
+                    </Grid.Row>
+                    <Grid.Row columns={ 1 }>
+                        <Grid.Column width={ 16 }>
+                            <DangerZoneGroup sectionHeader={ t("common:dangerZone") }>
+                                <DangerZone
+                                    actionTitle= { t("governanceConnectors:dangerZone.actionTitle") }
+                                    header= { t("governanceConnectors:dangerZone.heading") }
+                                    subheader= { t("governanceConnectors:dangerZone.subHeading") }
+                                    onActionClick={ () => onConfigRevert() }
+                                    data-componentid={ `${ componentId }-danger-zone` }
+                                />
+                            </DangerZoneGroup>
+                        </Grid.Column>
+                    </Grid.Row>
+                </Grid>
             </Ref>
         </PageLayout>
     );

--- a/features/admin.username-validation.v1/pages/username-validation-page.tsx
+++ b/features/admin.username-validation.v1/pages/username-validation-page.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,7 +19,11 @@
 import { ApplicationManagementConstants } from "@wso2is/admin.applications.v1/constants/application-management";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
-import { updateValidationConfigData, useValidationConfigData } from "@wso2is/admin.validation.v1/api";
+import { revertValidationConfigData,
+    updateValidationConfigData,
+    useValidationConfigData
+} from "@wso2is/admin.validation.v1/api";
+import { ValidationConfigurationFields } from "@wso2is/admin.validation.v1/constants/validation-config-constants";
 import {
     ValidationConfInterface,
     ValidationDataInterface,
@@ -29,7 +33,14 @@ import {
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form } from "@wso2is/form";
-import { ContentLoader, EmphasizedSegment, Hint, PageLayout, Text } from "@wso2is/react-components";
+import { ContentLoader,
+    DangerZone,
+    DangerZoneGroup,
+    EmphasizedSegment,
+    Hint,
+    PageLayout,
+    Text
+} from "@wso2is/react-components";
 import { AxiosError } from "axios";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -263,6 +274,42 @@ const UsernameValidationPage: FunctionComponent<UsernameValidationPageInterface>
         }
 
         return null;
+    };
+
+    const handleRevertSuccess = () => {
+        dispatch(
+            addAlert({
+                description: t("extensions:manage.accountLogin.notifications.revert.success.description"),
+                level: AlertLevels.SUCCESS,
+                message: t("extensions:manage.accountLogin.notifications.revert.success.message")
+            })
+        );
+    };
+
+    const handleRevertError = () => {
+        dispatch(
+            addAlert({
+                description: t("extensions:manage.accountLogin.notifications.revert.error.description"),
+                level: AlertLevels.ERROR,
+                message: t("extensions:manage.accountLogin.notifications.revert.error.message")
+            })
+        );
+    };
+
+    const onConfigRevert = (): void => {
+        setSubmitting(true);
+
+        revertValidationConfigData([ ValidationConfigurationFields.USERNAME ])
+            .then(() => {
+                mutateValidationConfigFetchRequest();
+                handleRevertSuccess();
+            })
+            .catch(() => {
+                handleRevertError();
+            })
+            .finally(() => {
+                setSubmitting(false);
+            });
     };
 
     const handleUpdateUsernameValidationData = (values: ValidationFormInterface): void => {
@@ -583,6 +630,19 @@ const UsernameValidationPage: FunctionComponent<UsernameValidationPageInterface>
                                     : <ContentLoader />
                                 }
                             </EmphasizedSegment>
+                        </Grid.Column>
+                    </Grid.Row>
+                    <Grid.Row columns={ 1 }>
+                        <Grid.Column width={ 16 }>
+                            <DangerZoneGroup sectionHeader={ t("common:dangerZone") }>
+                                <DangerZone
+                                    actionTitle= { t("governanceConnectors:dangerZone.actionTitle") }
+                                    header= { t("governanceConnectors:dangerZone.heading") }
+                                    subheader= { t("governanceConnectors:dangerZone.subHeading") }
+                                    onActionClick={ () => onConfigRevert() }
+                                    data-componentid={ `${ componentId }-danger-zone` }
+                                />
+                            </DangerZoneGroup>
                         </Grid.Column>
                     </Grid.Row>
                 </Grid>

--- a/features/admin.validation.v1/api/validation-config.ts
+++ b/features/admin.validation.v1/api/validation-config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2022-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -29,7 +29,12 @@ import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { HttpMethods } from "@wso2is/core/models";
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import { ValidationManagementConstants } from "../constants/validation-config-constants";
-import { ValidationConfInterface, ValidationDataInterface, ValidationFormInterface } from "../models";
+import {
+    RevertValidationConfigInterface,
+    ValidationConfInterface,
+    ValidationDataInterface,
+    ValidationFormInterface
+} from "../models";
 
 /**
  * Get an axios instance.
@@ -88,6 +93,48 @@ export const updateValidationConfigData = (
         .catch((error: AxiosError) => {
             throw new IdentityAppsApiException(
                 ValidationManagementConstants.CONFIGURATION_STATUS_UPDATE_ERROR,
+                error.stack,
+                error.code,
+                error.request,
+                error.response,
+                error.config);
+        });
+};
+
+export const revertValidationConfigData = (
+    fields: string[]
+): Promise<any> => {
+    const config: RevertValidationConfigInterface = {
+        fields: fields
+    };
+
+    const requestConfig: AxiosRequestConfig = {
+        data: config,
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.POST,
+        url: store.getState().config.endpoints.validationServiceMgt + "/revert"
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 200) {
+                throw new IdentityAppsApiException(
+                    ValidationManagementConstants.CONFIGURATION_REVERT_INVALID_STATUS_CODE_ERROR,
+                    null,
+                    response.status,
+                    response.request,
+                    response,
+                    response.config);
+            }
+
+            return Promise.resolve(response.data);
+        })
+        .catch((error: AxiosError) => {
+            throw new IdentityAppsApiException(
+                ValidationManagementConstants.CONFIGURATION_REVERT_ERROR,
                 error.stack,
                 error.code,
                 error.request,

--- a/features/admin.validation.v1/constants/validation-config-constants.ts
+++ b/features/admin.validation.v1/constants/validation-config-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2022-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -31,11 +31,11 @@ export class ValidationConfigConstants {
         PASSWORD_MIN_VALUE: number;
     } = {
 
-        MIN_LENGTH: 1,
-        MIN_VALUE: 0,
-        PASSWORD_MIN_LENGTH: 1,
-        PASSWORD_MIN_VALUE: 5
-    };
+            MIN_LENGTH: 1,
+            MIN_VALUE: 0,
+            PASSWORD_MIN_LENGTH: 1,
+            PASSWORD_MIN_VALUE: 5
+        };
 
     /**
      * Set of keys used to enable/disable features.
@@ -51,6 +51,17 @@ export class ValidationManagementConstants {
     public static readonly CONFIGURATION_STATUS_UPDATE_ERROR: string = "An error occurred while updating " +
         "validation configurations.";
 
+    public static readonly CONFIGURATION_REVERT_ERROR: string = "An error occurred while reverting validation " +
+        "configurations.";
+
     public static readonly CONFIGURATION_UPDATE_INVALID_STATUS_CODE_ERROR: string = "Received an " +
         "invalid status code while updating validation configurations.";
+
+    public static readonly CONFIGURATION_REVERT_INVALID_STATUS_CODE_ERROR: string = "Received an " +
+        "invalid status code while reverting validation configurations.";
+}
+
+export enum ValidationConfigurationFields {
+    USERNAME = "username",
+    PASSWORD = "password",
 }

--- a/features/admin.validation.v1/models/validation-config.ts
+++ b/features/admin.validation.v1/models/validation-config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2022-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,6 +25,10 @@ export interface ValidationDataInterface {
     field: string;
     rules?: ValidationConfInterface[];
     regEx?: ValidationConfInterface[];
+}
+
+export interface RevertValidationConfigInterface {
+    fields: string[];
 }
 
 export interface ValidationConfInterface {

--- a/features/admin.wsfed-configuration.v1/api/wsfed-configuration.ts
+++ b/features/admin.wsfed-configuration.v1/api/wsfed-configuration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -99,6 +99,44 @@ export const updateWSFederationConfigurations = (data: WSFederationConfigAPIResp
         }).catch((error: AxiosError) => {
             const errorMessage: string = WSFederationConfigConstants.ErrorMessages
                 .WS_FEDERATION_CONFIG_UPDATE_ERROR_CODE.getErrorMessage();
+
+            throw new IdentityAppsApiException(errorMessage, error.stack, error.response?.data?.code, error.request,
+                error.response, error.config);
+        });
+};
+
+/**
+ * Revert WSFederation configurations.
+ *
+ * @returns a promise to revert the WSFederation configurations.
+ */
+export const revertWSFederationConfigurations = (): Promise<void> => {
+    const requestConfig: AxiosRequestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.DELETE,
+        url: Config.getServiceResourceEndpoints().passiveStsConfigurations
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
+            if (response.status !== 204) {
+                throw new IdentityAppsApiException(
+                    WSFederationConfigConstants.ErrorMessages
+                        .WS_FEDERATION_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE.getErrorMessage(),
+                    null,
+                    response.status,
+                    response.request,
+                    response,
+                    response.config);
+            }
+
+            return Promise.resolve();
+        }).catch((error: AxiosError) => {
+            const errorMessage: string = WSFederationConfigConstants.ErrorMessages
+                .WS_FEDERATION_CONFIG_REVERT_ERROR_CODE.getErrorMessage();
 
             throw new IdentityAppsApiException(errorMessage, error.stack, error.response?.data?.code, error.request,
                 error.response, error.config);

--- a/features/admin.wsfed-configuration.v1/constants/wsfed-configuration.ts
+++ b/features/admin.wsfed-configuration.v1/constants/wsfed-configuration.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -22,32 +22,48 @@ export class WSFederationConfigConstants {
 
     private constructor() { }
 
-	public static readonly WS_FEDERATION_CONFIG_FETCH_ERROR_CODE: string = "WFC-00001";
+    public static readonly WS_FEDERATION_CONFIG_FETCH_ERROR_CODE: string = "WFC-00001";
     public static readonly WS_FEDERATION_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: string = "WFC-00002";
-	public static readonly WS_FEDERATION_CONFIG_UPDATE_ERROR_CODE: string = "WFC-00003";
+    public static readonly WS_FEDERATION_CONFIG_UPDATE_ERROR_CODE: string = "WFC-00003";
+    public static readonly WS_FEDERATION_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE: string = "WFC-00004";
+    public static readonly WS_FEDERATION_CONFIG_REVERT_ERROR_CODE: string = "WFC-00005";
 
-	public static ErrorMessages: {
+    public static ErrorMessages: {
         WS_FEDERATION_CONFIG_FETCH_ERROR_CODE: IdentityAppsError;
         WS_FEDERATION_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: IdentityAppsError;
         WS_FEDERATION_CONFIG_UPDATE_ERROR_CODE: IdentityAppsError;
+        WS_FEDERATION_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE: IdentityAppsError;
+        WS_FEDERATION_CONFIG_REVERT_ERROR_CODE: IdentityAppsError;
     } = {
-        WS_FEDERATION_CONFIG_FETCH_ERROR_CODE: new IdentityAppsError(
-            WSFederationConfigConstants.WS_FEDERATION_CONFIG_FETCH_ERROR_CODE,
-            "An error occurred while fetching the WS Federation configurations.",
-            "Error while fetching the WS Federation configurations",
-            null
-        ),
-        WS_FEDERATION_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: new IdentityAppsError(
-            WSFederationConfigConstants.WS_FEDERATION_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE,
-            "Received an invalid status code while fetching the WS Federation configurations.",
-            "Invalid Status Code while fetching the WS Federation configurations",
-            null
-        ),
-        WS_FEDERATION_CONFIG_UPDATE_ERROR_CODE: new IdentityAppsError(
-            WSFederationConfigConstants.WS_FEDERATION_CONFIG_UPDATE_ERROR_CODE,
-            "An error occurred while updating the WS Federation configurations.",
-            "Error while updating the WS Federation configurations",
-            null
-        )
-    };
+            WS_FEDERATION_CONFIG_FETCH_ERROR_CODE: new IdentityAppsError(
+                WSFederationConfigConstants.WS_FEDERATION_CONFIG_FETCH_ERROR_CODE,
+                "An error occurred while fetching the WS Federation configurations.",
+                "Error while fetching the WS Federation configurations",
+                null
+            ),
+            WS_FEDERATION_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE: new IdentityAppsError(
+                WSFederationConfigConstants.WS_FEDERATION_CONFIG_FETCH_INVALID_STATUS_CODE_ERROR_CODE,
+                "Received an invalid status code while fetching the WS Federation configurations.",
+                "Invalid Status Code while fetching the WS Federation configurations",
+                null
+            ),
+            WS_FEDERATION_CONFIG_REVERT_ERROR_CODE: new IdentityAppsError(
+                WSFederationConfigConstants.WS_FEDERATION_CONFIG_REVERT_ERROR_CODE,
+                "An error occurred while reverting the WS Federation configurations.",
+                "Error while reverting the WS Federation configurations",
+                null
+            ),
+            WS_FEDERATION_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE: new IdentityAppsError(
+                WSFederationConfigConstants.WS_FEDERATION_CONFIG_REVERT_INVALID_STATUS_CODE_ERROR_CODE,
+                "Received an invalid status code while reverting the WS Federation configurations.",
+                "Invalid Status Code while reverting the WS Federation configurations",
+                null
+            ),
+            WS_FEDERATION_CONFIG_UPDATE_ERROR_CODE: new IdentityAppsError(
+                WSFederationConfigConstants.WS_FEDERATION_CONFIG_UPDATE_ERROR_CODE,
+                "An error occurred while updating the WS Federation configurations.",
+                "Error while updating the WS Federation configurations",
+                null
+            )
+        };
 }

--- a/features/admin.wsfed-configuration.v1/pages/wsfed-configuration.tsx
+++ b/features/admin.wsfed-configuration.v1/pages/wsfed-configuration.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,13 +25,16 @@ import { hasRequiredScopes } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { Field, Form, FormPropsInterface } from "@wso2is/form";
-import { EmphasizedSegment, PageLayout } from "@wso2is/react-components";
+import { DangerZone, DangerZoneGroup, EmphasizedSegment, PageLayout } from "@wso2is/react-components";
 import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { Divider, Grid, Placeholder, Ref } from "semantic-ui-react";
-import { updateWSFederationConfigurations, useWSFederationConfig } from "../api/wsfed-configuration";
+import { revertWSFederationConfigurations,
+    updateWSFederationConfigurations,
+    useWSFederationConfig
+} from "../api/wsfed-configuration";
 import {
     WSFederationConfigAPIResponseInterface,
     WSFederationConfigFormValuesInterface
@@ -141,6 +144,36 @@ export const WSFederationConfigurationPage: FunctionComponent<WSFederationConfig
     };
 
     /**
+     * Displays the success banner when WSFederation configurations are reverted.
+     */
+    const handleRevertSuccess = () => {
+        dispatch(
+            addAlert({
+                description: t("wsFederationConfig:notifications." +
+                "revertConfiguration.success.description"),
+                level: AlertLevels.SUCCESS,
+                message: t("wsFederationConfig:notifications." +
+                "revertConfiguration.success.message")
+            })
+        );
+    };
+
+    /**
+     * Displays the error banner when unable to revert WSFederation configurations.
+     */
+    const handleRevertError = () => {
+        dispatch(
+            addAlert({
+                description: t("wsFederationConfig:notifications." +
+                "revertConfiguration.error.description"),
+                level: AlertLevels.ERROR,
+                message: t("wsFederationConfig:notifications." +
+                "revertConfiguration.error.message")
+            })
+        );
+    };
+
+    /**
      * Handle WSFederation form submit.
      */
     const handleSubmit = (value: boolean) => {
@@ -152,6 +185,19 @@ export const WSFederationConfigurationPage: FunctionComponent<WSFederationConfig
             handleUpdateSuccess();
         }).catch(() => {
             handleUpdateError();
+        }).finally(() => {
+            mutateWSFederationConfig();
+        });
+    };
+
+    /**
+     * Handle WSFederation configuration revert.
+     */
+    const onConfigRevert = (): void => {
+        revertWSFederationConfigurations().then(() => {
+            handleRevertSuccess();
+        }).catch(() => {
+            handleRevertError();
         }).finally(() => {
             mutateWSFederationConfig();
         });
@@ -255,6 +301,19 @@ export const WSFederationConfigurationPage: FunctionComponent<WSFederationConfig
                                     )
                                 }
                             </EmphasizedSegment>
+                        </Grid.Column>
+                    </Grid.Row>
+                    <Grid.Row columns={ 1 } className="mt-6">
+                        <Grid.Column width={ 16 }>
+                            <DangerZoneGroup sectionHeader={ t("common:dangerZone") }>
+                                <DangerZone
+                                    actionTitle= { t("governanceConnectors:dangerZone.actionTitle") }
+                                    header= { t("governanceConnectors:dangerZone.heading") }
+                                    subheader= { t("governanceConnectors:dangerZone.subHeading") }
+                                    onActionClick={ () => onConfigRevert() }
+                                    data-testid={ `${ componentId }-danger-zone` }
+                                />
+                            </DangerZoneGroup>
                         </Grid.Column>
                     </Grid.Row>
                 </Grid>

--- a/modules/i18n/src/models/namespaces/governance-connectors-ns.ts
+++ b/modules/i18n/src/models/namespaces/governance-connectors-ns.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,6 +19,11 @@
 import { NotificationItem } from "../common";
 
 export interface governanceConnectorsNS {
+    dangerZone: {
+        actionTitle: string;
+        heading: string;
+        subHeading: string;
+    };
     notifications: {
         getConnectorCategories: {
             error: {
@@ -54,6 +59,16 @@ export interface governanceConnectorsNS {
                 description: string;
             };
             genericError: {
+                message: string;
+                description: string;
+            };
+            success: {
+                message: string;
+                description: string;
+            };
+        };
+        revertConnector: {
+            error: {
                 message: string;
                 description: string;
             };
@@ -378,6 +393,16 @@ export interface governanceConnectorsNS {
                         configurationUpdate: {
                             success: NotificationItem;
                             error: NotificationItem;
+                        };
+                        revertConfiguration: {
+                            success: {
+                                description: string;
+                                message: string;
+                            };
+                            error: {
+                                description: string;
+                                message: string;
+                            };
                         };
                     };
                 };

--- a/modules/i18n/src/models/namespaces/saml2-config-ns.ts
+++ b/modules/i18n/src/models/namespaces/saml2-config-ns.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -37,6 +37,16 @@ export interface Saml2ConfigNS {
     };
     notifications: {
         updateConfiguration: {
+            error: {
+                message: string;
+                description: string;
+            };
+            success: {
+                message: string;
+                description: string;
+            };
+        };
+        revertConfiguration: {
             error: {
                 message: string;
                 description: string;

--- a/modules/i18n/src/models/namespaces/session-management-ns.ts
+++ b/modules/i18n/src/models/namespaces/session-management-ns.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -35,6 +35,16 @@ export interface SessionManagementNS {
         };
     };
     notifications: {
+        revertConfiguration: {
+            error: {
+                message: string;
+                description: string;
+            };
+            success: {
+                message: string;
+                description: string;
+            };
+        };
         updateConfiguration: {
             error: {
                 message: string;

--- a/modules/i18n/src/models/namespaces/validation-ns.ts
+++ b/modules/i18n/src/models/namespaces/validation-ns.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -23,6 +23,16 @@ export interface validationNS {
             message: string;
         };
         genericError: {
+            description: string;
+            message: string;
+        };
+    };
+    revertValidationConfigData: {
+        error: {
+            description: string;
+            message: string;
+        };
+        success: {
             description: string;
             message: string;
         };

--- a/modules/i18n/src/models/namespaces/ws-federation-config-ns.ts
+++ b/modules/i18n/src/models/namespaces/ws-federation-config-ns.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,6 +25,16 @@ export interface WsFederationConfigNS {
     };
     notifications: {
         updateConfiguration: {
+            error: {
+                message: string;
+                description: string;
+            };
+            success: {
+                message: string;
+                description: string;
+            };
+        };
+        revertConfiguration: {
             error: {
                 message: string;
                 description: string;

--- a/modules/i18n/src/translations/en-US/portals/governance-connectors.ts
+++ b/modules/i18n/src/translations/en-US/portals/governance-connectors.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -342,6 +342,16 @@ export const governanceConnectors: governanceConnectorsNS = {
                             success: {
                                 description: "Successfully updated the account disable configuration.",
                                 message: "Update Successful"
+                            }
+                        },
+                        revertConfiguration: {
+                            success: {
+                                description: "Successfully reverted the account disable configuration.",
+                                message: "Revert Successful"
+                            },
+                            error: {
+                                description: "An error occurred while reverting the account disable configuration.",
+                                message: "Revert Error"
                             }
                         }
                     }
@@ -686,6 +696,11 @@ export const governanceConnectors: governanceConnectorsNS = {
             }
         }
     },
+    dangerZone: {
+        actionTitle: "Revert",
+        heading: "Revert to default",
+        subHeading: "This action will discard all custom configurations on this page and restore the default settings."
+    },
     disabled: "Disabled",
     enabled: "Enabled",
     form: {
@@ -736,6 +751,16 @@ export const governanceConnectors: governanceConnectorsNS = {
             success: {
                 description: "{{ name }} configuration updated successfully.",
                 message: "Update Successful."
+            }
+        },
+        revertConnector: {
+            error: {
+                description: "An error occurred while reverting governance connector properties.",
+                message: "Revert Error"
+            },
+            success: {
+                description: "Successfully reverted the configuration to default.",
+                message: "Revert Successful."
             }
         }
     },

--- a/modules/i18n/src/translations/en-US/portals/saml2-config.ts
+++ b/modules/i18n/src/translations/en-US/portals/saml2-config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -48,6 +48,16 @@ export const saml2Config: Saml2ConfigNS = {
             error: {
                 description: "Error occurred while fetching saml2 configurations.",
                 message: "Error occurred"
+            }
+        },
+        revertConfiguration: {
+            error: {
+                message: "Error occurred",
+                description: "Error occurred while reverting saml2 configurations."
+            },
+            success: {
+                message: "Revert successful",
+                description: "Successfully reverted the saml2 configurations."
             }
         },
         updateConfiguration: {

--- a/modules/i18n/src/translations/en-US/portals/session-management.ts
+++ b/modules/i18n/src/translations/en-US/portals/session-management.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -47,6 +47,16 @@ export const sessionManagement: SessionManagementNS = {
             error: {
                 description: "Error occurred while fetching session management settings.",
                 message: "Error occurred"
+            }
+        },
+        revertConfiguration: {
+            error: {
+                message: "Error occurred",
+                description: "Error occurred while reverting session management settings."
+            },
+            success: {
+                message: "Revert successful",
+                description: "Successfully reverted the session management settings."
             }
         },
         updateConfiguration: {

--- a/modules/i18n/src/translations/en-US/portals/validation.ts
+++ b/modules/i18n/src/translations/en-US/portals/validation.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -75,6 +75,16 @@ export const validation: validationNS = {
                 info: "Rules will be applied in the order listed below, from top to bottom. Use the arrows to adjust the priority.",
                 skipMessage: "password expiry."
             }
+        }
+    },
+    revertValidationConfigData: {
+        error: {
+            description: "Error occurred while reverting validation configurations.",
+            message: "Revert failed"
+        },
+        success: {
+            description: "Successfully reverted validation configurations.",
+            message: "Revert successful"
         }
     },
     validationError: {

--- a/modules/i18n/src/translations/en-US/portals/ws-federation-config.ts
+++ b/modules/i18n/src/translations/en-US/portals/ws-federation-config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,6 +36,16 @@ export const wsFederationConfig: WsFederationConfigNS = {
             error: {
                 description: "Error occurred while fetching WS-Federation configurations.",
                 message: "Error occurred"
+            }
+        },
+        revertConfiguration: {
+            error: {
+                description: "Error occurred while reverting WS-Federation configurations.",
+                message: "Error occurred"
+            },
+            success: {
+                description: "Successfully reverted the WS-Federation configurations.",
+                message: "Revert successful"
             }
         },
         updateConfiguration: {


### PR DESCRIPTION
### Purpose

This pr adds the following UI elements in order to support inheriting, overriding and reverting login and registration related configurations in sub-organizations. 

- Enables the login and registration navbar item in sub-orgs
<img width="1475" height="738" alt="Screenshot 2025-07-14 at 8 42 40 PM" src="https://github.com/user-attachments/assets/e24729dd-ab13-4b4d-9b95-d00a0a1a15ed" />


- Provide the capability edit the configurations at the sub-organization level and add a danger zone at the bottom of each connector page to allow reverting the configurations
<img width="1148" height="662" alt="Screenshot 2025-07-14 at 8 43 11 PM" src="https://github.com/user-attachments/assets/c3031652-e077-4632-bf94-e3b177ce521d" />


### Related issue
- https://github.com/wso2/product-is/issues/24681