### PR TITLE
Hide outdated application banner in sub-orgs

### DIFF
--- a/.changeset/five-hotels-promise.md
+++ b/.changeset/five-hotels-promise.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.applications.v1": patch
+---
+
+Hide outdated applications banner for shared apps.

--- a/features/admin.applications.v1/components/application-list.tsx
+++ b/features/admin.applications.v1/components/application-list.tsx
@@ -451,6 +451,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
                                         ApplicationManagementUtils
                                             .isApplicationOutdated(app.applicationVersion,
                                                 app.clientId != undefined && !isEmpty(app.clientId))
+                                            && !app?.advancedConfigurations?.fragment
                                             && (<Grid>
                                                 <div>
                                                     <Label

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -180,7 +180,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
     );
 
     useEffect(() => {
-        if (application && applicationInboundConfigs) {
+        if (application && applicationInboundConfigs && !application?.advancedConfigurations?.fragment) {
             const isAppOutdated: boolean = ApplicationManagementUtils.isApplicationOutdated(
                 application?.applicationVersion, true);
 
@@ -1022,7 +1022,8 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                                 ApplicationManagementUtils.isApplicationOutdated(
                                     moderatedApplicationData?.applicationVersion,
                                     moderatedApplicationData?.clientId
-                                    && !isEmpty(moderatedApplicationData?.clientId)) && (
+                                    && !isEmpty(moderatedApplicationData?.clientId)) &&
+                                    !application?.advancedConfigurations?.fragment && (
                                     <>
                                         <Label
                                             className="outdated-app-label"


### PR DESCRIPTION
$subject

<img width="1503" height="527" alt="Screenshot 2025-08-25 at 15 32 24" src="https://github.com/user-attachments/assets/a2e0e682-9fea-494d-93ef-489cfed3fc02" />


Issue : https://github.com/wso2/product-is/issues/25354
Ported from : https://github.com/wso2/identity-apps/pull/8933