### PR TITLE
Add password recovery flow builder banner

### DIFF
--- a/.changeset/healthy-foxes-admire.md
+++ b/.changeset/healthy-foxes-admire.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.password-recovery-flow-builder.v1": patch
+"@wso2is/admin.server-configurations.v1": patch
+"@wso2is/admin.feature-gate.v1": patch
+"@wso2is/console": patch
+---
+
+Add password recovery flow builder banner

--- a/features/admin.feature-gate.v1/constants/feature-flag-constants.ts
+++ b/features/admin.feature-gate.v1/constants/feature-flag-constants.ts
@@ -49,6 +49,7 @@ class FeatureFlagConstants {
         BRANDING_STYLES_AND_TEXT_TITLE: "branding.stylesAndText.application.title",
         CUSTOM_PAGE_EDITOR_FEATURE_ID: "console.branding.design.layout.custom",
         FLOWS: "flows",
+        FLOWS_TYPES_PASSWORD_RECOVERY: "flows.types.list.passwordRecovery",
         FLOWS_TYPES_REGISTRATION: "flows.types.list.registration",
         INSIGHTS: "insights",
         LOGIN_AND_REGISTRATION: "loginAndRegistration",

--- a/features/admin.password-recovery-flow-builder.v1/components/password-recovery-flow-builder-banner.tsx
+++ b/features/admin.password-recovery-flow-builder.v1/components/password-recovery-flow-builder-banner.tsx
@@ -70,7 +70,7 @@ const PasswordRecoveryFlowBuilderBanner: FC<PasswordRecoveryFlowBuilderBannerPro
                         <span className="text-gradient primary">{ t("flows:passwordRecovery.name") }</span>
                         <FeatureFlagLabel
                             featureFlags={ flowsFeatureAIConfig?.featureFlags }
-                            featureKey={ FeatureFlagConstants.FEATURE_FLAG_KEY_MAP.FLOWS_TYPES_REGISTRATION }
+                            featureKey={ FeatureFlagConstants.FEATURE_FLAG_KEY_MAP.FLOWS_TYPES_PASSWORD_RECOVERY }
                             type="chip"
                         />
                     </Typography>
@@ -80,7 +80,7 @@ const PasswordRecoveryFlowBuilderBanner: FC<PasswordRecoveryFlowBuilderBannerPro
                     </Typography>
                 </Box>
                 <Button
-                    onClick={ () => history.push(AppConstants.getPaths().get("REGISTRATION_FLOW_BUILDER")) }
+                    onClick={ () => history.push(AppConstants.getPaths().get("PASSWORD_RECOVERY_FLOW_BUILDER")) }
                     color="primary"
                     variant="contained"
                 >

--- a/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
+++ b/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
@@ -50,6 +50,8 @@ import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { Checkbox, CheckboxProps, Grid, Icon, Message, Ref } from "semantic-ui-react";
 import { useGetCurrentOrganizationType } from "../../admin.organizations.v1/hooks/use-get-organization-type";
+import PasswordRecoveryFlowBuilderBanner
+    from "../../admin.password-recovery-flow-builder.v1/components/password-recovery-flow-builder-banner";
 import {
     getConnectorDetails,
     revertGovernanceConnectorProperties,
@@ -95,6 +97,8 @@ export const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = 
         (state: AppState) => state?.config?.ui?.features?.applications);
     const registrationFlowBuilderFeatureConfig: FeatureAccessConfigInterface = useSelector(
         (state: AppState) => state?.config?.ui?.features?.registrationFlowBuilder);
+    const passwordRecoveryFlowBuilderFeatureConfig: FeatureAccessConfigInterface = useSelector(
+        (state: AppState) => state?.config?.ui?.features?.passwordRecoveryFlowBuilder);
 
     const [ isConnectorRequestLoading, setConnectorRequestLoading ] = useState<boolean>(false);
     const [ connector, setConnector ] = useState<GovernanceConnectorInterface>(undefined);
@@ -109,6 +113,8 @@ export const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = 
         = useRequiredScopes(applicationFeatureConfig?.governanceConnectors?.scopes?.update);
     const hasRegistrationFlowBuilderViewPermissions: boolean
         = useRequiredScopes(registrationFlowBuilderFeatureConfig?.scopes?.read);
+    const hasPasswordRecoveryFlowBuilderViewPermissions: boolean
+        = useRequiredScopes(passwordRecoveryFlowBuilderFeatureConfig?.scopes?.read);
     const path: string[] = history.location.pathname.split("/");
     const type: string = path[ path.length - 3 ];
 
@@ -796,6 +802,16 @@ export const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = 
             }
 
             return <RegistrationFlowBuilderBanner />;
+        }
+
+        if (connector.id === ServerConfigurationsConstants.ACCOUNT_RECOVERY_CONNECTOR_ID) {
+
+            // if (isSubOrganization() || !passwordRecoveryFlowBuilderFeatureConfig?.enabled ||
+            //         !hasPasswordRecoveryFlowBuilderViewPermissions) {
+            //     return null;
+            // }
+
+            return <PasswordRecoveryFlowBuilderBanner />;
         }
 
         return null;


### PR DESCRIPTION
## Purpose
This pull request introduces a new banner component for the password recovery flow builder and integrates it into the connector edit page. The changes ensure that the password recovery flow builder banner is displayed under the correct conditions and that feature flag handling is updated accordingly.

**Password Recovery Flow Builder Integration:**

* Added a new `PasswordRecoveryFlowBuilderBanner` component and imported it into `connector-edit-page.tsx`.
* Updated the connector edit page to select the password recovery flow builder feature config from the Redux state and check for the appropriate view permissions. [[1]](diffhunk://#diff-1fd1a7fcec9e28b7e2861dc934d9cd5f113a5d9a55799cb91a0ce91c262834acR100-R101) [[2]](diffhunk://#diff-1fd1a7fcec9e28b7e2861dc934d9cd5f113a5d9a55799cb91a0ce91c262834acR116-R117)
* Modified the logic in the connector edit page to render the `PasswordRecoveryFlowBuilderBanner` when the `ACCOUNT_RECOVERY_CONNECTOR_ID` connector is being edited.

**Feature Flag and Navigation Updates:**

* Added `FLOWS_TYPES_PASSWORD_RECOVERY` to the `FeatureFlagConstants.FEATURE_FLAG_KEY_MAP` for correct feature flag mapping.
* Updated the `PasswordRecoveryFlowBuilderBanner` to use the new feature flag key and navigate to the correct password recovery flow builder route. [[1]](diffhunk://#diff-6b6eae779c8991665029449c8f5e1b07a67cdf77e759853178680a32dbd4fe34L73-R73) [[2]](diffhunk://#diff-6b6eae779c8991665029449c8f5e1b07a67cdf77e759853178680a32dbd4fe34L83-R83)

**Documentation/Metadata:**

* Added a changeset entry describing the addition of the password recovery flow builder banner.