### PR TITLE
Fix hardcoded English text in self-registration federated flow

### DIFF
--- a/.changeset/fix-self-registration-i18n.md
+++ b/.changeset/fix-self-registration-i18n.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix hardcoded English terms and conditions text in self-registration federated flow by replacing with i18n key lookup

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources.properties
@@ -350,6 +350,7 @@ or=Or
 and=and
 username=Username
 when.you.click.sign.up.you.are.agreeing=When you click Sign Up, you are agreeing to our
+when.you.continue.you.are.agreeing=When you continue, you are agreeing to our
 dob.must.in.correct.format=Date of Birth is not in the correct format of YYYY-MM-DD
 mobile.number.format.error=The format of the Mobile Number entered is incorrect. Valid format is [+][country code][area code][local phone number]
 please.contact.administrator.to.fix.issue=To fix this issue, please contact the administrator.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_de_DE.properties
@@ -308,6 +308,7 @@ or=oder
 and=und
 username=Benutzername
 when.you.click.sign.up.you.are.agreeing=Wenn Sie auf Anmelden klicken, stimmen Sie unseren zu
+when.you.continue.you.are.agreeing=Wenn Sie fortfahren, stimmen Sie unseren zu
 dob.must.in.correct.format=Das Geburtsdatum befindet sich nicht im richtigen Format von JJJ-MM-TT
 mobile.number.format.error=Das Format der eingegebenen Mobiltelefonnummer ist falsch. Gültiges Format ist [+] [Ländercode] [Vorwahl] [lokale Telefonnummer]
 please.contact.administrator.to.fix.issue=Bitte wenden Sie sich an den Administrator, um dieses Problem zu beheben.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_es_ES.properties
@@ -308,6 +308,7 @@ or=O
 and=y
 username=Nombre de usuario
 when.you.click.sign.up.you.are.agreeing=Cuando hace clic en Registro, está de acuerdo con nuestro
+when.you.continue.you.are.agreeing=Al continuar, usted acepta nuestros
 dob.must.in.correct.format=La fecha de nacimiento no está en el formato correcto de YYYY-MM-DD
 mobile.number.format.error=El formato del número móvil ingresado es incorrecto. El formato válido es [+] [Código de país] [Código de área] [Número de teléfono local]
 please.contact.administrator.to.fix.issue=Póngase en contacto con el administrador para solucionar este problema.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_fr_FR.properties
@@ -309,6 +309,7 @@ or=ou
 and=et
 username=Nom d'utilisateur
 when.you.click.sign.up.you.are.agreeing=Lorsque vous cliquez sur S'inscrire, vous acceptez nos
+when.you.continue.you.are.agreeing=En continuant, vous acceptez nos
 dob.must.in.correct.format=La date de naissance n'est pas au format correct AAAA-MM-JJ
 mobile.number.format.error=Le format du numéro de mobile saisi est incorrect. Le format valide est [+][code pays][indicatif régional][numéro de téléphone local]
 please.contact.administrator.to.fix.issue=Veuillez contacter l'administrateur pour résoudre ce problème.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_ja_JP.properties
@@ -304,6 +304,7 @@ or=または
 and=そして
 username=ユーザー名
 when.you.click.sign.up.you.are.agreeing=サインアップをクリックすると、以下の内容に同意したものとみなされます：
+when.you.continue.you.are.agreeing=続行すると、以下の内容に同意したものとみなされます：
 dob.must.in.correct.format=生年月日の形式が YYYY-MM-DD の正しい形式ではありません
 mobile.number.format.error=入力された携帯番号の形式が正しくありません。有効なフォーマットは[+][国番号][市外局番][電話番号]です。
 please.contact.administrator.to.fix.issue=この問題を解決するには、管理者に連絡してください。

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_BR.properties
@@ -308,6 +308,7 @@ or=Ou
 and=e
 username=Nome do usuário
 when.you.click.sign.up.you.are.agreeing=Quando você clica em se inscrever, você concorda com o nosso
+when.you.continue.you.are.agreeing=Ao continuar, você concorda com o nosso
 dob.must.in.correct.format=Data de nascimento não está no formato correto de AAAA-MM-DD
 mobile.number.format.error=O formato do número de celular inserido está incorreto. O formato válido é [+][código do país][código da área][número de telefone local]
 please.contact.administrator.to.fix.issue=Por favor, entre em contato com o administrador para corrigir este problema.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_pt_PT.properties
@@ -324,6 +324,7 @@ or=Ou
 and=e
 username=Nome do usuário
 when.you.click.sign.up.you.are.agreeing=Quando você clica em se inscrever, você concorda com o nosso
+when.you.continue.you.are.agreeing=Ao continuar, você concorda com o nosso
 dob.must.in.correct.format=Data de nascimento não está no formato correto de AAAA-MM-DD
 mobile.number.format.error=O formato do número de celular inserido está incorreto. O formato válido é [+] [código do país] [código da área] [número de telefone local]
 please.contact.administrator.to.fix.issue=Entre em contato com o administrador para corrigir este problema.

--- a/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/recovery-portal/src/main/resources/org/wso2/carbon/identity/mgt/recovery/endpoint/i18n/Resources_zh_CN.properties
@@ -305,6 +305,7 @@ or=或者
 and=和
 username=用户名
 when.you.click.sign.up.you.are.agreeing=单击注册时，您同意我们
+when.you.continue.you.are.agreeing=继续即表示您同意我们的
 dob.must.in.correct.format=出生日期不是YYYY-MM-DD的正确格式
 mobile.number.format.error=输入的手机号码的格式不正确。有效格式为[+] [国家代码] [区域代码] [本地电话号码]
 please.contact.administrator.to.fix.issue=请联系管理员解决此问题。

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -728,7 +728,8 @@
                         <%
                             if (StringUtils.isNotBlank(termsOfUseURL) && StringUtils.isNotBlank(privacyPolicyURL)) {
                         %>
-                        <p class="mt-2 mb-0 left privacy">When you continue, you are agreeing to our
+                        <p class="mt-2 mb-0 left privacy">
+                            <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "when.you.continue.you.are.agreeing")%>
                             <a href="<%= StringEscapeUtils.escapeHtml4(termsOfUseURL) %>" target="_blank"
                             data-testid="registration-form-tos-link"
                             rel="noopener noreferrer">
@@ -744,7 +745,8 @@
                         <%
                             } else if (StringUtils.isNotBlank(termsOfUseURL)) {
                         %>
-                        <p class="mt-2 mb-0 left privacy">When you continue, you are agreeing to our
+                        <p class="mt-2 mb-0 left privacy">
+                            <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "when.you.continue.you.are.agreeing")%>
                             <a href="<%= StringEscapeUtils.escapeHtml4(termsOfUseURL) %>" target="_blank"
                                 data-testid="registration-form-tos-link" rel="noopener noreferrer"
                             >
@@ -754,7 +756,8 @@
                         <%
                             } else if (StringUtils.isNotBlank(privacyPolicyURL)) {
                         %>
-                        <p class="mt-2 mb-0 left privacy">When you continue, you are agreeing to our
+                        <p class="mt-2 mb-0 left privacy">
+                            <%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "when.you.continue.you.are.agreeing")%>
                             <a href="<%= StringEscapeUtils.escapeHtml4(privacyPolicyURL) %>" target="_blank"
                                 data-testid="registration-form-privacy-link" rel="noopener noreferrer"
                             >


### PR DESCRIPTION
## Summary
- Replace hardcoded "When you continue, you are agreeing to our" text with i18n key `when.you.continue.you.are.agreeing` in the federated authenticator section of `self-registration-username-request.jsp`
- Add the new i18n key with translations for all supported locales (en, de, es, fr, ja, pt-BR, pt-PT, zh-CN)

## Related Issues
- Fixes: https://github.com/wso2/product-is/issues/27642

## Test plan
- [ ] Enable self-registration in IS 7.1.0
- [ ] Configure Terms of Use URL and Privacy Policy URL for the application
- [ ] Add a federated/social connection to the application login flow
- [ ] Navigate to the self-registration page via "Sign Up"
- [ ] Verify "When you continue, you are agreeing to our" text appears in English
- [ ] Switch language and verify the text is translated correctly