### PR TITLE
[DRAFT] Fix broken My Account link on FIDO2 cancel error page.

### DIFF
--- a/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
+++ b/apps/authentication-portal/src/main/webapp/fido2-auth.jsp
@@ -20,6 +20,8 @@
 <%@ page import="org.owasp.encoder.Encode" %>
 <%@ page import="java.io.File" %>
 <%@ page import="org.apache.commons.text.StringEscapeUtils" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 <%@ taglib prefix="layout" uri="org.wso2.identity.apps.taglibs.layout.controller" %>
 
 <%@include file="includes/localize.jsp" %>
@@ -164,15 +166,14 @@
     <script type="text/javascript" src="libs/base64js/base64js-1.3.0.min.js"></script>
     <script type="text/javascript" src="libs/base64url.js"></script>
 
+    <%
+        String myaccountUrl = IdentityManagementEndpointUtil.getUserPortalUrl(
+            application.getInitParameter(IdentityManagementEndpointConstants.ConfigConstants.USER_PORTAL_URL),
+            tenantDomain);
+    %>
     <script type="text/javascript">
         $(document).ready(function () {
-            var myaccountUrl = '<%=application.getInitParameter("MyAccountURL")%>';
-
-            if ("<%=tenantDomain%>" !== "" || "<%=tenantDomain%>" !== "null") {
-                myaccountUrl = myaccountUrl + "/t/" + "<%=tenantDomain%>";
-            }
-
-            $("#my-account-link").attr("href", myaccountUrl +"/myaccount");
+            $("#my-account-link").attr("href", '<%=Encode.forJavaScriptBlock(myaccountUrl)%>');
 
             if(navigator ){
                 let userAgent = navigator.userAgent;


### PR DESCRIPTION
## Summary

Fixes the broken "My Account" link rendered on the FIDO2 authentication cancel/error page (`fido2-auth.jsp`) in IS 6.1.0.

**Issue:** https://github.com/wso2/product-is/issues/16140

## Root Cause

Two compounding bugs in the client-side JavaScript URL construction block (lines 171–177 in IS 6.1.0):

1. **Tautological condition** — `"<tenantDomain>" !== "" || "<tenantDomain>" !== "null"` is **always `true`** regardless of the tenant domain value (logical `||` where `&&` was required). This caused the tenant path `/t/<tenant>` to always be appended.

2. **`MyAccountURL` not configured** — In IS 6.1.0, the `MyAccountURL` `<context-param>` is not emitted in `web.xml` by default. `application.getInitParameter("MyAccountURL")` returns Java `null`, which JSP renders as the string `"null"`. Combined with the tautological condition, the produced href is `null/t/null/myaccount` — a broken relative URL that resolves to an IS error page ("null is an invalid tenant domain").

## What Was Changed

`apps/authentication-portal/src/main/webapp/fido2-auth.jsp`

Replaces the buggy client-side JS URL construction with a server-side Java scriptlet that calls `IdentityManagementEndpointUtil.getUserPortalUrl(configuredUrl, tenantDomain)`. This is the same fix already shipped in IS 7.0.0 / master. The utility correctly handles the unconfigured URL case and produces a properly tenant-qualified absolute URL.

```diff
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointUtil" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
 ...
+    <%
+        String myaccountUrl = IdentityManagementEndpointUtil.getUserPortalUrl(
+            application.getInitParameter(IdentityManagementEndpointConstants.ConfigConstants.USER_PORTAL_URL),
+            tenantDomain);
+    %>
     <script type="text/javascript">
         $(document).ready(function () {
-            var myaccountUrl = '<%=application.getInitParameter("MyAccountURL")%>';
-
-            if ("<%=tenantDomain%>" !== "" || "<%=tenantDomain%>" !== "null") {
-                myaccountUrl = myaccountUrl + "/t/" + "<%=tenantDomain%>";
-            }
-
-            $("#my-account-link").attr("href", myaccountUrl +"/myaccount");
+            $("#my-account-link").attr("href", '<%=Encode.forJavaScriptBlock(myaccountUrl)%>');
```

## Verification

Verified with a Playwright automated test against IS 6.1.0:

1. Created an OIDC app configured with `FIDOAuthenticator` as the sole auth step.
2. Navigated to the FIDO2 auth page via an OAuth2 authorization URL.
3. Simulated user pressing Cancel on the native passkey picker (injected `navigator.credentials.get` throwing `NotAllowedError`).
4. Confirmed `#fido-error-content` became visible.
5. Read `#my-account-link` href:
   - **Before fix:** `null/t/null/myaccount` → error page ("null is an invalid tenant domain")
   - **After fix:** `https://localhost:9443/myaccount` → IS login flow for My Account (`login.do?client_id=MY_ACCOUNT&tenantDomain=carbon.super&sp=My+Account`)

All assertions passed (no `"null"` in href, absolute URL, navigation succeeds).

## Test Coverage

- 13 unit tests (Node.js) verifying the tautological condition and fixed URL construction across edge cases (null tenant, super-tenant, named tenant, unconfigured base URL).
- 8 Playwright integration tests (TC-01 through TC-08) covering `#my-account-link` href validity and successful navigation post-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)