### PR TITLE
Append organization handle instead of organizationId to userId for linked accounts

### DIFF
--- a/apps/myaccount/src/components/linked-accounts/linked-accounts.tsx
+++ b/apps/myaccount/src/components/linked-accounts/linked-accounts.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2019-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,7 +16,6 @@
  * under the License.
  */
 
-import { OrganizationType } from "@wso2is/admin.organizations.v1/constants";
 import { TestableComponentInterface } from "@wso2is/core/models";
 import { AxiosError } from "axios";
 import isEmpty from "lodash-es/isEmpty";
@@ -69,9 +68,8 @@ export const LinkedAccounts: FunctionComponent<LinkedAccountsProps> = (props: Li
 
     const linkedAccounts: LinkedAccountInterface[] = useSelector((state: AppState) => state.profile.linkedAccounts);
     const activeForm: string = useSelector((state: AppState) => state.global.activeForm);
-    const userOrganizationId: string = useSelector((state: AppState) => state?.organization?.userOrganizationId);
-    const organizationType: string = useSelector((state: AppState) => state?.organization?.organizationType);
-    const tenantDomain: string = useSelector((state: AppState) => state?.authenticationInformation?.tenantDomain);
+    const userOrganizationHandle: string
+        = useSelector((state: AppState) => state?.organization?.userOrganizationHandle);
 
     /**
      * Set the linked accounts.
@@ -94,15 +92,9 @@ export const LinkedAccounts: FunctionComponent<LinkedAccountsProps> = (props: Li
         const superTenant: string = "carbon.super";
         let userId: string = username;
 
-        if (organizationType === OrganizationType.SUBORGANIZATION) {
-            if (usernameSplit?.length >= 1 && !usernameSplit.includes(userOrganizationId)) {
-                userId = username + "@" + userOrganizationId;
-            }
-
-        } else {
-            if (usernameSplit?.length >= 1 && tenantDomain !== superTenant && !usernameSplit.includes(tenantDomain)) {
-                userId = username + "@" + tenantDomain;
-            }
+        if (usernameSplit?.length >= 1 && userOrganizationHandle !== superTenant
+                    && !usernameSplit.includes(userOrganizationHandle)) {
+            userId = username + "@" + userOrganizationHandle;
         }
 
         const data: {


### PR DESCRIPTION
### Purpose
$subject

This logic is unnecessary as the TENANT_DOMAIN_PARAM requires the tenant domain to be passed. Previously both the orgId and the tenant domain is equal for sub organisations. However, since the organization handle is introduced, this value can now be different from each other. As the organization handle now holds tenant domain for sub organisations.

### Related PRs
- https://github.com/wso2-extensions/identity-user-account-association/pull/58