### PR TITLE
[bug-fix] The account status is not reflected in the Administrator user list view

### DIFF
--- a/.changeset/twelve-lemons-pretend.md
+++ b/.changeset/twelve-lemons-pretend.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.console-settings.v1": patch
+---
+
+Add account lock/disable sign in console-administrator settings.

--- a/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-table.tsx
+++ b/features/admin.console-settings.v1/components/console-administrators/administrators-list/administrators-table.tsx
@@ -191,7 +191,7 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
      * @param user - each admin user belonging to a row of the table.
      * @returns the locked icon.
      */
-    const resolveAccountStatus = (user: UserBasicInterface): ReactNode => {
+    const resolveUserAccountStatusIcon = (user: UserBasicInterface): ReactNode => {
         const accountLocked: boolean = user[userConfig.userProfileSchema]?.accountLocked === "true" ||
             user[userConfig.userProfileSchema]?.accountLocked === true;
         const accountDisabled: boolean = user[userConfig.userProfileSchema]?.accountDisabled === "true" ||
@@ -274,7 +274,7 @@ const AdministratorsTable: React.FunctionComponent<AdministratorsTablePropsInter
                                 spaced="right"
                                 data-suppress=""
                             />
-                            { resolveAccountStatus(user) }
+                            { resolveUserAccountStatusIcon(user) }
                             <Header.Content>
                                 { header }
                                 { resolveMyselfLabel(user) }


### PR DESCRIPTION
### Purpose
Add acc lock/disable icon in user list in administrator list under console-settings.

### Related Issues
- https://github.com/wso2/product-is/issues/25519

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

https://github.com/user-attachments/assets/ab3fefa7-4f82-4532-8df7-71ff99923407

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
