### PR TITLE
CDS: Show server error description in delete attribute error modal

### DIFF
--- a/.changeset/fix-delete-attribute-error-description.md
+++ b/.changeset/fix-delete-attribute-error-description.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.cds.v1": patch
+---
+
+Show server error description in delete attribute error modal

--- a/features/admin.cds.v1/components/profile-attribute.tsx
+++ b/features/admin.cds.v1/components/profile-attribute.tsx
@@ -262,8 +262,8 @@ const ProfileAttributeEditPage: FunctionComponent<RouteComponentProps<RouteParam
 
             setModalAlert({
                 description: axiosErr?.response?.data?.description
-                    || axiosErr?.message
-                    || t("customerDataService:profileAttributes.edit.notifications" +
+                    ?? axiosErr?.message
+                    ?? t("customerDataService:profileAttributes.edit.notifications" +
                         ".deleteAttribute.error.description"),
                 level: AlertLevels.ERROR,
                 message: t("customerDataService:profileAttributes.edit.notifications" +

--- a/features/admin.cds.v1/components/profile-attribute.tsx
+++ b/features/admin.cds.v1/components/profile-attribute.tsx
@@ -261,8 +261,10 @@ const ProfileAttributeEditPage: FunctionComponent<RouteComponentProps<RouteParam
             const axiosErr: AxiosError<HttpErrorResponseDataInterface> = err as AxiosError<HttpErrorResponseDataInterface>;
 
             setModalAlert({
-                description: axiosErr?.message || t("customerDataService:profileAttributes.edit.notifications" +
-                    ".deleteAttribute.error.description"),
+                description: axiosErr?.response?.data?.description
+                    || axiosErr?.message
+                    || t("customerDataService:profileAttributes.edit.notifications" +
+                        ".deleteAttribute.error.description"),
                 level: AlertLevels.ERROR,
                 message: t("customerDataService:profileAttributes.edit.notifications" +
                     ".deleteAttribute.error.message")

--- a/features/admin.cds.v1/components/profile-attributes.tsx
+++ b/features/admin.cds.v1/components/profile-attributes.tsx
@@ -192,7 +192,8 @@ export const ProfileSchemaListing: FunctionComponent<ProfileSchemaListingPropsIn
             onRefresh();
         } catch (err: any) {
             dispatch(addAlert({
-                description: err?.message
+                description: err?.response?.data?.description
+                    ?? err?.message
                     ?? t("profileAttributes.list.notifications.deleteAttribute.error.description"),
                 level: AlertLevels.ERROR,
                 message: t("profileAttributes.list.notifications.deleteAttribute.error.message")

--- a/features/admin.cds.v1/components/profile-attributes.tsx
+++ b/features/admin.cds.v1/components/profile-attributes.tsx
@@ -190,10 +190,18 @@ export const ProfileSchemaListing: FunctionComponent<ProfileSchemaListingPropsIn
             }));
 
             onRefresh();
-        } catch (err: any) {
+        } catch (err: unknown) {
+            const typedErr: {
+                response?: { data?: { description?: string } };
+                message?: string;
+            } = err as {
+                response?: { data?: { description?: string } };
+                message?: string;
+            };
+
             dispatch(addAlert({
-                description: err?.response?.data?.description
-                    ?? err?.message
+                description: typedErr?.response?.data?.description
+                    ?? typedErr?.message
                     ?? t("profileAttributes.list.notifications.deleteAttribute.error.description"),
                 level: AlertLevels.ERROR,
                 message: t("profileAttributes.list.notifications.deleteAttribute.error.message")


### PR DESCRIPTION
## Purpose
When deleting a profile attribute fails, the error modal was showing a generic HTTP-level error message instead of the descriptive message returned by the server. This change ensures the server's error description is displayed so users understand why the operation failed and what action to take.

## Related Issue
- https://github.com/wso2/product-is/issues/27753

## Implementation
Updated the error handling in both `profile-attribute.tsx` and `profile-attributes.tsx` under `features/admin.cds.v1/components/` to read `response.data.description` from the Axios error first, falling back to `axiosErr.message` and then the i18n default string if neither is available.

Buggy Behavior
<img width="436" height="186" alt="Screenshot 2026-05-07 at 2 43 36 PM" src="https://github.com/user-attachments/assets/cce95fa0-45b1-4e21-86f1-93c25442cad2" />

Resolved Behavior
<img width="489" height="219" alt="Screenshot 2026-05-07 at 3 21 24 PM" src="https://github.com/user-attachments/assets/8fdb9a09-53a4-40fb-bd09-9ca1e9616a3f" />

