### PR TITLE
Add fee error codes

### DIFF
--- a/.changeset/happy-trains-sniff.md
+++ b/.changeset/happy-trains-sniff.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Adding Error FEE error codes.

--- a/identity-apps-core/apps/accounts/src/main/webapp/js/error-utils.js
+++ b/identity-apps-core/apps/accounts/src/main/webapp/js/error-utils.js
@@ -49,6 +49,7 @@ function getI18nKeyForError(errorCode, flowType, errorMessage) {
                 description: "sign.up.error.username.already.exists.description",
                 portalUrlStatus: "true"
             };
+            
         case "FE-60004":
             
             if( flowType === "USER_REGISTRATION") {

--- a/identity-apps-core/apps/accounts/src/main/webapp/js/error-utils.js
+++ b/identity-apps-core/apps/accounts/src/main/webapp/js/error-utils.js
@@ -40,7 +40,8 @@ function getI18nKeyForError(errorCode, flowType, errorMessage) {
                 description: "sign.up.error.username.not.provided.description",
                 portalUrlStatus: "true"
             };
-
+        
+        case "FEE-60001":
         case "FE-60003":
 
             return {
@@ -48,7 +49,6 @@ function getI18nKeyForError(errorCode, flowType, errorMessage) {
                 description: "sign.up.error.username.already.exists.description",
                 portalUrlStatus: "true"
             };
-
         case "FE-60004":
             
             if( flowType === "USER_REGISTRATION") {
@@ -71,7 +71,8 @@ function getI18nKeyForError(errorCode, flowType, errorMessage) {
                 message: "orchestration.flow.error.undefined.flow.id.message",
                 description: "orchestration.flow.error.undefined.flow.id.description"
             };
-
+        
+        case "FEE-60002":
         case "FE-60005":
 
             return {
@@ -202,7 +203,8 @@ function getI18nKeyForError(errorCode, flowType, errorMessage) {
                 description: "orchestration.flow.error.disabled.flow.description",
                 portalUrlStatus: "true"
             };
-
+        
+        case "FEE-60003":
         case "FE-60012":
 
             return {


### PR DESCRIPTION
This pull request introduces support for new FEE error codes in the `@wso2is/identity-apps-core` package, ensuring that these codes are properly mapped to user-friendly messages in the error handling logic. The main change is the addition of three new FEE error codes to the error mapping function.

**Error code support:**

* Added handling for `FEE-60001`, `FEE-60002`, and `FEE-60003` error codes in the `getI18nKeyForError` function within `error-utils.js`, mapping them to the same messages as their corresponding FE error codes. [[1]](diffhunk://#diff-90d806646d18a6eb9475ca3111db9c1b5aeb5d7bc13b1f4344abf48d59b9ca41R44-L51) [[2]](diffhunk://#diff-90d806646d18a6eb9475ca3111db9c1b5aeb5d7bc13b1f4344abf48d59b9ca41R75) [[3]](diffhunk://#diff-90d806646d18a6eb9475ca3111db9c1b5aeb5d7bc13b1f4344abf48d59b9ca41R207)

**Documentation and metadata:**

* Updated the changeset file `.changeset/happy-trains-sniff.md` to document the addition of FEE error codes.