### PR TITLE
Fix: Remove misleading user profile message for view-only admins (wso2/product-is#24908)

### DIFF
--- a/features/admin.users.v1/components/user-profile-updated.tsx
+++ b/features/admin.users.v1/components/user-profile-updated.tsx
@@ -2431,6 +2431,7 @@ export const UserProfileUpdated: FunctionComponent<UserProfilePropsInterface> = 
                             && !isReadOnlyUserStore
                             && (!isEmpty(tenantAdmin) || tenantAdmin !== null)
                             && !user[ SCIMConfigs.scim.systemSchema ]?.userSourceId
+                            && isUserManagedByParentOrg
                             && editUserDisclaimerMessage
                         }
                         <FinalForm

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -1409,6 +1409,7 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                         && !isReadOnlyUserStore
                         && (!isEmpty(tenantAdmin) || tenantAdmin !== null)
                         && !user[ SCIMConfigs.scim.systemSchema ]?.userSourceId
+                        && isUserManagedByParentOrg
                         && editUserDisclaimerMessage
                     }
 


### PR DESCRIPTION
### Purpose
Fixes [wso2/product-is#24908](https://github.com/wso2/product-is/issues/24908).

When an admin user with only **user-view** permission viewed another user's profile, the UI displayed an irrelevant edit disclaimer.  
This PR adds a guard (`isUserManagedByParentOrg`) so the disclaimer only appears when the viewed user is actually managed by a parent organization.

**UI/UX Change**  
- Before: Edit disclaimer shown for any read-only user, regardless of org hierarchy.  
- After: Disclaimer shown only for read-only users *managed by a parent org*.

_No visual regression for full-admin users._

---

### Related Issues
- [wso2/product-is#24908](https://github.com/wso2/product-is/issues/24908)

### Related PRs
- N/A

---

### Checklist
- [x] Manual test round performed and verified.
- [x] UX/UI review done locally during dev.
- [ ] Documentation provided. (N/A for this fix)
- [ ] Relevant backend changes deployed and verified (N/A — UI only)
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (N/A — minor UI conditional)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (N/A)

---

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

---

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact. (N/A — no developer checklist present in the related product-is issue.)

**Before (user-view-only admin)**  
<img width="1222" height="691" alt="Before-Fix" src="https://github.com/user-attachments/assets/4d6f89bf-17bf-413a-8b5e-f6fafc79f70d" />

**After (user-view-only admin)**  
<img width="1260" height="540" alt="After-Fix" src="https://github.com/user-attachments/assets/58cf5d83-0898-4713-a524-b862aea2f639" />
