### PR TITLE
Fix Username field not hidden during self-registration when email is used as username

### DIFF
--- a/.changeset/fuzzy-bikes-repeat.md
+++ b/.changeset/fuzzy-bikes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix Username field not hidden during self-registration when email is used as username

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -1507,6 +1507,10 @@
             $("#alphanumericUsernameField").show();
         }
 
+        if (<%=isEmailUsernameEnabled%> && <%=hideUsernameFieldWhenEmailAsUsernameIsEnabled%>) {
+            $("#alphanumericUsernameField").hide();
+        }
+
         // Reloads the page if the page is loaded by going back in history.
         // Fixes issues with Firefox.
         window.addEventListener( "pageshow", function ( event ) {


### PR DESCRIPTION
### Purpose
This PR fixes the issue where the username field is also displayed in the self-registration form, even when the feature to use email as useranme is enabled and the configuration is set to hide the username field when email as username is enabled.

To hide the username field in the self registration form when the feature to use email as the username is enabled, following configuration is used. 

```
[accountrecoveryendpoint]
hide_username_when_email_as_username_enabled = true
```

To use the email as the username, following configuration is used. 

```
[tenant_mgt]
enable_email_domain = true
```

### Implementation
A frontend conditional check is added in the in self-registration-username-request.jsp to ensure the username field is hidden when the feature to use email as the username is enabled and the hide_username_when_email_as_username_enabled setting is true. 

### Related Issue
- https://github.com/wso2/product-is/issues/24429
