### PR TITLE
Add flow extension management UI for connections

### DIFF
--- a/apps/console/src/configs/routes.tsx
+++ b/apps/console/src/configs/routes.tsx
@@ -722,6 +722,20 @@ export const getAppViewRoutes = (): RouteInterface[] => {
             showOnSidePanel: false
         },
         {
+            category: "console:develop.features.sidePanel.categories.application",
+            component: lazy(() => import(
+                "@wso2is/admin.connections.v1/pages/flow-extension-edit-page")
+            ),
+            exact: true,
+            icon: { icon: getSidePanelIcons().connections },
+            id: "flowExtensionEdit",
+            name: "Flow Extension Edit",
+            order: 4,
+            path: AppConstants.getPaths().get("FLOW_EXTENSION_EDIT"),
+            protected: true,
+            showOnSidePanel: false
+        },
+        {
             category: "extensions:manage.sidePanel.categories.attributeManagement",
             children: [
                 {

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -401,7 +401,9 @@
                     "actions.types.list.preUpdatePassword.headersAndParameters",
                     "actions.types.list.preUpdateProfile.headersAndParameters",
                     "actions.types.org.list.preIssueAccessToken",
-                    "actions.types.org.list.preRegistration"
+                    "actions.types.org.list.preRegistration",
+                    "actions.types.list.flowExtension.customErrors",
+                    "actions.types.list.flowExtension.flowLevelOverrides"
                 ],
                 "enabled": true,
                 "featureFlags": [],
@@ -1245,7 +1247,12 @@
                     "identityProviders.saml.attributeConsumingServiceIndex"
                 ],
                 "enabled": true,
-                "featureFlags": [],
+                "featureFlags": [
+                    {
+                        "feature": "console.connections.templates.flowExtension",
+                        "flag": "EXPERIMENTAL"
+                    }
+                ],
                 "scopes": {
                     "create": [
                         "internal_idp_create"

--- a/apps/console/src/public/resources/connections/assets/images/logos/flow-extension.svg
+++ b/apps/console/src/public/resources/connections/assets/images/logos/flow-extension.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="15 5 180 190" width="100%" height="100%">
+  <rect width="100%" height="100%" fill="transparent" />
+
+  <g stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+    
+    <polyline points="45,145 75,90 115,90 145,35" fill="none" stroke-width="8" />
+    
+    <circle cx="45" cy="145" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="75" cy="90" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="115" cy="90" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="145" cy="35" r="14" fill="#f0f0f0" stroke-width="8" />
+
+
+    <g transform="translate(125, 125) rotate(-45)">
+      
+      <rect x="-60" y="-26" width="120" height="52" rx="26" fill="transparent" stroke="none" />
+
+      <rect x="-50" y="-16" width="64" height="32" rx="16" fill="none" stroke-width="8" />
+
+      <rect x="-14" y="-16" width="64" height="32" rx="16" fill="none" stroke="#f0f0f0" stroke-width="20" />
+      <rect x="-14" y="-16" width="64" height="32" rx="16" fill="none" stroke-width="8" />
+
+      <path d="M -18 16 H -2 A 16 16 0 0 0 14 0" fill="none" stroke="#f0f0f0" stroke-width="20" />
+      <path d="M -18 16 H -2 A 16 16 0 0 0 14 0" fill="none" stroke-width="8" />
+
+    </g>
+  </g>
+</svg>

--- a/features/admin.actions.v1/components/action-endpoint-config-form.scss
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.scss
@@ -39,6 +39,10 @@
 
     .alert-nutral {
         background-color: var(--oxygen-palette-grey-100);
+
+        .secondary-button {
+            margin-top: 10px;
+        }
     }
 
     .endpoint-uri-alert {
@@ -60,6 +64,16 @@
         font-weight: normal;
     }
 
+    .box-container {
+        margin-top: 24px;
+
+        .box-field {
+            .secondary-button {
+                margin-top: 14px;
+            }
+        }
+    }
+
     .row.urlComponentTagRow {
         display: inline-block !important;
         width: auto           !important;
@@ -77,6 +91,10 @@
 
 .alert-nutral {
     background-color: var(--oxygen-palette-grey-100);
+
+    .secondary-button {
+        margin-top: 10px;
+    }
 }
 
 .endpoint-uri-alert {

--- a/features/admin.actions.v1/components/action-endpoint-config-form.tsx
+++ b/features/admin.actions.v1/components/action-endpoint-config-form.tsx
@@ -55,6 +55,12 @@ interface ActionEndpointConfigFormInterface extends IdentifiableComponentInterfa
      */
     showHeadersAndParams?: boolean;
     /**
+     * Specifies whether the allowed parameters field should be shown within the
+     * headers-and-parameters section. Defaults to true. Set to false for action types
+     * (e.g. Flow Extension) where query parameter forwarding is not supported.
+     */
+    showAllowedParameters?: boolean;
+    /**
      * Specifies whether the form is read-only.
      */
     isReadOnly: boolean;
@@ -80,6 +86,7 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
     isReadOnly,
     showHeadersAndParams,
     authenticationTypes = ActionsConstants.AUTH_TYPES,
+    showAllowedParameters = true,
     onAuthenticationTypeChange,
     ["data-componentid"]: _componentId = "action-endpoint-config-form"
 }: ActionEndpointConfigFormInterface): ReactElement => {
@@ -921,22 +928,24 @@ const ActionEndpointConfigForm: FunctionComponent<ActionEndpointConfigFormInterf
                 maxLength={ 100 }
                 minLength={ 0 }
             />
-            <FinalFormField
-                key="allowedParameters"
-                name="allowedParameters"
-                className="allowed-headers-and-params"
-                width={ 16 }
-                FormControlProps={ {
-                    margin: "dense"
-                } }
-                ariaLabel="allowedParameters"
-                required={ false }
-                data-componentid={ `${_componentId}-action-allowed-parameters` }
-                type="text"
-                component={ allowedParametersSection }
-                maxLength={ 100 }
-                minLength={ 0 }
-            />
+            { showAllowedParameters && (
+                <FinalFormField
+                    key="allowedParameters"
+                    name="allowedParameters"
+                    className="allowed-headers-and-params"
+                    width={ 16 }
+                    FormControlProps={ {
+                        margin: "dense"
+                    } }
+                    ariaLabel="allowedParameters"
+                    required={ false }
+                    data-componentid={ `${_componentId}-action-allowed-parameters` }
+                    type="text"
+                    component={ allowedParametersSection }
+                    maxLength={ 100 }
+                    minLength={ 0 }
+                />
+            ) }
         </>
     );
 

--- a/features/admin.actions.v1/models/actions.ts
+++ b/features/admin.actions.v1/models/actions.ts
@@ -255,6 +255,10 @@ export interface ActionBasicResponseInterface extends ActionBaseResponseInterfac
      * Links of the Action.
      */
     links: LinkInterface[];
+    /**
+     * Optional icon URL for the Action (e.g., Flow Extension).
+     */
+    iconUrl?: string;
 }
 
 /**
@@ -615,4 +619,28 @@ export interface ActionTypeCardInterface {
      * Disabled status of the Action type.
      */
     disabled?: boolean
+}
+
+/**
+ * Expose entry in access config.
+ * Also used for modify entries (same structure: path + optional encryption flag).
+ */
+export interface ContextPathInterface {
+    path: string;
+    encrypted: boolean;
+}
+
+/**
+ * Access config for Flow Extension actions.
+ */
+export interface AccessConfigInterface {
+    expose: ContextPathInterface[];
+    modify: ContextPathInterface[];
+}
+
+/**
+ * Encryption config for Flow Extension actions.
+ */
+export interface EncryptionInterface {
+    certificate?: string;
 }

--- a/features/admin.connections.v1/api/use-flow-extension-translations.ts
+++ b/features/admin.connections.v1/api/use-flow-extension-translations.ts
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import useGetCustomTextPreferenceMeta from "@wso2is/admin.branding.v1/api/use-get-custom-text-preference-meta";
+import { CustomTextPreferenceMeta } from "@wso2is/admin.branding.v1/models/custom-text-preference";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { AsgardeoSPAClient, HttpClientInstance } from "@asgardeo/auth-react";
+import { store } from "@wso2is/admin.core.v1/store";
+import { OrganizationType } from "@wso2is/admin.organizations.v1/constants/organization-constants";
+import { BrandingPreferenceTypes } from "@wso2is/common.branding.v1/models/branding-preferences";
+import { HttpMethods } from "@wso2is/core/models";
+import { SupportedLanguagesMeta } from "@wso2is/i18n";
+import { AxiosError, AxiosRequestConfig } from "axios";
+import pick from "lodash-es/pick";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSelector } from "react-redux";
+import { FLOW_EXTENSION_SCREEN } from "../utils/flow-extension-utils";
+
+/**
+ * Represents a grouped translation entry with its translations across locales.
+ */
+export interface TranslationEntry {
+    shortKey: string;
+    translations: Record<string, string>;
+}
+
+/**
+ * Return type of the `useFlowExtensionTranslations` hook.
+ */
+interface UseFlowExtensionTranslationsResult {
+    entries: TranslationEntry[];
+    localeData: Record<string, Record<string, string>>;
+    isConfiguredPerLocale: Record<string, boolean>;
+    supportedLocales: SupportedLanguagesMeta;
+    isLoading: boolean;
+    refetch: () => Promise<void>;
+}
+
+const httpClient: HttpClientInstance = AsgardeoSPAClient.getInstance()
+    .httpRequest.bind(AsgardeoSPAClient.getInstance());
+
+/**
+ * Fetch custom text preference for a given screen + locale.
+ * Returns null if not configured (404 with specific error code).
+ */
+const fetchCustomTextForLocale = async (
+    endpointUrl: string,
+    tenantDomain: string,
+    screen: string,
+    locale: string,
+    type: BrandingPreferenceTypes = BrandingPreferenceTypes.ORG
+): Promise<{ text: Record<string, string>; isConfigured: boolean }> => {
+    const requestConfig: AxiosRequestConfig = {
+        headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+        },
+        method: HttpMethods.GET,
+        params: {
+            locale,
+            name: tenantDomain,
+            screen,
+            type
+        },
+        url: endpointUrl
+    };
+
+    try {
+        const response: any = await httpClient(requestConfig);
+
+        if (response.status === 200 && response?.data?.preference?.text) {
+            return { isConfigured: true, text: response.data.preference.text };
+        }
+
+        return { isConfigured: false, text: {} };
+    } catch (error) {
+        const axiosError: AxiosError = error as AxiosError;
+
+        if (axiosError.response?.status === 404) {
+            return { isConfigured: false, text: {} };
+        }
+
+        return { isConfigured: false, text: {} };
+    }
+};
+
+/**
+ * Hook that fetches custom text preferences for all supported locales
+ * for the `flow-extension` screen, filters by a given key prefix,
+ * and groups them into `TranslationEntry` objects.
+ *
+ * @param keyPrefix - The key prefix to filter entries (e.g., "flow.extension.my.connection.").
+ * @param enabled - Whether data fetching is enabled.
+ */
+const useFlowExtensionTranslations = (
+    keyPrefix: string,
+    enabled: boolean
+): UseFlowExtensionTranslationsResult => {
+    const supportedI18nLanguages: SupportedLanguagesMeta = useSelector(
+        (state: AppState) => state.global.supportedI18nLanguages
+    );
+
+    const {
+        data: customTextPreferenceMeta,
+        isLoading: metaLoading
+    } = useGetCustomTextPreferenceMeta<CustomTextPreferenceMeta>();
+
+    const supportedLocales: SupportedLanguagesMeta = useMemo(() => {
+        if (!supportedI18nLanguages || !customTextPreferenceMeta) {
+            return {};
+        }
+
+        return pick(supportedI18nLanguages, customTextPreferenceMeta?.locales);
+    }, [ supportedI18nLanguages, customTextPreferenceMeta ]);
+
+    const [ localeData, setLocaleData ] = useState<Record<string, Record<string, string>>>({});
+    const [ isConfiguredPerLocale, setIsConfiguredPerLocale ] = useState<Record<string, boolean>>({});
+    const [ isLoading, setIsLoading ] = useState<boolean>(true);
+    const [ fetchCounter, setFetchCounter ] = useState<number>(0);
+
+    const isMounted: React.MutableRefObject<boolean> = useRef<boolean>(true);
+
+    useEffect(() => {
+        isMounted.current = true;
+
+        return () => {
+            isMounted.current = false;
+        };
+    }, []);
+
+    const localeKeys: string = useMemo(
+        () => Object.keys(supportedLocales).sort().join(","),
+        [ supportedLocales ]
+    );
+
+    useEffect(() => {
+        if (!enabled || !localeKeys || metaLoading) {
+            if (!enabled) {
+                setIsLoading(false);
+            }
+
+            return;
+        }
+
+        const locales: string[] = localeKeys.split(",").filter(Boolean);
+
+        if (locales.length === 0) {
+            setIsLoading(false);
+
+            return;
+        }
+
+        const organizationType: string = store.getState()?.organization?.organizationType;
+        const endpointUrl: string = organizationType === OrganizationType.SUBORGANIZATION
+            ? `${store.getState().config.endpoints.brandingTextPreferenceSubOrg}/resolve`
+            : `${store.getState().config.endpoints.brandingTextPreference}/resolve`;
+
+        const tenantDomain: string = organizationType === OrganizationType.SUBORGANIZATION
+            ? store.getState()?.organization?.organization?.id
+            : store.getState()?.auth?.tenantDomain;
+
+        setIsLoading(true);
+
+        Promise.all(
+            locales.map(async (locale: string) => {
+                const result: { text: Record<string, string>; isConfigured: boolean } =
+                    await fetchCustomTextForLocale(
+                        endpointUrl,
+                        tenantDomain,
+                        FLOW_EXTENSION_SCREEN,
+                        locale
+                    );
+
+                return { isConfigured: result.isConfigured, locale, text: result.text };
+            })
+        ).then((results: { locale: string; text: Record<string, string>; isConfigured: boolean }[]) => {
+            if (!isMounted.current) return;
+
+            const newLocaleData: Record<string, Record<string, string>> = {};
+            const newIsConfigured: Record<string, boolean> = {};
+
+            results.forEach(({ locale, text, isConfigured }: {
+                locale: string;
+                text: Record<string, string>;
+                isConfigured: boolean;
+            }) => {
+                newLocaleData[locale] = text;
+                newIsConfigured[locale] = isConfigured;
+            });
+
+            setLocaleData(newLocaleData);
+            setIsConfiguredPerLocale(newIsConfigured);
+            setIsLoading(false);
+        }).catch(() => {
+            if (!isMounted.current) return;
+
+            setIsLoading(false);
+        });
+    }, [ enabled, localeKeys, metaLoading, fetchCounter ]);
+
+    const entries: TranslationEntry[] = useMemo(() => {
+        if (!keyPrefix) return [];
+
+        const keyMap: Record<string, Record<string, string>> = {};
+
+        Object.entries(localeData).forEach(([ locale, textMap ]: [string, Record<string, string>]) => {
+            Object.entries(textMap).forEach(([ fullKey, text ]: [string, string]) => {
+                if (!fullKey.startsWith(keyPrefix)) return;
+
+                const shortKey: string = fullKey.slice(keyPrefix.length);
+
+                if (!keyMap[shortKey]) {
+                    keyMap[shortKey] = {};
+                }
+
+                keyMap[shortKey][locale] = text;
+            });
+        });
+
+        return Object.entries(keyMap).map(([ shortKey, translations ]: [string, Record<string, string>]) => ({
+            shortKey,
+            translations
+        }));
+    }, [ localeData, keyPrefix ]);
+
+    const refetch: () => Promise<void> = useCallback(async () => {
+        setFetchCounter((c: number) => c + 1);
+    }, []);
+
+    return {
+        entries,
+        isConfiguredPerLocale,
+        isLoading: isLoading || metaLoading,
+        localeData,
+        refetch,
+        supportedLocales
+    };
+};
+
+export default useFlowExtensionTranslations;

--- a/features/admin.connections.v1/api/use-get-connection-templates.ts
+++ b/features/admin.connections.v1/api/use-get-connection-templates.ts
@@ -23,8 +23,11 @@ import useRequest, {
 } from "@wso2is/admin.core.v1/hooks/use-request";
 import useResourceEndpoints from "@wso2is/admin.core.v1/hooks/use-resource-endpoints";
 import useUIConfig from "@wso2is/admin.core.v1/hooks/use-ui-configs";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import { isFeatureEnabled } from "@wso2is/core/helpers";
-import { HttpMethods } from "@wso2is/core/models";
+import { FeatureAccessConfigInterface, HttpMethods } from "@wso2is/core/models";
+import { useSelector } from "react-redux";
 import {
     CommonAuthenticatorConstants,
     ConnectionsFeatureDictionaryKeys
@@ -53,6 +56,12 @@ export const useGetConnectionTemplates = <Data = ConnectionTemplateInterface[], 
 
     const { resourceEndpoints } = useResourceEndpoints();
     const { UIConfig } = useUIConfig();
+    const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
+        (state: AppState) => state.config.ui.features?.actions);
+    const { isSubOrganization } = useGetCurrentOrganizationType();
+    const flowExtensionFeatureKey: string = isSubOrganization()
+        ? "actions.types.org.list.flowExtension"
+        : "actions.types.list.flowExtension";
     const isOutboundProvisioningConnectionV2Enabled: boolean = isFeatureEnabled(
         UIConfig?.features?.identityProviders,
         CommonAuthenticatorConstants.FEATURE_DICTIONARY.get(
@@ -91,6 +100,13 @@ export const useGetConnectionTemplates = <Data = ConnectionTemplateInterface[], 
             CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.CUSTOM_AUTHENTICATOR,
             ...(UIConfig?.hiddenConnectionTemplates || [])
         ];
+
+        // Hide Flow Extension template when the feature is disabled.
+        if (!isFeatureEnabled(actionsFeatureConfig, flowExtensionFeatureKey)) {
+            hiddenConnectionTemplateIds.push(
+                CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.FLOW_EXTENSION
+            );
+        }
 
         // Hide specific connection templates for login flow builder.
         if (isLoginFlow) {

--- a/features/admin.connections.v1/components/authenticator-grid.tsx
+++ b/features/admin.connections.v1/components/authenticator-grid.tsx
@@ -67,6 +67,7 @@ import {
     getConnectedApps,
     getConnectedAppsOfAuthenticator
 } from "../api/connections";
+import deleteFlowExtension from "@wso2is/admin.flow-builder-core.v1/api/delete-flow-extension";
 import { getConnectionIcons } from "../configs/ui";
 import { AuthenticatorMeta } from "../meta/authenticator-meta";
 import {
@@ -212,6 +213,13 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
 
                 break;
 
+            case ConnectionTypes.FLOW_EXTENSION:
+                history.push(
+                    AppConstants.getPaths().get("FLOW_EXTENSION_EDIT").replace(":id", id)
+                );
+
+                break;
+
             case AuthenticatorCategories.LOCAL:
                 if (isCustom) {
                     history.push(AppConstants.getPaths().get("AUTH_EDIT").replace(":id", id));
@@ -249,6 +257,16 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
 
         // If the connection is an Identity Verification Provider, then skip checking for connected apps.
         if (connectionType === ConnectionTypes.IDVP) {
+            setDeletingIDP(authenticators.find(
+                (idp: ConnectionInterface | AuthenticatorInterface) => idp.id === idpId)
+            );
+            setShowDeleteConfirmationModal(true);
+
+            return;
+        }
+
+        // Flow extension are managed via the flow management API; skip connected apps check.
+        if (connectionType === ConnectionTypes.FLOW_EXTENSION) {
             setDeletingIDP(authenticators.find(
                 (idp: ConnectionInterface | AuthenticatorInterface) => idp.id === idpId)
             );
@@ -379,6 +397,30 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
 
         setIsDeletionLoading(true);
 
+        if (connectionType === ConnectionTypes.FLOW_EXTENSION) {
+            deleteFlowExtension(id)
+                .then(() => {
+                    dispatch(addAlert({
+                        description: t("authenticationProvider:" +
+                            "notifications.deleteConnection.success.description"),
+                        level: AlertLevels.SUCCESS,
+                        message: t("authenticationProvider:notifications." +
+                            "deleteConnection.success.message")
+                    }));
+                })
+                .catch((error: AxiosError) => {
+                    handleConnectionDeleteError(error);
+                })
+                .finally(() => {
+                    setIsDeletionLoading(false);
+                    setShowDeleteConfirmationModal(false);
+                    setDeletingIDP(undefined);
+                    onConnectionUpdate();
+                });
+
+            return;
+        }
+
         let deleteAuthenticator: (id: string) => Promise<AxiosResponse>;
 
         if(connectionType === ConnectionTypes.IDVP) {
@@ -493,6 +535,10 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
             return hasIdVPDeletePermission;
         }
 
+        if (authenticator.type === ConnectionTypes.FLOW_EXTENSION) {
+            return hasConnectionDeletePermission;
+        }
+
         if (!hasConnectionDeletePermission) {
             return false;
         }
@@ -521,6 +567,10 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
                 : getConnectionIcons().default;
         }
 
+        if (connection.type === ConnectionTypes.FLOW_EXTENSION) {
+            return connection?.image || AuthenticatorMeta.getFlowExtensionIcon();
+        }
+
         if ((connection?.type === AuthenticatorTypes.FEDERATED || isIdP) && !isOrganizationSSOIDP) {
             return connection?.image
                 ? ConnectionsManagementUtils.resolveConnectionResourcePath(connectionResourcesUrl, connection.image)
@@ -541,6 +591,10 @@ export const AuthenticatorGrid: FunctionComponent<AuthenticatorGridPropsInterfac
     };
 
     const resolveAuthenticatorDescription = (authenticator: ConnectionInterface, isIdP: boolean): string => {
+        if (authenticator.type === ConnectionTypes.FLOW_EXTENSION) {
+            return authenticator.description || "";
+        }
+
         if (ConnectionsManagementUtils.IsCustomLocalAuthenticator(authenticator)) {
             return authenticator.description;
         }

--- a/features/admin.connections.v1/components/create/authenticator-create-wizard-factory.tsx
+++ b/features/admin.connections.v1/components/create/authenticator-create-wizard-factory.tsx
@@ -120,11 +120,19 @@ export const AuthenticatorCreateWizardFactory: FC<AuthenticatorCreateWizardFacto
         true
     );
 
+    const shouldFetchTemplate: boolean = type !== null
+        && type !== CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.FLOW_EXTENSION
+        && type !== "custom-authenticator"
+        && type !== "enterprise-protocols";
+
     const {
         data: connectionTemplate,
         isLoading: isConnectionTemplateFetchRequestLoading,
         error: connectionTemplateFetchRequestError
-    } = useGetConnectionTemplate(type === "enterprise-protocols" ? "enterprise-idp" : type, type !== null);
+    } = useGetConnectionTemplate(
+        type === "enterprise-protocols" ? "enterprise-idp" : type,
+        shouldFetchTemplate
+    );
 
     useEffect(() => {
         if (connectionsFetchRequestError) {

--- a/features/admin.connections.v1/components/create/connection-create-wizard-factory.tsx
+++ b/features/admin.connections.v1/components/create/connection-create-wizard-factory.tsx
@@ -17,9 +17,15 @@
  */
 
 import IdVPCreationModal from "@wso2is/admin.identity-verification-providers.v1/components/create/idvp-creation-modal";
-import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
+import { FeatureAccessConfigInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, { FC, ReactElement } from "react";
+import { useSelector } from "react-redux";
 import { AuthenticatorCreateWizardFactory } from "./authenticator-create-wizard-factory";
+import FlowExtensionCreateWizard from "./flow-extension-create-wizard";
+import { CommonAuthenticatorConstants } from "../../constants/common-authenticator-constants";
 import {
     ConnectionTemplateInterface,
     ConnectionTypes,
@@ -82,29 +88,54 @@ export const ConnectionCreateWizardFactory: FC<ConnectionCreateWizardFactoryProp
     }: ConnectionCreateWizardFactoryPropsInterface
 ): ReactElement => {
 
+    const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
+        (state: AppState) => state.config.ui.features?.actions);
+    const { isSubOrganization } = useGetCurrentOrganizationType();
+    const flowExtensionFeatureKey: string = isSubOrganization()
+        ? "actions.types.org.list.flowExtension"
+        : "actions.types.list.flowExtension";
+
     if (!isModalOpen) {
         return null;
     }
 
-    switch (connectionType) {
-        case ConnectionTypes.IDVP:
-            return (
-                <IdVPCreationModal
-                    selectedTemplate={ selectedTemplate }
-                    onClose={ onWizardClose }
-                />
-            );
+    if (connectionType === ConnectionTypes.IDVP) {
+        return (
+            <IdVPCreationModal
+                selectedTemplate={ selectedTemplate }
+                onClose={ onWizardClose }
+            />
+        );
+    }
 
-        default:
-            return (
-                <AuthenticatorCreateWizardFactory
-                    isModalOpen={ isModalOpen }
-                    handleModalVisibility={ handleModalVisibility }
-                    type={ type }
-                    selectedTemplate={ selectedTemplate }
-                    onWizardClose={ onWizardClose }
-                    { ...rest }
-                />
-            );
-    };
+    // Match either by the enum type on the template OR by the template's id string.
+    // The backend may type the template as "DEFAULT" even though it's an flow extension,
+    // so we fall back to checking the templateId string.
+    if (
+        (connectionType === ConnectionTypes.FLOW_EXTENSION ||
+        type === CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.FLOW_EXTENSION) &&
+        isFeatureEnabled(actionsFeatureConfig, flowExtensionFeatureKey)
+    ) {
+        return (
+            <FlowExtensionCreateWizard
+                title={ selectedTemplate?.name }
+                subTitle={ selectedTemplate?.description }
+                onWizardClose={ onWizardClose }
+                template={ selectedTemplate as ConnectionTemplateInterface }
+                data-componentid={ selectedTemplate?.templateId }
+                { ...rest }
+            />
+        );
+    }
+
+    return (
+        <AuthenticatorCreateWizardFactory
+            isModalOpen={ isModalOpen }
+            handleModalVisibility={ handleModalVisibility }
+            type={ type }
+            selectedTemplate={ selectedTemplate }
+            onWizardClose={ onWizardClose }
+            { ...rest }
+        />
+    );
 };

--- a/features/admin.connections.v1/components/create/flow-extension-create-wizard.tsx
+++ b/features/admin.connections.v1/components/create/flow-extension-create-wizard.tsx
@@ -1,0 +1,533 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Alert from "@oxygen-ui/react/Alert";
+import Box from "@oxygen-ui/react/Box";
+import Divider from "@oxygen-ui/react/Divider";
+import Typography from "@oxygen-ui/react/Typography";
+import ActionEndpointConfigForm from "@wso2is/admin.actions.v1/components/action-endpoint-config-form";
+import createFlowExtension from "@wso2is/admin.flow-builder-core.v1/api/create-flow-extension";
+import {
+    FlowExtensionCreateRequestInterface,
+    FlowExtensionResponseInterface
+} from "@wso2is/admin.flow-builder-core.v1/models/flow-extension";
+import {
+    AuthenticationType,
+    EndpointConfigFormPropertyInterface
+} from "@wso2is/admin.actions.v1/models/actions";
+import { validateActionEndpointFields } from "@wso2is/admin.actions.v1/util/form-field-util";
+import { AddCertificateFormComponent } from "@wso2is/admin.core.v1/components/add-certificate-form";
+import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
+import { history } from "@wso2is/admin.core.v1/helpers/history";
+import { ModalWithSidePanel } from "@wso2is/admin.core.v1/components/modals/modal-with-side-panel";
+import { IdentityAppsError } from "@wso2is/core/errors";
+import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { Field, Wizard2, WizardPage } from "@wso2is/forms";
+import { useTrigger } from "@wso2is/forms/legacy";
+import {
+    GenericIcon,
+    Heading,
+    Hint,
+    LinkButton,
+    PrimaryButton,
+    Steps,
+    useWizardAlert
+} from "@wso2is/react-components";
+import { AxiosError } from "axios";
+import React, {
+    FunctionComponent,
+    MutableRefObject,
+    ReactElement,
+    useEffect,
+    useRef,
+    useState
+} from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
+import { Icon, Grid as SemanticGrid } from "semantic-ui-react";
+import { getConnectionWizardStepIcons } from "../../configs/ui";
+import { ConnectionUIConstants } from "../../constants/connection-ui-constants";
+import { AuthenticatorMeta } from "../../meta/authenticator-meta";
+import {
+    ConnectionTemplateInterface,
+    GenericConnectionCreateWizardPropsInterface,
+    WizardStepInterface,
+    WizardStepsFlowExtension
+} from "../../models/connection";
+
+interface FlowExtensionCreateWizardPropsInterface
+    extends GenericConnectionCreateWizardPropsInterface,
+    IdentifiableComponentInterface {
+    "data-componentid"?: string;
+    template: ConnectionTemplateInterface;
+    title: string;
+    subTitle: string;
+    onWizardClose: () => void;
+}
+
+const ACTION_NAME_REGEX: RegExp = /^[a-zA-Z0-9][a-zA-Z0-9 _-]{0,254}$/;
+
+const SHOW_SERVICE_CERTIFICATE_SECTION: boolean = false;
+
+interface FlowExtensionWizardFormValues extends EndpointConfigFormPropertyInterface {
+    name: string;
+    description?: string;
+}
+
+/**
+ * Flow Extension create wizard component.
+ */
+const FlowExtensionCreateWizard: FunctionComponent<FlowExtensionCreateWizardPropsInterface> = ({
+    title,
+    subTitle,
+    onWizardClose,
+    "data-componentid": componentId = "flow-extension"
+}: FlowExtensionCreateWizardPropsInterface): ReactElement => {
+
+    const wizardRef: MutableRefObject<any> = useRef(null);
+    const [alert, setAlert, alertComponent] = useWizardAlert();
+
+    const [initWizard, setInitWizard] = useState<boolean>(false);
+    const [wizardSteps, setWizardSteps] = useState<WizardStepInterface[]>([]);
+    const [currentWizardStep, setCurrentWizardStep] = useState<number>(0);
+    const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+    const [endpointAuthType, setEndpointAuthType] = useState<AuthenticationType>(null);
+    const [nextShouldBeDisabled, setNextShouldBeDisabled] = useState<boolean>(true);
+
+    // Certificate state — managed in the endpoint config step.
+    const [certificatePEM, setCertificatePEM] = useState<string>("");
+    const [triggerCertUpload, setTriggerCertUpload] = useTrigger();
+    const [triggerCertSubmit, setTriggerCertSubmit] = useTrigger();
+
+    // Ref for deferred submission — waits for cert extraction before submitting.
+    const pendingSubmit: MutableRefObject<boolean> = useRef<boolean>(false);
+    const submitTimeout: MutableRefObject<ReturnType<typeof setTimeout> | null> =
+        useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Ref mirrors certificatePEM state so handleFormSubmit always reads the
+    // up-to-date value even when called synchronously from within the cert callback.
+    const certPEMRef: MutableRefObject<string> = useRef<string>("");
+
+    const dispatch: Dispatch = useDispatch();
+    const { t } = useTranslation();
+
+    useEffect(() => {
+        if (!initWizard) {
+            setWizardSteps(getWizardSteps());
+            setInitWizard(true);
+        }
+    }, [initWizard]);
+
+    const getWizardSteps = (): WizardStepInterface[] => {
+        return [
+            {
+                icon: getConnectionWizardStepIcons().general,
+                name: WizardStepsFlowExtension.GENERAL_SETTINGS,
+                submitCallback: null,
+                title: t("flowExtension:createWizard.steps.generalSettings.title")
+            },
+            {
+                icon: getConnectionWizardStepIcons().authenticatorSettings,
+                name: WizardStepsFlowExtension.ENDPOINT_CONFIG,
+                submitCallback: null,
+                title: t("flowExtension:createWizard.steps.endpointConfig.title")
+            }
+        ] as WizardStepInterface[];
+    };
+
+    const hasValidationErrors = (errors: Record<string, unknown>): boolean => {
+        return !Object.keys(errors).every((k: string) => !errors[k]);
+    };
+
+    const validateGeneralSettings = (
+        values: { name: string; description?: string }
+    ): Partial<{ name: string; description: string }> => {
+        const errors: Partial<{ name: string; description: string }> = {};
+
+        if (!values?.name || !ACTION_NAME_REGEX.test(values.name)) {
+            errors.name = t("flowExtension:createWizard.steps.generalSettings.name.validations.invalid");
+        }
+
+        if (values?.description && values.description.length > 255) {
+            errors.description = t("flowExtension:createWizard.steps.generalSettings.description.validations.maxLength");
+        }
+
+        if (!hasValidationErrors(errors)) {
+            setNextShouldBeDisabled(false);
+        } else {
+            setNextShouldBeDisabled(true);
+        }
+
+        return errors;
+    };
+
+    const validateEndpointConfigs = (
+        values: EndpointConfigFormPropertyInterface
+    ): Partial<EndpointConfigFormPropertyInterface> => {
+        const errors: Partial<EndpointConfigFormPropertyInterface> = validateActionEndpointFields(values, {
+            authenticationType: endpointAuthType,
+            isAuthenticationUpdateFormState: true
+        });
+
+        setNextShouldBeDisabled(hasValidationErrors(errors as Record<string, unknown>));
+
+        return errors;
+    };
+
+    const handleCreateErrors = (error: AxiosError<HttpErrorResponseDataInterface>): void => {
+        const identityAppsError: IdentityAppsError = ConnectionUIConstants.ERROR_CREATE_LIMIT_REACHED;
+
+        if (error?.response?.status === 403 && error?.response?.data?.code === identityAppsError.getErrorCode()) {
+            setAlert({
+                code: identityAppsError.getErrorCode(),
+                description: t(identityAppsError.getErrorDescription()),
+                level: AlertLevels.ERROR,
+                message: t(identityAppsError.getErrorMessage()),
+                traceId: identityAppsError.getErrorTraceId()
+            });
+            setTimeout(() => setAlert(undefined), ConnectionUIConstants.WIZARD_ERROR_CLEAR_TIMEOUT);
+
+            return;
+        }
+
+        if (error?.response?.data?.description) {
+            setAlert({
+                description: error.response.data.description,
+                level: AlertLevels.ERROR,
+                message: t("flowExtension:notifications.createError.message")
+            });
+        } else {
+            setAlert({
+                description: t("flowExtension:notifications.createGenericError.description"),
+                level: AlertLevels.ERROR,
+                message: t("flowExtension:notifications.createGenericError.message")
+            });
+        }
+        setTimeout(() => setAlert(undefined), ConnectionUIConstants.WIZARD_ERROR_CLEAR_TIMEOUT);
+    };
+
+    const handleFormSubmit = (values: FlowExtensionWizardFormValues): void => {
+        const authProperties: Record<string, string> = {};
+
+        switch (endpointAuthType) {
+            case AuthenticationType.BASIC:
+                authProperties["username"] = values.usernameAuthProperty ?? "";
+                authProperties["password"] = values.passwordAuthProperty ?? "";
+                break;
+            case AuthenticationType.BEARER:
+                authProperties["accessToken"] = values.accessTokenAuthProperty ?? "";
+                break;
+            case AuthenticationType.API_KEY:
+                authProperties["header"] = values.headerAuthProperty ?? "";
+                authProperties["value"] = values.valueAuthProperty ?? "";
+                break;
+            case AuthenticationType.CLIENT_CREDENTIAL:
+                authProperties["clientId"] = values.clientIdAuthProperty ?? "";
+                authProperties["clientSecret"] = values.clientSecretAuthProperty ?? "";
+                authProperties["tokenEndpoint"] = values.tokenEndpointAuthProperty ?? "";
+                if (values.scopesAuthProperty) {
+                    authProperties["scopes"] = values.scopesAuthProperty;
+                }
+                break;
+            case AuthenticationType.NONE:
+            default:
+                break;
+        }
+
+        // Build encryption object from the certificate in step 2.
+        // Read from the ref (not state) so we always get the value that was
+        // captured synchronously by handleCertificateSubmit before gotoNextPage().
+        const resolvedEncryption: { certificate: string } | undefined =
+            certPEMRef.current ? { certificate: certPEMRef.current } : undefined;
+
+        const actionBody: FlowExtensionCreateRequestInterface = {
+            description: values.description?.toString() || "",
+            encryption: resolvedEncryption,
+            endpoint: {
+                authentication: {
+                    properties: authProperties,
+                    type: endpointAuthType as unknown as AuthenticationType
+                },
+                uri: values.endpointUri?.toString()
+            },
+            name: values.name?.toString()
+        };
+
+        setIsSubmitting(true);
+        createFlowExtension(actionBody)
+            .then((response: FlowExtensionResponseInterface) => {
+                dispatch(
+                    addAlert({
+                        description: t("flowExtension:notifications.createSuccess.description"),
+                        level: AlertLevels.SUCCESS,
+                        message: t("flowExtension:notifications.createSuccess.message")
+                    })
+                );
+
+                // Navigate to the edit page so the user can configure access config.
+                const editPath: string = AppConstants.getPaths()
+                    .get("FLOW_EXTENSION_EDIT")
+                    .replace(":id", response.id);
+
+                history.push(editPath + "#tab=access-configuration");
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                handleCreateErrors(error);
+            })
+            .finally(() => {
+                setIsSubmitting(false);
+            });
+    };
+
+    const handleCertificateSubmit = (value: string): void => {
+        // Sync both state (for UI) and ref (for handleFormSubmit closure).
+        setCertificatePEM(value);
+        certPEMRef.current = value;
+
+        if (pendingSubmit.current) {
+            pendingSubmit.current = false;
+            if (submitTimeout.current) {
+                clearTimeout(submitTimeout.current);
+                submitTimeout.current = null;
+            }
+            wizardRef.current?.gotoNextPage();
+        }
+    };
+
+    const generalSettingsPage = (): ReactElement => (
+        <WizardPage validate={validateGeneralSettings}>
+            <Field.Input
+                ariaLabel="name"
+                inputType="text"
+                name="name"
+                label={t("flowExtension:createWizard.steps.generalSettings.name.label")}
+                placeholder={t("flowExtension:createWizard.steps.generalSettings.name.placeholder")}
+                required={true}
+                maxLength={255}
+                minLength={1}
+                data-componentid={`${componentId}-create-wizard-name`}
+                width={15}
+            />
+            <Hint>{t("flowExtension:createWizard.steps.generalSettings.name.hint")}</Hint>
+            <Field.Input
+                ariaLabel="description"
+                inputType="text"
+                name="description"
+                label={t("flowExtension:createWizard.steps.generalSettings.description.label")}
+                placeholder={t("flowExtension:createWizard.steps.generalSettings.description.placeholder")}
+                required={false}
+                maxLength={255}
+                minLength={0}
+                data-componentid={`${componentId}-create-wizard-description`}
+                width={15}
+            />
+        </WizardPage>
+    );
+
+    const endpointConfigPage = (): ReactElement => (
+        <WizardPage validate={validateEndpointConfigs}>
+            <ActionEndpointConfigForm
+                initialValues={null}
+                isCreateFormState={true}
+                isReadOnly={false}
+                showHeadersAndParams={false}
+                showAllowedParameters={false}
+                authenticationTypes={ConnectionUIConstants.FLOW_EXTENSION_AUTH_TYPES}
+                onAuthenticationTypeChange={(type: AuthenticationType) => {
+                    setEndpointAuthType(type);
+                }}
+                data-componentid={`${componentId}-endpoint-config-form`}
+            />
+            { SHOW_SERVICE_CERTIFICATE_SECTION && (
+                <>
+                    <Divider className="divider-container" sx={{ mb: "20px", mt: "20px" }} />
+                    <Heading className="heading-container" as="h5">
+                        {t("flowExtension:createWizard.steps.endpointConfig.certificate.title")}
+                    </Heading>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                        {t("flowExtension:createWizard.steps.endpointConfig.certificate.hint")}
+                    </Typography>
+                    { certificatePEM && (
+                        <Alert
+                            severity="success"
+                            sx={{ mb: 2 }}
+                            action={
+                                <LinkButton
+                                    onClick={ () => { setCertificatePEM(""); certPEMRef.current = ""; } }
+                                    data-componentid={ `${componentId}-clear-certificate` }
+                                >
+                                    Clear
+                                </LinkButton>
+                            }
+                            data-componentid={`${componentId}-certificate-status`}
+                        >
+                            <Trans i18nKey="flowExtension:createWizard.steps.endpointConfig.certificate.uploaded">
+                                Certificate uploaded successfully. You can re‑upload to replace it or clear it.
+                            </Trans>
+                        </Alert>
+                    ) }
+                    <AddCertificateFormComponent
+                        triggerCertificateUpload={triggerCertUpload}
+                        triggerSubmit={triggerCertSubmit}
+                        onSubmit={handleCertificateSubmit}
+                        data-componentid={`${componentId}-certificate-upload`}
+                    />
+                </>
+            ) }
+        </WizardPage>
+    );
+
+    const resolveWizardPages = (): ReactElement[] => {
+        return [generalSettingsPage(), endpointConfigPage()];
+    };
+
+    return (
+        <ModalWithSidePanel
+            open={true}
+            className="wizard identity-provider-create-wizard"
+            dimmer="blurring"
+            onClose={onWizardClose}
+            closeOnDimmerClick={false}
+            closeOnEscape
+            data-componentid={`${componentId}-modal`}
+        >
+            <ModalWithSidePanel.MainPanel>
+                <ModalWithSidePanel.Header
+                    className="wizard-header"
+                    data-componentid={`${componentId}-modal-header`}
+                >
+                    <div className="display-flex">
+                        <GenericIcon
+                            icon={AuthenticatorMeta.getFlowExtensionIcon()}
+                            size="x30"
+                            transparent
+                            spaced="right"
+                            data-componentid={`${componentId}-image`}
+                        />
+                        <div>
+                            {title}
+                            {subTitle && <Heading as="h6">{subTitle}</Heading>}
+                        </div>
+                    </div>
+                </ModalWithSidePanel.Header>
+                <React.Fragment>
+                    <ModalWithSidePanel.Content
+                        className="steps-container"
+                        data-componentid={`${componentId}-modal-steps`}
+                    >
+                        <Steps.Group current={currentWizardStep}>
+                            {wizardSteps.map((step: WizardStepInterface, index: number) => (
+                                <Steps.Step active key={index} icon={step.icon} title={step.title} />
+                            ))}
+                        </Steps.Group>
+                    </ModalWithSidePanel.Content>
+                    <ModalWithSidePanel.Content
+                        className="content-container"
+                        data-componentid={`${componentId}-modal-content`}
+                    >
+                        {alert && alertComponent}
+                        <Wizard2
+                            ref={wizardRef}
+                            initialValues={{ description: "", endpointUri: "", name: "" }}
+                            uncontrolledForm={true}
+                            onSubmit={handleFormSubmit}
+                            pageChanged={(index: number) => {
+                                setCurrentWizardStep(index);
+                            }}
+                            data-componentid={componentId}
+                        >
+                            {resolveWizardPages()}
+                        </Wizard2>
+                    </ModalWithSidePanel.Content>
+                </React.Fragment>
+                <ModalWithSidePanel.Actions data-componentid={`${componentId}-modal-actions`}>
+                    <SemanticGrid>
+                        <SemanticGrid.Row column={1}>
+                            <SemanticGrid.Column mobile={8} tablet={8} computer={8}>
+                                <LinkButton
+                                    floated="left"
+                                    onClick={onWizardClose}
+                                    data-componentid={`${componentId}-cancel-button`}
+                                >
+                                    {t("common:cancel")}
+                                </LinkButton>
+                            </SemanticGrid.Column>
+                            <SemanticGrid.Column mobile={8} tablet={8} computer={8}>
+                                {currentWizardStep < wizardSteps.length - 1 && (
+                                    <PrimaryButton
+                                        disabled={nextShouldBeDisabled}
+                                        floated="right"
+                                        onClick={() => {
+                                            wizardRef.current.gotoNextPage();
+                                        }}
+                                        data-componentid={`${componentId}-next-button`}
+                                    >
+                                        {t("authenticationProvider:wizards.buttons.next")}
+                                        <Icon name="arrow right" />
+                                    </PrimaryButton>
+                                )}
+                                {currentWizardStep === wizardSteps.length - 1 && (
+                                    <PrimaryButton
+                                        disabled={nextShouldBeDisabled || isSubmitting}
+                                        type="submit"
+                                        floated="right"
+                                        onClick={() => {
+                                            // Trigger cert extraction: AddCertificateFormComponent
+                                            // passes triggerCertificateUpload to UploadCertificate
+                                            // as its triggerSubmit — firing setTriggerCertUpload()
+                                            // causes UploadCertificate to flush its value via onSubmit,
+                                            // which eventually calls our handleCertificateSubmit.
+                                            // The 300ms timeout is a fallback for the no-cert case
+                                            // (UploadCertificate returns early without calling back).
+                                            setTriggerCertUpload();
+                                            pendingSubmit.current = true;
+                                            submitTimeout.current = setTimeout(() => {
+                                                if (pendingSubmit.current) {
+                                                    pendingSubmit.current = false;
+                                                    wizardRef.current?.gotoNextPage();
+                                                }
+                                            }, 300);
+                                        }}
+                                        data-componentid={`${componentId}-submit-button`}
+                                        loading={isSubmitting}
+                                    >
+                                        {t("authenticationProvider:wizards.buttons.finish")}
+                                    </PrimaryButton>
+                                )}
+                                {currentWizardStep > 0 && (
+                                    <LinkButton
+                                        type="submit"
+                                        floated="right"
+                                        onClick={() => wizardRef.current.gotoPreviousPage()}
+                                        data-componentid={`${componentId}-previous-button`}
+                                    >
+                                        <Icon name="arrow left" />
+                                        {t("authenticationProvider:wizards.buttons.previous")}
+                                    </LinkButton>
+                                )}
+                            </SemanticGrid.Column>
+                        </SemanticGrid.Row>
+                    </SemanticGrid>
+                </ModalWithSidePanel.Actions>
+            </ModalWithSidePanel.MainPanel>
+        </ModalWithSidePanel>
+    );
+};
+
+export default FlowExtensionCreateWizard;

--- a/features/admin.connections.v1/components/edit/settings/flow-extension-access-config-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/flow-extension-access-config-settings.tsx
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Alert from "@oxygen-ui/react/Alert";
+import Box from "@oxygen-ui/react/Box";
+import Button from "@oxygen-ui/react/Button";
+import updateFlowExtension from "@wso2is/admin.flow-builder-core.v1/api/update-flow-extension";
+import {
+    AccessConfigInterface,
+    FlowExtensionResponseInterface,
+    FlowExtensionUpdateRequestInterface
+} from "@wso2is/admin.flow-builder-core.v1/models/flow-extension";
+import useFlowExtensionContextTree
+    from "@wso2is/admin.flow-builder-core.v1/api/use-flow-extension-context-tree";
+import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import {
+    AccessConfigOutput,
+    EncryptionOutput,
+    FlowContextTree,
+    FlowExtensionContextTreeResponse,
+    InitialAccessConfig
+} from "@wso2is/common.ui.shared-access.v1/components/flow-context-tree";
+import { ConfirmationModal, EmphasizedSegment, LinkButton } from "@wso2is/react-components";
+import { AxiosError } from "axios";
+import React, { FunctionComponent, ReactElement, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
+
+const SHOW_ENCRYPTION_SECTION: boolean = false;
+
+interface FlowExtensionAccessConfigSettingsPropsInterface extends IdentifiableComponentInterface {
+    "data-componentid"?: string;
+    action: FlowExtensionResponseInterface;
+    isLoading: boolean;
+    isReadOnly: boolean;
+    onUpdate: () => void;
+    loader: () => ReactElement;
+}
+
+export const FlowExtensionAccessConfigSettings: FunctionComponent<
+    FlowExtensionAccessConfigSettingsPropsInterface
+> = ({
+    action,
+    isLoading,
+    isReadOnly,
+    onUpdate,
+    loader: Loader,
+    ["data-componentid"]: componentId = "flow-extension-access-config-settings"
+}: FlowExtensionAccessConfigSettingsPropsInterface): ReactElement => {
+
+    const dispatch: Dispatch = useDispatch();
+    const { t } = useTranslation();
+
+    // Connection-level (action-level) access config editor — not bound to a specific flow.
+    // The hook is called with no flowType so the server returns the *default* tree, which
+    // already has the deployment.toml whitelist applied.
+    const {
+        data: contextTreeData,
+        error: contextTreeError,
+        isLoading: isContextTreeLoading
+    } = useFlowExtensionContextTree<FlowExtensionContextTreeResponse>();
+
+    const [ accessConfig, setAccessConfig ] = useState<AccessConfigInterface>({
+        expose: [],
+        modify: []
+    });
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ showResetConfirmation, setShowResetConfirmation ] = useState<boolean>(false);
+    const [ resetKey, setResetKey ] = useState<number>(0);
+
+    const initialAccessConfig: InitialAccessConfig | undefined = useMemo(() => {
+        if (action?.accessConfig) {
+            return {
+                expose: action.accessConfig.expose ?? [],
+                modify: action.accessConfig.modify ?? []
+            };
+        }
+
+        return undefined;
+    }, [ action ]);
+
+    // Backend does not return the certificate value (security); presence of the
+    // `encryption` object indicates a certificate is configured.
+    const hasCertificate: boolean = !!action?.encryption;
+
+    const handleAccessConfigChange = (
+        newAccessConfig: AccessConfigOutput,
+        _newEncryption: EncryptionOutput
+    ): void => {
+        setAccessConfig(newAccessConfig as AccessConfigInterface);
+    };
+
+    const handleUpdate = (): void => {
+        setIsSubmitting(true);
+
+        const updateBody: FlowExtensionUpdateRequestInterface = {
+            accessConfig
+        };
+
+        updateFlowExtension(action.id, updateBody)
+            .then(() => {
+                dispatch(addAlert({
+                    description: t("authenticationProvider:notifications.updateIDP.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("authenticationProvider:notifications.updateIDP.success.message")
+                }));
+                onUpdate();
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                dispatch(addAlert({
+                    description: error?.response?.data?.description
+                        ?? t("authenticationProvider:notifications.updateIDP.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("authenticationProvider:notifications.updateIDP.genericError.message")
+                }));
+            })
+            .finally(() => {
+                setIsSubmitting(false);
+            });
+    };
+
+    const handleReset = (): void => {
+        setIsSubmitting(true);
+
+        const updateBody: FlowExtensionUpdateRequestInterface = {
+            accessConfig: { expose: [], modify: [] }
+        };
+
+        updateFlowExtension(action.id, updateBody)
+            .then(() => {
+                dispatch(addAlert({
+                    description: "Access configuration has been reset successfully.",
+                    level: AlertLevels.SUCCESS,
+                    message: t("authenticationProvider:notifications.updateIDP.success.message")
+                }));
+                setResetKey((prev: number) => prev + 1);
+                onUpdate();
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                dispatch(addAlert({
+                    description: error?.response?.data?.description
+                        ?? t("authenticationProvider:notifications.updateIDP.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("authenticationProvider:notifications.updateIDP.genericError.message")
+                }));
+            })
+            .finally(() => {
+                setIsSubmitting(false);
+                setShowResetConfirmation(false);
+            });
+    };
+
+    if (isLoading || !action || isContextTreeLoading) {
+        return <Loader />;
+    }
+
+    if (contextTreeError || !contextTreeData) {
+        // Hard error — the editor cannot render without the tree. Surface a clear message
+        // rather than falling back to a stale/static schema, which could let an admin save
+        // an access config that references paths the deployment has switched off.
+        return (
+            <Box className="flow-extension-access-config-tab">
+                <EmphasizedSegment padded="very" data-componentid={ `${componentId}-section` }>
+                    <Alert
+                        severity="error"
+                        sx={ { mb: 2 } }
+                        data-componentid={ `${componentId}-tree-load-error` }
+                    >
+                        Failed to load the Flow Extension context tree from the server.
+                        Refresh the page to retry. If the problem persists, ensure the
+                        flow-management API is reachable and the deployment is up to date.
+                    </Alert>
+                </EmphasizedSegment>
+            </Box>
+        );
+    }
+
+    return (
+        <Box className="flow-extension-access-config-tab">
+            <EmphasizedSegment
+                padded="very"
+                data-componentid={ `${componentId}-section` }
+            >
+                { SHOW_ENCRYPTION_SECTION && !hasCertificate && (
+                    <Alert
+                        severity="warning"
+                        sx={ { mb: 2 } }
+                        data-componentid={ `${componentId}-cert-warning` }
+                    >
+                        No encryption certificate provided. You cannot mark fields to be sent
+                        encrypted. You can upload a certificate in the Settings tab.
+                    </Alert>
+                ) }
+                { !initialAccessConfig && (
+                    <Alert
+                        severity="info"
+                        sx={ { mb: 2 } }
+                        data-componentid={ `${componentId}-empty-access-config-info` }
+                    >
+                        No access configuration has been set. The extension will not send any data
+                        and will not allow any modifications until you configure access here.
+                    </Alert>
+                ) }
+                <FlowContextTree
+                    key={ resetKey }
+                    contextTree={ contextTreeData.context }
+                    onChange={ handleAccessConfigChange }
+                    initialAccessConfig={ initialAccessConfig }
+                    hasCertificate={ hasCertificate }
+                    readOnly={ isReadOnly }
+                    allowReadOnlyClaimsModification={ contextTreeData.allowReadOnlyClaimsModification }
+                    redirectionEnabled={ contextTreeData.redirectionEnabled }
+                    data-componentid={ `${componentId}-tree` }
+                />
+                { !isReadOnly && (
+                    <Box sx={ { display: "flex", gap: 1, mt: 3 } }>
+                        <Button
+                            size="medium"
+                            variant="contained"
+                            onClick={ handleUpdate }
+                            loading={ isSubmitting }
+                            data-componentid={ `${componentId}-update-button` }
+                        >
+                            { t("actions:buttons.update") }
+                        </Button>
+                        { initialAccessConfig && (
+                            <LinkButton
+                                onClick={ () => setShowResetConfirmation(true) }
+                                data-componentid={ `${componentId}-reset-button` }
+                            >
+                                Reset
+                            </LinkButton>
+                        ) }
+                    </Box>
+                ) }
+            </EmphasizedSegment>
+            { showResetConfirmation && (
+                <ConfirmationModal
+                    primaryActionLoading={ isSubmitting }
+                    onClose={ (): void => setShowResetConfirmation(false) }
+                    type="negative"
+                    open={ showResetConfirmation }
+                    assertionType="checkbox"
+                    assertionHint="Please confirm your understanding that this action is irreversible."
+                    primaryAction={ t("common:confirm") }
+                    secondaryAction={ t("common:cancel") }
+                    onSecondaryActionClick={ (): void => setShowResetConfirmation(false) }
+                    onPrimaryActionClick={ handleReset }
+                    data-componentid={ `${componentId}-reset-confirmation` }
+                    closeOnDimmerClick={ false }
+                >
+                    <ConfirmationModal.Header
+                        data-componentid={ `${componentId}-reset-confirmation-header` }
+                    >
+                        Reset Access Configuration
+                    </ConfirmationModal.Header>
+                    <ConfirmationModal.Message
+                        attached
+                        negative
+                        data-componentid={ `${componentId}-reset-confirmation-message` }
+                    >
+                        This will clear all expose and modify annotations.
+                    </ConfirmationModal.Message>
+                    <ConfirmationModal.Content
+                        data-componentid={ `${componentId}-reset-confirmation-content` }
+                    >
+                        The extension will no longer send any data and will not allow any
+                        modifications until you reconfigure access here. This action cannot
+                        be undone.
+                    </ConfirmationModal.Content>
+                </ConfirmationModal>
+            ) }
+        </Box>
+    );
+};

--- a/features/admin.connections.v1/components/edit/settings/flow-extension-custom-errors.scss
+++ b/features/admin.connections.v1/components/edit/settings/flow-extension-custom-errors.scss
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.flow-extension-custom-errors {
+    background-color: var(--oxygen-palette-background-paper, #ffffff);
+    border: 1px solid var(--oxygen-palette-divider, rgba(0, 0, 0, 0.12));
+    border-radius: 8px;
+    padding: 24px;
+
+    .inflow-error-left-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .inflow-error-panel-header {
+        margin-bottom: 8px;
+    }
+
+    .inflow-error-entries-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    // ── Entry card ──────────────────────────────────────────────────────────
+
+    .inflow-error-entry-card {
+        border: 1px solid var(--oxygen-palette-divider, rgba(0, 0, 0, 0.12));
+        border-radius: 8px;
+        padding: 12px 16px;
+        transition: border-color 0.15s ease, box-shadow 0.15s ease;
+        cursor: pointer;
+
+        &:hover:not(.inflow-error-entry-card--expanded) {
+            border-color: var(--oxygen-palette-primary-main, #ff7300);
+            box-shadow: 0 0 0 1px var(--oxygen-palette-primary-main, #ff7300);
+        }
+
+        &--expanded {
+            cursor: default;
+            border-color: var(--oxygen-palette-primary-main, #ff7300);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+        }
+
+        &--new {
+            border-style: dashed;
+        }
+    }
+
+    .inflow-error-entry-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 8px;
+    }
+
+    .inflow-error-entry-key {
+        font-size: 13px;
+        background-color: var(--oxygen-palette-action-hover, rgba(0, 0, 0, 0.04));
+        color: var(--oxygen-palette-text-primary);
+        padding: 3px 10px;
+        border-radius: 12px;
+        border: 1px solid var(--oxygen-palette-divider, rgba(0, 0, 0, 0.1));
+        word-break: break-all;
+    }
+
+    .inflow-error-entry-locales {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+    }
+
+    .inflow-error-locale-chip {
+        font-size: 12px;
+
+        .flag {
+            display: inline-block;
+            margin-right: 2px;
+        }
+    }
+
+    // ── Expanded entry form ─────────────────────────────────────────────────
+
+    .inflow-error-entry-expanded-body {
+        margin-top: 12px;
+    }
+
+    .inflow-error-key-prefix {
+        font-size: 13px;
+        color: var(--oxygen-palette-text-secondary);
+        white-space: nowrap;
+    }
+
+    .inflow-error-locale-option {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        width: 100%;
+
+        .flag {
+            display: inline-block;
+        }
+    }
+
+    .inflow-error-locale-textfield {
+        textarea {
+            font-size: 14px;
+        }
+    }
+
+    .inflow-error-configured-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+    }
+
+    .inflow-error-entry-actions-expanded {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-top: 8px;
+        padding-top: 12px;
+        border-top: 1px solid var(--oxygen-palette-divider, rgba(0, 0, 0, 0.08));
+    }
+
+    // ── Add button / empty state ────────────────────────────────────────────
+
+    .inflow-error-add-button {
+        align-self: flex-start;
+    }
+
+    .inflow-error-empty-state {
+        padding: 24px 16px;
+        text-align: center;
+        border: 1px dashed var(--oxygen-palette-divider, rgba(0, 0, 0, 0.12));
+        border-radius: 8px;
+    }
+
+    // ── Misc ────────────────────────────────────────────────────────────────
+
+    .inflow-error-branding-warning {
+        margin-bottom: 0;
+    }
+}

--- a/features/admin.connections.v1/components/edit/settings/flow-extension-custom-errors.tsx
+++ b/features/admin.connections.v1/components/edit/settings/flow-extension-custom-errors.tsx
@@ -1,0 +1,846 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Alert from "@oxygen-ui/react/Alert";
+import Box from "@oxygen-ui/react/Box";
+import Button from "@oxygen-ui/react/Button";
+import Chip from "@oxygen-ui/react/Chip";
+import CircularProgress from "@oxygen-ui/react/CircularProgress";
+import Divider from "@oxygen-ui/react/Divider";
+import Grid from "@oxygen-ui/react/Grid";
+import IconButton from "@oxygen-ui/react/IconButton";
+import InputAdornment from "@oxygen-ui/react/InputAdornment";
+import Link from "@oxygen-ui/react/Link";
+import MenuItem from "@oxygen-ui/react/MenuItem";
+import TextField from "@oxygen-ui/react/TextField";
+import Tooltip from "@oxygen-ui/react/Tooltip";
+import Typography from "@oxygen-ui/react/Typography";
+import { CheckIcon, CopyIcon, PlusIcon, TrashIcon } from "@oxygen-ui/react-icons";
+import deleteCustomTextPreference from "@wso2is/admin.branding.v1/api/delete-custom-text-preference";
+import updateCustomTextPreference from "@wso2is/admin.branding.v1/api/update-custom-text-preference";
+import { FlowExtensionResponseInterface } from "@wso2is/admin.flow-builder-core.v1/models/flow-extension";
+import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
+import { history } from "@wso2is/admin.core.v1/helpers/history";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { BrandingPreferenceAPIResponseInterface } from "@wso2is/common.branding.v1/models";
+import useGetBrandingPreference from "@wso2is/common.branding.v1/api/use-get-branding-preference";
+import { AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { ConfirmationModal } from "@wso2is/react-components";
+import { LocaleMeta, SupportedLanguagesMeta } from "@wso2is/i18n";
+import React, {
+    FunctionComponent,
+    KeyboardEvent,
+    ReactElement,
+    useMemo,
+    useState
+} from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import { Dispatch } from "redux";
+import useFlowExtensionTranslations, {
+    TranslationEntry
+} from "../../../api/use-flow-extension-translations";
+import {
+    FLOW_EXTENSION_SCREEN,
+    getConnectionKeyPrefix
+} from "../../../utils/flow-extension-utils";
+import "./flow-extension-custom-errors.scss";
+
+/**
+ * Props interface for `FlowExtensionCustomErrors` component.
+ */
+interface FlowExtensionCustomErrorsPropsInterface extends IdentifiableComponentInterface {
+    "data-componentid"?: string;
+    action: FlowExtensionResponseInterface;
+    isLoading: boolean;
+    isReadOnly: boolean;
+    loader: () => ReactElement;
+}
+
+const DEFAULT_LOCALE: string = "en-US";
+
+/**
+ * Local state shape for an entry being created or edited inline.
+ */
+interface EditState {
+    shortKey: string;
+    translations: Record<string, string>;
+    isNew: boolean;
+    selectedLocale: string;
+}
+
+// ---------------------------------------------------------------------------
+// ExpandedEntryForm sub-component (shared by new-entry card and edit-in-place)
+// ---------------------------------------------------------------------------
+
+interface ExpandedEntryFormProps {
+    editState: EditState;
+    keyPrefix: string;
+    supportedLocales: SupportedLanguagesMeta;
+    isSaving: boolean;
+    onKeyChange: (v: string) => void;
+    onLocaleChange: (locale: string) => void;
+    onTranslationChange: (v: string) => void;
+    onSave: () => void;
+    onCancel: () => void;
+}
+
+const ExpandedEntryForm: FunctionComponent<ExpandedEntryFormProps> = ({
+    editState,
+    keyPrefix,
+    supportedLocales,
+    isSaving,
+    onKeyChange,
+    onLocaleChange,
+    onTranslationChange,
+    onSave,
+    onCancel
+}: ExpandedEntryFormProps): ReactElement => {
+
+    const { t } = useTranslation();
+    const hasKey: boolean = editState.shortKey.trim().length > 0;
+    const configuredLocales: string[] = Object.entries(editState.translations)
+        .filter(([ , value ]: [string, string]) => value?.trim().length > 0)
+        .map(([ locale ]: [string, string]) => locale);
+    const currentValue: string = editState.translations[editState.selectedLocale] ?? "";
+    const currentLocaleMeta: LocaleMeta | undefined = supportedLocales[editState.selectedLocale];
+
+    return (
+        <Box
+            className="inflow-error-entry-expanded-body"
+            onClick={ (e) => e.stopPropagation() }
+        >
+            {/* Error key input */}
+            <TextField
+                label={ t("flowExtension:customErrors.form.keyLabel", { defaultValue: "Error Key" }) }
+                value={ editState.shortKey }
+                onChange={ (e) => onKeyChange(e.target.value) }
+                InputProps={ {
+                    startAdornment: (
+                        <InputAdornment position="start">
+                            <Typography
+                                variant="body2"
+                                className="inflow-error-key-prefix"
+                            >
+                                { keyPrefix }
+                            </Typography>
+                        </InputAdornment>
+                    )
+                } }
+                inputProps={ { pattern: "[a-z.]*" } }
+                fullWidth
+                size="small"
+                disabled={ isSaving }
+                sx={ { mb: 2 } }
+            />
+
+            <Divider sx={ { mb: 2 } } />
+
+            {/* Locale dropdown */}
+            <TextField
+                select
+                label={ t("flowExtension:customErrors.form.localeLabel", { defaultValue: "Locale" }) }
+                value={ editState.selectedLocale }
+                onChange={ (e) => onLocaleChange(e.target.value) }
+                fullWidth
+                size="small"
+                disabled={ isSaving }
+                sx={ { mb: 1.5 } }
+                SelectProps={ {
+                    renderValue: (selected: unknown) => {
+                        const localeKey: string = selected as string;
+                        const meta: LocaleMeta | undefined = supportedLocales[localeKey];
+
+                        return (
+                            <Box component="span" className="inflow-error-locale-option">
+                                { meta && <i className={ `${meta.flag} flag` } /> }
+                                <span>{ meta ? `${meta.name} (${meta.code || localeKey})` : localeKey }</span>
+                            </Box>
+                        );
+                    }
+                } }
+            >
+                { Object.entries(supportedLocales).map(([ locale, meta ]: [string, LocaleMeta]) => (
+                    <MenuItem key={ locale } value={ locale }>
+                        <Box component="span" className="inflow-error-locale-option">
+                            <i className={ `${meta.flag} flag` } />
+                            <span>{ `${meta.name} (${meta.code || locale})` }</span>
+                        </Box>
+                    </MenuItem>
+                )) }
+            </TextField>
+
+            {/* Translation label + input for the selected locale */}
+            <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={ { mt: 0.5, mb: 0.5, display: "block" } }
+            >
+                { t("flowExtension:customErrors.form.translationLabel", { defaultValue: "Translation" }) }
+            </Typography>
+            <TextField
+                value={ currentValue }
+                onChange={ (e) => onTranslationChange(e.target.value) }
+                placeholder={ t("flowExtension:customErrors.form.translationPlaceholder", {
+                    defaultValue: "Enter error message for this locale..."
+                }) }
+                multiline
+                minRows={ 3 }
+                fullWidth
+                size="small"
+                disabled={ isSaving }
+                className="inflow-error-locale-textfield"
+                helperText={ currentLocaleMeta
+                    ? t("flowExtension:customErrors.form.translationHelper", {
+                        defaultValue: `Shown to users whose locale is ${currentLocaleMeta.name}.`,
+                        locale: currentLocaleMeta.name
+                    })
+                    : undefined
+                }
+            />
+
+            {/* Configured locales summary */}
+            { configuredLocales.length > 0 && (
+                <Box sx={ { mt: 1.5 } }>
+                    <Typography variant="caption" color="text.secondary">
+                        { t("flowExtension:customErrors.form.configuredLocales",
+                            { defaultValue: "Configured locales:" }) }
+                    </Typography>
+                    <Box className="inflow-error-configured-chips">
+                        { configuredLocales.map((locale: string) => {
+                            const meta: LocaleMeta | undefined = supportedLocales[locale];
+
+                            return (
+                                <Chip
+                                    key={ locale }
+                                    label={
+                                        <>
+                                            { meta && (
+                                                <i
+                                                    className={ `${meta.flag} flag` }
+                                                    style={ { marginRight: 4 } }
+                                                />
+                                            ) }
+                                            { meta?.code || locale }
+                                        </>
+                                    }
+                                    size="small"
+                                    variant="outlined"
+                                    className="inflow-error-locale-chip"
+                                />
+                            );
+                        }) }
+                    </Box>
+                </Box>
+            ) }
+
+            {/* Action buttons */}
+            <Box className="inflow-error-entry-actions-expanded">
+                <Button
+                    variant="outlined"
+                    size="small"
+                    onClick={ onCancel }
+                    disabled={ isSaving }
+                >
+                    { t("common:cancel") }
+                </Button>
+                <Button
+                    variant="contained"
+                    size="small"
+                    onClick={ onSave }
+                    disabled={ isSaving || !hasKey || configuredLocales.length === 0 }
+                    startIcon={ isSaving ? <CircularProgress size={ 14 } /> : undefined }
+                >
+                    { editState.isNew
+                        ? t("common:create", { defaultValue: "Create" })
+                        : t("common:update", { defaultValue: "Update" })
+                    }
+                </Button>
+            </Box>
+        </Box>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// EntryCard sub-component (collapsed / expanded)
+// ---------------------------------------------------------------------------
+
+interface EntryCardProps {
+    entry: TranslationEntry;
+    keyPrefix: string;
+    supportedLocales: SupportedLanguagesMeta;
+    isExpanded: boolean;
+    editState: EditState | null;
+    isSaving: boolean;
+    isDeleting: boolean;
+    isReadOnly: boolean;
+    onExpand: () => void;
+    onKeyChange: (v: string) => void;
+    onLocaleChange: (locale: string) => void;
+    onTranslationChange: (v: string) => void;
+    onSave: () => void;
+    onCancel: () => void;
+    onDeleteRequest: () => void;
+}
+
+const EntryCard: FunctionComponent<EntryCardProps> = ({
+    entry,
+    keyPrefix,
+    supportedLocales,
+    isExpanded,
+    editState,
+    isSaving,
+    isDeleting,
+    isReadOnly,
+    onExpand,
+    onKeyChange,
+    onLocaleChange,
+    onTranslationChange,
+    onSave,
+    onCancel,
+    onDeleteRequest
+}: EntryCardProps): ReactElement => {
+
+    const { t } = useTranslation();
+    const [ keyCopied, setKeyCopied ] = useState<boolean>(false);
+
+    return (
+        <Box
+            className={ `inflow-error-entry-card${isExpanded ? " inflow-error-entry-card--expanded" : ""}` }
+            onClick={ !isExpanded ? onExpand : undefined }
+            role={ !isExpanded ? "button" : undefined }
+            tabIndex={ !isExpanded ? 0 : undefined }
+            onKeyDown={ !isExpanded
+                ? (e: KeyboardEvent<HTMLDivElement>) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onExpand();
+                    }
+                }
+                : undefined
+            }
+        >
+            {/* Header row: key badge + copy button + delete button */}
+            <Box className="inflow-error-entry-header">
+                <Typography
+                    variant="body2"
+                    component="code"
+                    className="inflow-error-entry-key"
+                >
+                    { keyPrefix }{ entry.shortKey }
+                </Typography>
+                <Tooltip title={ keyCopied ? t("common:copied") : t("common:copyKey", { defaultValue: "Copy Key" }) }>
+                    <span>
+                        <IconButton
+                            size="small"
+                            onClick={ (e: React.MouseEvent) => {
+                                e.stopPropagation();
+                                navigator.clipboard.writeText(keyPrefix + entry.shortKey).then(() => {
+                                    setKeyCopied(true);
+                                    setTimeout(() => setKeyCopied(false), 2000);
+                                });
+                            } }
+                            disabled={ isSaving || isDeleting }
+                            aria-label={ `Copy key ${keyPrefix}${entry.shortKey}` }
+                        >
+                            { keyCopied ? <CheckIcon size={ 16 } /> : <CopyIcon size={ 16 } /> }
+                        </IconButton>
+                    </span>
+                </Tooltip>
+                { !isReadOnly && (
+                    <Tooltip title={ t("common:delete") }>
+                        <span>
+                            <IconButton
+                                size="small"
+                                color="error"
+                                onClick={ (e) => { e.stopPropagation(); onDeleteRequest(); } }
+                                disabled={ isDeleting || isSaving }
+                                aria-label={ `Delete ${entry.shortKey}` }
+                            >
+                                { isDeleting
+                                    ? <CircularProgress size={ 16 } />
+                                    : <TrashIcon />
+                                }
+                            </IconButton>
+                        </span>
+                    </Tooltip>
+                ) }
+            </Box>
+
+            {/* Collapsed: locale chips */}
+            { !isExpanded && (
+                <Box className="inflow-error-entry-locales">
+                    { Object.entries(entry.translations).map(([ locale, text ]: [string, string]) => {
+                        const meta: LocaleMeta = supportedLocales[locale];
+
+                        return (
+                            <Tooltip key={ locale } title={ text } placement="bottom">
+                                <Chip
+                                    size="small"
+                                    label={
+                                        <>
+                                            { meta && (
+                                                <i
+                                                    className={ `${meta.flag} flag` }
+                                                    style={ { marginRight: 4 } }
+                                                />
+                                            ) }
+                                            { meta?.code || locale }
+                                        </>
+                                    }
+                                    className="inflow-error-locale-chip"
+                                    variant="outlined"
+                                />
+                            </Tooltip>
+                        );
+                    }) }
+                </Box>
+            ) }
+
+            {/* Expanded: inline edit form */}
+            { isExpanded && editState && (
+                <ExpandedEntryForm
+                    editState={ editState }
+                    keyPrefix={ keyPrefix }
+                    supportedLocales={ supportedLocales }
+                    isSaving={ isSaving }
+                    onKeyChange={ onKeyChange }
+                    onLocaleChange={ onLocaleChange }
+                    onTranslationChange={ onTranslationChange }
+                    onSave={ onSave }
+                    onCancel={ onCancel }
+                />
+            ) }
+        </Box>
+    );
+};
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+/**
+ * Custom errors tab for flow extension.
+ * Allows admins to manage locale-specific error messages for a connection.
+ */
+export const FlowExtensionCustomErrors: FunctionComponent<FlowExtensionCustomErrorsPropsInterface> = ({
+    action,
+    isLoading: externalLoading,
+    isReadOnly,
+    loader: Loader,
+    ["data-componentid"]: componentId = "flow-extension-custom-errors"
+}: FlowExtensionCustomErrorsPropsInterface): ReactElement => {
+
+    const { t } = useTranslation();
+    const dispatch: Dispatch = useDispatch();
+    const tenantDomain: string = useSelector((state: AppState) => state.auth.tenantDomain);
+    const keyPrefix: string = action ? getConnectionKeyPrefix(action.name) : "";
+
+    const {
+        entries,
+        localeData,
+        isConfiguredPerLocale,
+        supportedLocales,
+        isLoading: translationsLoading,
+        refetch
+    } = useFlowExtensionTranslations(keyPrefix, !!action && !externalLoading);
+
+    const {
+        data: brandingPreferenceData,
+        error: brandingPreferenceError
+    } = useGetBrandingPreference<BrandingPreferenceAPIResponseInterface>(tenantDomain);
+
+    const isBrandingEnabled: boolean = useMemo(
+        () => (!brandingPreferenceError && brandingPreferenceData?.preference?.configs?.isBrandingEnabled) ?? false,
+        [ brandingPreferenceData, brandingPreferenceError ]
+    );
+
+    // ---- Local state ----
+    const [ expandedKey, setExpandedKey ] = useState<string | null>(null);
+    const [ editState, setEditState ] = useState<EditState | null>(null);
+    const [ isSaving, setIsSaving ] = useState<boolean>(false);
+    const [ deletingKey, setDeletingKey ] = useState<string | null>(null);
+    const [ deleteConfirmKey, setDeleteConfirmKey ] = useState<string | null>(null);
+
+    // ---- Expand / collapse ----
+    const handleExpand = (entry: TranslationEntry): void => {
+        if (!isBrandingEnabled || isSaving) return;
+        if (expandedKey === entry.shortKey) {
+            // Toggle collapse
+            setExpandedKey(null);
+            setEditState(null);
+
+            return;
+        }
+        const translations: Record<string, string> = {};
+
+        Object.keys(supportedLocales).forEach((locale: string) => {
+            translations[locale] = entry.translations[locale] ?? "";
+        });
+
+        const initialLocale: string = supportedLocales[DEFAULT_LOCALE]
+            ? DEFAULT_LOCALE
+            : Object.keys(supportedLocales)[0] ?? DEFAULT_LOCALE;
+
+        setExpandedKey(entry.shortKey);
+        setEditState({
+            isNew: false,
+            selectedLocale: initialLocale,
+            shortKey: entry.shortKey,
+            translations
+        });
+    };
+
+    // ---- Add new ----
+    const handleAddNew = (): void => {
+        if (!isBrandingEnabled || isSaving) return;
+        const translations: Record<string, string> = {};
+
+        Object.keys(supportedLocales).forEach((locale: string) => { translations[locale] = ""; });
+
+        const initialLocale: string = supportedLocales[DEFAULT_LOCALE]
+            ? DEFAULT_LOCALE
+            : Object.keys(supportedLocales)[0] ?? DEFAULT_LOCALE;
+
+        setExpandedKey("__new__");
+        setEditState({
+            isNew: true,
+            selectedLocale: initialLocale,
+            shortKey: "",
+            translations
+        });
+    };
+
+    // ---- Cancel ----
+    const handleCancel = (): void => {
+        setExpandedKey(null);
+        setEditState(null);
+    };
+
+    // ---- Field change handlers ----
+    const handleKeyChange = (value: string): void => {
+        if (!/^[a-z.]*$/.test(value)) return;
+        setEditState((prev: EditState | null) => prev ? { ...prev, shortKey: value } : null);
+    };
+
+    const handleLocaleChange = (locale: string): void => {
+        setEditState((prev: EditState | null) => prev ? { ...prev, selectedLocale: locale } : null);
+    };
+
+    const handleTranslationChange = (value: string): void => {
+        setEditState((prev: EditState | null) => prev
+            ? { ...prev, translations: { ...prev.translations, [prev.selectedLocale]: value } }
+            : null
+        );
+    };
+
+    // ---- Save (create / update) ----
+    const handleSave = async (): Promise<void> => {
+        if (!editState || !editState.shortKey.trim()) return;
+
+        const newFullKey: string = `${keyPrefix}${editState.shortKey}`;
+        const originalFullKey: string | null = editState.isNew ? null : `${keyPrefix}${expandedKey}`;
+
+        setIsSaving(true);
+        try {
+            for (const locale of Object.keys(supportedLocales)) {
+                const newText: string = editState.translations[locale]?.trim() ?? "";
+                const currentMap: Record<string, string> = { ...(localeData[locale] ?? {}) };
+
+                // Remove the old key when it has been renamed
+                if (originalFullKey && originalFullKey !== newFullKey) {
+                    delete currentMap[originalFullKey];
+                }
+
+                // Apply new translation (or remove it if cleared)
+                if (newText) {
+                    currentMap[newFullKey] = newText;
+                } else {
+                    delete currentMap[newFullKey];
+                }
+
+                const wasConfigured: boolean = isConfiguredPerLocale[locale] ?? false;
+
+                if (Object.keys(currentMap).length === 0) {
+                    if (wasConfigured) {
+                        await deleteCustomTextPreference(tenantDomain, FLOW_EXTENSION_SCREEN, locale);
+                    }
+                } else {
+                    await updateCustomTextPreference(
+                        wasConfigured,
+                        { text: currentMap },
+                        tenantDomain,
+                        FLOW_EXTENSION_SCREEN,
+                        locale
+                    );
+                }
+            }
+
+            await refetch();
+            handleCancel();
+            dispatch(addAlert({
+                description: t("flowExtension:customErrors.notifications.save.success.description",
+                    { defaultValue: "Translation saved successfully." }),
+                level: AlertLevels.SUCCESS,
+                message: t("flowExtension:customErrors.notifications.save.success.message",
+                    { defaultValue: "Translation Saved" })
+            }));
+        } catch {
+            dispatch(addAlert({
+                description: t("flowExtension:customErrors.notifications.save.error.description",
+                    { defaultValue: "Failed to save translation. Please try again." }),
+                level: AlertLevels.ERROR,
+                message: t("flowExtension:customErrors.notifications.save.error.message",
+                    { defaultValue: "Save Failed" })
+            }));
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    // ---- Delete ----
+    const handleDelete = async (shortKey: string): Promise<void> => {
+        const fullKey: string = `${keyPrefix}${shortKey}`;
+
+        setDeletingKey(shortKey);
+        try {
+            for (const [ locale, textMap ] of Object.entries(localeData)) {
+                if (!textMap[fullKey]) continue;
+
+                const { [fullKey]: _removed, ...remaining } = textMap;
+
+                if (Object.keys(remaining).length === 0) {
+                    await deleteCustomTextPreference(tenantDomain, FLOW_EXTENSION_SCREEN, locale);
+                } else {
+                    await updateCustomTextPreference(
+                        true,
+                        { text: remaining },
+                        tenantDomain,
+                        FLOW_EXTENSION_SCREEN,
+                        locale
+                    );
+                }
+            }
+
+            await refetch();
+            // Collapse if the deleted entry was expanded
+            if (expandedKey === shortKey) {
+                setExpandedKey(null);
+                setEditState(null);
+            }
+            dispatch(addAlert({
+                description: t("flowExtension:customErrors.notifications.delete.success.description",
+                    { defaultValue: "Translation deleted successfully." }),
+                level: AlertLevels.SUCCESS,
+                message: t("flowExtension:customErrors.notifications.delete.success.message",
+                    { defaultValue: "Translation Deleted" })
+            }));
+        } catch {
+            dispatch(addAlert({
+                description: t("flowExtension:customErrors.notifications.delete.error.description",
+                    { defaultValue: "Failed to delete translation. Please try again." }),
+                level: AlertLevels.ERROR,
+                message: t("flowExtension:customErrors.notifications.delete.error.message",
+                    { defaultValue: "Delete Failed" })
+            }));
+        } finally {
+            setDeletingKey(null);
+            setDeleteConfirmKey(null);
+        }
+    };
+
+    // ---- Loading guard ----
+    if (externalLoading || translationsLoading) {
+        return <Loader />;
+    }
+
+    const hasLocales: boolean = Object.keys(supportedLocales).length > 0;
+    const isNewEntryOpen: boolean = expandedKey === "__new__";
+
+    return (
+        <div
+            className="flow-extension-custom-errors"
+            data-componentid={ componentId }
+        >
+            <Grid container spacing={ 3 }>
+                {/* ── Entry management ── */}
+                <Grid xs={ 12 } sm={ 8 } md={ 6 }>
+                    <Box className="inflow-error-left-panel">
+
+                        {/* Header */}
+                        <Box className="inflow-error-panel-header">
+                            <Typography variant="h6">
+                                { t("flowExtension:customErrors.title",
+                                    { defaultValue: "Custom Error Messages" }) }
+                            </Typography>
+                            <Typography variant="body2" color="text.secondary" sx={ { mt: 0.5 } }>
+                                { t("flowExtension:customErrors.description", {
+                                    defaultValue:
+                                        "Define error messages this extension can return. " +
+                                        "Click a card to edit, or add a new translation below."
+                                }) }
+                            </Typography>
+                        </Box>
+
+                        {/* Branding disabled warning */}
+                        { !isBrandingEnabled && (
+                            <Alert severity="warning" className="inflow-error-branding-warning">
+                                <Trans
+                                    i18nKey="flowExtension:customErrors.brandingDisabledWarning"
+                                    defaults={ "Enable <brandingLink>branding</brandingLink> to manage " +
+                                        "custom error translations." }
+                                    components={ {
+                                        brandingLink: (
+                                            <Link
+                                                onClick={ () => history.push(
+                                                    AppConstants.getPaths().get("BRANDING")
+                                                ) }
+                                                sx={ { cursor: "pointer", fontWeight: 500 } }
+                                            />
+                                        )
+                                    } }
+                                />
+                            </Alert>
+                        ) }
+
+                        {/* No-locales warning */}
+                        { !hasLocales && (
+                            <Alert severity="warning">
+                                { t("flowExtension:customErrors.noLocalesWarning", {
+                                    defaultValue:
+                                        "No supported locales found. Check your branding configuration."
+                                }) }
+                            </Alert>
+                        ) }
+
+                        {/* New entry card (always in expanded / create mode) */}
+                        { isNewEntryOpen && editState && (
+                            <Box className="inflow-error-entry-card inflow-error-entry-card--expanded
+                                inflow-error-entry-card--new">
+                                <Box className="inflow-error-entry-header">
+                                    <Typography variant="subtitle2">
+                                        { t("flowExtension:customErrors.newEntry.heading",
+                                            { defaultValue: "New Translation" }) }
+                                    </Typography>
+                                </Box>
+                                <ExpandedEntryForm
+                                    editState={ editState }
+                                    keyPrefix={ keyPrefix }
+                                    supportedLocales={ supportedLocales }
+                                    isSaving={ isSaving }
+                                    onKeyChange={ handleKeyChange }
+                                    onLocaleChange={ handleLocaleChange }
+                                    onTranslationChange={ handleTranslationChange }
+                                    onSave={ handleSave }
+                                    onCancel={ handleCancel }
+                                />
+                            </Box>
+                        ) }
+
+                        {/* Existing entry cards */}
+                        { entries.length > 0 ? (
+                            <Box className="inflow-error-entries-list">
+                                { entries.map((entry: TranslationEntry) => (
+                                    <EntryCard
+                                        key={ entry.shortKey }
+                                        entry={ entry }
+                                        keyPrefix={ keyPrefix }
+                                        supportedLocales={ supportedLocales }
+                                        isExpanded={ expandedKey === entry.shortKey }
+                                        editState={ expandedKey === entry.shortKey ? editState : null }
+                                        isSaving={ isSaving }
+                                        isDeleting={ deletingKey === entry.shortKey }
+                                        isReadOnly={ isReadOnly }
+                                        onExpand={ () => handleExpand(entry) }
+                                        onKeyChange={ handleKeyChange }
+                                        onLocaleChange={ handleLocaleChange }
+                                        onTranslationChange={ handleTranslationChange }
+                                        onSave={ handleSave }
+                                        onCancel={ handleCancel }
+                                        onDeleteRequest={ () => setDeleteConfirmKey(entry.shortKey) }
+                                    />
+                                )) }
+                            </Box>
+                        ) : (
+                            !isNewEntryOpen && (
+                                <Box className="inflow-error-empty-state">
+                                    <Typography variant="body2" color="text.secondary">
+                                        { t("flowExtension:customErrors.emptyState", {
+                                            defaultValue:
+                                                "No custom error messages configured. Add translations to " +
+                                                "customize the error text your users see."
+                                        }) }
+                                    </Typography>
+                                </Box>
+                            )
+                        ) }
+
+                        {/* Add translation button */}
+                        { !isReadOnly && (
+                            <Button
+                                variant="outlined"
+                                startIcon={ <PlusIcon /> }
+                                onClick={ handleAddNew }
+                                disabled={ isSaving || !hasLocales || !isBrandingEnabled || isNewEntryOpen }
+                                className="inflow-error-add-button"
+                            >
+                                { t("flowExtension:customErrors.addButton",
+                                    { defaultValue: "Add Translation" }) }
+                            </Button>
+                        ) }
+                    </Box>
+                </Grid>
+            </Grid>
+
+            {/* Delete confirmation modal */}
+            { deleteConfirmKey && (
+                <ConfirmationModal
+                    onClose={ () => setDeleteConfirmKey(null) }
+                    type="negative"
+                    open={ !!deleteConfirmKey }
+                    assertionHint={ t("flowExtension:customErrors.deleteConfirm.assertionHint",
+                        { defaultValue: "Please confirm the action." }) }
+                    assertionType="checkbox"
+                    primaryAction={ t("common:delete") }
+                    secondaryAction={ t("common:cancel") }
+                    onSecondaryActionClick={ () => setDeleteConfirmKey(null) }
+                    onPrimaryActionClick={ () => handleDelete(deleteConfirmKey) }
+                    data-componentid="flow-extension-delete-confirmation-modal"
+                    closeOnDimmerClick={ false }
+                >
+                    <ConfirmationModal.Header>
+                        { t("flowExtension:customErrors.deleteConfirm.header",
+                            { defaultValue: "Delete Translation?" }) }
+                    </ConfirmationModal.Header>
+                    <ConfirmationModal.Message attached warning>
+                        { t("flowExtension:customErrors.deleteConfirm.message", {
+                            defaultValue:
+                                `This will delete all locale translations for key "${deleteConfirmKey}".`,
+                            key: deleteConfirmKey
+                        }) }
+                    </ConfirmationModal.Message>
+                    <ConfirmationModal.Content>
+                        { t("flowExtension:customErrors.deleteConfirm.content",
+                            { defaultValue: "This action cannot be undone." }) }
+                    </ConfirmationModal.Content>
+                </ConfirmationModal>
+            ) }
+        </div>
+    );
+};

--- a/features/admin.connections.v1/components/edit/settings/flow-extension-endpoint-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/flow-extension-endpoint-settings.tsx
@@ -1,0 +1,338 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Alert from "@oxygen-ui/react/Alert";
+import Box from "@oxygen-ui/react/Box";
+import Button from "@oxygen-ui/react/Button";
+import Divider from "@oxygen-ui/react/Divider";
+import Typography from "@oxygen-ui/react/Typography";
+import ActionEndpointConfigForm from "@wso2is/admin.actions.v1/components/action-endpoint-config-form";
+import updateFlowExtension from "@wso2is/admin.flow-builder-core.v1/api/update-flow-extension";
+import {
+    FlowExtensionResponseInterface,
+    FlowExtensionUpdateRequestInterface
+} from "@wso2is/admin.flow-builder-core.v1/models/flow-extension";
+import {
+    AuthenticationType,
+    EndpointConfigFormPropertyInterface
+} from "@wso2is/admin.actions.v1/models/actions";
+import { validateActionEndpointFields } from "@wso2is/admin.actions.v1/util/form-field-util";
+import { AddCertificateFormComponent } from "@wso2is/admin.core.v1/components/add-certificate-form";
+import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { FinalForm, FormRenderProps } from "@wso2is/forms";
+import { useTrigger } from "@wso2is/forms/legacy";
+import { EmphasizedSegment, Heading, LinkButton } from "@wso2is/react-components";
+import { AxiosError } from "axios";
+import React, { FunctionComponent, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
+import { Trans, useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
+import {
+    AuthenticationPropertiesInterface,
+    EndpointAuthenticationType
+} from "../../../models/connection";
+import { ConnectionUIConstants } from "../../../constants/connection-ui-constants";
+
+const SHOW_SERVICE_CERTIFICATE_SECTION: boolean = false;
+
+const areStringSetsEqual = (a: string[] | undefined, b: string[] | undefined): boolean => {
+    const setA: Set<string> = new Set(a ?? []);
+    const setB: Set<string> = new Set(b ?? []);
+
+    if (setA.size !== setB.size) {
+        return false;
+    }
+    for (const value of setA) {
+        if (!setB.has(value)) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+interface FlowExtensionEndpointSettingsPropsInterface extends IdentifiableComponentInterface {
+    "data-componentid"?: string;
+    action: FlowExtensionResponseInterface;
+    isLoading: boolean;
+    isReadOnly: boolean;
+    onUpdate: () => void;
+    loader: () => ReactElement;
+}
+
+export const FlowExtensionEndpointSettings: FunctionComponent<FlowExtensionEndpointSettingsPropsInterface> = ({
+    action,
+    isLoading,
+    isReadOnly,
+    onUpdate,
+    loader: Loader,
+    ["data-componentid"]: componentId = "flow-extension-endpoint-settings"
+}: FlowExtensionEndpointSettingsPropsInterface): ReactElement => {
+
+    const dispatch: Dispatch = useDispatch();
+    const { t } = useTranslation();
+
+    const [ initialValues, setInitialValues ] = useState<EndpointConfigFormPropertyInterface>(null);
+    const [ endpointAuthenticationType, setEndpointAuthenticationType ] = useState<AuthenticationType>(null);
+    const [ isEndpointAuthenticationUpdated, setIsEndpointAuthenticationUpdated ] = useState<boolean>(false);
+
+    // Certificate state
+    const [ certificatePEM, setCertificatePEM ] = useState<string>("");
+    const [ hasCertificate, setHasCertificate ] = useState<boolean>(false);
+    const [ isCertificateModified, setIsCertificateModified ] = useState<boolean>(false);
+    const [ userHasStagedCert, setUserHasStagedCert ] = useState<boolean>(false);
+    const [ triggerCertUpload, setTriggerCertUpload ] = useTrigger();
+    const [ triggerCertSubmit, setTriggerCertSubmit ] = useTrigger();
+
+    // Refs that mirror cert state so handleSubmit never reads a stale closure.
+    const isCertificateModifiedRef: MutableRefObject<boolean> = useRef<boolean>(false);
+    const certificatePEMRef: MutableRefObject<string> = useRef<string>("");
+    // Stores the FinalForm handleSubmit so the async cert callback can invoke it.
+    const formHandleSubmitRef: MutableRefObject<(() => void) | null> = useRef<(() => void) | null>(null);
+
+    useEffect(() => {
+        if (action) {
+            setInitialValues({
+                allowedHeaders: action.endpoint?.allowedHeaders ?? [],
+                authenticationType: action.endpoint?.authentication?.type,
+                endpointUri: action.endpoint?.uri
+            });
+            // Backend does not return the certificate value (security); presence of the
+            // `encryption` object indicates a certificate is configured.
+            setHasCertificate(!!action.encryption);
+        }
+    }, [ action ]);
+
+    const validateForm = (
+        values: EndpointConfigFormPropertyInterface
+    ): Partial<EndpointConfigFormPropertyInterface> => {
+
+        return validateActionEndpointFields(values, {
+            authenticationType: endpointAuthenticationType,
+            isAuthenticationUpdateFormState: isEndpointAuthenticationUpdated
+        });
+    };
+
+    const handleSubmit = (values: EndpointConfigFormPropertyInterface): void => {
+        const updateBody: FlowExtensionUpdateRequestInterface = {};
+
+        const isUriChanged: boolean = values.endpointUri !== action.endpoint?.uri;
+        const isHeadersChanged: boolean = !areStringSetsEqual(
+            values.allowedHeaders, action.endpoint?.allowedHeaders);
+
+        // Only include endpoint in update when URI, auth, or headers changed.
+        if (isUriChanged || isEndpointAuthenticationUpdated || isHeadersChanged) {
+            const endpointPatch: Partial<FlowExtensionUpdateRequestInterface["endpoint"]> = {};
+
+            if (isUriChanged || isEndpointAuthenticationUpdated) {
+                const authProperties: Partial<AuthenticationPropertiesInterface> = {};
+
+                switch (values.authenticationType) {
+                    case AuthenticationType.BASIC:
+                        authProperties.username = values.usernameAuthProperty;
+                        authProperties.password = values.passwordAuthProperty;
+
+                        break;
+                    case AuthenticationType.BEARER:
+                        authProperties.accessToken = values.accessTokenAuthProperty;
+
+                        break;
+                    case AuthenticationType.API_KEY:
+                        authProperties.header = values.headerAuthProperty;
+                        authProperties.value = values.valueAuthProperty;
+
+                        break;
+                    case AuthenticationType.CLIENT_CREDENTIAL:
+                        authProperties.clientId = values.clientIdAuthProperty;
+                        authProperties.clientSecret = values.clientSecretAuthProperty;
+                        authProperties.tokenEndpoint = values.tokenEndpointAuthProperty;
+                        if (values.scopesAuthProperty) {
+                            authProperties.scopes = values.scopesAuthProperty;
+                        }
+
+                        break;
+                    case AuthenticationType.NONE:
+                        break;
+                    default:
+                        break;
+                }
+
+                endpointPatch.authentication = {
+                    properties: authProperties,
+                    type: values.authenticationType as unknown as AuthenticationType
+                };
+                endpointPatch.uri = values.endpointUri;
+            }
+
+            if (isHeadersChanged) {
+                endpointPatch.allowedHeaders = values.allowedHeaders ?? [];
+            }
+
+            updateBody.endpoint = endpointPatch;
+        }
+
+        // Include encryption update if certificate was explicitly changed (including clearing).
+        // Read from refs to avoid stale closure when called from deferred setTimeout.
+        if (isCertificateModifiedRef.current) {
+            updateBody.encryption = { certificate: certificatePEMRef.current || "" };
+        }
+
+        // Nothing changed – skip the API call.
+        if (!updateBody.endpoint && !updateBody.encryption) {
+            return;
+        }
+
+        updateFlowExtension(action.id, updateBody)
+            .then(() => {
+                dispatch(addAlert({
+                    description: t("authenticationProvider:notifications.updateIDP.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("authenticationProvider:notifications.updateIDP.success.message")
+                }));
+                onUpdate();
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                dispatch(addAlert({
+                    description: error?.response?.data?.description
+                        ?? t("authenticationProvider:notifications.updateIDP.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("authenticationProvider:notifications.updateIDP.genericError.message")
+                }));
+            });
+    };
+
+    const handleCertificateSubmit = (value: string): void => {
+        if (value) {
+            setCertificatePEM(value);
+            setHasCertificate(true);
+            setIsCertificateModified(true);
+            certificatePEMRef.current = value;
+            isCertificateModifiedRef.current = true;
+        }
+        // Proceed with the form submission now that cert data is extracted.
+        formHandleSubmitRef.current?.();
+    };
+
+    if (isLoading || !action) {
+        return <Loader />;
+    }
+
+    return (
+        <Box className="flow-extension-endpoint-settings-tab">
+            <FinalForm
+                onSubmit={ handleSubmit }
+                initialValues={ initialValues }
+                validate={ validateForm }
+                render={ ({ handleSubmit: formHandleSubmit }: FormRenderProps) => {
+
+                    return (
+                    <EmphasizedSegment
+                        className="endpoint-settings-container"
+                        padded="very"
+                        data-componentid={ `${componentId}-section` }
+                    >
+                        <div className="form-container with-max-width">
+                            <ActionEndpointConfigForm
+                                initialValues={ initialValues }
+                                isCreateFormState={ false }
+                                isReadOnly={ isReadOnly }
+                                showHeadersAndParams={ true }
+                                showAllowedParameters={ false }
+                                authenticationTypes={ ConnectionUIConstants.FLOW_EXTENSION_AUTH_TYPES }
+                                onAuthenticationTypeChange={ (
+                                    authenticationType: AuthenticationType,
+                                    isAuthenticationUpdated: boolean
+                                ) => {
+                                    setEndpointAuthenticationType(authenticationType);
+                                    setIsEndpointAuthenticationUpdated(isAuthenticationUpdated);
+                                } }
+                            />
+                            { SHOW_SERVICE_CERTIFICATE_SECTION && (
+                                <>
+                                    <Divider sx={ { my: 3 } } />
+                                    <Heading as="h5">
+                                        { t("flowExtension:createWizard.steps.endpointConfig.certificate.title") }
+                                    </Heading>
+                                    <Typography variant="body2" color="text.secondary" sx={ { mb: 2 } }>
+                                        { t("flowExtension:createWizard.steps.endpointConfig.certificate.hint") }
+                                    </Typography>
+                                    { (hasCertificate || certificatePEM) && (
+                                        <Alert
+                                            severity="success"
+                                            sx={ { alignItems: "center", mb: 2 } }
+                                            action={
+                                                <LinkButton
+                                                    onClick={ () => {
+                                                        setCertificatePEM("");
+                                                        setHasCertificate(false);
+                                                        setIsCertificateModified(true);
+                                                        certificatePEMRef.current = "";
+                                                        isCertificateModifiedRef.current = true;
+                                                    } }
+                                                    data-componentid={ `${componentId}-clear-certificate` }
+                                                >
+                                                    Clear
+                                                </LinkButton>
+                                            }
+                                            data-componentid={ `${componentId}-certificate-status` }
+                                        >
+                                            <Trans
+                                                i18nKey={ "flowExtension:createWizard.steps.endpointConfig" +
+                                                    ".certificate.uploaded" }
+                                            >
+                                                Certificate configured. You can re-upload to replace it or clear it.
+                                            </Trans>
+                                        </Alert>
+                                    ) }
+                                    <AddCertificateFormComponent
+                                        triggerCertificateUpload={ triggerCertUpload }
+                                        triggerSubmit={ triggerCertSubmit }
+                                        onSubmit={ handleCertificateSubmit }
+                                        setShowFinishButton={ setUserHasStagedCert }
+                                        data-componentid={ `${componentId}-certificate-upload` }
+                                    />
+                                </>
+                            ) }
+                            { !isReadOnly && (
+                                <Button
+                                    size="medium"
+                                    variant="contained"
+                                    onClick={ () => {
+                                        formHandleSubmitRef.current = formHandleSubmit;
+                                        if (userHasStagedCert) {
+                                            // Two-phase: extract cert first, then submit.
+                                            setTriggerCertUpload();
+                                        } else {
+                                            formHandleSubmit();
+                                        }
+                                    } }
+                                    sx={ { mt: 4, display: "block" } }
+                                    data-componentid={ `${componentId}-update-button` }
+                                >
+                                    { t("actions:buttons.update") }
+                                </Button>
+                            ) }
+                        </div>
+                    </EmphasizedSegment>
+                    );
+                } }
+            />
+        </Box>
+    );
+};

--- a/features/admin.connections.v1/components/edit/settings/flow-extension-general-settings.tsx
+++ b/features/admin.connections.v1/components/edit/settings/flow-extension-general-settings.tsx
@@ -1,0 +1,283 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Divider from "@oxygen-ui/react/Divider";
+import deleteFlowExtension from "@wso2is/admin.flow-builder-core.v1/api/delete-flow-extension";
+import updateFlowExtension from "@wso2is/admin.flow-builder-core.v1/api/update-flow-extension";
+import {
+    FlowExtensionResponseInterface,
+    FlowExtensionUpdateRequestInterface
+} from "@wso2is/admin.flow-builder-core.v1/models/flow-extension";
+import { AlertLevels, HttpErrorResponseDataInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import { Field, Form } from "@wso2is/forms";
+import {
+    ConfirmationModal,
+    DangerZone,
+    DangerZoneGroup,
+    EmphasizedSegment
+} from "@wso2is/react-components";
+import { AxiosError } from "axios";
+import React, {
+    FunctionComponent,
+    ReactElement,
+    useState
+} from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
+import { ConnectionUIConstants } from "../../../constants/connection-ui-constants";
+
+const ACTION_NAME_REGEX: RegExp = /^[a-zA-Z0-9][a-zA-Z0-9 _-]{0,254}$/;
+const FORM_ID: string = "flow-extension-general-settings-form";
+
+interface FlowExtensionGeneralSettingsPropsInterface extends IdentifiableComponentInterface {
+    "data-componentid"?: string;
+    action: FlowExtensionResponseInterface;
+    isLoading: boolean;
+    isReadOnly: boolean;
+    onDelete: () => void;
+    onUpdate: () => void;
+    loader: () => ReactElement;
+}
+
+export const FlowExtensionGeneralSettings: FunctionComponent<FlowExtensionGeneralSettingsPropsInterface> = ({
+    action,
+    isLoading,
+    isReadOnly,
+    onDelete,
+    onUpdate,
+    loader: Loader,
+    ["data-componentid"]: componentId = "flow-extension-general-settings"
+}: FlowExtensionGeneralSettingsPropsInterface): ReactElement => {
+
+    const dispatch: Dispatch = useDispatch();
+    const { t } = useTranslation();
+
+    const [ showDeleteConfirmation, setShowDeleteConfirmation ] = useState<boolean>(false);
+    const [ isDeleting, setIsDeleting ] = useState<boolean>(false);
+    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+
+    const validateForm = (
+        values: { name: string; description?: string }
+    ): Partial<{ name: string; description: string }> => {
+        const errors: Partial<{ name: string; description: string }> = {};
+
+        if (!values?.name || !ACTION_NAME_REGEX.test(values.name)) {
+            errors.name = t("flowExtension:createWizard.steps.generalSettings.name.validations.invalid");
+        }
+
+        if (values?.description && values.description.length > 255) {
+            errors.description = t(
+                "flowExtension:createWizard.steps.generalSettings.description.validations.maxLength"
+            );
+        }
+
+        return errors;
+    };
+
+    const handleFormSubmit = (values: { name: string; description?: string; image?: string }): void => {
+        setIsSubmitting(true);
+
+        const updateBody: FlowExtensionUpdateRequestInterface = {
+            description: values.description?.toString() ?? "",
+            iconUrl: values.image?.toString() ?? "",
+            name: values.name?.toString()
+        };
+
+        updateFlowExtension(action.id, updateBody)
+            .then(() => {
+                dispatch(addAlert({
+                    description: t("authenticationProvider:notifications.updateIDP.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("authenticationProvider:notifications.updateIDP.success.message")
+                }));
+                onUpdate();
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                dispatch(addAlert({
+                    description: error?.response?.data?.description
+                        ?? t("authenticationProvider:notifications.updateIDP.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("authenticationProvider:notifications.updateIDP.genericError.message")
+                }));
+            })
+            .finally(() => {
+                setIsSubmitting(false);
+            });
+    };
+
+    const handleDelete = (): void => {
+        setIsDeleting(true);
+
+        deleteFlowExtension(action.id)
+            .then(() => {
+                dispatch(addAlert({
+                    description: t("authenticationProvider:notifications.deleteConnection.success.description"),
+                    level: AlertLevels.SUCCESS,
+                    message: t("authenticationProvider:notifications.deleteConnection.success.message")
+                }));
+                setShowDeleteConfirmation(false);
+                onDelete();
+            })
+            .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
+                dispatch(addAlert({
+                    description: error?.response?.data?.description
+                        ?? t("authenticationProvider:notifications.deleteIDP.genericError.description"),
+                    level: AlertLevels.ERROR,
+                    message: t("authenticationProvider:notifications.deleteIDP.genericError.message")
+                }));
+            })
+            .finally(() => {
+                setIsDeleting(false);
+            });
+    };
+
+    if (isLoading || !action) {
+        return <Loader />;
+    }
+
+    return (
+        <>
+            <EmphasizedSegment padded="very">
+                <Form
+                    id={ FORM_ID }
+                    uncontrolledForm={ false }
+                    enableReinitialize
+                    onSubmit={ handleFormSubmit }
+                    validate={ validateForm }
+                    initialValues={ {
+                        description: action.description ?? "",
+                        image: action.iconUrl ?? "",
+                        name: action.name ?? ""
+                    } }
+                    data-componentid={ componentId }
+                >
+                    <Field.Input
+                        ariaLabel="name"
+                        inputType="text"
+                        name="name"
+                        label={ t("flowExtension:createWizard.steps.generalSettings.name.label") }
+                        placeholder={
+                            t("flowExtension:createWizard.steps.generalSettings.name.placeholder")
+                        }
+                        required={ true }
+                        maxLength={ 255 }
+                        minLength={ 1 }
+                        data-componentid={ `${componentId}-name` }
+                        readOnly={ isReadOnly }
+                    />
+                    <Field.Input
+                        name="image"
+                        ariaLabel="image"
+                        inputType="url"
+                        label="Icon URL"
+                        required={ false }
+                        placeholder={ t("authenticationProvider:forms.generalDetails.image.placeholder") }
+                        data-componentid={ `${componentId}-image` }
+                        maxLength={
+                            ConnectionUIConstants.GENERAL_FORM_CONSTRAINTS.IMAGE_URL_MAX_LENGTH as number
+                        }
+                        minLength={
+                            ConnectionUIConstants.GENERAL_FORM_CONSTRAINTS.IMAGE_URL_MIN_LENGTH as number
+                        }
+                        hint={ t("customAuthenticator:fields.editPage.generalTab.iconUrl.hint") }
+                        readOnly={ isReadOnly }
+                    />
+                    <Field.Textarea
+                        name="description"
+                        ariaLabel="description"
+                        label={ t("authenticationProvider:forms.generalDetails.description.label") }
+                        required={ false }
+                        placeholder={ t("authenticationProvider:forms.generalDetails.description.placeholder") }
+                        data-componentid={ `${componentId}-description` }
+                        maxLength={ 255 }
+                        minLength={ 0 }
+                        readOnly={ isReadOnly }
+                    />
+                    { !isReadOnly && (
+                        <Field.Button
+                            form={ FORM_ID }
+                            ariaLabel="Update General Details"
+                            size="small"
+                            buttonType="primary_btn"
+                            label={ t("common:update") }
+                            name="submit"
+                            disabled={ isSubmitting }
+                            loading={ isSubmitting }
+                            data-componentid={ `${componentId}-update-button` }
+                        />
+                    ) }
+                </Form>
+            </EmphasizedSegment>
+            <Divider hidden />
+            { !isReadOnly && (
+                <DangerZoneGroup
+                    sectionHeader={ t("authenticationProvider:dangerZoneGroup.header") }
+                >
+                    <DangerZone
+                        actionTitle={ t("authenticationProvider:dangerZoneGroup.deleteIDP.actionTitle") }
+                        header={ t("authenticationProvider:dangerZoneGroup.deleteIDP.header") }
+                        subheader={
+                            "Deleting this flow extension may break flows that reference it. " +
+                            "This action is irreversible."
+                        }
+                        onActionClick={ (): void => setShowDeleteConfirmation(true) }
+                        data-componentid={ `${componentId}-delete-danger-zone` }
+                    />
+                </DangerZoneGroup>
+            ) }
+            { showDeleteConfirmation && (
+                <ConfirmationModal
+                    primaryActionLoading={ isDeleting }
+                    onClose={ (): void => setShowDeleteConfirmation(false) }
+                    type="negative"
+                    open={ showDeleteConfirmation }
+                    assertion={ action.name }
+                    assertionHint={ t("authenticationProvider:confirmations.deleteIDP.assertionHint") }
+                    assertionType="checkbox"
+                    primaryAction={ t("common:confirm") }
+                    secondaryAction={ t("common:cancel") }
+                    onSecondaryActionClick={ (): void => setShowDeleteConfirmation(false) }
+                    onPrimaryActionClick={ handleDelete }
+                    data-componentid={ `${componentId}-delete-confirmation` }
+                    closeOnDimmerClick={ false }
+                >
+                    <ConfirmationModal.Header
+                        data-componentid={ `${componentId}-delete-confirmation-header` }
+                    >
+                        { t("authenticationProvider:confirmations.deleteIDP.header") }
+                    </ConfirmationModal.Header>
+                    <ConfirmationModal.Message
+                        attached
+                        negative
+                        data-componentid={ `${componentId}-delete-confirmation-message` }
+                    >
+                        { t("authenticationProvider:confirmations.deleteIDP.message") }
+                    </ConfirmationModal.Message>
+                    <ConfirmationModal.Content
+                        data-componentid={ `${componentId}-delete-confirmation-content` }
+                    >
+                        Deleting this flow extension will break any flows that currently use it.
+                        Please proceed with caution.
+                    </ConfirmationModal.Content>
+                </ConfirmationModal>
+            ) }
+        </>
+    );
+};

--- a/features/admin.connections.v1/configs/templates.ts
+++ b/features/admin.connections.v1/configs/templates.ts
@@ -21,6 +21,7 @@ import values from "lodash-es/values";
 import DefaultConnectionTemplateCategory from "../meta/templates-meta/categories/default.json";
 import CustomAuthenticatorTemplateGroup from "../meta/templates-meta/groups/custom-authenticator.json";
 import EnterpriseConnetionTemplateGroup from "../meta/templates-meta/groups/enterprise.json";
+import FlowExtensionTemplateGroup from "../meta/templates-meta/groups/flow-extension.json";
 import { ConnectionTemplatesConfigInterface } from "../models/connection";
 
 export const getConnectionTemplatesConfig = (): ConnectionTemplatesConfigInterface => {
@@ -50,6 +51,11 @@ export const getConnectionTemplatesConfig = (): ConnectionTemplatesConfigInterfa
                         enabled: CustomAuthenticatorTemplateGroup.enabled,
                         id: CustomAuthenticatorTemplateGroup.id,
                         resource: CustomAuthenticatorTemplateGroup
+                    },
+                    {
+                        enabled: FlowExtensionTemplateGroup.enabled,
+                        id: FlowExtensionTemplateGroup.id,
+                        resource: FlowExtensionTemplateGroup
                     }
                 ],
                 "id"

--- a/features/admin.connections.v1/configs/ui.ts
+++ b/features/admin.connections.v1/configs/ui.ts
@@ -46,6 +46,7 @@ import EmailOTPIcon from "../resources/assets/images/icons/email-solid.svg";
 import { ReactComponent as EnterpriseConnectionIcon
 } from "../resources/assets/images/icons/enterprise-icon.svg";
 import { ReactComponent as GearsIcon } from "../resources/assets/images/icons/gears-icon.svg";
+import FlowExtensionIcon from "../resources/assets/images/icons/flow-extension.svg";
 import MagicLinkIcon from "../resources/assets/images/icons/magic-link-icon.svg";
 import OIDCConnectionIcon from "../resources/assets/images/icons/oidc-connection-icon.png";
 import OrganizationSSOIcon from "../resources/assets/images/icons/organization-sso-icon.svg";
@@ -99,6 +100,7 @@ export const getConnectionIcons = (): any => {
         githubAuthenticator: GithubIdPIcon,
         google: GoogleLogo,
         googleOIDCAuthenticator: GoogleLogo,
+        flowExtension: FlowExtensionIcon,
         iwaKerberos: KerberosLogo,
         jwtBasic: JWTLogo,
         magicLink: MagicLinkIcon,

--- a/features/admin.connections.v1/constants/common-authenticator-constants.ts
+++ b/features/admin.connections.v1/constants/common-authenticator-constants.ts
@@ -52,6 +52,7 @@ export class CommonAuthenticatorConstants {
         GITHUB: string;
         GOOGLE: string;
         HYPR: string;
+        FLOW_EXTENSION: string;
         INTERNAL_CUSTOM_AUTHENTICATOR: string;
         IPROOV: string;
         LINKEDIN: string;
@@ -75,6 +76,7 @@ export class CommonAuthenticatorConstants {
             GITHUB: "github-idp",
             GOOGLE: "google-idp",
             HYPR: "hypr-idp",
+            FLOW_EXTENSION: "flow-extension",
             INTERNAL_CUSTOM_AUTHENTICATOR: "internal-user-custom-authenticator",
             IPROOV: "iproov-idp",
             LINKEDIN: "linkedin-idp",

--- a/features/admin.connections.v1/constants/connection-ui-constants.ts
+++ b/features/admin.connections.v1/constants/connection-ui-constants.ts
@@ -17,6 +17,10 @@
  */
 
 import { ClaimManagementConstants } from "@wso2is/admin.claims.v1/constants";
+import { AuthenticationType } from "@wso2is/admin.actions.v1/models/actions";
+import {
+    AuthenticationTypeDropdownOption as ActionAuthenticationTypeDropdownOption
+} from "@wso2is/admin.actions.v1/models/actions";
 import { IdentityAppsError } from "@wso2is/core/errors";
 import {
     AuthenticationTypeDropdownOption,
@@ -383,9 +387,11 @@ export class ConnectionUIConstants {
     public static readonly CONNECTION_TEMPLATE_GROUPS: {
         CUSTOM_AUTHENTICATOR: string;
         ENTERPRISE_PROTOCOLS: string;
+        FLOW_EXTENSION: string;
     } = {
             CUSTOM_AUTHENTICATOR: "custom-authenticator",
-            ENTERPRISE_PROTOCOLS: "enterprise-protocols"
+            ENTERPRISE_PROTOCOLS: "enterprise-protocols",
+            FLOW_EXTENSION: "flow-extension"
         };
 
     public static readonly IMPLICIT_ACCOUNT_LINKING_ATTRIBUTES: string[] = [
@@ -459,6 +465,39 @@ export class ConnectionUIConstants {
             key: EndpointAuthenticationType.PASSWORD_CREDENTIAL,
             text: "actions:fields.authentication.types.passwordCredential.name",
             value: EndpointAuthenticationType.PASSWORD_CREDENTIAL
+        }
+    ];
+
+    /**
+     * Authentication types available for Flow Extension. Extends the standard
+     * auth types with CLIENT_CREDENTIAL (OAuth2 client credentials). Typed to match
+     * ActionEndpointConfigForm's authenticationTypes prop.
+     */
+    public static readonly FLOW_EXTENSION_AUTH_TYPES: ActionAuthenticationTypeDropdownOption[] = [
+        {
+            key: AuthenticationType.NONE,
+            text: "actions:fields.authentication.types.none.name",
+            value: AuthenticationType.NONE
+        },
+        {
+            key: AuthenticationType.BASIC,
+            text: "actions:fields.authentication.types.basic.name",
+            value: AuthenticationType.BASIC
+        },
+        {
+            key: AuthenticationType.BEARER,
+            text: "actions:fields.authentication.types.bearer.name",
+            value: AuthenticationType.BEARER
+        },
+        {
+            key: AuthenticationType.API_KEY,
+            text: "actions:fields.authentication.types.apiKey.name",
+            value: AuthenticationType.API_KEY
+        },
+        {
+            key: AuthenticationType.CLIENT_CREDENTIAL,
+            text: "actions:fields.authentication.types.clientCredential.name",
+            value: AuthenticationType.CLIENT_CREDENTIAL
         }
     ];
 

--- a/features/admin.connections.v1/hooks/use-get-combined-connection-list.ts
+++ b/features/admin.connections.v1/hooks/use-get-combined-connection-list.ts
@@ -16,7 +16,12 @@
  * under the License.
  */
 
+import useGetFlowExtension from "@wso2is/admin.flow-builder-core.v1/api/use-get-flow-extension";
 import { RequestErrorInterface, RequestResultInterface } from "@wso2is/admin.core.v1/hooks/use-request";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
+import { FeatureAccessConfigInterface } from "@wso2is/core/models";
 import { AuthenticatorExtensionsConfigInterface } from "@wso2is/admin.extensions.v1/configs/models";
 import {
     useGetIdentityVerificationProviderList
@@ -26,6 +31,7 @@ import {
 } from "@wso2is/admin.identity-verification-providers.v1/models/identity-verification-providers";
 import { AxiosError } from "axios";
 import get from "lodash-es/get";
+import { useSelector } from "react-redux";
 import { useGetAuthenticators } from "../api/authenticators";
 import { LocalAuthenticatorConstants } from "../constants/local-authenticator-constants";
 import { AuthenticatorMeta } from "../meta/authenticator-meta";
@@ -72,6 +78,14 @@ export const useGetCombinedConnectionList = <Data = ConnectionInterface[], Error
     shouldHideLocalSMSOTPAuthenticator: boolean = false
 ): Omit<RequestResultInterface<Data, Error>, "mutate"> & { mutate: () => void } => {
 
+    const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
+        (state: AppState) => state.config.ui.features?.actions);
+    const { isSubOrganization } = useGetCurrentOrganizationType();
+    const flowExtensionFeatureKey: string = isSubOrganization()
+        ? "actions.types.org.list.flowExtension"
+        : "actions.types.list.flowExtension";
+    const isFlowExtensionEnabled: boolean = isFeatureEnabled(actionsFeatureConfig, flowExtensionFeatureKey);
+
     const {
         data: fetchedAuthenticatorsList,
         isLoading: isAuthenticatorsFetchRequestLoading,
@@ -105,9 +119,18 @@ export const useGetCombinedConnectionList = <Data = ConnectionInterface[], Error
         shouldFetchIdVPs && shouldFilterIdVPs()
     );
 
+    const {
+        data: fetchedFlowExtension,
+        isLoading: isFlowExtensionFetchRequestLoading,
+        isValidating: isFlowExtensionFetchRequestValidating,
+        error: flowExtensionFetchRequestError,
+        mutate: mutateFlowExtensionFetchRequest
+    } = useGetFlowExtension(isFlowExtensionEnabled && shouldFetchAuthenticators && offset === 0);
+
     const combinedData: ConnectionInterface[] = [];
 
-    if (!isAuthenticatorsFetchRequestLoading && !isIdVPListFetchRequestLoading) {
+    if (!isAuthenticatorsFetchRequestLoading && !isIdVPListFetchRequestLoading
+        && !isFlowExtensionFetchRequestLoading) {
 
         // Add Local Authenticators to the beginning of the list.
         for (const authenticator of fetchedAuthenticatorsList) {
@@ -167,19 +190,37 @@ export const useGetCombinedConnectionList = <Data = ConnectionInterface[], Error
                 } as ConnectionInterface);
             }
         }
+
+        // Add Flow Extension to the list.
+        if (fetchedFlowExtension?.length) {
+            for (const extension of fetchedFlowExtension) {
+                combinedData.push({
+                    description: extension.description,
+                    id: extension.id,
+                    image: extension.iconUrl || AuthenticatorMeta.getFlowExtensionIcon(),
+                    name: extension.name,
+                    tags: [ "Custom" ],
+                    type: "FLOW_EXTENSION" as ConnectionTypes
+                } as ConnectionInterface);
+            }
+        }
     }
 
     return {
         data: combinedData as Data,
         error: authenticatorsFetchRequestError as AxiosError<Error>
-            || idVPListFetchRequestError as AxiosError<Error>,
+            || idVPListFetchRequestError as AxiosError<Error>
+            || flowExtensionFetchRequestError as AxiosError<Error>,
         isLoading: isAuthenticatorsFetchRequestLoading
-            || isIdVPListFetchRequestLoading,
+            || isIdVPListFetchRequestLoading
+            || isFlowExtensionFetchRequestLoading,
         isValidating: isAuthenticatorsFetchRequestValidating
-            || isIdVPListFetchRequestValidating,
+            || isIdVPListFetchRequestValidating
+            || isFlowExtensionFetchRequestValidating,
         mutate: () => {
             mutateAuthenticatorsFetchRequest();
             mutateIdVPListFetchRequest();
+            mutateFlowExtensionFetchRequest();
         }
     };
 };

--- a/features/admin.connections.v1/meta/authenticator-meta.ts
+++ b/features/admin.connections.v1/meta/authenticator-meta.ts
@@ -290,6 +290,15 @@ export class AuthenticatorMeta {
     }
 
     /**
+     * Get Flow Extension icon.
+     *
+     * @returns Flow Extension Icon.
+     */
+    public static getFlowExtensionIcon(): string {
+        return getConnectionIcons()?.flowExtension;
+    }
+
+    /**
      * Get Authenticator Type display name.
      *
      * @param authenticatorId - Authenticator ID.

--- a/features/admin.connections.v1/meta/templates-meta/groups/flow-extension.json
+++ b/features/admin.connections.v1/meta/templates-meta/groups/flow-extension.json
@@ -1,0 +1,15 @@
+{
+    "category": "DEFAULT",
+    "description": "Extend authentication flows with external services.",
+    "enabled": true,
+    "displayOrder": 13,
+    "id": "flow-extension",
+    "docLink": "",
+    "image": "assets/images/logos/flow-extension.svg",
+    "name": "Flow Extension",
+    "services": [],
+    "disabled": false,
+    "type": "DEFAULT",
+    "tags": [ "Custom" ],
+    "templateId": "flow-extension"
+}

--- a/features/admin.connections.v1/models/connection.ts
+++ b/features/admin.connections.v1/models/connection.ts
@@ -956,7 +956,8 @@ export interface AuthenticationTypeDropdownOption {
  */
 export enum ConnectionTypes {
     CONNECTION = "connections",
-    IDVP = "identity-verification-providers"
+    IDVP = "identity-verification-providers",
+    FLOW_EXTENSION = "FLOW_EXTENSION"
 }
 
 /**
@@ -986,11 +987,19 @@ export interface WizardStepInterface {
     icon: any;
     title: string;
     submitCallback: any;
-    name: WizardStepsCustomAuth;
+    name: WizardStepsCustomAuth | WizardStepsFlowExtension;
 }
 
 export type AvailableCustomAuthenticators = "external" | "internal" | "two-factor";
 export type FormErrors = { [key: string]: string };
+
+/**
+ * Enum for the steps of the flow extension create wizard.
+ */
+export enum WizardStepsFlowExtension {
+    GENERAL_SETTINGS = "General Settings",
+    ENDPOINT_CONFIG = "Endpoint Configuration"
+}
 
 /**
  * Enum for the custom local authentication types.

--- a/features/admin.connections.v1/pages/connection-templates.tsx
+++ b/features/admin.connections.v1/pages/connection-templates.tsx
@@ -29,11 +29,13 @@ import { RequestErrorInterface } from "@wso2is/admin.core.v1/hooks/use-request";
 import useUIConfig from "@wso2is/admin.core.v1/hooks/use-ui-configs";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { EventPublisher } from "@wso2is/admin.core.v1/utils/event-publisher";
+import FeatureFlagLabel from "@wso2is/admin.feature-gate.v1/components/feature-flag-label";
+import FeatureFlagConstants from "@wso2is/admin.feature-gate.v1/constants/feature-flag-constants";
 import { FeatureStatusLabel } from "@wso2is/admin.feature-gate.v1/models/feature-status";
 import {
     useGetIdVPTemplateList
 } from "@wso2is/admin.identity-verification-providers.v1/api/use-get-idvp-template-list";
-import { IdentifiableComponentInterface } from "@wso2is/core/models";
+import { FeatureFlagsInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
 import {
     DocumentationLink,
     EmptyPlaceholder,
@@ -95,6 +97,8 @@ const ConnectionTemplatesPage: FC<ConnectionTemplatePagePropsInterface> = (
     const idVPFeatureConfig: FeatureAccessConfigInterface = UIConfig?.features?.identityVerificationProviders;
     const isIdVPFeatureEnabled: boolean = idVPFeatureConfig?.enabled;
     const hasIdVPCreatePermissions: boolean = useRequiredScopes(idVPFeatureConfig?.scopes?.create);
+    const identityProvidersFeatureFlags: FeatureFlagsInterface[] = useSelector(
+        (state: AppState) => state?.config?.ui?.features?.identityProviders?.featureFlags);
 
     // External connection resources URL from the UI config.
     const connectionResourcesUrl: string = UIConfig?.connectionResourcesUrl;
@@ -423,6 +427,20 @@ const ConnectionTemplatesPage: FC<ConnectionTemplatePagePropsInterface> = (
                                     "authenticationProviderTemplate.disabledHint.apple");
                             }
 
+                            const templateFeatureFlagKey: string = template.id === CommonAuthenticatorConstants
+                                .CONNECTION_TEMPLATE_IDS.FLOW_EXTENSION
+                                ? FeatureFlagConstants.FEATURE_FLAG_KEY_MAP.CONNECTIONS_FLOW_EXTENSION
+                                : null;
+                            const templateRibbon: ReactNode = templateFeatureFlagKey && !template.comingSoon
+                                ? (
+                                    <FeatureFlagLabel
+                                        featureFlags={ identityProvidersFeatureFlags }
+                                        featureKey={ templateFeatureFlagKey }
+                                        type="ribbon"
+                                    />
+                                )
+                                : undefined;
+
                             return (
                                 <ResourceGrid.Card
                                     key={ templateIndex }
@@ -433,6 +451,7 @@ const ConnectionTemplatesPage: FC<ConnectionTemplatePagePropsInterface> = (
                                     disabled={ isTemplateDisabled }
                                     disabledHint={ disabledHint }
                                     comingSoonRibbonLabel={ t(FeatureStatusLabel.COMING_SOON) }
+                                    ribbon={ templateRibbon }
                                     resourceDescription={
                                         template?.description
                                             ?.replaceAll("{{productName}}", productName)

--- a/features/admin.connections.v1/pages/flow-extension-edit-page.tsx
+++ b/features/admin.connections.v1/pages/flow-extension-edit-page.tsx
@@ -1,0 +1,259 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useRequiredScopes } from "@wso2is/access-control";
+import useGetFlowExtensionById from "@wso2is/admin.flow-builder-core.v1/api/use-get-flow-extension-by-id";
+import { FlowExtensionResponseInterface } from "@wso2is/admin.flow-builder-core.v1/models/flow-extension";
+import { AppConstants } from "@wso2is/admin.core.v1/constants/app-constants";
+import { history } from "@wso2is/admin.core.v1/helpers/history";
+import { FeatureConfigInterface } from "@wso2is/admin.core.v1/models/config";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import { FeatureAccessConfigInterface, AlertLevels, IdentifiableComponentInterface } from "@wso2is/core/models";
+import { isFeatureEnabled } from "@wso2is/core/helpers";
+import { addAlert } from "@wso2is/core/store";
+import {
+    AnimatedAvatar,
+    AppAvatar,
+    ContentLoader,
+    EmphasizedSegment,
+    ResourceTab,
+    ResourceTabPaneInterface,
+    TabPageLayout
+} from "@wso2is/react-components";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch, useSelector } from "react-redux";
+import { RouteComponentProps } from "react-router";
+import { Dispatch } from "redux";
+import { TabProps } from "semantic-ui-react";
+import { FlowExtensionAccessConfigSettings } from
+    "../components/edit/settings/flow-extension-access-config-settings";
+import { FlowExtensionCustomErrors } from
+    "../components/edit/settings/flow-extension-custom-errors";
+import { FlowExtensionEndpointSettings } from "../components/edit/settings/flow-extension-endpoint-settings";
+import { FlowExtensionGeneralSettings } from "../components/edit/settings/flow-extension-general-settings";
+import { AuthenticatorMeta } from "../meta/authenticator-meta";
+
+type FlowExtensionEditPagePropsInterface = IdentifiableComponentInterface & RouteComponentProps;
+
+const FlowExtensionEditPage: FunctionComponent<FlowExtensionEditPagePropsInterface> = ({
+    location,
+    ["data-componentid"]: componentId = "flow-extension-edit-page"
+}: FlowExtensionEditPagePropsInterface): ReactElement => {
+
+    const { t } = useTranslation();
+    const dispatch: Dispatch = useDispatch();
+
+    const featureConfig: FeatureConfigInterface = useSelector((state: AppState) => state.config.ui.features);
+    const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
+        (state: AppState) => state.config.ui.features?.actions);
+    const isReadOnly: boolean = !useRequiredScopes(featureConfig?.identityProviders?.scopes?.update);
+    const isCustomErrorsEnabled: boolean = isFeatureEnabled(
+        actionsFeatureConfig, "actions.types.list.flowExtension.customErrors");
+
+    const [ defaultActiveIndex, setDefaultActiveIndex ] = useState<number>(0);
+
+    const getActionId = (pathname: string): string => {
+        const parts: string[] = pathname.split("/");
+
+        return parts[parts.length - 1];
+    };
+
+    const actionId: string = getActionId(location.pathname);
+
+    const {
+        data: action,
+        error: actionFetchError,
+        isLoading: isActionLoading,
+        mutate: mutateAction
+    } = useGetFlowExtensionById<FlowExtensionResponseInterface>(actionId);
+
+    useEffect(() => {
+        if (actionFetchError) {
+            dispatch(addAlert({
+                description: actionFetchError?.response?.data?.description
+                    ?? t("flowExtension:notifications.fetchError.description"),
+                level: AlertLevels.ERROR,
+                message: t("flowExtension:notifications.fetchError.message")
+            }));
+        }
+    }, [ actionFetchError ]);
+
+    const handleBackButtonClick = (): void => {
+        history.push(AppConstants.getPaths().get("IDP"));
+    };
+
+    const handleDelete = (): void => {
+        history.push(AppConstants.getPaths().get("IDP"));
+    };
+
+    const handleUpdate = (): void => {
+        mutateAction();
+    };
+
+    const Loader = (): ReactElement => (
+        <EmphasizedSegment padded>
+            <ContentLoader inline="centered" active />
+        </EmphasizedSegment>
+    );
+
+    const resolveImage = (): ReactElement => {
+        if (action?.name) {
+            return (
+                <AppAvatar
+                    hoverable={ false }
+                    name={ action.name }
+                    image={ action.iconUrl || AuthenticatorMeta.getFlowExtensionIcon() }
+                    size="tiny"
+                />
+            );
+        }
+
+        return (
+            <AnimatedAvatar
+                hoverable={ false }
+                name={ action?.name ?? "" }
+                size="tiny"
+                floated="left"
+            />
+        );
+    };
+
+    const GeneralSettingsTabPane = (): ReactElement => (
+        <ResourceTab.Pane controlledSegmentation>
+            <FlowExtensionGeneralSettings
+                action={ action }
+                isLoading={ isActionLoading }
+                isReadOnly={ isReadOnly }
+                onDelete={ handleDelete }
+                onUpdate={ handleUpdate }
+                loader={ Loader }
+                data-componentid={ `${componentId}-general-settings` }
+            />
+        </ResourceTab.Pane>
+    );
+
+    const EndpointSettingsTabPane = (): ReactElement => (
+        <ResourceTab.Pane controlledSegmentation>
+            <FlowExtensionEndpointSettings
+                action={ action }
+                isLoading={ isActionLoading }
+                isReadOnly={ isReadOnly }
+                onUpdate={ handleUpdate }
+                loader={ Loader }
+                data-componentid={ `${componentId}-endpoint-settings` }
+            />
+        </ResourceTab.Pane>
+    );
+
+    const AccessConfigTabPane = (): ReactElement => (
+        <ResourceTab.Pane controlledSegmentation>
+            <FlowExtensionAccessConfigSettings
+                action={ action }
+                isLoading={ isActionLoading }
+                isReadOnly={ isReadOnly }
+                onUpdate={ handleUpdate }
+                loader={ Loader }
+                data-componentid={ `${componentId}-access-config-settings` }
+            />
+        </ResourceTab.Pane>
+    );
+
+    const CustomErrorsTabPane = (): ReactElement => (
+        <ResourceTab.Pane controlledSegmentation>
+            <FlowExtensionCustomErrors
+                action={ action }
+                isLoading={ isActionLoading }
+                isReadOnly={ isReadOnly }
+                loader={ Loader }
+                data-componentid={ `${componentId}-custom-errors` }
+            />
+        </ResourceTab.Pane>
+    );
+
+    const getPanes = (): ResourceTabPaneInterface[] => {
+        const panes: ResourceTabPaneInterface[] = [];
+
+        panes.push({
+            "data-tabid": "general",
+            menuItem: "General",
+            render: GeneralSettingsTabPane
+        });
+
+        panes.push({
+            "data-tabid": "settings",
+            menuItem: "Settings",
+            render: EndpointSettingsTabPane
+        });
+
+        panes.push({
+            "data-tabid": "access-configuration",
+            menuItem: "Access Configuration",
+            render: AccessConfigTabPane
+        });
+
+        if (isCustomErrorsEnabled) {
+            panes.push({
+                "data-tabid": "custom-errors",
+                menuItem: "Custom Errors",
+                render: CustomErrorsTabPane
+            });
+        }
+
+        return panes;
+    };
+
+    return (
+        <TabPageLayout
+            pageTitle="Edit Flow Extension"
+            isLoading={ isActionLoading }
+            loadingStateOptions={ {
+                count: 5,
+                imageType: "square"
+            } }
+            title={ action?.name ?? "" }
+            contentTopMargin={ true }
+            description={ action?.description ?? "" }
+            image={ resolveImage() }
+            backButton={ {
+                "data-componentid": `${componentId}-back-button`,
+                onClick: handleBackButtonClick,
+                text: t("console:develop.pages.authenticationProviderTemplate.backButton")
+            } }
+            titleTextAlign="left"
+            bottomMargin={ false }
+            data-componentid={ `${componentId}-layout` }
+        >
+            <ResourceTab
+                controlTabRedirectionInternally
+                isLoading={ isActionLoading }
+                data-componentid={ `${componentId}-resource-tabs` }
+                panes={ getPanes() }
+                defaultActiveIndex={ defaultActiveIndex }
+                onTabChange={ (
+                    _e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+                    data: TabProps
+                ) => {
+                    setDefaultActiveIndex(data.activeIndex as number);
+                } }
+            />
+        </TabPageLayout>
+    );
+};
+
+export default FlowExtensionEditPage;

--- a/features/admin.connections.v1/resources/assets/images/icons/flow-extension.svg
+++ b/features/admin.connections.v1/resources/assets/images/icons/flow-extension.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="15 5 180 190" width="100%" height="100%">
+  <rect width="100%" height="100%" fill="transparent" />
+
+  <g stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+    
+    <polyline points="45,145 75,90 115,90 145,35" fill="none" stroke-width="8" />
+    
+    <circle cx="45" cy="145" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="75" cy="90" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="115" cy="90" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="145" cy="35" r="14" fill="#f0f0f0" stroke-width="8" />
+
+
+    <g transform="translate(125, 125) rotate(-45)">
+      
+      <rect x="-60" y="-26" width="120" height="52" rx="26" fill="transparent" stroke="none" />
+
+      <rect x="-50" y="-16" width="64" height="32" rx="16" fill="none" stroke-width="8" />
+
+      <rect x="-14" y="-16" width="64" height="32" rx="16" fill="none" stroke="#f0f0f0" stroke-width="20" />
+      <rect x="-14" y="-16" width="64" height="32" rx="16" fill="none" stroke-width="8" />
+
+      <path d="M -18 16 H -2 A 16 16 0 0 0 14 0" fill="none" stroke="#f0f0f0" stroke-width="20" />
+      <path d="M -18 16 H -2 A 16 16 0 0 0 14 0" fill="none" stroke-width="8" />
+
+    </g>
+  </g>
+</svg>

--- a/features/admin.connections.v1/utils/flow-extension-utils.ts
+++ b/features/admin.connections.v1/utils/flow-extension-utils.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The i18n key prefix for flow extension error messages.
+ */
+const FLOW_EXTENSION_KEY_PREFIX: string = "flow.extension.";
+
+/**
+ * The branding screen name for flow extension custom text.
+ */
+export const FLOW_EXTENSION_SCREEN: string = "flow-extension";
+
+/**
+ * Sanitize a connection name to be used as a segment in i18n keys.
+ * Converts to lowercase, replaces non-alphanumeric characters with dots,
+ * collapses consecutive dots, and trims leading/trailing dots.
+ *
+ * This mirrors the Java `FlowExtensionExecutor.sanitizeConnectionName()`.
+ *
+ * @param name - The display name of the connection.
+ * @returns The sanitized dot-separated lowercase name.
+ */
+const sanitizeConnectionName = (name: string | null | undefined): string => {
+
+    if (!name) {
+        return "";
+    }
+
+    return name
+        .toLowerCase()
+        .replace(/[^a-z0-9]/g, ".")
+        .replace(/\.{2,}/g, ".")
+        .replace(/^\.+|\.+$/g, "");
+};
+
+/**
+ * Build the full i18n key prefix for a specific connection.
+ *
+ * @param connectionName - The display name of the connection.
+ * @returns The prefix string, e.g. "flow.extension.risk.assessment.extension."
+ */
+export const getConnectionKeyPrefix = (connectionName: string): string => {
+
+    const sanitized: string = sanitizeConnectionName(connectionName);
+
+    return `${FLOW_EXTENSION_KEY_PREFIX}${sanitized}.`;
+};

--- a/features/admin.core.v1/store/reducers/config.ts
+++ b/features/admin.core.v1/store/reducers/config.ts
@@ -144,6 +144,8 @@ export const commonConfigReducerInitialState: CommonConfigReducerStateInterface<
             guestsList: "",
             identityProviders: "",
             impersonationConfigurations: "",
+            flowExtensionContextTree: "",
+            flowExtension: "",
             issuerUsageScope: "",
             localAuthenticators: "",
             localClaims: "",

--- a/features/admin.feature-gate.v1/constants/feature-flag-constants.ts
+++ b/features/admin.feature-gate.v1/constants/feature-flag-constants.ts
@@ -54,6 +54,7 @@ class FeatureFlagConstants {
         BRANDING_STYLES_AND_TEXT_TITLE: "branding.stylesAndText.application.title",
         CONNECTIONS_CUSTOM_AUTHENTICATOR: "console.connections.templates.customAuthenticator",
         CONNECTIONS_ENTERPRISE: "console.connections.templates.enterprise",
+        CONNECTIONS_FLOW_EXTENSION: "console.connections.templates.flowExtension",
         CONNECTIONS_IDVP: "console.connections.templates.idvp",
         CONSOLE_SETTINGS: "console.consoleSettings",
         CUSTOMER_DATA_PROFILES: "customerDataProfiles",

--- a/features/common.ui.shared-access.v1/components/flow-context-tree/add-claim-modal.tsx
+++ b/features/common.ui.shared-access.v1/components/flow-context-tree/add-claim-modal.tsx
@@ -1,0 +1,469 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Box from "@oxygen-ui/react/Box";
+import Button from "@oxygen-ui/react/Button";
+import CircularProgress from "@oxygen-ui/react/CircularProgress";
+import Dialog from "@oxygen-ui/react/Dialog";
+import DialogActions from "@oxygen-ui/react/DialogActions";
+import DialogContent from "@oxygen-ui/react/DialogContent";
+import DialogTitle from "@oxygen-ui/react/DialogTitle";
+import Divider from "@oxygen-ui/react/Divider";
+import IconButton from "@oxygen-ui/react/IconButton";
+import InputAdornment from "@oxygen-ui/react/InputAdornment";
+import TextField from "@oxygen-ui/react/TextField";
+import Tooltip from "@oxygen-ui/react/Tooltip";
+import Typography from "@oxygen-ui/react/Typography";
+import { getAllLocalClaims } from "@wso2is/admin.claims.v1/api";
+import { IdentityAppsApiException } from "@wso2is/core/exceptions";
+import { AlertLevels, Claim, ClaimsGetParams } from "@wso2is/core/models";
+import { addAlert } from "@wso2is/core/store";
+import React, {
+    FunctionComponent,
+    ReactElement,
+    useEffect,
+    useMemo,
+    useState
+} from "react";
+import { useDispatch } from "react-redux";
+import { Dispatch } from "redux";
+import { TreeNodeState } from "./models";
+
+const EXPOSE_COLOR: string = "var(--tree-expose, #2E7D32)";
+const EXPOSE_FAINT_RGBA: string = "rgba(46, 125, 50, 0.06)";
+const EXPOSE_FAINT_RGBA_HOVER: string = "rgba(46, 125, 50, 0.1)";
+const EXPOSE_FAINT_RGBA_SELECTED_HOVER: string = "rgba(46, 125, 50, 0.08)";
+
+const PlusIcon = (): ReactElement => (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <line x1="12" y1="5" x2="12" y2="19" />
+        <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+);
+
+const MinusIcon = (): ReactElement => (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+);
+
+const CloseIcon = (): ReactElement => (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <line x1="18" y1="6" x2="6" y2="18" />
+        <line x1="6" y1="6" x2="18" y2="18" />
+    </svg>
+);
+
+interface AddClaimModalProps {
+    open: boolean;
+    parentNode: TreeNodeState | null;
+    existingClaimURIs: string[];
+    externalClaims?: Claim[];
+    /**
+     * Whether the active flow type permits MODIFY on read-only claims. Drives the
+     * informational badge per claim row. Defaults to true.
+     */
+    allowReadOnlyClaimsModification?: boolean;
+    onClose: () => void;
+    onSubmit: (claims: Claim[]) => void;
+    "data-componentid"?: string;
+}
+
+const AddClaimModal: FunctionComponent<AddClaimModalProps> = ({
+    open,
+    parentNode: _parentNode,
+    existingClaimURIs,
+    externalClaims,
+    allowReadOnlyClaimsModification = true,
+    onClose,
+    onSubmit,
+    "data-componentid": componentId = "add-claim-modal"
+}: AddClaimModalProps): ReactElement => {
+
+    const [ allClaims, setAllClaims ] = useState<Claim[]>([]);
+    const [ selectedClaims, setSelectedClaims ] = useState<Claim[]>([]);
+    const [ isLoading, setIsLoading ] = useState<boolean>(false);
+    const [ searchTerm, setSearchTerm ] = useState<string>("");
+
+    const dispatch: Dispatch = useDispatch();
+
+    useEffect(() => {
+        if (!open) return;
+
+        if (externalClaims && externalClaims.length > 0) {
+            setAllClaims(externalClaims);
+
+            return;
+        }
+
+        const params: ClaimsGetParams = {
+            "exclude-hidden-claims": true,
+            "exclude-identity-claims": true,
+            filter: null,
+            limit: null,
+            offset: null,
+            sort: null
+        };
+
+        setIsLoading(true);
+        getAllLocalClaims(params)
+            .then((response: Claim[]) => {
+                const sorted: Claim[] = (response || []).sort((a: Claim, b: Claim) =>
+                    (a.displayName || "").localeCompare(b.displayName || "")
+                );
+
+                setAllClaims(sorted);
+            })
+            .catch((error: IdentityAppsApiException) => {
+                dispatch(addAlert({
+                    description: error?.response?.data?.description
+                        || "Failed to retrieve local claims.",
+                    level: AlertLevels.ERROR,
+                    message: error?.response?.data?.message
+                        || "Error fetching claims"
+                }));
+            })
+            .finally(() => setIsLoading(false));
+    }, [ open ]);
+
+    useEffect(() => {
+        if (open) {
+            setSelectedClaims([]);
+            setSearchTerm("");
+        }
+    }, [ open ]);
+
+    const selectedURIs: Set<string> = useMemo(
+        () => new Set(selectedClaims.map((c: Claim) => c.claimURI)),
+        [ selectedClaims ]
+    );
+
+    const availableClaims: Claim[] = useMemo(
+        () => allClaims.filter((c: Claim) => !existingClaimURIs.includes(c.claimURI)),
+        [ allClaims, existingClaimURIs ]
+    );
+
+    const filteredClaims: Claim[] = useMemo(() => {
+        if (!searchTerm.trim()) return availableClaims;
+
+        const term: string = searchTerm.toLowerCase();
+
+        return availableClaims.filter(
+            (c: Claim) =>
+                (c.displayName || "").toLowerCase().includes(term) ||
+                (c.claimURI || "").toLowerCase().includes(term)
+        );
+    }, [ availableClaims, searchTerm ]);
+
+    const handleToggleClaim = (claim: Claim): void => {
+        if (selectedURIs.has(claim.claimURI)) {
+            setSelectedClaims((prev: Claim[]) =>
+                prev.filter((c: Claim) => c.claimURI !== claim.claimURI)
+            );
+        } else {
+            setSelectedClaims((prev: Claim[]) => [ ...prev, claim ]);
+        }
+    };
+
+    const handleRemoveFromBulk = (claimURI: string): void => {
+        setSelectedClaims((prev: Claim[]) =>
+            prev.filter((c: Claim) => c.claimURI !== claimURI)
+        );
+    };
+
+    const handleSubmit = (): void => {
+        if (selectedClaims.length === 0) return;
+        onSubmit(selectedClaims);
+    };
+
+    const handleClose = (): void => {
+        setSelectedClaims([]);
+        setSearchTerm("");
+        onClose();
+    };
+
+    return (
+        <Dialog
+            open={ open }
+            onClose={ handleClose }
+            maxWidth="sm"
+            fullWidth
+            data-componentid={ componentId }
+            PaperProps={ {
+                sx: { border: "1px solid", borderColor: "grey.200", borderRadius: "10px" }
+            } }
+        >
+            <DialogTitle sx={ { pb: 0.5 } }>
+                <Typography variant="subtitle2" sx={ { fontWeight: 600 } }>
+                    Add Claims
+                </Typography>
+                <Typography variant="caption" color="text.disabled">
+                    Search and select claims to add to the claims map.
+                </Typography>
+            </DialogTitle>
+            <DialogContent sx={ { pt: "12px !important" } }>
+                <TextField
+                    fullWidth
+                    size="small"
+                    value={ searchTerm }
+                    onChange={ (e: React.ChangeEvent<HTMLInputElement>) =>
+                        setSearchTerm(e.target.value)
+                    }
+                    placeholder="Search claims by name or URI..."
+                    InputProps={ {
+                        startAdornment: (
+                            <InputAdornment position="start" sx={ { ml: 0.5, opacity: 0.45 } }>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                                    stroke="currentColor" strokeWidth="2"
+                                    strokeLinecap="round" strokeLinejoin="round">
+                                    <circle cx="11" cy="11" r="8" />
+                                    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                                </svg>
+                            </InputAdornment>
+                        )
+                    } }
+                    sx={ {
+                        "& .MuiOutlinedInput-root": {
+                            borderRadius: "7px"
+                        }
+                    } }
+                    data-componentid={ `${componentId}-search` }
+                />
+
+                <Box sx={ {
+                    border: "1px solid",
+                    borderColor: "grey.200",
+                    borderRadius: "8px",
+                    maxHeight: 260,
+                    minHeight: 100,
+                    mt: 1.5,
+                    overflowY: "auto",
+                    scrollbarColor: "#adb2b6 #f1f1f1",
+                    scrollbarWidth: "thin"
+                } }>
+                    { isLoading && (
+                        <Box sx={ { display: "flex", justifyContent: "center", py: 4 } }>
+                            <CircularProgress size={ 24 } />
+                        </Box>
+                    ) }
+                    { !isLoading && filteredClaims.length === 0 && (
+                        <Typography
+                            variant="caption"
+                            color="text.disabled"
+                            sx={ { display: "block", py: 4, textAlign: "center" } }
+                        >
+                            { searchTerm ? "No claims match your search." : "No claims available." }
+                        </Typography>
+                    ) }
+                    { !isLoading && filteredClaims.map((claim: Claim) => {
+                        const isSelected: boolean = selectedURIs.has(claim.claimURI);
+
+                        return (
+                            <Box
+                                key={ claim.id || claim.claimURI }
+                                sx={ {
+                                    "&:hover": {
+                                        bgcolor: isSelected ? EXPOSE_FAINT_RGBA_SELECTED_HOVER : "grey.50"
+                                    },
+                                    alignItems: "center",
+                                    bgcolor: isSelected ? EXPOSE_FAINT_RGBA : "transparent",
+                                    borderBottom: "1px solid",
+                                    borderColor: "grey.100",
+                                    display: "flex",
+                                    gap: 1,
+                                    justifyContent: "space-between",
+                                    px: 1.5,
+                                    py: 0.7
+                                } }
+                            >
+                                <Box sx={ { minWidth: 0, overflow: "hidden" } }>
+                                    <Box sx={ { alignItems: "center", display: "flex", gap: 0.8 } }>
+                                        <Typography
+                                            variant="body2"
+                                            sx={ { fontWeight: 500 } }
+                                        >
+                                            { claim.displayName }
+                                        </Typography>
+                                        { claim.readOnly && !allowReadOnlyClaimsModification && (
+                                            <Typography
+                                                variant="caption"
+                                                sx={ {
+                                                    bgcolor: "grey.100",
+                                                    borderRadius: "3px",
+                                                    color: "text.disabled",
+                                                    fontWeight: 600,
+                                                    lineHeight: 1,
+                                                    px: "4px",
+                                                    py: "2px"
+                                                } }
+                                            >
+                                                Read-only
+                                            </Typography>
+                                        ) }
+                                    </Box>
+                                    <Typography
+                                        variant="caption"
+                                        color="text.disabled"
+                                        sx={ {
+                                            display: "block",
+                                            fontFamily: "'JetBrains Mono', monospace",
+                                            overflow: "hidden",
+                                            textOverflow: "ellipsis",
+                                            whiteSpace: "nowrap"
+                                        } }
+                                    >
+                                        { claim.claimURI }
+                                    </Typography>
+                                </Box>
+                                <Tooltip title={ isSelected ? "Remove" : "Add" } placement="top">
+                                    <IconButton
+                                        size="small"
+                                        onClick={ () => handleToggleClaim(claim) }
+                                        sx={ {
+                                            "&:hover": {
+                                                bgcolor: isSelected
+                                                    ? "rgba(192,57,43,0.08)" : EXPOSE_FAINT_RGBA_HOVER,
+                                                color: isSelected ? "error.main" : EXPOSE_COLOR
+                                            },
+                                            color: isSelected ? "error.light" : "grey.400",
+                                            flexShrink: 0,
+                                            p: "4px"
+                                        } }
+                                    >
+                                        { isSelected ? <MinusIcon /> : <PlusIcon /> }
+                                    </IconButton>
+                                </Tooltip>
+                            </Box>
+                        );
+                    }) }
+                </Box>
+
+                { selectedClaims.length > 0 && (
+                    <Box sx={ { mt: 2 } }>
+                        <Box sx={ {
+                            alignItems: "center",
+                            display: "flex",
+                            justifyContent: "space-between",
+                            mb: 0.8
+                        } }>
+                            <Typography
+                                variant="subtitle2"
+                                color="text.secondary"
+                                sx={ { display: "block", fontWeight: 600 } }
+                            >
+                                To be added ({ selectedClaims.length })
+                            </Typography>
+                            <Button
+                                size="small"
+                                variant="text"
+                                onClick={ () => setSelectedClaims([]) }
+                                sx={ { color: "text.disabled", minWidth: 0 } }
+                            >
+                                Clear All
+                            </Button>
+                        </Box>
+                        <Box sx={ {
+                            border: "1px solid",
+                            borderColor: "grey.200",
+                            borderRadius: "8px",
+                            maxHeight: 150,
+                            overflowY: "auto",
+                            scrollbarColor: "#adb2b6 #f1f1f1",
+                            scrollbarWidth: "thin"
+                        } }>
+                            { selectedClaims.map((claim: Claim) => (
+                                <Box
+                                    key={ claim.claimURI }
+                                    sx={ {
+                                        "&:hover": { bgcolor: "grey.50" },
+                                        alignItems: "center",
+                                        borderBottom: "1px solid",
+                                        borderColor: "grey.100",
+                                        display: "flex",
+                                        gap: 1,
+                                        justifyContent: "space-between",
+                                        px: 1.5,
+                                        py: 0.6
+                                    } }
+                                >
+                                    <Box sx={ { minWidth: 0, overflow: "hidden" } }>
+                                        <Typography variant="body2" sx={ { fontWeight: 500 } }>
+                                            { claim.displayName }
+                                        </Typography>
+                                        <Typography
+                                            variant="caption"
+                                            color="text.disabled"
+                                            sx={ {
+                                                display: "block",
+                                                fontFamily: "'JetBrains Mono', monospace",
+                                                overflow: "hidden",
+                                                textOverflow: "ellipsis",
+                                                whiteSpace: "nowrap"
+                                            } }
+                                        >
+                                            { claim.claimURI }
+                                        </Typography>
+                                    </Box>
+                                    <Tooltip title="Remove" placement="top">
+                                        <IconButton
+                                            size="small"
+                                            onClick={ () => handleRemoveFromBulk(claim.claimURI) }
+                                            sx={ {
+                                                "&:hover": { color: "error.main" },
+                                                color: "grey.400",
+                                                flexShrink: 0,
+                                                p: "3px"
+                                            } }
+                                        >
+                                            <CloseIcon />
+                                        </IconButton>
+                                    </Tooltip>
+                                </Box>
+                            )) }
+                        </Box>
+                    </Box>
+                ) }
+            </DialogContent>
+            <Divider sx={ { borderColor: "grey.100" } } />
+            <DialogActions sx={ { gap: 1, px: 2.5, py: 1.5 } }>
+                <Button
+                    onClick={ handleClose }
+                    variant="outlined"
+                    size="small"
+                    data-componentid={ `${componentId}-cancel-button` }
+                >
+                    Cancel
+                </Button>
+                <Button
+                    onClick={ handleSubmit }
+                    variant="contained"
+                    size="small"
+                    disabled={ selectedClaims.length === 0 }
+                    data-componentid={ `${componentId}-submit-button` }
+                >
+                    Add Claims{ selectedClaims.length > 0 ? ` (${selectedClaims.length})` : "" }
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default AddClaimModal;

--- a/features/common.ui.shared-access.v1/components/flow-context-tree/add-entry-modal.tsx
+++ b/features/common.ui.shared-access.v1/components/flow-context-tree/add-entry-modal.tsx
@@ -1,0 +1,576 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Box from "@oxygen-ui/react/Box";
+import Button from "@oxygen-ui/react/Button";
+import Dialog from "@oxygen-ui/react/Dialog";
+import DialogActions from "@oxygen-ui/react/DialogActions";
+import DialogContent from "@oxygen-ui/react/DialogContent";
+import DialogTitle from "@oxygen-ui/react/DialogTitle";
+import Divider from "@oxygen-ui/react/Divider";
+import FormControlLabel from "@oxygen-ui/react/FormControlLabel";
+import IconButton from "@oxygen-ui/react/IconButton";
+import MenuItem from "@oxygen-ui/react/MenuItem";
+import Select, { SelectChangeEvent } from "@oxygen-ui/react/Select";
+import Switch from "@oxygen-ui/react/Switch";
+import TextField from "@oxygen-ui/react/TextField";
+import Tooltip from "@oxygen-ui/react/Tooltip";
+import Typography from "@oxygen-ui/react/Typography";
+import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import { TreeNodeState } from "./models";
+
+const FIELD_SX: Record<string, unknown> = {
+    "& .MuiOutlinedInput-root": {
+        "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+            borderColor: "rgba(0, 0, 0, 0.23)",
+            borderWidth: "1px"
+        },
+        borderRadius: "7px"
+    }
+};
+
+const SELECT_SX: Record<string, unknown> = {
+    "& .MuiOutlinedInput-root": {
+        "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+            borderColor: "rgba(0, 0, 0, 0.23)",
+            borderWidth: "1px"
+        },
+        borderRadius: "7px"
+    }
+};
+
+const PRIMARY_TYPES: string[] = [
+    "String",
+    "Integer",
+    "Boolean",
+    "Float",
+    "Double",
+    "Long",
+    "char[]"
+];
+
+interface AttributeDef {
+    name: string;
+    type: string;
+    isArray: boolean;
+}
+
+/**
+ * Parse a stored object-structure string back into the visual builder state.
+ * Inputs (no outer braces — those are added by buildAccessConfig):
+ *   ""                                   → primitive String, single
+ *   "Integer"                            → primitive Integer, single
+ *   "[Integer]"                          → primitive Integer, multivalued
+ *   "risk: String, scores: Integer[]"    → Object, single
+ *   "[risk: String, scores: Integer[]]"  → Object, multivalued
+ */
+const parseDataType = (raw: string): {
+    selectedType: string;
+    isMultiValued: boolean;
+    attributes: AttributeDef[];
+} => {
+    const empty: { selectedType: string; isMultiValued: boolean; attributes: AttributeDef[] } = {
+        attributes: [],
+        isMultiValued: false,
+        selectedType: "String"
+    };
+
+    if (!raw) return empty;
+
+    let working: string = raw.trim();
+    let isMultiValued: boolean = false;
+
+    if (working.startsWith("[") && working.endsWith("]")) {
+        isMultiValued = true;
+        working = working.slice(1, -1).trim();
+    }
+
+    if (working.includes(":")) {
+        const attrs: AttributeDef[] = working
+            .split(",")
+            .map((part: string) => part.trim())
+            .filter((part: string) => part.length > 0)
+            .map((part: string): AttributeDef | null => {
+                const [ rawName, rawType ] = part.split(":").map((s: string) => s.trim());
+
+                if (!rawName || !rawType) return null;
+
+                const isArray: boolean = rawType.endsWith("[]");
+                const type: string = isArray ? rawType.slice(0, -2).trim() : rawType;
+
+                return { isArray, name: rawName, type };
+            })
+            .filter((a: AttributeDef | null): a is AttributeDef => a !== null);
+
+        return { attributes: attrs, isMultiValued, selectedType: "Object" };
+    }
+
+    return { attributes: [], isMultiValued, selectedType: working || "String" };
+};
+
+interface AddEntryModalInitialValues {
+    keyName: string;
+    /**
+     * Raw stored data type string — same shape that `buildAccessConfig` round-trips.
+     * The modal parses this back into selectedType + isMultiValued + attributes.
+     */
+    dataType: string;
+}
+
+interface AddEntryModalProps {
+    open: boolean;
+    parentNode: TreeNodeState | null;
+    /** "create" (default) opens an empty form; "edit" prefills from `initialValues`. */
+    mode?: "create" | "edit";
+    initialValues?: AddEntryModalInitialValues;
+    onClose: () => void;
+    onSubmit: (entry: { keyName: string; objectStructure: string }) => void;
+    "data-componentid"?: string;
+}
+
+const AddEntryModal: FunctionComponent<AddEntryModalProps> = ({
+    open,
+    parentNode,
+    mode = "create",
+    initialValues,
+    onClose,
+    onSubmit,
+    "data-componentid": componentId = "add-entry-modal"
+}: AddEntryModalProps): ReactElement => {
+
+    const isPropertiesParent: boolean = parentNode?.path === "/properties/";
+    const isEdit: boolean = mode === "edit";
+
+    const [ keyName, setKeyName ] = useState<string>("");
+    const [ selectedType, setSelectedType ] = useState<string>("String");
+    const [ isMultiValued, setIsMultiValued ] = useState<boolean>(false);
+    const [ attributes, setAttributes ] = useState<AttributeDef[]>([]);
+    const [ attrName, setAttrName ] = useState<string>("");
+    const [ attrType, setAttrType ] = useState<string>("String");
+    const [ attrIsArray, setAttrIsArray ] = useState<boolean>(false);
+
+    // Reset / prefill state when the modal opens.
+    useEffect(() => {
+        if (!open) return;
+
+        if (isEdit && initialValues) {
+            const parsed: { selectedType: string; isMultiValued: boolean; attributes: AttributeDef[] } =
+                parseDataType(initialValues.dataType);
+
+            setKeyName(initialValues.keyName);
+            setSelectedType(parsed.selectedType);
+            setIsMultiValued(parsed.isMultiValued);
+            setAttributes(parsed.attributes);
+        } else {
+            setKeyName("");
+            setSelectedType("String");
+            setIsMultiValued(false);
+            setAttributes([]);
+        }
+        setAttrName("");
+        setAttrType("String");
+        setAttrIsArray(false);
+    }, [ open, isEdit, initialValues ]);
+
+    const isObjectSelected: boolean = selectedType === "Object";
+
+    const buildStructureString = (): string => {
+        const inner: string = attributes
+            .map((a: AttributeDef) => `${a.name}: ${a.type}${a.isArray ? "[]" : ""}`)
+            .join(", ");
+
+        return isMultiValued ? `[${inner}]` : inner;
+    };
+
+    const handleAddAttribute = (): void => {
+        const trimmed: string = attrName.trim();
+
+        if (!trimmed) return;
+        if (attributes.some((a: AttributeDef) => a.name === trimmed)) return;
+
+        setAttributes((prev: AttributeDef[]) => [
+            ...prev,
+            { isArray: attrIsArray, name: trimmed, type: attrType }
+        ]);
+        setAttrName("");
+        setAttrType("String");
+        setAttrIsArray(false);
+    };
+
+    const handleRemoveAttribute = (name: string): void => {
+        setAttributes((prev: AttributeDef[]) =>
+            prev.filter((a: AttributeDef) => a.name !== name)
+        );
+    };
+
+    const handleSubmit = (): void => {
+        if (!keyName.trim()) return;
+
+        if (!isPropertiesParent) {
+            onSubmit({ keyName: keyName.trim(), objectStructure: "" });
+
+            return;
+        }
+
+        if (isObjectSelected && attributes.length === 0) return;
+
+        let structure: string;
+
+        if (isObjectSelected) {
+            structure = buildStructureString();
+        } else if (selectedType === "String" && !isMultiValued) {
+            structure = "";
+        } else if (isMultiValued) {
+            structure = `[${selectedType}]`;
+        } else {
+            structure = selectedType;
+        }
+
+        onSubmit({
+            keyName: keyName.trim(),
+            objectStructure: structure
+        });
+    };
+
+    const handleClose = (): void => {
+        onClose();
+    };
+
+    const title: string = (() => {
+        if (isEdit) {
+            return isObjectSelected ? "Edit Complex Object Entry" : "Edit Map Entry";
+        }
+
+        return isObjectSelected ? "Add Complex Object Entry" : "Add Map Entry";
+    })();
+
+    const submitLabel: string = isEdit ? "Save Changes" : "Add Entry";
+
+    const canSubmit: boolean = isPropertiesParent && isObjectSelected
+        ? !!keyName.trim() && attributes.length > 0
+        : !!keyName.trim();
+
+    return (
+        <Dialog
+            open={ open }
+            onClose={ handleClose }
+            maxWidth="sm"
+            fullWidth
+            data-componentid={ componentId }
+            PaperProps={ {
+                sx: { border: "1px solid", borderColor: "grey.200", borderRadius: "10px" }
+            } }
+        >
+            <DialogTitle sx={ { pb: 0.5 } }>
+                <Typography variant="subtitle2" sx={ { fontWeight: 600 } }>
+                    { title }
+                </Typography>
+                <Typography variant="caption" color="text.disabled">
+                    { isObjectSelected
+                        ? "Define the key, value shape, and its attributes"
+                        : "Define the key that will be written into the map at runtime" }
+                </Typography>
+            </DialogTitle>
+            <DialogContent sx={ { pt: "12px !important" } }>
+                <Typography
+                    variant="subtitle2"
+                    color="text.secondary"
+                    sx={ { display: "block", fontWeight: 600, mb: 0.5 } }
+                >
+                    Key Name <span style={ { color: "var(--tree-danger, #C0392B)" } }>*</span>
+                </Typography>
+                <TextField
+                    fullWidth
+                    size="small"
+                    value={ keyName }
+                    onChange={ (e: React.ChangeEvent<HTMLInputElement>) => setKeyName(e.target.value) }
+                    placeholder="e.g. risk-factor"
+                    sx={ FIELD_SX }
+                    onKeyDown={ (e: React.KeyboardEvent) => {
+                        if (e.key === "Enter" && !isObjectSelected) handleSubmit();
+                    } }
+                    data-componentid={ `${componentId}-key-input` }
+                />
+
+                { isPropertiesParent && (
+                    <>
+                        <Typography
+                            variant="subtitle2"
+                            color="text.secondary"
+                            sx={ { display: "block", fontWeight: 600, mb: 0.5, mt: 1.5 } }
+                        >
+                            Data Type
+                        </Typography>
+                        <Select
+                            size="small"
+                            fullWidth
+                            value={ selectedType }
+                            onChange={ (e: SelectChangeEvent<string>) => {
+                                setSelectedType(e.target.value);
+                                if (e.target.value !== "Object") {
+                                    setAttributes([]);
+                                }
+                            } }
+                            sx={ SELECT_SX }
+                            data-componentid={ `${componentId}-type-select` }
+                        >
+                            { PRIMARY_TYPES.map((t: string) => (
+                                <MenuItem key={ t } value={ t }>
+                                    <Typography variant="body2">{ t }</Typography>
+                                </MenuItem>
+                            )) }
+                            <MenuItem key="Object" value="Object">
+                                <Typography variant="body2">Object</Typography>
+                            </MenuItem>
+                        </Select>
+
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={ isMultiValued }
+                                    onChange={ () => setIsMultiValued(!isMultiValued) }
+                                    size="small"
+                                />
+                            }
+                            label={
+                                <Typography variant="body2" sx={ { fontWeight: 500 } }>
+                                    Multivalued
+                                </Typography>
+                            }
+                            sx={ { mt: 1 } }
+                        />
+                    </>
+                ) }
+
+                { isPropertiesParent && isObjectSelected && (
+                    <>
+                        <Typography
+                            variant="subtitle2"
+                            color="text.secondary"
+                            sx={ { display: "block", fontWeight: 600, mb: 0.5, mt: 2 } }
+                        >
+                            Attributes <span style={ { color: "var(--tree-danger, #C0392B)" } }>*</span>
+                        </Typography>
+
+                        <Box sx={ {
+                            alignItems: "center",
+                            border: "1px solid",
+                            borderColor: "grey.200",
+                            borderRadius: "8px",
+                            display: "flex",
+                            gap: 1,
+                            p: 1
+                        } }>
+                            <TextField
+                                size="small"
+                                value={ attrName }
+                                onChange={ (e: React.ChangeEvent<HTMLInputElement>) =>
+                                    setAttrName(e.target.value)
+                                }
+                                placeholder="Attribute name"
+                                sx={ {
+                                    ...FIELD_SX,
+                                    flex: 1
+                                } }
+                                onKeyDown={ (e: React.KeyboardEvent) => {
+                                    if (e.key === "Enter") handleAddAttribute();
+                                } }
+                                data-componentid={ `${componentId}-attr-name-input` }
+                            />
+                            <Select
+                                size="small"
+                                value={ attrType }
+                                onChange={ (e: SelectChangeEvent<string>) =>
+                                    setAttrType(e.target.value)
+                                }
+                                sx={ {
+                                    ...SELECT_SX,
+                                    minWidth: 100
+                                } }
+                                data-componentid={ `${componentId}-attr-type-select` }
+                            >
+                                { PRIMARY_TYPES.map((t: string) => (
+                                    <MenuItem key={ t } value={ t }>
+                                        <Typography variant="body2">{ t }</Typography>
+                                    </MenuItem>
+                                )) }
+                            </Select>
+                            <Tooltip title="Array of this type" placement="top">
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            checked={ attrIsArray }
+                                            onChange={ () => setAttrIsArray(!attrIsArray) }
+                                            size="small"
+                                        />
+                                    }
+                                    label={
+                                        <Typography variant="caption" sx={ { fontWeight: 500 } }>
+                                            Multivalued
+                                        </Typography>
+                                    }
+                                    sx={ { mx: 0 } }
+                                />
+                            </Tooltip>
+                            <IconButton
+                                size="small"
+                                onClick={ handleAddAttribute }
+                                disabled={ !attrName.trim() }
+                                sx={ {
+                                    "&:hover": { bgcolor: "grey.100", color: "text.primary" },
+                                    border: "1px solid",
+                                    borderColor: "grey.200",
+                                    borderRadius: "6px",
+                                    color: attrName.trim() ? "text.secondary" : "grey.300",
+                                    p: "5px"
+                                } }
+                                data-componentid={ `${componentId}-add-attr-button` }
+                            >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                                    stroke="currentColor" strokeWidth="2"
+                                    strokeLinecap="round" strokeLinejoin="round">
+                                    <line x1="12" y1="5" x2="12" y2="19" />
+                                    <line x1="5" y1="12" x2="19" y2="12" />
+                                </svg>
+                            </IconButton>
+                        </Box>
+
+                        { attributes.length > 0 && (
+                            <Box sx={ {
+                                border: "1px solid",
+                                borderColor: "grey.200",
+                                borderRadius: "8px",
+                                maxHeight: 180,
+                                mt: 1,
+                                overflowY: "auto",
+                                scrollbarColor: "#adb2b6 #f1f1f1",
+                                scrollbarWidth: "thin"
+                            } }>
+                                { attributes.map((attr: AttributeDef) => (
+                                    <Box
+                                        key={ attr.name }
+                                        sx={ {
+                                            "&:hover": { bgcolor: "grey.50" },
+                                            alignItems: "center",
+                                            borderBottom: "1px solid",
+                                            borderColor: "grey.100",
+                                            display: "flex",
+                                            gap: 1,
+                                            justifyContent: "space-between",
+                                            px: 1.5,
+                                            py: 0.7
+                                        } }
+                                    >
+                                        <Box sx={ { alignItems: "center", display: "flex", gap: 1 } }>
+                                            <Typography variant="body2" sx={ { fontWeight: 500 } }>
+                                                { attr.name }
+                                            </Typography>
+                                            <Box sx={ {
+                                                bgcolor: "grey.100",
+                                                borderRadius: "4px",
+                                                px: "6px",
+                                                py: "2px"
+                                            } }>
+                                                <Typography
+                                                    variant="caption"
+                                                    color="text.secondary"
+                                                    sx={ { fontWeight: 500 } }
+                                                >
+                                                    { attr.type }{ attr.isArray ? "[]" : "" }
+                                                </Typography>
+                                            </Box>
+                                        </Box>
+                                        <IconButton
+                                            size="small"
+                                            onClick={ () => handleRemoveAttribute(attr.name) }
+                                            sx={ {
+                                                "&:hover": { color: "error.main" },
+                                                color: "grey.400",
+                                                p: "3px"
+                                            } }
+                                        >
+                                            <svg width="12" height="12" viewBox="0 0 24 24"
+                                                fill="none" stroke="currentColor"
+                                                strokeWidth="2" strokeLinecap="round"
+                                                strokeLinejoin="round">
+                                                <line x1="18" y1="6" x2="6" y2="18" />
+                                                <line x1="6" y1="6" x2="18" y2="18" />
+                                            </svg>
+                                        </IconButton>
+                                    </Box>
+                                )) }
+                            </Box>
+                        ) }
+
+                        { attributes.length > 0 && (
+                            <Box sx={ {
+                                bgcolor: "grey.50",
+                                borderRadius: "6px",
+                                mt: 1.2,
+                                px: 1.2,
+                                py: 0.8
+                            } }>
+                                <Typography
+                                    variant="caption"
+                                    color="text.disabled"
+                                    sx={ { display: "block", fontWeight: 600, mb: 0.3 } }
+                                >
+                                    Structure preview
+                                </Typography>
+                                <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={ {
+                                        display: "block",
+                                        fontFamily: "'JetBrains Mono', monospace",
+                                        lineHeight: 1.5,
+                                        overflowWrap: "break-word"
+                                    } }
+                                >
+                                    { `{${buildStructureString()}}` }
+                                </Typography>
+                            </Box>
+                        ) }
+                    </>
+                ) }
+            </DialogContent>
+            <Divider sx={ { borderColor: "grey.100" } } />
+            <DialogActions sx={ { gap: 1, px: 2.5, py: 1.5 } }>
+                <Button
+                    onClick={ handleClose }
+                    variant="outlined"
+                    size="small"
+                    data-componentid={ `${componentId}-cancel-button` }
+                >
+                    Cancel
+                </Button>
+                <Button
+                    onClick={ handleSubmit }
+                    variant="contained"
+                    size="small"
+                    disabled={ !canSubmit }
+                    data-componentid={ `${componentId}-submit-button` }
+                >
+                    { submitLabel }
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default AddEntryModal;

--- a/features/common.ui.shared-access.v1/components/flow-context-tree/flow-context-tree-node.tsx
+++ b/features/common.ui.shared-access.v1/components/flow-context-tree/flow-context-tree-node.tsx
@@ -1,0 +1,384 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Box from "@oxygen-ui/react/Box";
+import Chip from "@oxygen-ui/react/Chip";
+import Collapse from "@oxygen-ui/react/Collapse";
+import Typography from "@oxygen-ui/react/Typography";
+import React, { CSSProperties, FunctionComponent, ReactElement, useState } from "react";
+import "./flow-context-tree.scss";
+import { NodeType, TreeNodeState } from "./models";
+
+const INDENT: number = 18;
+
+interface FlowContextTreeNodeProps {
+    node: TreeNodeState;
+    depth?: number;
+    selectedKey?: string | null;
+    onSelect: (key: string) => void;
+    onToggleExpose: (key: string) => void;
+    onToggleModify: (key: string) => void;
+    onAddChild: (node: TreeNodeState) => void;
+    readOnly?: boolean;
+    "data-componentid"?: string;
+}
+
+/**
+ * Lock SVG used inside an active EXPOSE / MODIFY chip when the corresponding
+ * encryption flag is set. Inherits the chip's foreground color via `currentColor`.
+ */
+const ChipLockIcon = (): ReactElement => (
+    <svg width="8" height="8" viewBox="0 0 24 24" fill="none"
+        stroke="currentColor" strokeWidth="2.5"
+        strokeLinecap="round" strokeLinejoin="round"
+        style={ { marginRight: 3 } }
+    >
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+);
+
+/**
+ * EXPOSE / MODIFY / ADD ENTRY chips, always-visible, right-aligned.
+ * Lock indicator is folded inside the active chip when the field is encrypted —
+ * the chip's foreground color gives the lock its color automatically.
+ */
+const OpChips = ({
+    node,
+    onToggleExpose,
+    onToggleModify,
+    onAddChild,
+    readOnly
+}: {
+    node: TreeNodeState;
+    onToggleExpose: () => void;
+    onToggleModify: () => void;
+    onAddChild: () => void;
+    readOnly?: boolean;
+}): ReactElement | null => {
+
+    const isLeaf: boolean = node.nodeType === NodeType.LEAF;
+    const canExpose: boolean = node.allowedOperations.includes("EXPOSE") && isLeaf;
+    const canModify: boolean = node.allowedOperations.includes("MODIFY") && isLeaf && !node.readOnly;
+    const showAddEntry: boolean = node.dynamicEntryAllowed && !readOnly;
+
+    if (!canExpose && !canModify && !showAddEntry) {
+        return null;
+    }
+
+    return (
+        <Box
+            sx={ {
+                alignItems: "center",
+                display: "inline-flex",
+                flexShrink: 0,
+                gap: "4px",
+                marginLeft: "auto"
+            } }
+        >
+            { canExpose && (
+                <Chip
+                    label={ (
+                        <Box component="span" sx={ { alignItems: "center", display: "inline-flex" } }>
+                            { node.exposed && node.exposeEncrypted && <ChipLockIcon /> }
+                            READ
+                        </Box>
+                    ) }
+                    size="small"
+                    className={ `expose-chip${node.exposed ? " expose-chip-active" : ""}` }
+                    onClick={ readOnly ? undefined : (e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        onToggleExpose();
+                    } }
+                    sx={ {
+                        "& .MuiChip-label": { px: "6px" },
+                        cursor: readOnly ? "default" : "pointer"
+                    } }
+                />
+            ) }
+            { canModify && (
+                <Chip
+                    label={ (
+                        <Box component="span" sx={ { alignItems: "center", display: "inline-flex" } }>
+                            { node.modify && node.modifyEncrypted && <ChipLockIcon /> }
+                            WRITE
+                        </Box>
+                    ) }
+                    size="small"
+                    className={ `modify-chip${node.modify ? " modify-chip-active" : ""}` }
+                    onClick={ readOnly ? undefined : (e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        onToggleModify();
+                    } }
+                    sx={ {
+                        "& .MuiChip-label": { px: "6px" },
+                        cursor: readOnly ? "default" : "pointer"
+                    } }
+                />
+            ) }
+            { showAddEntry && (
+                <Chip
+                    label="+ ADD ENTRY"
+                    className="add-entry-chip"
+                    size="small"
+                    onClick={ (e: React.MouseEvent) => {
+                        e.stopPropagation();
+                        onAddChild();
+                    } }
+                    variant="outlined"
+                    sx={ {
+                        "&:hover": {
+                            bgcolor: "#FFF4EC",
+                            border: "1px dashed #FFB066",
+                            color: "#E07B2A"
+                        },
+                        border: "1px dashed",
+                        borderColor: "grey.300",
+                        borderRadius: "20px",
+                        color: "text.disabled",
+                        cursor: "pointer",
+                        flexShrink: 0,
+                        fontSize: "8px",
+                        fontWeight: 700,
+                        height: 15,
+                        letterSpacing: "0.06em",
+                        ml: 0,
+                        transition: "all 0.12s"
+                    } }
+                />
+            ) }
+        </Box>
+    );
+};
+
+/**
+ * Recursive tree node renderer. Field-config / encryption / rename / delete
+ * actions live in the parent's RHS panel, not on the row itself.
+ */
+const FlowContextTreeNode: FunctionComponent<FlowContextTreeNodeProps> = ({
+    node,
+    depth = 0,
+    selectedKey,
+    onSelect,
+    onToggleExpose,
+    onToggleModify,
+    onAddChild,
+    readOnly,
+    "data-componentid": componentId = "flow-context-tree-node"
+}: FlowContextTreeNodeProps): ReactElement => {
+
+    const [ open, setOpen ] = useState<boolean>(true);
+
+    const expandable: boolean = Array.isArray(node.children);
+    const isLeaf: boolean = node.nodeType === NodeType.LEAF;
+    const isContainer: boolean =
+        node.nodeType === NodeType.OBJECT ||
+        node.nodeType === NodeType.MAP ||
+        node.nodeType === NodeType.COMPLEX_MAP;
+    const selected: boolean = selectedKey === node.key && isLeaf;
+
+    // Container band sits a few pixels to the left of the row's content padding so
+    // the chevron + title get a small left gutter inside the band.
+    const containerBandLeft: number = Math.max(depth * INDENT + 2, 2);
+
+    const handleRowClick = (): void => {
+        if (isLeaf) {
+            onSelect(node.key);
+
+            return;
+        }
+        if (expandable) {
+            setOpen((o: boolean) => !o);
+        }
+    };
+
+    const rowClassName: string =
+        "tree-node-row" +
+        (expandable ? " expandable" : "") +
+        (selected ? " selected" : "") +
+        (isContainer ? " tree-node-row--container" : "");
+
+    const rowStyle: CSSProperties & Record<string, string | number> = isContainer
+        ? { ["--container-band-left" as string]: `${containerBandLeft}px` }
+        : {};
+
+    return (
+        <Box data-componentid={ `${componentId}-${node.key}` }>
+            <Box
+                className={ rowClassName }
+                onClick={ handleRowClick }
+                style={ rowStyle }
+                sx={ {
+                    pl: `${depth * INDENT + 6}px`
+                } }
+            >
+                { depth > 0 && (
+                    <>
+                        <Box
+                            className="tree-connector-vertical"
+                            sx={ {
+                                left: (depth - 1) * INDENT + 9
+                            } }
+                        />
+                        <Box
+                            className="tree-connector-horizontal"
+                            sx={ {
+                                left: (depth - 1) * INDENT + 9
+                            } }
+                        />
+                    </>
+                ) }
+
+                { /* Expand / leaf icon */ }
+                <Box
+                    sx={ {
+                        alignItems: "center",
+                        display: "flex",
+                        flexShrink: 0,
+                        justifyContent: "center",
+                        width: 12
+                    } }
+                >
+                    { expandable ? (
+                        <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="var(--tree-gray-20, #D0D0D0)"
+                            strokeWidth="2.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            style={ {
+                                transform: open ? "rotate(90deg)" : "rotate(0deg)",
+                                transition: "transform 0.18s ease"
+                            } }
+                        >
+                            <polyline points="9 18 15 12 9 6" />
+                        </svg>
+                    ) : (
+                        <svg
+                            width="5"
+                            height="5"
+                            viewBox="0 0 8 8"
+                        >
+                            <circle cx="4" cy="4" r="3" fill="var(--tree-gray-20, #D0D0D0)" />
+                        </svg>
+                    ) }
+                </Box>
+
+                { /* Title + optional Read-Only indicator (leaves only) */ }
+                <Box
+                    sx={ {
+                        alignItems: "center",
+                        display: "flex",
+                        flex: "0 1 auto",
+                        gap: "6px",
+                        minWidth: 0
+                    } }
+                >
+                    <Typography
+                        component="span"
+                        sx={ {
+                            color: node.readOnly
+                                ? "text.secondary"
+                                : isContainer
+                                    ? "text.primary"
+                                    : "text.secondary",
+                            fontFamily: isLeaf || node.canDelete
+                                ? "'JetBrains Mono', monospace"
+                                : "'Inter', sans-serif",
+                            fontSize: node.nodeType === NodeType.OBJECT
+                                ? 14
+                                : isContainer ? 13.5 : 13,
+                            fontWeight: node.nodeType === NodeType.OBJECT
+                                ? 700
+                                : isContainer ? 600 : 500,
+                            letterSpacing: "-0.015em",
+                            lineHeight: 1,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap"
+                        } }
+                    >
+                        { node.title }
+                    </Typography>
+                    { isLeaf && node.readOnly && (
+                        <Typography
+                            component="span"
+                            sx={ {
+                                color: "text.disabled",
+                                flexShrink: 0,
+                                fontSize: "9px",
+                                fontWeight: 500,
+                                lineHeight: 1
+                            } }
+                        >
+                            Read-Only
+                        </Typography>
+                    ) }
+                </Box>
+
+                { /* Operation chips — always pushed to the RHS via marginLeft: auto */ }
+                <OpChips
+                    node={ node }
+                    onToggleExpose={ () => onToggleExpose(node.key) }
+                    onToggleModify={ () => onToggleModify(node.key) }
+                    onAddChild={ () => onAddChild(node) }
+                    readOnly={ readOnly }
+                />
+            </Box>
+
+            { /* Children */ }
+            { expandable && (
+                <Collapse in={ open } timeout={ 180 }>
+                    { node.children.map((child: TreeNodeState) => (
+                        <FlowContextTreeNode
+                            key={ child.key }
+                            node={ child }
+                            depth={ depth + 1 }
+                            selectedKey={ selectedKey }
+                            onSelect={ onSelect }
+                            onToggleExpose={ onToggleExpose }
+                            onToggleModify={ onToggleModify }
+                            onAddChild={ onAddChild }
+                            readOnly={ readOnly }
+                            data-componentid={ componentId }
+                        />
+                    )) }
+                    { node.dynamicEntryAllowed && node.children.length === 0 && (
+                        <Typography
+                            sx={ {
+                                color: "grey.300",
+                                fontSize: 10,
+                                fontStyle: "italic",
+                                pb: "4px",
+                                pl: `${(depth + 1) * INDENT + 23}px`,
+                                pt: "2px"
+                            } }
+                        >
+                            No entries yet
+                        </Typography>
+                    ) }
+                </Collapse>
+            ) }
+        </Box>
+    );
+};
+
+export default FlowContextTreeNode;

--- a/features/common.ui.shared-access.v1/components/flow-context-tree/flow-context-tree.scss
+++ b/features/common.ui.shared-access.v1/components/flow-context-tree/flow-context-tree.scss
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// EXPOSE moved from orange to green; orange is now reserved for the brand
+// (selected-row highlight). MODIFY stays blue.
+$expose-color: #2E7D32;
+$expose-faint: #E8F5E9;
+$modify-color: #1565C0;
+$modify-faint: #E3F2FD;
+$danger-color: #C0392B;
+
+$row-selected-bg: #FFF4EC;
+$row-selected-border: #FFB066;
+$container-bg: #F4F4F4;
+
+$gray-05: #F5F5F5;
+$gray-10: #EBEBEB;
+$gray-20: #D0D0D0;
+$gray-35: #A0A0A0;
+$gray-50: #787878;
+$gray-70: #4A4A4A;
+$gray-90: #2C2C2C;
+
+$indent: 22px;
+$row-min-height: 36px;
+$chip-height: 19px;
+
+// ── Global: prevent Semantic UI blurring dimmer from blurring MUI Dialogs ──
+.blurring.dimmed.dimmable > :not(.dimmer).MuiDialog-root {
+    filter: none !important;
+    z-index: 2000 !important;
+}
+
+.flow-context-tree {
+    --tree-expose: #{$expose-color};
+    --tree-expose-faint: #{$expose-faint};
+    --tree-modify: #{$modify-color};
+    --tree-modify-faint: #{$modify-faint};
+    --tree-gray-20: #{$gray-20};
+    --tree-row-selected: #{$row-selected-bg};
+    --tree-container-bg: #{$container-bg};
+
+    .tree-node-row {
+        display: flex;
+        align-items: center;
+        flex-wrap: nowrap;
+        gap: 4px;
+        min-height: $row-min-height;
+        padding-top: 4px;
+        padding-right: 10px;
+        padding-bottom: 4px;
+        border: 1px solid transparent;
+        border-radius: 6px;
+        position: relative;
+        transition: background 0.1s;
+        cursor: pointer;
+
+        // Light-gray hover — only applies to leaf rows (containers opt out below).
+        &:hover {
+            background-color: #F4F4F4;
+        }
+
+        // Selected row uses the brand orange tint, no border.
+        &.selected {
+            background-color: $row-selected-bg;
+        }
+
+        // Container rows (OBJECT/MAP/COMPLEX_MAP) get a gray banded background that
+        // starts at the row's name column and extends to (just before) the right
+        // edge of the tree column. The band itself provides the visual emphasis —
+        // hover + selected backgrounds are suppressed so they don't compete.
+        &.tree-node-row--container {
+            &:hover {
+                background-color: transparent;
+            }
+
+            &::before {
+                content: "";
+                position: absolute;
+                left: var(--container-band-left, 0);
+                right: 6px;
+                top: 4px;
+                bottom: 4px;
+                background-color: $container-bg;
+                border-radius: 6px;
+                z-index: 0;
+                pointer-events: none;
+            }
+        }
+
+        // Lift row content above the container band.
+        > * {
+            position: relative;
+            z-index: 1;
+        }
+    }
+
+    .add-entry-chip {
+        margin-left: 6px;
+    }
+
+    // ── Operation chip styles ──
+    .expose-chip,
+    .modify-chip {
+        flex-shrink: 0;
+        font-size: 9.5px;
+        font-weight: 600;
+        height: $chip-height;
+        letter-spacing: 0.05em;
+        border-radius: 20px;
+        transition: all 0.12s ease;
+    }
+
+    .expose-chip-active {
+        background-color: $expose-faint;
+        border: 1px solid $expose-color;
+        color: $expose-color;
+        font-weight: 700;
+    }
+
+    .expose-chip:not(.expose-chip-active) {
+        background-color: transparent;
+        border: 1px solid $gray-10;
+        color: $gray-50;
+
+        &:hover {
+            background-color: $expose-faint;
+            border-color: $expose-color;
+            color: $expose-color;
+        }
+    }
+
+    .modify-chip-active {
+        background-color: $modify-faint;
+        border: 1px solid $modify-color;
+        color: $modify-color;
+        font-weight: 700;
+    }
+
+    .modify-chip:not(.modify-chip-active) {
+        background-color: transparent;
+        border: 1px solid $gray-10;
+        color: $gray-50;
+
+        &:hover {
+            background-color: $modify-faint;
+            border-color: $modify-color;
+            color: $modify-color;
+        }
+    }
+
+    // ── Tree connector lines ──
+    .tree-connector-vertical {
+        position: absolute;
+        width: 1.5px;
+        top: 0;
+        bottom: 0;
+        background-color: $gray-10;
+        pointer-events: none;
+    }
+    .tree-connector-horizontal {
+        position: absolute;
+        height: 1.5px;
+        top: 50%;
+        width: 11px;
+        background-color: $gray-10;
+        pointer-events: none;
+    }
+}
+
+// ── Field configuration panel ──
+// Fixed min-height so switching between fields with different op shapes does
+// not change the panel size.
+.field-config-panel {
+    min-height: 100px;
+    display: flex;
+    flex-direction: column;
+}
+
+// ── Access config Monaco wrapper ──
+// Internal flex grow so the editor fills the RHS column when the tree is tall;
+// min-height keeps it readable when the tree is short.
+.access-config-monaco {
+    min-height: 280px;
+    flex: 1 1 auto;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    .access-config-monaco__editor {
+        flex: 1 1 auto;
+        min-height: 0;
+    }
+}

--- a/features/common.ui.shared-access.v1/components/flow-context-tree/flow-context-tree.tsx
+++ b/features/common.ui.shared-access.v1/components/flow-context-tree/flow-context-tree.tsx
@@ -1,0 +1,1002 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Box from "@oxygen-ui/react/Box";
+import Chip from "@oxygen-ui/react/Chip";
+import IconButton from "@oxygen-ui/react/IconButton";
+import Switch from "@oxygen-ui/react/Switch";
+import TextField from "@oxygen-ui/react/TextField";
+import Tooltip from "@oxygen-ui/react/Tooltip";
+import Typography from "@oxygen-ui/react/Typography";
+import { getAllLocalClaims } from "@wso2is/admin.claims.v1/api";
+import { Claim, ClaimsGetParams } from "@wso2is/core/models";
+import React, {
+    FunctionComponent,
+    LazyExoticComponent,
+    ReactElement,
+    Suspense,
+    lazy,
+    useCallback,
+    useEffect,
+    useMemo,
+    useState
+} from "react";
+import AddClaimModal from "./add-claim-modal";
+import AddEntryModal from "./add-entry-modal";
+import FlowContextTreeNode from "./flow-context-tree-node";
+import "./flow-context-tree.scss";
+import {
+    AddEntryModalState,
+    FlowContextTreeProps,
+    NodeType,
+    TreeNodeState
+} from "./models";
+import {
+    addChild,
+    buildAccessConfig,
+    deleteNode,
+    findFirstLeafKey,
+    findNode,
+    mapMetadataToState,
+    mapMetadataToStateWithAccessConfig,
+    updateNode
+} from "./utils";
+
+const MonacoEditor: LazyExoticComponent<any> = lazy(() =>
+    import("@monaco-editor/react" /* webpackChunkName: "FCTMonacoEditor" */)
+);
+
+const SHOW_ENCRYPTION_SECTION: boolean = false;
+
+const SHOW_ACCESS_CONFIG_PAYLOAD: boolean = false;
+
+/**
+ * Small lock SVG used in the encryption rows of the field-configuration panel.
+ */
+const PanelLockIcon = ({ color }: { color: string }): ReactElement => (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+        stroke={ color } strokeWidth="2.2"
+        strokeLinecap="round" strokeLinejoin="round"
+    >
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+        <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+);
+
+/**
+ * Returns the parent path for a node (everything up to and including the trailing slash
+ * before the last segment). Used when renaming nodes — the path's last segment is replaced
+ * with the new title to keep `path` and `title` in sync for dynamic entries.
+ */
+const getParentPath = (path: string): string => {
+    const trimmed: string = path.replace(/\/$/, "");
+    const idx: number = trimmed.lastIndexOf("/");
+
+    return idx >= 0 ? trimmed.substring(0, idx + 1) : "/";
+};
+
+interface EncryptionCardProps {
+    title: string;
+    color: string;
+    checked: boolean;
+    disabled: boolean;
+    disabledReason: string;
+    enabledDescription: string;
+    onToggle: () => void;
+    "data-componentid"?: string;
+}
+
+/**
+ * Encryption configuration card for the field-configuration panel.
+ * Shows an explanatory line both when disabled (why it can't be enabled) and
+ * when active (what enabling means) so the height stays stable across states.
+ */
+const EncryptionCard: FunctionComponent<EncryptionCardProps> = ({
+    title,
+    color,
+    checked,
+    disabled,
+    disabledReason,
+    enabledDescription,
+    onToggle,
+    "data-componentid": componentId
+}: EncryptionCardProps): ReactElement => (
+    <Tooltip title={ disabled ? disabledReason : "" } placement="top" arrow>
+        <Box
+            sx={ {
+                alignItems: "center",
+                bgcolor: "grey.50",
+                border: "1px solid",
+                borderColor: "grey.200",
+                borderRadius: "8px",
+                display: "flex",
+                gap: 1.5,
+                minHeight: 64,
+                opacity: disabled ? 0.55 : 1,
+                px: 1.5,
+                py: 1
+            } }
+            data-componentid={ componentId }
+        >
+            <PanelLockIcon color={ disabled ? "#A0A0A0" : color } />
+            <Box sx={ { flex: "1 1 auto", minWidth: 0 } }>
+                <Typography variant="body2" sx={ { fontWeight: 600, lineHeight: 1.2 } }>
+                    { title }
+                </Typography>
+                <Typography
+                    variant="caption"
+                    color="text.disabled"
+                    sx={ { display: "block", lineHeight: 1.3, mt: 0.3 } }
+                >
+                    { disabled ? disabledReason : enabledDescription }
+                </Typography>
+            </Box>
+            <Switch
+                size="small"
+                checked={ checked }
+                disabled={ disabled }
+                onChange={ disabled ? undefined : onToggle }
+                sx={ {
+                    // Track gets a faint shade of the operation color; thumb stays white when on.
+                    "& .MuiSwitch-switchBase.Mui-checked, & .MuiSwitch-switchBase.Mui-checked.MuiSwitch-colorPrimary": {
+                        color: "#fff"
+                    },
+                    "& .MuiSwitch-switchBase.Mui-checked .MuiSwitch-thumb, & .MuiSwitch-switchBase.Mui-checked.MuiSwitch-colorPrimary .MuiSwitch-thumb": {
+                        backgroundColor: "#fff",
+                        boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.18), 0 1px 2px rgba(0, 0, 0, 0.12)",
+                        color: "#fff"
+                    },
+                    "& .MuiSwitch-switchBase.Mui-checked + .MuiSwitch-track, & .MuiSwitch-switchBase.Mui-checked.MuiSwitch-colorPrimary + .MuiSwitch-track": {
+                        backgroundColor: color,
+                        opacity: 0.50
+                    }
+                } }
+            />
+        </Box>
+    </Tooltip>
+);
+
+interface FieldConfigPanelProps {
+    selectedNode: TreeNodeState | null;
+    hasCertificate: boolean;
+    readOnly: boolean;
+    onToggleExposeEncrypt: (key: string) => void;
+    onToggleModifyEncrypt: (key: string) => void;
+    onRename: (key: string, newTitle: string) => void;
+    onDelete: (key: string) => void;
+    onEditPropertiesEntry: (node: TreeNodeState) => void;
+}
+
+/**
+ * Right-side panel that surfaces details of the currently-selected leaf and lets the
+ * user rename, delete, and configure encryption flags for it.
+ */
+const FieldConfigPanel: FunctionComponent<FieldConfigPanelProps> = ({
+    selectedNode,
+    hasCertificate,
+    readOnly,
+    onToggleExposeEncrypt,
+    onToggleModifyEncrypt,
+    onRename,
+    onDelete,
+    onEditPropertiesEntry
+}: FieldConfigPanelProps): ReactElement => {
+
+    const [ editing, setEditing ] = useState<boolean>(false);
+    const [ editValue, setEditValue ] = useState<string>("");
+
+    // Reset inline-edit state whenever the selection changes.
+    useEffect(() => {
+        setEditing(false);
+        setEditValue(selectedNode?.title ?? "");
+    }, [ selectedNode?.key ]);
+
+    const isLeaf: boolean = selectedNode?.nodeType === NodeType.LEAF;
+    const isPropertiesEntry: boolean = !!selectedNode?.path?.startsWith("/properties/")
+        && selectedNode?.path !== "/properties/";
+
+    /**
+     * For dynamic /properties/ entries, the raw dataType is a structure string like
+     * "Integer", "[String]", or "risk: String, scores: Integer[]". Collapse it to a
+     * compact display label (e.g. "Object", "Object[]") for the chip in the header.
+     * Static-tree leaves and non-properties entries already carry a friendly type.
+     */
+    const displayDataType: string = (() => {
+        if (!selectedNode?.dataType) return "";
+        if (!isPropertiesEntry) return selectedNode.dataType;
+        const raw: string = selectedNode.dataType.trim();
+
+        if (!raw) return "String";
+        if (raw.startsWith("[") && raw.endsWith("]")) {
+            const inner: string = raw.slice(1, -1).trim();
+
+            if (inner.includes(":")) return "Object[]";
+
+            return `${inner || "String"}[]`;
+        }
+        if (raw.includes(":")) return "Object";
+
+        return raw;
+    })();
+
+    const canRename: boolean = !readOnly
+        && !!selectedNode?.canDelete
+        && !selectedNode?.isClaim
+        && !selectedNode?.readOnly;
+    const canDeleteNode: boolean = !readOnly && !!selectedNode?.canDelete;
+
+    const canExposeOp: boolean = !!selectedNode?.allowedOperations.includes("EXPOSE") && isLeaf;
+    const canModifyOp: boolean = !!selectedNode?.allowedOperations.includes("MODIFY")
+        && isLeaf
+        && !selectedNode?.readOnly;
+
+    const handleStartEdit = (): void => {
+        if (!selectedNode) return;
+
+        if (isPropertiesEntry) {
+            onEditPropertiesEntry(selectedNode);
+
+            return;
+        }
+        setEditValue(selectedNode.title);
+        setEditing(true);
+    };
+
+    const handleSaveEdit = (): void => {
+        if (!selectedNode) return;
+        const next: string = editValue.trim() || selectedNode.title;
+
+        if (next !== selectedNode.title) {
+            onRename(selectedNode.key, next);
+        }
+        setEditing(false);
+    };
+
+    return (
+        <Box
+            className="field-config-panel"
+            sx={ {
+                bgcolor: "background.paper",
+                border: "1px solid",
+                borderColor: "grey.200",
+                borderRadius: "8px",
+                p: 2
+            } }
+        >
+            <Typography variant="subtitle2" sx={ { fontWeight: 600, mb: 1.5 } }>
+                Field Configuration
+            </Typography>
+
+            { !selectedNode || !isLeaf ? (
+                <Box
+                    sx={ {
+                        alignItems: "center",
+                        display: "flex",
+                        flex: "1 1 auto",
+                        flexDirection: "column",
+                        gap: 1,
+                        justifyContent: "center",
+                        py: 4
+                    } }
+                >
+                    <Typography variant="body2" color="text.secondary">
+                        No field selected
+                    </Typography>
+                    <Typography variant="caption" color="text.disabled">
+                        Select a leaf field from the tree to configure it.
+                    </Typography>
+                </Box>
+            ) : (
+                <>
+                    { /* ── Header: name (or rename input), datatype label, actions ── */ }
+                    <Box sx={ { alignItems: "flex-start", display: "flex", gap: 1.5 } }>
+                        <Box sx={ { flex: "1 1 auto", minWidth: 0 } }>
+                            <Box sx={ { alignItems: "center", display: "flex", gap: 1 } }>
+                                { editing ? (
+                                    <TextField
+                                        size="small"
+                                        autoFocus
+                                        value={ editValue }
+                                        onChange={ (e: React.ChangeEvent<HTMLInputElement>) =>
+                                            setEditValue(e.target.value)
+                                        }
+                                        onBlur={ handleSaveEdit }
+                                        onKeyDown={ (e: React.KeyboardEvent) => {
+                                            if (e.key === "Enter") handleSaveEdit();
+                                            if (e.key === "Escape") setEditing(false);
+                                        } }
+                                        sx={ { flex: "1 1 auto" } }
+                                    />
+                                ) : (
+                                    <Typography
+                                        variant="body2"
+                                        sx={ {
+                                            fontFamily: "'JetBrains Mono', monospace",
+                                            fontWeight: 600,
+                                            overflow: "hidden",
+                                            textOverflow: "ellipsis",
+                                            whiteSpace: "nowrap"
+                                        } }
+                                    >
+                                        { selectedNode.title }
+                                    </Typography>
+                                ) }
+                                { !editing && displayDataType && (
+                                    <Chip
+                                        label={ displayDataType }
+                                        size="small"
+                                        sx={ {
+                                            "& .MuiChip-label": { px: "6px" },
+                                            bgcolor: "grey.100",
+                                            color: "text.secondary",
+                                            fontFamily: "'JetBrains Mono', monospace",
+                                            fontSize: "9px",
+                                            height: 16
+                                        } }
+                                    />
+                                ) }
+                                { !editing && selectedNode.readOnly && (
+                                    <Chip
+                                        label="Read-Only"
+                                        size="small"
+                                        sx={ {
+                                            "& .MuiChip-label": { px: "6px" },
+                                            bgcolor: "grey.100",
+                                            color: "text.disabled",
+                                            fontSize: "9px",
+                                            fontWeight: 600,
+                                            height: 16
+                                        } }
+                                    />
+                                ) }
+                            </Box>
+                            <Typography
+                                variant="caption"
+                                color="text.disabled"
+                                sx={ {
+                                    display: "block",
+                                    fontFamily: "'JetBrains Mono', monospace",
+                                    mt: 0.3,
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    whiteSpace: "nowrap"
+                                } }
+                            >
+                                { selectedNode.path }
+                            </Typography>
+                        </Box>
+                        { (canRename || canDeleteNode) && !editing && (
+                            <Box sx={ { display: "flex", flexShrink: 0, gap: 0.5 } }>
+                                { canRename && (
+                                    <Tooltip title="Edit" placement="top">
+                                        <IconButton
+                                            size="small"
+                                            onClick={ handleStartEdit }
+                                            sx={ {
+                                                "&:hover": {
+                                                    bgcolor: "var(--tree-expose-faint)",
+                                                    color: "var(--tree-expose)"
+                                                },
+                                                color: "grey.500"
+                                            } }
+                                        >
+                                            <svg width="14" height="14" viewBox="0 0 24 24"
+                                                fill="none" stroke="currentColor"
+                                                strokeWidth="2" strokeLinecap="round"
+                                                strokeLinejoin="round">
+                                                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                                                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                                            </svg>
+                                        </IconButton>
+                                    </Tooltip>
+                                ) }
+                                { canDeleteNode && (
+                                    <Tooltip title="Delete" placement="top">
+                                        <IconButton
+                                            size="small"
+                                            onClick={ () => onDelete(selectedNode.key) }
+                                            sx={ {
+                                                "&:hover": { color: "error.main" },
+                                                color: "grey.500"
+                                            } }
+                                        >
+                                            <svg width="14" height="14" viewBox="0 0 24 24"
+                                                fill="none" stroke="currentColor"
+                                                strokeWidth="2" strokeLinecap="round"
+                                                strokeLinejoin="round">
+                                                <polyline points="3 6 5 6 21 6" />
+                                                <path
+                                                    d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1
+                                                        2-2h4a2 2 0 0 1 2 2v2"
+                                                />
+                                            </svg>
+                                        </IconButton>
+                                    </Tooltip>
+                                ) }
+                            </Box>
+                        ) }
+                    </Box>
+
+                    { /* ── Encryption section ── */ }
+                    { SHOW_ENCRYPTION_SECTION && (
+                        <>
+                            <Typography
+                                variant="subtitle2"
+                                color="text.secondary"
+                                sx={ { display: "block", fontWeight: 600, mt: 2.5 } }
+                            >
+                                Encryption
+                            </Typography>
+                            <Box sx={ { display: "flex", flexDirection: "column", gap: 1.5, mt: 1 } }>
+                                <EncryptionCard
+                                    title="Read encrypted"
+                                    color="var(--tree-expose)"
+                                    checked={ !!selectedNode.exposeEncrypted }
+                                    disabled={ !canExposeOp || readOnly || !selectedNode.exposed || !hasCertificate }
+                                    disabledReason={
+                                        !canExposeOp
+                                            ? "Read is not allowed for this field."
+                                            : !selectedNode.exposed
+                                                ? "Mark this field as READ in the tree to enable encryption."
+                                                : !hasCertificate
+                                                    ? "Add a certificate to enable encryption."
+                                                    : "Read only."
+                                    }
+                                    enabledDescription="This field will be sent to the extension encrypted."
+                                    onToggle={ () => onToggleExposeEncrypt(selectedNode.key) }
+                                    data-componentid="field-config-panel-expose-enc"
+                                />
+                                <EncryptionCard
+                                    title="Write encrypted"
+                                    color="var(--tree-modify)"
+                                    checked={ !!selectedNode.modifyEncrypted }
+                                    disabled={ !canModifyOp || readOnly || !selectedNode.modify }
+                                    disabledReason={
+                                        !canModifyOp
+                                            ? "Write is not allowed for this field."
+                                            : !selectedNode.modify
+                                                ? "Mark this field as WRITE in the tree to enable encryption."
+                                                : "Read only."
+                                    }
+                                    enabledDescription="The extension will return this field's value encrypted."
+                                    onToggle={ () => onToggleModifyEncrypt(selectedNode.key) }
+                                    data-componentid="field-config-panel-modify-enc"
+                                />
+                            </Box>
+                        </>
+                    ) }
+                </>
+            ) }
+        </Box>
+    );
+};
+
+interface AccessConfigMonacoProps {
+    accessConfig: { expose: { path: string; encrypted: boolean }[]; modify: { path: string; encrypted: boolean }[] };
+}
+
+/**
+ * Read-only Monaco editor showing the access config payload (the slice that
+ * gets sent to the backend). Lazy-loaded the same way as branding's CustomText.
+ */
+const AccessConfigMonaco: FunctionComponent<AccessConfigMonacoProps> = ({
+    accessConfig
+}: AccessConfigMonacoProps): ReactElement => {
+
+    const value: string = useMemo(
+        () => JSON.stringify({ accessConfig }, null, 4),
+        [ accessConfig ]
+    );
+
+    return (
+        <Box
+            className="access-config-monaco"
+            sx={ {
+                bgcolor: "background.paper",
+                border: "1px solid",
+                borderColor: "grey.200",
+                borderRadius: "8px",
+                overflow: "hidden"
+            } }
+        >
+            <Box
+                sx={ {
+                    alignItems: "baseline",
+                    borderBottom: "1px solid",
+                    borderColor: "grey.200",
+                    display: "flex",
+                    gap: 1,
+                    px: 2,
+                    py: 1
+                } }
+            >
+                <Typography variant="subtitle2" sx={ { fontWeight: 600 } }>
+                    Access configuration payload
+                </Typography>
+                <Typography variant="caption" color="text.disabled">
+                    JSON sent to the backend on update
+                </Typography>
+            </Box>
+            <Box className="access-config-monaco__editor" sx={ { height: 300 } }>
+                <Suspense fallback={ null }>
+                    <MonacoEditor
+                        loading={ null }
+                        width="100%"
+                        height="300px"
+                        language="json"
+                        theme="vs-dark"
+                        value={ value }
+                        options={ {
+                            automaticLayout: true,
+                            lineNumbers: "off",
+                            minimap: { enabled: false },
+                            readOnly: true,
+                            scrollBeyondLastLine: false
+                        } }
+                    />
+                </Suspense>
+            </Box>
+        </Box>
+    );
+};
+
+/**
+ * Flow Context Tree — renders the metadata context tree with expose/modify/encryption
+ * controls on the left and a field-configuration panel + read-only access-config JSON
+ * preview on the right.
+ */
+const FlowContextTree: FunctionComponent<FlowContextTreeProps> = ({
+    contextTree,
+    onChange,
+    initialAccessConfig,
+    hasCertificate,
+    readOnly,
+    allowReadOnlyClaimsModification = true,
+    "data-componentid": componentId = "flow-context-tree"
+}: FlowContextTreeProps): ReactElement => {
+
+    const [ allClaims, setAllClaims ] = useState<Claim[]>([]);
+
+    const claimDisplayNames: Map<string, string> = useMemo(() => {
+        const map: Map<string, string> = new Map();
+
+        allClaims.forEach((c: Claim) => {
+            if (c.claimURI && c.displayName) {
+                map.set(c.claimURI, c.displayName);
+            }
+        });
+
+        return map;
+    }, [ allClaims ]);
+
+    const claimReadOnlyMap: Map<string, boolean> = useMemo(() => {
+        const map: Map<string, boolean> = new Map();
+
+        allClaims.forEach((c: Claim) => {
+            if (c.claimURI) {
+                map.set(c.claimURI, !!c.readOnly);
+            }
+        });
+
+        return map;
+    }, [ allClaims ]);
+
+    const [ tree, setTree ] = useState<TreeNodeState[]>(() =>
+        initialAccessConfig
+            ? mapMetadataToStateWithAccessConfig(contextTree, initialAccessConfig, undefined, {
+                allowReadOnlyClaimsModification,
+                claimReadOnlyMap: undefined
+            })
+            : mapMetadataToState(contextTree)
+    );
+
+    const [ selectedKey, setSelectedKey ] = useState<string | null>(null);
+
+    const [ modal, setModal ] = useState<AddEntryModalState & {
+        mode?: "create" | "edit";
+        editingKey?: string | null;
+        initialKeyName?: string;
+        initialDataType?: string;
+    }>({
+        editingKey: null,
+        initialDataType: "",
+        initialKeyName: "",
+        mode: "create",
+        open: false,
+        parentNode: null
+    });
+
+    const [ claimModal, setClaimModal ] = useState<AddEntryModalState>({
+        open: false,
+        parentNode: null
+    });
+
+    const builtConfig: ReturnType<typeof buildAccessConfig> = useMemo(
+        () => buildAccessConfig(tree),
+        [ tree ]
+    );
+
+    // Notify parent whenever tree state changes.
+    useEffect(() => {
+        onChange(builtConfig.accessConfig, builtConfig.encryption);
+    }, [ builtConfig ]);
+
+    // Fetch all local claims once on mount.
+    useEffect(() => {
+        const params: ClaimsGetParams = {
+            "exclude-hidden-claims": true,
+            "exclude-identity-claims": true,
+            filter: null,
+            limit: null,
+            offset: null,
+            sort: null
+        };
+
+        getAllLocalClaims(params)
+            .then((response: Claim[]) => {
+                setAllClaims(
+                    (response || []).sort((a: Claim, b: Claim) =>
+                        (a.displayName || "").localeCompare(b.displayName || "")
+                    )
+                );
+            })
+            .catch(() => {
+                // Silently fail — claims are optional for display name resolution.
+            });
+    }, []);
+
+    // Re-initialise tree when input changes / once claims load.
+    useEffect(() => {
+        setTree(
+            initialAccessConfig
+                ? mapMetadataToStateWithAccessConfig(contextTree, initialAccessConfig, claimDisplayNames, {
+                    allowReadOnlyClaimsModification,
+                    claimReadOnlyMap
+                })
+                : mapMetadataToState(contextTree)
+        );
+    }, [ contextTree, initialAccessConfig, claimDisplayNames, claimReadOnlyMap, allowReadOnlyClaimsModification ]);
+
+    // Default-select the first leaf once the tree is populated, and re-target if
+    // the current selection no longer resolves (e.g. after a delete).
+    useEffect(() => {
+        if (selectedKey && findNode(tree, selectedKey)) {
+            return;
+        }
+        const fallback: string | null = findFirstLeafKey(tree);
+
+        if (fallback !== selectedKey) {
+            setSelectedKey(fallback);
+        }
+    }, [ tree, selectedKey ]);
+
+    const selectedNode: TreeNodeState | null = useMemo(
+        () => (selectedKey ? findNode(tree, selectedKey) : null),
+        [ tree, selectedKey ]
+    );
+
+    const handleToggleExpose = useCallback((key: string): void => {
+        setTree((prev: TreeNodeState[]) =>
+            updateNode(prev, key, (n: TreeNodeState) => ({
+                ...n,
+                exposeEncrypted: !n.exposed ? n.exposeEncrypted : false,
+                exposed: !n.exposed
+            }))
+        );
+    }, []);
+
+    const handleToggleModify = useCallback((key: string): void => {
+        setTree((prev: TreeNodeState[]) =>
+            updateNode(prev, key, (n: TreeNodeState) => ({
+                ...n,
+                modify: !n.modify,
+                modifyEncrypted: n.modify ? false : n.modifyEncrypted
+            }))
+        );
+    }, []);
+
+    const handleToggleExposeEncrypt = useCallback((key: string): void => {
+        setTree((prev: TreeNodeState[]) =>
+            updateNode(prev, key, (n: TreeNodeState) => ({
+                ...n,
+                exposeEncrypted: !n.exposeEncrypted
+            }))
+        );
+    }, []);
+
+    const handleToggleModifyEncrypt = useCallback((key: string): void => {
+        setTree((prev: TreeNodeState[]) =>
+            updateNode(prev, key, (n: TreeNodeState) => ({
+                ...n,
+                modifyEncrypted: !n.modifyEncrypted
+            }))
+        );
+    }, []);
+
+    const handleDelete = useCallback((key: string): void => {
+        setTree((prev: TreeNodeState[]) => deleteNode(prev, key));
+    }, []);
+
+    const handleRename = useCallback((key: string, newTitle: string): void => {
+        setTree((prev: TreeNodeState[]) =>
+            updateNode(prev, key, (n: TreeNodeState) => {
+                const parentPath: string = getParentPath(n.path);
+
+                return {
+                    ...n,
+                    path: `${parentPath}${newTitle}`,
+                    title: newTitle
+                };
+            })
+        );
+    }, []);
+
+    const handleAddChild = useCallback((node: TreeNodeState): void => {
+        if (node.path === "/user/claims/") {
+            setClaimModal({ open: true, parentNode: node });
+        } else {
+            setModal({
+                editingKey: null,
+                initialDataType: "",
+                initialKeyName: "",
+                mode: "create",
+                open: true,
+                parentNode: node
+            });
+        }
+    }, []);
+
+    const handleEditPropertiesEntry = useCallback((node: TreeNodeState): void => {
+        // The /properties/ container is always the direct parent for these entries.
+        const parent: TreeNodeState | null = findNode(tree, "properties");
+
+        // Fall back to a synthesised parent node carrying the path; only `path` is
+        // read by the modal's `isPropertiesParent` check.
+        const parentNode: TreeNodeState = parent ?? ({
+            ...node,
+            path: "/properties/"
+        });
+
+        setModal({
+            editingKey: node.key,
+            initialDataType: node.dataType ?? "",
+            initialKeyName: node.title,
+            mode: "edit",
+            open: true,
+            parentNode
+        });
+    }, [ tree ]);
+
+    const handleModalSubmit = useCallback(({ keyName, objectStructure }: {
+        keyName: string;
+        objectStructure: string;
+    }): void => {
+        const { parentNode, mode, editingKey } = modal;
+
+        if (!parentNode) return;
+
+        if (mode === "edit" && editingKey) {
+            setTree((prev: TreeNodeState[]) =>
+                updateNode(prev, editingKey, (n: TreeNodeState) => {
+                    const parentPath: string = getParentPath(n.path);
+
+                    return {
+                        ...n,
+                        dataType: objectStructure || n.dataType,
+                        path: `${parentPath}${keyName}`,
+                        title: keyName
+                    };
+                })
+            );
+            setModal({
+                editingKey: null,
+                initialDataType: "",
+                initialKeyName: "",
+                mode: "create",
+                open: false,
+                parentNode: null
+            });
+
+            return;
+        }
+
+        const isParentReadOnly: boolean = !!parentNode.readOnly;
+        const newEntry: TreeNodeState = {
+            allowedOperations: isParentReadOnly ? [ "EXPOSE" ] : [ "EXPOSE", "MODIFY" ],
+            canDelete: true,
+            children: undefined,
+            dataType: objectStructure || "String",
+            dynamicEntryAllowed: false,
+            dynamicEntryType: "",
+            exposeEncrypted: false,
+            exposed: false,
+            key: `e-${Date.now()}`,
+            modify: false,
+            modifyEncrypted: false,
+            nodeType: NodeType.LEAF,
+            path: `${parentNode.path}${keyName}`,
+            readOnly: isParentReadOnly,
+            replaceable: false,
+            title: keyName
+        };
+
+        setTree((prev: TreeNodeState[]) => addChild(prev, parentNode.key, newEntry));
+        setModal({
+            editingKey: null,
+            initialDataType: "",
+            initialKeyName: "",
+            mode: "create",
+            open: false,
+            parentNode: null
+        });
+    }, [ modal ]);
+
+    const handleModalClose = useCallback((): void => {
+        setModal({
+            editingKey: null,
+            initialDataType: "",
+            initialKeyName: "",
+            mode: "create",
+            open: false,
+            parentNode: null
+        });
+    }, []);
+
+    const handleClaimModalSubmit = useCallback((claims: Claim[]): void => {
+        const { parentNode } = claimModal;
+
+        if (!parentNode) return;
+
+        setTree((prev: TreeNodeState[]) => {
+            let updated: TreeNodeState[] = prev;
+
+            claims.forEach((claim: Claim, idx: number) => {
+                // When the flow type permits modifying read-only claims, the claim's
+                // read-only flag is ignored entirely — it's treated as a normal writable
+                // entry. Only when modification is disallowed do we honour the flag.
+                const treatAsReadOnly: boolean = !!claim.readOnly && !allowReadOnlyClaimsModification;
+                const allowedOps: string[] = treatAsReadOnly
+                    ? [ "EXPOSE" ]
+                    : [ "EXPOSE", "MODIFY" ];
+
+                const newEntry: TreeNodeState = {
+                    allowedOperations: allowedOps,
+                    canDelete: true,
+                    children: undefined,
+                    dataType: "String",
+                    dynamicEntryAllowed: false,
+                    dynamicEntryType: "",
+                    exposeEncrypted: false,
+                    exposed: false,
+                    isClaim: true,
+                    key: `claim-${Date.now()}-${idx}`,
+                    modify: false,
+                    modifyEncrypted: false,
+                    nodeType: NodeType.LEAF,
+                    path: `${parentNode.path}${claim.claimURI}`,
+                    readOnly: treatAsReadOnly,
+                    replaceable: false,
+                    title: claim.displayName
+                };
+
+                updated = addChild(updated, parentNode.key, newEntry);
+            });
+
+            return updated;
+        });
+        setClaimModal({ open: false, parentNode: null });
+    }, [ claimModal, allowReadOnlyClaimsModification ]);
+
+    const handleClaimModalClose = useCallback((): void => {
+        setClaimModal({ open: false, parentNode: null });
+    }, []);
+
+    const initialModalValues: { keyName: string; dataType: string } | undefined =
+        modal.mode === "edit"
+            ? {
+                dataType: modal.initialDataType ?? "",
+                keyName: modal.initialKeyName ?? ""
+            }
+            : undefined;
+
+    return (
+        <Box
+            className="flow-context-tree"
+            data-componentid={ componentId }
+            sx={ { display: "flex", flexDirection: "column", gap: 2 } }
+        >
+            { /* ── Top row: tree (left, 50%) + field config (right, 50%) ── */ }
+            <Box sx={ { alignItems: "stretch", display: "flex", gap: 2 } }>
+                <Box
+                    sx={ {
+                        bgcolor: "background.paper",
+                        border: "1px solid",
+                        borderColor: "grey.200",
+                        borderRadius: "8px",
+                        flex: "1 1 0",
+                        minWidth: 0,
+                        overflow: "auto",
+                        pb: "14px",
+                        pt: "10px",
+                        px: "10px"
+                    } }
+                >
+                    { tree.map((node: TreeNodeState) => (
+                        <FlowContextTreeNode
+                            key={ node.key }
+                            node={ node }
+                            depth={ 0 }
+                            selectedKey={ selectedKey }
+                            onSelect={ setSelectedKey }
+                            onToggleExpose={ handleToggleExpose }
+                            onToggleModify={ handleToggleModify }
+                            onAddChild={ handleAddChild }
+                            readOnly={ readOnly }
+                            data-componentid={ `${componentId}-node` }
+                        />
+                    )) }
+                </Box>
+
+                <Box sx={ { display: "flex", flex: "1 1 0", flexDirection: "column", minWidth: 0 } }>
+                    <FieldConfigPanel
+                        selectedNode={ selectedNode }
+                        hasCertificate={ !!hasCertificate }
+                        readOnly={ !!readOnly }
+                        onToggleExposeEncrypt={ handleToggleExposeEncrypt }
+                        onToggleModifyEncrypt={ handleToggleModifyEncrypt }
+                        onRename={ handleRename }
+                        onDelete={ handleDelete }
+                        onEditPropertiesEntry={ handleEditPropertiesEntry }
+                    />
+                </Box>
+            </Box>
+
+            { /* ── Bottom row: monaco editor full width ── */ }
+            { SHOW_ACCESS_CONFIG_PAYLOAD && (
+                <AccessConfigMonaco accessConfig={ builtConfig.accessConfig } />
+            ) }
+
+            <AddEntryModal
+                open={ modal.open }
+                parentNode={ modal.parentNode }
+                mode={ modal.mode }
+                initialValues={ initialModalValues }
+                onClose={ handleModalClose }
+                onSubmit={ handleModalSubmit }
+                data-componentid={ `${componentId}-add-entry-modal` }
+            />
+
+            <AddClaimModal
+                open={ claimModal.open }
+                parentNode={ claimModal.parentNode }
+                existingClaimURIs={
+                    claimModal.parentNode?.children?.map(
+                        (c: TreeNodeState) => c.path.replace(/^\/user\/claims\//, "")
+                    ) || []
+                }
+                externalClaims={ allClaims }
+                allowReadOnlyClaimsModification={ allowReadOnlyClaimsModification }
+                onClose={ handleClaimModalClose }
+                onSubmit={ handleClaimModalSubmit }
+                data-componentid={ `${componentId}-add-claim-modal` }
+            />
+        </Box>
+    );
+};
+
+export default FlowContextTree;

--- a/features/common.ui.shared-access.v1/components/flow-context-tree/index.ts
+++ b/features/common.ui.shared-access.v1/components/flow-context-tree/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export { default as FlowContextTree } from "./flow-context-tree";
+export type {
+    AccessConfigOutput,
+    EncryptionOutput,
+    FlowExtensionContextTreeResponse,
+    InitialAccessConfig
+} from "./models";

--- a/features/common.ui.shared-access.v1/components/flow-context-tree/models.ts
+++ b/features/common.ui.shared-access.v1/components/flow-context-tree/models.ts
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { IdentifiableComponentInterface } from "@wso2is/core/models";
+
+/**
+ * Node types matching the backend ContextTreeNode.NodeType enum.
+ */
+export enum NodeType {
+    OBJECT = "OBJECT",
+    MAP = "MAP",
+    COMPLEX_MAP = "COMPLEX_MAP",
+    LEAF = "LEAF"
+}
+
+/**
+ * Metadata for a single node in the context tree, matching the backend JSON shape.
+ */
+export interface ContextTreeNodeMetadata {
+    key: string;
+    title: string;
+    path: string;
+    dataType: string;
+    nodeType: NodeType;
+    allowedOperations?: string[];
+    readOnly?: boolean;
+    replaceable?: boolean;
+    canDelete?: boolean;
+    dynamicEntryAllowed?: boolean;
+    dynamicEntryType?: string;
+    children?: ContextTreeNodeMetadata[];
+}
+
+/**
+ * Backend response for the flow context metadata endpoint.
+ */
+interface FlowContextMetadataResponse {
+    contextTree: ContextTreeNodeMetadata[];
+    flowType: string;
+    claimDialect: string;
+}
+
+/**
+ * Response shape for `GET /flow/extension/meta`.
+ *
+ * The tree itself is filtered server-side by the deployment.toml whitelist —
+ * disabled fields are omitted entirely. The two policy flags drive UI behaviour
+ * that depends on the active flow type (REDIRECT op gating, MODIFY-on-read-only
+ * claim permission).
+ */
+export interface FlowExtensionContextTreeResponse {
+    /** Echoed flow type, or null when the default tree was requested. */
+    flowType?: string | null;
+    /** Filtered context tree. Disabled fields are absent, not flagged. */
+    context: ContextTreeNodeMetadata[];
+    /** Whether REDIRECT is advertised in `allowedOperations` for this flow type. */
+    redirectionEnabled: boolean;
+    /**
+     * Whether the Console UI may permit MODIFY on read-only claims for this flow type.
+     * Hardcoded enumerative mapping in the engine — see FlowExtensionContextTreeBuilder.
+     */
+    allowReadOnlyClaimsModification: boolean;
+}
+
+/**
+ * UI state for a single tree node. Extends metadata with selection flags.
+ */
+export interface TreeNodeState {
+    key: string;
+    title: string;
+    path: string;
+    dataType: string;
+    nodeType: NodeType;
+    allowedOperations: string[];
+    readOnly: boolean;
+    replaceable: boolean;
+    canDelete: boolean;
+    dynamicEntryAllowed: boolean;
+    dynamicEntryType: string;
+    exposed: boolean;
+    modify: boolean;
+    exposeEncrypted: boolean;
+    modifyEncrypted: boolean;
+    isClaim?: boolean;
+    children?: TreeNodeState[];
+}
+
+/**
+ * Props for the FlowContextTree component.
+ */
+export interface FlowContextTreeProps extends IdentifiableComponentInterface {
+    contextTree: ContextTreeNodeMetadata[];
+    onChange: (accessConfig: AccessConfigOutput, encryption: EncryptionOutput) => void;
+    initialAccessConfig?: InitialAccessConfig;
+    hasCertificate?: boolean;
+    readOnly?: boolean;
+    /**
+     * Whether the active flow type permits MODIFY on read-only claims (and other read-only
+     * leaves). When false:
+     *   - The add-claim modal does not allow adding read-only claims with the MODIFY flag.
+     *   - Existing access configs with MODIFY on a read-only claim render with the flag dropped.
+     * Defaults to true (matches the historical permissive behaviour).
+     */
+    allowReadOnlyClaimsModification?: boolean;
+    /**
+     * Whether REDIRECT is advertised in `allowedOperations` for this flow type. Surfaced as
+     * a prop so the embedding screen can render an informational banner. The tree component
+     * itself does not gate any controls on this — it is purely presentational.
+     */
+    redirectionEnabled?: boolean;
+}
+
+/**
+ * Initial access config shape for populating tree state from an existing action.
+ * Matches the AccessConfigInterface from the Actions API models.
+ */
+export interface InitialAccessConfig {
+    expose: ContextPathOutput[];
+    modify: ContextPathOutput[];
+}
+
+/**
+ * Access config output shape — matches the existing AccessConfigInterface.
+ */
+export interface AccessConfigOutput {
+    expose: ContextPathOutput[];
+    modify: ContextPathOutput[];
+}
+
+/**
+ * A single path entry with encryption flag.
+ */
+export interface ContextPathOutput {
+    path: string;
+    encrypted: boolean;
+}
+
+/**
+ * Encryption configuration output.
+ */
+export interface EncryptionOutput {
+    certificate?: string;
+}
+
+/**
+ * State for the add-entry modal.
+ */
+export interface AddEntryModalState {
+    open: boolean;
+    parentNode: TreeNodeState | null;
+}

--- a/features/common.ui.shared-access.v1/components/flow-context-tree/utils.ts
+++ b/features/common.ui.shared-access.v1/components/flow-context-tree/utils.ts
@@ -1,0 +1,512 @@
+/**
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+    AccessConfigOutput,
+    ContextPathOutput,
+    ContextTreeNodeMetadata,
+    EncryptionOutput,
+    InitialAccessConfig,
+    NodeType,
+    TreeNodeState
+} from "./models";
+
+/**
+ * Check if a node is a container (OBJECT, MAP, or COMPLEX_MAP).
+ */
+const isContainer = (node: TreeNodeState): boolean =>
+    node.nodeType === NodeType.OBJECT ||
+    node.nodeType === NodeType.MAP ||
+    node.nodeType === NodeType.COMPLEX_MAP;
+
+// ── Propagation Engine ────────────────────────────────────────────────────────
+// expose: LEAF-ONLY, no propagation.
+//   Non-leaf (container) nodes never hold an expose flag. Only leaf nodes can be
+//   marked as exposed. This prevents parent-level paths like /user/claims/ from
+//   appearing in the access config, which would cause the backend to expose ALL
+//   runtime entries in the map rather than only the ones the user configured.
+//
+// modify: LEAF-ONLY, no propagation.
+//
+// exposeEncrypted: LEAF-ONLY, no propagation.
+// modifyEncrypted: LEAF-ONLY, no propagation.
+
+// ── Tree Mutation Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Immutably update a node by key.
+ */
+export const updateNode = (
+    nodes: TreeNodeState[],
+    key: string,
+    fn: (node: TreeNodeState) => TreeNodeState
+): TreeNodeState[] =>
+    nodes.map((n: TreeNodeState) =>
+        n.key === key
+            ? fn(n)
+            : {
+                ...n,
+                children: n.children ? updateNode(n.children, key, fn) : undefined
+            }
+    );
+
+/**
+ * Immutably delete a node by key.
+ */
+export const deleteNode = (
+    nodes: TreeNodeState[],
+    key: string
+): TreeNodeState[] =>
+    nodes
+        .filter((n: TreeNodeState) => n.key !== key)
+        .map((n: TreeNodeState) => ({
+            ...n,
+            children: n.children ? deleteNode(n.children, key) : undefined
+        }));
+
+/**
+ * Immutably add a child node under the given parent key.
+ */
+export const addChild = (
+    nodes: TreeNodeState[],
+    parentKey: string,
+    child: TreeNodeState
+): TreeNodeState[] =>
+    nodes.map((n: TreeNodeState) => {
+        if (n.key === parentKey) {
+            return { ...n, children: [...(n.children || []), child] };
+        }
+
+        return {
+            ...n,
+            children: n.children ? addChild(n.children, parentKey, child) : undefined
+        };
+    });
+
+// ── Metadata → State Conversion ──────────────────────────────────────────────
+
+/**
+ * Convert backend metadata nodes to UI state nodes.
+ * All selection flags start as false.
+ */
+export const mapMetadataToState = (
+    nodes: ContextTreeNodeMetadata[]
+): TreeNodeState[] =>
+    nodes.map((node: ContextTreeNodeMetadata) => ({
+        allowedOperations: node.allowedOperations || [],
+        canDelete: node.canDelete ?? false,
+        children: node.children ? mapMetadataToState(node.children) : undefined,
+        dataType: node.dataType,
+        dynamicEntryAllowed: node.dynamicEntryAllowed ?? false,
+        dynamicEntryType: node.dynamicEntryType ?? "",
+        exposeEncrypted: false,
+        exposed: false,
+        // Path-derived key — backend metadata reuses bare names like "id" across
+        // siblings (user.id, organization.id, application.id). Using node.key
+        // verbatim makes updateNode match all of them at once.
+        key: `node:${normalisePath(node.path)}`,
+        modify: false,
+        modifyEncrypted: false,
+        nodeType: node.nodeType,
+        path: node.path,
+        readOnly: node.readOnly ?? false,
+        replaceable: node.replaceable ?? false,
+        title: node.title
+    }));
+
+// ── Metadata → State Conversion (with existing Access Config) ────────────────
+
+/**
+ * Normalise a path for prefix matching.
+ * Ensures container-style paths end with "/" while leaf paths do not.
+ */
+const normalisePath = (p: string): string => p.replace(/\/+$/, "");
+
+/**
+ * Convert backend metadata nodes to UI state nodes, pre-populating the
+ * expose/modify/encryption flags from an existing access config returned
+ * by the GET action API.
+ *
+ * For each node the algorithm:
+ *   1. Checks if the node's path appears in `expose[]` → set exposed + exposeEncrypted.
+ *   2. Checks if a *parent* path in `expose[]` covers this node → cascade exposed.
+ *   3. Checks if the node's path appears in `modify[]` → set modify + modifyEncrypted.
+ *
+ * Dynamic entries (e.g. claim keys under /user/claims/) that exist in the
+ * access config but NOT in the metadata are synthesised as children.
+ *
+ * @param claimDisplayNames - Optional map of claim URI → display name for rendering
+ *                            human-readable titles on synthesised claim entries.
+ */
+export const mapMetadataToStateWithAccessConfig = (
+    nodes: ContextTreeNodeMetadata[],
+    accessConfig: InitialAccessConfig,
+    claimDisplayNames?: Map<string, string>,
+    options: {
+        /** Whether the active flow type permits MODIFY on read-only nodes. Defaults to true. */
+        allowReadOnlyClaimsModification?: boolean;
+        /** claimURI → readOnly map; used when synthesising claim leaves to inherit per-claim
+         *  read-only status from the Claims API. Without this every synthesised claim is
+         *  treated as not-readOnly and the modify-drop rule below cannot fire on it. */
+        claimReadOnlyMap?: Map<string, boolean>;
+    } = {}
+): TreeNodeState[] => {
+
+    const allowReadOnlyClaimsModification: boolean =
+        options.allowReadOnlyClaimsModification !== false;
+    const claimReadOnlyMap: Map<string, boolean> = options.claimReadOnlyMap ?? new Map();
+    const exposePaths: Map<string, boolean> = new Map();
+    const modifyPaths: Map<string, boolean> = new Map();
+    // Preserve the type-hint string ("Integer", "[String]", "risk: String, …") keyed
+    // by clean path so synthesised properties children get the correct dataType on
+    // reload. Without this, the round-trip collapses every dynamic entry's type back
+    // to the container's `dynamicEntryType` ("Object").
+    const modifyTypeHints: Map<string, string> = new Map();
+
+    (accessConfig.expose ?? []).forEach((e: { path: string; encrypted: boolean }) => {
+        exposePaths.set(normalisePath(e.path), e.encrypted);
+    });
+    (accessConfig.modify ?? []).forEach((m: { path: string; encrypted: boolean }) => {
+        const typeHintMatch: RegExpMatchArray | null = m.path.match(/\{([^}]+)\}$/);
+        const cleanPath: string = m.path.replace(/\{[^}]+\}$/, "");
+        const norm: string = normalisePath(cleanPath);
+
+        modifyPaths.set(norm, m.encrypted);
+        if (typeHintMatch) {
+            modifyTypeHints.set(norm, typeHintMatch[1]);
+        }
+    });
+
+    /**
+     * Check if a path is covered by an ancestor path in the expose set.
+     */
+    const isCoveredByAncestor = (path: string): { covered: boolean; encrypted: boolean } => {
+        const normalised: string = normalisePath(path);
+        const parts: string[] = normalised.split("/").filter(Boolean);
+        let current: string = "";
+
+        for (const part of parts) {
+            current += "/" + part;
+            if (current !== normalised && exposePaths.has(current)) {
+                return { covered: true, encrypted: exposePaths.get(current) };
+            }
+        }
+
+        return { covered: false, encrypted: false };
+    };
+
+    const convert = (
+        metaNodes: ContextTreeNodeMetadata[],
+        parentExposed: boolean,
+        parentEncrypted: boolean
+    ): TreeNodeState[] => {
+        const result: TreeNodeState[] = [];
+
+        for (const node of metaNodes) {
+            const np: string = normalisePath(node.path);
+            const nodeIsContainer: boolean = isContainer({
+                nodeType: node.nodeType
+            } as TreeNodeState);
+
+            // Direct match in expose (only meaningful for leaf nodes)
+            const directExpose: boolean = exposePaths.has(np);
+            const directExposeEnc: boolean = directExpose ? exposePaths.get(np) : false;
+
+            // For leaf nodes: exposed if directly in expose paths or covered by ancestor
+            // For container nodes: never exposed (expose is leaf-only)
+            const ancestor: { covered: boolean; encrypted: boolean } = isCoveredByAncestor(np);
+            const exposed: boolean = nodeIsContainer
+                ? false
+                : (directExpose || ancestor.covered || parentExposed);
+            const exposeEncrypted: boolean = nodeIsContainer
+                ? false
+                : (directExpose
+                    ? directExposeEnc
+                    : ancestor.covered
+                        ? ancestor.encrypted
+                        : parentEncrypted);
+
+            // Modify (leaf-only in practice). When the flow type forbids modifying read-only
+            // nodes, drop a previously-saved MODIFY mark on render. The cleanup commits on
+            // the next save — the saved access config remains untouched until then.
+            const nodeReadOnly: boolean = node.readOnly ?? false;
+            let directModify: boolean = modifyPaths.has(np);
+            let modifyEncrypted: boolean = directModify ? modifyPaths.get(np) : false;
+
+            if (nodeReadOnly && !allowReadOnlyClaimsModification) {
+                directModify = false;
+                modifyEncrypted = false;
+            }
+
+            let children: TreeNodeState[] | undefined;
+
+            if (node.children) {
+                // Pass parent exposed state down so child leaves inherit coverage
+                const childExposed: boolean = directExpose || ancestor.covered || parentExposed;
+                const childEncrypted: boolean = directExpose
+                    ? directExposeEnc
+                    : ancestor.covered
+                        ? ancestor.encrypted
+                        : parentEncrypted;
+
+                children = convert(node.children, childExposed, childEncrypted);
+            }
+
+            // Synthesise dynamic entries that exist in accessConfig but not in metadata
+            if (node.dynamicEntryAllowed) {
+                const existingChildPaths: Set<string> = new Set(
+                    (children || []).map((c: TreeNodeState) => normalisePath(c.path))
+                );
+
+                const containerPrefix: string = normalisePath(node.path) + "/";
+
+                // Collect unique dynamic keys from both expose and modify entries.
+                // Use the full remaining path after the container prefix (not split("/")[0])
+                // because claim URIs contain slashes (e.g. http://wso2.org/claims/displayName).
+                const dynamicKeys: Set<string> = new Set<string>();
+
+                exposePaths.forEach((_enc: boolean, ePath: string) => {
+                    if (ePath.startsWith(containerPrefix)) {
+                        const key: string = ePath.slice(containerPrefix.length);
+
+                        if (key) {
+                            dynamicKeys.add(key);
+                        }
+                    }
+                });
+
+                modifyPaths.forEach((_enc: boolean, mPath: string) => {
+                    if (mPath.startsWith(containerPrefix)) {
+                        const key: string = mPath.slice(containerPrefix.length);
+
+                        if (key) {
+                            dynamicKeys.add(key);
+                        }
+                    }
+                });
+
+                // Create or update children for each unique dynamic key.
+                dynamicKeys.forEach((key: string) => {
+                    const synthPath: string = containerPrefix + key;
+
+                    if (existingChildPaths.has(synthPath)) {
+                        // Already exists from metadata children — update its modify flags.
+                        const existingChild: TreeNodeState | undefined = (children || []).find(
+                            (c: TreeNodeState) => normalisePath(c.path) === synthPath
+                        );
+
+                        if (existingChild && modifyPaths.has(synthPath)) {
+                            // Same drop rule as below — don't reinstate MODIFY on a read-only
+                            // node when the flow type forbids it.
+                            if (existingChild.readOnly && !allowReadOnlyClaimsModification) {
+                                existingChild.modify = false;
+                                existingChild.modifyEncrypted = false;
+                            } else {
+                                existingChild.modify = true;
+                                existingChild.modifyEncrypted = modifyPaths.get(synthPath) ?? false;
+                            }
+                        }
+
+                        return;
+                    }
+
+                    const isExposed: boolean = exposePaths.has(synthPath);
+                    const synthExEnc: boolean = exposePaths.get(synthPath) ?? false;
+                    let isModify: boolean = modifyPaths.has(synthPath);
+                    let synthModEnc: boolean = modifyPaths.get(synthPath) ?? false;
+                    const displayName: string = claimDisplayNames?.get(key) ?? key;
+                    // For dynamic entries under a claims map, prefer the per-claim readOnly
+                    // status (from the Claims API) over the parent container's flag. Falls
+                    // back to the parent's flag if the map doesn't carry the URI.
+                    const claimReadOnly: boolean | undefined = claimReadOnlyMap.get(key);
+                    const synthReadOnly: boolean = claimReadOnly ?? (node.readOnly ?? false);
+
+                    // Drop a previously-saved MODIFY when this flow type forbids modifying
+                    // read-only nodes (e.g., PASSWORD_RECOVERY). The saved access config still
+                    // carries it; the cleanup commits on the next save.
+                    if (synthReadOnly && !allowReadOnlyClaimsModification) {
+                        isModify = false;
+                        synthModEnc = false;
+                    }
+
+                    const isUnderClaims: boolean = containerPrefix === "/user/claims/";
+                    // Prefer the type hint extracted from the modify path (e.g. "Integer"
+                    // from /properties/riskScore{Integer}) so dataType round-trips correctly
+                    // and the edit modal pre-populates with the actual configured type.
+                    const synthDataType: string =
+                        modifyTypeHints.get(synthPath) ?? node.dynamicEntryType ?? "String";
+
+                    children = children || [];
+                    children.push({
+                        allowedOperations: synthReadOnly
+                            ? [ "EXPOSE" ]
+                            : [ "EXPOSE", "MODIFY" ],
+                        canDelete: true,
+                        children: undefined,
+                        dataType: synthDataType,
+                        dynamicEntryAllowed: false,
+                        dynamicEntryType: "",
+                        exposeEncrypted: synthExEnc,
+                        exposed: isExposed,
+                        isClaim: isUnderClaims,
+                        // Path-derived key so two synthesised entries in different containers
+                        // never collide (Date.now() collisions caused dual-row highlighting).
+                        key: `synth:${synthPath}`,
+                        modify: isModify,
+                        modifyEncrypted: synthModEnc,
+                        nodeType: NodeType.LEAF,
+                        path: synthPath,
+                        readOnly: synthReadOnly,
+                        replaceable: false,
+                        title: displayName
+                    });
+                    existingChildPaths.add(synthPath);
+                });
+            }
+
+            result.push({
+                allowedOperations: node.allowedOperations || [],
+                canDelete: node.canDelete ?? false,
+                children,
+                dataType: node.dataType,
+                dynamicEntryAllowed: node.dynamicEntryAllowed ?? false,
+                dynamicEntryType: node.dynamicEntryType ?? "",
+                exposeEncrypted,
+                exposed,
+                // Path-derived key — backend metadata reuses bare names like "id"
+                // across siblings, which caused updateNode to toggle every node
+                // sharing the same key at once.
+                key: `node:${np}`,
+                modify: directModify,
+                modifyEncrypted,
+                nodeType: node.nodeType,
+                path: node.path,
+                readOnly: node.readOnly ?? false,
+                replaceable: node.replaceable ?? false,
+                title: node.title
+            });
+        }
+
+        return result;
+    };
+
+    return convert(nodes, false, false);
+};
+
+// ── Access Config Builder ────────────────────────────────────────────────────
+//
+// expose[]:  LEAF nodes with exposed=true.
+//            Container nodes are never exposed; only individual leaf paths appear.
+//            If exposeEncrypted → { path, encrypted: true }, else { path, encrypted: false }.
+//
+// modify[]:  LEAF nodes with modify=true.
+//            If modifyEncrypted → { path, encrypted: true }, else { path, encrypted: false }.
+
+// ── Selection Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Depth-first lookup for the first leaf node's key. Used to seed the default
+ * selection in the field-configuration panel when the tree first renders.
+ */
+export const findFirstLeafKey = (nodes: TreeNodeState[]): string | null => {
+    for (const node of nodes) {
+        if (node.nodeType === NodeType.LEAF) {
+            return node.key;
+        }
+        if (node.children) {
+            const found: string | null = findFirstLeafKey(node.children);
+
+            if (found) {
+                return found;
+            }
+        }
+    }
+
+    return null;
+};
+
+/**
+ * Find a node by key anywhere in the tree.
+ */
+export const findNode = (
+    nodes: TreeNodeState[],
+    key: string
+): TreeNodeState | null => {
+    for (const node of nodes) {
+        if (node.key === key) {
+            return node;
+        }
+        if (node.children) {
+            const found: TreeNodeState | null = findNode(node.children, key);
+
+            if (found) {
+                return found;
+            }
+        }
+    }
+
+    return null;
+};
+
+/**
+ * Build the access config output from the current tree state.
+ * Only leaf nodes contribute to the output — containers are never exposed.
+ */
+export const buildAccessConfig = (
+    nodes: TreeNodeState[]
+): { accessConfig: AccessConfigOutput; encryption: EncryptionOutput } => {
+
+    const expose: ContextPathOutput[] = [];
+    const modify: ContextPathOutput[] = [];
+
+    const walk = (ns: TreeNodeState[]): void => {
+        ns.forEach((node: TreeNodeState) => {
+            const isLeaf: boolean = node.nodeType === NodeType.LEAF;
+
+            if (isLeaf) {
+                // Expose: leaf-only
+                if (node.exposed) {
+                    expose.push({ encrypted: !!node.exposeEncrypted, path: node.path });
+                }
+
+                // Modify: leaf-only
+                if (node.modify) {
+                    const modifyPath: string = node.canDelete &&
+                        node.dataType &&
+                        node.dataType !== "String"
+                        ? `${node.path}{${node.dataType}}`
+                        : node.path;
+
+                    modify.push({ encrypted: !!node.modifyEncrypted, path: modifyPath });
+                }
+            }
+
+            // Descend into children
+            if (node.children) {
+                walk(node.children);
+            }
+        });
+    };
+
+    walk(nodes);
+
+    return {
+        accessConfig: { expose, modify },
+        encryption: {}
+    };
+};

--- a/knip.json
+++ b/knip.json
@@ -73,7 +73,8 @@
                 "config": []
             },
             "ignoreDependencies": [
-                "buffer"
+                "buffer",
+                "autoprefixer"
             ]
         },
         "apps/myaccount": {
@@ -89,7 +90,8 @@
             },
             "ignoreDependencies": [
                 "@wso2is/theme",
-                "buffer"
+                "buffer",
+                "autoprefixer"
             ]
         },
         "features": {

--- a/modules/i18n/src/models/namespaces/flow-extension-ns.ts
+++ b/modules/i18n/src/models/namespaces/flow-extension-ns.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -17,11 +17,138 @@
  */
 
 export interface flowExtensionNS {
-    properties: {
-        description: string;
-        connectionLabel: string;
-        connectionPlaceholder: string;
-        noConnectionsWarning: string;
-        noConnectionsWarningWithSupport: string;
+    createWizard: {
+        title: string;
+        subTitle: string;
+        steps: {
+            generalSettings: {
+                title: string;
+                name: {
+                    label: string;
+                    placeholder: string;
+                    hint: string;
+                    validations: {
+                        duplicate: string;
+                        invalid: string;
+                    };
+                };
+                description: {
+                    label: string;
+                    placeholder: string;
+                    validations: {
+                        maxLength: string;
+                    };
+                };
+            };
+            endpointConfig: {
+                title: string;
+                endpoint: {
+                    label: string;
+                    placeholder: string;
+                    hint: string;
+                    validations: {
+                        empty: string;
+                        general: string;
+                    };
+                };
+                authenticationType: {
+                    title: string;
+                    label: string;
+                    placeholder: string;
+                    hint: string;
+                    validations: {
+                        required: string;
+                    };
+                };
+                authProperties: {
+                    username: {
+                        label: string;
+                        placeholder: string;
+                        validations: {
+                            required: string;
+                        };
+                    };
+                    password: {
+                        label: string;
+                        placeholder: string;
+                        validations: {
+                            required: string;
+                        };
+                    };
+                    accessToken: {
+                        label: string;
+                        placeholder: string;
+                        validations: {
+                            required: string;
+                        };
+                    };
+                    header: {
+                        label: string;
+                        placeholder: string;
+                        validations: {
+                            required: string;
+                            invalid: string;
+                        };
+                    };
+                    value: {
+                        label: string;
+                        placeholder: string;
+                        validations: {
+                            required: string;
+                        };
+                    };
+                };
+                certificate: {
+                    title: string;
+                    hint: string;
+                };
+            };
+            accessConfig: {
+                title: string;
+                expose: {
+                    heading: string;
+                    hint: string;
+                    add: string;
+                };
+                encrypted: string;
+                operations: {
+                    heading: string;
+                    hint: string;
+                    addPath: string;
+                    addOperation: string;
+                    types: {
+                        add: {
+                            heading: string;
+                            description: string;
+                        };
+                        replace: {
+                            heading: string;
+                            description: string;
+                        };
+                        remove: {
+                            heading: string;
+                            description: string;
+                        };
+                    };
+                };
+                encryption: {
+                    heading: string;
+                    hint: string;
+                };
+            };
+        };
+    };
+    notifications: {
+        createSuccess: {
+            description: string;
+            message: string;
+        };
+        createError: {
+            message: string;
+        };
+        createGenericError: {
+            description: string;
+            message: string;
+        };
     };
 }

--- a/modules/i18n/src/translations/en-US/portals/flow-extension.ts
+++ b/modules/i18n/src/translations/en-US/portals/flow-extension.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,11 +19,145 @@
 import { flowExtensionNS } from "../../../models";
 
 export const flowExtension: flowExtensionNS = {
-    properties: {
-        connectionLabel: "Connection",
-        connectionPlaceholder: "Select a connection",
-        description: "Select an flow extension to link with this flow step.",
-        noConnectionsWarning: "No active flow extensions available. You can create a flow extension connection using the {{productName}} APIs.",
-        noConnectionsWarningWithSupport: "No active flow extensions available. You can create a flow extension connection using the {{productName}} APIs. Please contact <1>{{productName}} support</1> to get started."
+    createWizard: {
+        steps: {
+            accessConfig: {
+                encrypted: "Encrypted",
+                encryption: {
+                    heading: "Encryption Certificate",
+                    hint: "Provide a Base64-encoded PEM certificate used to encrypt sensitive " +
+                        "data before sending it to the extension endpoint."
+                },
+                expose: {
+                    add: "Add Path",
+                    heading: "Expose Paths",
+                    hint: "Define the paths that should be exposed from the authentication " +
+                        "flow to the extension endpoint."
+                },
+                operations: {
+                    addOperation: "Add Operation",
+                    addPath: "Add Path",
+                    heading: "Allowed Operations",
+                    hint: "Define the operations that the extension endpoint is allowed to " +
+                        "perform on the authentication flow.",
+                    types: {
+                        add: {
+                            description: "Paths the extension can add new values to.",
+                            heading: "ADD"
+                        },
+                        remove: {
+                            description: "Paths the extension can remove values from.",
+                            heading: "REMOVE"
+                        },
+                        replace: {
+                            description: "Paths the extension can replace existing values in.",
+                            heading: "REPLACE"
+                        }
+                    }
+                },
+                title: "Access Configuration"
+            },
+            endpointConfig: {
+                authProperties: {
+                    accessToken: {
+                        label: "Access Token",
+                        placeholder: "Access Token",
+                        validations: {
+                            required: "Access token is required."
+                        }
+                    },
+                    header: {
+                        label: "Header",
+                        placeholder: "Header",
+                        validations: {
+                            invalid: "Header must be a valid HTTP header name.",
+                            required: "Header is required."
+                        }
+                    },
+                    password: {
+                        label: "Password",
+                        placeholder: "Password",
+                        validations: {
+                            required: "Password is required."
+                        }
+                    },
+                    username: {
+                        label: "Username",
+                        placeholder: "Username",
+                        validations: {
+                            required: "Username is required."
+                        }
+                    },
+                    value: {
+                        label: "Value",
+                        placeholder: "Value",
+                        validations: {
+                            required: "Value is required."
+                        }
+                    }
+                },
+                authenticationType: {
+                    hint: "Once added, these secrets will not be displayed. " +
+                        "You will only be able to reset them.",
+                    label: "Authentication Scheme",
+                    placeholder: "Select Authentication Type",
+                    title: "Endpoint Authentication",
+                    validations: {
+                        required: "Authentication type is required."
+                    }
+                },
+                certificate: {
+                    hint: "Upload or paste the external service's PEM certificate. " +
+                        "This is used to encrypt sensitive data before sending it to the extension endpoint.",
+                    title: "Service Certificate"
+                },
+                endpoint: {
+                    hint: "The URL of the external endpoint that this extension will call.",
+                    label: "Endpoint URL",
+                    placeholder: "https://extension.example.com/handle",
+                    validations: {
+                        empty: "Endpoint URL is required.",
+                        general: "Please enter a valid URL."
+                    }
+                },
+                title: "Endpoint Configuration"
+            },
+            generalSettings: {
+                description: {
+                    label: "Description",
+                    placeholder: "A brief description of the flow extension.",
+                    validations: {
+                        maxLength: "Description must not exceed 255 characters."
+                    }
+                },
+                name: {
+                    hint: "A unique name for this flow extension. " +
+                        "Must be alphanumeric and can include spaces, hyphens, and underscores.",
+                    label: "Name",
+                    placeholder: "My Flow Extension",
+                    validations: {
+                        duplicate: "An action with this name already exists. Please choose a different name.",
+                        invalid: "Name must start with an alphanumeric character and can only " +
+                            "contain alphanumeric characters, spaces, hyphens, and underscores."
+                    }
+                },
+                title: "General Settings"
+            }
+        },
+        subTitle: "Create a new Flow Extension to customize the authentication flow.",
+        title: "Create Flow Extension"
+    },
+    notifications: {
+        createError: {
+            message: "Create error"
+        },
+        createGenericError: {
+            description: "An error occurred while creating the flow extension.",
+            message: "Something went wrong"
+        },
+        createSuccess: {
+            description: "Successfully created the flow extension.",
+            message: "Create successful"
+        }
     }
 };

--- a/modules/i18n/src/translations/en-US/portals/flows.ts
+++ b/modules/i18n/src/translations/en-US/portals/flows.ts
@@ -113,6 +113,7 @@ export const flows: flowsNS = {
                 flowExtension: "Flow Extension",
                 github: "GitHub",
                 google: "Google",
+                flowExtension: "Flow Extension",
                 magicLink: "Magic Link",
                 microsoft: "Microsoft",
                 passkeyEnrollment: "Enroll Passkey"

--- a/modules/react-components/src/components/grid/resource-grid/resource-grid-card.tsx
+++ b/modules/react-components/src/components/grid/resource-grid/resource-grid-card.tsx
@@ -117,6 +117,7 @@ export const ResourceGridCard: FunctionComponent<PropsWithChildren<ResourceGridC
         onDelete,
         onEdit,
         isResourceComingSoon,
+        ribbon,
         resourceCategory,
         resourceDescription,
         resourceDocumentationLink,
@@ -152,7 +153,7 @@ export const ResourceGridCard: FunctionComponent<PropsWithChildren<ResourceGridC
     return (
         <InfoCard
             className={ classes }
-            ribbon={ isResourceComingSoon && comingSoonRibbonLabel }
+            ribbon={ ribbon ?? (isResourceComingSoon && comingSoonRibbonLabel) }
             header={ resourceName }
             subHeader={ resourceCategory }
             description={ resourceDescription }

--- a/modules/theme/src/themes/default/assets/images/identity-providers/flow-extension.svg
+++ b/modules/theme/src/themes/default/assets/images/identity-providers/flow-extension.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="15 5 180 190" width="100%" height="100%">
+  <rect width="100%" height="100%" fill="transparent" />
+
+  <g stroke="#000" stroke-linecap="round" stroke-linejoin="round">
+    
+    <polyline points="45,145 75,90 115,90 145,35" fill="none" stroke-width="8" />
+    
+    <circle cx="45" cy="145" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="75" cy="90" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="115" cy="90" r="14" fill="#f0f0f0" stroke-width="8" />
+    <circle cx="145" cy="35" r="14" fill="#f0f0f0" stroke-width="8" />
+
+
+    <g transform="translate(125, 125) rotate(-45)">
+      
+      <rect x="-60" y="-26" width="120" height="52" rx="26" fill="transparent" stroke="none" />
+
+      <rect x="-50" y="-16" width="64" height="32" rx="16" fill="none" stroke-width="8" />
+
+      <rect x="-14" y="-16" width="64" height="32" rx="16" fill="none" stroke="#f0f0f0" stroke-width="20" />
+      <rect x="-14" y="-16" width="64" height="32" rx="16" fill="none" stroke-width="8" />
+
+      <path d="M -18 16 H -2 A 16 16 0 0 0 14 0" fill="none" stroke="#f0f0f0" stroke-width="20" />
+      <path d="M -18 16 H -2 A 16 16 0 0 0 14 0" fill="none" stroke-width="8" />
+
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Purpose
Introduce the front-end for managing flow extensions from the connections area, along with the shared flow-context-tree component and supporting translations. This is a pruned slice of the in-flow extension work — the flow-builder packages, JSP portal changes, and react-ui-core changes are merged separately and are intentionally excluded here.

## Implementation
- **admin.connections.v1**: new flow extension create wizard, edit page, and edit settings (general, endpoint, access config, custom errors), translation hook, utils, template group metadata, and icon; wired into the authenticator/connection create factories, templates, and UI configs.
- **common.ui.shared-access.v1**: new reusable `flow-context-tree` component (tree, node, add-claim and add-entry modals, models, utils).
- **admin.actions.v1**: endpoint config form updates shared with the flow extension endpoint settings.
- **admin.core.v1 / admin.feature-gate.v1**: config reducer and feature flag entries.
- **modules/i18n**: flow extension namespace interface and English translations (extends the entries already present on master).
- **modules/react-components / modules/theme**: resource grid card adjustment and identity-provider icon asset.
- **apps/console**: route registration, deployment config entry, and connection logo asset.

Dependency manifest changes (`package.json`, `pnpm-lock.yaml`) are intentionally omitted and will be regenerated separately.