### PR TITLE
[bug-fix] Deleting custom claim dialect is not consistent

### DIFF
--- a/.changeset/eighty-apricots-smash.md
+++ b/.changeset/eighty-apricots-smash.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/i18n": patch
+"@wso2is/console": patch
+---
+
+Add checkbox instead of input format for delete confimation modal.

--- a/features/admin.claims.v1/pages/external-dialect-edit.tsx
+++ b/features/admin.claims.v1/pages/external-dialect-edit.tsx
@@ -120,18 +120,8 @@ const ExternalDialectEditPage: FunctionComponent<ExternalDialectEditPageInterfac
             type="negative"
             open={ confirmDelete }
             assertion={ dialect.dialectURI }
-            assertionHint={ (
-                /**
-                 * TODO: Trans component with strong tags doesn't seem to
-                 * work here properly, hence removed for now.
-                 *
-                 * Need to find the root cause and fix this.
-                 */
-                <p>
-                    Please type <strong>{ dialect.dialectURI }</strong> to confirm.
-                </p>
-            ) }
-            assertionType="input"
+            assertionHint={ t("claims:dialects.confirmations.hint") }
+            assertionType="checkbox"
             primaryAction={ t("claims:dialects.confirmations.action") }
             secondaryAction={ t("common:cancel") }
             onSecondaryActionClick={ (): void => setConfirmDelete(false) }

--- a/modules/i18n/src/translations/en-US/portals/claims.ts
+++ b/modules/i18n/src/translations/en-US/portals/claims.ts
@@ -74,7 +74,7 @@ export const claims: ClaimsNS = {
             content: "If you delete this attribute mapping, all the associated {{type}} attributes will "
                 + "also be deleted. Please proceed with caution.",
             header: "Are you sure?",
-            hint: "Please type <1>{{confirm}}</1> to confirm.",
+            hint: "Please confirm your action.",
             message: "This action is irreversible and will permanently delete the selected attribute " +
                 "mapping."
         },


### PR DESCRIPTION
### Purpose
Update the delete confirmation modal for custom claim dialects to be consistent with other delete confirmation modals.

### Related Issues
- https://github.com/wso2/product-is/issues/25234

<img width="691" height="394" alt="image" src="https://github.com/user-attachments/assets/ce869ffa-bf0a-4fe6-ba69-dbe68d5a372a" />

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
