### PR TITLE
Remove AGENT domain from user store dropdown in JIT provisioning configuration in Connections

### DIFF
--- a/.changeset/blue-squids-march.md
+++ b/.changeset/blue-squids-march.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.connections.v1": patch
+---
+
+Exclude Agent userstore from JIT provisioning user store domain dropdown

--- a/features/admin.connections.v1/components/edit/forms/jit-provisioning-configuration-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/jit-provisioning-configuration-form.tsx
@@ -24,6 +24,7 @@ import { history } from "@wso2is/admin.core.v1/helpers/history";
 import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { identityProviderConfig, userstoresConfig } from "@wso2is/admin.extensions.v1";
+import { AGENT_USERSTORE } from "@wso2is/admin.userstores.v1/constants/user-store-constants";
 import useUserStores from "@wso2is/admin.userstores.v1/hooks/use-user-stores";
 import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-stores";
 import { AlertLevels, Claim, TestableComponentInterface, UniquenessScope } from "@wso2is/core/models";
@@ -168,7 +169,9 @@ export const JITProvisioningConfigurationsForm: FunctionComponent<JITProvisionin
                 const isReadOnly: boolean = isUserStoreReadOnly(store.name);
                 const isEnabled: boolean = store.enabled;
 
-                if (store.name.toUpperCase() !== userstoresConfig.primaryUserstoreName && !isReadOnly && isEnabled) {
+                if (store.name.toUpperCase() !== userstoresConfig.primaryUserstoreName
+                    && store.name.toUpperCase() !== AGENT_USERSTORE
+                    && !isReadOnly && isEnabled) {
                     const storeOption: DropdownItemProps = {
                         key: index,
                         text: store.name,


### PR DESCRIPTION
Filter out the Agent userstore from the user store domain dropdown in the Just-in-time provisioning configuration
  for connections. This prevents users from selecting the Agent store as a provisioning target, which is not a valid
  option for JIT provisioning.
  
  Issue :- https://github.com/wso2/product-is/issues/27119
  
  
<img width="1512" height="861" alt="image" src="https://github.com/user-attachments/assets/764cdff9-6a8e-4517-8a7b-cf679c21eb89" />
