### PR TITLE
[Next] Update portal URL logic for password recovery flow

### DIFF
--- a/.changeset/modern-snakes-refuse.md
+++ b/.changeset/modern-snakes-refuse.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Update portal URL logic for password recovery flow

--- a/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
@@ -308,7 +308,7 @@
                     if (error && error.code) {
                         const errorDetails = getI18nKeyForError(error.code, flowType);
                         let portal_url = authPortalURL + "/register";
-                        if (flowType === "INVITED_USER_REGISTRATION" || flowType === "PASSWORD_RECOVERY") {
+                        if (flowType === "PASSWORD_RECOVERY") {
                             portal_url = authPortalURL + "/recovery";
                         }
                         const errorPageURL = authPortalURL + "/error?" + "ERROR_MSG="


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/25437

## Purpose
This pull request makes a targeted update to the registration and recovery flow error handling logic. The main change is to the URL routing for error pages, ensuring that invited user registration errors are no longer redirected to the recovery page.

* Error Handling Logic Update:
  - In `execution-flow.jsp`, the condition for redirecting to the recovery portal URL is now limited to `"PASSWORD_RECOVERY"` only, removing `"INVITED_USER_REGISTRATION"` from this logic. This ensures that invited user registration errors will follow the correct registration flow instead of being misrouted to recovery.