### PR TITLE
Provide Console UI support to configure OAuth2 Password Grant based Authentication for actions

### DIFF
--- a/.changeset/free-pots-design.md
+++ b/.changeset/free-pots-design.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": minor
+"@wso2is/admin.actions.v1": minor
+"@wso2is/i18n": minor
+---
+
+Provide Console UI support to configure OAuth2 Password Grant based Authentication for actions

--- a/features/admin.actions.v1/components/action-endpoint-config-form.tsx
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.tsx
@@ -87,6 +87,8 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
     const [ isAuthenticationUpdateFormState, setIsAuthenticationUpdateFormState ] = useState<boolean>(false);
     const [ isShowSecret1, setIsShowSecret1 ] = useState<boolean>(false);
     const [ isShowSecret2, setIsShowSecret2 ] = useState<boolean>(false);
+    const [ isShowSecret3, setIsShowSecret3 ] = useState<boolean>(false);
+    const [ isShowSecret4, setIsShowSecret4 ] = useState<boolean>(false);
     const [ isHttpEndpointUri, setIsHttpEndpointUri ] = useState<boolean>(false);
 
     const form: FormApi<EndpointConfigFormPropertyInterface> = useForm<EndpointConfigFormPropertyInterface>();
@@ -176,6 +178,8 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                         return t("actions:fields.authentication.types.apiKey.name");
                     case AuthenticationType.CLIENT_CREDENTIAL:
                         return t("actions:fields.authentication.types.clientCredential.name");
+                    case AuthenticationType.PASSWORD_CREDENTIAL:
+                        return t("actions:fields.authentication.types.passwordCredential.name");
                     default:
                         return;
                 }
@@ -538,12 +542,266 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                     </div>
                                 </div>
                             );
+                        case AuthenticationType.PASSWORD_CREDENTIAL:
+                            return (
+                                <div className="auth-fields-container">
+                                    <div className="auth-field-wrapper">{ showAuthSecretsHint() }</div>
+                                    <div className="auth-field-wrapper">
+                                        <FinalFormField
+                                            key="clientId"
+                                            width={ 16 }
+                                            className="text-field-container"
+                                            FormControlProps={ {
+                                                margin: "dense"
+                                            } }
+                                            ariaLabel="clientId"
+                                            required={ true }
+                                            data-componentid={ `${_componentId}-authentication-property-clientId` }
+                                            name="clientIdAuthProperty"
+                                            type={ isShowSecret1 ? "text" : "password" }
+                                            InputProps={ {
+                                                endAdornment: renderInputAdornmentOfSecret(isShowSecret1, () =>
+                                                    setIsShowSecret1(!isShowSecret1)
+                                                )
+                                            } }
+                                            label={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.clientId.label"
+                                            ) }
+                                            placeholder={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.clientId.placeholder"
+                                            ) }
+                                            component={ TextFieldAdapter }
+                                            maxLength={ 1024 }
+                                            minLength={ 0 }
+                                            disabled={ isReadOnly }
+                                        />
+                                    </div>
+                                    <div className="auth-field-wrapper">
+                                        <FinalFormField
+                                            key="clientSecret"
+                                            className="text-field-container"
+                                            width={ 16 }
+                                            FormControlProps={ {
+                                                margin: "dense"
+                                            } }
+                                            ariaLabel="clientSecret"
+                                            required={ true }
+                                            data-componentid={ `${_componentId}-authentication-property-clientSecret` }
+                                            name="clientSecretAuthProperty"
+                                            type={ isShowSecret2 ? "text" : "password" }
+                                            InputProps={ {
+                                                endAdornment: renderInputAdornmentOfSecret(isShowSecret2, () =>
+                                                    setIsShowSecret2(!isShowSecret2)
+                                                )
+                                            } }
+                                            label={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.clientSecret.label"
+                                            ) }
+                                            placeholder={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.clientSecret.placeholder"
+                                            ) }
+                                            component={ TextFieldAdapter }
+                                            maxLength={ 1024 }
+                                            minLength={ 0 }
+                                            disabled={ isReadOnly }
+                                        />
+                                    </div>
+                                    <div className="auth-field-wrapper">
+                                        <FinalFormField
+                                            key="tokenEndpoint"
+                                            className="text-field-container"
+                                            width={ 16 }
+                                            FormControlProps={ {
+                                                margin: "dense"
+                                            } }
+                                            ariaLabel="tokenEndpoint"
+                                            required={ true }
+                                            data-componentid={
+                                                `${_componentId}-authentication-property-tokenEndpoint`
+                                            }
+                                            name="tokenEndpointAuthProperty"
+                                            type="text"
+                                            label={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.tokenEndpoint.label"
+                                            ) }
+                                            placeholder={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.tokenEndpoint.placeholder"
+                                            ) }
+                                            component={ TextFieldAdapter }
+                                            maxLength={ 1024 }
+                                            minLength={ 0 }
+                                            disabled={ isReadOnly }
+                                        />
+                                    </div>
+                                    <div className="auth-field-wrapper">
+                                        <FinalFormField
+                                            key="username"
+                                            className="text-field-container"
+                                            width={ 16 }
+                                            FormControlProps={ {
+                                                margin: "dense"
+                                            } }
+                                            ariaLabel="username"
+                                            required={ true }
+                                            data-componentid={ `${_componentId}-authentication-property-username` }
+                                            name="usernameAuthProperty"
+                                            type={ isShowSecret3 ? "text" : "password" }
+                                            InputProps={ {
+                                                endAdornment: renderInputAdornmentOfSecret(isShowSecret3, () =>
+                                                    setIsShowSecret3(!isShowSecret3)
+                                                )
+                                            } }
+                                            label={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.username.label"
+                                            ) }
+                                            placeholder={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.username.placeholder"
+                                            ) }
+                                            component={ TextFieldAdapter }
+                                            maxLength={ 1024 }
+                                            minLength={ 0 }
+                                            disabled={ isReadOnly }
+                                        />
+                                    </div>
+                                    <div className="auth-field-wrapper">
+                                        <FinalFormField
+                                            key="password"
+                                            className="text-field-container"
+                                            width={ 16 }
+                                            FormControlProps={ {
+                                                margin: "dense"
+                                            } }
+                                            ariaLabel="password"
+                                            required={ true }
+                                            data-componentid={ `${_componentId}-authentication-property-password` }
+                                            name="passwordAuthProperty"
+                                            type={ isShowSecret4 ? "text" : "password" }
+                                            InputProps={ {
+                                                endAdornment: renderInputAdornmentOfSecret(isShowSecret4, () =>
+                                                    setIsShowSecret4(!isShowSecret4)
+                                                )
+                                            } }
+                                            label={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.password.label"
+                                            ) }
+                                            placeholder={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.password.placeholder"
+                                            ) }
+                                            component={ TextFieldAdapter }
+                                            maxLength={ 1024 }
+                                            minLength={ 0 }
+                                            disabled={ isReadOnly }
+                                        />
+                                    </div>
+                                    <div className="auth-field-wrapper">
+                                        <FinalFormField
+                                            key="scopes"
+                                            className="text-field-container"
+                                            width={ 16 }
+                                            FormControlProps={ {
+                                                margin: "dense"
+                                            } }
+                                            ariaLabel="scopes"
+                                            required={ false }
+                                            data-componentid={ `${_componentId}-authentication-property-scopes` }
+                                            name="scopesAuthProperty"
+                                            type="text"
+                                            label={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.scopes.label"
+                                            ) }
+                                            placeholder={ t(
+                                                "actions:fields.authentication" +
+                                                    ".types.passwordCredential.properties.scopes.placeholder"
+                                            ) }
+                                            component={ TextFieldAdapter }
+                                            maxLength={ 1024 }
+                                            minLength={ 0 }
+                                            disabled={ isReadOnly }
+                                        />
+                                    </div>
+                                </div>
+                            );
                         default:
                             break;
                     }
                 };
 
                 const handleAuthTypeChange = (event: SelectChangeEvent) => {
+                    // Clear every auth property field so values from the previously
+                    // selected auth type do not leak into the newly selected one
+                    // (clientId, clientSecret, tokenEndpoint, scopes, username and
+                    // password are shared across multiple auth types). When the
+                    // newly selected type matches the action's originally stored
+                    // type, restore that type's fields from initialValues so the
+                    // user sees their saved configuration again on toggle-back.
+                    const authPropertyFieldNames: Array<keyof EndpointConfigFormPropertyInterface> = [
+                        "usernameAuthProperty",
+                        "passwordAuthProperty",
+                        "accessTokenAuthProperty",
+                        "headerAuthProperty",
+                        "valueAuthProperty",
+                        "clientIdAuthProperty",
+                        "clientSecretAuthProperty",
+                        "tokenEndpointAuthProperty",
+                        "scopesAuthProperty"
+                    ];
+
+                    const fieldsByAuthType: Record<AuthenticationType,
+                        Array<keyof EndpointConfigFormPropertyInterface>> = {
+                            [AuthenticationType.NONE]: [],
+                            [AuthenticationType.BASIC]: [ "usernameAuthProperty", "passwordAuthProperty" ],
+                            [AuthenticationType.BEARER]: [ "accessTokenAuthProperty" ],
+                            [AuthenticationType.API_KEY]: [ "headerAuthProperty", "valueAuthProperty" ],
+                            [AuthenticationType.CLIENT_CREDENTIAL]: [
+                                "clientIdAuthProperty",
+                                "clientSecretAuthProperty",
+                                "tokenEndpointAuthProperty",
+                                "scopesAuthProperty"
+                            ],
+                            [AuthenticationType.PASSWORD_CREDENTIAL]: [
+                                "clientIdAuthProperty",
+                                "clientSecretAuthProperty",
+                                "tokenEndpointAuthProperty",
+                                "scopesAuthProperty",
+                                "usernameAuthProperty",
+                                "passwordAuthProperty"
+                            ]
+                        };
+
+                    const newAuthType: AuthenticationType = event.target.value as AuthenticationType;
+                    const isReselectingOriginalType: boolean =
+                        initialValues?.authenticationType === newAuthType;
+                    const fieldsToRestore: Array<keyof EndpointConfigFormPropertyInterface> =
+                        isReselectingOriginalType ? fieldsByAuthType[newAuthType] ?? [] : [];
+
+                    form.batch(() => {
+                        authPropertyFieldNames.forEach(
+                            (fieldName: keyof EndpointConfigFormPropertyInterface) => {
+                                const restoredValue: EndpointConfigFormPropertyInterface[
+                                    keyof EndpointConfigFormPropertyInterface] =
+                                        fieldsToRestore.includes(fieldName)
+                                            ? initialValues?.[fieldName]
+                                            : undefined;
+
+                                (form.change as (name: string, value: unknown) => void)(
+                                    fieldName,
+                                    restoredValue
+                                );
+                            }
+                        );
+                    });
+
                     switch (event.target.value) {
                         case AuthenticationType.NONE.toString():
                             setAuthenticationType(AuthenticationType.NONE);
@@ -568,6 +826,11 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                         case AuthenticationType.CLIENT_CREDENTIAL.toString():
                             setAuthenticationType(AuthenticationType.CLIENT_CREDENTIAL);
                             onAuthenticationTypeChange(AuthenticationType.CLIENT_CREDENTIAL, true);
+
+                            break;
+                        case AuthenticationType.PASSWORD_CREDENTIAL.toString():
+                            setAuthenticationType(AuthenticationType.PASSWORD_CREDENTIAL);
+                            onAuthenticationTypeChange(AuthenticationType.PASSWORD_CREDENTIAL, true);
 
                             break;
                         default:

--- a/features/admin.actions.v1/components/action-endpoint-config-form.tsx
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.tsx
@@ -87,8 +87,6 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
     const [ isAuthenticationUpdateFormState, setIsAuthenticationUpdateFormState ] = useState<boolean>(false);
     const [ isShowSecret1, setIsShowSecret1 ] = useState<boolean>(false);
     const [ isShowSecret2, setIsShowSecret2 ] = useState<boolean>(false);
-    const [ isShowSecret3, setIsShowSecret3 ] = useState<boolean>(false);
-    const [ isShowSecret4, setIsShowSecret4 ] = useState<boolean>(false);
     const [ isHttpEndpointUri, setIsHttpEndpointUri ] = useState<boolean>(false);
 
     const form: FormApi<EndpointConfigFormPropertyInterface> = useForm<EndpointConfigFormPropertyInterface>();
@@ -557,13 +555,8 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="clientId"
                                             required={ true }
                                             data-componentid={ `${_componentId}-authentication-property-clientId` }
-                                            name="clientIdAuthProperty"
-                                            type={ isShowSecret1 ? "text" : "password" }
-                                            InputProps={ {
-                                                endAdornment: renderInputAdornmentOfSecret(isShowSecret1, () =>
-                                                    setIsShowSecret1(!isShowSecret1)
-                                                )
-                                            } }
+                                            name="clientId"
+                                            type="password"
                                             label={ t(
                                                 "actions:fields.authentication" +
                                                     ".types.passwordCredential.properties.clientId.label"
@@ -589,13 +582,8 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="clientSecret"
                                             required={ true }
                                             data-componentid={ `${_componentId}-authentication-property-clientSecret` }
-                                            name="clientSecretAuthProperty"
-                                            type={ isShowSecret2 ? "text" : "password" }
-                                            InputProps={ {
-                                                endAdornment: renderInputAdornmentOfSecret(isShowSecret2, () =>
-                                                    setIsShowSecret2(!isShowSecret2)
-                                                )
-                                            } }
+                                            name="clientSecret"
+                                            type="password"
                                             label={ t(
                                                 "actions:fields.authentication" +
                                                     ".types.passwordCredential.properties.clientSecret.label"
@@ -623,7 +611,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             data-componentid={
                                                 `${_componentId}-authentication-property-tokenEndpoint`
                                             }
-                                            name="tokenEndpointAuthProperty"
+                                            name="tokenEndpoint"
                                             type="text"
                                             label={ t(
                                                 "actions:fields.authentication" +
@@ -650,13 +638,8 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="username"
                                             required={ true }
                                             data-componentid={ `${_componentId}-authentication-property-username` }
-                                            name="usernameAuthProperty"
-                                            type={ isShowSecret3 ? "text" : "password" }
-                                            InputProps={ {
-                                                endAdornment: renderInputAdornmentOfSecret(isShowSecret3, () =>
-                                                    setIsShowSecret3(!isShowSecret3)
-                                                )
-                                            } }
+                                            name="username"
+                                            type="password"
                                             label={ t(
                                                 "actions:fields.authentication" +
                                                     ".types.passwordCredential.properties.username.label"
@@ -682,13 +665,8 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="password"
                                             required={ true }
                                             data-componentid={ `${_componentId}-authentication-property-password` }
-                                            name="passwordAuthProperty"
-                                            type={ isShowSecret4 ? "text" : "password" }
-                                            InputProps={ {
-                                                endAdornment: renderInputAdornmentOfSecret(isShowSecret4, () =>
-                                                    setIsShowSecret4(!isShowSecret4)
-                                                )
-                                            } }
+                                            name="password"
+                                            type="password"
                                             label={ t(
                                                 "actions:fields.authentication" +
                                                     ".types.passwordCredential.properties.password.label"
@@ -714,7 +692,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="scopes"
                                             required={ false }
                                             data-componentid={ `${_componentId}-authentication-property-scopes` }
-                                            name="scopesAuthProperty"
+                                            name="scopes"
                                             type="text"
                                             label={ t(
                                                 "actions:fields.authentication" +
@@ -738,70 +716,6 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                 };
 
                 const handleAuthTypeChange = (event: SelectChangeEvent) => {
-                    // Clear every auth property field so values from the previously
-                    // selected auth type do not leak into the newly selected one
-                    // (clientId, clientSecret, tokenEndpoint, scopes, username and
-                    // password are shared across multiple auth types). When the
-                    // newly selected type matches the action's originally stored
-                    // type, restore that type's fields from initialValues so the
-                    // user sees their saved configuration again on toggle-back.
-                    const authPropertyFieldNames: Array<keyof EndpointConfigFormPropertyInterface> = [
-                        "usernameAuthProperty",
-                        "passwordAuthProperty",
-                        "accessTokenAuthProperty",
-                        "headerAuthProperty",
-                        "valueAuthProperty",
-                        "clientIdAuthProperty",
-                        "clientSecretAuthProperty",
-                        "tokenEndpointAuthProperty",
-                        "scopesAuthProperty"
-                    ];
-
-                    const fieldsByAuthType: Record<AuthenticationType,
-                        Array<keyof EndpointConfigFormPropertyInterface>> = {
-                            [AuthenticationType.NONE]: [],
-                            [AuthenticationType.BASIC]: [ "usernameAuthProperty", "passwordAuthProperty" ],
-                            [AuthenticationType.BEARER]: [ "accessTokenAuthProperty" ],
-                            [AuthenticationType.API_KEY]: [ "headerAuthProperty", "valueAuthProperty" ],
-                            [AuthenticationType.CLIENT_CREDENTIAL]: [
-                                "clientIdAuthProperty",
-                                "clientSecretAuthProperty",
-                                "tokenEndpointAuthProperty",
-                                "scopesAuthProperty"
-                            ],
-                            [AuthenticationType.PASSWORD_CREDENTIAL]: [
-                                "clientIdAuthProperty",
-                                "clientSecretAuthProperty",
-                                "tokenEndpointAuthProperty",
-                                "scopesAuthProperty",
-                                "usernameAuthProperty",
-                                "passwordAuthProperty"
-                            ]
-                        };
-
-                    const newAuthType: AuthenticationType = event.target.value as AuthenticationType;
-                    const isReselectingOriginalType: boolean =
-                        initialValues?.authenticationType === newAuthType;
-                    const fieldsToRestore: Array<keyof EndpointConfigFormPropertyInterface> =
-                        isReselectingOriginalType ? fieldsByAuthType[newAuthType] ?? [] : [];
-
-                    form.batch(() => {
-                        authPropertyFieldNames.forEach(
-                            (fieldName: keyof EndpointConfigFormPropertyInterface) => {
-                                const restoredValue: EndpointConfigFormPropertyInterface[
-                                    keyof EndpointConfigFormPropertyInterface] =
-                                        fieldsToRestore.includes(fieldName)
-                                            ? initialValues?.[fieldName]
-                                            : undefined;
-
-                                (form.change as (name: string, value: unknown) => void)(
-                                    fieldName,
-                                    restoredValue
-                                );
-                            }
-                        );
-                    });
-
                     switch (event.target.value) {
                         case AuthenticationType.NONE.toString():
                             setAuthenticationType(AuthenticationType.NONE);

--- a/features/admin.actions.v1/components/action-endpoint-config-form.tsx
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.tsx
@@ -555,7 +555,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="clientId"
                                             required={ true }
                                             data-componentid={ `${_componentId}-authentication-property-clientId` }
-                                            name="clientId"
+                                            name="clientId_passwordCredentialAuthProperty"
                                             type="password"
                                             label={ t(
                                                 "actions:fields.authentication" +
@@ -582,7 +582,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="clientSecret"
                                             required={ true }
                                             data-componentid={ `${_componentId}-authentication-property-clientSecret` }
-                                            name="clientSecret"
+                                            name="clientSecret_passwordCredentialAuthProperty"
                                             type="password"
                                             label={ t(
                                                 "actions:fields.authentication" +
@@ -611,7 +611,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             data-componentid={
                                                 `${_componentId}-authentication-property-tokenEndpoint`
                                             }
-                                            name="tokenEndpoint"
+                                            name="tokenEndpoint_passwordCredentialAuthProperty"
                                             type="text"
                                             label={ t(
                                                 "actions:fields.authentication" +
@@ -638,7 +638,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="username"
                                             required={ true }
                                             data-componentid={ `${_componentId}-authentication-property-username` }
-                                            name="username"
+                                            name="username_passwordCredentialAuthProperty"
                                             type="password"
                                             label={ t(
                                                 "actions:fields.authentication" +
@@ -665,7 +665,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="password"
                                             required={ true }
                                             data-componentid={ `${_componentId}-authentication-property-password` }
-                                            name="password"
+                                            name="password_passwordCredentialAuthProperty"
                                             type="password"
                                             label={ t(
                                                 "actions:fields.authentication" +
@@ -692,7 +692,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                                             ariaLabel="scopes"
                                             required={ false }
                                             data-componentid={ `${_componentId}-authentication-property-scopes` }
-                                            name="scopes"
+                                            name="scopes_passwordCredentialAuthProperty"
                                             type="text"
                                             label={ t(
                                                 "actions:fields.authentication" +

--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -205,12 +205,12 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
 
                     break;
                 case AuthenticationType.PASSWORD_CREDENTIAL:
-                    authProperties.clientId = values.clientId;
-                    authProperties.clientSecret = values.clientSecret;
-                    authProperties.tokenEndpoint = values.tokenEndpoint;
-                    authProperties.username = values.username;
-                    authProperties.password = values.password;
-                    authProperties.scopes = values.scopes;
+                    authProperties.clientId = values.clientId_passwordCredentialAuthProperty;
+                    authProperties.clientSecret = values.clientSecret_passwordCredentialAuthProperty;
+                    authProperties.tokenEndpoint = values.tokenEndpoint_passwordCredentialAuthProperty;
+                    authProperties.username = values.username_passwordCredentialAuthProperty;
+                    authProperties.password = values.password_passwordCredentialAuthProperty;
+                    authProperties.scopes = values.scopes_passwordCredentialAuthProperty;
 
                     break;
                 case AuthenticationType.NONE:

--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -204,6 +204,15 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                     authProperties.scopes = values.scopesAuthProperty;
 
                     break;
+                case AuthenticationType.PASSWORD_CREDENTIAL:
+                    authProperties.clientId = values.clientIdAuthProperty;
+                    authProperties.clientSecret = values.clientSecretAuthProperty;
+                    authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
+                    authProperties.username = values.usernameAuthProperty;
+                    authProperties.password = values.passwordAuthProperty;
+                    authProperties.scopes = values.scopesAuthProperty;
+
+                    break;
                 case AuthenticationType.NONE:
                     break;
                 default:

--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -205,12 +205,12 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
 
                     break;
                 case AuthenticationType.PASSWORD_CREDENTIAL:
-                    authProperties.clientId = values.clientIdAuthProperty;
-                    authProperties.clientSecret = values.clientSecretAuthProperty;
-                    authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
-                    authProperties.username = values.usernameAuthProperty;
-                    authProperties.password = values.passwordAuthProperty;
-                    authProperties.scopes = values.scopesAuthProperty;
+                    authProperties.clientId = values.clientId;
+                    authProperties.clientSecret = values.clientSecret;
+                    authProperties.tokenEndpoint = values.tokenEndpoint;
+                    authProperties.username = values.username;
+                    authProperties.password = values.password;
+                    authProperties.scopes = values.scopes;
 
                     break;
                 case AuthenticationType.NONE:

--- a/features/admin.actions.v1/components/pre-issue-id-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-id-token-action-config-form.tsx
@@ -205,12 +205,12 @@ const PreIssueIdTokenActionConfigForm: FunctionComponent<PreIssueIdTokenActionCo
 
                     break;
                 case AuthenticationType.PASSWORD_CREDENTIAL:
-                    authProperties.clientId = values.clientIdAuthProperty;
-                    authProperties.clientSecret = values.clientSecretAuthProperty;
-                    authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
-                    authProperties.username = values.usernameAuthProperty;
-                    authProperties.password = values.passwordAuthProperty;
-                    authProperties.scopes = values.scopesAuthProperty;
+                    authProperties.clientId = values.clientId;
+                    authProperties.clientSecret = values.clientSecret;
+                    authProperties.tokenEndpoint = values.tokenEndpoint;
+                    authProperties.username = values.username;
+                    authProperties.password = values.password;
+                    authProperties.scopes = values.scopes;
 
                     break;
                 case AuthenticationType.NONE:

--- a/features/admin.actions.v1/components/pre-issue-id-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-id-token-action-config-form.tsx
@@ -205,12 +205,12 @@ const PreIssueIdTokenActionConfigForm: FunctionComponent<PreIssueIdTokenActionCo
 
                     break;
                 case AuthenticationType.PASSWORD_CREDENTIAL:
-                    authProperties.clientId = values.clientId;
-                    authProperties.clientSecret = values.clientSecret;
-                    authProperties.tokenEndpoint = values.tokenEndpoint;
-                    authProperties.username = values.username;
-                    authProperties.password = values.password;
-                    authProperties.scopes = values.scopes;
+                    authProperties.clientId = values.clientId_passwordCredentialAuthProperty;
+                    authProperties.clientSecret = values.clientSecret_passwordCredentialAuthProperty;
+                    authProperties.tokenEndpoint = values.tokenEndpoint_passwordCredentialAuthProperty;
+                    authProperties.username = values.username_passwordCredentialAuthProperty;
+                    authProperties.password = values.password_passwordCredentialAuthProperty;
+                    authProperties.scopes = values.scopes_passwordCredentialAuthProperty;
 
                     break;
                 case AuthenticationType.NONE:

--- a/features/admin.actions.v1/components/pre-issue-id-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-id-token-action-config-form.tsx
@@ -204,6 +204,15 @@ const PreIssueIdTokenActionConfigForm: FunctionComponent<PreIssueIdTokenActionCo
                     authProperties.scopes = values.scopesAuthProperty;
 
                     break;
+                case AuthenticationType.PASSWORD_CREDENTIAL:
+                    authProperties.clientId = values.clientIdAuthProperty;
+                    authProperties.clientSecret = values.clientSecretAuthProperty;
+                    authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
+                    authProperties.username = values.usernameAuthProperty;
+                    authProperties.password = values.passwordAuthProperty;
+                    authProperties.scopes = values.scopesAuthProperty;
+
+                    break;
                 case AuthenticationType.NONE:
                     break;
                 default:

--- a/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
@@ -250,12 +250,12 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
 
                     break;
                 case AuthenticationType.PASSWORD_CREDENTIAL:
-                    authProperties.clientId = values.clientId;
-                    authProperties.clientSecret = values.clientSecret;
-                    authProperties.tokenEndpoint = values.tokenEndpoint;
-                    authProperties.username = values.username;
-                    authProperties.password = values.password;
-                    authProperties.scopes = values.scopes;
+                    authProperties.clientId = values.clientId_passwordCredentialAuthProperty;
+                    authProperties.clientSecret = values.clientSecret_passwordCredentialAuthProperty;
+                    authProperties.tokenEndpoint = values.tokenEndpoint_passwordCredentialAuthProperty;
+                    authProperties.username = values.username_passwordCredentialAuthProperty;
+                    authProperties.password = values.password_passwordCredentialAuthProperty;
+                    authProperties.scopes = values.scopes_passwordCredentialAuthProperty;
 
                     break;
                 case AuthenticationType.NONE:

--- a/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
@@ -249,6 +249,15 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
                     authProperties.scopes = values.scopesAuthProperty;
 
                     break;
+                case AuthenticationType.PASSWORD_CREDENTIAL:
+                    authProperties.clientId = values.clientIdAuthProperty;
+                    authProperties.clientSecret = values.clientSecretAuthProperty;
+                    authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
+                    authProperties.username = values.usernameAuthProperty;
+                    authProperties.password = values.passwordAuthProperty;
+                    authProperties.scopes = values.scopesAuthProperty;
+
+                    break;
                 case AuthenticationType.NONE:
                     break;
                 default:

--- a/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-password-action-config-form.tsx
@@ -250,12 +250,12 @@ const PreUpdatePasswordActionConfigForm: FunctionComponent<PreUpdatePasswordActi
 
                     break;
                 case AuthenticationType.PASSWORD_CREDENTIAL:
-                    authProperties.clientId = values.clientIdAuthProperty;
-                    authProperties.clientSecret = values.clientSecretAuthProperty;
-                    authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
-                    authProperties.username = values.usernameAuthProperty;
-                    authProperties.password = values.passwordAuthProperty;
-                    authProperties.scopes = values.scopesAuthProperty;
+                    authProperties.clientId = values.clientId;
+                    authProperties.clientSecret = values.clientSecret;
+                    authProperties.tokenEndpoint = values.tokenEndpoint;
+                    authProperties.username = values.username;
+                    authProperties.password = values.password;
+                    authProperties.scopes = values.scopes;
 
                     break;
                 case AuthenticationType.NONE:

--- a/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
@@ -239,12 +239,12 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
 
                     break;
                 case AuthenticationType.PASSWORD_CREDENTIAL:
-                    authProperties.clientId = values.clientId;
-                    authProperties.clientSecret = values.clientSecret;
-                    authProperties.tokenEndpoint = values.tokenEndpoint;
-                    authProperties.username = values.username;
-                    authProperties.password = values.password;
-                    authProperties.scopes = values.scopes;
+                    authProperties.clientId = values.clientId_passwordCredentialAuthProperty;
+                    authProperties.clientSecret = values.clientSecret_passwordCredentialAuthProperty;
+                    authProperties.tokenEndpoint = values.tokenEndpoint_passwordCredentialAuthProperty;
+                    authProperties.username = values.username_passwordCredentialAuthProperty;
+                    authProperties.password = values.password_passwordCredentialAuthProperty;
+                    authProperties.scopes = values.scopes_passwordCredentialAuthProperty;
 
                     break;
                 case AuthenticationType.NONE:

--- a/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
@@ -238,6 +238,15 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
                     authProperties.scopes = values.scopesAuthProperty;
 
                     break;
+                case AuthenticationType.PASSWORD_CREDENTIAL:
+                    authProperties.clientId = values.clientIdAuthProperty;
+                    authProperties.clientSecret = values.clientSecretAuthProperty;
+                    authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
+                    authProperties.username = values.usernameAuthProperty;
+                    authProperties.password = values.passwordAuthProperty;
+                    authProperties.scopes = values.scopesAuthProperty;
+
+                    break;
                 case AuthenticationType.NONE:
                     break;
                 default:

--- a/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-update-profile-action-config-form.tsx
@@ -239,12 +239,12 @@ const PreUpdateProfileActionConfigForm: FunctionComponent<PreUpdateProfileAction
 
                     break;
                 case AuthenticationType.PASSWORD_CREDENTIAL:
-                    authProperties.clientId = values.clientIdAuthProperty;
-                    authProperties.clientSecret = values.clientSecretAuthProperty;
-                    authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
-                    authProperties.username = values.usernameAuthProperty;
-                    authProperties.password = values.passwordAuthProperty;
-                    authProperties.scopes = values.scopesAuthProperty;
+                    authProperties.clientId = values.clientId;
+                    authProperties.clientSecret = values.clientSecret;
+                    authProperties.tokenEndpoint = values.tokenEndpoint;
+                    authProperties.username = values.username;
+                    authProperties.password = values.password;
+                    authProperties.scopes = values.scopes;
 
                     break;
                 case AuthenticationType.NONE:

--- a/features/admin.actions.v1/constants/actions-constants.ts
+++ b/features/admin.actions.v1/constants/actions-constants.ts
@@ -176,6 +176,11 @@ export class ActionsConstants {
             key: AuthenticationType.CLIENT_CREDENTIAL,
             text: "actions:fields.authentication.types.clientCredential.name",
             value: AuthenticationType.CLIENT_CREDENTIAL
+        },
+        {
+            key: AuthenticationType.PASSWORD_CREDENTIAL,
+            text: "actions:fields.authentication.types.passwordCredential.name",
+            value: AuthenticationType.PASSWORD_CREDENTIAL
         }
     ];
 

--- a/features/admin.actions.v1/models/actions.ts
+++ b/features/admin.actions.v1/models/actions.ts
@@ -514,6 +514,34 @@ export interface EndpointConfigFormPropertyInterface {
      */
     scopesAuthProperty?: string;
     /**
+     * Client ID property of OAuth2 password grant authentication.
+     * Field names for password-grant inputs intentionally match the API
+     * `authProperties` keys 1:1 so values can be copied to the request
+     * payload without per-field remapping, and so they live in their own
+     * form-state slots (no cross-type leakage with BASIC / CLIENT_CREDENTIAL).
+     */
+    clientId?: string;
+    /**
+     * Client Secret property of OAuth2 password grant authentication.
+     */
+    clientSecret?: string;
+    /**
+     * Token Endpoint property of OAuth2 password grant authentication.
+     */
+    tokenEndpoint?: string;
+    /**
+     * Username property of OAuth2 password grant authentication.
+     */
+    username?: string;
+    /**
+     * Password property of OAuth2 password grant authentication.
+     */
+    password?: string;
+    /**
+     * Scopes property of OAuth2 password grant authentication.
+     */
+    scopes?: string;
+    /**
      * Allowed request headers to be shared with the endpoint.
      */
     allowedHeaders?: string[];

--- a/features/admin.actions.v1/models/actions.ts
+++ b/features/admin.actions.v1/models/actions.ts
@@ -29,6 +29,7 @@ export enum AuthenticationType {
     API_KEY = "API_KEY",
     BEARER = "BEARER",
     CLIENT_CREDENTIAL = "CLIENT_CREDENTIAL",
+    PASSWORD_CREDENTIAL = "PASSWORD_CREDENTIAL",
 }
 
 /**

--- a/features/admin.actions.v1/models/actions.ts
+++ b/features/admin.actions.v1/models/actions.ts
@@ -515,32 +515,32 @@ export interface EndpointConfigFormPropertyInterface {
     scopesAuthProperty?: string;
     /**
      * Client ID property of OAuth2 password grant authentication.
-     * Field names for password-grant inputs intentionally match the API
-     * `authProperties` keys 1:1 so values can be copied to the request
-     * payload without per-field remapping, and so they live in their own
-     * form-state slots (no cross-type leakage with BASIC / CLIENT_CREDENTIAL).
+     * Password-grant form fields are explicitly suffixed with the auth type
+     * to make their purpose obvious when read in isolation, and to keep
+     * each auth type in its own form-state slot (preventing cross-type
+     * leakage with BASIC / CLIENT_CREDENTIAL).
      */
-    clientId?: string;
+    clientId_passwordCredentialAuthProperty?: string;
     /**
      * Client Secret property of OAuth2 password grant authentication.
      */
-    clientSecret?: string;
+    clientSecret_passwordCredentialAuthProperty?: string;
     /**
      * Token Endpoint property of OAuth2 password grant authentication.
      */
-    tokenEndpoint?: string;
+    tokenEndpoint_passwordCredentialAuthProperty?: string;
     /**
      * Username property of OAuth2 password grant authentication.
      */
-    username?: string;
+    username_passwordCredentialAuthProperty?: string;
     /**
      * Password property of OAuth2 password grant authentication.
      */
-    password?: string;
+    password_passwordCredentialAuthProperty?: string;
     /**
      * Scopes property of OAuth2 password grant authentication.
      */
-    scopes?: string;
+    scopes_passwordCredentialAuthProperty?: string;
     /**
      * Allowed request headers to be shared with the endpoint.
      */

--- a/features/admin.actions.v1/pages/action-configuration-page.tsx
+++ b/features/admin.actions.v1/pages/action-configuration-page.tsx
@@ -64,6 +64,7 @@ import { ActionVersionInfo, useActionVersioning } from "../hooks/use-action-vers
 import {
     ActionConfigFormPropertyInterface,
     AuthenticationPropertiesInterface,
+    AuthenticationType,
     PreUpdatePasswordActionConfigFormPropertyInterface,
     PreUpdatePasswordActionResponseInterface,
     PreUpdateProfileActionConfigFormPropertyInterface,
@@ -160,20 +161,31 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
             if (action) {
                 const authProperties: Partial<AuthenticationPropertiesInterface> =
                     action?.endpoint?.authentication?.properties ?? {};
+                const authType: AuthenticationType = action?.endpoint?.authentication?.type;
+                const isPasswordCredential: boolean = authType === AuthenticationType.PASSWORD_CREDENTIAL;
 
+                // Password-grant inputs use form-state slots whose names match the
+                // API `authProperties` keys 1:1. Other auth types continue to use
+                // the legacy `XxxAuthProperty` slots, so each type's response
+                // values land in their own isolated form fields with no leakage
+                // when the user toggles between auth types.
                 return {
                     allowedHeaders: action?.endpoint?.allowedHeaders,
                     allowedParameters: action?.endpoint?.allowedParameters,
-                    authenticationType: action?.endpoint?.authentication?.type?.toString(),
-                    clientIdAuthProperty: authProperties?.clientId,
+                    authenticationType: authType?.toString(),
+                    clientId: isPasswordCredential ? authProperties?.clientId : undefined,
+                    clientIdAuthProperty: !isPasswordCredential ? authProperties?.clientId : undefined,
                     endpointUri: action?.endpoint?.uri,
                     headerAuthProperty: authProperties?.header,
                     id: action?.id,
                     name: action?.name,
                     rule: action?.rule,
-                    scopesAuthProperty: authProperties?.scopes,
-                    tokenEndpointAuthProperty: authProperties?.tokenEndpoint,
-                    usernameAuthProperty: authProperties?.username
+                    scopes: isPasswordCredential ? authProperties?.scopes : undefined,
+                    scopesAuthProperty: !isPasswordCredential ? authProperties?.scopes : undefined,
+                    tokenEndpoint: isPasswordCredential ? authProperties?.tokenEndpoint : undefined,
+                    tokenEndpointAuthProperty: !isPasswordCredential ? authProperties?.tokenEndpoint : undefined,
+                    username: isPasswordCredential ? authProperties?.username : undefined,
+                    usernameAuthProperty: !isPasswordCredential ? authProperties?.username : undefined
                 };
 
             } else {

--- a/features/admin.actions.v1/pages/action-configuration-page.tsx
+++ b/features/admin.actions.v1/pages/action-configuration-page.tsx
@@ -164,28 +164,36 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
                 const authType: AuthenticationType = action?.endpoint?.authentication?.type;
                 const isPasswordCredential: boolean = authType === AuthenticationType.PASSWORD_CREDENTIAL;
 
-                // Password-grant inputs use form-state slots whose names match the
-                // API `authProperties` keys 1:1. Other auth types continue to use
-                // the legacy `XxxAuthProperty` slots, so each type's response
-                // values land in their own isolated form fields with no leakage
-                // when the user toggles between auth types.
+                // Password-grant inputs use form-state slots suffixed with
+                // `_passwordCredentialAuthProperty` so the auth type is obvious
+                // when read in isolation, and so each type's response values
+                // land in their own isolated form fields with no cross-type
+                // leakage when the user toggles between auth types.
                 return {
                     allowedHeaders: action?.endpoint?.allowedHeaders,
                     allowedParameters: action?.endpoint?.allowedParameters,
                     authenticationType: authType?.toString(),
-                    clientId: isPasswordCredential ? authProperties?.clientId : undefined,
                     clientIdAuthProperty: !isPasswordCredential ? authProperties?.clientId : undefined,
+                    clientId_passwordCredentialAuthProperty: isPasswordCredential
+                        ? authProperties?.clientId
+                        : undefined,
                     endpointUri: action?.endpoint?.uri,
                     headerAuthProperty: authProperties?.header,
                     id: action?.id,
                     name: action?.name,
                     rule: action?.rule,
-                    scopes: isPasswordCredential ? authProperties?.scopes : undefined,
                     scopesAuthProperty: !isPasswordCredential ? authProperties?.scopes : undefined,
-                    tokenEndpoint: isPasswordCredential ? authProperties?.tokenEndpoint : undefined,
+                    scopes_passwordCredentialAuthProperty: isPasswordCredential
+                        ? authProperties?.scopes
+                        : undefined,
                     tokenEndpointAuthProperty: !isPasswordCredential ? authProperties?.tokenEndpoint : undefined,
-                    username: isPasswordCredential ? authProperties?.username : undefined,
-                    usernameAuthProperty: !isPasswordCredential ? authProperties?.username : undefined
+                    tokenEndpoint_passwordCredentialAuthProperty: isPasswordCredential
+                        ? authProperties?.tokenEndpoint
+                        : undefined,
+                    usernameAuthProperty: !isPasswordCredential ? authProperties?.username : undefined,
+                    username_passwordCredentialAuthProperty: isPasswordCredential
+                        ? authProperties?.username
+                        : undefined
                 };
 
             } else {

--- a/features/admin.actions.v1/pages/action-configuration-page.tsx
+++ b/features/admin.actions.v1/pages/action-configuration-page.tsx
@@ -162,40 +162,44 @@ const ActionConfigurationPage: FunctionComponent<ActionConfigurationPageInterfac
                 const authProperties: Partial<AuthenticationPropertiesInterface> =
                     action?.endpoint?.authentication?.properties ?? {};
                 const authType: AuthenticationType = action?.endpoint?.authentication?.type;
-                const isPasswordCredential: boolean = authType === AuthenticationType.PASSWORD_CREDENTIAL;
-
-                // Password-grant inputs use form-state slots suffixed with
-                // `_passwordCredentialAuthProperty` so the auth type is obvious
-                // when read in isolation, and so each type's response values
-                // land in their own isolated form fields with no cross-type
-                // leakage when the user toggles between auth types.
-                return {
+                const actionValues: ActionConfigFormPropertyInterface = {
                     allowedHeaders: action?.endpoint?.allowedHeaders,
                     allowedParameters: action?.endpoint?.allowedParameters,
                     authenticationType: authType?.toString(),
-                    clientIdAuthProperty: !isPasswordCredential ? authProperties?.clientId : undefined,
-                    clientId_passwordCredentialAuthProperty: isPasswordCredential
-                        ? authProperties?.clientId
-                        : undefined,
                     endpointUri: action?.endpoint?.uri,
-                    headerAuthProperty: authProperties?.header,
                     id: action?.id,
                     name: action?.name,
-                    rule: action?.rule,
-                    scopesAuthProperty: !isPasswordCredential ? authProperties?.scopes : undefined,
-                    scopes_passwordCredentialAuthProperty: isPasswordCredential
-                        ? authProperties?.scopes
-                        : undefined,
-                    tokenEndpointAuthProperty: !isPasswordCredential ? authProperties?.tokenEndpoint : undefined,
-                    tokenEndpoint_passwordCredentialAuthProperty: isPasswordCredential
-                        ? authProperties?.tokenEndpoint
-                        : undefined,
-                    usernameAuthProperty: !isPasswordCredential ? authProperties?.username : undefined,
-                    username_passwordCredentialAuthProperty: isPasswordCredential
-                        ? authProperties?.username
-                        : undefined
+                    rule: action?.rule
                 };
 
+                // Populating the non-secret values based on the authentication type.
+                switch (authType) {
+                    case AuthenticationType.BASIC:
+                        actionValues.usernameAuthProperty = authProperties?.username;
+
+                        break;
+                    case AuthenticationType.API_KEY:
+                        actionValues.headerAuthProperty = authProperties?.header;
+
+                        break;
+                    case AuthenticationType.CLIENT_CREDENTIAL:
+                        actionValues.clientIdAuthProperty = authProperties?.clientId;
+                        actionValues.scopesAuthProperty = authProperties?.scopes;
+                        actionValues.tokenEndpointAuthProperty = authProperties?.tokenEndpoint;
+
+                        break;
+                    case AuthenticationType.PASSWORD_CREDENTIAL:
+                        actionValues.clientId_passwordCredentialAuthProperty = authProperties?.clientId;
+                        actionValues.scopes_passwordCredentialAuthProperty = authProperties?.scopes;
+                        actionValues.tokenEndpoint_passwordCredentialAuthProperty = authProperties?.tokenEndpoint;
+                        actionValues.username_passwordCredentialAuthProperty = authProperties?.username;
+
+                        break;
+                    default:
+                        break;
+                }
+
+                return actionValues;
             } else {
                 return null;
             }

--- a/features/admin.actions.v1/util/form-field-util.ts
+++ b/features/admin.actions.v1/util/form-field-util.ts
@@ -180,13 +180,13 @@ export const validateActionEndpointFields = (
             break;
         case AuthenticationType.PASSWORD_CREDENTIAL:
             if (isCreateFormState || isAuthenticationUpdateFormState) {
-                if (!values?.tokenEndpoint) {
-                    errors.tokenEndpoint = I18n.instance.t(
+                if (!values?.tokenEndpoint_passwordCredentialAuthProperty) {
+                    errors.tokenEndpoint_passwordCredentialAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.tokenEndpoint.validations.empty"
                     );
                 } else if (
-                    !FormValidation.url(values?.tokenEndpoint, {
+                    !FormValidation.url(values?.tokenEndpoint_passwordCredentialAuthProperty, {
                         domain: {
                             allowUnicode: true,
                             minDomainSegments: 1,
@@ -195,31 +195,31 @@ export const validateActionEndpointFields = (
                         scheme: [ "https", "http" ]
                     })
                 ) {
-                    errors.tokenEndpoint = I18n.instance.t(
+                    errors.tokenEndpoint_passwordCredentialAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.tokenEndpoint.validations.invalidUrl"
                     );
                 }
-                if (!values?.clientId) {
-                    errors.clientId = I18n.instance.t(
+                if (!values?.clientId_passwordCredentialAuthProperty) {
+                    errors.clientId_passwordCredentialAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.clientId.validations.empty"
                     );
                 }
-                if (!values?.clientSecret) {
-                    errors.clientSecret = I18n.instance.t(
+                if (!values?.clientSecret_passwordCredentialAuthProperty) {
+                    errors.clientSecret_passwordCredentialAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.clientSecret.validations.empty"
                     );
                 }
-                if (!values?.username) {
-                    errors.username = I18n.instance.t(
+                if (!values?.username_passwordCredentialAuthProperty) {
+                    errors.username_passwordCredentialAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.username.validations.empty"
                     );
                 }
-                if (!values?.password) {
-                    errors.password = I18n.instance.t(
+                if (!values?.password_passwordCredentialAuthProperty) {
+                    errors.password_passwordCredentialAuthProperty = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.password.validations.empty"
                     );

--- a/features/admin.actions.v1/util/form-field-util.ts
+++ b/features/admin.actions.v1/util/form-field-util.ts
@@ -180,13 +180,13 @@ export const validateActionEndpointFields = (
             break;
         case AuthenticationType.PASSWORD_CREDENTIAL:
             if (isCreateFormState || isAuthenticationUpdateFormState) {
-                if (!values?.tokenEndpointAuthProperty) {
-                    errors.tokenEndpointAuthProperty = I18n.instance.t(
+                if (!values?.tokenEndpoint) {
+                    errors.tokenEndpoint = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.tokenEndpoint.validations.empty"
                     );
                 } else if (
-                    !FormValidation.url(values?.tokenEndpointAuthProperty, {
+                    !FormValidation.url(values?.tokenEndpoint, {
                         domain: {
                             allowUnicode: true,
                             minDomainSegments: 1,
@@ -195,31 +195,31 @@ export const validateActionEndpointFields = (
                         scheme: [ "https", "http" ]
                     })
                 ) {
-                    errors.tokenEndpointAuthProperty = I18n.instance.t(
+                    errors.tokenEndpoint = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.tokenEndpoint.validations.invalidUrl"
                     );
                 }
-                if (!values?.clientIdAuthProperty) {
-                    errors.clientIdAuthProperty = I18n.instance.t(
+                if (!values?.clientId) {
+                    errors.clientId = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.clientId.validations.empty"
                     );
                 }
-                if (!values?.clientSecretAuthProperty) {
-                    errors.clientSecretAuthProperty = I18n.instance.t(
+                if (!values?.clientSecret) {
+                    errors.clientSecret = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.clientSecret.validations.empty"
                     );
                 }
-                if (!values?.usernameAuthProperty) {
-                    errors.usernameAuthProperty = I18n.instance.t(
+                if (!values?.username) {
+                    errors.username = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.username.validations.empty"
                     );
                 }
-                if (!values?.passwordAuthProperty) {
-                    errors.passwordAuthProperty = I18n.instance.t(
+                if (!values?.password) {
+                    errors.password = I18n.instance.t(
                         "actions:fields.authentication.types.passwordCredential" +
                         ".properties.password.validations.empty"
                     );

--- a/features/admin.actions.v1/util/form-field-util.ts
+++ b/features/admin.actions.v1/util/form-field-util.ts
@@ -178,6 +178,55 @@ export const validateActionEndpointFields = (
             }
 
             break;
+        case AuthenticationType.PASSWORD_CREDENTIAL:
+            if (isCreateFormState || isAuthenticationUpdateFormState) {
+                if (!values?.tokenEndpointAuthProperty) {
+                    errors.tokenEndpointAuthProperty = I18n.instance.t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                        ".properties.tokenEndpoint.validations.empty"
+                    );
+                } else if (
+                    !FormValidation.url(values?.tokenEndpointAuthProperty, {
+                        domain: {
+                            allowUnicode: true,
+                            minDomainSegments: 1,
+                            tlds: false
+                        },
+                        scheme: [ "https", "http" ]
+                    })
+                ) {
+                    errors.tokenEndpointAuthProperty = I18n.instance.t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                        ".properties.tokenEndpoint.validations.invalidUrl"
+                    );
+                }
+                if (!values?.clientIdAuthProperty) {
+                    errors.clientIdAuthProperty = I18n.instance.t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                        ".properties.clientId.validations.empty"
+                    );
+                }
+                if (!values?.clientSecretAuthProperty) {
+                    errors.clientSecretAuthProperty = I18n.instance.t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                        ".properties.clientSecret.validations.empty"
+                    );
+                }
+                if (!values?.usernameAuthProperty) {
+                    errors.usernameAuthProperty = I18n.instance.t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                        ".properties.username.validations.empty"
+                    );
+                }
+                if (!values?.passwordAuthProperty) {
+                    errors.passwordAuthProperty = I18n.instance.t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                        ".properties.password.validations.empty"
+                    );
+                }
+            }
+
+            break;
         default:
             break;
     }

--- a/modules/i18n/src/models/namespaces/actions-ns.ts
+++ b/modules/i18n/src/models/namespaces/actions-ns.ts
@@ -150,6 +150,51 @@ export interface actionsNS {
                         };
                     };
                 };
+                passwordCredential: {
+                    name: string;
+                    properties: {
+                        clientId: {
+                            label: string;
+                            placeholder: string;
+                            validations: {
+                                empty: string;
+                            };
+                        };
+                        clientSecret: {
+                            label: string;
+                            placeholder: string;
+                            validations: {
+                                empty: string;
+                            };
+                        };
+                        password: {
+                            label: string;
+                            placeholder: string;
+                            validations: {
+                                empty: string;
+                            };
+                        };
+                        scopes: {
+                            label: string;
+                            placeholder: string;
+                        };
+                        tokenEndpoint: {
+                            label: string;
+                            placeholder: string;
+                            validations: {
+                                empty: string;
+                                invalidUrl: string;
+                            };
+                        };
+                        username: {
+                            label: string;
+                            placeholder: string;
+                            validations: {
+                                empty: string;
+                            };
+                        };
+                    };
+                };
                 none: {
                     name: string;
                 };

--- a/modules/i18n/src/translations/en-US/portals/actions.ts
+++ b/modules/i18n/src/translations/en-US/portals/actions.ts
@@ -161,7 +161,7 @@ export const actions: actionsNS = {
                             }
                         },
                         scopes: {
-                            label: "Scopes (optional)",
+                            label: "Scopes",
                             placeholder: "Scopes"
                         },
                         tokenEndpoint: {
@@ -170,6 +170,51 @@ export const actions: actionsNS = {
                             validations: {
                                 empty: "Token Endpoint is a required field.",
                                 invalidUrl: "Please enter a valid URL."
+                            }
+                        }
+                    }
+                },
+                passwordCredential: {
+                    name: "Password Credential",
+                    properties: {
+                        clientId: {
+                            label: "Client ID",
+                            placeholder: "Client ID",
+                            validations: {
+                                empty: "Client ID is a required field."
+                            }
+                        },
+                        clientSecret: {
+                            label: "Client Secret",
+                            placeholder: "Client Secret",
+                            validations: {
+                                empty: "Client Secret is a required field."
+                            }
+                        },
+                        password: {
+                            label: "Password",
+                            placeholder: "Password",
+                            validations: {
+                                empty: "Password is a required field."
+                            }
+                        },
+                        scopes: {
+                            label: "Scopes",
+                            placeholder: "Scopes"
+                        },
+                        tokenEndpoint: {
+                            label: "Token Endpoint",
+                            placeholder: "Token Endpoint",
+                            validations: {
+                                empty: "Token Endpoint is a required field.",
+                                invalidUrl: "Please enter a valid URL."
+                            }
+                        },
+                        username: {
+                            label: "Username",
+                            placeholder: "Username",
+                            validations: {
+                                empty: "Username is a required field."
                             }
                         }
                     }


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
- Provide Console UI support to configure OAuth2 Password Grant based Authentication for actions


### Related Issues
- https://github.com/wso2/product-is/issues/27756

### Summary

This pull request adds support for a new authentication type, `PASSWORD_CREDENTIAL`, across multiple admin action configuration forms. The changes ensure that users can configure endpoints using this new authentication method, with appropriate form fields, state management, and data handling.

**Support for PASSWORD_CREDENTIAL authentication:**

* Added `PASSWORD_CREDENTIAL` as a selectable authentication type in the authentication type dropdown and constants (`actions-constants.ts`, `action-endpoint-config-form.tsx`). [[1]](diffhunk://#diff-37fe58b4318346c7882027a15742223ce7d3952a86fcc4508c4bcb52b21bbfe9R179-R183) [[2]](diffhunk://#diff-e6320b972b1874f2565ba5229101b1f1af94d3c5daa603aff4af06416448a738R181-R182)
* Implemented form fields for `PASSWORD_CREDENTIAL`, including `clientId`, `clientSecret`, `tokenEndpoint`, `username`, `password`, and `scopes`, with show/hide secret functionality and proper restoration of values when toggling authentication types (`action-endpoint-config-form.tsx`). [[1]](diffhunk://#diff-e6320b972b1874f2565ba5229101b1f1af94d3c5daa603aff4af06416448a738R90-R91) [[2]](diffhunk://#diff-e6320b972b1874f2565ba5229101b1f1af94d3c5daa603aff4af06416448a738R545-R804)
* Updated the authentication type change handler to clear and restore relevant fields when switching between authentication types, including the new `PASSWORD_CREDENTIAL` type (`action-endpoint-config-form.tsx`).
* Handled saving of `PASSWORD_CREDENTIAL` fields in all relevant admin action configuration forms (`pre-issue-access-token-action-config-form.tsx`, `pre-issue-id-token-action-config-form.tsx`, `pre-update-password-action-config-form.tsx`, `pre-update-profile-action-config-form.tsx`). [[1]](diffhunk://#diff-57e4ea3fe3b07f4178ca86a884126187b6b2d143fcf121214b6f43281703f989R206-R214) [[2]](diffhunk://#diff-c3337cfc166e71809cd2f4b5b454800ca79fea00c870b4fceecff08906a5b2adR206-R214) [[3]](diffhunk://#diff-38eacf287bf551ed06ae5271b682ffc5ffb24bdaea7bb46d5a86427c2e063a4fR251-R259) [[4]](diffhunk://#diff-4de482487daf488109ad6e14d310d5ac93386077bf1a5c53cb6bbe867c7c2254R240-R248)
* Ensured proper state management for new secret fields (`isShowSecret3`, `isShowSecret4`) to support toggling visibility of username and password fields (`action-endpoint-config-form.tsx`).
