### PR TITLE
Protect user impersonation button with console:userImpersonation scope

### DIFF
--- a/.changeset/ninety-bugs-applaud.md
+++ b/.changeset/ninety-bugs-applaud.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Protect user impersonation button with console:userImpersonation scope

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -1977,6 +1977,14 @@
                     ]
                 },
                 "subFeatures": {
+                    "userImpersonation": {
+                        "enabled": true,
+                        "scopes": {
+                            "feature": [
+                                "console:userImpersonation"
+                            ]
+                        }
+                    },
                     "userSharingV2": {
                         "disabledFeatures": [
                         ],

--- a/features/admin.users.v1/components/user-impersonation-action.tsx
+++ b/features/admin.users.v1/components/user-impersonation-action.tsx
@@ -17,6 +17,7 @@
  */
 
 import { HttpResponse, useAuthContext } from "@asgardeo/auth-react";
+import { useRequiredScopes } from "@wso2is/access-control";
 import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
 import { OrganizationType } from "@wso2is/admin.core.v1/constants/organization-constants";
 import { AppState } from "@wso2is/admin.core.v1/store";
@@ -373,6 +374,10 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
     const primaryUserStoreDomainName: string = useSelector((state: AppState) =>
         state?.config?.ui?.primaryUserStoreDomainName);
 
+    const hasImpersonationScope: boolean = useRequiredScopes(
+        userFeatureConfig?.subFeatures?.userImpersonation?.scopes?.feature
+    );
+
     /**
      * This function checks whether the authenticated user's (impersonator) tenant is the logged tenant.
      */
@@ -495,7 +500,8 @@ export const UserImpersonationAction: FunctionComponent<UserImpersonationActionI
             !isUserCurrentLoggedInUser && !isUserManagedByParentOrg &&
             (orgType === OrganizationType.SUBORGANIZATION ? !isSwitchedFromRootOrg : true) &&
             isAuthenticatedUserInAnAllowedUserstore() &&
-            isFeatureEnabled(userFeatureConfig, UserManagementConstants.FEATURE_DICTIONARY.get("USER_IMPERSONATION")) ?
+            isFeatureEnabled(userFeatureConfig, UserManagementConstants.FEATURE_DICTIONARY.get("USER_IMPERSONATION")) &&
+            hasImpersonationScope ?
                 (
                     <React.Fragment>
                         <DangerZoneGroup


### PR DESCRIPTION
## Purpose
  Gate the user impersonation button behind the `console:userImpersonation` scope so only authorized users can see and use it.

  ## Changes
  - Added `userImpersonation` sub-feature under the `users` feature config in `deployment.config.json` with the `console:userImpersonation` feature scope
  - Used `useRequiredScopes` in `UserImpersonationAction` to conditionally render the impersonate button based on that scope

  ## Related Issues
