### PR TITLE
Enhance access URL validation in password reset success page

### DIFF
--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-success.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-success.jsp
@@ -21,8 +21,12 @@
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
 <%@ page import="org.owasp.encoder.Encode" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.ApplicationDataRetrievalClient" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.application.authentication.endpoint.util.AuthenticationEndpointUtil" %>
 <%@ page import="java.io.File" %>
 <%@ page import="org.wso2.carbon.identity.core.util.IdentityTenantUtil" %>
 <%@ page import="org.wso2.carbon.utils.multitenancy.MultitenantUtils" %>
@@ -43,6 +47,30 @@
 
 <%
     String accessUrl = (String) request.getAttribute("accessUrl");
+%>
+
+<%
+    boolean isValidAccessURL = true;
+
+    try {
+        isValidAccessURL = AuthenticationEndpointUtil.isSchemeSafeURL(accessUrl);
+
+        if (isValidAccessURL && StringUtils.isNotBlank(accessUrl)) {
+            ApplicationDataRetrievalClient applicationDataRetrievalClient = new ApplicationDataRetrievalClient();
+            String applicationAccessUrl = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain, spAppName);
+
+            if (StringUtils.isNotBlank(applicationAccessUrl)) {
+                // If the application access URL is equal to the provided access URL, then only allow it to be that URL.
+                isValidAccessURL = StringUtils.equals(accessUrl, applicationAccessUrl);
+            } else {
+                // If the application access URL is not present, provided access URL should be a valid multi option URL.
+                String encodedCallback = IdentityManagementEndpointUtil.getURLEncodedCallback(accessUrl);
+                isValidAccessURL = AuthenticationEndpointUtil.isValidMultiOptionURI(encodedCallback);
+            }
+        }
+    } catch (Exception e) {
+        isValidAccessURL = false;
+    }
 %>
 
 <% request.setAttribute("pageName", "password-reset-success"); %>
@@ -89,7 +117,7 @@
                         <%=i18n(recoveryResourceBundle, customText, "password.reset.success.body")%>
                     </span>
                     <%
-                        if(StringUtils.isNotBlank(accessUrl)) {
+                        if(StringUtils.isNotBlank(accessUrl) && isValidAccessURL) {
                     %>
                         <br/><br/>
                         <i class="caret left icon primary"></i>


### PR DESCRIPTION
## Purpose

This pull request enhances the handling of the accessUrl parameter displayed on the password reset success page. The objective is to improve the overall recovery flow by ensuring that only meaningful and valid continuation links are presented to the user, resulting in a more consistent and reliable experience when navigating back to applications.

## Implementation

The update introduces additional checks to better manage how the accessUrl is evaluated and displayed. The focus is on ensuring that the continuation link shown on the page is relevant, accurate, and aligned with the intended application behavior.

### Enhancements to access URL handling:

- Added logic to evaluate the accessUrl with AuthenticationEndpointUtil.isSchemeSafeURL, ensuring that only supported and expected URL schemes are used.

- Integrated ApplicationDataRetrievalClient to confirm whether the provided accessUrl matches an application's registered access URL, so that navigation aligns with the configured application details.

- If no registered application access URL is available, the system now checks that the value is a valid multi-option URI using AuthenticationEndpointUtil.isValidMultiOptionURI.

- Updated the conditional rendering logic so that the continuation link is displayed only if it is non-blank and passes the evaluation checks.

### Dependency and import updates:

- Added imports for ApplicationDataRetrievalClient, PreferenceRetrievalClient, and AuthenticationEndpointUtil to support the enhanced link-handling logic.