### PR TITLE
Skip auth-property validation when actions auth flow is not in update mode

### DIFF
--- a/.changeset/wacky-books-type.md
+++ b/.changeset/wacky-books-type.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.actions.v1": patch
+---
+
+Skip auth-property validation when actions auth flow is not in update mode

--- a/features/admin.actions.v1/util/form-field-util.ts
+++ b/features/admin.actions.v1/util/form-field-util.ts
@@ -97,10 +97,7 @@ export const validateActionEndpointFields = (
 
     switch (authenticationType) {
         case AuthenticationType.BASIC:
-            if (
-                isCreateFormState || isAuthenticationUpdateFormState || values?.usernameAuthProperty ||
-                    values?.passwordAuthProperty
-            ) {
+            if (isCreateFormState || isAuthenticationUpdateFormState) {
                 if (!values?.usernameAuthProperty) {
                     errors.usernameAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.basic.properties.username.validations.empty"
@@ -125,9 +122,7 @@ export const validateActionEndpointFields = (
 
             break;
         case AuthenticationType.API_KEY:
-            if (isCreateFormState || isAuthenticationUpdateFormState || values?.headerAuthProperty ||
-                   values?.valueAuthProperty
-            ) {
+            if (isCreateFormState || isAuthenticationUpdateFormState) {
                 if (!values?.headerAuthProperty) {
                     errors.headerAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.apiKey.properties.header.validations.empty"
@@ -147,11 +142,7 @@ export const validateActionEndpointFields = (
 
             break;
         case AuthenticationType.CLIENT_CREDENTIAL:
-            if (
-                isCreateFormState || isAuthenticationUpdateFormState ||
-                values?.clientIdAuthProperty || values?.clientSecretAuthProperty ||
-                values?.tokenEndpointAuthProperty
-            ) {
+            if (isCreateFormState || isAuthenticationUpdateFormState) {
                 if (!values?.tokenEndpointAuthProperty) {
                     errors.tokenEndpointAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.clientCredential" +


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

After #10230 and wso2/identity-api-server#1109, updating an action with Basic, API Key, or Client Credential auth silently fails if you only change non-auth fields like the endpoint URL. The Update button appears to do nothing.

The reason: the API server stopped returning the secret fields (password, API key value, client secret) in the action GET response, but still returns the non-secret ones (username, header, client ID, token endpoint, scopes). The validator in `form-field-util.ts` was running its required-field checks whenever any of those auth values were present in the form, which is now always — so it kept flagging the missing secret and Final Form blocked submission.

Fix is to only validate auth properties when the user is actually creating an action or has clicked **Change Authentication**, matching what the Bearer branch already does. Non-auth edits go through cleanly because the PATCH payload already skips the `authentication` block when the user isn't in the change-auth flow, so existing credentials are preserved server-side.


### Related Issues
- https://github.com/wso2/product-is/issues/27681

### Related PRs
- #10230

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
