### PR TITLE
Fix invited user registration flow initiation depending on legacy config

### DIFF
--- a/.changeset/modern-schools-tell.md
+++ b/.changeset/modern-schools-tell.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.users.v1": patch
+---
+
+Fix invited user registration initiation depending on legacy config

--- a/.changeset/modern-schools-tell.md
+++ b/.changeset/modern-schools-tell.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
 ---
 
 Fix invited user registration initiation depending on legacy config

--- a/features/admin.users.v1/package.json
+++ b/features/admin.users.v1/package.json
@@ -27,7 +27,7 @@
         "@wso2is/admin.core.v1": "^2.49.17",
         "@wso2is/admin.extensions.v1": "^2.40.1",
         "@wso2is/admin.feature-gate.v1": "^1.7.4",
-        "@wso2is/admin.flows.v1": "^1.0.18",
+        "@wso2is/admin.flows.v1": "workspace:^",
         "@wso2is/admin.groups.v1": "^2.27.123",
         "@wso2is/admin.identity-providers.v1": "^2.26.206",
         "@wso2is/admin.organizations.v1": "^2.27.2",

--- a/features/admin.users.v1/package.json
+++ b/features/admin.users.v1/package.json
@@ -27,7 +27,7 @@
         "@wso2is/admin.core.v1": "^2.49.17",
         "@wso2is/admin.extensions.v1": "^2.40.1",
         "@wso2is/admin.feature-gate.v1": "^1.7.4",
-        "@wso2is/admin.flows.v1": "workspace:^",
+        "@wso2is/admin.flows.v1": "^1.0.18",
         "@wso2is/admin.groups.v1": "^2.27.123",
         "@wso2is/admin.identity-providers.v1": "^2.26.206",
         "@wso2is/admin.organizations.v1": "^2.27.2",

--- a/features/admin.users.v1/package.json
+++ b/features/admin.users.v1/package.json
@@ -27,6 +27,7 @@
         "@wso2is/admin.core.v1": "^2.49.17",
         "@wso2is/admin.extensions.v1": "^2.40.1",
         "@wso2is/admin.feature-gate.v1": "^1.7.4",
+        "@wso2is/admin.flows.v1": "workspace:^",
         "@wso2is/admin.groups.v1": "^2.27.123",
         "@wso2is/admin.identity-providers.v1": "^2.26.206",
         "@wso2is/admin.organizations.v1": "^2.27.2",

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -32,6 +32,8 @@ import { userstoresConfig } from "@wso2is/admin.extensions.v1";
 import { userConfig } from "@wso2is/admin.extensions.v1/configs";
 import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
 import { FeatureStatusLabel } from "@wso2is/admin.feature-gate.v1/models/feature-status";
+import  useGetFlowConfig from "@wso2is/admin.flows.v1/api/use-get-flow-config";
+import { FlowTypes } from "@wso2is/admin.flows.v1/models/flows";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import {
     ConnectorPropertyInterface,
@@ -159,6 +161,10 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
     );
     const hasGuestUserCreatePermissions: boolean = useRequiredScopes(
         featureConfig?.guestUser?.scopes?.create
+    );
+
+    const { data: invitedUserRegistrationConfigs } = useGetFlowConfig(
+        FlowTypes.INVITED_USER_REGISTRATION
     );
 
     const [ searchQuery, setSearchQuery ] = useState<string>("");
@@ -615,7 +621,8 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                     (property: ConnectorPropertyInterface) =>
                         property.name === ServerConfigurationsConstants.EMAIL_VERIFICATION_ENABLED);
 
-                setEmailVerificationEnabled(emailVerification.value === "true");
+                setEmailVerificationEnabled(emailVerification.value === "true" ||
+                    invitedUserRegistrationConfigs?.isEnabled);
             }).catch((error: AxiosError) => {
                 handleAlerts({
                     description: error?.response?.data?.description ?? t(

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -32,7 +32,7 @@ import { userstoresConfig } from "@wso2is/admin.extensions.v1";
 import { userConfig } from "@wso2is/admin.extensions.v1/configs";
 import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
 import { FeatureStatusLabel } from "@wso2is/admin.feature-gate.v1/models/feature-status";
-import  useGetFlowConfig from "@wso2is/admin.flows.v1/api/use-get-flow-config";
+import useGetFlowConfig from "@wso2is/admin.flows.v1/api/use-get-flow-config";
 import { FlowTypes } from "@wso2is/admin.flows.v1/models/flows";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19267,6 +19267,9 @@ importers:
       '@wso2is/admin.feature-gate.v1':
         specifier: ^1.7.4
         version: link:../admin.feature-gate.v1
+      '@wso2is/admin.flows.v1':
+        specifier: workspace:^
+        version: link:../admin.flows.v1
       '@wso2is/admin.groups.v1':
         specifier: ^2.27.123
         version: link:../admin.groups.v1
@@ -43945,8 +43948,6 @@ packages:
       webpack: '*'
     peerDependenciesMeta:
       webpack:
-        optional: true
-      webpack-sources:
         optional: true
     dependencies:
       webpack: 5.84.1(@swc/core@1.3.99)(esbuild@0.18.20)(webpack-cli@4.10.0)


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24944

This pull request introduces support for flow-based configuration in the user management feature, specifically for invited user registration. The main change is the integration of the `@wso2is/admin.flows.v1` package and its use to determine if invited user registration is enabled, which impacts the email verification logic.

**Flow configuration integration:**

* Added `@wso2is/admin.flows.v1` as a dependency in `package.json` to enable flow-based features.
* Imported `useGetFlowConfig` and `FlowTypes` from `@wso2is/admin.flows.v1` in `users.tsx` to fetch flow configuration for invited user registration.
* Utilized `useGetFlowConfig` to retrieve the configuration for `INVITED_USER_REGISTRATION` flow in the `UsersPage` component.

**Email verification logic update:**

* Modified the logic for setting `emailVerificationEnabled` to also consider if invited user registration is enabled via flow configuration, not just the connector property.