### PR TITLE
Enable the application creation UI capability for sub organizations

### DIFF
--- a/features/admin.application-templates.v1/constants/templates.ts
+++ b/features/admin.application-templates.v1/constants/templates.ts
@@ -72,4 +72,9 @@ export class ApplicationTemplateConstants {
         "single-page-application",
         "traditional-web-application"
     ];
+
+    public static readonly ALLOWED_APP_TEMPLATES_FOR_SUB_ORGANIZATIONS: string[] = [
+        "m2m-application",
+        "custom-application"
+    ];
 }

--- a/features/admin.application-templates.v1/package.json
+++ b/features/admin.application-templates.v1/package.json
@@ -9,7 +9,8 @@
         "@wso2is/admin.applications.v1": "^2.36.2",
         "@wso2is/admin.core.v1": "^2.46.41",
         "@wso2is/admin.template-core.v1": "^1.5.158",
-        "@wso2is/admin.feature-gate.v1": "^1.7.2"
+        "@wso2is/admin.feature-gate.v1": "^1.7.2",
+        "@wso2is/admin.organizations.v1": "^2.27.2"
     },
     "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/features/admin.applications.v1/components/application-list.tsx
+++ b/features/admin.applications.v1/components/application-list.tsx
@@ -615,8 +615,7 @@ export const ApplicationList: FunctionComponent<ApplicationListPropsInterface> =
             return (
                 <EmptyPlaceholder
                     className={ !isRenderedOnPortal ? "list-placeholder mr-0" : "" }
-                    action={ (onEmptyListPlaceholderActionClick
-                        && organizationType !== OrganizationType.SUBORGANIZATION)
+                    action={ onEmptyListPlaceholderActionClick
                         && (
                             <Show
                                 when={ featureConfig?.applications?.scopes?.create }

--- a/features/admin.applications.v1/components/edit-application.tsx
+++ b/features/admin.applications.v1/components/edit-application.tsx
@@ -845,7 +845,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
             if (isFeatureEnabled(featureConfig?.applications,
                 ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_SIGN_ON_METHOD_CONFIG"))
                 && !isM2MApplication
-                && (isSuperOrganization() || (isSubOrganization() && isFragmentApp) || isFirstLevelOrg)) {
+                && (isSuperOrganization() || (isSubOrganization()) || isFirstLevelOrg)) {
 
                 applicationConfig.editApplication.
                     isTabEnabledForApp(
@@ -879,7 +879,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
             }
             if (isFeatureEnabled(featureConfig?.applications,
                 ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_ADVANCED_SETTINGS"))
-                && !isSubOrganization()
+                && !isFragmentApp
                 && !isM2MApplication
                 && (UIConfig?.legacyMode?.applicationSystemAppsSettings ||
                     application?.name !== ApplicationManagementConstants.MY_ACCOUNT_APP_NAME)) {

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -1267,9 +1267,8 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 // Remove un-allowed grant types.
                 if (template
                     && template.id
-                    && get(applicationConfig.allowedGrantTypes, template.id)
-                    && !applicationConfig.allowedGrantTypes[ isSubOrganization() ? "sub-organization-application" :
-                        template.id ].includes(name)
+                    && get(applicationConfig.getAllowedGrantTypes(orgType), template.id)
+                    && !applicationConfig.getAllowedGrantTypes(orgType)[ template.id ].includes(name)
                     && ApplicationManagementConstants.AVAILABLE_GRANT_TYPES.includes(name)) {
 
                     return;
@@ -1277,7 +1276,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
 
                 if (
                     template?.[ApplicationManagementConstants.ORIGINAL_TEMPLATE_ID_PROPERTY] &&
-                    !applicationConfig.allowedGrantTypes[
+                    !applicationConfig.getAllowedGrantTypes(orgType)[
                         template[ApplicationManagementConstants.ORIGINAL_TEMPLATE_ID_PROPERTY]]?.includes(name)
                 ) {
                     return;
@@ -2345,6 +2344,7 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
                 && !isSystemApplication
                 && !isDefaultApplication
                 && !isM2MApplication
+                && !isSubOrganization()
                 && (
                     <Grid.Row columns={ 2 } data-componentid={ testId + "-hybrid-flow" }>
                         <Grid.Column mobile={ 16 } tablet={ 16 } computer={ 16 }>

--- a/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
+++ b/features/admin.applications.v1/components/wizard/minimal-application-create-wizard.tsx
@@ -908,6 +908,10 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
      */
     const getSupportedCustomProtocols = (filterProtocol?: string): SupportedAuthProtocolTypes[] => {
 
+        if (orgType === OrganizationType.SUBORGANIZATION) {
+            return [ SupportedAuthProtocolTypes.OAUTH2_OIDC ];
+        }
+
         let supportedProtocols: SupportedAuthProtocolTypes[] = Object.values(SupportedAuthProtocolTypes);
 
         // Filter out legacy and unsupported auth protocols.
@@ -1140,7 +1144,8 @@ export const MinimalAppCreateWizard: FunctionComponent<MinimalApplicationCreateW
                     </Grid.Row>
                     {
                         // The FAPI App creation checkbox is only present in OIDC Standard-Based apps
-                        customApplicationProtocol === SupportedAuthProtocolTypes.OAUTH2_OIDC
+                        orgType !== OrganizationType.SUBORGANIZATION
+                        && customApplicationProtocol === SupportedAuthProtocolTypes.OAUTH2_OIDC
                         && selectedTemplate?.name === ApplicationTemplateNames.STANDARD_BASED_APPLICATION
                         && isFAPIAppCreationEnabled
                         && (

--- a/features/admin.applications.v1/pages/applications.tsx
+++ b/features/admin.applications.v1/pages/applications.tsx
@@ -548,53 +548,55 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
         >
             <PageLayout
                 pageTitle="Applications"
-                action={ (organizationType !== OrganizationType.SUBORGANIZATION &&
-                    filteredApplicationList?.totalResults > 0) ? (
-                        <>
-                            <Show when={ featureConfig?.applications?.scopes?.create }>
+                action={ (filteredApplicationList?.totalResults > 0) ? (
+                    <>
+                        { organizationType !== OrganizationType.SUBORGANIZATION && (
+                            <Show
+                                when={ featureConfig?.applications?.scopes?.create }>
                                 {
                                     !applicationDisabledFeatures?.includes(
                                         ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATIONS_SETTINGS")
                                     ) &&
-                                    (
-                                        <Popup
-                                            trigger={ (
-                                                <Button
-                                                    data-componentid={ "applications-settings-button" }
-                                                    icon={ GearIcon }
-                                                    onClick={ handleSettingsButton }
-                                                />
-                                            ) }
-                                            content={ t("applications:forms.applicationsSettings.title") }
-                                            position="top center"
-                                            size="mini"
-                                            hideOnScroll
-                                            inverted
-                                        />
-                                    )
+                                        (
+                                            <Popup
+                                                trigger={ (
+                                                    <Button
+                                                        data-componentid={ "applications-settings-button" }
+                                                        icon={ GearIcon }
+                                                        onClick={ handleSettingsButton }
+                                                    />
+                                                ) }
+                                                content={ t("applications:forms.applicationsSettings.title") }
+                                                position="top center"
+                                                size="mini"
+                                                hideOnScroll
+                                                inverted
+                                            />
+                                        )
                                 }
                             </Show>
-                            <Show
-                                when={ featureConfig?.applications?.scopes?.create }
+                        ) }
+                        <Show
+                            when={ featureConfig?.applications?.scopes?.create }
+                        >
+                            <PrimaryButton
+                                onClick={ (): void => {
+                                    eventPublisher.publish("application-click-new-application-button");
+                                    history.push(AppConstants.getPaths().get("APPLICATION_TEMPLATES"));
+                                } }
+                                data-testid={ `${ testId }-list-layout-add-button` }
                             >
-                                <PrimaryButton
-                                    onClick={ (): void => {
-                                        eventPublisher.publish("application-click-new-application-button");
-                                        history.push(AppConstants.getPaths().get("APPLICATION_TEMPLATES"));
-                                    } }
-                                    data-testid={ `${ testId }-list-layout-add-button` }
-                                >
-                                    <Icon name="add" />
-                                    { t("applications:list.actions.add") }
-                                </PrimaryButton>
-                            </Show>
-                        </>
-                    ) : ( organizationType !== OrganizationType.SUBORGANIZATION ? (
-                        <Show when={ featureConfig?.applications?.scopes?.create }>
-                            {
-                                !applicationDisabledFeatures?.includes(
-                                    ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATIONS_SETTINGS")
-                                ) &&
+                                <Icon name="add" />
+                                { t("applications:list.actions.add") }
+                            </PrimaryButton>
+                        </Show>
+                    </>
+                ) : ( organizationType !== OrganizationType.SUBORGANIZATION ? (
+                    <Show when={ featureConfig?.applications?.scopes?.create }>
+                        {
+                            !applicationDisabledFeatures?.includes(
+                                ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATIONS_SETTINGS")
+                            ) &&
                                 (
                                     <Popup
                                         trigger={ (
@@ -611,10 +613,10 @@ const ApplicationsPage: FunctionComponent<ApplicationsPageInterface> = (
                                         inverted
                                     />
                                 )
-                            }
-                        </Show>
-                    ) : null
-                    ) }
+                        }
+                    </Show>
+                ) : null
+                ) }
                 title={ t("console:develop.pages.applications.title") }
                 description={ organizationType !== OrganizationType.SUBORGANIZATION
                     ? (

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -34,6 +34,7 @@ import getTryItClientId from "@wso2is/admin.applications.v1/utils/get-try-it-cli
 import { ClaimManagementConstants } from "@wso2is/admin.claims.v1/constants/claim-management-constants";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
+import { OrganizationType } from "@wso2is/admin.organizations.v1/constants";
 import { ApplicationRoles } from "@wso2is/admin.roles.v2/components/application-roles";
 import { I18n } from "@wso2is/i18n";
 import {
@@ -107,74 +108,6 @@ export const applicationConfig: ApplicationConfig = {
         showReturnAuthenticatedIdPs: true,
         showSaaS: true,
         showTrustedAppConsentWarning: false
-    },
-    allowedGrantTypes: {
-        // single page app template
-        [ "6a90e4b0-fbff-42d7-bfde-1efd98f07cd7" ]: [
-            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
-            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.IMPLICIT_GRANT,
-            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT
-        ],
-        // oidc traditional web app template
-        [ "b9c5e11e-fc78-484b-9bec-015d247561b8" ]: [
-            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
-            ApplicationManagementConstants.IMPLICIT_GRANT,
-            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT,
-            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT,
-            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE
-        ],
-        // oidc standard app template
-        [ "custom-application" ]: [
-            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
-            ApplicationManagementConstants.IMPLICIT_GRANT,
-            ApplicationManagementConstants.PASSWORD,
-            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT,
-            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT,
-            ApplicationManagementConstants.DEVICE_GRANT,
-            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE,
-            ApplicationManagementConstants.SAML2_BEARER,
-            ApplicationManagementConstants.JWT_BEARER,
-            ApplicationManagementConstants.IWA_NTLM
-        ],
-        [ "m2m-application" ]: [
-            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT
-        ],
-        [ "mcp-client-application" ]: [
-            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
-            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT
-        ],
-        [ "mobile-application" ]: [
-            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
-            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.IMPLICIT_GRANT,
-            ApplicationManagementConstants.PASSWORD,
-            ApplicationManagementConstants.DEVICE_GRANT,
-            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT,
-            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE
-        ],
-        [ "nextjs-application" ]: [
-            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
-            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT,
-            ApplicationManagementConstants.IMPLICIT_GRANT,
-            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE,
-            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT
-        ],
-        [ "react-application" ]: [
-            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
-            ApplicationManagementConstants.IMPLICIT_GRANT,
-            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT
-        ],
-        [ "sub-organization-application" ]: [
-            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.PASSWORD,
-            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT
-        ]
     },
     attributeSettings: {
         advancedAttributeSettings: {
@@ -465,6 +398,80 @@ export const applicationConfig: ApplicationConfig = {
             return true;
         }
     },
+    getAllowedGrantTypes: (orgType : OrganizationType) => ({
+        // single page app template
+        [ "6a90e4b0-fbff-42d7-bfde-1efd98f07cd7" ]: [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.IMPLICIT_GRANT,
+            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT
+        ],
+        // oidc traditional web app template
+        [ "b9c5e11e-fc78-484b-9bec-015d247561b8" ]: [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.IMPLICIT_GRANT,
+            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT,
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT,
+            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE
+        ],
+        // oidc standard app template
+        [ "custom-application" ]:
+        orgType === OrganizationType.SUBORGANIZATION ? [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.PASSWORD,
+            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT
+        ] : [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.IMPLICIT_GRANT,
+            ApplicationManagementConstants.PASSWORD,
+            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT,
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT,
+            ApplicationManagementConstants.DEVICE_GRANT,
+            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE,
+            ApplicationManagementConstants.SAML2_BEARER,
+            ApplicationManagementConstants.JWT_BEARER,
+            ApplicationManagementConstants.IWA_NTLM
+        ],
+        [ "m2m-application" ]: [
+            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT
+        ],
+        [ "mcp-client-application" ]: [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT
+        ],
+        [ "mobile-application" ]: [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.IMPLICIT_GRANT,
+            ApplicationManagementConstants.PASSWORD,
+            ApplicationManagementConstants.DEVICE_GRANT,
+            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT,
+            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE
+        ],
+        [ "nextjs-application" ]: [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT,
+            ApplicationManagementConstants.IMPLICIT_GRANT,
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE,
+            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT
+        ],
+        [ "react-application" ]: [
+            ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
+            ApplicationManagementConstants.IMPLICIT_GRANT,
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.ORGANIZATION_SWITCH_GRANT
+        ],
+        [ "sub-organization-application" ]: [
+            ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
+            ApplicationManagementConstants.PASSWORD,
+            ApplicationManagementConstants.CLIENT_CREDENTIALS_GRANT
+        ]
+    }),
     hiddenGrantTypes: [ ApplicationManagementConstants.ACCOUNT_SWITCH_GRANT ],
     inboundOIDCForm: {
         disabledGrantTypes: {

--- a/features/admin.extensions.v1/configs/models/application.ts
+++ b/features/admin.extensions.v1/configs/models/application.ts
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { OrganizationType } from "@wso2is/access-control";
 import {
     ExtendedClaimInterface,
     ExtendedExternalClaimInterface,
@@ -47,7 +48,7 @@ export interface ApplicationConfig {
         showReturnAuthenticatedIdPs: boolean;
         showTrustedAppConsentWarning: boolean;
     };
-    allowedGrantTypes: Record<string, string[]>,
+    getAllowedGrantTypes: (orgType: OrganizationType) => Record<string, string[]>,
     generalSettings: {
         getFieldReadOnlyStatus: (application: ApplicationInterface, fieldName: string) => boolean;
     };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2781,6 +2781,9 @@ importers:
       '@wso2is/admin.feature-gate.v1':
         specifier: ^1.7.2
         version: link:../admin.feature-gate.v1
+      '@wso2is/admin.organizations.v1':
+        specifier: ^2.27.2
+        version: link:../admin.organizations.v1
       '@wso2is/admin.template-core.v1':
         specifier: ^1.5.158
         version: link:../admin.template-core.v1
@@ -27065,7 +27068,6 @@ packages:
   /@mui/base@5.0.0-alpha.108(@types/react@18.0.18)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-KjzRUts2i/ODlMfywhFTqTzQl+Cr9nlDSZxJcnYjrbOV/iRyQNBTDoiFJt+XEdRi0fZBHnk74AFbnP56ehybsA==}
     engines: {node: '>=12.0.0'}
-    deprecated: This package has been replaced by @base-ui-components/react
     peerDependencies:
       '@types/react': 18.0.18
       react: ^17.0.0 || ^18.0.0


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
- $subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization-type-aware filtering: sub-organizations see a reduced set of application templates and restricted custom-template/protocol choices.
  * Grant-type availability now varies by organization type, altering allowed grant options for some application types.
  * Creation UI adapts: protocol options and FAPI creation toggle hidden for sub-organization contexts.

* **Bug Fixes**
  * Empty-list placeholders, edit flows and tab visibility now consistently respect organization-type restrictions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->