### PR TITLE
fix: add language switcher to B2B invitation accept page(#25899)

### DIFF
--- a/.changeset/hungry-stingrays-turn.md
+++ b/.changeset/hungry-stingrays-turn.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add language switcher for b2b invitation page

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/includes/product-footer.jsp
@@ -99,7 +99,7 @@
             <% } %>
 
                 <%
-                    List<String> langSwitcherEnabledServlets = Arrays.asList("/password-recovery.jsp", "/register.do", "/passwordreset.do", "/error.jsp", "/self-registration-with-verification.jsp");
+                    List<String> langSwitcherEnabledServlets = Arrays.asList("/password-recovery.jsp", "/register.do", "/passwordreset.do", "/error.jsp", "/self-registration-with-verification.jsp", "/acceptinvitation.do");
                     if (langSwitcherEnabledServlets.contains(request.getServletPath())) {
                         File languageSwitcherFile = new File(getServletContext().getRealPath("extensions/language-switcher.jsp"));
                         if (languageSwitcherFile.exists()) {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
Fixes the issue where the language switcher was missing from the footer of the B2B invitation acceptance page (`acceptinvitation.do`) for parent/root organization users.


### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- Fixes https://github.com/wso2/product-is/issues/25899

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


https://github.com/user-attachments/assets/beb71a30-c457-4f0b-b8eb-d0139758a9d9


