### PR TITLE
Account portal improvements

### DIFF
--- a/.changeset/thirty-foxes-repeat.md
+++ b/.changeset/thirty-foxes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add missing i18n resources and consume flowType from response

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources.properties
@@ -59,6 +59,20 @@ cookie.policy=Cookie Policy
 cookie.consent.banner.content=We use cookies to ensure that you get the best overall experience. These cookies are used to maintain an uninterrupted continuous session whilst providing smooth and personalized services. To learn more about how we use cookies, refer our
 cookie.consent.banner.clear=Got it
 
+# Errors
+error.occurred=Error Occurred
+error.400=Error 400 - Bad Request
+error.401=Error 401 - Unauthorized
+error.403=Error 403 - Forbidden
+error.404=Error 404 - Page Not Found
+error.405=Error 405 - Method Not Allowed
+error.408=Error 408 - Request Timeout
+error.410=Error 410 - Gone
+error.500=Error 500 - Internal Server Error
+error.502=Error 502 - Bad Gateway
+error.503=Error 503 - Service Unavailable
+error.504=Error 504 - Gateway Timeout
+
 # Registration flow errors.
 sign.up.error.username.not.provided.message=Username is not Provided
 sign.up.error.username.not.provided.description=Username is not provided in the registration request

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_de_DE.properties
@@ -50,6 +50,20 @@ cookie.policy=Cookie-Richtlinie
 cookie.consent.banner.content=Wir verwenden Cookies, um dir das bestmögliche Erlebnis zu bieten. Diese Cookies sorgen für eine unterbrechungsfreie Sitzung und personalisierte Dienste. Weitere Informationen findest du in unserer
 cookie.consent.banner.clear=Verstanden
 
+# Errors
+error.occurred=Ein Fehler ist aufgetreten
+error.400=Fehler 400 - schlechte Anfrage
+error.401=Fehler 401 - nicht autorisiert
+error.403=Fehler 403 - verboten
+error.404=Fehler 404 - Seite nicht gefunden
+error.405=Fehler 405 - Methode nicht erlaubt
+error.408=Fehler 408 - Timeout anfordern
+error.410=Fehler 410 - nicht vorhanden
+error.500=Fehler 500 - interner Server-Fehler
+error.502=Fehler 502 - schlechtes Gateway
+error.503=Fehler 503 - Service nicht verfügbar
+error.504=Fehler 504 - Timeout von Gateway
+
 # Registration flow errors.
 sign.up.error.username.not.provided.message=Benutzername nicht angegeben
 sign.up.error.username.not.provided.description=Im Registrierungsantrag wurde kein Benutzername angegeben

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_es_ES.properties
@@ -50,6 +50,20 @@ cookie.policy=Política de Cookies
 cookie.consent.banner.content=Utilizamos cookies para garantizar que tengas la mejor experiencia posible. Estas cookies se usan para mantener una sesión continua y proporcionar servicios fluidos y personalizados. Para obtener más información, consulta nuestra
 cookie.consent.banner.clear=Entendido
 
+# Errors
+error.occurred=Se produjo un error
+error.400=Error 400 - Solicitud incorrecta
+error.401=Error 401 - No autorizado
+error.403=Error 403 - Prohibido
+error.404=Error 404 - Página no encontrada
+error.405=Error 405 - Método no permitido
+error.408=Error 408 - Tiempo de espera de solicitud agotado
+error.410=Error 410 - Gone
+error.500=Error 500 - Error interno del servidor
+error.502=Error 502 - Puerta de enlace incorrecta
+error.503=Error 503 - Servicio no disponible
+error.504=Error 504 - Tiempo de espera de la puerta de enlace agotado
+
 # Registration flow errors.
 sign.up.error.username.not.provided.message=Nombre de usuario no proporcionado
 sign.up.error.username.not.provided.description=No se proporcionó el nombre de usuario en la solicitud de registro

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_fr_FR.properties
@@ -50,6 +50,20 @@ cookie.policy=Politique de cookies
 cookie.consent.banner.content=Nous utilisons des cookies pour vous garantir la meilleure expérience possible. Ces cookies permettent de maintenir une session continue et de fournir des services personnalisés et fluides. Pour en savoir plus sur l'utilisation des cookies, consultez notre
 cookie.consent.banner.clear=Compris
 
+# Errors
+error.occurred=Erreur est survenue
+error.400=Erreur 400 - Demande incorrecte
+error.401=Erreur 401 - Non autorisé
+error.403=Erreur 403 - Interdit
+error.404=Erreur 404 - Page non trouvée
+error.405=Erreur 405 - Méthode non autorisée
+error.408=Erreur 408 - Délai d'expiration de la demande
+error.410=Erreur 410 - Disparu
+error.500=Erreur 500 - Erreur interne du serveur
+error.502=Erreur 502 - Mauvaise passerelle
+error.503=Erreur 503 - Service indisponible
+error.504=Erreur 504 - Délai d'expiration de la passerelle
+
 # Registration flow errors.
 sign.up.error.username.not.provided.message=Nom d'utilisateur non fourni
 sign.up.error.username.not.provided.description=Le nom d'utilisateur n'est pas fourni dans la demande d'inscription

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_ja_JP.properties
@@ -50,6 +50,20 @@ cookie.policy=クッキーポリシー
 cookie.consent.banner.content=当社は、最適な体験を提供するためにクッキーを使用しています。クッキーは、セッションを維持し、スムーズでパーソナライズされたサービスを提供するために使用されます。詳細はクッキーポリシーをご覧ください。
 cookie.consent.banner.clear=了解しました
 
+## Errors
+error.occurred=エラーが発生しました
+error.400=エラー 400 - 不正なリクエスト
+error.401=エラー 401 - 認証なし
+error.403=エラー 403 - アクセス禁止
+error.404=エラー 404 - ページが見つかりません
+error.405=エラー 405 - メソッドは許可されていません
+error.408=エラー 408 - リクエストタイムアウト
+error.410=エラー 410 - 消失
+error.500=エラー 500 - 内部サーバー エラー
+error.502=エラー 502 - 不正なゲートウェイ
+error.503=エラー 503 - サービスは利用できません
+error.504=エラー 504 - ゲートウェイのタイムアウト
+
 # Registration flow errors.
 sign.up.error.username.not.provided.message=ユーザー名が未入力です
 sign.up.error.username.not.provided.description=登録リクエストにユーザー名が含まれていません

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_BR.properties
@@ -50,6 +50,20 @@ cookie.policy=Política de Cookies
 cookie.consent.banner.content=Usamos cookies para garantir que você tenha a melhor experiência possível. Esses cookies mantêm sessões contínuas e fornecem serviços personalizados. Para saber mais sobre como usamos cookies, consulte nossa
 cookie.consent.banner.clear=Entendi
 
+# Errors
+error.occurred=Ocorreu um erro
+error.400=Erro 400 - Bad Request
+error.401=Erro 401 - Unauthorized
+error.403=Erro 403 - Forbidden
+error.404=Erro 404 - Page Not Found
+error.405=Erro 405 - Method Not Allowed
+error.408=Erro 408 - Request Timeout
+error.410=Erro 410 - Gone
+error.500=Erro 500 - Internal Server Error
+error.502=Erro 502 - Bad Gateway
+error.503=Erro 503 - Service Unavailable
+error.504=Erro 504 - Gateway Timeout
+
 # Registration flow errors.
 sign.up.error.username.not.provided.message=Nome de usuário não fornecido
 sign.up.error.username.not.provided.description=O nome de usuário não foi fornecido na solicitação de registro

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_PT.properties
@@ -50,6 +50,20 @@ cookie.policy=Política de Cookies
 cookie.consent.banner.content=Utilizamos cookies para garantir que obtém a melhor experiência possível. Estes cookies são utilizados para manter uma sessão contínua e fornecer serviços personalizados e fluídos. Para saber mais sobre como utilizamos cookies, consulte a nossa
 cookie.consent.banner.clear=Percebi
 
+# Errors
+error.occurred=Ocorreu um erro
+error.400=Erro 400 - Pedido ruim
+error.401=Erro 401 - Não autorizado
+error.403=Erro 403 - Proibido
+error.404=Erro 404 - Página não encontrada
+error.405=Erro 405 - Método não permitido
+error.408=Erro 408 - Tempo de solicitação esgotado
+error.410=Erro 410 - Perdido
+error.500=Erro 500 - Erro interno do servidor
+error.502=Erro 502 - Gateway ruim
+error.503=Erro 503 Serviço Indisponível
+error.504=Erro 504 - Tempo limite do gateway
+
 # Registration flow errors.
 sign.up.error.username.not.provided.message=Nome de utilizador não fornecido
 sign.up.error.username.not.provided.description=O nome de utilizador não foi fornecido no pedido de registo

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_zh_CN.properties
@@ -50,6 +50,20 @@ cookie.policy=Cookie 政策
 cookie.consent.banner.content=我们使用 Cookie 来确保您获得最佳体验。这些 Cookie 用于维持不间断的会话，并提供流畅且个性化的服务。要了解更多信息，请参阅我们的
 cookie.consent.banner.clear=知道了
 
+## Errors
+error.occurred=错误发生
+error.400=错误400-不良要求
+error.401=错误401-未经授权
+error.403=错误403-禁止
+error.404=错误404-找不到页面
+error.405=错误405-不允许的方法
+error.408=错误408-请求超时
+error.410=错误410-走了
+error.500=错误500-内部服务器错误
+error.502=错误502-不良门户
+error.503=错误503-服务不可用
+error.504=错误504-网关超时
+
 # Registration flow errors.
 sign.up.error.username.not.provided.message=未提供用户名
 sign.up.error.username.not.provided.description=注册请求中未提供用户名

--- a/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
@@ -196,7 +196,6 @@
                 const code = "<%= Encode.forJavaScript(code) != null ? Encode.forJavaScript(code) : null %>";
                 const state = "<%= Encode.forJavaScript(state) != null ? Encode.forJavaScript(state) : null %>";
                 const confirmationCode = "<%= Encode.forJavaScript(confirmationCode) != null ? Encode.forJavaScript(confirmationCode) : null %>";
-                const flowType = "<%= Encode.forJavaScript(flowType) != null ? Encode.forJavaScript(flowType) : null %>";
                 const mlt = "<%= Encode.forJavaScript(mlt) != null ? Encode.forJavaScript(mlt) : null %>";
                 const flowId = "<%= Encode.forJavaScript(flowId) != null ? Encode.forJavaScript(flowId) : null %>";
                 const spId = "<%= !StringUtils.isBlank(spId) && spId != "null" ? Encode.forJavaScript(spId) : "new-application" %>";
@@ -209,6 +208,7 @@
                 const [ flowError, setFlowError ] = useState(undefined);
                 const [confirmationEffectDone, setConfirmationEffectDone] = useState(false);
                 const [userAssertion, setUserAssertion] = useState(null);
+                const [flowType, setFlowType] = useState("<%= Encode.forJavaScript(flowType) != null ? Encode.forJavaScript(flowType) : null %>");
 
                 useEffect(() => {
                     const savedFlowId = localStorage.getItem("flowId");
@@ -276,6 +276,9 @@
                     })
                     .then((data) => {
                         if (data.error) {
+                            if (data.error.flowType) {
+                                setFlowType(data.error.flowType);
+                            }
                             setError(data.error);
 
                             return;
@@ -283,6 +286,10 @@
 
                         if (data.flowId) {
                             localStorage.setItem("flowId", data.flowId);
+                        }
+
+                        if (data.flowType) {
+                            setFlowType(data.flowType);
                         }
 
                         const isFlowEnded = handleFlowStatus(data);


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25509

This pull request adds missing internationalization (i18n) resources for error messages across multiple languages and updates how the `flowType` value is handled in the authentication flow. These changes improve error reporting for users in their preferred language and ensure the frontend correctly consumes the `flowType` from backend responses.

**Internationalization improvements:**

* Added a comprehensive set of error message translations (e.g., 400, 401, 404, 500 errors) to the following i18n resource files: `Resources.properties`, `Resources_de_DE.properties`, `Resources_es_ES.properties`, `Resources_fr_FR.properties`, `Resources_ja_JP.properties`, `Resources_pt_BR.properties`, `Resources_pt_PT.properties`, and `Resources_zh_CN.properties`. This ensures users see localized error messages throughout the application. [[1]](diffhunk://#diff-25bf4e40a8d650693daca5505a137acb43417bdde8d6dd2f7d6816671b0dba8bR62-R75) [[2]](diffhunk://#diff-ee6ef92c6f8a0753d7a27b84218eedfa84b1b7bc62838aa53ee05df82ab4b948R53-R66) [[3]](diffhunk://#diff-94da16236ace49611273c702522323b22f12127ba3d2bb14d6dfb8dd8cc57892R53-R66) [[4]](diffhunk://#diff-11e98861dad2fe2ae8f92968df4dff96b677a3fab18de176662b5df3e3966f59R53-R66) [[5]](diffhunk://#diff-8c74e6b3b41084cac67247384db668e384f40b1fbb93cf7bcbaf98aa6434ddf7R53-R66) [[6]](diffhunk://#diff-a98ac636a33ce6092b8a0bd648136daca0d287418f522fbdd5addc8e3f3fd694R53-R66) [[7]](diffhunk://#diff-38825c7dd40e85ab7fd57c6c24f945ccff2d1c2dbffaaa8afbb6a72cb9849b81R53-R66) [[8]](diffhunk://#diff-d03a310fd47859854bbc490a4f1da5692e0bfa02096ff2ff09d07e648bbb6809R53-R66)

**Authentication flow enhancements:**

* Changed the handling of `flowType` in `execution-flow.jsp` so that it is now set and updated using React state, allowing dynamic updates based on backend responses. [[1]](diffhunk://#diff-549603c2d607cb37011a2528f2b591258b239c1b043f1b8a9b1801ce309825e8L199) [[2]](diffhunk://#diff-549603c2d607cb37011a2528f2b591258b239c1b043f1b8a9b1801ce309825e8R211)
* Updated the logic to consume `flowType` from both error and success responses, ensuring the frontend accurately reflects the current authentication flow type. [[1]](diffhunk://#diff-549603c2d607cb37011a2528f2b591258b239c1b043f1b8a9b1801ce309825e8R279-R281) [[2]](diffhunk://#diff-549603c2d607cb37011a2528f2b591258b239c1b043f1b8a9b1801ce309825e8R291-R294)

**Meta changes:**

* Added a changeset file documenting the addition of missing i18n resources and the consumption of `flowType` from the response.