### PR TITLE
[Next]Add Token Exchange grant type to agent application template

### DIFF
--- a/.changeset/fluffy-parents-burn.md
+++ b/.changeset/fluffy-parents-burn.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.extensions.v1": patch
+"@wso2is/console": patch
+---
+
+Add Token Exchange grant type to agent application template

--- a/features/admin.extensions.v1/application-templates/templates/agent-application/agent-application.json
+++ b/features/admin.extensions.v1/application-templates/templates/agent-application/agent-application.json
@@ -48,7 +48,8 @@
                 "grantTypes": [
                     "authorization_code",
                     "refresh_token",
-                    "urn:openid:params:grant-type:ciba"
+                    "urn:openid:params:grant-type:ciba",
+                    "urn:ietf:params:oauth:grant-type:token-exchange"
                 ],
                 "pkce": {
                     "mandatory": true,

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -461,7 +461,8 @@ export const applicationConfig: ApplicationConfig = {
         [ "agent-application" ]: [
             ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,
             ApplicationManagementConstants.REFRESH_TOKEN_GRANT,
-            ApplicationManagementConstants.CIBA_GRANT
+            ApplicationManagementConstants.CIBA_GRANT,
+            ApplicationManagementConstants.OAUTH2_TOKEN_EXCHANGE
         ],
         [ "angular-application" ]: [
             ApplicationManagementConstants.AUTHORIZATION_CODE_GRANT,


### PR DESCRIPTION
## Summary

  This PR enhances the agent application template and creation flow with one key improvements:

 **Token Exchange Grant Type Support** - Agent applications now include the Token Exchange grant type (`urn:ietf:params:oauth:grant-type:token-exchange`) by default
  
  ## Changes

  ### Token Exchange Grant Type

  **Files Modified:**
  - `features/admin.extensions.v1/application-templates/templates/agent-application/agent-application.json`
  - `features/admin.extensions.v1/configs/application.tsx`

  **What Changed:**
  - Added `urn:ietf:params:oauth:grant-type:token-exchange` to the default grant types in the agent application template
  - Updated the allowed grant types configuration to display Token Exchange as a selectable option in the UI
  - Agent applications now support token exchange grant type

  **Grant Types for Agent Applications:**
  - Authorization Code
  - Refresh Token
  - CIBA
  - Token Exchange *(newly added)*
 
 Issue:- https://github.com/wso2/product-is/issues/27653
 
 
<img width="815" height="300" alt="image" src="https://github.com/user-attachments/assets/842c703c-6881-4943-893b-c0dce2fb1021" />

