### PR TITLE
Fix user creation with multi-select dropdown options crash

### DIFF
--- a/.changeset/tasty-numbers-sort.md
+++ b/.changeset/tasty-numbers-sort.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Fix user creation wizard becomes unresponsive when a custom attribute with multi-select dropdown options is added

--- a/features/admin.users.v1/components/wizard/steps/add-user-basic/dynamic-field-renderer.tsx
+++ b/features/admin.users.v1/components/wizard/steps/add-user-basic/dynamic-field-renderer.tsx
@@ -36,6 +36,9 @@ import MultiValuedTextField from "../../../user-profile/fields/multi-valued-text
 import RadioGroupFormField from "../../../user-profile/fields/radio-group-form-field";
 import TextFormField from "../../../user-profile/fields/text-form-field";
 
+// Create a empty array reference to prevent infinite re-renders.
+const EMPTY_ARRAY: string[] = [];
+
 /**
  * User add wizard form field renderer component props interface.
  */
@@ -171,7 +174,7 @@ const DynamicFieldRenderer: FunctionComponent<DynamicFieldRendererPropsInterface
     }
 
     if (isMultiValued) {
-        initialValue = initialValue ?? [];
+        initialValue = initialValue ?? EMPTY_ARRAY;
 
         switch (inputType) {
             case ClaimInputFormat.CHECKBOX_GROUP:


### PR DESCRIPTION
### Purpose

This pull request addresses a bug where the user creation wizard becomes unresponsive when a custom attribute with multi-select dropdown options is added. The main fix involves preventing infinite re-renders by using a shared empty array reference for multi-valued fields.

Bug fix for unresponsive wizard:

* Ensured that multi-valued fields use a shared `EMPTY_ARRAY` reference instead of a new array instance to prevent infinite re-renders in the user creation wizard (`features/admin.users.v1/components/wizard/steps/add-user-basic/dynamic-field-renderer.tsx`). [[1]](diffhunk://#diff-be4e563e470b2706895357905a4a50406fe347dad5f725ffde008555a9e4fe8eR39-R41) [[2]](diffhunk://#diff-be4e563e470b2706895357905a4a50406fe347dad5f725ffde008555a9e4fe8eL174-R177)

https://github.com/user-attachments/assets/50d2008d-ddd1-469c-bef7-b9d56e0ea83b


Release notes:

* Added a patch changelog entry describing the fix for the user creation wizard issue when custom attributes with multi-select dropdowns are present (`.changeset/tasty-numbers-sort.md`).


### Related Issues
- https://github.com/wso2/product-is/issues/25710

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
