### PR TITLE
[bug-fix] Fix inconsistency in radio group field in Console and My Account

### DIFF
--- a/.changeset/good-feet-promise.md
+++ b/.changeset/good-feet-promise.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Fix inconsistency in radio group field in Console

--- a/features/admin.users.v1/components/user-profile/fields/radio-group-form-field.tsx
+++ b/features/admin.users.v1/components/user-profile/fields/radio-group-form-field.tsx
@@ -19,6 +19,7 @@
 import { LabelValue } from "@wso2is/core/models";
 import { FinalFormField, RadioGroupFieldAdapter } from "@wso2is/form";
 import React, { FunctionComponent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
 import { RadioGroupFormFieldPropsInterface } from "../../../models/ui";
 
 /**
@@ -37,7 +38,17 @@ const RadioGroupFormField: FunctionComponent<RadioGroupFormFieldPropsInterface> 
         ["data-componentid"]: componentId = "radio-group-form-field"
     }: RadioGroupFormFieldPropsInterface
 ): ReactElement => {
-    const radioOptions: LabelValue[] = schema.canonicalValues ?? [];
+    const { t } = useTranslation();
+
+    let radioOptions: LabelValue[] = schema.canonicalValues ?? [];
+
+    if (!isRequired) {
+        // Add an empty value option when the field is optional.
+        radioOptions = [
+            { label: t("common:none"), value: "" },
+            ...radioOptions
+        ];
+    }
 
     return (
         <FinalFormField

--- a/modules/i18n/src/models/namespaces/common-ns.ts
+++ b/modules/i18n/src/models/namespaces/common-ns.ts
@@ -213,6 +213,7 @@ export interface CommonNS {
     name: string;
     new: string;
     next: string;
+    none: string;
     organizationName: string;
     operatingSystem: string;
     operations: string;

--- a/modules/i18n/src/translations/de-DE/portals/common.ts
+++ b/modules/i18n/src/translations/de-DE/portals/common.ts
@@ -233,6 +233,7 @@ export const common: CommonNS = {
     "new": "Neu",
     "next": "Nächster",
     "noResultsFound": "Keine Ergebnisse gefunden",
+    "none": "Keine",
     "okay": "Okay",
     "operatingSystem": "Betriebssystem",
     "operationType": "Operationstyp",

--- a/modules/i18n/src/translations/en-US/portals/common.ts
+++ b/modules/i18n/src/translations/en-US/portals/common.ts
@@ -233,6 +233,7 @@ export const common: CommonNS = {
     new: "New",
     next: "Next",
     noResultsFound: "No results found",
+    none: "None",
     okay: "Okay",
     operatingSystem: "Operating system",
     operationType: "Operation Type",

--- a/modules/i18n/src/translations/es-ES/portals/common.ts
+++ b/modules/i18n/src/translations/es-ES/portals/common.ts
@@ -233,6 +233,7 @@ export const common: CommonNS = {
     new: "Nuevo",
     next: "próximo",
     noResultsFound: "No se han encontrado resultados",
+    none: "Ninguna",
     okay: "Okey",
     operatingSystem: "Sistema operativo",
     operationType: "Tipo de operación",

--- a/modules/i18n/src/translations/fr-FR/portals/common.ts
+++ b/modules/i18n/src/translations/fr-FR/portals/common.ts
@@ -234,6 +234,7 @@ export const common: CommonNS = {
     new: "Nouveau",
     next: "Suivant",
     noResultsFound: "Aucun résultat trouvé",
+    none: "Aucun",
     okay: "d'accord",
     operatingSystem: "Système d'exploitation",
     operationType: "Type d'opération",

--- a/modules/i18n/src/translations/ja-JP/portals/common.ts
+++ b/modules/i18n/src/translations/ja-JP/portals/common.ts
@@ -233,6 +233,7 @@ export const common: CommonNS = {
     "new": "新しい",
     "next": "次",
     "noResultsFound": "結果が見つかりません",
+    "none": "なし",
     "okay": "わかった",
     "operatingSystem": "オペレーティング·システム",
     "operationType": "操作タイプ",

--- a/modules/i18n/src/translations/pt-BR/portals/common.ts
+++ b/modules/i18n/src/translations/pt-BR/portals/common.ts
@@ -233,6 +233,7 @@ export const common: CommonNS = {
     new: "Novo",
     next: "Próximo",
     noResultsFound: "Nenhum resultado encontrado",
+    none: "Nenhum",
     okay: "Ok",
     operatingSystem: "Sistema operacional",
     operationType: "Tipo de Operação",

--- a/modules/i18n/src/translations/pt-PT/portals/common.ts
+++ b/modules/i18n/src/translations/pt-PT/portals/common.ts
@@ -233,6 +233,7 @@ export const common: CommonNS = {
     new: "novo",
     next: "Próximo",
     noResultsFound: "Nenhum resultado encontrado",
+    none: "Nenhum",
     okay: "OK",
     operatingSystem: "Sistema operacional",
     operationType: "Tipo de Operação",

--- a/modules/i18n/src/translations/si-LK/portals/common.ts
+++ b/modules/i18n/src/translations/si-LK/portals/common.ts
@@ -233,6 +233,7 @@ export const common: CommonNS = {
     new: "නවතම",
     next: "ඊළඟ ",
     noResultsFound: "ප්‍රතිඵල හමු නොවීය",
+    none: "කිසිවක් නැත",
     okay: "හරි",
     operatingSystem: "මෙහෙයුම් පද්ධතිය",
     operationType: "ක්‍රියාකාරී වර්ගය",

--- a/modules/i18n/src/translations/ta-IN/portals/common.ts
+++ b/modules/i18n/src/translations/ta-IN/portals/common.ts
@@ -234,6 +234,7 @@ export const common: CommonNS = {
     new: "புதிய",
     next: "அடுத்தது",
     noResultsFound: "முடிவுகள் எதுவும் இல்லை",
+    none: "இல்லை",
     okay: "சரி",
     operatingSystem: "இயங்கு தளம்",
     operationType: "செயலாக்க வகை",

--- a/modules/i18n/src/translations/zh-CN/portals/common.ts
+++ b/modules/i18n/src/translations/zh-CN/portals/common.ts
@@ -233,6 +233,7 @@ export const common: CommonNS = {
     "new": "新的",
     "next": "下一个",
     "noResultsFound": "未找到结果",
+    "none": "没有任何",
     "okay": "好的",
     "operatingSystem": "操作系统",
     "operationType": "操作类型",


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Fix the inconsistency in the radio group field when showing the `None` option, in Console and My Account

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/25333

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
