### PR TITLE
[Next] "Address" claim value not getting updated/displayed in My Account and Console

### DIFF
--- a/.changeset/smooth-cobras-relax.md
+++ b/.changeset/smooth-cobras-relax.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/admin.users.v1": patch
+---
+
+UI logic to avoid displaying complex type attributes.

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -21,6 +21,7 @@ import { IdentityAppsApiException } from "@wso2is/core/exceptions";
 import { getUserNameWithoutDomain, hasRequiredScopes, isFeatureEnabled, resolveUserstore } from "@wso2is/core/helpers";
 import {
     AlertLevels,
+    ClaimDataType,
     PatchOperationRequest,
     ProfileSchemaInterface,
     SBACInterface,
@@ -765,6 +766,13 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
             if (!resolveSupportedByDefaultValue) {
                 return false;
             }
+        }
+
+        // If the attribute is a complex type, it should not be displayed.
+        if (schema.type?.toLowerCase() === ClaimDataType.COMPLEX.toLowerCase() &&
+        schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.emails &&
+        schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.mobile) {
+            return false;
         }
 
         return true;

--- a/apps/myaccount/src/components/profile/profile.tsx
+++ b/apps/myaccount/src/components/profile/profile.tsx
@@ -770,8 +770,8 @@ export const Profile: FunctionComponent<ProfileProps> = (props: ProfileProps): R
 
         // If the attribute is a complex type, it should not be displayed.
         if (schema.type?.toLowerCase() === ClaimDataType.COMPLEX.toLowerCase() &&
-        schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.emails &&
-        schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.mobile) {
+            schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.emails &&
+            schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.mobile) {
             return false;
         }
 

--- a/features/admin.users.v1/components/user-profile/user-profile-form.tsx
+++ b/features/admin.users.v1/components/user-profile/user-profile-form.tsx
@@ -828,7 +828,7 @@ const UserProfileForm: FunctionComponent<UserProfileFormPropsInterface> = ({
 
         const attributeValue: unknown = extractAttributeValue(schema);
 
-        if (schema.type?.toLowerCase() !== ClaimDataType.BOOLEAN.toLocaleLowerCase() && isEmpty(attributeValue)) {
+        if (schema.type?.toLowerCase() !== ClaimDataType.BOOLEAN.toLowerCase() && isEmpty(attributeValue)) {
             // If the profile UI is in read only mode, the empty field should not be displayed.
             if (isReadOnlyMode) {
                 return false;
@@ -844,8 +844,8 @@ const UserProfileForm: FunctionComponent<UserProfileFormPropsInterface> = ({
 
         // If the attribute is a complex type, it should not be displayed.
         if (schema.type?.toLowerCase() === ClaimDataType.COMPLEX.toLowerCase() &&
-        schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.emails &&
-        schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.mobile) {
+            schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.emails &&
+            schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.mobile) {
             return false;
         }
 

--- a/features/admin.users.v1/components/user-profile/user-profile-form.tsx
+++ b/features/admin.users.v1/components/user-profile/user-profile-form.tsx
@@ -828,7 +828,7 @@ const UserProfileForm: FunctionComponent<UserProfileFormPropsInterface> = ({
 
         const attributeValue: unknown = extractAttributeValue(schema);
 
-        if (schema.type !== ClaimDataType.BOOLEAN && isEmpty(attributeValue)) {
+        if (schema.type?.toLowerCase() !== ClaimDataType.BOOLEAN.toLocaleLowerCase() && isEmpty(attributeValue)) {
             // If the profile UI is in read only mode, the empty field should not be displayed.
             if (isReadOnlyMode) {
                 return false;
@@ -840,6 +840,13 @@ const UserProfileForm: FunctionComponent<UserProfileFormPropsInterface> = ({
             if (resolvedMutabilityValue === ProfileConstants.READONLY_SCHEMA) {
                 return false;
             }
+        }
+
+        // If the attribute is a complex type, it should not be displayed.
+        if (schema.type?.toLowerCase() === ClaimDataType.COMPLEX.toLowerCase() &&
+        schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.emails &&
+        schema.schemaUri !== ProfileConstants.SCIM2_CORE_USER_SCHEMA_ATTRIBUTES.mobile) {
+            return false;
         }
 
         return true;


### PR DESCRIPTION
### Purpose
Complex attributes (i.e., attributes with dataType set to complex) do not directly hold values, except in special cases such as emails. Currently, when a parent complex attribute is enabled but none of its sub-attributes are enabled, the parent attribute still appears in Console and My Account, even though it has no value.

This fix ensures that such parent complex attributes are filtered out from the flattened attribute list on the UI side, preventing them from being displayed unnecessarily in Console and My Account.

### Related Issues
- https://github.com/wso2/product-is/issues/24420

### Related PRs
- https://github.com/wso2/identity-apps/pull/8926

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
