### PR TITLE
Webhook UI delete section fix

### DIFF
--- a/.changeset/wild-geese-sleep.md
+++ b/.changeset/wild-geese-sleep.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.webhooks.v1": patch
+---
+
+Fix delete section view of webhooks in websubhub mode.

--- a/features/admin.webhooks.v1/components/webhook-list.tsx
+++ b/features/admin.webhooks.v1/components/webhook-list.tsx
@@ -286,7 +286,7 @@ const WebhookList: FunctionComponent<WebhookListPropsInterface> = ({
             );
         }
 
-        if (list?.totalResults === 0) {
+        if (list?.totalResults === 0 && !isLoading) {
             return (
                 <EmptyPlaceholder
                     action={

--- a/features/admin.webhooks.v1/hooks/use-webhook-navigation.ts
+++ b/features/admin.webhooks.v1/hooks/use-webhook-navigation.ts
@@ -22,20 +22,44 @@ import { WebhookListItemInterface } from "../models/webhooks";
 export interface UseWebhookNavigationInterface {
     navigateToWebhookCreation: () => void;
     navigateToWebhookEdit: (webhookId: WebhookListItemInterface) => void;
+    navigateToWebhookEditById: (webhookId: string) => void;
+    navigateToWebhooksList: () => void;
 }
 
 const useWebhookNavigation = (): UseWebhookNavigationInterface => {
     const navigateToWebhookCreation = (): void => {
-        history.push(AppConstants.getPaths().get("WEBHOOK_EDIT").replace(":id", "new"));
+        history.push(
+            AppConstants.getPaths()
+                .get("WEBHOOK_EDIT")
+                .replace(":id", "new")
+        );
     };
 
     const navigateToWebhookEdit = (webhook: WebhookListItemInterface): void => {
-        history.push(AppConstants.getPaths().get("WEBHOOK_EDIT").replace(":id", webhook.id));
+        history.push(
+            AppConstants.getPaths()
+                .get("WEBHOOK_EDIT")
+                .replace(":id", webhook.id)
+        );
+    };
+
+    const navigateToWebhookEditById = (webhookId: string): void => {
+        history.push(
+            AppConstants.getPaths()
+                .get("WEBHOOK_EDIT")
+                .replace(":id", webhookId)
+        );
+    };
+
+    const navigateToWebhooksList = (): void => {
+        history.push(AppConstants.getPaths().get("WEBHOOKS"));
     };
 
     return {
         navigateToWebhookCreation,
-        navigateToWebhookEdit
+        navigateToWebhookEdit,
+        navigateToWebhookEditById,
+        navigateToWebhooksList
     };
 };
 

--- a/features/admin.webhooks.v1/pages/webhook-list-page.tsx
+++ b/features/admin.webhooks.v1/pages/webhook-list-page.tsx
@@ -96,7 +96,11 @@ const WebhooksPage: FunctionComponent<WebhooksPageInterface> = ({
     const handleSuccess: (action: string) => void = useHandleWebhookSuccess();
     const handleError: (error: unknown, action: string) => void = useHandleWebhookError();
 
-    const isLoading: boolean = isWebhookListFetchRequestLoading || isDeletingWebhook || isWebhooksMetadataLoading;
+    const isLoading: boolean =
+        isWebhookListFetchRequestLoading ||
+        isDeletingWebhook ||
+        isWebhooksMetadataLoading ||
+        (!webhookListResponse && !webhookListFetchRequestError);
 
     useEffect(() => {
         resetToFirstPage();
@@ -151,7 +155,6 @@ const WebhooksPage: FunctionComponent<WebhooksPageInterface> = ({
      * Handles webhook edit navigation with permission check.
      */
     const handleWebhookEdit = (webhook: WebhookListItemInterface): void => {
-        // Allow to navigage to edit page if the user has view permissions
         navigateToWebhookEdit(webhook);
     };
 
@@ -233,16 +236,15 @@ const WebhooksPage: FunctionComponent<WebhooksPageInterface> = ({
             data-componentid={ `${_componentId}-page-layout` }
         >
             <ListLayout
-                advancedSearch={ renderAdvancedSearch() }
+                advancedSearch={ !isLoading ? renderAdvancedSearch() : null }
                 currentListSize={ paginatedWebhooks.length }
                 isLoading={ isLoading }
                 listItemLimit={ itemsPerPage }
                 onItemsPerPageDropdownChange={ handleItemsPerPageDropdownChange }
                 onPageChange={ handlePaginationChange }
-                showPagination={ totalPages > 1 }
+                showPagination={ totalPages > 1 && !isLoading }
                 showTopActionPanel={
-                    isWebhookListFetchRequestLoading ||
-                    isWebhooksMetadataLoading ||
+                    isLoading ||
                     !((!searchQuery || searchQuery.trim() === "") && enhancedWebhookList?.totalResults <= 0)
                 }
                 totalPages={ totalPages }


### PR DESCRIPTION
### Purpose

Resolves https://github.com/wso2/product-is/issues/24821

https://github.com/user-attachments/assets/c37c8b9f-8036-4e70-b267-609b54f806b3

This PR,
- Fixes re loading webhook in webhook edit page that moving to listing page as a user creates an webhook
- Fixes appearance and disappearance of delete section based on webhook active inactive state in websubhub mode.