### PR TITLE
Fix claim add wizard showing mapping step with empty content when hidden userstores are present

### DIFF
--- a/.changeset/smooth-months-boil.md
+++ b/.changeset/smooth-months-boil.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/console": patch
+---
+
+Fix claim add wizard showing mapping step with empty content when hidden userstores are present

--- a/features/admin.claims.v1/components/add/add-local-claim.tsx
+++ b/features/admin.claims.v1/components/add/add-local-claim.tsx
@@ -142,9 +142,16 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
      */
     useEffect(() => {
 
-        let userStoresEnabled: boolean = false;
+        if (systemReservedUserStores?.length > 0) {
+            const userPluggedUserStores: UserStoreListItem[] = userStoresList.filter(
+                (userStore: UserStoreListItem) => !systemReservedUserStores?.includes(userStore.name) &&
+                    !hiddenUserStores?.includes(userStore.name)
+            );
 
-        if ( hiddenUserStores && hiddenUserStores.length > 0) {
+            setShowMapAttributes(userPluggedUserStores?.length > 0);
+        } else if (hiddenUserStores && hiddenUserStores.length > 0) {
+            let userStoresEnabled: boolean = false;
+
             attributeConfig.localAttributes.isUserStoresHidden(hiddenUserStores).then((state: UserStoreListItem[]) => {
                 state.map((store: UserStoreListItem) => {
                     if(store.enabled){
@@ -154,12 +161,6 @@ export const AddLocalClaims: FunctionComponent<AddLocalClaimsPropsInterface> = (
 
                 setShowMapAttributes(state.length > 0 && userStoresEnabled);
             });
-        } else if (systemReservedUserStores?.length > 0) {
-            const userPluggedUserStores: UserStoreListItem[] = userStoresList.filter(
-                (userStore: UserStoreListItem) => !systemReservedUserStores?.includes(userStore.name)
-            );
-
-            setShowMapAttributes(userPluggedUserStores?.length > 0);
         } else if (userStoresList?.length > 0) {
             setShowMapAttributes(true);
         } else {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
