### PR TITLE
Remove misleading aud claim info from API resource and MCP server wizards

### DIFF
--- a/.changeset/remove-misleading-aud-claim-text.md
+++ b/.changeset/remove-misleading-aud-claim-text.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.api-resources.v1": patch
+"@wso2is/admin.api-resources.v2": patch
+---
+
+Remove misleading information about aud claim from API resource and MCP server creation wizards

--- a/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
+++ b/apps/console/src/extensions/i18n/resources/en-US/extensions.ts
@@ -330,7 +330,7 @@ export const extensions: Extensions = {
                                         alreadyExistsError: "Identifier already exists in the organization. Please choose a different one.",
                                         errorOccurred: "An error occurred while validating the identifier.",
                                         invalid: "Identifier cannot contain spaces",
-                                        hint: "We recommend using a URI as the identifier, but it does not need to be publicly accessible since {{productName}} will only use it as the audience (aud) claim in the issued JWT tokens and will not attempt to access your API. <1>This field should be unique. Once created, it is not editable.</1>",
+                                        hint: "We recommend using a URI as the identifier, but it does not need to be a publicly accessible URI. <1>This field should be unique. Once created, it is not editable.</1>",
                                         label: "Identifier",
                                         placeholder: "https://api.bookmyhotel.com"
                                     },

--- a/features/admin.api-resources.v1/components/wizard/add-api-resource-steps/add-api-resource-basic.tsx
+++ b/features/admin.api-resources.v1/components/wizard/add-api-resource-steps/add-api-resource-basic.tsx
@@ -160,10 +160,8 @@ export const AddAPIResourceBasic: FunctionComponent<AddAPIResourceBasicInterface
                                 i18nKey= { "extensions:develop.apiResource.wizard.addApiResource.steps.basic." +
                                     "form.fields.identifier.hint" }
                                 tOptions={ { productName } }>
-                                We recommend using a URI as the identifier, but you do not need to make the URI
-                                publicly available since Asgardeo will not access your API.
-                                Asgardeo will use this identifier value as the audience(aud) claim in the
-                                issued JWT tokens. <b>This field should be unique; once created, it is not editable.</b>
+                                We recommend using a URI as the identifier, but it does not need to be a
+                                publicly accessible URI. <b>This field should be unique; once created, it is not editable.</b>
                             </Trans>
                         </Hint>
                     </Grid.Column>

--- a/features/admin.api-resources.v2/components/wizard/add-api-resource-steps/add-api-resource-basic.tsx
+++ b/features/admin.api-resources.v2/components/wizard/add-api-resource-steps/add-api-resource-basic.tsx
@@ -162,10 +162,8 @@ export const AddAPIResourceBasic: FunctionComponent<AddAPIResourceBasicInterface
                                 i18nKey= { "extensions:develop.apiResource.wizard.addApiResource.steps.basic." +
                                     "form.fields.identifier.hint" }
                                 tOptions={ { productName } }>
-                                We recommend using a URI as the identifier, but you do not need to make the URI
-                                publicly available since WSO2 Identity Server will not access your API.
-                                WSO2 Identity Server will use this identifier value as the audience(aud) claim in the
-                                issued JWT tokens. <b>This field should be unique; once created, it is not editable.</b>
+                                We recommend using a URI as the identifier, but it does not need to be a
+                                publicly accessible URI. <b>This field should be unique; once created, it is not editable.</b>
                             </Trans>
                         </Hint>
                     </Grid.Column>


### PR DESCRIPTION
## Summary
- Remove misleading text from the API resource and MCP server creation wizards that claimed the resource identifier would be included in the `aud` claim of issued JWT tokens
- IS doesn't support the resource server concept yet, so this information was incorrect
- Updated the identifier hint in both v1 and v2 wizard components and the i18n extension strings

Fixes https://github.com/wso2/product-is/issues/27257

## Test plan
- [x] Open the API resource creation wizard and verify the identifier hint no longer mentions `aud` claim
- [x] Open the MCP server creation wizard and verify the identifier hint no longer mentions `aud` claim
- [x] Verify the updated hint text reads: "We recommend using a URI as the identifier, but it does not need to be a publicly accessible URI. This field should be unique. Once created, it is not editable."

🤖 Generated with [Claude Code](https://claude.ai/claude-code)