### PR TITLE
[bug-fix] Unable to remove passkey from the flow

### DIFF
--- a/.changeset/famous-mugs-lay.md
+++ b/.changeset/famous-mugs-lay.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.flow-builder-core.v1": patch
+---
+
+Resolve issue on edge creation after node deletion.

--- a/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
+++ b/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
@@ -326,7 +326,7 @@ const DecoratedVisualFlow: FunctionComponent<DecoratedVisualFlowPropsInterface> 
                         outgoers.map(({ id: target }: { id: string }) => {
                             // Find the edge from incomer to the node being deleted
                             const edge: Edge = connectedEdges.find(
-                                (e: any) => e.source === source && e.target === node.id
+                                (e: Edge) => e.source === source && e.target === node.id
                             );
 
                             return {

--- a/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
+++ b/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
@@ -323,11 +323,20 @@ const DecoratedVisualFlow: FunctionComponent<DecoratedVisualFlowPropsInterface> 
                     const remainingEdges: Edge[] = acc.filter((edge: Edge) => !connectedEdges.includes(edge));
 
                     const createdEdges: Edge[] = incomers.flatMap(({ id: source }: { id: string }) =>
-                        outgoers.map(({ id: target }: { id: string }) => ({
-                            id: `${source}->${target}`,
-                            source,
-                            target
-                        }))
+                        outgoers.map(({ id: target }: { id: string }) => {
+                            // Find the edge from incomer to the node being deleted
+                            const edge: Edge = connectedEdges.find(
+                                (e: any) => e.source === source && e.target === node.id
+                            );
+
+                            return {
+                                id: `${edge.source}->${target}`,
+                                source,
+                                sourceHandle: edge?.sourceHandle,
+                                target,
+                                type: edge?.type
+                            };
+                        })
                     );
 
                     return [ ...remainingEdges, ...createdEdges ];


### PR DESCRIPTION
### Purpose
Passkey cannot be removed from the flow. Issue was identified while testing invitation workflow but the issue persists in other flows as well. To remove passkeys, the entire flow needs to be reset.

The issue occurs because the new edge created after deleting a node is only partially initialized. As a result, the flow transformer cannot set the `next` parameter since some required fields are missing from the edge. This fix ensures the new edge is fully initialized by appending the missing parameters.

### Related Issues
- https://github.com/wso2/product-is/issues/25338

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
