### PR TITLE
Fix the issue where the last dropped node ID is missing from the last accessed resource

### DIFF
--- a/.changeset/fuzzy-results-wink.md
+++ b/.changeset/fuzzy-results-wink.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.flow-builder-core.v1": patch
+---
+
+Fix the issue where the last dropped node ID is missing from the last accessed resource

--- a/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
+++ b/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
@@ -159,7 +159,7 @@ const DecoratedVisualFlow: FunctionComponent<DecoratedVisualFlowPropsInterface> 
 
         setNodes((nodes: Node[]) => [ ...nodes, generatedStep ]);
 
-        onResourceDropOnCanvas(generatedStep as Step, null);
+        onResourceDropOnCanvas(generatedStep as Step, generatedStep?.id ?? null);
     };
 
     const addToView = (event: any, sourceData: any, targetData: any): void => {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
> $subject

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- N/A

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
