### PR TITLE
Add condition to show Ask Password toggle

### DIFF
--- a/features/admin.server-configurations.v1/constants/ask-password-constants.ts
+++ b/features/admin.server-configurations.v1/constants/ask-password-constants.ts
@@ -18,13 +18,6 @@
 
 import { ServerConfigurationsConstants } from "./server-configurations-constants";
 
-/**
- * Keys used in feature dictionary.
- */
-export enum GovernanceConnectorFeatureDictionaryKeys {
-    HIDE_INVITED_USER_REGISTRATION_TOGGLE = "hideInvitedUserRegistrationToggle"
-}
-
 export class AskPasswordFormConstants {
 
     /**
@@ -46,14 +39,4 @@ export class AskPasswordFormConstants {
         ServerConfigurationsConstants.ASK_PASSWORD_OTP_USE_UPPERCASE,
         ServerConfigurationsConstants.ASK_PASSWORD_OTP_LENGTH
     ];
-
-    /**
-     * Feature dictionary for governance connectors.
-     * Key: Feature dictionary key.
-     * Value: Corresponding config key in deployment config.
-     */
-    public static readonly featureDictionary: Record<string, string> = {
-        [GovernanceConnectorFeatureDictionaryKeys.HIDE_INVITED_USER_REGISTRATION_TOGGLE]:
-            "governanceConnectors.invitedUserRegistration.enableDisableControl"
-    };
 }

--- a/features/admin.server-configurations.v1/constants/governance-connector-constants.ts
+++ b/features/admin.server-configurations.v1/constants/governance-connector-constants.ts
@@ -17,9 +17,26 @@
  */
 
 /**
+ * Keys used in feature dictionary.
+ */
+export enum GovernanceConnectorFeatureDictionaryKeys {
+    HIDE_INVITED_USER_REGISTRATION_TOGGLE = "hideInvitedUserRegistrationToggle"
+}
+
+/**
  * Class containing governance connector constants.
  */
 export class GovernanceConnectorConstants {
+
+    /**
+     * Feature dictionary for governance connectors.
+     * Key: Feature dictionary key.
+     * Value: Corresponding config key in deployment config.
+     */
+    public static readonly featureDictionary: Record<string, string> = {
+        [GovernanceConnectorFeatureDictionaryKeys.HIDE_INVITED_USER_REGISTRATION_TOGGLE]:
+            "governanceConnectors.invitedUserRegistration.enableDisableControl"
+    };
 
     /**
      * Ask Password Form element constraints.

--- a/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
+++ b/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
@@ -56,7 +56,7 @@ import {
     revertGovernanceConnectorProperties,
     updateGovernanceConnector
 } from "../api/governance-connectors";
-import { AskPasswordFormConstants, GovernanceConnectorFeatureDictionaryKeys } from "../constants";
+import { GovernanceConnectorConstants, GovernanceConnectorFeatureDictionaryKeys } from "../constants";
 import { ServerConfigurationsConstants } from "../constants/server-configurations-constants";
 import { ConnectorFormFactory } from "../forms";
 import {
@@ -119,7 +119,7 @@ export const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = 
 
     const showInvitedUserRegistrationToggle: boolean = isFeatureEnabled(
         governanceConnectorsFeatureConfig,
-        AskPasswordFormConstants.featureDictionary[
+        GovernanceConnectorConstants.featureDictionary[
             GovernanceConnectorFeatureDictionaryKeys.HIDE_INVITED_USER_REGISTRATION_TOGGLE
         ]
     );


### PR DESCRIPTION
### Purpose
Give option to hide the toggle shown in the "Invite User to Set Password" Governance Connector under Login & Registration.

Feature flag - `governanceConnectors.invitedUserRegistration.enableDisableControl`

### Related Issues
- https://github.com/wso2/product-is/issues/25582

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
