### PR TITLE
Enable flows UI in v1 sub-orgs

### DIFF
--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -1822,7 +1822,7 @@
                 "branding": "v0.0.0",
                 "consoleSettings": "v0.0.0",
                 "emailTemplates": "v0.0.0",
-                "flows": "v0.0.0",
+                "flows": "v1.0.0",
                 "gettingStarted": "v0.0.0",
                 "governanceConnectors": "v0.0.0",
                 "groups": "v0.0.0",


### PR DESCRIPTION
### Purpose
Since inheritance is disabled in v0 organizations, side panel item related to flows should be disabled in sub-organizations

### Related issue
- https://github.com/wso2/product-is/issues/25580