### PR TITLE
Remove notification from properties panel

### DIFF
--- a/.changeset/mighty-students-boil.md
+++ b/.changeset/mighty-students-boil.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.ask-password-flow-builder.v1": patch
+"@wso2is/console": patch
+---
+
+Remove send notification from confirmation code properties.

--- a/features/admin.ask-password-flow-builder.v1/components/resource-property-panel/steps/execution/ask-password-configurations.tsx
+++ b/features/admin.ask-password-flow-builder.v1/components/resource-property-panel/steps/execution/ask-password-configurations.tsx
@@ -276,13 +276,6 @@ export const AskPasswordConfigurations: FunctionComponent<AskPasswordConfigurati
                         };
 
                         break;
-                    case ServerConfigurationsConstants.ASK_PASSWORD_ACCOUNT_ACTIVATION:
-                        resolvedInitialValues = {
-                            ...resolvedInitialValues,
-                            enableAccountActivationEmail: CommonUtils.parseBoolean(property.value)
-                        };
-
-                        break;
                     case ServerConfigurationsConstants.ASK_PASSWORD_OTP_EXPIRY_TIME:
                         resolvedInitialValues = {
                             ...resolvedInitialValues,
@@ -345,7 +338,7 @@ export const AskPasswordConfigurations: FunctionComponent<AskPasswordConfigurati
         setIsNumericEnabled(resolvedInitialValues?.otpUseNumeric);
         setExpiryTime(resolvedInitialValues?.expiryTime);
         setOtpLength(resolvedInitialValues?.otpLength);
-        setEnableAccountActivationEmail(resolvedInitialValues?.enableAccountActivationEmail);
+        // setEnableAccountActivationEmail(resolvedInitialValues?.enableAccountActivationEmail);
         setEnableAccountLockOnCreation(resolvedInitialValues?.enableAccountLockOnCreation);
         if (resolvedInitialValues?.enableSmsOtp) {
             setAskPasswordOption(VerificationOption.SMS_OTP);
@@ -469,28 +462,6 @@ export const AskPasswordConfigurations: FunctionComponent<AskPasswordConfigurati
                                     "inviteUserToSetPassword.form.fields.expiryTime.hint") }
                         </FormHelperText>
                     </Stack>
-                    <FormControlLabel
-                        control={
-                            (<Checkbox
-                                aria-label="enableAccountActivationEmail"
-                                name="enableAccountActivationEmail"
-                                checked={ enableAccountActivationEmail }
-                                onChange={
-                                    (event: React.ChangeEvent<HTMLInputElement>) =>
-                                        setEnableAccountActivationEmail(event.target.checked)
-                                }
-                                required={ false }
-                                disabled={ !isInviteUserToSetPasswordEnabled || readOnly }
-                                data-componentid={ `${ componentId }-account-activation-email` }
-                            />)
-                        }
-                        label={ t("extensions:manage.serverConfigurations.userOnboarding." +
-                            "inviteUserToSetPassword.form.fields.enableAccountActivationEmail.label") }
-                    />
-                    <FormHelperText>
-                        { t("extensions:manage.serverConfigurations.userOnboarding." +
-                                "inviteUserToSetPassword.form.fields.enableAccountActivationEmail.hint") }
-                    </FormHelperText>
                     <FormControlLabel
                         control={
                             (<Checkbox

--- a/features/admin.ask-password-flow-builder.v1/components/resource-property-panel/steps/execution/ask-password-configurations.tsx
+++ b/features/admin.ask-password-flow-builder.v1/components/resource-property-panel/steps/execution/ask-password-configurations.tsx
@@ -338,7 +338,6 @@ export const AskPasswordConfigurations: FunctionComponent<AskPasswordConfigurati
         setIsNumericEnabled(resolvedInitialValues?.otpUseNumeric);
         setExpiryTime(resolvedInitialValues?.expiryTime);
         setOtpLength(resolvedInitialValues?.otpLength);
-        // setEnableAccountActivationEmail(resolvedInitialValues?.enableAccountActivationEmail);
         setEnableAccountLockOnCreation(resolvedInitialValues?.enableAccountLockOnCreation);
         if (resolvedInitialValues?.enableSmsOtp) {
             setAskPasswordOption(VerificationOption.SMS_OTP);


### PR DESCRIPTION
**Related Issues**

- https://github.com/wso2/product-is/issues/26036

This pull request removes the "send notification" (account activation email) option from the Ask Password flow builder in the admin console. The changes ensure that the account activation email property is no longer handled or displayed in the UI for configuring the Ask Password flow.

Key changes include:

**Removal of account activation email option:**

* The logic for handling the `enableAccountActivationEmail` property has been removed from the initial values resolution in `ask-password-configurations.tsx`.
* The state update for `enableAccountActivationEmail` is now removed and no longer set.
* The UI elements (checkbox, label, and helper text) for enabling the account activation email have been removed from the form.

**Documentation and configuration updates:**

* The `.changeset/mighty-students-boil.md` file documents the removal of the send notification option from confirmation code properties for both `@wso2is/admin.ask-password-flow-builder.v1` and `@wso2is/console`.