### PR TITLE
Fix JSON deserialisation error during self-registration username validation

### DIFF
--- a/.changeset/tough-beans-rescue.md
+++ b/.changeset/tough-beans-rescue.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix JSON deserialisation error during self-registration username validation

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -225,16 +225,14 @@
 
     Integer userNameValidityStatusCode = usernameValidityResponse.getInt("code");
     String errorCode = String.valueOf(userNameValidityStatusCode);
-    String usernameErrorMessage = usernameValidityResponse.has("message") ? usernameValidityResponse.getString("message") : null;
 
     if (!SelfRegistrationStatusCodes.CODE_USER_NAME_AVAILABLE.equalsIgnoreCase(userNameValidityStatusCode.toString())) {
         if (allowchangeusername) {
             request.setAttribute("error", true);
             request.setAttribute("errorCode", userNameValidityStatusCode);
-            if (usernameValidityResponse.has("message")) {
-                if (usernameValidityResponse.get("message") instanceof String) {
-                    request.setAttribute("errorMessage", usernameValidityResponse.getString("message"));
-                }
+            if (usernameValidityResponse.has("message") &&
+                usernameValidityResponse.get("message") instanceof String) {
+                request.setAttribute("errorMessage", usernameValidityResponse.getString("message"));
             }
             request.getRequestDispatcher("register.do").forward(request, response);
         } else if (!skipSignUpEnableCheck
@@ -272,8 +270,10 @@
                     // If there is no i18n entry for the error message, check if there is a custom error message
                     // UsernameJavaRegExViolationErrorMsg configured in deployment.toml
                     // Else, use the default error message
-                    if (StringUtils.isNotBlank(usernameErrorMessage)) {
-                        errorMsg = usernameErrorMessage;
+                    if (usernameValidityResponse.has("message") &&
+                        usernameValidityResponse.get("message") instanceof String &&
+                        StringUtils.isNotBlank(usernameValidityResponse.getString("message"))) {
+                        errorMsg = usernameValidityResponse.getString("message");
                     } else {
                         errorMsg = user.getUsername() + " " + i18n(recoveryResourceBundle, customText,
                             "invalid.username.pick.a.valid.username");


### PR DESCRIPTION

### Purpose
This pull request refines the error handling logic for username validation during self-registration in the `self-registration-process.jsp` file. The changes ensure that custom error messages are only set and displayed when they are present and of the correct type, improving robustness and reducing the risk of displaying invalid error messages.

Improvements to error handling:

* Updated the logic to set the `errorMessage` attribute only if the `message` field exists and is a string in the `usernameValidityResponse` object.
* Refined the condition for displaying a custom error message to check that the `message` field exists, is a string, and is not blank before using it as the error message.


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/25563

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [x] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [x] Documentation provided. (Add links if there are any)
- [x] Relevant backend changes deployed and verified
- [x] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [x] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
