### PR TITLE
Remove tooltip from authenticator buttons on login page

### DIFF
--- a/.changeset/remove-tooltip-from-authenticator-buttons.md
+++ b/.changeset/remove-tooltip-from-authenticator-buttons.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Remove unnecessary `title` attributes from IWA, X509 Certificate, FIDO/Passkey, and Magic Link authenticator buttons on the login page to prevent unwanted browser tooltips on hover, consistent with other authenticator buttons (TOTP, SMS OTP, Email OTP, Push Notification).

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -877,8 +877,7 @@
                                     onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
                                         '<%=IWA_AUTHENTICATOR%>')"
-                                    id="icon-<%=iconId%>"
-                                    title="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> IWA">
+                                    id="icon-<%=iconId%>">
                                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> <strong>IWA</strong>
                                 </button>
                             </div>
@@ -891,7 +890,6 @@
                                     <button class="ui secondary button" onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
                                         'x509CertificateAuthenticator')" id="icon-<%=iconId%>"
-                                        title="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%> X509 Certificate"
                                     >
                                         <img
                                             class="ui image"
@@ -915,8 +913,6 @@
                                     <button class="ui button" onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
                                         'FIDOAuthenticator')" id="icon-<%=iconId%>"
-                                        title="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%>
-                                            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "fido.authenticator" )%>"
                                         data-componentid="login-page-sign-in-with-fido"
                                     >
                                         <img
@@ -942,8 +938,6 @@
                                     <button class="ui secondary button" onclick="handleNoDomain(this,
                                         '<%=Encode.forJavaScriptAttribute(Encode.forUriComponent(idpEntry.getKey()))%>',
                                         '<%=MAGIC_LINK_AUTHENTICATOR%>')" id="icon-<%=iconId%>"
-                                        title="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "sign.in.with")%>
-                                            <%=AuthenticationEndpointUtil.i18n(resourceBundle, "magic.link" )%>"
                                         data-componentid="login-page-sign-in-with-magic-link">
                                         <img
                                             class="ui image"


### PR DESCRIPTION
## Summary

- Remove unnecessary `title` attributes from IWA, X509 Certificate, FIDO/Passkey, and Magic Link authenticator buttons on the login page
- Prevents unwanted browser tooltips appearing on hover
- Consistent with other authenticator buttons (TOTP, SMS OTP, Email OTP, Push Notification) that don't have `title` attributes

## Test plan

- [ ] Verify IWA, X509 Certificate, FIDO/Passkey, and Magic Link authenticator buttons no longer show browser tooltips on hover
- [ ] Verify button functionality is unaffected
- [ ] Verify other authenticator buttons remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)