### PR TITLE
[hotfix][@wso2is/console@2.77.4] Support hiding toggle under "Invite User to Set Password"

### DIFF
--- a/features/admin.server-configurations.v1/constants/governance-connector-constants.ts
+++ b/features/admin.server-configurations.v1/constants/governance-connector-constants.ts
@@ -17,9 +17,26 @@
  */
 
 /**
+ * Keys used in feature dictionary.
+ */
+export enum GovernanceConnectorFeatureDictionaryKeys {
+    HIDE_INVITED_USER_REGISTRATION_TOGGLE = "hideInvitedUserRegistrationToggle"
+}
+
+/**
  * Class containing governance connector constants.
  */
 export class GovernanceConnectorConstants {
+
+    /**
+     * Feature dictionary for governance connectors.
+     * Key: Feature dictionary key.
+     * Value: Corresponding config key in deployment config.
+     */
+    public static readonly featureDictionary: Record<string, string> = {
+        [GovernanceConnectorFeatureDictionaryKeys.HIDE_INVITED_USER_REGISTRATION_TOGGLE]:
+            "governanceConnectors.invitedUserRegistration.enableDisableControl"
+    };
 
     /**
      * Ask Password Form element constraints.

--- a/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
+++ b/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
@@ -24,6 +24,7 @@ import {  AppState  } from "@wso2is/admin.core.v1/store";
 import { serverConfigurationConfig } from "@wso2is/admin.extensions.v1/configs/server-configuration";
 import RegistrationFlowBuilderBanner
     from "@wso2is/admin.registration-flow-builder.v1/components/registration-flow-builder-banner";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertLevels, TestableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import {
@@ -55,6 +56,7 @@ import {
     revertGovernanceConnectorProperties,
     updateGovernanceConnector
 } from "../api/governance-connectors";
+import { GovernanceConnectorConstants, GovernanceConnectorFeatureDictionaryKeys } from "../constants";
 import { ServerConfigurationsConstants } from "../constants/server-configurations-constants";
 import { ConnectorFormFactory } from "../forms";
 import {
@@ -95,6 +97,9 @@ export const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = 
         (state: AppState) => state?.config?.ui?.features?.applications);
     const registrationFlowBuilderFeatureConfig: FeatureAccessConfigInterface = useSelector(
         (state: AppState) => state?.config?.ui?.features?.registrationFlowBuilder);
+    const governanceConnectorsFeatureConfig: FeatureAccessConfigInterface = useSelector(
+        (state: AppState) => state?.config?.ui?.features?.governanceConnectors
+    );
 
     const [ isConnectorRequestLoading, setConnectorRequestLoading ] = useState<boolean>(false);
     const [ connector, setConnector ] = useState<GovernanceConnectorInterface>(undefined);
@@ -111,6 +116,13 @@ export const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = 
         = useRequiredScopes(registrationFlowBuilderFeatureConfig?.scopes?.read);
     const path: string[] = history.location.pathname.split("/");
     const type: string = path[ path.length - 3 ];
+
+    const showInvitedUserRegistrationToggle: boolean = isFeatureEnabled(
+        governanceConnectorsFeatureConfig,
+        GovernanceConnectorConstants.featureDictionary[
+            GovernanceConnectorFeatureDictionaryKeys.HIDE_INVITED_USER_REGISTRATION_TOGGLE
+        ]
+    );
 
     useEffect(() => {
         // If Governance Connector update permission is not available, prevent from trying to load the connectors.
@@ -675,6 +687,11 @@ export const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = 
 
         if (connectorId === ServerConfigurationsConstants.CAPTCHA_FOR_SSO_LOGIN_CONNECTOR_ID) {
             ssoLoginConnectorId = true;
+        }
+
+        if (connectorId === ServerConfigurationsConstants.ASK_PASSWORD_CONNECTOR_ID &&
+            !showInvitedUserRegistrationToggle) {
+            return <></>;
         }
 
         return (


### PR DESCRIPTION
### Purpose
Give option to hide the toggle shown in the "Invite User to Set Password" Governance Connector under Login & Registration.

Feature flag - `governanceConnectors.invitedUserRegistration. enableDisableControl`

### Related Issues
- N/A

### Related PRs
- https://github.com/wso2/identity-apps/pull/9077

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
