### PR TITLE
[Next] Fixing app branding not getting applied to Username recovery channel selection page

### DIFF
--- a/.changeset/sweet-scissors-drum.md
+++ b/.changeset/sweet-scissors-drum.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix app branding not getting applied to Username recovery channel selection page

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery-channel.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery-channel.jsp
@@ -199,6 +199,7 @@
                         </div>
                         <div>
                             <input type="hidden" name="sp" value="<%=Encode.forHtmlAttribute(request.getParameter("sp"))%>"/>
+                            <input type="hidden" name="spId" value="<%=Encode.forHtmlAttribute(request.getParameter("spId"))%>"/>
                         </div>
 
                         <% } %>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -254,6 +254,7 @@
                         </div>
                         <div>
                             <input type="hidden" name="sp" value="<%=Encode.forHtmlAttribute(request.getParameter("sp"))%>"/>
+                            <input type="hidden" name="spId" value="<%=Encode.forHtmlAttribute(request.getParameter("spId"))%>"/>
                         </div>
                         <%
                             }


### PR DESCRIPTION
### Purpose

>  $subject


### Related Issues
- https://github.com/wso2/product-is/issues/24039

### Related PRs
- https://github.com/wso2/identity-apps/pull/8785

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
