### PR TITLE
Add useDefaultFlow hook to resolve default password recovery template

### DIFF
--- a/.changeset/clever-keys-hear.md
+++ b/.changeset/clever-keys-hear.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.password-recovery-flow-builder.v1": patch
+"@wso2is/console": patch
+---
+
+Add useDefaultFlow hook to resolve default password recovery template

--- a/features/admin.password-recovery-flow-builder.v1/components/password-recovery-flow-builder-core.tsx
+++ b/features/admin.password-recovery-flow-builder.v1/components/password-recovery-flow-builder-core.tsx
@@ -71,6 +71,7 @@ import {
 } from "../constants/password-recovery-flow-ai-constants";
 import PasswordRecoveryFlowExecutorConstants from "../constants/password-recovery-flow-executor-constants";
 import useAIGeneratedPasswordRecoveryFlow from "../hooks/use-ai-generated-password-recovery-flow";
+import useDefaultFlow from "../hooks/use-default-flow";
 import useGeneratePasswordRecoveryFlow, {
     UseGeneratePasswordRecoveryFlowFunction
 } from "../hooks/use-generate-password-recovery-flow";
@@ -128,6 +129,7 @@ const PasswordRecoveryFlowBuilderCore: FunctionComponent<PasswordRecoveryFlowBui
     const { data: resources } = useGetPasswordRecoveryFlowBuilderResources();
 
     const { steps, templates } = resources;
+    const defaultTemplate: Template = useDefaultFlow(templates);
 
     const INITIAL_FLOW_START_STEP_ID: string = StaticStepTypes.Start.toLowerCase();
     const INITIAL_FLOW_USER_ONBOARD_STEP_ID: string = StaticStepTypes.End;
@@ -517,18 +519,16 @@ const PasswordRecoveryFlowBuilderCore: FunctionComponent<PasswordRecoveryFlowBui
     };
 
     const initialNodes: Node[] = useMemo<Node[]>(() => {
-        const basicTemplate: Template = cloneDeep(
-            templates.find((template: Template) => template.type === TemplateTypes.Basic)
-        );
+        const template: Template = cloneDeep(defaultTemplate);
 
-        const steps: Step[] = basicTemplate?.config?.data?.steps || [];
+        const steps: Step[] = template?.config?.data?.steps || [];
 
         const nodes: Node[] = generateSteps(steps);
 
-        const replacers: any = basicTemplate?.config?.data?.__generationMeta__?.replacers || [];
+        const replacers: any = template?.config?.data?.__generationMeta__?.replacers || [];
 
         return updateTemplatePlaceholderReferences(nodes, replacers)[0] as Node[];
-    }, [ generateSteps ]);
+    }, [ generateSteps, defaultTemplate ]);
 
     const [ nodes, setNodes, onNodesChange ] = useNodesState([]);
     const [ edges, setEdges, onEdgesChange ] = useEdgesState([]);

--- a/features/admin.password-recovery-flow-builder.v1/hooks/use-default-flow.ts
+++ b/features/admin.password-recovery-flow-builder.v1/hooks/use-default-flow.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import useAuthenticationFlowBuilderCore 
+import useAuthenticationFlowBuilderCore
     from "@wso2is/admin.flow-builder-core.v1/hooks/use-authentication-flow-builder-core-context";
 import { Template, TemplateTypes } from "@wso2is/admin.flow-builder-core.v1/models/templates";
 import { useMemo } from "react";

--- a/features/admin.password-recovery-flow-builder.v1/hooks/use-default-flow.ts
+++ b/features/admin.password-recovery-flow-builder.v1/hooks/use-default-flow.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import useAuthenticationFlowBuilderCore 
+    from "@wso2is/admin.flow-builder-core.v1/hooks/use-authentication-flow-builder-core-context";
+import { Template, TemplateTypes } from "@wso2is/admin.flow-builder-core.v1/models/templates";
+import { useMemo } from "react";
+
+/**
+ * Hook to resolve the default password recovery flow template based on the
+ * connector configuration metadata.
+ *
+ * @param templates - Available templates list.
+ * @returns Resolved default template.
+ */
+const useDefaultFlow = (templates: Template[]): Template => {
+    const { metadata } = useAuthenticationFlowBuilderCore();
+
+    return useMemo(() => {
+        if (!templates || templates.length === 0) {
+            return null;
+        }
+
+        const connectorConfig: any = metadata?.connectorConfig ?? {};
+
+        const emailOTPEnabled: boolean = connectorConfig.passwordRecoveryEmailOtpEnabled === true
+            || connectorConfig.passwordRecoveryEmailOtpEnabled === "true";
+        const smsOTPEnabled: boolean = connectorConfig.passwordRecoverySmsOtpEnabled === true
+            || connectorConfig.passwordRecoverySmsOtpEnabled === "true";
+        const magicLinkEnabled: boolean = connectorConfig.passwordRecoveryMagicLinkEnabled === true
+            || connectorConfig.passwordRecoveryMagicLinkEnabled === "true";
+
+        if (magicLinkEnabled) {
+            return templates.find(
+                (template: Template) =>
+                    template.type === "PASSWORD_RECOVERY_WITH_MAGIC_LINK"
+            );
+        }
+
+        if (smsOTPEnabled && emailOTPEnabled) {
+            return templates.find(
+                (template: Template) =>
+                    template.type === "PASSWORD_RECOVERY_WITH_SMS_OR_EMAIL_OTP_AND_PASSWORD_RESET"
+            );
+        }
+
+        if (smsOTPEnabled) {
+            return templates.find(
+                (template: Template) =>
+                    template.type === "PASSWORD_RECOVERY_WITH_SMS_OTP_AND_PASSWORD_RESET"
+            );
+        }
+
+        // Default to the basic (email OTP) template.
+        return templates.find((template: Template) => template.type === TemplateTypes.Basic);
+    }, [ metadata, templates ]);
+};
+
+export default useDefaultFlow;


### PR DESCRIPTION
### Related Issue
- https://github.com/wso2/product-is/issues/24819

### Purpose
This pull request introduces a new hook, `useDefaultFlow`, to dynamically resolve the default password recovery flow template based on connector configuration metadata. The changes aim to improve flexibility and maintainability by centralizing the logic for selecting the default template. Below are the most important changes grouped by theme:

### New Hook Implementation:
* Added a new `useDefaultFlow` hook in `features/admin.password-recovery-flow-builder.v1/hooks/use-default-flow.ts`. This hook uses metadata from the authentication flow builder context to determine the appropriate default password recovery template based on connector configurations such as email OTP, SMS OTP, and magic link support.

### Integration of `useDefaultFlow`:
* Updated `features/admin.password-recovery-flow-builder.v1/components/password-recovery-flow-builder-core.tsx` to import and use the `useDefaultFlow` hook for resolving the default template. [[1]](diffhunk://#diff-c10177505a80a0beae6cdd2ccf717c393e5c394958cd57aecfef83695a0575aaR74) [[2]](diffhunk://#diff-c10177505a80a0beae6cdd2ccf717c393e5c394958cd57aecfef83695a0575aaR132)
* Replaced the hardcoded logic for selecting the "basic" template with the dynamically resolved `defaultTemplate` from `useDefaultFlow`. This change ensures that the initial nodes and steps are based on the resolved template.

