### PR TITLE
Fix floating publish button hidden under side panel

### DIFF
--- a/.changeset/chilled-chefs-wash.md
+++ b/.changeset/chilled-chefs-wash.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.flow-builder-core.v1": patch
+---
+
+Fix the publish button hidden under side configuration panel

--- a/features/admin.flow-builder-core.v1/components/flow-builder-page-skeleton/floating-publish-button.scss
+++ b/features/admin.flow-builder-core.v1/components/flow-builder-page-skeleton/floating-publish-button.scss
@@ -23,7 +23,7 @@
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 
     &.transition {
-        transform: translateX(calc(-1 * var(--wso2is-flow-builder-element-property-panel-width)));
+        transform: translateX(calc(-1 * var(--wso2is-flow-builder-right-panel-width)));
     }
 
     &.MuiButton-containedPrimary.Mui-disabled {


### PR DESCRIPTION
**Related Issues**

- https://github.com/wso2/product-is/issues/25851

This pull request addresses a UI issue in the Flow Builder where the publish button was hidden behind the side configuration panel. The fix updates the button's positioning logic to use the correct panel width variable, ensuring the button remains visible when the side panel is open.

UI bug fix:

* Updated the CSS in `floating-publish-button.scss` to use `--wso2is-flow-builder-right-panel-width` instead of `--wso2is-flow-builder-element-property-panel-width` for the publish button's horizontal translation, resolving the issue of the button being hidden by the side configuration panel.
* Documented the patch change in `.changeset/chilled-chefs-wash.md` for `@wso2is/admin.flow-builder-core.v1`.