### PR TITLE
Change share all operation from checkbox to button

### DIFF
--- a/.changeset/eleven-kings-flow.md
+++ b/.changeset/eleven-kings-flow.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.applications.v1": patch
+"@wso2is/console": patch
 ---
 
 Change share all operation from checkbox to button

--- a/.changeset/four-cows-count.md
+++ b/.changeset/four-cows-count.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+Change share all operation from checkbox to button

--- a/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
+++ b/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
@@ -18,7 +18,6 @@
 
 import Alert from "@oxygen-ui/react/Alert";
 import Button from "@oxygen-ui/react/Button";
-import Checkbox from "@oxygen-ui/react/Checkbox";
 import FormControl from "@oxygen-ui/react/FormControl";
 import FormControlLabel from "@oxygen-ui/react/FormControlLabel";
 import Grid from "@oxygen-ui/react/Grid";

--- a/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
+++ b/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
@@ -1068,10 +1068,11 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
             const unshareSuccess: boolean = await unshareWithAllOrganizations();
 
             if (unshareSuccess) {
-                setShowShareTypeSwitchModal(false);
                 setShareType(ShareType.SHARE_SELECTED);
                 setRoleShareTypeSelected(RoleShareType.SHARE_SELECTED);
             }
+
+            setShowShareTypeSwitchModal(false);
         } else if (shareTypeSwitchApproach === ShareTypeSwitchApproach.WITHOUT_UNSHARE) {
             // Switch to selective sharing without unsharing the application with all organizations
             // But we have to change the policy of the to selected org only from all existing and future orgs policy
@@ -1080,10 +1081,11 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
                 ApplicationSharingPolicy.ALL_EXISTING_ORGS_ONLY);
 
             if (shareSuccess) {
-                setShowShareTypeSwitchModal(false);
                 setShareType(ShareType.SHARE_SELECTED);
                 setRoleShareTypeSelected(RoleShareType.SHARE_SELECTED);
             }
+
+            setShowShareTypeSwitchModal(false);
         }
     };
 

--- a/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
+++ b/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
@@ -1068,6 +1068,7 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
             const unshareSuccess: boolean = await unshareWithAllOrganizations();
 
             if (unshareSuccess) {
+                setShowShareTypeSwitchModal(false);
                 setShareType(ShareType.SHARE_SELECTED);
                 setRoleShareTypeSelected(RoleShareType.SHARE_SELECTED);
             }
@@ -1079,6 +1080,7 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
                 ApplicationSharingPolicy.ALL_EXISTING_ORGS_ONLY);
 
             if (shareSuccess) {
+                setShowShareTypeSwitchModal(false);
                 setShareType(ShareType.SHARE_SELECTED);
                 setRoleShareTypeSelected(RoleShareType.SHARE_SELECTED);
             }
@@ -1147,7 +1149,6 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
                         }
 
                         switchShareTypeFromAllToSelected();
-                        setShowShareTypeSwitchModal(false);
                     } }
                     onSecondaryActionClick={ (): void => {
                         setShowShareTypeSwitchModal(false);

--- a/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
+++ b/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
@@ -148,7 +148,7 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
 
     const [ shareType, setShareType ] = useState<ShareType>(ShareType.UNSHARE);
     const [ roleShareTypeAll, setRoleShareTypeAll ] = useState<RoleShareType>(RoleShareType.SHARE_WITH_ALL);
-    const [ roleShareTypeSelected, setRoleShareTypeSelected ] = useState<RoleShareType>(RoleShareType.SHARE_WITH_ALL);
+    const [ roleShareTypeSelected, setRoleShareTypeSelected ] = useState<RoleShareType>(RoleShareType.SHARE_SELECTED);
     const { isOrganizationManagementEnabled } = useGlobalVariables();
     const [ showConfirmationModal, setShowConfirmationModal ] = useState<boolean>(false);
     const [ showShareTypeSwitchModal, setShowShareTypeSwitchModal ] = useState<boolean>(false);
@@ -1070,7 +1070,7 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
 
             if (unshareSuccess) {
                 setShareType(ShareType.SHARE_SELECTED);
-                setRoleShareTypeSelected(RoleShareType.SHARE_WITH_ALL);
+                setRoleShareTypeSelected(RoleShareType.SHARE_SELECTED);
             }
         } else if (shareTypeSwitchApproach === ShareTypeSwitchApproach.WITHOUT_UNSHARE) {
             // Switch to selective sharing without unsharing the application with all organizations
@@ -1081,7 +1081,7 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
 
             if (shareSuccess) {
                 setShareType(ShareType.SHARE_SELECTED);
-                setRoleShareTypeSelected(RoleShareType.SHARE_WITH_ALL);
+                setRoleShareTypeSelected(RoleShareType.SHARE_SELECTED);
             }
         }
     };
@@ -1426,29 +1426,28 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
                                             className="ml-5"
                                         >
                                             <Grid xs={ 12 }>
-                                                <FormControlLabel
-                                                    control={ (
-                                                        <Checkbox
-                                                            checked={
-                                                                roleShareTypeSelected === RoleShareType.SHARE_WITH_ALL }
-                                                        />
-                                                    ) }
-                                                    label="Share all roles with selected organizations"
+                                                <Button
+                                                    variant="text"
+                                                    size="small"
                                                     data-componentid={
-                                                        `${ componentId }-share-all-roles-with-selected-orgs-checkbox` }
-                                                    value={ roleShareTypeSelected === RoleShareType.SHARE_WITH_ALL }
-                                                    onChange={ (
-                                                        _event: ChangeEvent<HTMLInputElement>,
-                                                        checked: boolean
-                                                    ) => {
-                                                        if (checked) {
-                                                            setRoleShareTypeSelected(RoleShareType.SHARE_WITH_ALL);
-                                                        } else {
+                                                        `${ componentId }-share-all-roles-with-selected-orgs-btn` }
+                                                    onClick={ () => {
+                                                        if (roleShareTypeSelected === RoleShareType.SHARE_WITH_ALL) {
                                                             setRoleShareTypeSelected(RoleShareType.SHARE_SELECTED);
+                                                        } else if (roleShareTypeSelected ===
+                                                            RoleShareType.SHARE_SELECTED) {
+                                                            setRoleShareTypeSelected(RoleShareType.SHARE_WITH_ALL);
                                                         }
                                                     } }
                                                     disabled={ readOnly }
-                                                />
+                                                >
+                                                    {
+                                                        roleShareTypeSelected === RoleShareType.SHARE_WITH_ALL
+                                                            ? t("applications:edit.sections.sharedAccess." +
+                                                                "shareSelectedRoles")
+                                                            : t("applications:edit.sections.sharedAccess.shareAllRoles")
+                                                    }
+                                                </Button>
                                                 <SelectiveOrgShareWithSelectiveRoles
                                                     applicationId={ application?.id }
                                                     applicationRolesList={ applicationRolesList }

--- a/features/admin.console-settings.v1/components/console-shared-access/console-shared-access.tsx
+++ b/features/admin.console-settings.v1/components/console-shared-access/console-shared-access.tsx
@@ -235,7 +235,6 @@ const ConsoleSharedAccess: FunctionComponent<ConsoleSharedAccessPropsInterface> 
         setRoleSelections({});
         setSelectedRoles([ administratorRole?.Resources[0] ]);
         setInitialSelectedRoles([ administratorRole?.Resources[0] ]);
-        mutateOriginalOrganizationTree();
         setClearAdvancedRoleSharing(false);
     };
 


### PR DESCRIPTION
This pull request updates the application sharing UI in the admin portal to improve the user experience when choosing how to share roles with selected organizations. The main change is replacing the "Share all" checkbox with a toggle button, and ensuring the default and post-action states are consistent with the new UI logic.

**UI/UX Improvements:**

* Changed the "Share all roles with selected organizations" option from a `Checkbox` to a `Button` in `share-application-form-updated.tsx`, providing a clearer and more intuitive toggle between sharing all roles or selected roles.
* Updated the button label to dynamically reflect the current sharing mode, using translation keys for clarity.

**State Management Adjustments:**

* Changed the default value of `roleShareTypeSelected` from `SHARE_WITH_ALL` to `SHARE_SELECTED` to align with the new UX, and ensured that after unshare/share actions, the state resets to `SHARE_SELECTED` instead of `SHARE_WITH_ALL`. [[1]](diffhunk://#diff-777e2df3a05f31f3c5b5812da2acecc58f005468bb4f839d0774d2f1108a097dL151-R151) [[2]](diffhunk://#diff-777e2df3a05f31f3c5b5812da2acecc58f005468bb4f839d0774d2f1108a097dL1073-R1073) [[3]](diffhunk://#diff-777e2df3a05f31f3c5b5812da2acecc58f005468bb4f839d0774d2f1108a097dL1084-R1084)

**Documentation:**

* Added a changeset describing the UI change from checkbox to button for the share all operation.


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
