### PR TITLE
Fix application branding not applied issues

### DIFF
--- a/.changeset/five-parents-dance.md
+++ b/.changeset/five-parents-dance.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix application branding not applied issues

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -119,7 +119,9 @@
             applicationAccessUrl = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain, sp);
         }
     } catch (Exception e) {
-        spId = "";
+        spId = (StringUtils.isBlank(spId) || (request.getParameter("spId") != "null" ))?
+                    Encode.forJava(request.getParameter("spId")) :
+                    "";
     }
 
     Boolean isValidCallBackURL = false;

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery-channel.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery-channel.jsp
@@ -199,6 +199,8 @@
                         </div>
                         <div>
                             <input type="hidden" name="sp" value="<%=Encode.forHtmlAttribute(request.getParameter("sp"))%>"/>
+                        </div>
+                        <div>
                             <input type="hidden" name="spId" value="<%=Encode.forHtmlAttribute(request.getParameter("spId"))%>"/>
                         </div>
 

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -254,6 +254,8 @@
                         </div>
                         <div>
                             <input type="hidden" name="sp" value="<%=Encode.forHtmlAttribute(request.getParameter("sp"))%>"/>
+                        </div>
+                        <div>
                             <input type="hidden" name="spId" value="<%=Encode.forHtmlAttribute(request.getParameter("spId"))%>"/>
                         </div>
                         <%


### PR DESCRIPTION
### Purpose

This PR resolves the branding inconsistency that occurs when application-level branding is enabled. The following pages currently do not reflect application-level branding and instead fall back to organizational or root-level branding due to the absence of the application ID (spId) in the request:

- Username Recovery – Request Completed Page

- Self-Registration – Account Confirmation Page

### Implementation
- Added spId as hidden input fields in `username-recovery.jsp` and `username-recovery-channel.jsp` to ensure it is preserved in the request.

- Updated `self-registration-process.jsp` to extract spId from the request when it is not available in the exception object, ensuring it is passed correctly for branding resolution.

### Related PR
- https://github.com/wso2/identity-apps/pull/8593

### Related Issue 
- https://github.com/wso2/product-is/issues/24771