### PR TITLE
Add i18n support for magic link and otp error messages

### DIFF
--- a/.changeset/khaki-frogs-rhyme.md
+++ b/.changeset/khaki-frogs-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add i18n error message support

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources.properties
@@ -47,6 +47,10 @@ sign.up.heading=Create Account
 
 # Email link expiry message
 email.link.expiry.message=The link has expired. Please request a new one.
+otp.error.message=Invalid or Expired OTP. Please try again.
+magic.link.error.message=Invalid or Expired Magic Link. Please try again.
+otp.max.retry.error.message=Maximum retry count exceeded.
+otp.not.generated.error.message=OTP not generated.
 
 wso2.identity.server=WSO2 Identity Server
 select.country=Select Country

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_de_DE.properties
@@ -38,6 +38,10 @@ sign.up.heading=Konto erstellen
 
 # Email link expiry message
 email.link.expiry.message=Der Link ist abgelaufen. Bitte fordern Sie einen neuen an.
+otp.error.message=Ungültiges oder abgelaufenes OTP. Bitte versuchen Sie es erneut.
+magic.link.error.message=Ungültiger oder abgelaufener Magic Link. Bitte versuchen Sie es erneut.
+otp.max.retry.error.message=Maximale Anzahl an Versuchen überschritten.
+otp.not.generated.error.message=OTP wurde nicht generiert.
 
 wso2.identity.server=WSO2 Identity Server
 select.country=Land auswählen

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_es_ES.properties
@@ -38,6 +38,10 @@ sign.up.heading=Crear Cuenta
 
 # Email link expiry message
 email.link.expiry.message=El enlace ha expirado. Por favor, solicita uno nuevo.
+otp.error.message=OTP inválido o expirado. Por favor, inténtalo de nuevo.
+magic.link.error.message=Enlace mágico inválido o caducado. Inténtalo de nuevo.
+otp.max.retry.error.message=Se ha superado el número máximo de intentos.
+otp.not.generated.error.message=OTP no generado.
 
 wso2.identity.server=Servidor de Identidad WSO2
 select.country=Seleccionar país

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_fr_FR.properties
@@ -38,6 +38,10 @@ sign.up.heading=Créer un compte
 
 # Email link expiry message
 email.link.expiry.message=Le lien a expiré. Veuillez en demander un nouveau.
+otp.error.message=Mot de passe à usage unique invalide ou expiré. Veuillez réessayer.
+magic.link.error.message=Lien magique invalide ou expiré. Veuillez réessayer.
+otp.max.retry.error.message=Nombre maximum de tentatives dépassé.
+otp.not.generated.error.message=OTP non généré.
 
 wso2.identity.server=Serveur d'identité WSO2
 select.country=Sélectionner un pays

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_ja_JP.properties
@@ -38,6 +38,10 @@ sign.up.heading=アカウント作成
 
 # Email link expiry message
 email.link.expiry.message=リンクが期限切れです。新しいリンクをリクエストしてください。
+otp.error.message=OTPが無効または期限切れです。もう一度お試しください。
+magic.link.error.message=マジックリンクが無効または期限切れです。もう一度お試しください。
+otp.max.retry.error.message=最大リトライ回数を超えました。
+otp.not.generated.error.message=OTPが生成されていません。
 
 wso2.identity.server=WSO2 アイデンティティサーバー
 select.country=国を選択

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_BR.properties
@@ -38,6 +38,10 @@ sign.up.heading=Criar Conta
 
 # Email link expiry message
 email.link.expiry.message=O link expirou. Por favor, solicite um novo.
+otp.error.message=OTP inválido ou expirado. Por favor, tente novamente.
+magic.link.error.message=Link mágico inválido ou expirado. Tente novamente.
+otp.max.retry.error.message=Número máximo de tentativas excedido.
+otp.not.generated.error.message=OTP não gerado.
 
 wso2.identity.server=WSO2 Servidor de Identidade
 select.country=Selecione o País

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_pt_PT.properties
@@ -38,6 +38,10 @@ sign.up.heading=Criar Conta
 
 # Email link expiry message
 email.link.expiry.message=O link expirou. Por favor, solicite um novo.
+otp.error.message=OTP inválido ou expirado. Tente novamente.
+magic.link.error.message=Link mágico inválido ou expirado. Tente novamente.
+otp.max.retry.error.message=Número máximo de tentativas excedido.
+otp.not.generated.error.message=OTP não gerado.
 
 wso2.identity.server=WSO2 Servidor de Identidade
 select.country=Selecionar País

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_zh_CN.properties
@@ -38,6 +38,10 @@ sign.up.heading=创建帐户
 
 # Email link expiry message
 email.link.expiry.message=链接已过期。请申请一个新的。
+otp.error.message=OTP 无效或已过期。请重试。
+magic.link.error.message=魔法链接无效或已过期。请重试。
+otp.max.retry.error.message=超过最大重试次数。
+otp.not.generated.error.message=未生成 OTP。
 
 wso2.identity.server=WSO2 身份服务器
 select.country=选择国家

--- a/identity-apps-core/react-ui-core/src/components/dynamic-content.js
+++ b/identity-apps-core/react-ui-core/src/components/dynamic-content.js
@@ -21,9 +21,12 @@ import React, { useMemo, useRef } from "react";
 import { Message } from "semantic-ui-react";
 import Field from "./field";
 import Form from "./form";
+import { useTranslations } from "../hooks/use-translations";
+import { resolveElementText } from "../utils/i18n-utils";
 
 const DynamicContent = ({ contentData, handleFlowRequest, error }) => {
     const recaptchaRef = useRef(null);
+    const { translations } = useTranslations();
 
     const captchaNode = useMemo(() => contentData.components.find(el => el.type === "CAPTCHA"),
         [ contentData.components ]);
@@ -58,7 +61,7 @@ const DynamicContent = ({ contentData, handleFlowRequest, error }) => {
                 <>
                     { error && (
                         <Message negative>
-                            <p>{ error }</p>
+                            <p>{ resolveElementText(translations, error) }</p>
                         </Message>
                     ) }
                     <Form


### PR DESCRIPTION
### Issue

https://github.com/wso2-enterprise/asgardeo-product/issues/33037

This pull request adds improved internationalization (i18n) support for error messages related to OTP and magic link authentication throughout the application. The main changes include adding new localized error messages in multiple languages and updating the frontend to display these messages using the i18n system.

**Internationalization (i18n) Enhancements:**

* Added new error message keys for OTP and magic link failures (e.g., invalid/expired OTP, maximum retries exceeded, OTP not generated) to all supported language resource files, including English, German, Spanish, French, Japanese, Portuguese (Brazil and Portugal), and Chinese. [[1]](diffhunk://#diff-25bf4e40a8d650693daca5505a137acb43417bdde8d6dd2f7d6816671b0dba8bR50-R53) [[2]](diffhunk://#diff-ee6ef92c6f8a0753d7a27b84218eedfa84b1b7bc62838aa53ee05df82ab4b948R41-R44) [[3]](diffhunk://#diff-94da16236ace49611273c702522323b22f12127ba3d2bb14d6dfb8dd8cc57892R41-R44) [[4]](diffhunk://#diff-11e98861dad2fe2ae8f92968df4dff96b677a3fab18de176662b5df3e3966f59R41-R44) [[5]](diffhunk://#diff-8c74e6b3b41084cac67247384db668e384f40b1fbb93cf7bcbaf98aa6434ddf7R41-R44) [[6]](diffhunk://#diff-a98ac636a33ce6092b8a0bd648136daca0d287418f522fbdd5addc8e3f3fd694R41-R44) [[7]](diffhunk://#diff-38825c7dd40e85ab7fd57c6c24f945ccff2d1c2dbffaaa8afbb6a72cb9849b81R41-R44) [[8]](diffhunk://#diff-d03a310fd47859854bbc490a4f1da5692e0bfa02096ff2ff09d07e648bbb6809R41-R44)

**Frontend Integration:**

* Updated the `DynamicContent` component in `react-ui-core` to use the `useTranslations` hook and the `resolveElementText` utility, ensuring error messages are displayed in the user's selected language. [[1]](diffhunk://#diff-08b3fcdc657110b743adb0cfb033435c47fb8a2351bcea6e6e7c69c27bae87c6R24-R29) [[2]](diffhunk://#diff-08b3fcdc657110b743adb0cfb033435c47fb8a2351bcea6e6e7c69c27bae87c6L61-R64)

**Changelog:**

* Added a changeset entry documenting the addition of i18n error message support for `@wso2is/identity-apps-core`.