### PR TITLE
Fix change password UI fixes

### DIFF
--- a/.changeset/flat-fireants-invite.md
+++ b/.changeset/flat-fireants-invite.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Show new password API error response when password update fails

--- a/apps/myaccount/src/components/change-password/change-password.tsx
+++ b/apps/myaccount/src/components/change-password/change-password.tsx
@@ -201,7 +201,21 @@ export const ChangePassword: FunctionComponent<ChangePasswordProps> = (props: Ch
                 }
             })
             .catch((error: any) => {
-                if (error.response && error.response.status === 400) {
+                if (error.response && error.response.status === 400
+                    && error.response.data && error.response.data.description) {
+                    onAlertFired({
+                        description: t(
+                            "myAccount:components.changePassword.forms.passwordResetForm.validations." +
+                            "submitError.description",
+                            { description: error.response.data.description }
+                        ),
+                        level: AlertLevels.ERROR,
+                        message: t(
+                            "myAccount:components.changePassword.forms.passwordResetForm.validations." +
+                            "submitError.message"
+                        )
+                    });
+                } else if (error.response && error.response.status === 400) {
                     // Set an error in the current password field.
                     setErrors({
                         ...errors,


### PR DESCRIPTION
### Purpose
This pull request improves the user experience when updating passwords by displaying more informative error messages if the password update fails due to API errors. Now, users will see the actual error response from the API when available, making it clearer why the update failed.

**User feedback improvements:**

* Updated the `ChangePassword` component to show the API's error description in the alert when a password update fails with a 400 status and a description is provided in the response.




https://github.com/user-attachments/assets/94791ece-a7fc-40c5-b55e-4d8262fce58d



