### PR TITLE
Move pnpm install before the changeset pre-release step

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -99,14 +99,14 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-pnpm-store-
 
+            - name: 🧩 Install Dependencies
+              id: install-dependencies
+              run: pnpm install
+
             - name: 🔄 Enter Changeset Pre-release Mode (next branch only)
               id: changeset-pre-release
               if: github.ref_name == 'next'
               run: pnpm changeset pre enter next
-
-            - name: 🧩 Install Dependencies
-              id: install-dependencies
-              run: pnpm install
 
             - name: 📝 Create settings.xml with Nexus credentials in ~/.m2
               run: |


### PR DESCRIPTION
This pull request makes a small change to the order of steps in the `.github/workflows/release-workflow.yml` file. The "Install Dependencies" step is now run earlier in the workflow, before entering Changeset pre-release mode. This ensures that all required dependencies are installed before any pre-release operations are performed.