### PR TITLE
Improve handling of missing primary email and mobile number

### DIFF
--- a/.changeset/shaggy-wombats-whisper.md
+++ b/.changeset/shaggy-wombats-whisper.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
+---
+
+Improve multiple email addresses and mobile numbers display

--- a/features/admin.approval-workflows.v1/api/approval-workflow.ts
+++ b/features/admin.approval-workflows.v1/api/approval-workflow.ts
@@ -22,7 +22,7 @@ import { HttpMethods,
     HttpErrorResponseDataInterface
 } from "@wso2is/core/models";
 import { AxiosError, AxiosResponse } from "axios";
-import { ApprovalWorkflowPayload } from "../models/approval-workflows";
+import { ApprovalWorkflowPayload, WorkflowListResponseInterface } from "../models/approval-workflows";
 
 /**
  * Get an axios instance.
@@ -106,6 +106,32 @@ export const updateApprovalWorkflow = (id: string, data: ApprovalWorkflowPayload
                 return Promise.reject(`An error occurred. The server returned ${response.status}`);
             }
 
+            return Promise.resolve(response.data);
+        })
+        .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+            return Promise.reject(error?.response?.data);
+        });
+};
+
+/**
+ * Fetches approval workflows with an optional filter.
+ *
+ * @param filter - Filter string to narrow results (e.g. by name).
+ * @returns A promise resolving to the workflow list response.
+ */
+export const getApprovalWorkflows = (filter?: string): Promise<WorkflowListResponseInterface> => {
+    const requestConfig: RequestConfigInterface = {
+        headers: {
+            Accept: "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        params: { filter },
+        url: store.getState()?.config?.endpoints?.workflows
+    };
+
+    return httpClient(requestConfig)
+        .then((response: AxiosResponse) => {
             return Promise.resolve(response.data);
         })
         .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {

--- a/features/admin.approval-workflows.v1/components/create/general-approval-workflow-details-form.tsx
+++ b/features/admin.approval-workflows.v1/components/create/general-approval-workflow-details-form.tsx
@@ -16,8 +16,7 @@
  * under the License.
  */
 
-import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
-import { addAlert } from "@wso2is/core/store";
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { FinalForm, FinalFormField, FormRenderProps, TextFieldAdapter } from "@wso2is/form";
 import isEqual from "lodash-es/isEqual";
 import React, {
@@ -27,15 +26,11 @@ import React, {
     ReactElement,
     RefAttributes,
     forwardRef,
-    useEffect,
     useImperativeHandle,
-    useRef,
-    useState
+    useRef
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useDispatch } from "react-redux";
-import { Dispatch } from "redux";
-import { useGetApprovalWorkflows } from "../../api/use-get-approval-workflows";
+import { getApprovalWorkflows } from "../../api/approval-workflow";
 import { APPROVAL_WORKFLOW_VALIDATION_REGEX_PATTERNS } from "../../constants/approval-workflow-constants";
 import { GeneralDetailsFormValuesInterface } from "../../models/ui";
 import "./general-approval-workflow-details-form.scss";
@@ -93,49 +88,61 @@ const GeneralApprovalWorkflowDetailsForm: ForwardRefExoticComponent<RefAttribute
         ): ReactElement => {
             const triggerFormSubmit: MutableRefObject<() => void> = useRef<(() => void) | null>(null);
             const currentValuesRef: any = useRef(null);
+            const formApiRef: MutableRefObject<any> = useRef<any>(null);
 
-            const dispatch: Dispatch = useDispatch();
             const { t } = useTranslation([ "approvalWorkflows" ]);
 
-            const [ filterQuery, setFilterQuery ] = useState<string>("");
-
-            const {
-                data: workflowResponse,
-                error: workflowsError
-            } = useGetApprovalWorkflows(null, null, filterQuery, true);
+            const nameExistsErrorRef: MutableRefObject<string | null> = useRef<string | null>(null);
+            const checkedNameRef: MutableRefObject<string | null> = useRef<string | null>(null);
 
             // Expose triggerSubmit to the parent via the ref
             useImperativeHandle(ref, () => ({
                 isFormEdited: () => {
                     return !isEqual(initialValues, currentValuesRef.current);
                 },
-                triggerSubmit: () => {
+                triggerSubmit: async () => {
+                    const currentName: string = currentValuesRef.current?.name;
+
+                    nameExistsErrorRef.current = null;
+                    checkedNameRef.current = null;
+
+                    if (currentName) {
+                        try {
+                            const response: { workflows?: { id: string; name: string }[] } =
+                                await getApprovalWorkflows(currentName);
+                            const nameExists: boolean =
+                                response?.workflows?.some((workflow: { id: string; name: string }) => {
+                                    return (
+                                        workflow.name === currentName &&
+                                        (approvalWorkflowId ? approvalWorkflowId !== workflow.id : true)
+                                    );
+                                }) ?? false;
+
+                            if (nameExists) {
+                                nameExistsErrorRef.current = t(
+                                    "approvalWorkflows:forms.general.name.validationErrorMessages" +
+                                    ".alreadyExistsErrorMessage"
+                                );
+                                checkedNameRef.current = currentName;
+                                // Force FinalForm to re-run validateForm (which reads the refs)
+                                // by briefly changing the value. React batches both DOM updates
+                                // so only the final state (with the error) is rendered.
+                                formApiRef.current?.change("name", "");
+                                formApiRef.current?.change("name", currentName);
+                                formApiRef.current?.blur("name");
+
+                                return;
+                            }
+                        } catch (_error: unknown) {
+                            // Silently fail — do not block submission on a lookup error.
+                        }
+                    }
+
                     if (triggerFormSubmit.current) {
                         triggerFormSubmit.current();
                     }
                 }
             }));
-
-            useEffect(() => {
-                if (workflowsError) {
-                    dispatch(
-                        addAlert({
-                            description:
-                            workflowsError?.response?.data?.description ??
-                            workflowsError?.response?.data?.detail ??
-                            t(
-                                "approvalWorkflows:notifications.fetchApprovalWorkflows.genericError.description"
-                            ),
-                            level: AlertLevels.ERROR,
-                            message:
-                            workflowsError?.response?.data?.message ??
-                            t(
-                                "approvalWorkflows:notifications.fetchApprovalWorkflows.genericError.message"
-                            )
-                        })
-                    );
-                }
-            }, [ workflowsError ]);
 
             const validateForm = (
                 values: GeneralDetailsFormValuesInterface
@@ -173,19 +180,12 @@ const GeneralApprovalWorkflowDetailsForm: ForwardRefExoticComponent<RefAttribute
                             { invalidString }
                         );
                     }
-                    setFilterQuery(values?.name);
-                    const nameExists: boolean =
-                    workflowResponse?.workflows?.some((workflow: { id: string; name: string }) => {
-                        return (
-                            workflow.name === values.name &&
-                            (approvalWorkflowId ? approvalWorkflowId !== workflow.id : true)
-                        );
-                    }) ?? false;
 
-                    if (nameExists) {
-                        error.name = t(
-                            "approvalWorkflows:forms.general.name.validationErrorMessages.alreadyExistsErrorMessage"
-                        );
+                    if (
+                        values?.name === checkedNameRef.current &&
+                        nameExistsErrorRef.current
+                    ) {
+                        error.name = nameExistsErrorRef.current;
                     }
                 }
 
@@ -217,9 +217,10 @@ const GeneralApprovalWorkflowDetailsForm: ForwardRefExoticComponent<RefAttribute
                     } }
                     validate={ validateForm }
                     initialValues={ initialValues }
-                    render={ ({ handleSubmit, values }: FormRenderProps) => {
+                    render={ ({ handleSubmit, values, form }: FormRenderProps) => {
                         triggerFormSubmit.current = handleSubmit;
                         currentValuesRef.current = values;
+                        formApiRef.current = form;
 
                         return (
                             <form onSubmit={ handleSubmit } className="general-workflow-model-details-form">

--- a/features/admin.users.v1/components/user-profile/user-profile-form.tsx
+++ b/features/admin.users.v1/components/user-profile/user-profile-form.tsx
@@ -243,12 +243,10 @@ const UserProfileForm: FunctionComponent<UserProfileFormPropsInterface> = ({
                         typeof email === "object" && email !== null && (email as any).primary === true
                 )?.value;
 
-                if (isMultipleEmailAndMobileNumberEnabled && isEmpty(emailAddresses)) {
-                    if (primaryEmail) {
-                        (
-                            initialValues[systemSchema] as Record<string, unknown>
-                        )[emailAddressesField] = [ primaryEmail ];
-                    }
+                if (isMultipleEmailAndMobileNumberEnabled && primaryEmail && !emailAddresses.includes(primaryEmail)) {
+                    (
+                        initialValues[systemSchema] as Record<string, unknown>
+                    )[emailAddressesField] = [ primaryEmail, ...emailAddresses ];
                 }
 
                 if (isMultipleEmailAndMobileNumberEnabled && isEmailVerificationEnabled) {
@@ -283,12 +281,10 @@ const UserProfileForm: FunctionComponent<UserProfileFormPropsInterface> = ({
                         (phone as { type: string; value: string }).type === "mobile"
                 )?.value;
 
-                if (isMultipleEmailAndMobileNumberEnabled && isEmpty(mobileNumbers)) {
-                    if (primaryMobile) {
-                        (
-                            initialValues[systemSchema] as Record<string, unknown>
-                        )[mobileNumbersField] = [ primaryMobile ];
-                    }
+                if (isMultipleEmailAndMobileNumberEnabled && primaryMobile && !mobileNumbers.includes(primaryMobile)) {
+                    (
+                        initialValues[systemSchema] as Record<string, unknown>
+                    )[mobileNumbersField] = [ primaryMobile, ...mobileNumbers ];
                 }
 
                 if (isMultipleEmailAndMobileNumberEnabled && isMobileVerificationEnabled) {


### PR DESCRIPTION
### Purpose
This pull request improves how multiple email addresses and mobile numbers are displayed and initialized in the user profile form, especially when the "multiple email and mobile number" feature is enabled. The logic now ensures that the primary email and mobile number are included in their respective lists if they're not already present, providing a more accurate and user-friendly experience.

**Enhancements to user profile form initialization:**

* Ensures the primary email is included in the list of email addresses when multiple emails are enabled and avoids duplicates (`user-profile-form.tsx`).
* Ensures the primary mobile number is included in the list of mobile numbers when multiple numbers are enabled and avoids duplicates (`user-profile-form.tsx`).

**Documentation and changelog:**

* Adds a changeset entry describing the improvements to displaying multiple email addresses and mobile numbers. (.changeset/shaggy-wombats-whisper.md)


### Related Issues
- https://github.com/wso2/product-is/issues/26753
