### PR TITLE
[Next] Add Magic Link widget and execution step to flow builder

### DIFF
--- a/features/admin.ask-password-flow-builder.v1/data/widgets.json
+++ b/features/admin.ask-password-flow-builder.v1/data/widgets.json
@@ -310,5 +310,89 @@
                 ]
             }
         }
+    },
+    {
+        "resourceType": "WIDGET",
+        "category": "FLOW",
+        "type": "MAGIC_LINK",
+        "version": "0.1.0",
+        "deprecated": false,
+        "display": {
+            "label": "Continue with Magic Link",
+            "description": "Registration experience with Magic Link",
+            "image": "https://www.svgrepo.com/show/532869/link-alt-1.svg",
+            "showOnResourcePanel": true
+        },
+        "config": {
+            "data": {
+                "__generationMeta__": {
+                    "defaultPropertySelectorId": "{{MAGIC_LINK_EXECUTION_STEP_ID}}",
+                    "replacers": [
+                        {
+                            "key": "MAGIC_LINK_EXECUTION_STEP_ID",
+                            "type": "ID"
+                        }
+                    ]
+                },
+                "steps": [
+                    {
+                        "__generationMeta__": {
+                            "strategy": "MERGE_WITH_DROP_POINT"
+                        },
+                        "type": "VIEW",
+                        "data": {
+                            "components": [
+                                {
+                                    "id": "{{ID}}",
+                                    "category": "ACTION",
+                                    "type": "BUTTON",
+                                    "variant": "SOCIAL",
+                                    "config": {
+                                        "type": "button",
+                                        "text": "Continue with Magic Link",
+                                        "image": "https://www.svgrepo.com/show/532869/link-alt-1.svg"
+                                    },
+                                    "action": {
+                                        "type": "NEXT",
+                                        "next": "{{MAGIC_LINK_EXECUTION_STEP_ID}}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "{{MAGIC_LINK_EXECUTION_STEP_ID}}",
+                        "type": "EXECUTION",
+                        "size": {
+                            "width": 350,
+                            "height": 291
+                        },
+                        "position": {
+                            "x": 690,
+                            "y": 500
+                        },
+                        "data": {
+                            "action": {
+                                "type": "EXECUTOR",
+                                "executor": {
+                                    "name": "MagicLinkExecutor"
+                                },
+                                "next": "End"
+                            },
+                            "components": [
+                                {
+                                    "id": "{{ID}}",
+                                    "category": "DISPLAY",
+                                    "type": "RICH_TEXT",
+                                    "config": {
+                                        "text": "<h3 class=\"rich-text-heading-h3 rich-text-align-center\"><span class=\"rich-text-pre-wrap\">Check Your Email</span></h3><h5 class=\"rich-text-heading-h5 rich-text-align-center\"><br><span class=\"rich-text-pre-wrap\">An email containing further instructions has been sent to your email address. Please check your inbox to continue.</span></h5>"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
     }
 ]

--- a/features/admin.flow-builder-core.v1/constants/visual-flow-constants.ts
+++ b/features/admin.flow-builder-core.v1/constants/visual-flow-constants.ts
@@ -65,7 +65,8 @@ class VisualFlowConstants {
         WidgetTypes.FacebookFederation,
         WidgetTypes.MicrosoftFederation,
         WidgetTypes.GithubFederation,
-        WidgetTypes.PasskeyEnrollment
+        WidgetTypes.PasskeyEnrollment,
+        WidgetTypes.MagicLink
     ];
 
     public static readonly FLOW_BUILDER_FORM_ALLOWED_RESOURCE_TYPES: string[] = [

--- a/features/admin.flow-builder-core.v1/data/steps.json
+++ b/features/admin.flow-builder-core.v1/data/steps.json
@@ -167,5 +167,36 @@
             "showOnResourcePanel": false
         },
         "config": {}
+    },
+    {
+        "resourceType": "STEP",
+        "category": "WORKFLOW",
+        "type": "EXECUTION",
+        "version": "0.1.0",
+        "deprecated": false,
+        "display": {
+            "label": "Magic Link View",
+            "image": "https://www.svgrepo.com/show/532869/link-alt-1.svg",
+            "showOnResourcePanel": true
+        },
+        "data": {
+            "action": {
+                "type": "EXECUTOR",
+                "executor": {
+                    "name": "MagicLinkExecutor"
+                },
+                "next": ""
+            },
+            "components": [
+                {
+                    "id": "{{ID}}",
+                    "category": "DISPLAY",
+                    "type": "RICH_TEXT",
+                    "config": {
+                        "text": "<h3 class=\"rich-text-heading-h3 rich-text-align-center\"><span class=\"rich-text-pre-wrap\">Check Your Email</span></h3><h5 class=\"rich-text-heading-h5 rich-text-align-center\"><br><span class=\"rich-text-pre-wrap\">An email containing further instructions has been sent to your email address. Please check your inbox to continue.</span></h5>"
+                    }
+                }
+            ]
+        }
     }
 ]

--- a/features/admin.flow-builder-core.v1/hooks/use-static-content-field.tsx
+++ b/features/admin.flow-builder-core.v1/hooks/use-static-content-field.tsx
@@ -24,7 +24,7 @@ import VisualFlowConstants from "../constants/visual-flow-constants";
 import { Properties } from "../models/base";
 import { Element, ElementCategories, ElementTypes } from "../models/elements";
 import { EventTypes } from "../models/extension";
-import { StepTypes } from "../models/steps";
+import { ExecutionTypes, StepTypes } from "../models/steps";
 import PluginRegistry from "../plugins/plugin-registry";
 import generateResourceId from "../utils/generate-resource-id";
 
@@ -117,6 +117,10 @@ const useStaticContentField = (): void => {
         // Check if this is a execution step.
         if (resource?.type === StepTypes.Execution && VisualFlowConstants
             .FLOW_BUILDER_STATIC_CONTENT_ALLOWED_EXECUTION_TYPES.includes(resource?.data?.action?.executor?.name)) {
+
+            if (resource?.data?.action?.executor?.name === ExecutionTypes.MagicLinkExecutor) {
+                return true;
+            }
             const components: Element[] = (node?.data?.components as Element[]) || [];
 
             properties[STATIC_CONTENT_ENABLED_PROPERTY] = components.length > 0;

--- a/features/admin.flow-builder-core.v1/models/widget.ts
+++ b/features/admin.flow-builder-core.v1/models/widget.ts
@@ -47,4 +47,5 @@ export enum WidgetTypes {
     MicrosoftFederation = "MICROSOFT_FEDERATION",
     GithubFederation = "GITHUB_FEDERATION",
     PasskeyEnrollment = "PASSKEY_ENROLLMENT",
+    MagicLink = "MAGIC_LINK",
 }

--- a/features/admin.password-recovery-flow-builder.v1/data/widgets.json
+++ b/features/admin.password-recovery-flow-builder.v1/data/widgets.json
@@ -228,5 +228,89 @@
                 ]
             }
         }
+    },
+    {
+        "resourceType": "WIDGET",
+        "category": "FLOW",
+        "type": "MAGIC_LINK",
+        "version": "0.1.0",
+        "deprecated": false,
+        "display": {
+            "label": "Continue with Magic Link",
+            "description": "Registration experience with Magic Link",
+            "image": "https://www.svgrepo.com/show/532869/link-alt-1.svg",
+            "showOnResourcePanel": true
+        },
+        "config": {
+            "data": {
+                "__generationMeta__": {
+                    "defaultPropertySelectorId": "{{MAGIC_LINK_EXECUTION_STEP_ID}}",
+                    "replacers": [
+                        {
+                            "key": "MAGIC_LINK_EXECUTION_STEP_ID",
+                            "type": "ID"
+                        }
+                    ]
+                },
+                "steps": [
+                    {
+                        "__generationMeta__": {
+                            "strategy": "MERGE_WITH_DROP_POINT"
+                        },
+                        "type": "VIEW",
+                        "data": {
+                            "components": [
+                                {
+                                    "id": "{{ID}}",
+                                    "category": "ACTION",
+                                    "type": "BUTTON",
+                                    "variant": "SOCIAL",
+                                    "config": {
+                                        "type": "button",
+                                        "text": "Continue with Magic Link",
+                                        "image": "https://www.svgrepo.com/show/532869/link-alt-1.svg"
+                                    },
+                                    "action": {
+                                        "type": "NEXT",
+                                        "next": "{{MAGIC_LINK_EXECUTION_STEP_ID}}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "{{MAGIC_LINK_EXECUTION_STEP_ID}}",
+                        "type": "EXECUTION",
+                        "size": {
+                            "width": 350,
+                            "height": 291
+                        },
+                        "position": {
+                            "x": 690,
+                            "y": 500
+                        },
+                        "data": {
+                            "action": {
+                                "type": "EXECUTOR",
+                                "executor": {
+                                    "name": "MagicLinkExecutor"
+                                },
+                                "next": "End"
+                            },
+                            "components": [
+                                {
+                                    "id": "{{ID}}",
+                                    "category": "DISPLAY",
+                                    "type": "RICH_TEXT",
+                                    "config": {
+                                        "text": "<h3 class=\"rich-text-heading-h3 rich-text-align-center\"><span class=\"rich-text-pre-wrap\">Check Your Email</span></h3><h5 class=\"rich-text-heading-h5 rich-text-align-center\"><br><span class=\"rich-text-pre-wrap\">An email containing further instructions has been sent to your email address. Please check your inbox to continue.</span></h5>"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
     }
 ]

--- a/features/admin.registration-flow-builder.v1/data/widgets.json
+++ b/features/admin.registration-flow-builder.v1/data/widgets.json
@@ -384,7 +384,7 @@
             }
         }
     },
-        {
+    {
         "resourceType": "WIDGET",
         "category": "COMPOSITE",
         "type": "IDENTIFIER_PASSWORD",
@@ -697,77 +697,161 @@
         }
     },
     {
-    "resourceType": "WIDGET",
-    "category": "FLOW",
-    "type": "PASSKEY_ENROLLMENT",
-    "version": "0.1.0",
-    "deprecated": false,
-    "display": {
-        "label": "Continue with Passkey",
-        "description": "Registration experience with Passkeys",
-        "image": "https://www.svgrepo.com/show/340307/fingerprint-recognition.svg",
-        "showOnResourcePanel": true
-    },
-    "config": {
-        "data": {
-            "__generationMeta__": {
-                "defaultPropertySelectorId": "{{PASSKEY_EXECUTION_STEP_ID}}",
-                "replacers": [
-                    {
-                        "key": "PASSKEY_EXECUTION_STEP_ID",
-                        "type": "ID"
-                    }
-                ]
-            },
-            "steps": [
-                {
-                    "__generationMeta__": {
-                        "strategy": "MERGE_WITH_DROP_POINT"
-                    },
-                    "type": "VIEW",
-                    "data": {
-                        "components": [
-                            {
-                                "id": "{{ID}}",
-                                "category": "ACTION",
-                                "type": "BUTTON",
-                                "variant": "SOCIAL",
-                                "config": {
-                                    "type": "button",
-                                    "text": "Continue with Passkey",
-                                    "image": "https://www.svgrepo.com/show/340307/fingerprint-recognition.svg"
-                                },
-                                "action": {
-                                    "type": "NEXT",
-                                    "next": "{{PASSKEY_EXECUTION_STEP_ID}}"
-                                }
-                            }
-                        ]
-                    }
+        "resourceType": "WIDGET",
+        "category": "FLOW",
+        "type": "PASSKEY_ENROLLMENT",
+        "version": "0.1.0",
+        "deprecated": false,
+        "display": {
+            "label": "Continue with Passkey",
+            "description": "Registration experience with Passkeys",
+            "image": "https://www.svgrepo.com/show/340307/fingerprint-recognition.svg",
+            "showOnResourcePanel": true
+        },
+        "config": {
+            "data": {
+                "__generationMeta__": {
+                    "defaultPropertySelectorId": "{{PASSKEY_EXECUTION_STEP_ID}}",
+                    "replacers": [
+                        {
+                            "key": "PASSKEY_EXECUTION_STEP_ID",
+                            "type": "ID"
+                        }
+                    ]
                 },
-                {
-                    "id": "{{PASSKEY_EXECUTION_STEP_ID}}",
-                    "type": "EXECUTION",
-                    "size": {
-                        "width": 350,
-                        "height": 291
+                "steps": [
+                    {
+                        "__generationMeta__": {
+                            "strategy": "MERGE_WITH_DROP_POINT"
+                        },
+                        "type": "VIEW",
+                        "data": {
+                            "components": [
+                                {
+                                    "id": "{{ID}}",
+                                    "category": "ACTION",
+                                    "type": "BUTTON",
+                                    "variant": "SOCIAL",
+                                    "config": {
+                                        "type": "button",
+                                        "text": "Continue with Passkey",
+                                        "image": "https://www.svgrepo.com/show/340307/fingerprint-recognition.svg"
+                                    },
+                                    "action": {
+                                        "type": "NEXT",
+                                        "next": "{{PASSKEY_EXECUTION_STEP_ID}}"
+                                    }
+                                }
+                            ]
+                        }
                     },
-                    "position": {
-                        "x": 690,
-                        "y": 500
-                    },
-                    "data": {
-                        "action": {
-                            "type": "EXECUTOR",
-                            "executor": {
-                                "name": "FIDO2Executor"
-                            },
-                            "next": "USER_ONBOARD"
+                    {
+                        "id": "{{PASSKEY_EXECUTION_STEP_ID}}",
+                        "type": "EXECUTION",
+                        "size": {
+                            "width": 350,
+                            "height": 291
+                        },
+                        "position": {
+                            "x": 690,
+                            "y": 500
+                        },
+                        "data": {
+                            "action": {
+                                "type": "EXECUTOR",
+                                "executor": {
+                                    "name": "FIDO2Executor"
+                                },
+                                "next": "USER_ONBOARD"
+                            }
                         }
                     }
-                }
-            ]
+                ]
+            }
+        }
+    },
+    {
+        "resourceType": "WIDGET",
+        "category": "FLOW",
+        "type": "MAGIC_LINK",
+        "version": "0.1.0",
+        "deprecated": false,
+        "display": {
+            "label": "Continue with Magic Link",
+            "description": "Registration experience with Magic Link",
+            "image": "https://www.svgrepo.com/show/532869/link-alt-1.svg",
+            "showOnResourcePanel": true
+        },
+        "config": {
+            "data": {
+                "__generationMeta__": {
+                    "defaultPropertySelectorId": "{{MAGIC_LINK_EXECUTION_STEP_ID}}",
+                    "replacers": [
+                        {
+                            "key": "MAGIC_LINK_EXECUTION_STEP_ID",
+                            "type": "ID"
+                        }
+                    ]
+                },
+                "steps": [
+                    {
+                        "__generationMeta__": {
+                            "strategy": "MERGE_WITH_DROP_POINT"
+                        },
+                        "type": "VIEW",
+                        "data": {
+                            "components": [
+                                {
+                                    "id": "{{ID}}",
+                                    "category": "ACTION",
+                                    "type": "BUTTON",
+                                    "variant": "SOCIAL",
+                                    "config": {
+                                        "type": "button",
+                                        "text": "Continue with Magic Link",
+                                        "image": "https://www.svgrepo.com/show/532869/link-alt-1.svg"
+                                    },
+                                    "action": {
+                                        "type": "NEXT",
+                                        "next": "{{MAGIC_LINK_EXECUTION_STEP_ID}}"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "id": "{{MAGIC_LINK_EXECUTION_STEP_ID}}",
+                        "type": "EXECUTION",
+                        "size": {
+                            "width": 350,
+                            "height": 291
+                        },
+                        "position": {
+                            "x": 690,
+                            "y": 500
+                        },
+                        "data": {
+                            "action": {
+                                "type": "EXECUTOR",
+                                "executor": {
+                                    "name": "MagicLinkExecutor"
+                                },
+                                "next": "USER_ONBOARD"
+                            },
+                            "components": [
+                                {
+                                    "id": "{{ID}}",
+                                    "category": "DISPLAY",
+                                    "type": "RICH_TEXT",
+                                    "config": {
+                                        "text": "<h3 class=\"rich-text-heading-h3 rich-text-align-center\"><span class=\"rich-text-pre-wrap\">Check Your Email</span></h3><h5 class=\"rich-text-heading-h5 rich-text-align-center\"><br><span class=\"rich-text-pre-wrap\">An email containing further instructions has been sent to your email address. Please check your inbox to continue.</span></h5>"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
         }
     }
-}
 ]


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/25424

## Behaviour
<img width="1907" height="965" alt="Screenshot 2025-08-25 at 10 51 00 AM" src="https://github.com/user-attachments/assets/5dad8a9e-8296-49c7-a0bb-a12ae16e5aed" />

## Implementation
This pull request introduces support for a "Magic Link" authentication flow across the registration, password recovery, and ask-password experiences. The changes add new widget and step definitions for the Magic Link flow, update core constants and enums to recognize the new type, and ensure static content handling for Magic Link execution steps. This enables a new registration and recovery experience where users receive instructions via email.

**Magic Link Flow Additions**

* Added new `MAGIC_LINK` widget definitions to `widgets.json` for registration, password recovery, and ask-password flows, enabling the Magic Link experience in each flow builder. [[1]](diffhunk://#diff-912a5a22e3ab0125dad33cea9f44824a54d781487b79e15ecdb11a64fc4f00b9R772-R855) [[2]](diffhunk://#diff-877ffeeed4b7aae53c3822c4ba8c68bd1a9c2269bd7a7476b2edf4da51965a3aR231-R314) [[3]](diffhunk://#diff-ec89a11dfea77928d504a7214bed5b589148d6e9f344b55ad28410cd4d73c01eR313-R396)
* Introduced a new "Magic Link View" execution step in `steps.json`, with display and executor configuration for the Magic Link email instructions.

**Core System Updates**

* Updated the `WidgetTypes` enum in `widget.ts` to include `MagicLink`, allowing the system to recognize and process this new widget type.
* Added `MagicLink` to the allowed widget types in `VisualFlowConstants`, making it available in the flow builder UI.
* Enhanced static content field logic in `use-static-content-field.tsx` to handle Magic Link execution steps, ensuring proper UI behavior for steps using the `MagicLinkExecutor`. [[1]](diffhunk://#diff-281285c03fafec036d7a08dba499979aa4c9fda8340d8f5087c611ea2f32e712L27-R27) [[2]](diffhunk://#diff-281285c03fafec036d7a08dba499979aa4c9fda8340d8f5087c611ea2f32e712R120-R123)