### PR TITLE
Use flowId to handle magic link

### DIFF
--- a/.changeset/spotty-humans-press.md
+++ b/.changeset/spotty-humans-press.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Use flowId to handle magic link

--- a/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
@@ -226,18 +226,16 @@
                 }, [code, state]);
 
                 useEffect(() => {
-                    if (mlt !== "null" && state !== "null") {
-                        const savedFlowId = localStorage.getItem(state);
-                        localStorage.removeItem(state);
+                    if (mlt !== "null" && flowId !== "null") {
                         setPostBody({
-                            flowId: savedFlowId,
+                            flowId: flowId,
                             actionId: "",
                             inputs: {
                                 mlt
                             }
                         });
                     }
-                }, [mlt, state]);
+                }, [mlt, flowId]);
 
                 useEffect(() => {
                     if (confirmationCode !== "null" && !confirmationEffectDone) {


### PR DESCRIPTION
### Issue

https://github.com/wso2/product-is/issues/25694

This pull request introduces a patch to the `@wso2is/identity-apps-core` package, focusing on improving how magic link authentication flows are handled. The main change is to consistently use `flowId` instead of `state` for managing the magic link process, which streamlines the flow and reduces reliance on local storage.

**Magic Link Flow Handling:**

* Updated the logic in `execution-flow.jsp` to use the `flowId` parameter directly for the magic link authentication flow, instead of retrieving and removing it from local storage using the `state` parameter. This simplifies and clarifies the handling of the magic link process.

**Changelog:**

* Added a changeset file documenting the update to use `flowId` for magic link handling in `@wso2is/identity-apps-core`.