### PR TITLE
Add seperate UI configs to enable/disable the organization display name or handle

### DIFF
--- a/.changeset/spicy-peas-whisper.md
+++ b/.changeset/spicy-peas-whisper.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.organizations.v1": patch
+"@wso2is/admin.tenants.v1": patch
+"@wso2is/console": patch
+---
+
+Add seperate UI configs to enable/disable the organization display name or handle

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -1495,9 +1495,22 @@
                     {% endif %}
                 },
                 "disabledFeatures": [
+                    {% set ns = namespace(has_items=false) %}
+                    {% if console.ui.organizations.organization_display_name.enable is defined and console.ui.organizations.organization_display_name.enable == false %}
+                    {% if ns.has_items %},{% endif %}
+                    "organizationDisplayName"
+                    {% set ns.has_items = true %}
+                    {% endif %}
+                    {% if console.ui.organizations.organization_handle.enable is defined and console.ui.organizations.organization_handle.enable == false %}
+                    {% if ns.has_items %},{% endif %}
+                    "organizationHandle"
+                    {% set ns.has_items = true %}
+                    {% endif %}
                     {% if console.organizations.disabled_features is defined %}
                     {% for feature in console.organizations.disabled_features %}
-                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% if ns.has_items %},{% endif %}
+                    "{{ feature }}"
+                    {% set ns.has_items = true %}
                     {% endfor %}
                     {% endif %}
                 ]

--- a/features/admin.organizations.v1/components/add-organization-modal.tsx
+++ b/features/admin.organizations.v1/components/add-organization-modal.tsx
@@ -104,10 +104,7 @@ export const AddOrganizationModal: FunctionComponent<AddOrganizationModalPropsIn
     const featureConfig: FeatureConfigInterface = useSelector(
         (state: AppState) => state.config.ui.features
     );
-    const isOrgHandleFeatureEnabled: boolean = isFeatureEnabled(
-        featureConfig.organizations,
-        "organizations.orgHandle"
-    );
+    const isOrgHandleFeatureEnabled: boolean = isFeatureEnabled(featureConfig.organizations, "organizationHandle");
 
     const submitOrganization = async (values: OrganizationAddFormProps): Promise<Record<string, string> | void> => {
 

--- a/features/admin.organizations.v1/components/edit-organization/organization-overview.tsx
+++ b/features/admin.organizations.v1/components/edit-organization/organization-overview.tsx
@@ -121,10 +121,7 @@ export const OrganizationOverview: FunctionComponent<OrganizationOverviewPropsIn
         setShowOrgDeleteConfirmationModal
     ] = useState(false);
 
-    const isOrgHandleFeatureEnabled: boolean = isFeatureEnabled(
-        featureConfig.organizations,
-        "organizations.orgHandle"
-    );
+    const isOrgHandleFeatureEnabled: boolean = isFeatureEnabled(featureConfig.organizations, "organizationHandle");
 
     const handleSubmit: (values: OrganizationResponseInterface) => Promise<void> = useCallback(
         async (values: OrganizationResponseInterface): Promise<void> => {

--- a/features/admin.organizations.v1/components/organization-list.tsx
+++ b/features/admin.organizations.v1/components/organization-list.tsx
@@ -184,10 +184,7 @@ export const OrganizationList: FunctionComponent<OrganizationListPropsInterface>
 
     const eventPublisher: EventPublisher = EventPublisher.getInstance();
 
-    const isOrgHandleFeatureEnabled: boolean = isFeatureEnabled(
-        featureConfig.organizations,
-        "organizations.orgHandle"
-    );
+    const isOrgHandleFeatureEnabled: boolean = isFeatureEnabled(featureConfig.organizations, "organizationHandle");
 
     /**
      * Redirects to the organizations edit page when the edit button is clicked.

--- a/features/admin.tenants.v1/components/add-tenant/add-tenant-form.tsx
+++ b/features/admin.tenants.v1/components/add-tenant/add-tenant-form.tsx
@@ -21,6 +21,7 @@ import InputAdornment from "@oxygen-ui/react/InputAdornment";
 import Stack from "@oxygen-ui/react/Stack";
 import Typography from "@oxygen-ui/react/Typography/Typography";
 import { GlobeIcon } from "@oxygen-ui/react-icons";
+import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { SharedUserStoreUtils } from "@wso2is/admin.core.v1/utils/user-store-utils";
 import { generatePassword, getConfiguration } from "@wso2is/admin.users.v1/utils/generate-password.utils";
@@ -28,6 +29,7 @@ import getUsertoreUsernameValidationPattern from "@wso2is/admin.users.v1/utils/g
 import { getUsernameConfiguration } from "@wso2is/admin.users.v1/utils/user-management-utils";
 import { useValidationConfigData } from "@wso2is/admin.validation.v1/api/validation-config";
 import { ValidationFormInterface } from "@wso2is/admin.validation.v1/models/validation-config";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import {
     FinalForm,
@@ -100,6 +102,11 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
     const passwordValidationConfig: ValidationFormInterface = useMemo((): ValidationFormInterface => {
         return getConfiguration(validationData);
     }, [ validationData ]);
+
+    const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const isOrgDisplayNameFeatureEnabled: boolean = isFeatureEnabled(
+        featureConfig.organizations, "organizationDisplayName"
+    );
 
     /**
      * Form validator to validate the username against the userstore regex.
@@ -354,32 +361,34 @@ const AddTenantForm: FunctionComponent<AddTenantFormProps> = ({
                         onSubmit={ handleSubmit }
                         className="add-tenant-form"
                     >
-                        <FinalFormField
-                            key="organizationName"
-                            width={ 16 }
-                            className="text-field-container"
-                            ariaLabel="organizationName"
-                            required={ false }
-                            data-componentid={ `${componentId}-organization-name` }
-                            name="organizationName"
-                            type="text"
-                            helperText={ (
-                                <Hint>
-                                    <Typography variant="inherit">
-                                        <Trans
-                                            i18nKey="tenants:common.form.fields.organizationName.helperText"
-                                            components={ { bold: <span style={ { fontWeight: "bold" } } /> } }
-                                        />
-                                    </Typography>
-                                </Hint>
-                            ) }
-                            label={ t("tenants:common.form.fields.organizationName.label") }
-                            placeholder={ t("tenants:common.form.fields.organizationName.placeholder") }
-                            component={ TextFieldAdapter }
-                            maxLength={ 100 }
-                            minLength={ 1 }
-                            validate={ validateOrganizationName }
-                        />
+                        { isOrgDisplayNameFeatureEnabled && (
+                            <FinalFormField
+                                key="organizationName"
+                                width={ 16 }
+                                className="text-field-container"
+                                ariaLabel="organizationName"
+                                required={ false }
+                                data-componentid={ `${componentId}-organization-name` }
+                                name="organizationName"
+                                type="text"
+                                helperText={ (
+                                    <Hint>
+                                        <Typography variant="inherit">
+                                            <Trans
+                                                i18nKey="tenants:common.form.fields.organizationName.helperText"
+                                                components={ { bold: <span style={ { fontWeight: "bold" } } /> } }
+                                            />
+                                        </Typography>
+                                    </Hint>
+                                ) }
+                                label={ t("tenants:common.form.fields.organizationName.label") }
+                                placeholder={ t("tenants:common.form.fields.organizationName.placeholder") }
+                                component={ TextFieldAdapter }
+                                maxLength={ 100 }
+                                minLength={ 1 }
+                                validate={ validateOrganizationName }
+                            />
+                        ) }
                         <FinalFormField
                             key="organizationHandle"
                             width={ 16 }

--- a/features/admin.tenants.v1/components/dropdown/tenant-dropdown.tsx
+++ b/features/admin.tenants.v1/components/dropdown/tenant-dropdown.tsx
@@ -179,8 +179,9 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
     const featureConfig: FeatureConfigInterface = useSelector(
         (state: AppState) => state.config.ui.features
     );
-    const isOrgHandleFeatureEnabled: boolean = isFeatureEnabled(
-        featureConfig.organizations,"organizations.orgHandle"
+    const isOrgHandleFeatureEnabled: boolean = isFeatureEnabled(featureConfig.organizations, "organizationHandle");
+    const isOrgDisplayNameFeatureEnabled: boolean = isFeatureEnabled(
+        featureConfig.organizations, "organizationDisplayName"
     );
 
     const [ tenantAssociations, setTenantAssociations ] = useState<TenantAssociationsInterface>(undefined);
@@ -689,29 +690,31 @@ const TenantDropdown: FunctionComponent<TenantDropdownInterface> = (props: Tenan
             });
         }
 
-        options.push(
-            <Dropdown.Item
-                className="action-panel"
-                onClick={ (): void => {
-                    history.push(AppConstants.getPaths().get("EDIT_SELF_ORGANIZATION"));
-                } }
-                data-compnentid="edit-self-organization"
-            >
-                {
-                    hasOrganizationUpdatePermissions ? (
-                        <>
-                            <PenToSquareIcon />
-                            { t("tenants:tenantDropdown.options.edit.label") }
-                        </>
-                    ) : (
-                        <>
-                            <EyeIcon />
-                            { t("tenants:tenantDropdown.options.view.label") }
-                        </>
-                    )
-                }
-            </Dropdown.Item>
-        );
+        if (isOrgDisplayNameFeatureEnabled) {
+            options.push(
+                <Dropdown.Item
+                    className="action-panel"
+                    onClick={ (): void => {
+                        history.push(AppConstants.getPaths().get("EDIT_SELF_ORGANIZATION"));
+                    } }
+                    data-compnentid="edit-self-organization"
+                >
+                    {
+                        hasOrganizationUpdatePermissions ? (
+                            <>
+                                <PenToSquareIcon />
+                                { t("tenants:tenantDropdown.options.edit.label") }
+                            </>
+                        ) : (
+                            <>
+                                <EyeIcon />
+                                { t("tenants:tenantDropdown.options.view.label") }
+                            </>
+                        )
+                    }
+                </Dropdown.Item>
+            );
+        }
 
         if (hasTenantsReadPermissions && isManagingTenantsFromDropdownEnabled && isSuperOrganization()) {
             options.push(

--- a/features/admin.tenants.v1/components/edit-tenant/edit-tenant-form.tsx
+++ b/features/admin.tenants.v1/components/edit-tenant/edit-tenant-form.tsx
@@ -23,11 +23,13 @@ import Stack from "@oxygen-ui/react/Stack";
 import Tooltip from "@oxygen-ui/react/Tooltip";
 import Typography from "@oxygen-ui/react/Typography/Typography";
 import { CopyIcon, GlobeIcon } from "@oxygen-ui/react-icons";
+import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { generatePassword, getConfiguration } from "@wso2is/admin.users.v1/utils/generate-password.utils";
 import { getUsernameConfiguration } from "@wso2is/admin.users.v1/utils/user-management-utils";
 import { useValidationConfigData } from "@wso2is/admin.validation.v1/api/validation-config";
 import { ValidationFormInterface } from "@wso2is/admin.validation.v1/models/validation-config";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { CommonUtils } from "@wso2is/core/utils";
@@ -106,6 +108,11 @@ const EditTenantForm: FunctionComponent<EditTenantFormProps> = ({
     const passwordValidationConfig: ValidationFormInterface = useMemo((): ValidationFormInterface => {
         return getConfiguration(validationData);
     }, [ validationData ]);
+
+    const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const isOrgDisplayNameFeatureEnabled: boolean = isFeatureEnabled(
+        featureConfig.organizations, "organizationDisplayName"
+    );
 
     /**
      * Handles the form submit action.
@@ -333,38 +340,40 @@ const EditTenantForm: FunctionComponent<EditTenantFormProps> = ({
                         onSubmit={ handleSubmit }
                         className="edit-tenant-form"
                     >
-                        <FinalFormField
-                            key="organizationName"
-                            width={ 16 }
-                            className="text-field-container"
-                            ariaLabel="organizationName"
-                            required={ false }
-                            data-componentid={ `${componentId}-organization-name` }
-                            name="organizationName"
-                            type="text"
-                            label={ t("tenants:common.form.fields.organizationName.label") }
-                            component={ TextFieldAdapter }
-                            readOnly={ true }
-                            InputProps={ {
-                                endAdornment: (
-                                    <Tooltip title="Copy">
-                                        <div>
-                                            <IconButton
-                                                aria-label="Reset field to default"
-                                                className="reset-field-to-default-adornment"
-                                                onClick={ async () => {
-                                                    await CommonUtils.copyTextToClipboard(tenant?.name);
-                                                } }
-                                                edge="end"
-                                            >
-                                                <CopyIcon size={ 12 } />
-                                            </IconButton>
-                                        </div>
-                                    </Tooltip>
-                                ),
-                                readOnly: true
-                            } }
-                        />
+                        { isOrgDisplayNameFeatureEnabled && (
+                            <FinalFormField
+                                key="organizationName"
+                                width={ 16 }
+                                className="text-field-container"
+                                ariaLabel="organizationName"
+                                required={ false }
+                                data-componentid={ `${componentId}-organization-name` }
+                                name="organizationName"
+                                type="text"
+                                label={ t("tenants:common.form.fields.organizationName.label") }
+                                component={ TextFieldAdapter }
+                                readOnly={ true }
+                                InputProps={ {
+                                    endAdornment: (
+                                        <Tooltip title="Copy">
+                                            <div>
+                                                <IconButton
+                                                    aria-label="Reset field to default"
+                                                    className="reset-field-to-default-adornment"
+                                                    onClick={ async () => {
+                                                        await CommonUtils.copyTextToClipboard(tenant?.name);
+                                                    } }
+                                                    edge="end"
+                                                >
+                                                    <CopyIcon size={ 12 } />
+                                                </IconButton>
+                                            </div>
+                                        </Tooltip>
+                                    ),
+                                    readOnly: true
+                                } }
+                            />
+                        ) }
                         <FinalFormField
                             key="organizationHandle"
                             width={ 16 }


### PR DESCRIPTION
### Purpose

```
[console.ui]
organizations.organization_handle.enable = true
```

```
[console.ui]
organizations.organization_display_name.enable = true
```

Adding the above two configs in the **deployment.toml** file would remove these from the feature from the console UI. This config will add the following to the disabledFeature list for organizations.

<img width="475" height="419" alt="Screenshot 2025-09-02 at 08 08 14" src="https://github.com/user-attachments/assets/f66a593b-4c36-4b58-a7dc-0ed3c9fc58d7" />
