### PR TITLE
Fix Client secret hash support to console

### DIFF
--- a/.changeset/quiet-rocks-smile.md
+++ b/.changeset/quiet-rocks-smile.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.applications.v1": patch
+---
+
+get client secret hash from first call

--- a/.changeset/quiet-rocks-smile.md
+++ b/.changeset/quiet-rocks-smile.md
@@ -2,4 +2,4 @@
 "@wso2is/admin.applications.v1": patch
 ---
 
-get client secret hash from first call
+Fix Client secret hash support to console

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -2642,7 +2642,7 @@
         "isClaimUniquenessValidationEnabled": {{ identity_mgt.user_claim_update.uniqueness.enable }},
         {% endif %}
         {% if oauth.hash_tokens_and_secrets is defined %}
-        "isClientSecretHashEnabled": {{ oauth.hash_tokens_and_secrets }},
+        "isClientSecretHashEnabled": {{ (oauth.hash_client_secret | default(false)) or (oauth.hash_tokens_and_secrets) }},
         {% endif %}
         {% if authentication.endpoint.enable_custom_claim_mappings is defined %}
         "isCustomClaimMappingEnabled": {{ authentication.endpoint.enable_custom_claim_mappings }},

--- a/features/admin.applications.v1/components/edit-application.tsx
+++ b/features/admin.applications.v1/components/edit-application.tsx
@@ -143,6 +143,10 @@ interface EditApplicationPropsInterface extends SBACInterface<FeatureConfigInter
      * URL Search params received to the parent edit page component.
      */
     urlSearchParams?: URLSearchParams;
+    /**
+     * OIDC inbound config fetched by the SWR hook on the parent page.
+     */
+    applicationInboundConfigs?: OIDCDataInterface;
 }
 
 /**
@@ -168,6 +172,7 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
         template,
         readOnly,
         urlSearchParams,
+        applicationInboundConfigs,
         [ "data-componentid" ]: componentId
     } = props;
 
@@ -1357,18 +1362,20 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
 
         const isOIDCConfigured: boolean = inboundProtocolList.includes(SupportedAuthProtocolTypes.OIDC);
 
+        const oidcConfigForSecret: OIDCDataInterface = applicationInboundConfigs ?? inboundProtocolConfig?.oidc;
+
         if (!isOIDCConfigured
-            || isEmpty(inboundProtocolConfig?.oidc)
-            || !inboundProtocolConfig.oidc.clientId
-            || !inboundProtocolConfig.oidc.clientSecret) {
+            || isEmpty(oidcConfigForSecret)
+            || !oidcConfigForSecret.clientId
+            || !oidcConfigForSecret.clientSecret) {
 
             return null;
         }
 
         const clientSecret: string = clientSecretHashDisclaimerModalInputs.clientSecret
-            || inboundProtocolConfig.oidc.clientSecret;
+            || oidcConfigForSecret.clientSecret;
         const clientId: string = clientSecretHashDisclaimerModalInputs.clientId
-            || inboundProtocolConfig.oidc.clientId;
+            || oidcConfigForSecret.clientId;
 
         return (
             <ConfirmationModal

--- a/features/admin.applications.v1/components/edit-application.tsx
+++ b/features/admin.applications.v1/components/edit-application.tsx
@@ -1362,20 +1362,20 @@ export const EditApplication: FunctionComponent<EditApplicationPropsInterface> =
 
         const isOIDCConfigured: boolean = inboundProtocolList.includes(SupportedAuthProtocolTypes.OIDC);
 
-        const oidcConfigForSecret: OIDCDataInterface = applicationInboundConfigs ?? inboundProtocolConfig?.oidc;
+        const oidcConfig: OIDCDataInterface = applicationInboundConfigs ?? inboundProtocolConfig?.oidc;
 
         if (!isOIDCConfigured
-            || isEmpty(oidcConfigForSecret)
-            || !oidcConfigForSecret.clientId
-            || !oidcConfigForSecret.clientSecret) {
+            || isEmpty(oidcConfig)
+            || !oidcConfig.clientId
+            || !oidcConfig.clientSecret) {
 
             return null;
         }
 
         const clientSecret: string = clientSecretHashDisclaimerModalInputs.clientSecret
-            || oidcConfigForSecret.clientSecret;
+            || oidcConfig.clientSecret;
         const clientId: string = clientSecretHashDisclaimerModalInputs.clientId
-            || oidcConfigForSecret.clientId;
+            || oidcConfig.clientId;
 
         return (
             <ConfirmationModal

--- a/features/admin.applications.v1/pages/application-edit.tsx
+++ b/features/admin.applications.v1/pages/application-edit.tsx
@@ -1126,6 +1126,7 @@ const ApplicationEditPage: FunctionComponent<ApplicationEditPageInterface> = (
                         template={ applicationTemplate }
                         data-componentid={ componentId }
                         urlSearchParams={ urlSearchParams }
+                        applicationInboundConfigs={ applicationInboundConfigs }
                         getConfiguredInboundProtocolsList={ (list: string[]) => {
                             setInboundProtocolList(list);
                         } }


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/27252

Currently client secret hash enabled only hashed secret is shown in console after creation.

https://github.com/user-attachments/assets/568ec62d-368d-4fbc-b192-8c34fe0d9425

This PR fix it.

https://github.com/user-attachments/assets/ed184f1e-754b-4da6-9661-5a0ba986803c

**Root cause**

There are two calls after creating an app.
1 -  Get the app version and show app outdated banner.
2 - Actual call to get oidc configs for the app.

Currently client secret is getting from the 2nd calls which contains hashed secret. This fix will get the first hashed secret from the first call.



### Related PRs
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/3230

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation. - N/A
- [ ] Documentation provided. (Add links if there are any) - N/A
- [x] Relevant backend changes deployed and verified 
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
