### PR TITLE
Disable local agent template to use extension template

### DIFF
--- a/.changeset/late-taxis-shake.md
+++ b/.changeset/late-taxis-shake.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.extensions.v1": patch
+---
+
+disable local agent template to use extension template

--- a/features/admin.extensions.v1/configs/application.tsx
+++ b/features/admin.extensions.v1/configs/application.tsx
@@ -693,7 +693,7 @@ export const applicationConfig: ApplicationConfig = {
         }
     },
     templates:{
-        agent: true,
+        agent: false,
         custom: true,
         customProtocol: true,
         m2m: !featureConfig?.applications?.disabledFeatures?.includes("m2mTemplate"),


### PR DESCRIPTION
## Purpose
  Configure agent-application template to use the extension template from `identity-integration-ui-templates`
  
  - Disables local hardcoded agent template
  - Enables metadata.json-based tab configuration