### PR TITLE
[bug-fix] Operations input in not mandatory in workflows.

### DIFF
--- a/.changeset/famous-masks-bathe.md
+++ b/.changeset/famous-masks-bathe.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.approval-workflows.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Make operations input mandatory in workflow update and creation.

--- a/features/admin.approval-workflows.v1/components/create/workflow-operations-details-form.tsx
+++ b/features/admin.approval-workflows.v1/components/create/workflow-operations-details-form.tsx
@@ -67,6 +67,12 @@ interface WorkflowOperationsDetailsPropsInterface extends IdentifiableComponentI
      * Whether the component is used in edit page or not.
      */
     isEditPage?: boolean;
+    /**
+     * Callback to be called when operations selection changes.
+     * @param operations - Selected operations.
+     * @returns void
+     */
+    onChange?: (operations: DropdownPropsInterface[]) => void;
 }
 
 /**
@@ -104,6 +110,7 @@ const WorkflowOperationsDetailsForm: ForwardRefExoticComponent<RefAttributes<Wor
                 onSubmit,
                 initialValues,
                 isEditPage,
+                onChange,
                 ["data-componentid"]: componentId
                 = "workflow-operations"
             }: WorkflowOperationsDetailsPropsInterface,
@@ -130,6 +137,19 @@ const WorkflowOperationsDetailsForm: ForwardRefExoticComponent<RefAttributes<Wor
                 }
             }, [ initialValues ]);
 
+            const validateForm = ():
+                Partial<WorkflowOperationsDetailsFormValuesInterface> => {
+                const error: Partial<WorkflowOperationsDetailsFormValuesInterface> = {};
+
+                if (selectedOperations.length === 0) {
+                    error.matchedOperations = t(
+                        "approvalWorkflows:forms.operations.dropDown.nullValidationErrorMessage"
+                    );
+                }
+
+                return error;
+            };
+
             return (
                 <FinalForm
                     onSubmit={ (values: WorkflowOperationsDetailsFormValuesInterface) => {
@@ -139,6 +159,7 @@ const WorkflowOperationsDetailsForm: ForwardRefExoticComponent<RefAttributes<Wor
                         });
                     } }
                     initialValues={ initialValues }
+                    validate={ validateForm }
                     render={ ({ handleSubmit }: FormRenderProps) => {
                         triggerFormSubmit.current = handleSubmit;
 
@@ -172,6 +193,15 @@ const WorkflowOperationsDetailsForm: ForwardRefExoticComponent<RefAttributes<Wor
                                                     placeholder={
                                                         t("approvalWorkflows:forms.operations.dropDown.placeholder")
                                                     }
+                                                    helperText={
+                                                        selectedOperations.length === 0
+                                                            ? t(
+                                                                "approvalWorkflows:forms.operations.dropDown." +
+                                                                "nullValidationErrorMessage"
+                                                            )
+                                                            : ""
+                                                    }
+                                                    error={ selectedOperations.length === 0 }
                                                     data-componentid={ `${componentId}-field-operation-search` }
                                                 />
                                             ) }
@@ -180,6 +210,7 @@ const WorkflowOperationsDetailsForm: ForwardRefExoticComponent<RefAttributes<Wor
                                                 selectedOperations: DropdownPropsInterface[]
                                             ) => {
                                                 setSelectedOperations(selectedOperations);
+                                                onChange?.(selectedOperations);
                                             } }
                                             filterOptions={ (
                                                 options: DropdownPropsInterface[],

--- a/features/admin.approval-workflows.v1/components/edit/approval-workflow-edit.tsx
+++ b/features/admin.approval-workflows.v1/components/edit/approval-workflow-edit.tsx
@@ -142,6 +142,7 @@ const EditApprovalWorkflow: FunctionComponent<EditApprovalWorkflowPropsInterface
     const [ hasErrors, setHasErrors ] = useState<boolean>(false);
     const [ stepValues, setStepValues ] = useState<ConfigurationsFormValuesInterface>();
     const [ isGeneralDetailsSubmitted, setGeneralDetailsSubmitted ] = useState<boolean>(false);
+    const [ isOperationDetailsNull, setIsOperationDetailsNull ] = useState<boolean>(true);
 
     const {
         data: workflowAssociationDetails,
@@ -199,6 +200,9 @@ const EditApprovalWorkflow: FunctionComponent<EditApprovalWorkflowPropsInterface
             ...prev,
             matchedOperations: matchedOps
         }));
+
+        // Update isOperationDetailsNull based on whether there are any matched operations
+        setIsOperationDetailsNull(!matchedOps || matchedOps.length === 0);
     }, [ operationDetails, operations ]);
 
     /**
@@ -577,6 +581,9 @@ const EditApprovalWorkflow: FunctionComponent<EditApprovalWorkflowPropsInterface
                                 isReadOnly={ isReadOnly || !hasApprovalWorkflowUpdatePermissions }
                                 initialValues={ matchedOperations }
                                 onSubmit={ onWorkflowOperationsDetailsFormSubmit }
+                                onChange={ (selectedOperations: DropdownPropsInterface[]) => {
+                                    setIsOperationDetailsNull(!selectedOperations || selectedOperations.length === 0);
+                                } }
                                 data-componentid={ `${componentId}-general-details-form` }
                                 isEditPage={ true }
                             />
@@ -601,7 +608,7 @@ const EditApprovalWorkflow: FunctionComponent<EditApprovalWorkflowPropsInterface
 
                         <PrimaryButton
                             type="submit"
-                            disabled={ isReadOnly || !hasApprovalWorkflowUpdatePermissions }
+                            disabled={ isReadOnly || !hasApprovalWorkflowUpdatePermissions || isOperationDetailsNull }
                             onClick={ () => {
                                 handleUpdateButtonClick();
                             } }

--- a/modules/i18n/src/models/namespaces/approval-workflows-ns.ts
+++ b/modules/i18n/src/models/namespaces/approval-workflows-ns.ts
@@ -40,6 +40,10 @@ export interface approvalWorkflowsNS {
                 message: string;
                 description: string;
             };
+            noAssociationsSelectedError: {
+                message: string;
+                description: string;
+            };
             success: {
                 message: string;
                 description: string;
@@ -250,6 +254,7 @@ export interface approvalWorkflowsNS {
         operations: {
             dropDown: {
                 label: string;
+                nullValidationErrorMessage: string;
                 placeholder: string;
             }
         }

--- a/modules/i18n/src/translations/en-US/portals/approval-workflows.ts
+++ b/modules/i18n/src/translations/en-US/portals/approval-workflows.ts
@@ -194,6 +194,7 @@ export const approvalWorkflows: approvalWorkflowsNS = {
         operations: {
             dropDown: {
                 label: "Operations",
+                nullValidationErrorMessage: "Please select at least one operation",
                 placeholder: "Type operation/s to search and assign"
             }
         }
@@ -255,6 +256,10 @@ export const approvalWorkflows: approvalWorkflowsNS = {
             genericError: {
                 description: "There was an error while removing workflow operations.",
                 message: "Something went wrong!"
+            },
+            noAssociationsSelectedError: {
+                description: "At least one workflow operation must be selected.",
+                message: "No workflow operations selected"
             },
             success: {
                 description: "Workflow operation has been deleted successfully!",


### PR DESCRIPTION
### Purpose
Modify the operations field to mandate a input value.

https://github.com/user-attachments/assets/9c8cab43-957b-4d5a-bfe2-1b30574391bd


### Related Issues
- https://github.com/wso2/product-is/issues/25704

### Related PRs
- https://github.com/wso2/identity-api-server/pull/1013

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
