### PR TITLE
[Next] Fix invited user registration initiation depending on legacy config

### DIFF
--- a/.changeset/thin-lamps-appear.md
+++ b/.changeset/thin-lamps-appear.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Fix invited user registration initiation depending on legacy config

--- a/features/admin.users.v1/package.json
+++ b/features/admin.users.v1/package.json
@@ -28,6 +28,7 @@
         "@wso2is/admin.core.v1": "^2.49.23",
         "@wso2is/admin.extensions.v1": "^2.40.1",
         "@wso2is/admin.feature-gate.v1": "^1.7.4",
+        "@wso2is/admin.flows.v1": "workspace:^",
         "@wso2is/admin.groups.v1": "^2.27.123",
         "@wso2is/admin.identity-providers.v1": "^2.26.206",
         "@wso2is/admin.organizations.v1": "^2.27.2",

--- a/features/admin.users.v1/pages/users.tsx
+++ b/features/admin.users.v1/pages/users.tsx
@@ -32,6 +32,8 @@ import { userstoresConfig } from "@wso2is/admin.extensions.v1";
 import { userConfig } from "@wso2is/admin.extensions.v1/configs";
 import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
 import { FeatureStatusLabel } from "@wso2is/admin.feature-gate.v1/models/feature-status";
+import useGetFlowConfig from "@wso2is/admin.flows.v1/api/use-get-flow-config";
+import { FlowTypes } from "@wso2is/admin.flows.v1/models/flows";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import {
     ConnectorPropertyInterface,
@@ -159,6 +161,10 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
     );
     const hasGuestUserCreatePermissions: boolean = useRequiredScopes(
         featureConfig?.guestUser?.scopes?.create
+    );
+
+    const { data: invitedUserRegistrationConfigs } = useGetFlowConfig(
+        FlowTypes.INVITED_USER_REGISTRATION
     );
 
     const [ searchQuery, setSearchQuery ] = useState<string>("");
@@ -615,7 +621,8 @@ const UsersPage: FunctionComponent<UsersPageInterface> = (
                     (property: ConnectorPropertyInterface) =>
                         property.name === ServerConfigurationsConstants.EMAIL_VERIFICATION_ENABLED);
 
-                setEmailVerificationEnabled(emailVerification.value === "true");
+                setEmailVerificationEnabled(emailVerification.value === "true" ||
+                    invitedUserRegistrationConfigs?.isEnabled);
             }).catch((error: AxiosError) => {
                 handleAlerts({
                     description: error?.response?.data?.description ?? t(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19270,6 +19270,9 @@ importers:
       '@wso2is/admin.feature-gate.v1':
         specifier: ^1.7.4
         version: link:../admin.feature-gate.v1
+      '@wso2is/admin.flows.v1':
+        specifier: workspace:^
+        version: link:../admin.flows.v1
       '@wso2is/admin.groups.v1':
         specifier: ^2.27.123
         version: link:../admin.groups.v1
@@ -43951,8 +43954,6 @@ packages:
       webpack: '*'
     peerDependenciesMeta:
       webpack:
-        optional: true
-      webpack-sources:
         optional: true
     dependencies:
       webpack: 5.84.1(@swc/core@1.3.99)(esbuild@0.18.20)(webpack-cli@4.10.0)


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/24944

This pull request introduces a patch to improve the initiation of invited user registration by ensuring it correctly respects legacy configuration settings. The main changes involve integrating flow configuration checks for invited user registration and updating dependencies to support this logic.

**Invited User Registration Improvements**
* Integrated `useGetFlowConfig` and `FlowTypes` from `@wso2is/admin.flows.v1` into `users.tsx` to fetch and utilize invited user registration flow configuration. [[1]](diffhunk://#diff-cd19f83925cda57847f6bc549d1e8f8cdb57adc4a5bec3444987fd3e6c95d5b5R35-R36) [[2]](diffhunk://#diff-cd19f83925cda57847f6bc549d1e8f8cdb57adc4a5bec3444987fd3e6c95d5b5R166-R169)
* Updated logic to enable email verification if either the legacy config or the invited user registration flow is enabled, improving compatibility with legacy setups.

**Dependency and Configuration Updates**
* Added `@wso2is/admin.flows.v1` as a dependency in `package.json` and updated `pnpm-lock.yaml` accordingly. [[1]](diffhunk://#diff-f84b1a183a5062fb20b5b44bf8f7e7ea43bd1010922f813b3e5a64a4fa4a089cR31) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR19273-R19275)
* Documented the patch and its purpose in `.changeset/thin-lamps-appear.md`.

These changes ensure that invited user registration initiation works as intended, regardless of legacy configuration, and that the codebase is prepared for future flow-based registration logic.