### PR TITLE
Idp add user identifier to meta properties

### DIFF
--- a/.changeset/sharp-months-fetch.md
+++ b/.changeset/sharp-months-fetch.md
@@ -2,6 +2,7 @@
 "@wso2is/admin.password-recovery-flow-builder.v1": patch
 "@wso2is/admin.ask-password-flow-builder.v1": patch
 "@wso2is/admin.registration-flow-builder.v1": patch
+"@wso2is/admin.flow-builder-core.v1": patch
 "@wso2is/console": patch
 "@wso2is/i18n": patch
 ---

--- a/.changeset/sharp-months-fetch.md
+++ b/.changeset/sharp-months-fetch.md
@@ -1,0 +1,9 @@
+---
+"@wso2is/admin.password-recovery-flow-builder.v1": patch
+"@wso2is/admin.ask-password-flow-builder.v1": patch
+"@wso2is/admin.registration-flow-builder.v1": patch
+"@wso2is/console": patch
+"@wso2is/i18n": patch
+---
+
+Add user_identifier to flow builder.

--- a/features/admin.ask-password-flow-builder.v1/api/use-get-supported-profile-attributes.ts
+++ b/features/admin.ask-password-flow-builder.v1/api/use-get-supported-profile-attributes.ts
@@ -60,12 +60,25 @@ const useGetSupportedProfileAttributes = <Data = Attribute[], Error = RequestErr
     );
 
     /**
-     * Transform the claims to ensure the username claim is always included.
-     * Sort the claims by displayName alphabetically.
+     * Resolve supported attributes from the meta endpoint as primary source.
+     * Falls back to local claims API if metadata is not available.
+     * Ensures the username claim is always included and sorts alphabetically.
      */
     const sortedAttributesWithUsername: Attribute[] = useMemo(() => {
+        const metadataAttributes: Attribute[] = (metadata?.attributeMetadata ?? []).map(
+            (attr: { claimURI: string; name: string }) => ({
+                claimURI: attr.claimURI,
+                displayName: attr.name
+            })
+        ) as Attribute[];
+
+        if (metadataAttributes.length > 0) {
+            return transformClaimsWithUsername(metadataAttributes);
+        }
+
+        // Fallback to local claims API if metadata attributes are not available
         return transformClaimsWithUsername(data as Attribute[]);
-    }, [ data ]);
+    }, [ metadata?.attributeMetadata, data ]);
 
     return {
         data: sortedAttributesWithUsername as Data,

--- a/features/admin.flow-builder-core.v1/components/resources/elements/adapters/button-adapter.tsx
+++ b/features/admin.flow-builder-core.v1/components/resources/elements/adapters/button-adapter.tsx
@@ -27,6 +27,7 @@ import PlaceholderComponent from "@wso2is/common.branding.v1/components/placehol
 import VisualFlowConstants from "../../../../constants/visual-flow-constants";
 import usePasswordExecutorValidation from "../../../../hooks/use-password-executor-validation";
 import useRequiredFields, { RequiredFieldInterface } from "../../../../hooks/use-required-fields";
+import useUserResolveExecutorValidation from "../../../../hooks/use-user-resolve-executor-validation";
 import { ButtonVariants, Element } from "../../../../models/elements";
 import { CommonElementFactoryPropsInterface } from "../common-element-factory";
 import "./button-adapter.scss";
@@ -83,6 +84,7 @@ const ButtonAdapter: FunctionComponent<ButtonAdapterPropsInterface> = ({
     );
 
     usePasswordExecutorValidation((resource as unknown) as Element);
+    useUserResolveExecutorValidation((resource as unknown) as Element);
 
     let config: ButtonProps = {};
     let image: string = "";

--- a/features/admin.flow-builder-core.v1/hooks/use-user-resolve-executor-validation.ts
+++ b/features/admin.flow-builder-core.v1/hooks/use-user-resolve-executor-validation.ts
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ClaimManagementConstants } from "@wso2is/admin.claims.v1/constants/claim-management-constants";
+import { Node, useReactFlow } from "@xyflow/react";
+import { useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import useAuthenticationFlowBuilderCore from "./use-authentication-flow-builder-core-context";
+import useValidationStatus from "./use-validation-status";
+import { BlockTypes, Element, ElementTypes, InputVariants } from "../models/elements";
+import Notification, { NotificationType } from "../models/notification";
+import { Resource } from "../public-api";
+
+const USER_RESOLVE_EXECUTOR: string = "UserResolveExecutor";
+const USER_IDENTIFIER: string = "userIdentifier";
+
+/**
+ * Custom hook for validating UserResolveExecutor form configuration.
+ * Ensures that forms containing a UserResolveExecutor button only have
+ * text input fields mapped to username or userIdentifier (if multi-attribute login is enabled).
+ *
+ * @param resource - The button action resource from button-adapter.tsx
+ */
+const useUserResolveExecutorValidation = (resource: Element): void => {
+    const { t } = useTranslation();
+    const { getNodes } = useReactFlow();
+    const { addNotification, removeNotification } = useValidationStatus();
+    const { metadata } = useAuthenticationFlowBuilderCore();
+
+    const nodes: Node[] = getNodes();
+    const notificationId: string = `user-resolve-executor-validation-${resource?.id}`;
+
+    /**
+     * Check if the button has a UserResolveExecutor.
+     */
+    const isUserResolveExecutor: boolean = useMemo(() => {
+        return resource?.action?.executor?.name === USER_RESOLVE_EXECUTOR;
+    }, [ resource?.action?.executor?.name ]);
+
+    /**
+     * Find the parent form that contains this button resource.
+     */
+    const parentForm: Element | undefined = useMemo(() => {
+        if (!isUserResolveExecutor || !resource?.id || !nodes?.length) {
+            return undefined;
+        }
+
+        for (const node of nodes) {
+            const components: Element[] = node?.data?.components as Element[];
+
+            if (!components?.length) {
+                continue;
+            }
+
+            for (const component of components) {
+                if (component.type === BlockTypes.Form && component.components?.length) {
+                    const containsButton: boolean = component.components.some(
+                        (nestedComponent: Element) => nestedComponent.id === resource.id
+                    );
+
+                    if (containsButton) {
+                        return component;
+                    }
+                }
+            }
+        }
+
+        return undefined;
+    }, [ isUserResolveExecutor, resource?.id, nodes ]);
+
+    /**
+     * Check if multi-attribute login is enabled from metadata.
+     */
+    const multiAttributeLoginEnabled: boolean = useMemo(() => {
+        return metadata?.connectorConfigs?.multiAttributeLoginEnabled ?? false;
+    }, [ metadata?.connectorConfigs?.multiAttributeLoginEnabled ]);
+
+    /**
+     * Validate that all input fields in the form are text inputs mapped to allowed identifiers.
+     */
+    const isValidConfiguration: boolean = useMemo(() => {
+        if (!isUserResolveExecutor || !parentForm?.components?.length) {
+            return true;
+        }
+
+        const allowedIdentifiers: string[] = [ ClaimManagementConstants.USER_NAME_CLAIM_URI ];
+
+        if (multiAttributeLoginEnabled) {
+            allowedIdentifiers.push(USER_IDENTIFIER);
+        }
+
+        const inputFields: Element[] = parentForm.components.filter(
+            (component: Element) => component.type === ElementTypes.Input
+        );
+
+        return inputFields.every((field: Element) =>
+            field.variant === InputVariants.Text
+            && allowedIdentifiers.includes(field.config?.identifier)
+        );
+    }, [ isUserResolveExecutor, parentForm, multiAttributeLoginEnabled ]);
+
+    /**
+     * Effect to handle user resolve executor validation notifications.
+     */
+    useEffect(() => {
+        if (!isUserResolveExecutor || !resource?.id || !parentForm) {
+            removeNotification(notificationId);
+
+            return;
+        }
+
+        removeNotification(notificationId);
+
+        if (!isValidConfiguration) {
+            const message: string = multiAttributeLoginEnabled
+                ? t("flows:core.validation.userResolveExecutorFields.messageWithUserIdentifier")
+                : t("flows:core.validation.userResolveExecutorFields.message");
+
+            const notification: Notification = new Notification(
+                notificationId,
+                message,
+                NotificationType.ERROR
+            );
+
+            notification.addResource((resource as unknown) as Resource);
+            addNotification(notification);
+        }
+    }, [ isUserResolveExecutor, isValidConfiguration, resource?.id, parentForm,
+        notificationId, multiAttributeLoginEnabled, t, addNotification, removeNotification ]);
+
+    /**
+     * Cleanup function to remove notifications on unmount.
+     */
+    useEffect(() => {
+        return () => {
+            removeNotification(notificationId);
+        };
+    }, [ notificationId, removeNotification ]);
+};
+
+export default useUserResolveExecutorValidation;

--- a/features/admin.password-recovery-flow-builder.v1/providers/password-recovery-flow-builder-provider.tsx
+++ b/features/admin.password-recovery-flow-builder.v1/providers/password-recovery-flow-builder-provider.tsx
@@ -123,24 +123,27 @@ const FlowContextWrapper: FC<PasswordRecoveryFlowBuilderProviderProps> = ({
     );
 
     /**
-     * Transform the claims to ensure the username claim is always included.
-     * Sort the claims by displayName alphabetically.
+     * Resolve supported attributes from the meta endpoint as primary source.
+     * Falls back to local claims API if metadata is not available.
+     * Ensures the username claim is always included and sorts alphabetically.
      */
     const sortedAttributesWithUsername: Attribute[] = useMemo(() => {
-        const claims: Attribute[] = claimsData as Attribute[];
-
-        if (!claims || claims.length === 0) {
-            // Fallback to metadata if API data is not available
-            const metadataClaims: any = (metadata?.attributeMetadata ?? []).map((attr: any) => ({
+        const metadataAttributes: Attribute[] = (metadata?.attributeMetadata ?? []).map(
+            (attr: { claimURI: string; name: string }) => ({
                 claimURI: attr.claimURI,
                 displayName: attr.name
-            }));
+            })
+        ) as Attribute[];
 
-            return transformClaimsWithUsername(metadataClaims as Attribute[]);
+        if (metadataAttributes.length > 0) {
+            return transformClaimsWithUsername(metadataAttributes);
         }
 
+        // Fallback to local claims API if metadata attributes are not available
+        const claims: Attribute[] = claimsData as Attribute[];
+
         return transformClaimsWithUsername(claims);
-    }, [ claimsData, metadata?.attributeMetadata ]);
+    }, [ metadata?.attributeMetadata, claimsData ]);
 
     const handlePublish = async (): Promise<boolean> => {
         setIsPublishing(true);

--- a/features/admin.registration-flow-builder.v1/api/use-get-supported-profile-attributes.ts
+++ b/features/admin.registration-flow-builder.v1/api/use-get-supported-profile-attributes.ts
@@ -60,12 +60,25 @@ const useGetSupportedProfileAttributes = <Data = Attribute[], Error = RequestErr
     );
 
     /**
-     * Transform the claims to ensure the username claim is always included.
-     * Sort the claims by displayName alphabetically.
+     * Resolve supported attributes from the meta endpoint as primary source.
+     * Falls back to local claims API if metadata is not available.
+     * Ensures the username claim is always included and sorts alphabetically.
      */
     const sortedAttributesWithUsername: Attribute[] = useMemo(() => {
+        const metadataAttributes: Attribute[] = (metadata?.attributeMetadata ?? []).map(
+            (attr: { claimURI: string; name: string }) => ({
+                claimURI: attr.claimURI,
+                displayName: attr.name
+            })
+        ) as Attribute[];
+
+        if (metadataAttributes.length > 0) {
+            return transformClaimsWithUsername(metadataAttributes);
+        }
+
+        // Fallback to local claims API if metadata attributes are not available
         return transformClaimsWithUsername(data as Attribute[]);
-    }, [ data ]);
+    }, [ metadata?.attributeMetadata, data ]);
 
     return {
         data: sortedAttributesWithUsername as Data,

--- a/modules/i18n/src/models/namespaces/flows-ns.ts
+++ b/modules/i18n/src/models/namespaces/flows-ns.ts
@@ -314,6 +314,10 @@ export interface flowsNS {
                     actionId: string;
                 };
             };
+            userResolveExecutorFields: {
+                message: string;
+                messageWithUserIdentifier: string;
+            };
         };
         steps: {
             end: {

--- a/modules/i18n/src/translations/en-US/portals/flows.ts
+++ b/modules/i18n/src/translations/en-US/portals/flows.ts
@@ -310,6 +310,10 @@ export const flows: flowsNS = {
                     text: "Typography must have text content to be displayed to users.",
                     variant: "Typography must have a variant defined for proper text styling."
                 }
+            },
+            userResolveExecutorFields: {
+                message: "Forms with a 'Resolve User' action can only contain a text input field mapped to Username.",
+                messageWithUserIdentifier: "Forms with a 'Resolve User' action can only contain text input fields mapped to Username or User Identifier."
             }
         },
         validationStatusLabels: {


### PR DESCRIPTION
Related Issues:

- [x] https://github.com/wso2/product-is/issues/27804

This pull request introduces support for a new `userIdentifier` attribute in the flow builder, improves the way supported profile attributes are resolved across multiple flow builders, and adds validation for forms using the "UserResolveExecutor" action. It also enhances internationalization support for new validation messages.

**Flow builder attribute resolution and validation improvements:**

* Updated the logic in the password recovery, registration, and ask-password flow builders to resolve supported profile attributes primarily from the metadata endpoint, with a fallback to the local claims API. This ensures the username claim is always included and the attributes are sorted alphabetically. [[1]](diffhunk://#diff-1bad2dc516dbf19592d910d4ee1f92826ea6e9228a110bd066d06453611affe8L126-R146) [[2]](diffhunk://#diff-1bec47620b25e127ba28c377f644b52b0f2d0f0a971cfd1888f9d930c574d83eL63-R81)
* Added support for the new `userIdentifier` attribute in the flow builder, as documented in the changeset.

**UserResolveExecutor validation:**

* Introduced a new custom hook `useUserResolveExecutorValidation` to validate that forms containing a "UserResolveExecutor" button only have text input fields mapped to allowed identifiers (username or userIdentifier if multi-attribute login is enabled). This includes notification management for invalid configurations.
* Integrated the new validation hook into the button adapter component to ensure validation logic is applied when rendering form elements. [[1]](diffhunk://#diff-cc319c2095679b64916f7b6304df0e64a9a7006f6d0d485f5b19a59f831163f0R30) [[2]](diffhunk://#diff-cc319c2095679b64916f7b6304df0e64a9a7006f6d0d485f5b19a59f831163f0R87)

**Internationalization updates:**

* Added new i18n keys and English translations for validation messages related to the "UserResolveExecutor" field requirements. [[1]](diffhunk://#diff-68672e459833c5e9f825ed9c76abc2dcd3246df56307bf4deb6689626386a7e0R317-R320) [[2]](diffhunk://#diff-e459aadc3085389d0afe0cc0cb377299df5de68f72791339eebb9eb553e9fd87R313-R316)