### PR TITLE
Fix discovery config PUT call to include defaultParam

### DIFF
--- a/.changeset/orange-vans-flow.md
+++ b/.changeset/orange-vans-flow.md
@@ -1,8 +1,6 @@
 ---
 "@wso2is/admin.organization-discovery.v1": patch
-"@wso2is/admin.organizations.v1": patch
 "@wso2is/console": patch
-"@wso2is/i18n": patch
 ---
 
 Fix discovery config PUT call to include defaultParam

--- a/.changeset/orange-vans-flow.md
+++ b/.changeset/orange-vans-flow.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/admin.organization-discovery.v1": patch
+"@wso2is/admin.organizations.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Fix discovery config PUT call to include defaultParam

--- a/features/admin.organization-discovery.v1/api/use-get-organization-discovery-config.ts
+++ b/features/admin.organization-discovery.v1/api/use-get-organization-discovery-config.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -55,6 +55,7 @@ const useGetOrganizationDiscoveryConfig = <
 
     let isOrganizationDiscoveryEnabled: boolean = false;
     let isEmailDomainBasedSelfRegistrationEnabled: boolean = false;
+    let defaultParam: string;
 
     if ((data as OrganizationDiscoveryConfigInterface)?.properties) {
         (data as OrganizationDiscoveryConfigInterface).properties?.forEach(
@@ -67,6 +68,10 @@ const useGetOrganizationDiscoveryConfig = <
                 if (property.key === OrganizationDiscoveryConfigConstants.EMAIL_DOMAIN_DISCOVERY_SELF_REG_PROPERTY_KEY
                     && property.value === "true") {
                     isEmailDomainBasedSelfRegistrationEnabled = true;
+                }
+
+                if (property.key === OrganizationDiscoveryConfigConstants.DEFAULT_DISCOVERY_PARAM) {
+                    defaultParam = property.value;
                 }
             }
         );
@@ -91,6 +96,7 @@ const useGetOrganizationDiscoveryConfig = <
 
     return {
         data: {
+            defaultParam,
             isEmailDomainBasedSelfRegistrationEnabled,
             isOrganizationDiscoveryEnabled,
             ...data

--- a/features/admin.organization-discovery.v1/constants/organization-discovery-config-constants.ts
+++ b/features/admin.organization-discovery.v1/constants/organization-discovery-config-constants.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -27,6 +27,7 @@ export class OrganizationDiscoveryConfigConstants {
 
     public static readonly EMAIL_DOMAIN_DISCOVERY_PROPERTY_KEY: string = "emailDomain.enable";
     public static readonly EMAIL_DOMAIN_DISCOVERY_SELF_REG_PROPERTY_KEY: string = "emailDomainBasedSelfSignup.enable";
+    public static readonly DEFAULT_DISCOVERY_PARAM: string = "defaultParam";
 
     public static readonly ORGANIZATION_DISCOVERY_DOMAINS_NOT_CONFIGURED_ERROR_CODE: string = "OCM-60002";
 }

--- a/features/admin.organization-discovery.v1/models/organization-discovery.ts
+++ b/features/admin.organization-discovery.v1/models/organization-discovery.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -40,6 +40,7 @@ export interface OrganizationDiscoveryAttributeDataInterface {
 export interface OrganizationDiscoveryResponseInterface {
     isOrganizationDiscoveryEnabled: boolean;
     isEmailDomainBasedSelfRegistrationEnabled: boolean;
+    defaultParam: string;
 }
 
 export interface OrganizationLinkInterface {

--- a/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
+++ b/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -119,7 +119,11 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
     } = useGetGovernanceConnectorById(ServerConfigurationsConstants.USER_ONBOARDING_CONNECTOR_ID,
         ServerConfigurationsConstants.SELF_SIGN_UP_CONNECTOR_ID);
 
-    const { isOrganizationDiscoveryEnabled, isEmailDomainBasedSelfRegistrationEnabled } = organizationDiscoveryConfig;
+    const {
+        isOrganizationDiscoveryEnabled,
+        isEmailDomainBasedSelfRegistrationEnabled,
+        defaultParam
+    } = organizationDiscoveryConfig;
     const [ isSelfRegEnabled, setIsSelfRegEnabled ] = useState<boolean>(false);
 
     useEffect(() => {
@@ -132,6 +136,7 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
     }, [ selfRegistrationConnectorDetetails ]);
 
     const handleEmailDomainBasedSelfRegistration = (value: boolean): void => {
+
         const updateData: OrganizationDiscoveryConfigInterface = {
             properties: []
         };
@@ -145,6 +150,13 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
             key: OrganizationDiscoveryConfigConstants.EMAIL_DOMAIN_DISCOVERY_SELF_REG_PROPERTY_KEY,
             value: value.toString()
         });
+
+        if (defaultParam != null) {
+            updateData.properties.push({
+                key: OrganizationDiscoveryConfigConstants.DEFAULT_DISCOVERY_PARAM,
+                value: defaultParam
+            });
+        }
 
         updateOrganizationDiscoveryConfig(updateData)
             .then(() => {
@@ -268,6 +280,12 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
             updateData.properties.push({
                 key: OrganizationDiscoveryConfigConstants.EMAIL_DOMAIN_DISCOVERY_SELF_REG_PROPERTY_KEY,
                 value: "false"
+            });
+        }
+        if (defaultParam != null) {
+            updateData.properties.push({
+                key: OrganizationDiscoveryConfigConstants.DEFAULT_DISCOVERY_PARAM,
+                value: defaultParam
             });
         }
 

--- a/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
+++ b/features/admin.organization-discovery.v1/pages/organization-discovery-domains-page.tsx
@@ -136,7 +136,6 @@ const OrganizationDiscoveryDomainsPage: FunctionComponent<OrganizationDiscoveryD
     }, [ selfRegistrationConnectorDetetails ]);
 
     const handleEmailDomainBasedSelfRegistration = (value: boolean): void => {
-
         const updateData: OrganizationDiscoveryConfigInterface = {
             properties: []
         };


### PR DESCRIPTION
### Purpose
$subject

This will put the **defaultParam**, into the PUT API repsonse so it will be retained.

### Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/29871