### PR TITLE
Disable session and token event configs in ui

### DIFF
--- a/.changeset/nice-carpets-explain.md
+++ b/.changeset/nice-carpets-explain.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.webhooks.v1": patch
+"@wso2is/console": patch
+---
+
+Disable session and token event configs in ui

--- a/features/admin.webhooks.v1/constants/webhooks-constants.ts
+++ b/features/admin.webhooks.v1/constants/webhooks-constants.ts
@@ -53,5 +53,7 @@ export class WebhooksConstants {
      * @defaultValue
      */
     public static readonly FEATURE_DICTIONARY: Map<string, string> = new Map<string, string>()
-        .set("WEBHOOK_SETTINGS", "webhooks.settings");
+        .set("WEBHOOK_SETTINGS", "webhooks.settings")
+        .set("SESSION_EVENT_HANDLER", "webhook.events.session")
+        .set("TOKEN_EVENT_HANDLER", "webhook.events.token");
 }

--- a/features/admin.webhooks.v1/pages/webhook-edit-page.tsx
+++ b/features/admin.webhooks.v1/pages/webhook-edit-page.tsx
@@ -23,6 +23,7 @@ import Button from "@oxygen-ui/react/Button";
 import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { AppState } from "@wso2is/admin.core.v1/store";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import {
     ConfirmationModal,
@@ -55,6 +56,7 @@ import updateWebhook from "../api/update-webhook";
 import useGetDefaultEventProfile from "../api/use-get-default-event-profile";
 import useGetWebhookById from "../api/use-get-webhook-by-id";
 import useGetWebhooksMetadata from "../api/use-get-webhooks-metadata";
+import { WebhooksConstants } from "../constants/webhooks-constants";
 import WebhookConfigForm from "../components/webhook-config-form";
 import useWebhookNavigation from "../hooks/use-webhook-navigation";
 import { WebhookChannelConfigInterface } from "../models/event-profile";
@@ -113,6 +115,12 @@ const WebhookEditPage: FunctionComponent<WebhookEditPageInterface> = ({
     const [ isDeletingWebhook, setIsDeletingWebhook ] = useState<boolean>(false);
     const [ isRetrying, setIsRetrying ] = useState<boolean>(false);
 
+    // Disable webhook event profiles
+    const showWebhookSessionEventHandler: boolean = isFeatureEnabled(
+        webhooksFeatureConfig, WebhooksConstants.FEATURE_DICTIONARY.get("SESSION_EVENT_HANDLER"));
+    const showWebhookTokenEventHandler: boolean = isFeatureEnabled(
+        webhooksFeatureConfig, WebhooksConstants.FEATURE_DICTIONARY.get("TOKEN_EVENT_HANDLER"));
+
     // API hooks
     const {
         data: webhook,
@@ -141,15 +149,32 @@ const WebhookEditPage: FunctionComponent<WebhookEditPageInterface> = ({
     const isLoading: boolean = isWebhookLoading || isEventProfileLoading || isWebhooksMetadataLoading;
 
     const channelConfigs: WebhookChannelConfigInterface[] = useMemo(() => {
-        return eventProfile
-            ? mapEventProfileApiToUI(eventProfile).map((config: any) => ({
-                channelUri: config.channelUri,
-                description: config.description ?? "",
-                key: config.key,
-                name: config.name ?? ""
-            }))
-            : [];
-    }, [ eventProfile ]);
+    if (!eventProfile) {
+        return [];
+    }
+
+    return mapEventProfileApiToUI(eventProfile)
+        .map((config: any) => ({
+            channelUri: config.channelUri,
+            description: config.description ?? "",
+            key: config.key,
+            name: config.name ?? ""
+        }))
+        .filter((config: WebhookChannelConfigInterface) => {
+            // Filter out session events if feature is disabled
+            if (config.channelUri === "https://schemas.identity.wso2.org/events/session" && !showWebhookSessionEventHandler) {
+                return false;
+            }
+            
+            // Filter out token events if feature is disabled
+            if (config.channelUri === "https://schemas.identity.wso2.org/events/token" && !showWebhookTokenEventHandler) {
+                return false;
+            }
+            
+            return true;
+        });
+    }, [ eventProfile, showWebhookSessionEventHandler, showWebhookTokenEventHandler ]);
+
 
     const webhookInitialValues: WebhookConfigFormPropertyInterface = useMemo(() => {
         const baseFormValues: WebhookConfigFormPropertyInterface = {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

This pull request disables the session and token event configurations in the webhooks UI by introducing feature flags. The changes ensure that session and token event handlers are only shown if their corresponding features are enabled, and they are filtered out otherwise.

**Feature flag integration:**

* Added `SESSION_EVENT_HANDLER` and `TOKEN_EVENT_HANDLER` to the `FEATURE_DICTIONARY` in `webhooks-constants.ts` to support feature-based toggling of session and token event handlers.
* Utilized the `isFeatureEnabled` helper in `webhook-edit-page.tsx` to determine whether to show session and token event handlers based on the feature config. [[1]](diffhunk://#diff-6cb27999894caa8580318abb2f5855135db97d87c313d0c0852ce684483fb0e2R26) [[2]](diffhunk://#diff-6cb27999894caa8580318abb2f5855135db97d87c313d0c0852ce684483fb0e2R118-R123)

**UI logic updates:**

* Updated the `channelConfigs` memoized value in `webhook-edit-page.tsx` to filter out session and token event configurations if their respective features are disabled.

**General:**

* Added a changeset entry documenting the patch and the purpose of disabling session and token event configs in the UI.
* Imported `WebhooksConstants` into `webhook-edit-page.tsx` to access the new feature flag keys.
