### PR TITLE
Fix unexpected error when reusing admin invite password link with new Flows by showing expired link error instead.

### DIFF
--- a/identity-apps-core/apps/accounts/pom.xml
+++ b/identity-apps-core/apps/accounts/pom.xml
@@ -164,7 +164,7 @@
                     </webResources>
                     <warName>accounts</warName>
                     <packagingExcludes>WEB-INF/lib/commons-logging*.jar</packagingExcludes>
-                    <packagingExcludes>org/wso2/carbon/identity/application/authentication/endpoint/i18n/*
+                    <packagingExcludes>org/wso2/carbon/identity/application/accounts/endpoint/i18n/*
                     </packagingExcludes>
                 </configuration>
             </plugin>

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources.properties
@@ -109,14 +109,16 @@ orchestration.flow.error.preUpdatePassword.action.failure.message=Password valid
 orchestration.flow.error.preUpdatePassword.action.failure.description=Please provide a different password
 
 # Invite user registration errors
-invite.user.registration.flow.error.undefined.flow.id.message=Flow Id is not Defined
-invite.user.registration.flow.error.undefined.flow.id.description=The flow Id is not defined in the invite user registration request
-invite.user.registration.failed.message=Invite User Registration Unsuccessful
-invite.user.registration.failed.description=Invite User Registration Unsuccessful
-invite.user.registration.error.request.processing.failed.message=An unexpected error occurred
-invite.user.registration.error.request.processing.failed.description=An unexpected error occurred while processing the invite user registration request
-invite.user.registration.error.unexpected.message=Invite user registraiton Unsuccessful
-invite.user.registration.error.unexpected.description=An unexpected error occurred during invite user registration
+invited.user.registration.flow.error.undefined.flow.id.message=Flow Id is not Defined
+invited.user.registration.flow.error.undefined.flow.id.description=The flow Id is not defined in the Invited user registration request
+invited.user.registration.failed.message=Invited User Registration Unsuccessful
+invited.user.registration.failed.description=Invited User Registration Unsuccessful
+invited.user.registration.error.request.processing.failed.message=An unexpected error occurred
+invited.user.registration.error.request.processing.failed.description=An unexpected error occurred while processing the Invited user registration request
+invited.user.registration.error.unexpected.message=Invited user registration Unsuccessful
+invited.user.registration.error.unexpected.description=An unexpected error occurred during Invited user registration
+invited.user.registration.flow.error.invalid.code.message=Invalid or Expired Invitation Link
+invited.user.registration.flow.error.invalid.code.description=The invitation link is invalid or has expired
 
 # Password reset errors
 password.reset.flow.error.undefined.flow.id.message=Flow Id is not Defined

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_de_DE.properties
@@ -100,14 +100,16 @@ orchestration.flow.error.preUpdatePassword.action.failure.message=Passwortvalidi
 orchestration.flow.error.preUpdatePassword.action.failure.description=Bitte geben Sie ein anderes Passwort ein
 
 # Invite user registration errors
-invite.user.registration.flow.error.undefined.flow.id.message=Flow-ID nicht definiert
-invite.user.registration.flow.error.undefined.flow.id.description=Die Flow-ID wurde im Einladungseintrag nicht definiert
-invite.user.registration.failed.message=Benutzereinladung fehlgeschlagen
-invite.user.registration.failed.description=Die Benutzereinladung war nicht erfolgreich
-invite.user.registration.error.request.processing.failed.message=Ein unerwarteter Fehler ist aufgetreten
-invite.user.registration.error.request.processing.failed.description=Beim Verarbeiten der Benutzereinladung ist ein unerwarteter Fehler aufgetreten
-invite.user.registration.error.unexpected.message=Benutzereinladung fehlgeschlagen
-invite.user.registration.error.unexpected.description=Während der Benutzereinladung ist ein unerwarteter Fehler aufgetreten
+invited.user.registration.flow.error.undefined.flow.id.message=Flow-ID nicht definiert
+invited.user.registration.flow.error.undefined.flow.id.description=Die Flow-ID wurde im Einladungseintrag nicht definiert
+invited.user.registration.failed.message=Benutzereinladung fehlgeschlagen
+invited.user.registration.failed.description=Die Benutzereinladung war nicht erfolgreich
+invited.user.registration.error.request.processing.failed.message=Ein unerwarteter Fehler ist aufgetreten
+invited.user.registration.error.request.processing.failed.description=Beim Verarbeiten der Benutzereinladung ist ein unerwarteter Fehler aufgetreten
+invited.user.registration.error.unexpected.message=Benutzereinladung fehlgeschlagen
+invited.user.registration.error.unexpected.description=Während der Benutzereinladung ist ein unerwarteter Fehler aufgetreten
+invited.user.registration.flow.error.invalid.code.message=Ungültiger oder abgelaufener Einladungslink
+invited.user.registration.flow.error.invalid.code.description=Der Einladungslink ist ungültig oder abgelaufen
 
 # Password reset errors
 password.reset.flow.error.undefined.flow.id.message=Flow-ID nicht definiert

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_es_ES.properties
@@ -100,14 +100,16 @@ orchestration.flow.error.preUpdatePassword.action.failure.message=Fallo en la va
 orchestration.flow.error.preUpdatePassword.action.failure.description=Por favor, proporciona una contraseña diferente
 
 # Invite user registration errors
-invite.user.registration.flow.error.undefined.flow.id.message=ID de flujo no definido
-invite.user.registration.flow.error.undefined.flow.id.description=El ID de flujo no está definido en la solicitud de registro por invitación
-invite.user.registration.failed.message=Fallo en el registro por invitación
-invite.user.registration.failed.description=Fallo en el registro por invitación
-invite.user.registration.error.request.processing.failed.message=Ocurrió un error inesperado
-invite.user.registration.error.request.processing.failed.description=Se produjo un error inesperado al procesar la solicitud de registro por invitación
-invite.user.registration.error.unexpected.message=Fallo en el registro por invitación
-invite.user.registration.error.unexpected.description=Ocurrió un error inesperado durante el registro por invitación
+invited.user.registration.flow.error.undefined.flow.id.message=ID de flujo no definido
+invited.user.registration.flow.error.undefined.flow.id.description=El ID de flujo no está definido en la solicitud de registro por invitación
+invited.user.registration.failed.message=Fallo en el registro por invitación
+invited.user.registration.failed.description=Fallo en el registro por invitación
+invited.user.registration.error.request.processing.failed.message=Ocurrió un error inesperado
+invited.user.registration.error.request.processing.failed.description=Se produjo un error inesperado al procesar la solicitud de registro por invitación
+invited.user.registration.error.unexpected.message=Fallo en el registro por invitación
+invited.user.registration.error.unexpected.description=Ocurrió un error inesperado durante el registro por invitación
+invited.user.registration.flow.error.invalid.code.message=Enlace de invitación inválido o caducado
+invited.user.registration.flow.error.invalid.code.description=El enlace de invitación no es válido o ha caducado
 
 # Password reset errors
 password.reset.flow.error.undefined.flow.id.message=ID de flujo no definido

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_fr_FR.properties
@@ -100,14 +100,16 @@ orchestration.flow.error.preUpdatePassword.action.failure.message=Échec de la v
 orchestration.flow.error.preUpdatePassword.action.failure.description=Veuillez fournir un mot de passe différent
 
 # Invite user registration errors
-invite.user.registration.flow.error.undefined.flow.id.message=ID du flux non défini
-invite.user.registration.flow.error.undefined.flow.id.description=L'ID du flux n'est pas défini dans la demande d'inscription par invitation
-invite.user.registration.failed.message=Échec de l'inscription par invitation
-invite.user.registration.failed.description=Échec de l'inscription par invitation
-invite.user.registration.error.request.processing.failed.message=Une erreur inattendue s'est produite
-invite.user.registration.error.request.processing.failed.description=Une erreur inattendue s'est produite lors du traitement de la demande d'inscription par invitation
-invite.user.registration.error.unexpected.message=Échec de l'inscription par invitation
-invite.user.registration.error.unexpected.description=Une erreur inattendue s'est produite pendant l'inscription par invitation
+invited.user.registration.flow.error.undefined.flow.id.message=ID du flux non défini
+invited.user.registration.flow.error.undefined.flow.id.description=L'ID du flux n'est pas défini dans la demande d'inscription par invitation
+invited.user.registration.failed.message=Échec de l'inscription par invitation
+invited.user.registration.failed.description=Échec de l'inscription par invitation
+invited.user.registration.error.request.processing.failed.message=Une erreur inattendue s'est produite
+invited.user.registration.error.request.processing.failed.description=Une erreur inattendue s'est produite lors du traitement de la demande d'inscription par invitation
+invited.user.registration.error.unexpected.message=Échec de l'inscription par invitation
+invited.user.registration.error.unexpected.description=Une erreur inattendue s'est produite pendant l'inscription par invitation
+invited.user.registration.flow.error.invalid.code.message=Lien d’invitation invalide ou expiré
+invited.user.registration.flow.error.invalid.code.description=Le lien d’invitation est invalide ou a expiré
 
 # Password reset errors
 password.reset.flow.error.undefined.flow.id.message=ID du flux non défini

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_ja_JP.properties
@@ -100,14 +100,16 @@ orchestration.flow.error.preUpdatePassword.action.failure.message=パスワー�
 orchestration.flow.error.preUpdatePassword.action.failure.description=別のパスワードを入力してください
 
 # Invite user registration errors
-invite.user.registration.flow.error.undefined.flow.id.message=フローIDが定義されていません
-invite.user.registration.flow.error.undefined.flow.id.description=招待ユーザー登録リクエストにフローIDが定義されていません
-invite.user.registration.failed.message=招待ユーザー登録に失敗しました
-invite.user.registration.failed.description=招待ユーザー登録に失敗しました
-invite.user.registration.error.request.processing.failed.message=予期しないエラーが発生しました
-invite.user.registration.error.request.processing.failed.description=招待ユーザー登録リクエストの処理中に予期しないエラーが発生しました
-invite.user.registration.error.unexpected.message=招待ユーザー登録に失敗しました
-invite.user.registration.error.unexpected.description=招待ユーザー登録中に予期しないエラーが発生しました
+invited.user.registration.flow.error.undefined.flow.id.message=フローIDが定義されていません
+invited.user.registration.flow.error.undefined.flow.id.description=招待ユーザー登録リクエストにフローIDが定義されていません
+invited.user.registration.failed.message=招待ユーザー登録に失敗しました
+invited.user.registration.failed.description=招待ユーザー登録に失敗しました
+invited.user.registration.error.request.processing.failed.message=予期しないエラーが発生しました
+invited.user.registration.error.request.processing.failed.description=招待ユーザー登録リクエストの処理中に予期しないエラーが発生しました
+invited.user.registration.error.unexpected.message=招待ユーザー登録に失敗しました
+invited.user.registration.error.unexpected.description=招待ユーザー登録中に予期しないエラーが発生しました
+invited.user.registration.flow.error.invalid.code.message=無効または期限切れの招待リンク
+invited.user.registration.flow.error.invalid.code.description=招待リンクが無効であるか、有効期限が切れています
 
 # Password reset errors
 password.reset.flow.error.undefined.flow.id.message=フローIDが定義されていません

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_BR.properties
@@ -100,14 +100,16 @@ orchestration.flow.error.preUpdatePassword.action.failure.message=Falha na valid
 orchestration.flow.error.preUpdatePassword.action.failure.description=Por favor, forneça uma senha diferente
 
 # Invite user registration errors
-invite.user.registration.flow.error.undefined.flow.id.message=ID do fluxo não definido
-invite.user.registration.flow.error.undefined.flow.id.description=O ID do fluxo não foi definido na solicitação de registro por convite
-invite.user.registration.failed.message=Registro por convite não realizado
-invite.user.registration.failed.description=Registro por convite não realizado
-invite.user.registration.error.request.processing.failed.message=Ocorreu um erro inesperado
-invite.user.registration.error.request.processing.failed.description=Ocorreu um erro inesperado ao processar a solicitação de registro por convite
-invite.user.registration.error.unexpected.message=Registro por convite não realizado
-invite.user.registration.error.unexpected.description=Ocorreu um erro inesperado durante o registro por convite
+invited.user.registration.flow.error.undefined.flow.id.message=ID do fluxo não definido
+invited.user.registration.flow.error.undefined.flow.id.description=O ID do fluxo não foi definido na solicitação de registro por convite
+invited.user.registration.failed.message=Registro por convite não realizado
+invited.user.registration.failed.description=Registro por convite não realizado
+invited.user.registration.error.request.processing.failed.message=Ocorreu um erro inesperado
+invited.user.registration.error.request.processing.failed.description=Ocorreu um erro inesperado ao processar a solicitação de registro por convite
+invited.user.registration.error.unexpected.message=Registro por convite não realizado
+invited.user.registration.error.unexpected.description=Ocorreu um erro inesperado durante o registro por convite
+invited.user.registration.flow.error.invalid.code.message=Link de convite inválido ou expirado
+invited.user.registration.flow.error.invalid.code.description=O link de convite é inválido ou expirou
 
 # Password reset errors
 password.reset.flow.error.undefined.flow.id.message=ID do fluxo não definido

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_PT.properties
@@ -100,14 +100,16 @@ orchestration.flow.error.preUpdatePassword.action.failure.message=Falha na valid
 orchestration.flow.error.preUpdatePassword.action.failure.description=Por favor, forneça uma senha diferente
 
 # Invite user registration errors
-invite.user.registration.flow.error.undefined.flow.id.message=ID do fluxo não definido
-invite.user.registration.flow.error.undefined.flow.id.description=O ID do fluxo não foi definido no pedido de registo de utilizador convidado
-invite.user.registration.failed.message=Falha no registo de utilizador convidado
-invite.user.registration.failed.description=Falha no registo de utilizador convidado
-invite.user.registration.error.request.processing.failed.message=Ocorreu um erro inesperado
-invite.user.registration.error.request.processing.failed.description=Ocorreu um erro inesperado ao processar o pedido de registo de utilizador convidado
-invite.user.registration.error.unexpected.message=Falha no registo de utilizador convidado
-invite.user.registration.error.unexpected.description=Ocorreu um erro inesperado durante o registo de utilizador convidado
+invited.user.registration.flow.error.undefined.flow.id.message=ID do fluxo não definido
+invited.user.registration.flow.error.undefined.flow.id.description=O ID do fluxo não foi definido no pedido de registo de utilizador convidado
+invited.user.registration.failed.message=Falha no registo de utilizador convidado
+invited.user.registration.failed.description=Falha no registo de utilizador convidado
+invited.user.registration.error.request.processing.failed.message=Ocorreu um erro inesperado
+invited.user.registration.error.request.processing.failed.description=Ocorreu um erro inesperado ao processar o pedido de registo de utilizador convidado
+invited.user.registration.error.unexpected.message=Falha no registo de utilizador convidado
+invited.user.registration.error.unexpected.description=Ocorreu um erro inesperado durante o registo de utilizador convidado
+invited.user.registration.flow.error.invalid.code.message=Link de convite inválido ou expirado
+invited.user.registration.flow.error.invalid.code.description=O link de convite é inválido ou expirou
 
 # Password reset errors
 password.reset.flow.error.undefined.flow.id.message=ID do fluxo não definido

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_zh_CN.properties
@@ -100,14 +100,16 @@ orchestration.flow.error.preUpdatePassword.action.failure.message=密码验证�
 orchestration.flow.error.preUpdatePassword.action.failure.description=请提供一个不同的密码
 
 # Invite user registration errors
-invite.user.registration.flow.error.undefined.flow.id.message=未定义流程 ID
-invite.user.registration.flow.error.undefined.flow.id.description=邀请用户注册请求中未定义流程 ID
-invite.user.registration.failed.message=邀请用户注册失败
-invite.user.registration.failed.description=邀请用户注册失败
-invite.user.registration.error.request.processing.failed.message=发生意外错误
-invite.user.registration.error.request.processing.failed.description=处理邀请用户注册请求时发生意外错误
-invite.user.registration.error.unexpected.message=邀请用户注册失败
-invite.user.registration.error.unexpected.description=邀请用户注册过程中发生意外错误
+invited.user.registration.flow.error.undefined.flow.id.message=未定义流程 ID
+invited.user.registration.flow.error.undefined.flow.id.description=邀请用户注册请求中未定义流程 ID
+invited.user.registration.failed.message=邀请用户注册失败
+invited.user.registration.failed.description=邀请用户注册失败
+invited.user.registration.error.request.processing.failed.message=发生意外错误
+invited.user.registration.error.request.processing.failed.description=处理邀请用户注册请求时发生意外错误
+invited.user.registration.error.unexpected.message=邀请用户注册失败
+invited.user.registration.error.unexpected.description=邀请用户注册过程中发生意外错误
+invited.user.registration.flow.error.invalid.code.message=无效或已过期的邀请链接
+invited.user.registration.flow.error.invalid.code.description=该邀请链接无效或已过期
 
 # Password reset errors
 password.reset.flow.error.undefined.flow.id.message=未定义流程 ID

--- a/identity-apps-core/apps/accounts/src/main/webapp/errors/execution_flow_error.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/errors/execution_flow_error.jsp
@@ -83,7 +83,7 @@
                     errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "sign.up.error.unexpected.message");
                     break;
                 case INVITED_USER_REGISTRATION:
-                    errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invite.user.registration.error.unexpected.message");
+                    errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "invited.user.registration.error.unexpected.message");
                     break;
                 case PASSWORD_RECOVERY:
                     errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle, "password.reset.error.unexpected.message");
@@ -104,7 +104,7 @@
                     errorDescription = AuthenticationEndpointUtil.i18n(resourceBundle, "sign.up.error.unexpected.description");
                     break;
                 case INVITED_USER_REGISTRATION:
-                    errorDescription = AuthenticationEndpointUtil.i18n(resourceBundle, "invite.user.registration.error.unexpected.description");
+                    errorDescription = AuthenticationEndpointUtil.i18n(resourceBundle, "invited.user.registration.error.unexpected.description");
                     break;
                 case PASSWORD_RECOVERY:
                     errorDescription = AuthenticationEndpointUtil.i18n(resourceBundle, "password.reset.error.unexpected.description");
@@ -159,10 +159,13 @@
                 <p class="portal-tagline-description">
                     <%= errorDescription %>
                 </p>
-                <button class="ui primary basic button"
-                    onclick="location.href='<%= IdentityManagementEndpointUtil.getURLEncodedCallback(registrationPortalURL) %>';">
-                    <%= i18n(resourceBundle, customText, "sign.up.try.again.button") %>
-                </button>
+                <% if (StringUtils.isNotEmpty(registrationPortalURL) && 
+                    StringUtils.isNotEmpty(request.getParameter("PORTAL_URL"))) { %>
+                    <button class="ui primary basic button"
+                        onclick="location.href='<%= IdentityManagementEndpointUtil.getURLEncodedCallback(registrationPortalURL) %>';">
+                        <%= i18n(resourceBundle, customText, "sign.up.try.again.button") %>
+                    </button>
+                <% } %>
                 <div class="ui divider hidden"></div>
             </div>
             <div class="ui bottom attached warning message">

--- a/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
@@ -306,16 +306,21 @@
 
                 useEffect(() => {
                     if (error && error.code) {
-                        const errorDetails = getI18nKeyForError(error.code, flowType);
+                        const errorDetails = getI18nKeyForError(error.code, flowType, error.description);
                         let portal_url = authPortalURL + "/register";
                         if (flowType === "PASSWORD_RECOVERY") {
                             portal_url = authPortalURL + "/recovery";
                         }
-                        const errorPageURL = authPortalURL + "/error?" + "ERROR_MSG="
+                        let errorPageURL = authPortalURL + "/error?" + "ERROR_MSG="
                             + errorDetails.message + "&" + "ERROR_DESC=" + errorDetails.description + "&" + "SP_ID="
                             + "<%= Encode.forJavaScript(spId) %>" + "&" + "flowType=" + flowType + "&" + "confirmation="
-                            + "<%= Encode.forJavaScript(confirmationCode) %>" + "&" +
-                            "PORTAL_URL=" + portal_url + "&SP=" + "<%= Encode.forJavaScript(sp) %>";
+                            + "<%= Encode.forJavaScript(confirmationCode) %>" + "&";
+                        
+                        if (errorDetails.portalUrlStatus === "true") {
+                            errorPageURL += "PORTAL_URL=" + portal_url + "&";
+                        }
+                        
+                        errorPageURL += "SP=" + "<%= Encode.forJavaScript(sp) %>";
 
                         window.location.href = errorPageURL;
                     }

--- a/identity-apps-core/apps/accounts/src/main/webapp/js/error-utils.js
+++ b/identity-apps-core/apps/accounts/src/main/webapp/js/error-utils.js
@@ -24,7 +24,7 @@
  * @param {string} errorCode - The error code (e.g., "60001")
  * @returns {object} The i18n keys for the given error code.
  */
-function getI18nKeyForError(errorCode, flowType) {
+function getI18nKeyForError(errorCode, flowType, errorMessage) {
     switch (errorCode) {
         case "FE-60001":
 
@@ -37,14 +37,16 @@ function getI18nKeyForError(errorCode, flowType) {
 
             return {
                 message: "sign.up.error.username.not.provided.message",
-                description: "sign.up.error.username.not.provided.description"
+                description: "sign.up.error.username.not.provided.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60003":
 
             return {
                 message: "sign.up.error.username.already.exists.message",
-                description: "sign.up.error.username.already.exists.description"
+                description: "sign.up.error.username.already.exists.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60004":
@@ -56,8 +58,8 @@ function getI18nKeyForError(errorCode, flowType) {
                 };
             } else if (flowType === "INVITED_USER_REGISTRATION") {
                 return {
-                    message: "invite.user.registration.flow.error.undefined.flow.id.message",
-                    description: "invite.user.registration.flow.error.undefined.flow.id.description"
+                    message: "invited.user.registration.flow.error.undefined.flow.id.message",
+                    description: "invited.user.registration.flow.error.undefined.flow.id.description"
                 };
             } else if( flowType === "PASSWORD_RECOVERY") {
                 return {
@@ -74,7 +76,8 @@ function getI18nKeyForError(errorCode, flowType) {
 
             return {
                 message: "sign.up.error.invalid.username.message", 
-                description: "sign.up.error.invalid.username.description" 
+                description: "sign.up.error.invalid.username.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60006":
@@ -82,22 +85,32 @@ function getI18nKeyForError(errorCode, flowType) {
             if( flowType === "USER_REGISTRATION") { 
                 return {
                     message: "sign.up.error.failed.message",
-                    description: "sign.up.error.failed.description"
+                    description: "sign.up.error.failed.description",
+                    portalUrlStatus: "true"
                 };
             } else if (flowType === "INVITED_USER_REGISTRATION") {
+                if (errorMessage.startsWith("Invalid Code")) {
+                    return {
+                        message: "invited.user.registration.flow.error.invalid.code.message",
+                        description: "invited.user.registration.flow.error.invalid.code.description"
+                    };
+                }
                 return {
-                    message: "invite.user.registration.failed.message",
-                    description: "invite.user.registration.failed.description"
+                    message: "invited.user.registration.failed.message",
+                    description: "invited.user.registration.failed.description",
+                    portalUrlStatus: "true"
                 };
             } else if( flowType === "PASSWORD_RECOVERY") {
                 return {
                     message: "password.reset.failed.message",
-                    description: "password.reset.failed.description"
+                    description: "password.reset.failed.description",
+                    portalUrlStatus: "true"
                 };
             }        
             return {
                 message: "orchestration.flow.error.failed.message",
-                description: "orchestration.flow.error.failed.description"
+                description: "orchestration.flow.error.failed.description",
+                portalUrlStatus: "true"
             };
             
 
@@ -106,29 +119,34 @@ function getI18nKeyForError(errorCode, flowType) {
             if( flowType === "USER_REGISTRATION") {
                 return {
                     message: "sign.up.error.request.processing.failed.message",
-                    description: "sign.up.error.request.processing.failed.description"
+                    description: "sign.up.error.request.processing.failed.description",
+                    portalUrlStatus: "true"
                 };
             } else if (flowType === "INVITED_USER_REGISTRATION") {
                 return {
-                    message: "invite.user.registration.error.request.processing.failed.message",
-                    description: "invite.user.registration.error.request.processing.failed.description"
+                    message: "invited.user.registration.error.request.processing.failed.message",
+                    description: "invited.user.registration.error.request.processing.failed.description",
+                    portalUrlStatus: "true"
                 };
             } else if( flowType === "PASSWORD_RECOVERY") {
                 return {
                     message: "password.reset.error.request.processing.failed.message",
-                    description: "password.reset.error.request.processing.failed.description"
+                    description: "password.reset.error.request.processing.failed.description",
+                    portalUrlStatus: "true"
                 };
             }   
             return {
                 message: "orchestration.flow.error.request.processing.failed.message",
-                description: "orchestration.flow.error.request.processing.failed.description"
+                description: "orchestration.flow.error.request.processing.failed.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60008":
 
             return {
                 message: "orchestration.flow.error.invalid.user.input.message",
-                description: "orchestration.flow.error.invalid.user.input.description"
+                description: "orchestration.flow.error.invalid.user.input.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60009":
@@ -142,28 +160,32 @@ function getI18nKeyForError(errorCode, flowType) {
 
             return {
                 message: "orchestration.flow.error.invalid.captcha.message",
-                description: "orchestration.flow.error.invalid.captcha.description"
+                description: "orchestration.flow.error.invalid.captcha.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60011":
 
             return {
                 message: "orchestration.flow.error.no.flowType.message",
-                description: "orchestration.flow.error.no.flowType.description"
+                description: "orchestration.flow.error.no.flowType.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60101":
     
             return {
                 message: "orchestration.flow.error.dynamic.portal.not.enabled.message",
-                description: "orchestration.flow.error.dynamic.portal.not.enabled.description"
+                description: "orchestration.flow.error.dynamic.portal.not.enabled.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60102":
         
             return {
                 message: "orchestration.flow.error.self.registration.not.enabled.message",
-                description: "orchestration.flow.error.self.registration.not.enabled.description"
+                description: "orchestration.flow.error.self.registration.not.enabled.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60103":
@@ -177,21 +199,24 @@ function getI18nKeyForError(errorCode, flowType) {
         
             return {
                 message: "orchestration.flow.error.disabled.flow.message",
-                description: "orchestration.flow.error.disabled.flow.description"
+                description: "orchestration.flow.error.disabled.flow.description",
+                portalUrlStatus: "true"
             };
 
         case "FE-60012":
 
             return {
                 message: "orchestration.flow.error.preUpdatePassword.action.failure.message",
-                description: "orchestration.flow.error.preUpdatePassword.action.failure.description"
+                description: "orchestration.flow.error.preUpdatePassword.action.failure.description",
+                portalUrlStatus: "true"
             };
 
         default:
 
             return {
                 message: "orchestration.flow.error.failed.message",
-                description: "orchestration.flow.error.failed.description"
+                description: "orchestration.flow.error.failed.description",
+                portalUrlStatus: "true"
             };
     }
 }


### PR DESCRIPTION
## Related Issue
- https://github.com/wso2/product-is/issues/25370

## Behaviour


<img width="688" height="500" alt="Screenshot 2025-08-26 at 12 11 58 PM" src="https://github.com/user-attachments/assets/881b8097-ef48-422f-ab8a-9dda9e562453" />
<img width="517" height="450" alt="Screenshot 2025-08-26 at 12 15 15 PM" src="https://github.com/user-attachments/assets/0b875f10-c122-4499-a96f-467bd57eec74" />

## Implementation
This pull request updates the invite user registration error handling and messaging across the accounts application, focusing on consistency, internationalization, and improved user experience. The main changes include renaming error keys from `invite.user.registration` to `invited.user.registration` in all resource files, adding new error messages for invalid or expired invitation links, updating code references to match the new keys, and enhancing error page logic to conditionally display the "Try Again" button.

**Error Message and Key Standardization**
* Renamed all invite user registration error keys from `invite.user.registration` to `invited.user.registration` in resource files for consistency across all supported languages (`Resources.properties`, `Resources_de_DE.properties`, `Resources_es_ES.properties`, `Resources_fr_FR.properties`, `Resources_ja_JP.properties`, `Resources_pt_BR.properties`, `Resources_pt_PT.properties`, `Resources_zh_CN.properties`). [[1]](diffhunk://#diff-25bf4e40a8d650693daca5505a137acb43417bdde8d6dd2f7d6816671b0dba8bL112-R121) [[2]](diffhunk://#diff-ee6ef92c6f8a0753d7a27b84218eedfa84b1b7bc62838aa53ee05df82ab4b948L103-R112) [[3]](diffhunk://#diff-94da16236ace49611273c702522323b22f12127ba3d2bb14d6dfb8dd8cc57892L103-R112) [[4]](diffhunk://#diff-11e98861dad2fe2ae8f92968df4dff96b677a3fab18de176662b5df3e3966f59L103-R112) [[5]](diffhunk://#diff-8c74e6b3b41084cac67247384db668e384f40b1fbb93cf7bcbaf98aa6434ddf7L103-R112) [[6]](diffhunk://#diff-a98ac636a33ce6092b8a0bd648136daca0d287418f522fbdd5addc8e3f3fd694L103-R112) [[7]](diffhunk://#diff-38825c7dd40e85ab7fd57c6c24f945ccff2d1c2dbffaaa8afbb6a72cb9849b81L103-R112) [[8]](diffhunk://#diff-d03a310fd47859854bbc490a4f1da5692e0bfa02096ff2ff09d07e648bbb6809L103-R112)

* Added new error keys and messages for handling invalid or expired invitation links in all resource files. [[1]](diffhunk://#diff-25bf4e40a8d650693daca5505a137acb43417bdde8d6dd2f7d6816671b0dba8bL112-R121) [[2]](diffhunk://#diff-ee6ef92c6f8a0753d7a27b84218eedfa84b1b7bc62838aa53ee05df82ab4b948L103-R112) [[3]](diffhunk://#diff-94da16236ace49611273c702522323b22f12127ba3d2bb14d6dfb8dd8cc57892L103-R112) [[4]](diffhunk://#diff-11e98861dad2fe2ae8f92968df4dff96b677a3fab18de176662b5df3e3966f59L103-R112) [[5]](diffhunk://#diff-8c74e6b3b41084cac67247384db668e384f40b1fbb93cf7bcbaf98aa6434ddf7L103-R112) [[6]](diffhunk://#diff-a98ac636a33ce6092b8a0bd648136daca0d287418f522fbdd5addc8e3f3fd694L103-R112) [[7]](diffhunk://#diff-38825c7dd40e85ab7fd57c6c24f945ccff2d1c2dbffaaa8afbb6a72cb9849b81L103-R112) [[8]](diffhunk://#diff-d03a310fd47859854bbc490a4f1da5692e0bfa02096ff2ff09d07e648bbb6809L103-R112)

**Code Reference Updates**
* Updated references in `execution_flow_error.jsp` to use the new `invited.user.registration.error.unexpected.message` and `invited.user.registration.error.unexpected.description` keys. [[1]](diffhunk://#diff-08fccaaaefef6a1b0ea2d49cf81b6bcd03d805764453ef337feaf1ae66843fdaL86-R86) [[2]](diffhunk://#diff-08fccaaaefef6a1b0ea2d49cf81b6bcd03d805764453ef337feaf1ae66843fdaL107-R107)

**Error Page Logic Improvements**
* Enhanced the error page in `execution_flow_error.jsp` to conditionally display the "Try Again" button only if both `registrationPortalURL` and the `PORTAL_URL` request parameter are present.
* Refined error handling logic in `execution-flow.jsp` to construct the error page URL dynamically based on the presence of the portal URL status, improving navigation and user experience.

**Configuration Update**
* Updated the packaging excludes path in `pom.xml` to match the new resource location for invite user registration errors.