### PR TITLE
Fix: Hide AI agent create button for users without permission

### DIFF
--- a/.changeset/fix-agent-create-button-permissions.md
+++ b/.changeset/fix-agent-create-button-permissions.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.agents.v1": patch
+---
+
+Hide AI agent create button for users without sufficient permissions

--- a/features/admin.agents.v1/components/agent-list.tsx
+++ b/features/admin.agents.v1/components/agent-list.tsx
@@ -43,6 +43,7 @@ interface AgentListProps extends IdentifiableComponentInterface {
     isLoading: boolean;
     mutateAgentList: any;
     list: any[];
+    hasAgentCreatePermissions: boolean;
     setShowAgentAddWizard: () => void;
 }
 
@@ -56,6 +57,7 @@ export default function AgentList ({
     isLoading,
     list,
     mutateAgentList,
+    hasAgentCreatePermissions,
     setShowAgentAddWizard,
     [ "data-componentid" ]: componentId
 }: AgentListProps) {
@@ -182,7 +184,7 @@ export default function AgentList ({
                 <EmptyPlaceholder
                     className="list-placeholder mr-0"
                     action={
-                        (<PrimaryButton
+                        hasAgentCreatePermissions && (<PrimaryButton
                             data-testid={ `${ componentId }-empty-placeholder-add-agent-button` }
                             onClick={ () => setShowAgentAddWizard() }
                         >

--- a/features/admin.agents.v1/pages/agents.tsx
+++ b/features/admin.agents.v1/pages/agents.tsx
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+import { FeatureAccessConfigInterface, useRequiredScopes } from "@wso2is/access-control";
 import { AdvancedSearchWithBasicFilters } from "@wso2is/admin.core.v1/components/advanced-search-with-basic-filters";
 import { UIConstants } from "@wso2is/admin.core.v1/constants/ui-constants";
 import { AppState } from "@wso2is/admin.core.v1/store";
@@ -40,6 +41,10 @@ export default function Agents ({
     "data-componentid": componentId
 }: AgentPageProps) {
     const isSAASDeployment: boolean = useSelector((state: AppState) => state?.config?.ui?.isSAASDeployment);
+
+    const agentFeatureConfig: FeatureAccessConfigInterface =
+        useSelector((state: AppState) => state?.config?.ui?.features?.agents);
+    const hasAgentCreatePermissions: boolean = useRequiredScopes(agentFeatureConfig?.scopes?.create);
 
     const [ isAddAgentWizardOpen,setIsAddAgentWizardOpen ] = useState(false);
 
@@ -117,7 +122,7 @@ export default function Agents ({
             bottomMargin={ false }
             contentTopMargin={ true }
             pageHeaderMaxWidth={ false }
-            action={ agentList?.Resources?.length > 0 && !isAgentListLoading && (<PrimaryButton
+            action={ hasAgentCreatePermissions && agentList?.Resources?.length > 0 && !isAgentListLoading && (<PrimaryButton
                 onClick={ () => {
                     setIsAddAgentWizardOpen(true);
                 } }>
@@ -241,6 +246,7 @@ export default function Agents ({
                     mutateAgentList={ mutateAgentList }
                     isLoading={ isAgentListLoading }
                     list={ agentList?.Resources }
+                    hasAgentCreatePermissions={ hasAgentCreatePermissions }
                     setShowAgentAddWizard={ () => {
                         setIsAddAgentWizardOpen(true);
                     } }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/product-is/issues/27724

The AI agent **Create** button was visible to administrators who do not have sufficient user permissions to create agents. This PR adds a permission check so the button is only rendered for users with the appropriate gents.create scope.

## Changes

### `features/admin.agents.v1/pages/agents.tsx`
- Import `FeatureAccessConfigInterface` and `useRequiredScopes` from `@wso2is/access-control`
- Read the agent feature config from the Redux store (`state.config.ui.features.agents`)
- Use `useRequiredScopes(agentFeatureConfig?.scopes?.create)` to determine if the current user has create permissions
- Gate the header-level **Create** button with `hasAgentCreatePermissions`
- Pass `hasAgentCreatePermissions` as a prop to `AgentList`

### `features/admin.agents.v1/components/agent-list.tsx`
- Add `hasAgentCreatePermissions: boolean` to the `AgentListProps` interface
- Gate the empty-state placeholder **Create** button with `hasAgentCreatePermissions`

## Testing Steps

1. Login to the WSO2 Identity Server Console as a **privileged user with agent read-only permission** (no `agents.create` scope)
2. Navigate to **Agents** page
3. **Expected:** The 'Create' button should **not** be visible (both in the page header and in the empty placeholder)
4. Login as a user **with** full agent permissions (including `agents.create` scope)
5. Navigate to **Agents** page
6. **Expected:** The 'Create' button **should** be visible and functional

## Related Issue
Resolves wso2/product-is#27724