### PR TITLE
Provide Console UI support to configure OAuth Client Credentials and Password Credentials Based Authentication for Custom Authenticators

### DIFF
--- a/.changeset/lovely-tables-bow.md
+++ b/.changeset/lovely-tables-bow.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": minor
+"@wso2is/admin.connections.v1": minor
+---
+
+Provide Console UI support to configure OAuth Client Credentials and Password Credentials Based Authentication for Custom Authenticators

--- a/features/admin.connections.v1/components/create/custom-authenticator-create-wizard.tsx
+++ b/features/admin.connections.v1/components/create/custom-authenticator-create-wizard.tsx
@@ -20,7 +20,6 @@ import Backdrop from "@mui/material/Backdrop";
 import Alert from "@oxygen-ui/react/Alert";
 import Box from "@oxygen-ui/react/Box";
 import Divider from "@oxygen-ui/react/Divider";
-import InputAdornment from "@oxygen-ui/react/InputAdornment";
 import { FeatureStatus, useCheckFeatureStatus } from "@wso2is/access-control";
 import { EndpointConfigFormPropertyInterface } from "@wso2is/admin.actions.v1/models/actions";
 import { ModalWithSidePanel } from "@wso2is/admin.core.v1/components/modals/modal-with-side-panel";
@@ -137,8 +136,6 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
     );
     const [ selectedTemplateId, setSelectedTemplateId ] = useState<string>(null);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const [ showPrimarySecret, setShowPrimarySecret ] = useState<boolean>(false);
-    const [ showSecondarySecret, setShowSecondarySecret ] = useState<boolean>(false);
     const [ endpointAuthType, setEndpointAuthType ] = useState<EndpointAuthenticationType>(null);
     const [ isHttpEndpointUri, setIsHttpEndpointUri ] = useState<boolean>(false);
     const [ nextShouldBeDisabled, setNextShouldBeDisabled ] = useState<boolean>(true);
@@ -229,20 +226,6 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
         history.push(AppConstants.getPaths().get("IDP"));
     };
 
-    const renderInputAdornmentOfSecret = (showSecret: boolean, onClick: () => void): ReactElement => (
-        <InputAdornment position="end">
-            <Icon
-                link={ true }
-                className="list-icon reset-field-to-default-adornment"
-                size="small"
-                color="grey"
-                name={ !showSecret ? "eye" : "eye slash" }
-                data-componentid={ `${componentId}-endpoint-authentication-property-secret-view-button` }
-                onClick={ onClick }
-            />
-        </InputAdornment>
-    );
-
     const renderDimmerOverlay = (): ReactNode => {
         return <Backdrop open={ true }>{ !isFeatureLocked && t("common:featureAvailable") }</Backdrop>;
     };
@@ -292,12 +275,7 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
                                     "authenticationTypeDropdown.authProperties.username.placeholder"
                             ) }
                             inputType="password"
-                            type={ showPrimarySecret ? "text" : "password" }
-                            InputProps={ {
-                                endAdornment: renderInputAdornmentOfSecret(showPrimarySecret, () =>
-                                    setShowPrimarySecret(!showPrimarySecret)
-                                )
-                            } }
+                            type="password"
                             required={ true }
                             maxLength={ 100 }
                             minLength={ 0 }
@@ -317,12 +295,7 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
                             ) }
                             name="passwordAuthProperty"
                             inputType="password"
-                            type={ showSecondarySecret ? "text" : "password" }
-                            InputProps={ {
-                                endAdornment: renderInputAdornmentOfSecret(showSecondarySecret, () =>
-                                    setShowSecondarySecret(!showSecondarySecret)
-                                )
-                            } }
+                            type="password"
                             required={ true }
                             maxLength={ 100 }
                             minLength={ 0 }
@@ -339,12 +312,7 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
                             className="addon-field-wrapper"
                             name="accessTokenAuthProperty"
                             inputType="password"
-                            type={ showPrimarySecret ? "text" : "password" }
-                            InputProps={ {
-                                endAdornment: renderInputAdornmentOfSecret(showPrimarySecret, () =>
-                                    setShowPrimarySecret(!showPrimarySecret)
-                                )
-                            } }
+                            type="password"
                             label={ t(
                                 "customAuthenticator:fields.createWizard.configurationsStep." +
                                     "authenticationTypeDropdown.authProperties.accessToken.label"
@@ -389,12 +357,7 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
                             className="addon-field-wrapper"
                             name="valueAuthProperty"
                             inputType="password"
-                            type={ showSecondarySecret ? "text" : "password" }
-                            InputProps={ {
-                                endAdornment: renderInputAdornmentOfSecret(showSecondarySecret, () =>
-                                    setShowSecondarySecret(!showSecondarySecret)
-                                )
-                            } }
+                            type="password"
                             label={ t(
                                 "customAuthenticator:fields.createWizard.configurationsStep." +
                                     "authenticationTypeDropdown.authProperties.value.label"
@@ -419,12 +382,7 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
                             className="addon-field-wrapper"
                             name="clientIdAuthProperty"
                             inputType="password"
-                            type={ showPrimarySecret ? "text" : "password" }
-                            InputProps={ {
-                                endAdornment: renderInputAdornmentOfSecret(showPrimarySecret, () =>
-                                    setShowPrimarySecret(!showPrimarySecret)
-                                )
-                            } }
+                            type="password"
                             label={ t(
                                 "actions:fields.authentication.types.clientCredential.properties.clientId.label"
                             ) }
@@ -442,12 +400,7 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
                             className="addon-field-wrapper"
                             name="clientSecretAuthProperty"
                             inputType="password"
-                            type={ showSecondarySecret ? "text" : "password" }
-                            InputProps={ {
-                                endAdornment: renderInputAdornmentOfSecret(showSecondarySecret, () =>
-                                    setShowSecondarySecret(!showSecondarySecret)
-                                )
-                            } }
+                            type="password"
                             label={ t(
                                 "actions:fields.authentication.types.clientCredential.properties.clientSecret.label"
                             ) }

--- a/features/admin.connections.v1/components/create/custom-authenticator-create-wizard.tsx
+++ b/features/admin.connections.v1/components/create/custom-authenticator-create-wizard.tsx
@@ -73,6 +73,7 @@ import { CommonAuthenticatorConstants } from "../../constants/common-authenticat
 import { ConnectionUIConstants } from "../../constants/connection-ui-constants";
 import { AuthenticatorMeta } from "../../meta/authenticator-meta";
 import {
+    AuthenticationPropertiesInterface,
     AuthenticationTypeDropdownOption,
     AvailableCustomAuthenticators,
     ConnectionInterface,
@@ -410,6 +411,213 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
                         />
                     </>
                 );
+            case EndpointAuthenticationType.CLIENT_CREDENTIAL:
+                return (
+                    <>
+                        <Field.Input
+                            ariaLabel="clientId"
+                            className="addon-field-wrapper"
+                            name="clientIdAuthProperty"
+                            inputType="password"
+                            type={ showPrimarySecret ? "text" : "password" }
+                            InputProps={ {
+                                endAdornment: renderInputAdornmentOfSecret(showPrimarySecret, () =>
+                                    setShowPrimarySecret(!showPrimarySecret)
+                                )
+                            } }
+                            label={ t(
+                                "actions:fields.authentication.types.clientCredential.properties.clientId.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.clientCredential.properties.clientId.placeholder"
+                            ) }
+                            required={ true }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-clientId` }
+                            width={ 15 }
+                        />
+                        <Field.Input
+                            ariaLabel="clientSecret"
+                            className="addon-field-wrapper"
+                            name="clientSecretAuthProperty"
+                            inputType="password"
+                            type={ showSecondarySecret ? "text" : "password" }
+                            InputProps={ {
+                                endAdornment: renderInputAdornmentOfSecret(showSecondarySecret, () =>
+                                    setShowSecondarySecret(!showSecondarySecret)
+                                )
+                            } }
+                            label={ t(
+                                "actions:fields.authentication.types.clientCredential.properties.clientSecret.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.clientCredential" +
+                                    ".properties.clientSecret.placeholder"
+                            ) }
+                            required={ true }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-clientSecret` }
+                            width={ 15 }
+                        />
+                        <Field.Input
+                            ariaLabel="tokenEndpoint"
+                            className="addon-field-wrapper"
+                            name="tokenEndpointAuthProperty"
+                            inputType="url"
+                            type="text"
+                            label={ t(
+                                "actions:fields.authentication.types.clientCredential.properties.tokenEndpoint.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.clientCredential" +
+                                    ".properties.tokenEndpoint.placeholder"
+                            ) }
+                            required={ true }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-tokenEndpoint` }
+                            width={ 15 }
+                        />
+                        <Field.Input
+                            ariaLabel="scopes"
+                            className="addon-field-wrapper"
+                            name="scopesAuthProperty"
+                            inputType="text"
+                            type="text"
+                            label={ t(
+                                "actions:fields.authentication.types.clientCredential.properties.scopes.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.clientCredential.properties.scopes.placeholder"
+                            ) }
+                            required={ false }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-scopes` }
+                            width={ 15 }
+                        />
+                    </>
+                );
+            case EndpointAuthenticationType.PASSWORD_CREDENTIAL:
+                return (
+                    <>
+                        <Field.Input
+                            ariaLabel="clientId"
+                            className="addon-field-wrapper"
+                            name="clientId_passwordCredentialAuthProperty"
+                            inputType="password"
+                            type="password"
+                            label={ t(
+                                "actions:fields.authentication.types.passwordCredential.properties.clientId.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.passwordCredential" +
+                                    ".properties.clientId.placeholder"
+                            ) }
+                            required={ true }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-clientId` }
+                            width={ 15 }
+                        />
+                        <Field.Input
+                            ariaLabel="clientSecret"
+                            className="addon-field-wrapper"
+                            name="clientSecret_passwordCredentialAuthProperty"
+                            inputType="password"
+                            type="password"
+                            label={ t(
+                                "actions:fields.authentication.types.passwordCredential.properties.clientSecret.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.passwordCredential" +
+                                    ".properties.clientSecret.placeholder"
+                            ) }
+                            required={ true }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-clientSecret` }
+                            width={ 15 }
+                        />
+                        <Field.Input
+                            ariaLabel="tokenEndpoint"
+                            className="addon-field-wrapper"
+                            name="tokenEndpoint_passwordCredentialAuthProperty"
+                            inputType="url"
+                            type="text"
+                            label={ t(
+                                "actions:fields.authentication.types.passwordCredential.properties.tokenEndpoint.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.passwordCredential" +
+                                    ".properties.tokenEndpoint.placeholder"
+                            ) }
+                            required={ true }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-tokenEndpoint` }
+                            width={ 15 }
+                        />
+                        <Field.Input
+                            ariaLabel="username"
+                            className="addon-field-wrapper"
+                            name="username_passwordCredentialAuthProperty"
+                            inputType="password"
+                            type="password"
+                            label={ t(
+                                "actions:fields.authentication.types.passwordCredential.properties.username.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.passwordCredential" +
+                                    ".properties.username.placeholder"
+                            ) }
+                            required={ true }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-username` }
+                            width={ 15 }
+                        />
+                        <Field.Input
+                            ariaLabel="password"
+                            className="addon-field-wrapper"
+                            name="password_passwordCredentialAuthProperty"
+                            inputType="password"
+                            type="password"
+                            label={ t(
+                                "actions:fields.authentication.types.passwordCredential.properties.password.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.passwordCredential" +
+                                    ".properties.password.placeholder"
+                            ) }
+                            required={ true }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-password` }
+                            width={ 15 }
+                        />
+                        <Field.Input
+                            ariaLabel="scopes"
+                            className="addon-field-wrapper"
+                            name="scopes_passwordCredentialAuthProperty"
+                            inputType="text"
+                            type="text"
+                            label={ t(
+                                "actions:fields.authentication.types.passwordCredential.properties.scopes.label"
+                            ) }
+                            placeholder={ t(
+                                "actions:fields.authentication.types.passwordCredential.properties.scopes.placeholder"
+                            ) }
+                            required={ false }
+                            maxLength={ 1024 }
+                            minLength={ 0 }
+                            data-componentid={ `${componentId}-endpoint-authentication-property-scopes` }
+                            width={ 15 }
+                        />
+                    </>
+                );
             default:
                 break;
         }
@@ -529,6 +737,88 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
                                 "authenticationTypeDropdown.authProperties.value.validations.required"
                         );
                     }
+                }
+
+                break;
+            case EndpointAuthenticationType.CLIENT_CREDENTIAL:
+                if (!values?.clientIdAuthProperty) {
+                    errors.clientIdAuthProperty = t(
+                        "actions:fields.authentication.types.clientCredential" +
+                            ".properties.clientId.validations.empty"
+                    );
+                }
+                if (!values?.clientSecretAuthProperty) {
+                    errors.clientSecretAuthProperty = t(
+                        "actions:fields.authentication.types.clientCredential" +
+                            ".properties.clientSecret.validations.empty"
+                    );
+                }
+                if (!values?.tokenEndpointAuthProperty) {
+                    errors.tokenEndpointAuthProperty = t(
+                        "actions:fields.authentication.types.clientCredential" +
+                            ".properties.tokenEndpoint.validations.empty"
+                    );
+                } else if (
+                    !FormValidation.url(values?.tokenEndpointAuthProperty, {
+                        domain: {
+                            allowUnicode: true,
+                            minDomainSegments: 1,
+                            tlds: false
+                        },
+                        scheme: [ "https", "http" ]
+                    })
+                ) {
+                    errors.tokenEndpointAuthProperty = t(
+                        "actions:fields.authentication.types.clientCredential" +
+                            ".properties.tokenEndpoint.validations.invalidUrl"
+                    );
+                }
+
+                break;
+            case EndpointAuthenticationType.PASSWORD_CREDENTIAL:
+                if (!values?.clientId_passwordCredentialAuthProperty) {
+                    errors.clientId_passwordCredentialAuthProperty = t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                            ".properties.clientId.validations.empty"
+                    );
+                }
+                if (!values?.clientSecret_passwordCredentialAuthProperty) {
+                    errors.clientSecret_passwordCredentialAuthProperty = t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                            ".properties.clientSecret.validations.empty"
+                    );
+                }
+                if (!values?.tokenEndpoint_passwordCredentialAuthProperty) {
+                    errors.tokenEndpoint_passwordCredentialAuthProperty = t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                            ".properties.tokenEndpoint.validations.empty"
+                    );
+                } else if (
+                    !FormValidation.url(values?.tokenEndpoint_passwordCredentialAuthProperty, {
+                        domain: {
+                            allowUnicode: true,
+                            minDomainSegments: 1,
+                            tlds: false
+                        },
+                        scheme: [ "https", "http" ]
+                    })
+                ) {
+                    errors.tokenEndpoint_passwordCredentialAuthProperty = t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                            ".properties.tokenEndpoint.validations.invalidUrl"
+                    );
+                }
+                if (!values?.username_passwordCredentialAuthProperty) {
+                    errors.username_passwordCredentialAuthProperty = t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                            ".properties.username.validations.empty"
+                    );
+                }
+                if (!values?.password_passwordCredentialAuthProperty) {
+                    errors.password_passwordCredentialAuthProperty = t(
+                        "actions:fields.authentication.types.passwordCredential" +
+                            ".properties.password.validations.empty"
+                    );
                 }
 
                 break;
@@ -698,6 +988,44 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
         const prefixedIdentifier: string = CustomAuthConstants.PREFIX + values?.identifier?.toString();
         const encodedPrefixedIdentifier: string = encodeString(prefixedIdentifier);
 
+        const authProperties: Partial<AuthenticationPropertiesInterface> = {};
+
+        switch (endpointAuthType) {
+            case EndpointAuthenticationType.BASIC:
+                authProperties.username = values?.usernameAuthProperty;
+                authProperties.password = values?.passwordAuthProperty;
+
+                break;
+            case EndpointAuthenticationType.BEARER:
+                authProperties.accessToken = values?.accessTokenAuthProperty;
+
+                break;
+            case EndpointAuthenticationType.API_KEY:
+                authProperties.header = values?.headerAuthProperty;
+                authProperties.value = values?.valueAuthProperty;
+
+                break;
+            case EndpointAuthenticationType.CLIENT_CREDENTIAL:
+                authProperties.clientId = values?.clientIdAuthProperty;
+                authProperties.clientSecret = values?.clientSecretAuthProperty;
+                authProperties.tokenEndpoint = values?.tokenEndpointAuthProperty;
+                authProperties.scopes = values?.scopesAuthProperty;
+
+                break;
+            case EndpointAuthenticationType.PASSWORD_CREDENTIAL:
+                authProperties.clientId = values?.clientId_passwordCredentialAuthProperty;
+                authProperties.clientSecret = values?.clientSecret_passwordCredentialAuthProperty;
+                authProperties.tokenEndpoint = values?.tokenEndpoint_passwordCredentialAuthProperty;
+                authProperties.username = values?.username_passwordCredentialAuthProperty;
+                authProperties.password = values?.password_passwordCredentialAuthProperty;
+                authProperties.scopes = values?.scopes_passwordCredentialAuthProperty;
+
+                break;
+            case EndpointAuthenticationType.NONE:
+            default:
+                break;
+        }
+
         if (selectedAuthenticator === CustomAuthConstants.EXTERNAL_AUTHENTICATOR) {
             const FIRST_ENTRY: number = 0;
 
@@ -716,14 +1044,6 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
             identityProvider.federatedAuthenticators.authenticators[
                 FIRST_ENTRY
             ].endpoint.authentication.type = endpointAuthType;
-
-            const authProperties: any = {};
-
-            authProperties["username"] = values?.usernameAuthProperty;
-            authProperties["password"] = values?.passwordAuthProperty;
-            authProperties["accessToken"] = values?.accessTokenAuthProperty;
-            authProperties["header"] = values?.headerAuthProperty;
-            authProperties["value"] = values?.valueAuthProperty;
             identityProvider.federatedAuthenticators.authenticators[
                 FIRST_ENTRY
             ].endpoint.authentication.properties = authProperties;
@@ -740,14 +1060,6 @@ const CustomAuthenticatorCreateWizard: FunctionComponent<CustomAuthenticatorCrea
 
             customAuthenticator.endpoint.authentication.type = endpointAuthType;
             customAuthenticator.endpoint.uri = values?.endpointUri.toString();
-
-            const authProperties: any = {};
-
-            authProperties["username"] = values?.usernameAuthProperty;
-            authProperties["password"] = values?.passwordAuthProperty;
-            authProperties["accessToken"] = values?.accessTokenAuthProperty;
-            authProperties["header"] = values?.headerAuthProperty;
-            authProperties["value"] = values?.valueAuthProperty;
             customAuthenticator.endpoint.authentication.properties = authProperties;
 
             setIsSubmitting(true);

--- a/features/admin.connections.v1/components/edit/forms/custom-authenticator-general-details-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/custom-authenticator-general-details-form.tsx
@@ -140,12 +140,11 @@ CustomAuthenticatorGeneralDetailsFormPopsInterface> = ({
             // requires the authentication object on every update and rejects
             // a payload that includes the non-confidential auth properties
             // without their corresponding confidentials (which the API never
-            // returns). Preserve the existing auth type and send an empty
-            // properties bag so the server keeps the stored credentials.
+            // returns). Preserve the existing auth type so the server keeps
+            // the stored credentials.
             const sanitizedEndpoint: ExternalEndpoint = {
                 ...existingEndpoint,
                 authentication: {
-                    properties: {},
                     type: existingEndpoint?.authentication?.type
                 }
             };

--- a/features/admin.connections.v1/components/edit/forms/custom-authenticator-general-details-form.tsx
+++ b/features/admin.connections.v1/components/edit/forms/custom-authenticator-general-details-form.tsx
@@ -28,7 +28,8 @@ import {
     ConnectionListResponseInterface,
     CustomAuthConnectionInterface,
     CustomAuthGeneralDetailsFormValuesInterface,
-    CustomAuthenticatorCreateWizardGeneralFormValuesInterface
+    CustomAuthenticatorCreateWizardGeneralFormValuesInterface,
+    ExternalEndpoint
 } from "../../../models/connection";
 import {
     resolveCustomAuthenticatorDisplayName
@@ -132,10 +133,27 @@ CustomAuthenticatorGeneralDetailsFormPopsInterface> = ({
     const updateConfigurations = (values: CustomAuthGeneralDetailsFormValuesInterface): void => {
 
         if (isCustomLocalAuth) {
+            const existingEndpoint: ExternalEndpoint =
+                (editingIDP as CustomAuthConnectionInterface)?.endpoint;
+
+            // The General tab doesn't touch authentication, but the backend
+            // requires the authentication object on every update and rejects
+            // a payload that includes the non-confidential auth properties
+            // without their corresponding confidentials (which the API never
+            // returns). Preserve the existing auth type and send an empty
+            // properties bag so the server keeps the stored credentials.
+            const sanitizedEndpoint: ExternalEndpoint = {
+                ...existingEndpoint,
+                authentication: {
+                    properties: {},
+                    type: existingEndpoint?.authentication?.type
+                }
+            };
+
             onSubmit({
                 description: values.description?.toString(),
                 displayName: values.displayName?.toString(),
-                endpoint: (editingIDP as CustomAuthConnectionInterface)?.endpoint,
+                endpoint: sanitizedEndpoint,
                 image: values.image?.toString(),
                 isEnabled: values?.isEnabled
             });

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -214,11 +214,12 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
      * Update custom local authenticator.
      *
      * @param values - Form values.
-     * @param authProperties - Endpoint authentication properties.
+     * @param authProperties - Endpoint authentication properties. When undefined, the existing
+     *                        authentication configuration is preserved (only the type is sent).
      */
     const handleUpdateCustomLocalAuthenticator = (
         values: EndpointConfigFormPropertyInterface,
-        authProperties: Partial<AuthenticationPropertiesInterface>
+        authProperties?: Partial<AuthenticationPropertiesInterface>
     ) => {
         const updatingValues: EndpointAuthenticationUpdateInterface = {
             description: connector.description,
@@ -226,10 +227,14 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
             endpoint: {
                 allowedHeaders: values?.allowedHeaders,
                 allowedParameters: values?.allowedParameters,
-                authentication: {
-                    properties: authProperties,
-                    type: values.authenticationType as EndpointAuthenticationType
-                },
+                authentication: authProperties
+                    ? {
+                        properties: authProperties,
+                        type: values.authenticationType as EndpointAuthenticationType
+                    }
+                    : {
+                        type: values.authenticationType as EndpointAuthenticationType
+                    },
                 uri: values?.endpointUri
             },
             image: connector.image,
@@ -257,12 +262,12 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
      * Update custom federated authenticator.
      *
      * @param values - Form values.
-     * @param changedFields - Changed fields.
-     * @param authProperties - Endpoint authentication properties.
+     * @param authProperties - Endpoint authentication properties. When undefined, the existing
+     *                        authentication configuration is preserved (only the type is sent).
      */
     const handleUpdateCustomFederatedAuthenticator = (
         values: EndpointConfigFormPropertyInterface,
-        authProperties: Partial<AuthenticationPropertiesInterface>
+        authProperties?: Partial<AuthenticationPropertiesInterface>
     ) => {
         const federatedAuthenticatorId: string =
             connector?.federatedAuthenticators?.authenticators[0]?.authenticatorId;
@@ -271,10 +276,14 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
             endpoint: {
                 allowedHeaders: values?.allowedHeaders,
                 allowedParameters: values?.allowedParameters,
-                authentication: {
-                    properties: authProperties,
-                    type: values.authenticationType as EndpointAuthenticationType
-                },
+                authentication: authProperties
+                    ? {
+                        properties: authProperties,
+                        type: values.authenticationType as EndpointAuthenticationType
+                    }
+                    : {
+                        type: values.authenticationType as EndpointAuthenticationType
+                    },
                 uri: values.endpointUri
             },
             isDefault: true,
@@ -302,54 +311,56 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
     const handleSubmit = (
         values: EndpointConfigFormPropertyInterface
     ) => {
-        const authProperties: Partial<AuthenticationPropertiesInterface> = {};
+        // Leave `authProperties` undefined when the auth section is untouched so the existing
+        // stored credentials are preserved instead of being wiped by an empty properties bag.
+        let authProperties: Partial<AuthenticationPropertiesInterface> | undefined;
 
-        if (!isEndpointAuthenticationUpdated) {
-            if (isCustomLocalAuthenticator) {
-                handleUpdateCustomLocalAuthenticator(values, authProperties);
+        if (isEndpointAuthenticationUpdated) {
+            switch (values.authenticationType) {
+                case AuthenticationType.BASIC:
+                    authProperties = {
+                        password: values.passwordAuthProperty,
+                        username: values.usernameAuthProperty
+                    };
 
-                return;
+                    break;
+                case AuthenticationType.BEARER:
+                    authProperties = {
+                        accessToken: values.accessTokenAuthProperty
+                    };
+
+                    break;
+                case AuthenticationType.API_KEY:
+                    authProperties = {
+                        header: values.headerAuthProperty,
+                        value: values.valueAuthProperty
+                    };
+
+                    break;
+                case AuthenticationType.CLIENT_CREDENTIAL:
+                    authProperties = {
+                        clientId: values.clientIdAuthProperty,
+                        clientSecret: values.clientSecretAuthProperty,
+                        scopes: values.scopesAuthProperty,
+                        tokenEndpoint: values.tokenEndpointAuthProperty
+                    };
+
+                    break;
+                case AuthenticationType.PASSWORD_CREDENTIAL:
+                    authProperties = {
+                        clientId: values.clientId_passwordCredentialAuthProperty,
+                        clientSecret: values.clientSecret_passwordCredentialAuthProperty,
+                        password: values.password_passwordCredentialAuthProperty,
+                        scopes: values.scopes_passwordCredentialAuthProperty,
+                        tokenEndpoint: values.tokenEndpoint_passwordCredentialAuthProperty,
+                        username: values.username_passwordCredentialAuthProperty
+                    };
+
+                    break;
+                case AuthenticationType.NONE:
+                default:
+                    break;
             }
-            handleUpdateCustomFederatedAuthenticator(values, authProperties);
-
-            return;
-        }
-
-        switch (values.authenticationType) {
-            case AuthenticationType.BASIC:
-                authProperties.username = values.usernameAuthProperty;
-                authProperties.password = values.passwordAuthProperty;
-
-                break;
-            case AuthenticationType.BEARER:
-                authProperties.accessToken = values.accessTokenAuthProperty;
-
-                break;
-            case AuthenticationType.API_KEY:
-                authProperties.header = values.headerAuthProperty;
-                authProperties.value = values.valueAuthProperty;
-
-                break;
-            case AuthenticationType.CLIENT_CREDENTIAL:
-                authProperties.clientId = values.clientIdAuthProperty;
-                authProperties.clientSecret = values.clientSecretAuthProperty;
-                authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
-                authProperties.scopes = values.scopesAuthProperty;
-
-                break;
-            case AuthenticationType.PASSWORD_CREDENTIAL:
-                authProperties.clientId = values.clientId_passwordCredentialAuthProperty;
-                authProperties.clientSecret = values.clientSecret_passwordCredentialAuthProperty;
-                authProperties.tokenEndpoint = values.tokenEndpoint_passwordCredentialAuthProperty;
-                authProperties.username = values.username_passwordCredentialAuthProperty;
-                authProperties.password = values.password_passwordCredentialAuthProperty;
-                authProperties.scopes = values.scopes_passwordCredentialAuthProperty;
-
-                break;
-            case AuthenticationType.NONE:
-                break;
-            default:
-                break;
         }
 
         if (isCustomLocalAuthenticator) {

--- a/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/custom-authenticator-settings.tsx
@@ -18,6 +18,7 @@
 
 import Button from "@oxygen-ui/react/Button";
 import ActionEndpointConfigForm from "@wso2is/admin.actions.v1/components/action-endpoint-config-form";
+import { ActionsConstants } from "@wso2is/admin.actions.v1/constants/actions-constants";
 import { AuthenticationType, EndpointConfigFormPropertyInterface } from "@wso2is/admin.actions.v1/models/actions";
 import { validateActionEndpointFields } from "@wso2is/admin.actions.v1/util/form-field-util";
 import {
@@ -45,7 +46,8 @@ import {
     ConnectionInterface,
     CustomAuthConnectionInterface,
     EndpointAuthenticationType,
-    EndpointAuthenticationUpdateInterface
+    EndpointAuthenticationUpdateInterface,
+    ExternalEndpoint
 } from "../../../models/connection";
 import {
     handleConnectionUpdateError,
@@ -107,14 +109,60 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
     const [ isEndpointAuthenticationUpdated, setIsEndpointAuthenticationUpdated ] = useState<boolean>(false);
     const [ isEndpointDetailsLoading, setIsEndpointDetailsLoading ] = useState<boolean>(false);
 
+    /**
+     * Builds initial form values from an endpoint configuration, populating
+     * the non-secret auth-type-specific fields so the Authentication section
+     * shows the previously saved values. Secrets (password, clientSecret,
+     * accessToken, value) are intentionally omitted because the API does not
+     * return them.
+     */
+    const buildEndpointInitialValues = (
+        endpoint: ExternalEndpoint
+    ): EndpointConfigFormPropertyInterface => {
+        const authProperties: Partial<AuthenticationPropertiesInterface> =
+            endpoint?.authentication?.properties ?? {};
+        const authType: EndpointAuthenticationType = endpoint?.authentication?.type;
+        const values: EndpointConfigFormPropertyInterface = {
+            allowedHeaders: endpoint?.allowedHeaders,
+            allowedParameters: endpoint?.allowedParameters,
+            authenticationType: authType,
+            endpointUri: endpoint?.uri
+        };
+
+        switch (authType) {
+            case EndpointAuthenticationType.BASIC:
+                values.usernameAuthProperty = authProperties?.username;
+
+                break;
+            case EndpointAuthenticationType.API_KEY:
+                values.headerAuthProperty = authProperties?.header;
+
+                break;
+            case EndpointAuthenticationType.CLIENT_CREDENTIAL:
+                values.clientIdAuthProperty = authProperties?.clientId;
+                values.tokenEndpointAuthProperty = authProperties?.tokenEndpoint;
+                values.scopesAuthProperty = authProperties?.scopes;
+
+                break;
+            case EndpointAuthenticationType.PASSWORD_CREDENTIAL:
+                values.clientId_passwordCredentialAuthProperty = authProperties?.clientId;
+                values.tokenEndpoint_passwordCredentialAuthProperty = authProperties?.tokenEndpoint;
+                values.username_passwordCredentialAuthProperty = authProperties?.username;
+                values.scopes_passwordCredentialAuthProperty = authProperties?.scopes;
+
+                break;
+            default:
+                break;
+        }
+
+        return values;
+    };
+
     useEffect(() => {
         if (isCustomLocalAuthenticator) {
-            setInitialValues({
-                allowedHeaders: (connector as CustomAuthConnectionInterface)?.endpoint?.allowedHeaders,
-                allowedParameters: (connector as CustomAuthConnectionInterface)?.endpoint?.allowedParameters,
-                authenticationType: (connector as CustomAuthConnectionInterface)?.endpoint?.authentication?.type,
-                endpointUri: (connector as CustomAuthConnectionInterface)?.endpoint?.uri
-            });
+            setInitialValues(
+                buildEndpointInitialValues((connector as CustomAuthConnectionInterface)?.endpoint)
+            );
         } else {
             const customAuthenticatorId: string = connector?.federatedAuthenticators?.
                 authenticators[0]?.authenticatorId;
@@ -136,14 +184,7 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
         setIsEndpointDetailsLoading(true);
         getFederatedAuthenticatorDetails(connector?.id, customFederatedAuthenticatorId)
             .then((data: FederatedAuthenticatorListItemInterface) => {
-                const endpointAuth: EndpointConfigFormPropertyInterface = {
-                    allowedHeaders: data?.endpoint?.allowedHeaders,
-                    allowedParameters: data?.endpoint?.allowedParameters,
-                    authenticationType: data?.endpoint?.authentication?.type,
-                    endpointUri: data?.endpoint?.uri
-                };
-
-                setInitialValues(endpointAuth);
+                setInitialValues(buildEndpointInitialValues(data?.endpoint as ExternalEndpoint));
             })
             .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
                 handleGetCustomAuthenticatorError(error);
@@ -263,6 +304,17 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
     ) => {
         const authProperties: Partial<AuthenticationPropertiesInterface> = {};
 
+        if (!isEndpointAuthenticationUpdated) {
+            if (isCustomLocalAuthenticator) {
+                handleUpdateCustomLocalAuthenticator(values, authProperties);
+
+                return;
+            }
+            handleUpdateCustomFederatedAuthenticator(values, authProperties);
+
+            return;
+        }
+
         switch (values.authenticationType) {
             case AuthenticationType.BASIC:
                 authProperties.username = values.usernameAuthProperty;
@@ -276,6 +328,22 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
             case AuthenticationType.API_KEY:
                 authProperties.header = values.headerAuthProperty;
                 authProperties.value = values.valueAuthProperty;
+
+                break;
+            case AuthenticationType.CLIENT_CREDENTIAL:
+                authProperties.clientId = values.clientIdAuthProperty;
+                authProperties.clientSecret = values.clientSecretAuthProperty;
+                authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
+                authProperties.scopes = values.scopesAuthProperty;
+
+                break;
+            case AuthenticationType.PASSWORD_CREDENTIAL:
+                authProperties.clientId = values.clientId_passwordCredentialAuthProperty;
+                authProperties.clientSecret = values.clientSecret_passwordCredentialAuthProperty;
+                authProperties.tokenEndpoint = values.tokenEndpoint_passwordCredentialAuthProperty;
+                authProperties.username = values.username_passwordCredentialAuthProperty;
+                authProperties.password = values.password_passwordCredentialAuthProperty;
+                authProperties.scopes = values.scopes_passwordCredentialAuthProperty;
 
                 break;
             case AuthenticationType.NONE:
@@ -314,6 +382,7 @@ const CustomAuthenticatorSettings: FunctionComponent<CustomAuthenticatorSettings
                                 initialValues={ initialValues }
                                 isCreateFormState={ false }
                                 isReadOnly={ isReadOnly }
+                                authenticationTypes={ ActionsConstants.ACTION_AUTH_TYPES }
                                 onAuthenticationTypeChange={ (
                                     authenticationType: AuthenticationType,
                                     isAuthenticationUpdated: boolean

--- a/features/admin.connections.v1/constants/connection-ui-constants.ts
+++ b/features/admin.connections.v1/constants/connection-ui-constants.ts
@@ -449,6 +449,16 @@ export class ConnectionUIConstants {
             key: EndpointAuthenticationType.API_KEY,
             text: "actions:fields.authentication.types.apiKey.name",
             value: EndpointAuthenticationType.API_KEY
+        },
+        {
+            key: EndpointAuthenticationType.CLIENT_CREDENTIAL,
+            text: "actions:fields.authentication.types.clientCredential.name",
+            value: EndpointAuthenticationType.CLIENT_CREDENTIAL
+        },
+        {
+            key: EndpointAuthenticationType.PASSWORD_CREDENTIAL,
+            text: "actions:fields.authentication.types.passwordCredential.name",
+            value: EndpointAuthenticationType.PASSWORD_CREDENTIAL
         }
     ];
 

--- a/features/admin.connections.v1/models/connection.ts
+++ b/features/admin.connections.v1/models/connection.ts
@@ -924,6 +924,22 @@ export interface AuthenticationPropertiesInterface {
      * Value auth property.
      */
     value: string;
+    /**
+     * Client ID auth property (Client / Password credential).
+     */
+    clientId: string;
+    /**
+     * Client Secret auth property (Client / Password credential).
+     */
+    clientSecret: string;
+    /**
+     * Token endpoint auth property (Client / Password credential).
+     */
+    tokenEndpoint: string;
+    /**
+     * Scopes auth property (Client / Password credential).
+     */
+    scopes: string;
 }
 
 /**
@@ -951,6 +967,8 @@ export enum EndpointAuthenticationType {
     BASIC = "BASIC",
     API_KEY = "API_KEY",
     BEARER = "BEARER",
+    CLIENT_CREDENTIAL = "CLIENT_CREDENTIAL",
+    PASSWORD_CREDENTIAL = "PASSWORD_CREDENTIAL",
 }
 
 interface CustomAuthenticatorCreateWizardProps extends GenericConnectionCreateWizardPropsInterface,


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
- Provide Console UI support to configure OAuth Client Credentials and Password Credentials Based Authentication for Custom Authenticators

<img width="623" height="631" alt="image" src="https://github.com/user-attachments/assets/cf45ab92-2e62-47d3-bd56-1665e1978b72" />

<img width="631" height="789" alt="image" src="https://github.com/user-attachments/assets/012a0d83-7afe-4d51-8495-1996fb5441ef" />


### Related Issues
- https://github.com/wso2/product-is/issues/27832

### Summary

This pull request enhances the custom authenticator creation and editing workflows by adding support for new authentication types, improving form validation, and ensuring robust handling of authentication properties. The most significant changes are grouped below.

**Support for New Authentication Types and Form Handling:**

* Added UI and backend support for `CLIENT_CREDENTIAL` and `PASSWORD_CREDENTIAL` authentication types in the `CustomAuthenticatorCreateWizard` component, including new input fields for their required properties.
* Implemented comprehensive validation for the new authentication types, ensuring all required fields are present and URLs are valid.
* Refactored the logic for constructing the `authProperties` object to dynamically handle all supported authentication types, replacing hardcoded assignments. [[1]](diffhunk://#diff-72967613f391af34c17e22acb2d15d7591546ebb20784d16a249f613e7507f8fR991-R1028) [[2]](diffhunk://#diff-72967613f391af34c17e22acb2d15d7591546ebb20784d16a249f613e7507f8fL719-L726) [[3]](diffhunk://#diff-72967613f391af34c17e22acb2d15d7591546ebb20784d16a249f613e7507f8fL743-L750)

**Editing and Update Workflow Improvements:**

* In the general details form for editing a custom authenticator, ensured that the authentication object is always included in updates, preserving confidential credentials by sending an empty properties bag when only non-confidential fields are present.

**Codebase Maintenance:**

* Updated imports and type references to support the new authentication types and maintain type safety. [[1]](diffhunk://#diff-72967613f391af34c17e22acb2d15d7591546ebb20784d16a249f613e7507f8fR76) [[2]](diffhunk://#diff-6b3557e81c7ac953f46a8cf7590f8607bda284c9113baa637c1daff189fc5d88L31-R32) [[3]](diffhunk://#diff-d13d16fde41eafda9cfd7f2c90780238bde656da8f71b05489e9b9572e772b8fR21) [[4]](diffhunk://#diff-d13d16fde41eafda9cfd7f2c90780238bde656da8f71b05489e9b9572e772b8fL48-R50)

