### PR TITLE
Fix self-registration flow stalling on passkey screen when auto-login is enabled

### DIFF
--- a/.changeset/fix-passkey-autologin-flow-halt.md
+++ b/.changeset/fix-passkey-autologin-flow-halt.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix self-registration flow halting on the passkey screen when auto-login is enabled and a passkey (WEBAUTHN) step completes the flow

--- a/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
+++ b/identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp
@@ -427,18 +427,6 @@
                     }
                 };
 
-                if (flowData && flowData.type === "WEBAUTHN") {
-                    return createElement(
-                        "div",
-                        { className: "registration-content-container loaded" },
-                        createElement(
-                            PasskeyEnrollment, {
-                                passkeyError: flowError
-                            }
-                        )
-                    );
-                }
-
                 const AutoLoginForm = (data) => {
                     const formRef = React.useRef();
                     const handleSubmit = () => {
@@ -467,10 +455,25 @@
                     );
                 }
 
+                // An auto-login assertion means the flow has completed. Submit the auto-login form
+                // regardless of the previous step type, so a passkey (WEBAUTHN) step that completes
+                // the flow does not get re-rendered and stall the auto-login.
                 if (userAssertion) {
                     return createElement(
                         AutoLoginForm,
                         { userAssertion: userAssertion }
+                    );
+                }
+
+                if (flowData && flowData.type === "WEBAUTHN") {
+                    return createElement(
+                        "div",
+                        { className: "registration-content-container loaded" },
+                        createElement(
+                            PasskeyEnrollment, {
+                                passkeyError: flowError
+                            }
+                        )
                     );
                 }
 


### PR DESCRIPTION
## Description

When a self-registration **flow** is configured with a **passkey (FIDO2) step as the last step** and **auto-login is enabled**, the flow halts on the "Passkey Verification" screen after the passkey is registered. The user is never logged in even though the server completes the flow and issues an auto-login assertion.

## Root cause

In `identity-apps-core/apps/accounts/src/main/webapp/execution-flow.jsp`, on a `COMPLETE` flow status with auto-login, `handleFlowStatus()` sets the `userAssertion` state and returns early **without** updating `flowData`. So `flowData` still holds the previous `WEBAUTHN` step.

The render block then evaluated the `WEBAUTHN` guard **before** the `userAssertion` guard:

```js
if (flowData && flowData.type === "WEBAUTHN") { return <PasskeyEnrollment/>; } // wins, flowData is stale
...
if (userAssertion) { return <AutoLoginForm/>; } // never reached
```

Because the stale `WEBAUTHN` guard short-circuits the render, the hidden `AutoLoginForm` (which POSTs `sessionDataKey` + `userAssertion` to `/commonauth`) never mounts and the page stays stuck on the passkey screen.

This only affects **passkey-as-last-step + auto-login**:
- Non-passkey last step → `flowData.type` is `VIEW`, guard is false, auto-login works.
- Passkey last step **without** auto-login → the non-auto-login completion branch calls `setFlowData(flow)`, clearing the stale `WEBAUTHN` type, so it redirects normally.

## Fix

Move the `AutoLoginForm` definition and the `userAssertion` guard **above** the `WEBAUTHN` guard. An auto-login assertion means the flow has completed, so the auto-login form should be submitted regardless of the previous step type. No data-flow change; `userAssertion` is only ever set in the auto-login completion branch, so non-auto-login paths are unaffected.

## How to test

Configure a `REGISTRATION` flow with a `FIDO2Executor` step right before `END`, enable the flow's `isAutoLoginEnabled` completion config, and register a new user (with a passkey) from an application's login page "Register" link.

Verified end-to-end against a master build using a virtual WebAuthn authenticator. With the same flow-API sequence (`… → WEBAUTHN → COMPLETE/REDIRECTION` with a `userAssertion`):

| | Before | After |
|---|---|---|
| `/commonauth` auto-login POST | 0 | 1 |
| Final state | stuck on "Passkey Verification" | logged in (My Account overview) |

Issue https://github.com/wso2/product-is/issues/27989

🤖 Generated with [Claude Code](https://claude.com/claude-code)
