### PR TITLE
Enhance onboarding flow with localized error messages for validation failures

### DIFF
--- a/.changeset/rare-jokes-beam.md
+++ b/.changeset/rare-jokes-beam.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+add error messages for pre-update password validation in multiple languages

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources.properties
@@ -105,6 +105,8 @@ orchestration.flow.error.invalid.flowType.message=Invalid Flow Type
 orchestration.flow.error.invalid.flowType.description=The provided flow type is not supported
 orchestration.flow.error.disabled.flow.message=Flow Disabled
 orchestration.flow.error.disabled.flow.description=The requested flow is disabled. Please contact your administrator
+orchestration.flow.error.preUpdatePassword.action.failure.message=Password validation failed
+orchestration.flow.error.preUpdatePassword.action.failure.description=Please provide a different password
 
 # Invite user registration errors
 invite.user.registration.flow.error.undefined.flow.id.message=Flow Id is not Defined

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_de_DE.properties
@@ -96,6 +96,8 @@ orchestration.flow.error.invalid.flowType.message=Ungültiger Flow-Typ
 orchestration.flow.error.invalid.flowType.description=Der angegebene Flow-Typ wird nicht unterstützt
 orchestration.flow.error.disabled.flow.message=Flow deaktiviert
 orchestration.flow.error.disabled.flow.description=Der angeforderte Flow ist deaktiviert. Bitte kontaktiere den Administrator
+orchestration.flow.error.preUpdatePassword.action.failure.message=Passwortvalidierung fehlgeschlagen
+orchestration.flow.error.preUpdatePassword.action.failure.description=Bitte geben Sie ein anderes Passwort ein
 
 # Invite user registration errors
 invite.user.registration.flow.error.undefined.flow.id.message=Flow-ID nicht definiert

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_es_ES.properties
@@ -96,6 +96,8 @@ orchestration.flow.error.invalid.flowType.message=Tipo de flujo inválido
 orchestration.flow.error.invalid.flowType.description=El tipo de flujo proporcionado no es compatible
 orchestration.flow.error.disabled.flow.message=Flujo deshabilitado
 orchestration.flow.error.disabled.flow.description=El flujo solicitado está deshabilitado. Contacta al administrador
+orchestration.flow.error.preUpdatePassword.action.failure.message=Fallo en la validación de la contraseña
+orchestration.flow.error.preUpdatePassword.action.failure.description=Por favor, proporciona una contraseña diferente
 
 # Invite user registration errors
 invite.user.registration.flow.error.undefined.flow.id.message=ID de flujo no definido

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_fr_FR.properties
@@ -96,6 +96,8 @@ orchestration.flow.error.invalid.flowType.message=Type de flux invalide
 orchestration.flow.error.invalid.flowType.description=Le type de flux fourni n'est pas pris en charge
 orchestration.flow.error.disabled.flow.message=Flux désactivé
 orchestration.flow.error.disabled.flow.description=Le flux demandé est désactivé. Veuillez contacter l'administrateur
+orchestration.flow.error.preUpdatePassword.action.failure.message=Échec de la validation du mot de passe
+orchestration.flow.error.preUpdatePassword.action.failure.description=Veuillez fournir un mot de passe différent
 
 # Invite user registration errors
 invite.user.registration.flow.error.undefined.flow.id.message=ID du flux non défini

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_ja_JP.properties
@@ -96,6 +96,8 @@ orchestration.flow.error.invalid.flowType.message=無効なフロータイプ
 orchestration.flow.error.invalid.flowType.description=指定されたフロータイプはサポートされていません
 orchestration.flow.error.disabled.flow.message=フローが無効です
 orchestration.flow.error.disabled.flow.description=リクエストされたフローは無効化されています。管理者にお問い合わせください
+orchestration.flow.error.preUpdatePassword.action.failure.message=パスワードの検証に失敗しました
+orchestration.flow.error.preUpdatePassword.action.failure.description=別のパスワードを入力してください
 
 # Invite user registration errors
 invite.user.registration.flow.error.undefined.flow.id.message=フローIDが定義されていません

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_BR.properties
@@ -96,6 +96,8 @@ orchestration.flow.error.invalid.flowType.message=Tipo de fluxo inválido
 orchestration.flow.error.invalid.flowType.description=O tipo de fluxo fornecido não é suportado
 orchestration.flow.error.disabled.flow.message=Fluxo desativado
 orchestration.flow.error.disabled.flow.description=O fluxo solicitado está desativado. Entre em contato com o administrador
+orchestration.flow.error.preUpdatePassword.action.failure.message=Falha na validação da senha
+orchestration.flow.error.preUpdatePassword.action.failure.description=Por favor, forneça uma senha diferente
 
 # Invite user registration errors
 invite.user.registration.flow.error.undefined.flow.id.message=ID do fluxo não definido

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_PT.properties
@@ -96,6 +96,8 @@ orchestration.flow.error.invalid.flowType.message=Tipo de fluxo inválido
 orchestration.flow.error.invalid.flowType.description=O tipo de fluxo fornecido não é suportado
 orchestration.flow.error.disabled.flow.message=Fluxo desativado
 orchestration.flow.error.disabled.flow.description=O fluxo solicitado está desativado. Contacte o administrador
+orchestration.flow.error.preUpdatePassword.action.failure.message=Falha na validação da senha
+orchestration.flow.error.preUpdatePassword.action.failure.description=Por favor, forneça uma senha diferente
 
 # Invite user registration errors
 invite.user.registration.flow.error.undefined.flow.id.message=ID do fluxo não definido

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_zh_CN.properties
@@ -96,6 +96,8 @@ orchestration.flow.error.invalid.flowType.message=流程类型无效
 orchestration.flow.error.invalid.flowType.description=所提供的流程类型不受支持
 orchestration.flow.error.disabled.flow.message=流程已禁用
 orchestration.flow.error.disabled.flow.description=请求的流程已被禁用。请联系管理员
+orchestration.flow.error.preUpdatePassword.action.failure.message=密码验证失败
+orchestration.flow.error.preUpdatePassword.action.failure.description=请提供一个不同的密码
 
 # Invite user registration errors
 invite.user.registration.flow.error.undefined.flow.id.message=未定义流程 ID

--- a/identity-apps-core/apps/accounts/src/main/webapp/js/error-utils.js
+++ b/identity-apps-core/apps/accounts/src/main/webapp/js/error-utils.js
@@ -180,6 +180,13 @@ function getI18nKeyForError(errorCode, flowType) {
                 description: "orchestration.flow.error.disabled.flow.description"
             };
 
+        case "FE-60012":
+
+            return {
+                message: "orchestration.flow.error.preUpdatePassword.action.failure.message",
+                description: "orchestration.flow.error.preUpdatePassword.action.failure.description"
+            };
+
         default:
 
             return {


### PR DESCRIPTION
This pull request adds support for a new password validation error in the account orchestration flow. Specifically, it introduces a new error code (`FE-60012`) for pre-update password validation failures, along with localized error messages and descriptions in all supported languages.

**Error handling improvements:**

* Added handling for error code `FE-60012` in `getI18nKeyForError` to return the appropriate message and description keys for pre-update password validation failures in `error-utils.js`.

**Localization updates:**

* Added new error message (`orchestration.flow.error.preUpdatePassword.action.failure.message`) and description (`orchestration.flow.error.preUpdatePassword.action.failure.description`) for pre-update password validation failures to English resource file `Resources.properties`.
* Added corresponding translations for the new error message and description in supported languages



### Related Issues
- https://github.com/wso2/product-is/issues/25279

### Related PRs
- https://github.com/wso2/carbon-identity-framework/pull/7207

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
