### PR TITLE
fix: update copilot endpoint to enable /o paths

### DIFF
--- a/.changeset/purple-trees-attack.md
+++ b/.changeset/purple-trees-attack.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/core": patch
+---
+
+fix: update copilot endpoint to include skipAuthzRuntimePath parameter

--- a/.changeset/purple-trees-attack.md
+++ b/.changeset/purple-trees-attack.md
@@ -1,6 +1,6 @@
 ---
 "@wso2is/console": patch
-"@wso2is/core": patch
+"@wso2is/admin.core.v1": patch
 ---
 
 fix: update copilot endpoint to include skipAuthzRuntimePath parameter

--- a/features/admin.core.v1/configs/app.ts
+++ b/features/admin.core.v1/configs/app.ts
@@ -385,7 +385,7 @@ export class Config {
             ...getCompatibilitySettingsResourceEndpoints(this.resolveServerHost(true)),
             CORSOrigins: `${ this.resolveServerHostFromConfig() }/api/server/v1/cors/origins`,
             asyncStatus: `${ this.resolveServerHost(false, true) }/api/server/v1/async-operations`,
-            copilot: `${ this.resolveServerHost() }/api/server/v1/copilot`,
+            copilot: `${ this.resolveServerHost(false, true) }/api/server/v1/copilot`,
             // TODO: Remove this endpoint and use ID token to get the details
             me: `${ this.getDeploymentConfig()?.serverHost }/scim2/Me`,
             saml2Meta: `${ this.resolveServerHost(false, true) }/identity/metadata/saml2`,


### PR DESCRIPTION
### Purpose
$subject

Need to update copilot BE service to enable sub-org paths

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
