### PR TITLE
[bug-fix] Fix issue with sub org user profile

### DIFF
--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -1316,6 +1316,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                         setIsUpdating={ (isUpdating: boolean): void => setIsSubmitting(isUpdating) }
                         onUserUpdate={ handleUserUpdate }
                         accountConfigSettings={ configSettings }
+                        isUserManagedByParentOrg={ isUserManagedByParentOrg }
                         data-componentid={ testId }
                     />
                 </EmphasizedSegment>

--- a/features/admin.users.v1/components/user-profile/legacy-user-profile-form.tsx
+++ b/features/admin.users.v1/components/user-profile/legacy-user-profile-form.tsx
@@ -98,7 +98,7 @@ interface UserProfileFormPropsInterface extends IdentifiableComponentInterface {
     onUserUpdate: (userId: string) => void;
     isUpdating: boolean;
     adminUserType?: string;
-    isUserManagedByParentOrg?: boolean;
+    isUserManagedByParentOrg: boolean;
     setIsUpdating: (isUpdating: boolean) => void;
     accountConfigSettings: AccountConfigSettingsInterface;
     onUpdate: (userId: string) => void;


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Fixes the issue where the shared parent user profile is not disabled in sub organization view.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/identity-apps/pull/8464

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
