### PR TITLE
Fix toggle being active while form submission

### DIFF
--- a/.changeset/dull-pugs-cross.md
+++ b/.changeset/dull-pugs-cross.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.actions.v1": patch
+---
+
+Fix active toggle while state change happens.

--- a/features/admin.actions.v1/pages/action-configuration-page.tsx
+++ b/features/admin.actions.v1/pages/action-configuration-page.tsx
@@ -368,9 +368,9 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
                 toggle
                 onChange={ handleToggle }
                 checked={ isActive }
-                readOnly={ !hasActionUpdatePermissions }
+                readOnly={ !hasActionUpdatePermissions || isSubmitting }
                 data-componentId={ `${ _componentId }-${ actionTypeApiPath }-enable-toggle` }
-                disabled={ !hasActionUpdatePermissions }
+                disabled={ !hasActionUpdatePermissions || isSubmitting }
             />
         );
     };


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Active/Inactive toggle stays enabled when form submission happens provoking users to re-toggle.
This action change the state of the action again than intended by the user.

Thus it's rather a best practice to keep it in disabled state when action is happening
