### PR TITLE
Add support for shared user direct login to sub-organizations

### DIFF
--- a/.changeset/major-webs-grab.md
+++ b/.changeset/major-webs-grab.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add support for shared user direct login.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/login.jsp
@@ -78,6 +78,7 @@
     private static final String IS_SAAS_APP = "isSaaSApp";
     private static final String BASIC_AUTHENTICATOR = "BasicAuthenticator";
     private static final String IDENTIFIER_EXECUTOR = "IdentifierExecutor";
+    private static final String SHARED_USER_IDENTIFIER_EXECUTOR = "SharedUserIdentifierExecutor";
     private static final String JWT_BASIC_AUTHENTICATOR = "JWTBasicAuthenticator";
     private static final String X509_CERTIFICATE_AUTHENTICATOR = "x509CertificateAuthenticator";
     private static final String GOOGLE_AUTHENTICATOR = "GoogleOIDCAuthenticator";
@@ -190,7 +191,7 @@
     List<String> registeredLocalAuthenticators = Arrays.asList(
         BACKUP_CODE_AUTHENTICATOR, TOTP_AUTHENTICATOR, EMAIL_OTP_AUTHENTICATOR,
         MAGIC_LINK_AUTHENTICATOR,SMS_OTP_AUTHENTICATOR,
-        IDENTIFIER_EXECUTOR,JWT_BASIC_AUTHENTICATOR,BASIC_AUTHENTICATOR,
+        IDENTIFIER_EXECUTOR,SHARED_USER_IDENTIFIER_EXECUTOR,JWT_BASIC_AUTHENTICATOR,BASIC_AUTHENTICATOR,
         IWA_AUTHENTICATOR,X509_CERTIFICATE_AUTHENTICATOR,FIDO_AUTHENTICATOR,
         PUSH_NOTIFICATION_AUTHENTICATOR, ORG_IDENTIFIER_HANDLER
    );
@@ -546,7 +547,8 @@
                 <div class="segment-form">
                     <%
                         if (localAuthenticatorNames.size() > 0) {
-                            if (localAuthenticatorNames.contains(IDENTIFIER_EXECUTOR)) {
+                            if (localAuthenticatorNames.contains(IDENTIFIER_EXECUTOR) ||
+                            localAuthenticatorNames.contains(SHARED_USER_IDENTIFIER_EXECUTOR)) {
                             hasLocalLoginOptions = true;
                     %>
                         <%@ include file="identifierauth.jsp" %>
@@ -590,7 +592,8 @@
                                 || (hasLocalLoginOptions && idpAuthenticatorMapping != null && idpAuthenticatorMapping.size() > 1)) {
                     %>
                     <% if (localAuthenticatorNames.contains(BASIC_AUTHENTICATOR) ||
-                            localAuthenticatorNames.contains(IDENTIFIER_EXECUTOR)) { %>
+                            localAuthenticatorNames.contains(IDENTIFIER_EXECUTOR) ||
+                            localAuthenticatorNames.contains(SHARED_USER_IDENTIFIER_EXECUTOR)) { %>
                     <div class="ui horizontal divider">
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "or")%>
                     </div>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/error.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/error.jsp
@@ -47,6 +47,13 @@
 <jsp:directive.include file="includes/branding-preferences.jsp"/>
 
 <%
+    String errorKey = request.getParameter("errorKey");
+    if (StringUtils.isNotBlank(errorKey)) {
+        request.setAttribute("error", true);
+        request.setAttribute("errorMsg", IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
+                Encode.forJava(errorKey)));
+    }
+    
     String errorMsg = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorMsg"));
     String errorCode = IdentityManagementEndpointUtil.getStringValue(request.getAttribute("errorCode"));
     String invalidConfirmationErrorCode = IdentityRecoveryConstants.ErrorMessages.ERROR_CODE_INVALID_CODE.getCode();

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-confirm.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-confirm.jsp
@@ -58,14 +58,6 @@
         return;
     }
 
-    String isSharedUser = request.getParameter("isSharedUser");
-    if (Boolean.parseBoolean(isSharedUser)) {
-        request.setAttribute("error", true);
-        request.setAttribute("errorMsg", IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Password.Expired"));
-        request.getRequestDispatcher("error.jsp").forward(request, response);
-        return;
-    }
-
     String errorKey = request.getParameterMap().containsKey("errorKey") 
     	? request.getParameter("errorKey") 
     	: StringUtils.EMPTY;

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-confirm.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-confirm.jsp
@@ -58,6 +58,14 @@
         return;
     }
 
+    String isSharedUser = request.getParameter("isSharedUser");
+    if (Boolean.parseBoolean(isSharedUser)) {
+        request.setAttribute("error", true);
+        request.setAttribute("errorMsg", IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Password.Expired"));
+        request.getRequestDispatcher("error.jsp").forward(request, response);
+        return;
+    }
+
     String errorKey = request.getParameterMap().containsKey("errorKey") 
     	? request.getParameter("errorKey") 
     	: StringUtils.EMPTY;


### PR DESCRIPTION
This pull request introduces support for a new authenticator, `SharedUserIdentifierExecutor`, in the authentication portal, and adds logic in the password recovery portal to handle shared user scenarios by displaying an error if the user is identified as shared. The main changes focus on expanding authenticator handling and improving error feedback for shared users.

**Authentication Portal Enhancements:**

* Added the `SHARED_USER_IDENTIFIER_EXECUTOR` constant and included it in the list of registered local authenticators in `login.jsp`, allowing the portal to recognize and support this new authenticator. 
* Updated authenticator checks and UI logic to consider both `IDENTIFIER_EXECUTOR` and `SHARED_USER_IDENTIFIER_EXECUTOR` when determining available login options and displaying the "or" divider in the login form. 

**Password Recovery Portal Enhancement:**

* Added logic in `password-recovery-confirm.jsp` to check if the user is a shared user (via the `isSharedUser` parameter) and, if so, display a password expired error and forward to the error page.

### Dependent on
- https://github.com/wso2/carbon-identity-framework/pull/7964
- https://github.com/wso2-extensions/identity-governance/pull/1117

### Related issue
- https://github.com/wso2/product-is/issues/27371