### PR TITLE
[hotfix][@wso2is/myaccount@2.23.2] Fix issue in multi-value email/mobile fields

### DIFF
--- a/apps/myaccount/src/components/profile/fields/email-field-form.tsx
+++ b/apps/myaccount/src/components/profile/fields/email-field-form.tsx
@@ -245,7 +245,7 @@ const EmailFieldForm: FunctionComponent<EmailFieldFormPropsInterface> = ({
                                 { renderVerifiedIcon() }
                             </div>
                         ) }
-                        { emailAddress.isPrimary && (
+                        { !emailAddress.isVerificationPending && emailAddress.isPrimary && (
                             <div
                                 className="verified-icon"
                                 data-componentid={
@@ -373,6 +373,25 @@ const EmailFieldForm: FunctionComponent<EmailFieldFormPropsInterface> = ({
             Operations: [],
             schemas: [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ]
         };
+
+        // If the email address list is empty, add the new email address as the primary.
+        if (sortedEmailAddressesList.length === 0) {
+            const updatedEmailsList: (string | MultiValue)[] = [];
+
+            for (const emailAddress of profileDetails?.profileInfo?.emails) {
+                if (typeof emailAddress === "object") {
+                    updatedEmailsList.push(emailAddress);
+                }
+            }
+            updatedEmailsList.push(emailAddress);
+
+            data.Operations.push({
+                op: "replace",
+                value: {
+                    [ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("EMAILS")]: updatedEmailsList
+                }
+            });
+        }
 
         if (schema.extended && schema.multiValued) {
             // In case of switching from single-valued to multi-valued
@@ -587,6 +606,7 @@ const EmailFieldForm: FunctionComponent<EmailFieldFormPropsInterface> = ({
                                                 )
                                             }
                                             {
+                                                !emailAddress.isVerificationPending &&
                                                 emailAddress.isPrimary && (
                                                     <div
                                                         className="verified-icon"

--- a/apps/myaccount/src/components/profile/fields/mobile-field-form.tsx
+++ b/apps/myaccount/src/components/profile/fields/mobile-field-form.tsx
@@ -383,6 +383,18 @@ const MobileFieldForm: FunctionComponent<MobileFieldFormPropsInterface> = ({
             schemas: [ "urn:ietf:params:scim:api:messages:2.0:PatchOp" ]
         };
 
+        // Set the first mobile number as primary.
+        if (sortedMobileNumbersList.length === 0) {
+            data.Operations.push({
+                op: "replace",
+                value: {
+                    [ProfileConstants.SCIM2_SCHEMA_DICTIONARY.get("PHONE_NUMBERS")]: [
+                        { type: "mobile", value: mobileNumber }
+                    ]
+                }
+            });
+        }
+
         if (schema.extended && schema.multiValued) {
             // In case of switching from single-valued to multi-valued
             // `sortedMobileNumbersList` will contain the single valued mobile number as well.


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This pull request updates the logic for handling primary status assignment and verification icons for email and mobile fields in the profile forms. The main improvements ensure that the first email or mobile entry is set as primary when the list is empty.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/identity-apps/pull/8796

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
