### PR TITLE
Add unified MCP capability feature for All existing Applications except Digital Wallet Application

### DIFF
--- a/.changeset/bright-dogs-wash.md
+++ b/.changeset/bright-dogs-wash.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/console": patch
+---
+
+Add unified MCP capability feature for All existing Applications except Digital Wallet Application

--- a/features/admin.applications.v1/components/api-authorization/api-authorization.tsx
+++ b/features/admin.applications.v1/components/api-authorization/api-authorization.tsx
@@ -16,11 +16,12 @@
  * under the License.
  */
 
-import { useRequiredScopes } from "@wso2is/access-control";
+import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
 import { useAPIResources } from "@wso2is/admin.api-resources.v2/api";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import { AppState } from "@wso2is/admin.core.v1/store";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertInterface, AlertLevels, IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import {
@@ -49,6 +50,7 @@ import {
     removeAuthorizedAPI
 } from "../../api/api-authorization";
 import useSubscribedAPIResources from "../../api/use-subscribed-api-resources";
+import { ApplicationManagementConstants } from "../../constants/application-management";
 import {
     AuthorizedAPIListItemInterface,
     AuthorizedPermissionListItemInterface
@@ -95,10 +97,20 @@ export const APIAuthorization: FunctionComponent<APIAuthorizationResourcesProps>
 
     const isDigitalWallet: boolean = originalTemplateId === "digital-wallet-application";
     const isMCPClient: boolean = originalTemplateId === "mcp-client-application";
-    const resourceText: string = isMCPClient
-        ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.genericResource")
-        : isDigitalWallet
-            ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.vcResource")
+
+    const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const applicationFeatureConfig: FeatureAccessConfigInterface = featureConfig?.applications;
+
+    const isUnifiedMcpCapabilitiesEnabled: boolean = isFeatureEnabled(
+        applicationFeatureConfig,
+        ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_UNIFIED_MCP_CAPABILITIES")
+    );
+
+    // Determine resource text based on feature flag and application type
+    const resourceText: string = isDigitalWallet
+        ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.vcResource")
+        : (isUnifiedMcpCapabilitiesEnabled || isMCPClient)
+            ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.genericResource")
             : t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.apiResource");
 
     const [ isSubAPIResourcesSectionLoading, setSubAPIResourcesSectionLoading ] = useState<boolean>(false);
@@ -110,8 +122,6 @@ export const APIAuthorization: FunctionComponent<APIAuthorizationResourcesProps>
     const [ isUpdateData, setIsUpdateData ] = useState<boolean>(false);
     const [ allAuthorizedScopes, setAllAuthorizedScopes ] = useState<AuthorizedPermissionListItemInterface[]>([]);
     const [ hideAuthorizeAPIResourceButton, setHideAuthorizeAPIResourceButton ] = useState<boolean>(true);
-
-    const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
 
     const path: string[] = history.location.pathname.split("/");
     const appId: string = path[path.length - 1].split("#")[0];

--- a/features/admin.applications.v1/components/api-authorization/subscribed-api-resources.tsx
+++ b/features/admin.applications.v1/components/api-authorization/subscribed-api-resources.tsx
@@ -16,12 +16,15 @@
  * under the License.
  */
 
+import { FeatureAccessConfigInterface } from "@wso2is/access-control";
 import { APIResourcesConstants } from "@wso2is/admin.api-resources.v2/constants";
 import { APIResourceInterface } from "@wso2is/admin.api-resources.v2/models";
 import { getEmptyPlaceholderIllustrations } from "@wso2is/admin.core.v1/configs/ui";
 import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { RequestErrorInterface } from "@wso2is/admin.core.v1/hooks/use-request";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
 import { AlertInterface, AlertLevels, IdentifiableComponentInterface, SBACInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { I18n } from "@wso2is/i18n";
@@ -41,12 +44,13 @@ import {
 import { AxiosError } from "axios";
 import React, { Fragment, FunctionComponent, ReactElement, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Dispatch } from "redux";
 import { Form, Grid, Header, Icon, Input } from "semantic-ui-react";
 import { ScopeForm } from "./scope-form";
 import useScopesOfAPIResources from "../../api/use-scopes-of-api-resources";
 import { Policy } from "../../constants/api-authorization";
+import { ApplicationManagementConstants } from "../../constants/application-management";
 import {
     AuthorizedAPIListItemInterface,
     AuthorizedPermissionListItemInterface
@@ -150,10 +154,21 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
 
     const isDigitalWallet: boolean = originalTemplateId === "digital-wallet-application";
     const isMCPClient: boolean = originalTemplateId === "mcp-client-application";
-    const resourceText: string = isMCPClient
-        ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.genericResource")
-        : isDigitalWallet
-            ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.vcResource")
+
+    const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const applicationFeatureConfig: FeatureAccessConfigInterface = featureConfig?.applications;
+
+    const isUnifiedMcpCapabilitiesEnabled: boolean = isFeatureEnabled(
+        applicationFeatureConfig,
+        ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_UNIFIED_MCP_CAPABILITIES")
+    );
+
+    // Determine resource text based on feature flag and application type
+
+    const resourceText: string = isDigitalWallet
+        ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.vcResource")
+        : (isUnifiedMcpCapabilitiesEnabled || isMCPClient)
+            ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.genericResource")
             : t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.apiResource");
 
     const [ activeSubscribedAPIResource, setActiveSubscribedAPIResource ] = useState<string>(null);
@@ -498,14 +513,7 @@ export const SubscribedAPIResources: FunctionComponent<SubscribedAPIResourcesPro
                                             onChange={ searchSubscribedAPIResources }
                                             placeholder={ t("extensions:develop.applications.edit.sections." +
                                                 "apiAuthorization.sections.apiSubscriptions.search", {
-                                                resourceText:  isMCPClient
-                                                    ? t("extensions:develop.applications.edit.sections.apiAuthorization"
-                                                        + ".resourceText.genericResource")
-                                                    : isDigitalWallet
-                                                        ? t("extensions:develop.applications.edit.sections" +
-                                                            ".apiAuthorization.resourceText.vcResource")
-                                                        : t("extensions:develop.applications.edit.sections" +
-                                                            ".apiAuthorization.resourceText.apiResource")
+                                                resourceText: resourceText
                                             }) }
                                             floated="right"
                                             size="small"

--- a/features/admin.applications.v1/components/api-authorization/wizard/authorize-api-resource.tsx
+++ b/features/admin.applications.v1/components/api-authorization/wizard/authorize-api-resource.tsx
@@ -102,11 +102,6 @@ export const AuthorizeAPIResource: FunctionComponent<AuthorizeAPIResourcePropsIn
     const isDigitalWallet: boolean = originalTemplateId === "digital-wallet-application";
     const isMCPClient: boolean = originalTemplateId === "mcp-client-application";
 
-    // Use "resource" for all apps that can access MCP Servers, "verifiable credential" for Digital Wallet
-    const resourceText: string = isDigitalWallet
-        ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.vcResource")
-        : t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.genericResource");
-
     const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector(
         (state: AppState) => state.config.ui?.features?.applications);
 
@@ -114,6 +109,12 @@ export const AuthorizeAPIResource: FunctionComponent<AuthorizeAPIResourcePropsIn
         applicationFeatureConfig,
         ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_UNIFIED_MCP_CAPABILITIES")
     );
+
+    const resourceText: string = isDigitalWallet
+        ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.vcResource")
+        : (isUnifiedMcpCapabilitiesEnabled || isMCPClient)
+            ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.genericResource")
+            : t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.apiResource");
 
     const isApplicationEditEnforceAuthorizedAPIUpdatePermissionEnabled: boolean = isFeatureEnabled(
         applicationFeatureConfig,

--- a/features/admin.applications.v1/components/api-authorization/wizard/authorize-api-resource.tsx
+++ b/features/admin.applications.v1/components/api-authorization/wizard/authorize-api-resource.tsx
@@ -545,9 +545,10 @@ export const AuthorizeAPIResource: FunctionComponent<AuthorizeAPIResourcePropsIn
                                                 APIResourceCategories.BUSINESS
                                             ];
 
-                                            const allowedTypes: string[] = (isUnifiedMcpCapabilitiesEnabled || isMCPClient)
-                                                ? [ ...baseTypes, APIResourceCategories.MCP ]
-                                                : baseTypes;
+                                            const allowedTypes: string[] =
+                                                (isUnifiedMcpCapabilitiesEnabled || isMCPClient)
+                                                    ? [ ...baseTypes, APIResourceCategories.MCP ]
+                                                    : baseTypes;
 
                                             return allowedTypes.includes(item?.type);
                                         }).sort((a: DropdownItemProps, b: DropdownItemProps) =>

--- a/features/admin.applications.v1/components/api-authorization/wizard/authorize-api-resource.tsx
+++ b/features/admin.applications.v1/components/api-authorization/wizard/authorize-api-resource.tsx
@@ -102,14 +102,18 @@ export const AuthorizeAPIResource: FunctionComponent<AuthorizeAPIResourcePropsIn
     const isDigitalWallet: boolean = originalTemplateId === "digital-wallet-application";
     const isMCPClient: boolean = originalTemplateId === "mcp-client-application";
 
-    const resourceText: string = isMCPClient
-        ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.genericResource")
-        : isDigitalWallet
-            ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.vcResource")
-            : t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.apiResource");
+    // Use "resource" for all apps that can access MCP Servers, "verifiable credential" for Digital Wallet
+    const resourceText: string = isDigitalWallet
+        ? t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.vcResource")
+        : t("extensions:develop.applications.edit.sections.apiAuthorization.resourceText.genericResource");
 
     const applicationFeatureConfig: FeatureAccessConfigInterface = useSelector(
         (state: AppState) => state.config.ui?.features?.applications);
+
+    const isUnifiedMcpCapabilitiesEnabled: boolean = isFeatureEnabled(
+        applicationFeatureConfig,
+        ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_UNIFIED_MCP_CAPABILITIES")
+    );
 
     const isApplicationEditEnforceAuthorizedAPIUpdatePermissionEnabled: boolean = isFeatureEnabled(
         applicationFeatureConfig,
@@ -532,18 +536,20 @@ export const AuthorizeAPIResource: FunctionComponent<AuthorizeAPIResourcePropsIn
                                             if (isDigitalWallet) {
                                                 return item?.type === APIResourceCategories.VC;
                                             }
-                                            // For MCP client apps, show MCP type resources along with others
-                                            if (isMCPClient) {
-                                                return item?.type === APIResourceCategories.MCP ||
-                                                    item?.type === APIResourceCategories.TENANT ||
-                                                    item?.type === APIResourceCategories.ORGANIZATION ||
-                                                    item?.type === APIResourceCategories.BUSINESS;
-                                            }
 
-                                            // For other apps, show standard types
-                                            return item?.type === APIResourceCategories.TENANT ||
-                                                            item?.type === APIResourceCategories.ORGANIZATION ||
-                                                            item?.type === APIResourceCategories.BUSINESS;
+                                            // For other apps: show standard API resources, with MCP included
+                                            // when unified capabilities is enabled or for MCP clients
+                                            const baseTypes: string[] = [
+                                                APIResourceCategories.TENANT,
+                                                APIResourceCategories.ORGANIZATION,
+                                                APIResourceCategories.BUSINESS
+                                            ];
+
+                                            const allowedTypes: string[] = (isUnifiedMcpCapabilitiesEnabled || isMCPClient)
+                                                ? [ ...baseTypes, APIResourceCategories.MCP ]
+                                                : baseTypes;
+
+                                            return allowedTypes.includes(item?.type);
                                         }).sort((a: DropdownItemProps, b: DropdownItemProps) =>
                                             APIResourceUtils.sortApiResourceTypes(a, b)
                                         )

--- a/features/admin.applications.v1/components/api-authorization/wizard/authorize-api-resource.tsx
+++ b/features/admin.applications.v1/components/api-authorization/wizard/authorize-api-resource.tsx
@@ -537,21 +537,20 @@ export const AuthorizeAPIResource: FunctionComponent<AuthorizeAPIResourcePropsIn
                                             if (isDigitalWallet) {
                                                 return item?.type === APIResourceCategories.VC;
                                             }
-
-                                            // For other apps: show standard API resources, with MCP included
-                                            // when unified capabilities is enabled or for MCP clients
-                                            const baseTypes: string[] = [
-                                                APIResourceCategories.TENANT,
-                                                APIResourceCategories.ORGANIZATION,
-                                                APIResourceCategories.BUSINESS
-                                            ];
-
-                                            const allowedTypes: string[] =
-                                                (isUnifiedMcpCapabilitiesEnabled || isMCPClient)
-                                                    ? [ ...baseTypes, APIResourceCategories.MCP ]
-                                                    : baseTypes;
-
-                                            return allowedTypes.includes(item?.type);
+                                            // When unified MCP capabilities is enabled: all apps can access MCP servers
+                                            // When disabled: only MCP client apps can access MCP servers
+                                            if (isUnifiedMcpCapabilitiesEnabled || isMCPClient) {
+                                                return item?.type === APIResourceCategories.MCP ||
+                                                    item?.type === APIResourceCategories.TENANT ||
+                                                    item?.type === APIResourceCategories.ORGANIZATION ||
+                                                    item?.type === APIResourceCategories.BUSINESS;
+                                            } else {
+                                                // For other apps when flag is disabled: show only standard
+                                                // API resources
+                                                return item?.type === APIResourceCategories.TENANT ||
+                                                    item?.type === APIResourceCategories.ORGANIZATION ||
+                                                    item?.type === APIResourceCategories.BUSINESS;
+                                            }
                                         }).sort((a: DropdownItemProps, b: DropdownItemProps) =>
                                             APIResourceUtils.sortApiResourceTypes(a, b)
                                         )

--- a/features/admin.applications.v1/constants/application-management.ts
+++ b/features/admin.applications.v1/constants/application-management.ts
@@ -113,7 +113,8 @@ export class ApplicationManagementConstants {
         .set(ApplicationFeatureDictionaryKeys.ApplicationOutboundProvisioning,
             "applications.outboundProvisioning")
         .set(ApplicationFeatureDictionaryKeys.SubOrgApplicationOutboundProvisioning,
-            "applications.outboundProvisioning.subOrg");
+            "applications.outboundProvisioning.subOrg")
+        .set("APPLICATION_UNIFIED_MCP_CAPABILITIES", "applications.unifiedMcpCapabilities");
 
     /**
      * Key for the URL search param for application state.

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -94,6 +94,11 @@ const isFrontChannelLogoutEnabled: boolean = isFeatureEnabled(
     ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_EDIT_ACCESS_CONFIG_FRONT_CHANNEL_LOGOUT")
 );
 
+const isUnifiedMcpCapabilitiesEnabled: boolean = isFeatureEnabled(
+    featureConfig?.applications,
+    ApplicationManagementConstants.FEATURE_DICTIONARY.get("APPLICATION_UNIFIED_MCP_CAPABILITIES")
+);
+
 /**
  * Check whether claims is  identity claims or not.
  *
@@ -219,19 +224,38 @@ export const applicationConfig: ApplicationConfig = {
 
             const onApplicationUpdate: () => void = props?.onApplicationUpdate as () => void;
 
+            const isMCPClientApp: boolean = application?.originalTemplateId ===
+                ApplicationTemplateIdTypes.MCP_CLIENT_APPLICATION;
+            const isDigitalWalletApp: boolean = application?.originalTemplateId ===
+                ApplicationTemplateIdTypes.DIGITAL_WALLET_APPLICATION;
+
             const tabExtensions: ResourceTabPaneInterface[] = [];
 
             // Enable the API authorization tab for supported templates when the api resources config is enabled.
+            // When unified MCP capabilities is enabled, all apps show "Authorization" tab
+            // When disabled, only MCP client and Digital Wallet show "Authorization", others show "API Authorization"
             if (
                 apiResourceFeatureEnabled && !application?.advancedConfigurations?.fragment &&
                 (
-                    application?.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
-                    || application?.templateId === MobileAppTemplate?.id
-                    || application?.templateId === OIDCWebAppTemplate?.id
-                    || application?.templateId === SinglePageAppTemplate?.id
-                    || application?.templateId === ApplicationManagementConstants.M2M_APP_TEMPLATE_ID
-                    || application?.templateId === ApplicationTemplateIdTypes.DIGITAL_WALLET_APPLICATION
-                    || application?.templateId === ApplicationTemplateIdTypes.AGENT_APPLICATION
+                    (isUnifiedMcpCapabilitiesEnabled && (
+                        application?.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
+                        || application?.templateId === MobileAppTemplate?.id
+                        || application?.templateId === OIDCWebAppTemplate?.id
+                        || application?.templateId === SinglePageAppTemplate?.id
+                        || application?.templateId === ApplicationManagementConstants.M2M_APP_TEMPLATE_ID
+                        || application?.templateId === ApplicationTemplateIdTypes.DIGITAL_WALLET_APPLICATION
+                        || application?.templateId === ApplicationTemplateIdTypes.AGENT_APPLICATION
+                    )) ||
+                    (!isUnifiedMcpCapabilitiesEnabled && (
+                        isMCPClientApp ||
+                        application?.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
+                        || application?.templateId === MobileAppTemplate?.id
+                        || application?.templateId === OIDCWebAppTemplate?.id
+                        || application?.templateId === SinglePageAppTemplate?.id
+                        || application?.templateId === ApplicationManagementConstants.M2M_APP_TEMPLATE_ID
+                        || application?.templateId === ApplicationTemplateIdTypes.DIGITAL_WALLET_APPLICATION
+                        || application?.templateId === ApplicationTemplateIdTypes.AGENT_APPLICATION
+                    ))
                 )
                 && application.name !== ApplicationManagementConstants.MY_ACCOUNT_APP_NAME
             ) {
@@ -242,18 +266,13 @@ export const applicationConfig: ApplicationConfig = {
                         index: application?.templateId === ApplicationManagementConstants.M2M_APP_TEMPLATE_ID
                             ? M2M_API_AUTHORIZATION_INDEX + tabExtensions.length
                             : API_AUTHORIZATION_INDEX + tabExtensions.length,
-                        menuItem: application?.originalTemplateId === ApplicationTemplateIdTypes.MCP_CLIENT_APPLICATION
+                        menuItem: (isUnifiedMcpCapabilitiesEnabled || isMCPClientApp || isDigitalWalletApp)
                             ? I18n.instance.t(
                                 "extensions:develop.applications.edit.sections.resourceAuthorization.title"
                             )
-                            : (application?.originalTemplateId
-                                === ApplicationTemplateIdTypes.DIGITAL_WALLET_APPLICATION)
-                                ? I18n.instance.t(
-                                    "extensions:develop.applications.edit.sections.resourceAuthorization.title"
-                                )
-                                : I18n.instance.t(
-                                    "extensions:develop.applications.edit.sections.apiAuthorization.title"
-                                ),
+                            : I18n.instance.t(
+                                "extensions:develop.applications.edit.sections.apiAuthorization.title"
+                            ),
                         render: () => (
                             <ResourceTab.Pane controlledSegmentation>
                                 <APIAuthorization

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -238,6 +238,7 @@ export const applicationConfig: ApplicationConfig = {
                 apiResourceFeatureEnabled && !application?.advancedConfigurations?.fragment &&
                 (
                     (isUnifiedMcpCapabilitiesEnabled && (
+                        isMCPClientApp ||
                         application?.templateId === ApplicationManagementConstants.CUSTOM_APPLICATION_OIDC
                         || application?.templateId === MobileAppTemplate?.id
                         || application?.templateId === OIDCWebAppTemplate?.id


### PR DESCRIPTION
## Summary

  - Add `applications.unifiedMcpCapabilities` feature flag to control MCP server
  access across application types
  - Update API authorization UI to conditionally use "Authorization" vs "API
  Authorization" tab naming based on the flag
  - Refactor resource text logic to centralize terminology ("resource", "API
  resource", or "verifiable credential")
  - Update authorization wizard to filter MCP-type resources based on feature flag
  state

  ## Changes

  ### Feature Flag Configuration
  - Added `applications.unifiedMcpCapabilities` to `deployment.config.json` disabled
  features list
  - Registered flag in `ApplicationManagementConstants.FEATURE_DICTIONARY`

  ### Application Configuration
  - **configs/application.tsx**: Updated tab visibility logic to show "Authorization"
  tab for all app types when flag is enabled, otherwise restrict to MCP client and
  Digital Wallet only

  ## Behavior

  **When `unifiedMcpCapabilities` is enabled:**
  - All application types can access MCP servers
  - Tab displays as "Authorization" with "resource" terminology
  - MCP resources appear in the authorization wizard for all apps

  **When `unifiedMcpCapabilities` is disabled (current state):**
  - Only MCP client apps can access MCP servers
  - Standard apps show "API Authorization" with "API resource" terminology
  - MCP resources only appear for MCP client applications

  **Digital Wallet apps:**
  - Always display "verifiable credential" terminology regardless of flag state


https://github.com/user-attachments/assets/f83ae35b-43c0-4b13-a191-e2833867d489

