### PR TITLE
Depend both feature config on the server config

### DIFF
--- a/.changeset/healthy-numbers-joke.md
+++ b/.changeset/healthy-numbers-joke.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Change role assignment feature enable config.

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1630,7 +1630,7 @@
                 }
             },
             {% endif %}
-            {% if console.role_assignments is defined %}
+            {% if console.role_assignments && scim2.enable_scim2_roles_v3_api is defined %}
             "roleAssignments": {
                 "disabledFeatures": [
                     {% if console.role_assignments.disabled_features is defined %}
@@ -1639,7 +1639,7 @@
                     {% endfor %}
                     {% endif %}
                 ],
-                "enabled": {% if console.role_assignments.enabled is defined %} {{ console.role_assignments.enabled }},
+                "enabled": {% if scim2.enable_scim2_roles_v3_api is defined %} {{ scim2.enable_scim2_roles_v3_api }},
                 {% else %} true,
                 {% endif %}
                 "scopes": {


### PR DESCRIPTION
### Purpose
Makes the roleAssignments feature and User role v3 feature depend on the same server config, `scim2.enable_scim2_roles_v3_api`.

### Related Issues
- https://github.com/wso2/product-is/issues/21686