### PR TITLE
fix: hide super admin management options for non-super-admin users

### DIFF
--- a/.changeset/hide-super-admin-delete.md
+++ b/.changeset/hide-super-admin-delete.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.users.v1": patch
+---
+
+Hide super admin management options (delete, lock, disable) for non-super-admin users

--- a/features/admin.users.v1/components/user-profile.tsx
+++ b/features/admin.users.v1/components/user-profile.tsx
@@ -1031,7 +1031,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                             (
                                                 !isReadOnly &&
                                                 !isReadOnlyUserStore &&
-                                                user.userName !== adminUsername
+                                                (getUserNameWithoutDomain(user.userName) !== adminUsername
+                                                    || isUserCurrentLoggedInUser)
                                             ) ? (
                                                     <Show when={ featureConfig?.users?.scopes?.update }>
                                                         { isSetPassword ? (
@@ -1136,7 +1137,8 @@ export const UserProfile: FunctionComponent<UserProfilePropsInterface> = (
                                                 />
                                             )
                                         }
-                                        { !isUserCurrentLoggedInUser && (
+                                        { !isUserCurrentLoggedInUser &&
+                                            getUserNameWithoutDomain(user.userName) !== adminUsername && (
                                             <DangerZone
                                                 data-testid={ `${ testId }-danger-zone` }
                                                 actionTitle={ t("user:editUser.dangerZoneGroup." +

--- a/features/admin.users.v1/components/users-list.tsx
+++ b/features/admin.users.v1/components/users-list.tsx
@@ -27,6 +27,7 @@ import { SCIMConfigs } from "@wso2is/admin.extensions.v1/configs/scim";
 import { userConfig } from "@wso2is/admin.extensions.v1/configs/user";
 import { userstoresConfig } from "@wso2is/admin.extensions.v1/configs/userstores";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
+import { useServerConfigs } from "@wso2is/admin.server-configurations.v1/api/server-config";
 import { RealmConfigInterface } from "@wso2is/admin.server-configurations.v1/models/governance-connectors";
 import useUserStores from "@wso2is/admin.userstores.v1/hooks/use-user-stores";
 import { getUserNameWithoutDomain, isFeatureEnabled } from "@wso2is/core/helpers";
@@ -174,6 +175,11 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
     const [ showDeleteConfirmationModal, setShowDeleteConfirmationModal ] = useState<boolean>(false);
     const [ deletingUser, setDeletingUser ] = useState<UserBasicInterface>(undefined);
     const [ loading, setLoading ] = useState(false);
+
+    const { data: serverConfigs } = useServerConfigs();
+    const adminUsername: string = getUserNameWithoutDomain(
+        serverConfigs?.realmConfig?.adminUser ?? props.realmConfigs?.adminUser ?? ""
+    );
 
     const profileInfo: ProfileInfoInterface = useSelector((state: AppState) => state.profile.profileInfo);
     const isUpdatingSharedProfilesEnabled: boolean = !featureConfig?.users?.disabledFeatures?.includes(
@@ -498,6 +504,8 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
                         UserManagementConstants.FEATURE_DICTIONARY.get("USER_UPDATE"))
                     || readOnlyUserStores?.includes(userStore.toString())
                     || (!isUpdatingSharedProfilesEnabled && user[SCIMConfigs.scim.systemSchema]?.managedOrg)
+                    || (getUserNameWithoutDomain(user?.userName) === adminUsername
+                        && !UserManagementUtils.isAuthenticatedUser(profileInfo.userName, user?.userName))
                         ? "eye"
                         : "pencil alternate";
                 },
@@ -513,6 +521,8 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
                         UserManagementConstants.FEATURE_DICTIONARY.get("USER_UPDATE"))
                     || readOnlyUserStores?.includes(userStore.toString())
                     || (!isUpdatingSharedProfilesEnabled && user[SCIMConfigs.scim.systemSchema]?.managedOrg)
+                    || (getUserNameWithoutDomain(user?.userName) === adminUsername
+                        && !UserManagementUtils.isAuthenticatedUser(profileInfo.userName, user?.userName))
                         ? t("common:view")
                         : t("common:edit");
                 },
@@ -539,7 +549,8 @@ export const UsersList: React.FunctionComponent<UsersListProps> = (props: UsersL
                     UserManagementConstants.FEATURE_DICTIONARY.get("USER_DELETE"))
                     || !hasUsersDeletePermissions
                     || readOnlyUserStores?.includes(userStore.toString())
-                    || UserManagementUtils.isAuthenticatedUser(profileInfo.userName, user?.userName);
+                    || UserManagementUtils.isAuthenticatedUser(profileInfo.userName, user?.userName)
+                    || getUserNameWithoutDomain(user?.userName) === adminUsername;
             },
             icon: (): SemanticICONS => "trash alternate",
             onClick: (e: SyntheticEvent, user: UserBasicInterface): void => {

--- a/features/admin.users.v1/pages/user-edit.tsx
+++ b/features/admin.users.v1/pages/user-edit.tsx
@@ -28,6 +28,7 @@ import { AppState } from "@wso2is/admin.core.v1/store";
 import { SCIMConfigs } from "@wso2is/admin.extensions.v1/configs/scim";
 import { userstoresConfig } from "@wso2is/admin.extensions.v1/configs/userstores";
 import { getIdPIcons } from "@wso2is/admin.identity-providers.v1/configs/ui";
+import { useServerConfigs } from "@wso2is/admin.server-configurations.v1/api/server-config";
 import { useGovernanceConnectors } from "@wso2is/admin.server-configurations.v1/api/governance-connectors";
 import {
     ServerConfigurationsConstants
@@ -81,6 +82,8 @@ const UserEditPage = (): ReactElement => {
     const dispatch: Dispatch<any> = useDispatch();
 
     const { mutateUserStoreList, isUserStoreReadOnly, readOnlyUserStoreNamesList } = useUserStores();
+
+    const { data: serverConfigs } = useServerConfigs();
 
     const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
     const profileInfo: ProfileInfoInterface = useSelector((state: AppState) => state.profile.profileInfo);
@@ -165,7 +168,10 @@ const UserEditPage = (): ReactElement => {
         || isReadOnlyUserStore
         || user[ SCIMConfigs.scim.systemSchema ]?.userSourceId
         || user[ SCIMConfigs.scim.systemSchema ]?.isReadOnlyUser === "true"
-        || (user[ SCIMConfigs.scim.systemSchema ]?.managedOrg && !isUpdatingSharedProfilesFeatureEnabled);
+        || (user[ SCIMConfigs.scim.systemSchema ]?.managedOrg && !isUpdatingSharedProfilesFeatureEnabled)
+        || (getUserNameWithoutDomain(user?.userName) === getUserNameWithoutDomain(
+            serverConfigs?.realmConfig?.adminUser ?? "")
+            && !UserManagementUtils.isAuthenticatedUser(profileInfo?.userName, user?.userName));
 
     /**
      * As there is a delay in updating user stores,


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-is/issues/27728

Hide the delete, disable, and lock options for the super admin user when viewed by non-super-admin users in the User Management section. The edit page is also set to read-only for non-super-admins viewing the super admin profile.

## Summary

- Hide delete button for super admin user in users list (no one can delete the super admin)
- Show view icon instead of edit icon for super admin when viewed by other admins
- Make user edit page read-only when non-super-admin users view the super admin profile
- Allow super admin to manage their own profile (password reset, lock, disable, etc.)
- Hide delete user option in user profile danger zone for the super admin

## Affected Components

- `features/admin.users.v1/components/users-list.tsx`
- `features/admin.users.v1/pages/user-edit.tsx`
- `features/admin.users.v1/components/user-profile.tsx`

## Test Plan

- [ ] Log in as a non-super-admin user → navigate to User Management → verify the super admin user shows a view icon (not edit) and no delete button
- [ ] Click on the super admin user → verify the profile is read-only with no danger zone options
- [ ] Log in as the super admin → navigate to User Management → verify the super admin's own entry shows edit icon and no delete button
- [ ] Click on own profile → verify the profile is editable with password reset and lock options visible, but no delete option
- [ ] Verify other users' edit/delete behavior is unchanged