### PR TITLE
[bug-fix] UI side fix for dataType mismatch in claim-dialect and scim2 config for totpEnabled and backupCodeEnabled.

### DIFF
--- a/.changeset/many-comics-bake.md
+++ b/.changeset/many-comics-bake.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+A fix to dataType mismatch for totpEnabled and backupCodeEnabled claims.

--- a/.changeset/nine-books-fail.md
+++ b/.changeset/nine-books-fail.md
@@ -1,6 +1,0 @@
----
-"@wso2is/admin.core.v1": patch
-"@wso2is/console": patch
----
-
-"A fix to dataType mismatch for totpEnabled and backupCodeEnabled claims."


### PR DESCRIPTION
### Purpose
A UI side fix to handle the `dataType` mismatch for `totpEnabled` and `backupCodeEnabled` claims. 


### Related Issues
- https://github.com/wso2/product-is/issues/24814

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
