### PR TITLE
Fix redirection to MyAccount app always after the password reset

### DIFF
--- a/.changeset/tough-windows-hunt.md
+++ b/.changeset/tough-windows-hunt.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix redirection to MyAccount app always after the password reset

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -115,9 +115,9 @@
             applicationName = MY_ACCOUNT_APP_NAME;
         }
     } else {
-            if (StringUtils.isNotBlank(spId)) {
+        if (StringUtils.isNotBlank(spId) && !StringUtils.equalsIgnoreCase(spId, "null")) {
             try {
-                if (spId.equals(MY_ACCOUNT_APP_ID) || isUserPortalUrl(callback, tenantDomain, application)) {
+                if (spId.equals(MY_ACCOUNT_APP_ID)) {
                     applicationName = MY_ACCOUNT_APP_NAME;
                 } else {
                     applicationName = applicationDataRetrieval.getApplicationName(tenantDomain,spId);
@@ -125,6 +125,8 @@
             } catch (Exception e) {
                 // Ignored and fallback to my account page url.
             }
+        } else if (isUserPortalUrl(callback, tenantDomain, application)) {
+            applicationName = MY_ACCOUNT_APP_NAME;
         }
     }
 


### PR DESCRIPTION
### Purpose
After successfully resetting the password, the redirection link always showed the "Back to My Account" and it always redirects users to the MyAccount application—even when they initiated login from a different service provider (SP) application. The current logic checks if the callback URL matches the MyAccount URL using isUserPortalUrl, and if true, redirects to MyAccount. However, in many cases, the callback URL is defaulted to MyAccount, even though a valid spId (Service Provider ID) is available.

This PR updates the logic to ensure redirection to the correct application after password reset if the accessURL is configured for the application. With this change, if a valid spId is available and not "null", the application name is resolved using the spId, and redirection is based on that. Redirection to MyAccount will occur only when spId is not available or invalid, avoiding incorrect assumptions based on the callback URL alone. 

### Related Issue
- https://github.com/wso2/product-is/issues/24429