### PR TITLE
Add validation to check Password Provision Executor

### DIFF
--- a/.changeset/weak-tips-sleep.md
+++ b/.changeset/weak-tips-sleep.md
@@ -1,0 +1,10 @@
+---
+"@wso2is/admin.password-recovery-flow-builder.v1": patch
+"@wso2is/admin.ask-password-flow-builder.v1": patch
+"@wso2is/admin.registration-flow-builder.v1": patch
+"@wso2is/admin.flow-builder-core.v1": patch
+"@wso2is/i18n": patch
+"@wso2is/console": patch
+---
+
+Add validation to check Password Provision Executor in flow builder.

--- a/features/admin.ask-password-flow-builder.v1/providers/ask-password-flow-builder-provider.tsx
+++ b/features/admin.ask-password-flow-builder.v1/providers/ask-password-flow-builder-provider.tsx
@@ -84,6 +84,7 @@ const AskPasswordFlowBuilderProvider: FC<AskPasswordFlowBuilderProviderProps> = 
             ResourceProperties={ ResourceProperties }
             flowType={ FlowTypes.INVITED_USER_REGISTRATION }
             screenTypes={ screensList }
+            validationConfig={ { isPasswordExecutorValidationEnabled: true } }
         >
             <FlowContextWrapper>{ children }</FlowContextWrapper>
         </AuthenticationFlowBuilderCoreProvider>

--- a/features/admin.flow-builder-core.v1/components/resources/elements/adapters/button-adapter.tsx
+++ b/features/admin.flow-builder-core.v1/components/resources/elements/adapters/button-adapter.tsx
@@ -26,7 +26,7 @@ import PlaceholderComponent from "./placeholder-component";
 import VisualFlowConstants from "../../../../constants/visual-flow-constants";
 import usePasswordExecutorValidation from "../../../../hooks/use-password-executor-validation";
 import useRequiredFields, { RequiredFieldInterface } from "../../../../hooks/use-required-fields";
-import { ButtonVariants } from "../../../../models/elements";
+import { ButtonVariants, Element } from "../../../../models/elements";
 import { CommonElementFactoryPropsInterface } from "../common-element-factory";
 import "./button-adapter.scss";
 
@@ -81,7 +81,7 @@ const ButtonAdapter: FunctionComponent<ButtonAdapterPropsInterface> = ({
         fields
     );
 
-    usePasswordExecutorValidation((resource as unknown) as any);
+    usePasswordExecutorValidation((resource as unknown) as Element);
 
     let config: ButtonProps = {};
     let image: string = "";

--- a/features/admin.flow-builder-core.v1/components/resources/elements/adapters/button-adapter.tsx
+++ b/features/admin.flow-builder-core.v1/components/resources/elements/adapters/button-adapter.tsx
@@ -24,6 +24,7 @@ import React, { FunctionComponent, ReactElement, useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import PlaceholderComponent from "./placeholder-component";
 import VisualFlowConstants from "../../../../constants/visual-flow-constants";
+import usePasswordExecutorValidation from "../../../../hooks/use-password-executor-validation";
 import useRequiredFields, { RequiredFieldInterface } from "../../../../hooks/use-required-fields";
 import { ButtonVariants } from "../../../../models/elements";
 import { CommonElementFactoryPropsInterface } from "../common-element-factory";
@@ -79,6 +80,8 @@ const ButtonAdapter: FunctionComponent<ButtonAdapterPropsInterface> = ({
         generalMessage,
         fields
     );
+
+    usePasswordExecutorValidation((resource as unknown) as any);
 
     let config: ButtonProps = {};
     let image: string = "";

--- a/features/admin.flow-builder-core.v1/context/validation-context.tsx
+++ b/features/admin.flow-builder-core.v1/context/validation-context.tsx
@@ -31,6 +31,10 @@ export interface ValidationConfig {
      * Whether recovery factor validation is enabled.
      */
     isRecoveryFactorValidationEnabled?: boolean;
+    /**
+     * Whether password executor validation is enabled.
+     */
+    isPasswordExecutorValidationEnabled?: boolean;
 }
 
 /**
@@ -117,6 +121,7 @@ export const ValidationContext: Context<ValidationContextProps> = createContext<
     setOpenValidationPanel: null,
     validationConfig: {
         isOTPValidationEnabled: false,
+        isPasswordExecutorValidationEnabled: false,
         isRecoveryFactorValidationEnabled: false
     }
 });

--- a/features/admin.flow-builder-core.v1/hooks/use-password-executor-validation.ts
+++ b/features/admin.flow-builder-core.v1/hooks/use-password-executor-validation.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Node, useReactFlow } from "@xyflow/react";
+import { useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import useValidationStatus from "./use-validation-status";
+import { Element, ElementTypes, InputVariants } from "../models/elements";
+import Notification, { NotificationType } from "../models/notification";
+import { Resource } from "../public-api";
+
+/**
+ * Custom hook for validating password executor configuration.
+ * Finds the node that contains the button resource and validates password field requirements.
+ *
+ * @param resource - The button action resource from button-adapter.tsx
+ */
+const usePasswordExecutorValidation = (resource: Element): void => {
+    const { t } = useTranslation();
+    const { getNodes } = useReactFlow();
+    const { addNotification, removeNotification } = useValidationStatus();
+
+    const nodes: Node[] = getNodes();
+    const notificationId: string = `password-executor-validation-${resource?.id}`;
+
+    /**
+     * Find the node that contains this button resource by searching through all nodes components.
+     */
+    const parentNode: Node | undefined = useMemo(() => {
+        if (!resource?.id || !nodes?.length) {
+            return undefined;
+        }
+
+        return nodes?.find((node: Node) => {
+            const components: Element[] = node?.data?.components as Element[];
+
+            if (!components?.length) {
+                return false;
+            }
+
+            // Search through all components in the node to find the one with matching ID
+            return components?.some((component: Element) => {
+
+                if (component.components?.length) {
+                    return component.components.some((nestedComponent: Element) =>
+                        nestedComponent.id === resource.id
+                    );
+                }
+
+                return false;
+            });
+        });
+    }, [ resource?.id, nodes ]);
+
+    /**
+     * Check if the parent node has password fields.
+     */
+    const hasPasswordField: boolean = useMemo(() => {
+        if (!parentNode?.data?.components) {
+            return false;
+        }
+
+        const components: Element[] = parentNode.data.components as Element[];
+
+        return components.some((component: Element) => {
+
+            if (component.components?.length) {
+
+                return component.components.some((nestedComponent: Element) =>
+                    nestedComponent.type === ElementTypes.Input && nestedComponent.config.identifier === "password"
+                );
+            }
+
+            return false;
+        });
+    }, [ parentNode ]);
+
+
+    /**
+     * Check if the button has a password provisioner executor
+     */
+    const isPasswordProvisioner: boolean = useMemo(() => {
+        return resource?.action?.executor?.name === "PasswordProvisioningExecutor";
+    }, [ resource?.action?.executor?.name ]);
+
+    /**
+     * Validate the configuration: if there's a password field, there should be a password provisioner
+     */
+    const isValidConfiguration: boolean = useMemo(() => {
+        if (hasPasswordField) {
+            return isPasswordProvisioner;
+        }
+
+        return true;
+    }, [ hasPasswordField, isPasswordProvisioner ]);
+
+    /**
+     * Effect to handle password executor validation notifications.
+     */
+    useEffect(() => {
+        if (!resource?.id || !parentNode) {
+            return;
+        }
+
+        removeNotification(notificationId);
+
+        if (!isValidConfiguration) {
+            const notification: Notification = new Notification(
+                notificationId,
+                t("flowBuilder:validation.passwordExecutorRequired.message",
+                    "Forms with a Password field requires a 'Provision Password' Action" +
+                    " to be configured for the button."),
+                NotificationType.ERROR
+            );
+
+            notification.addResource((resource as unknown) as Resource);
+            addNotification(notification);
+        }
+    }, [ hasPasswordField, isPasswordProvisioner, isValidConfiguration, resource?.id,
+        notificationId, t, addNotification, removeNotification ]);
+
+    /**
+     * Cleanup function to remove notifications on unmount
+     */
+    useEffect(() => {
+        return () => {
+            removeNotification(notificationId);
+        };
+    }, [ notificationId, removeNotification ]);
+
+};
+
+export default usePasswordExecutorValidation;

--- a/features/admin.flow-builder-core.v1/hooks/use-password-executor-validation.ts
+++ b/features/admin.flow-builder-core.v1/hooks/use-password-executor-validation.ts
@@ -20,7 +20,7 @@ import { Node, useReactFlow } from "@xyflow/react";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import useValidationStatus from "./use-validation-status";
-import { Element, ElementTypes, InputVariants } from "../models/elements";
+import { Element, ElementTypes } from "../models/elements";
 import Notification, { NotificationType } from "../models/notification";
 import { Resource } from "../public-api";
 

--- a/features/admin.password-recovery-flow-builder.v1/providers/password-recovery-flow-builder-provider.tsx
+++ b/features/admin.password-recovery-flow-builder.v1/providers/password-recovery-flow-builder-provider.tsx
@@ -74,6 +74,7 @@ const PasswordRecoveryFlowBuilderProvider: FC<PasswordRecoveryFlowBuilderProvide
             flowType={ FlowTypes.PASSWORD_RECOVERY }
             screenTypes={ screensList }
             validationConfig={ {
+                isPasswordExecutorValidationEnabled: true,
                 isRecoveryFactorValidationEnabled: true
             } }
         >

--- a/features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx
+++ b/features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx
@@ -69,7 +69,10 @@ const RegistrationFlowBuilderProvider: FC<RegistrationFlowBuilderProviderProps> 
             ResourceProperties={ ResourceProperties }
             flowType={ FlowTypes.REGISTRATION }
             screenTypes={ screensList }
-            validationConfig={ { isOTPValidationEnabled: true } }
+            validationConfig={ {
+                isOTPValidationEnabled: true,
+                isPasswordExecutorValidationEnabled: true
+            } }
         >
             <FlowContextWrapper>{ children }</FlowContextWrapper>
         </AuthenticationFlowBuilderCoreProvider>

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -756,6 +756,9 @@ export interface ApplicationsNS {
                                 passwordRecoveryRequiresFactors: {
                                     message: string;
                                 };
+                                passwordExecutorRequired: {
+                                    message: string;
+                                };
                             }
                         };
                     };

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1133,6 +1133,9 @@ export const applications: ApplicationsNS = {
                                     message: "Password recovery requires at least one of the following " +
                                         "factors to be present in the flow: Email OTP, SMS OTP, " +
                                         "or Magic Link."
+                                },
+                                passwordExecutorRequired: {
+                                    message: "Forms with a Password field requires a 'Provision Password' Action to be configured for the button."
                                 }
                             }
                         }


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Add validation to check Password Provision Executor. 

This validation checks if the button action is set to "Password Provision" when there is a password field in the form.

<img width="998" height="727" alt="Screenshot 2025-10-07 at 21 44 05" src="https://github.com/user-attachments/assets/ddaeea49-0fae-4800-bdf5-30dfa3ce99a7" />


<img width="1181" height="770" alt="Screenshot 2025-10-07 at 21 21 31" src="https://github.com/user-attachments/assets/ffeabb3b-b481-48c9-930d-baba1d32dc98" />

### Related Issues
- fixes https://github.com/wso2/product-is/issues/25914

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
