### PR TITLE
Fix: Remove misleading aud claim info from API resource creation wizard

### DIFF
--- a/.changeset/fix-misleading-aud-claim.md
+++ b/.changeset/fix-misleading-aud-claim.md
@@ -1,0 +1,10 @@
+\---
+
+"@wso2is/admin.api-resources.v2": patch
+
+\---
+
+
+
+Remove misleading aud claim statement from API resource creation wizard identifier hint text.
+

--- a/.changeset/fix-misleading-aud-claim.md
+++ b/.changeset/fix-misleading-aud-claim.md
@@ -1,10 +1,5 @@
-\---
-
+---
 "@wso2is/admin.api-resources.v2": patch
-
-\---
-
-
+---
 
 Remove misleading aud claim statement from API resource creation wizard identifier hint text.
-

--- a/features/admin.api-resources.v2/components/wizard/add-api-resource-steps/add-api-resource-basic.tsx
+++ b/features/admin.api-resources.v2/components/wizard/add-api-resource-steps/add-api-resource-basic.tsx
@@ -164,8 +164,7 @@ export const AddAPIResourceBasic: FunctionComponent<AddAPIResourceBasicInterface
                                 tOptions={ { productName } }>
                                 We recommend using a URI as the identifier, but you do not need to make the URI
                                 publicly available since WSO2 Identity Server will not access your API.
-                                WSO2 Identity Server will use this identifier value as the audience(aud) claim in the
-                                issued JWT tokens. <b>This field should be unique; once created, it is not editable.</b>
+                                 <b>This field should be unique; once created, it is not editable.</b>
                             </Trans>
                         </Hint>
                     </Grid.Column>


### PR DESCRIPTION
### Purpose
Remove the misleading statement from the API resource creation wizard
that claimed WSO2 Identity Server would use the identifier value as
the audience (aud) claim in issued JWT tokens, as this does not
happen automatically in Identity Server yet.

### Related Issues
- wso2/product-is#27257

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.