### PR TITLE
Fix account portal url

### DIFF
--- a/.changeset/perfect-icons-jog.md
+++ b/.changeset/perfect-icons-jog.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add account portal url.

--- a/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
@@ -62,6 +62,7 @@
     String contextPath = request.getContextPath();
     String subPath = servletPath + contextPath;
     String baseURL = accessedURL.substring(0, accessedURL.length() - subPath.length());
+    String accountsBaseURL = ServiceURLBuilder.create().addPath(contextPath).build().getAbsolutePublicURL();
 
     String state = request.getParameter("state");
     String code = request.getParameter("code");
@@ -180,7 +181,7 @@
 
             const Content = () => {
                 const baseUrl = "<%= identityServerEndpointContextParam %>";
-                const accountsPortalUrl = baseUrl + "${pageContext.request.contextPath}";
+                const accountsPortalUrl = "<%= accountsBaseURL %>";
                 const defaultMyAccountUrl = "<%= myaccountUrl %>";
                 const executionFlowApiProxyPath = accountsPortalUrl + "/util/execution-flow-api.jsp";
                 const code = "<%= Encode.forJavaScript(code) != null ? Encode.forJavaScript(code) : null %>";


### PR DESCRIPTION
This pull request introduces a patch to the `@wso2is/identity-apps-core` package to add the account portal URL and ensures it is consistently generated and used throughout the accounts application. The most important changes include calculating the portal URL server-side and updating its usage in the frontend code.

**Account portal URL improvements:**

* Added calculation of `accountsBaseURL` using `ServiceURLBuilder` in `execution-flow.jsp` to ensure the correct public URL is generated for the accounts portal.
* Updated the frontend variable `accountsPortalUrl` in the `Content` component to use the new server-side `accountsBaseURL` instead of concatenating strings, improving reliability and maintainability.

**Package update:**

* Published a patch for `@wso2is/identity-apps-core` to document and track the addition of the account portal URL.