### PR TITLE
Fix tenant domain field shown as mandatory on username recovery error

### DIFF
--- a/.changeset/fix-username-recovery-tenant-domain.md
+++ b/.changeset/fix-username-recovery-tenant-domain.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix tenant domain field incorrectly shown as mandatory input on username recovery error

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/username-recovery.jsp
@@ -277,7 +277,7 @@
                         </div>
                         <% } %>
 
-                        <% if (!isSaaSApp && (StringUtils.isNotEmpty(tenantDomain) && !error)) { %>
+                        <% if (!isSaaSApp && StringUtils.isNotEmpty(tenantDomain)) { %>
                         <div>
                             <input id="tenant-domain" type="hidden" name="tenantDomain" value="<%=Encode.forHtmlAttribute(tenantDomain)%>"/>
                         </div>


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-is/issues/27706

## Description

When a username recovery error occurs (e.g., for an unconfirmed self-registered user), the `tenantDomain` field is incorrectly displayed as a mandatory visible input, even though the tenant domain is already available through application routing.

This happens because the visibility condition includes `&& !error`, which forces the else branch (visible input) on any error — regardless of whether the tenant domain is known.

### Fix

Remove `&& !error` from the condition:

**Before:** `if (!isSaaSApp && (StringUtils.isNotEmpty(tenantDomain) && !error))`
**After:** `if (!isSaaSApp && StringUtils.isNotEmpty(tenantDomain))`

The `error` flag has no bearing on whether the tenant domain is available — it is resolved from URL routing via `tenant-resolve.jsp` and always populated before this condition is evaluated.

## Test plan

- [ ] Create a root organization (e.g., wso2.com) with self-registration and username recovery enabled
- [ ] Self-register a new user (do not confirm the account)
- [ ] Attempt username recovery for the unconfirmed user
- [ ] Verify the error message appears but the tenant domain field remains hidden (not shown as a mandatory input)
- [ ] Verify normal username recovery flow still works correctly (no regression)