### PR TITLE
Add language switcher to SAML login page

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/includes/product-footer.jsp
@@ -108,7 +108,7 @@
                     "/confirmregistration.do", "/confirmrecovery.do", "/claims.do", "/oauth2_consent.do",
                     "/fido2-auth.jsp", "/fido2-identifierfirst.jsp", "/fido2-enroll.jsp", "/fido2-passkey-status.jsp",
                     "/fido2-error.jsp", "/email_otp.do", "/org_name.do", "/org_handle.do", "/org_discovery.do", "/retry.do", "/totp_enroll.do",
-                    "/backup_code.do", "/device.do", "/error.do");
+                    "/backup_code.do", "/device.do", "/error.do", "/samlsso_login.do");
                 if (langSwitcherEnabledServlets.contains(request.getServletPath())) {
                     File languageSwitcherFile = new File(getServletContext().getRealPath("extensions/language-switcher.jsp"));
                     if (languageSwitcherFile.exists()) {


### PR DESCRIPTION
### Purpose

Add language switcher to SAML login page

<img width="538" height="645" alt="Screenshot 2025-07-18 at 17 11 16" src="https://github.com/user-attachments/assets/d91929bf-87eb-44fc-a245-c970c1327bdd" />

### Related Issues
- https://github.com/wso2/product-is/issues/24151

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
