### PR TITLE
Fix user sharing view being read only for Administrators

### DIFF
--- a/.changeset/wild-pants-move.md
+++ b/.changeset/wild-pants-move.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Fix user sharing view being read only for Administrators

--- a/features/admin.users.v1/components/edit-user.tsx
+++ b/features/admin.users.v1/components/edit-user.tsx
@@ -60,7 +60,7 @@ interface EditUserPropsInterface extends IdentifiableComponentInterface {
     /**
      * Handle user update callback.
      */
-    handleUserUpdate: (userId: string) => void;
+    handleUserUpdate: (_userId: string) => void;
     /**
      * Password reset connector properties
      */
@@ -331,7 +331,7 @@ export const EditUser: FunctionComponent<EditUserPropsInterface> = (
                     <ResourceTab.Pane controlledSegmentation attached={ false }>
                         <ShareUserForm
                             user={ user }
-                            readOnly={ isReadOnly || !hasSharedAccessUpdatePermission }
+                            readOnly={ !hasSharedAccessUpdatePermission }
                             enableConsoleAdminRole={ enableConsoleAdminRole }
                         />
                     </ResourceTab.Pane>


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

$subject

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets