### PR TITLE
[bug-fix] Fix security section crashing upon questionSet updates.

### DIFF
--- a/apps/myaccount/src/components/account-recovery/options/security-questions-recovery.tsx
+++ b/apps/myaccount/src/components/account-recovery/options/security-questions-recovery.tsx
@@ -114,9 +114,11 @@ export const SecurityQuestionsComponent: React.FunctionComponent<SecurityQuestio
             return answerParam.questionSetId === questionSetId;
         });
 
-        return questions.find((questionParam: QuestionsInterface) => {
+        const result: QuestionsInterface | null = questions.find((questionParam: QuestionsInterface) => {
             return questionParam.question === answer.question;
         });
+
+        return result || null;
     };
 
     /**
@@ -136,9 +138,15 @@ export const SecurityQuestionsComponent: React.FunctionComponent<SecurityQuestio
             challengesCopy.push({
                 answer: answer ? answer.answer : "",
                 challengeQuestion: {
-                    locale: answer ? questionInSet.locale : "",
-                    question: answer ? questionInSet.question : "",
-                    questionId: answer ? questionInSet.questionId : ""
+                    /**
+                     * If the answered question is not found in the set,
+                     * it means the questionSet has been modified.
+                     * In that case, we set the question and questionId to empty strings
+                     * to avoid uncontrolled to controlled input error in React.
+                     */
+                    locale: answer && questionInSet ? questionInSet.locale : "",
+                    question: answer ? answer.question : "",
+                    questionId: answer && questionInSet ? questionInSet.questionId : ""
                 },
                 questionSetId: question.questionSetId
             });


### PR DESCRIPTION
### Purpose
The myaccount crashes when navigating to the security section after recovery-question update by
- Add/remove questions from question sets.
- Add/remove question sets.


### Related Issues
- https://github.com/wso2/product-is/issues/24107

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
