### PR TITLE
[improvement] Improve self organization edit form

### DIFF
--- a/.changeset/cyan-rivers-leave.md
+++ b/.changeset/cyan-rivers-leave.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.tenants.v1": patch
+"@wso2is/console": patch
+---
+
+Improve self organization edit form

--- a/features/admin.tenants.v1/components/edit-self-organization/edit-self-organization-form.tsx
+++ b/features/admin.tenants.v1/components/edit-self-organization/edit-self-organization-form.tsx
@@ -173,7 +173,7 @@ const EditSelfOrganizationForm: FunctionComponent<EditSelfOrganizationFormProps>
             keepDirtyOnReinitialize={ true }
             onSubmit={ handleSubmit }
             validate={ handleValidate }
-            render={ ({ handleSubmit }: FormRenderProps) => {
+            render={ ({ handleSubmit, dirty }: FormRenderProps) => {
                 return (
                     <form
                         onSubmit={ handleSubmit }
@@ -303,6 +303,7 @@ const EditSelfOrganizationForm: FunctionComponent<EditSelfOrganizationFormProps>
                                 variant="contained"
                                 color="primary"
                                 type="submit"
+                                disabled={ !dirty }
                             >
                                 { t("tenants:editSelfOrganization.actions.save.label") }
                             </Button>)


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This pull request improves the self-organization edit form by enhancing the user experience and preventing unnecessary form submissions. The main change ensures that the "Save" button is only enabled when the form has unsaved changes.

Improved UX:

https://github.com/user-attachments/assets/455eb3b2-4646-4118-8627-eda580b2cb06


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- https://github.com/wso2/product-is/issues/25829

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
