### PR TITLE
Properly clear flow error state

### DIFF
--- a/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
@@ -323,7 +323,9 @@
 
                     if (flowData && flowData.data && flowData.data.additionalData && flowData.data.additionalData.error) {
                         setFlowError(flowData.data.additionalData.error);
+                        return;
                     }
+                    setFlowError(null);
                 }, [ error, flowType, flowData && flowData.data && flowData.data.additionalData && flowData.data.additionalData.error ]);
 
                 const handleInternalPrompt = (flowData) => {


### PR DESCRIPTION
### Issue

https://github.com/wso2-enterprise/asgardeo-product/issues/33042

This pull request makes a small improvement to the error handling logic in the `execution-flow.jsp` file. The change ensures that the error state is cleared (`setFlowError(null)`) when there is no error present in the `flowData`.