### PR TITLE
Fix routing in preference management

### DIFF
--- a/.changeset/clever-kings-rest.md
+++ b/.changeset/clever-kings-rest.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.core.v1": patch
+"@wso2is/admin.server-configurations.v1": patch
+---
+
+Fix routing in preference management

--- a/apps/console/src/configs/routes.tsx
+++ b/apps/console/src/configs/routes.tsx
@@ -575,9 +575,6 @@ export const getAppViewRoutes = (): RouteInterface[] => {
                 {
                     component: lazy(() => import("@wso2is/admin.consents.v1/pages/policy-consent-new")),
                     exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
-                    },
                     id: "consents-new",
                     name: "Consent New",
                     path: AppConstants.getPaths().get("POLICY_CONSENTS_NEW"),
@@ -587,9 +584,6 @@ export const getAppViewRoutes = (): RouteInterface[] => {
                 {
                     component: lazy(() => import("@wso2is/admin.consents.v1/pages/policy-consent-edit")),
                     exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
-                    },
                     id: "consents-edit",
                     name: "Consent Edit",
                     path: AppConstants.getPaths().get("POLICY_CONSENTS_EDIT"),
@@ -597,51 +591,38 @@ export const getAppViewRoutes = (): RouteInterface[] => {
                     showOnSidePanel: false
                 },
                 {
-                    children: [
-                        {
-                            component: lazy(() =>
-                                import("@wso2is/admin.consents.v1/pages/preference-management-new")),
-                            exact: true,
-                            icon: {
-                                icon: getSidePanelIcons().childIcon
-                            },
-                            id: "preference-management-new",
-                            name: "Preference Management New",
-                            path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT_NEW"),
-                            protected: true,
-                            showOnSidePanel: false
-                        },
-                        {
-                            component: lazy(() =>
-                                import("@wso2is/admin.consents.v1/pages/preference-management-edit")),
-                            exact: true,
-                            icon: {
-                                icon: getSidePanelIcons().childIcon
-                            },
-                            id: "preference-management-edit",
-                            name: "Preference Management Edit",
-                            path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT_EDIT"),
-                            protected: true,
-                            showOnSidePanel: false
-                        }
-                    ],
                     component: lazy(() => import("@wso2is/admin.consents.v1/pages/preference-management")),
                     exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().consents
-                    },
                     id: "preferenceManagement",
                     name: "extensions:develop.sidePanel.preferenceManagement",
                     path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT"),
+                    protected: true,
+                    showOnSidePanel: false
+                },
+                {
+                    component: lazy(() =>
+                        import("@wso2is/admin.consents.v1/pages/preference-management-new")),
+                    exact: true,
+                    id: "preference-management-new",
+                    name: "Preference Management New",
+                    path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT_NEW"),
+                    protected: true,
+                    showOnSidePanel: false
+                },
+                {
+                    component: lazy(() =>
+                        import("@wso2is/admin.consents.v1/pages/preference-management-edit")),
+                    exact: true,
+                    id: "preference-management-edit",
+                    name: "Preference Management Edit",
+                    path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT_EDIT"),
                     protected: true,
                     showOnSidePanel: false
                 }
             ],
             component: lazy(() => import("@wso2is/admin.consents.v1/pages/policy-consents")),
             exact: true,
-            icon: {
-                icon: getSidePanelIcons().consents
-            },
+            icon: null,
             id: "consents",
             name: "extensions:develop.sidePanel.consents",
             order: 7,

--- a/apps/console/src/configs/routes.tsx
+++ b/apps/console/src/configs/routes.tsx
@@ -595,6 +595,46 @@ export const getAppViewRoutes = (): RouteInterface[] => {
                     path: AppConstants.getPaths().get("POLICY_CONSENTS_EDIT"),
                     protected: true,
                     showOnSidePanel: false
+                },
+                {
+                    children: [
+                        {
+                            component: lazy(() =>
+                                import("@wso2is/admin.consents.v1/pages/preference-management-new")),
+                            exact: true,
+                            icon: {
+                                icon: getSidePanelIcons().childIcon
+                            },
+                            id: "preference-management-new",
+                            name: "Preference Management New",
+                            path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT_NEW"),
+                            protected: true,
+                            showOnSidePanel: false
+                        },
+                        {
+                            component: lazy(() =>
+                                import("@wso2is/admin.consents.v1/pages/preference-management-edit")),
+                            exact: true,
+                            icon: {
+                                icon: getSidePanelIcons().childIcon
+                            },
+                            id: "preference-management-edit",
+                            name: "Preference Management Edit",
+                            path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT_EDIT"),
+                            protected: true,
+                            showOnSidePanel: false
+                        }
+                    ],
+                    component: lazy(() => import("@wso2is/admin.consents.v1/pages/preference-management")),
+                    exact: true,
+                    icon: {
+                        icon: getSidePanelIcons().consents
+                    },
+                    id: "preferenceManagement",
+                    name: "extensions:develop.sidePanel.preferenceManagement",
+                    path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT"),
+                    protected: true,
+                    showOnSidePanel: false
                 }
             ],
             component: lazy(() => import("@wso2is/admin.consents.v1/pages/policy-consents")),
@@ -606,46 +646,6 @@ export const getAppViewRoutes = (): RouteInterface[] => {
             name: "extensions:develop.sidePanel.consents",
             order: 7,
             path: AppConstants.getPaths().get("POLICY_CONSENTS"),
-            protected: true,
-            showOnSidePanel: false
-        },
-        {
-            category: "extensions:manage.sidePanel.categories.userManagement",
-            children: [
-                {
-                    component: lazy(() => import("@wso2is/admin.consents.v1/pages/preference-management-new")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
-                    },
-                    id: "preference-management-new",
-                    name: "Preference Management New",
-                    path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT_NEW"),
-                    protected: true,
-                    showOnSidePanel: false
-                },
-                {
-                    component: lazy(() => import("@wso2is/admin.consents.v1/pages/preference-management-edit")),
-                    exact: true,
-                    icon: {
-                        icon: getSidePanelIcons().childIcon
-                    },
-                    id: "preference-management-edit",
-                    name: "Preference Management Edit",
-                    path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT_EDIT"),
-                    protected: true,
-                    showOnSidePanel: false
-                }
-            ],
-            component: lazy(() => import("@wso2is/admin.consents.v1/pages/preference-management")),
-            exact: true,
-            icon: {
-                icon: getSidePanelIcons().consents
-            },
-            id: "preferenceManagement",
-            name: "extensions:develop.sidePanel.preferenceManagement",
-            order: 8,
-            path: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT"),
             protected: true,
             showOnSidePanel: false
         },

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -2265,7 +2265,6 @@
                 "groups": "v0.0.0",
                 "identityProviders": "v0.0.0",
                 "loginAndRegistration": "v1.0.0",
-                "preferenceManagement": "v0.0.0",
                 "mcpServers": "v0.0.0",
                 "oidcScopes": "v0.0.0",
                 "organizations": "v0.0.0",

--- a/features/admin.core.v1/constants/app-constants.ts
+++ b/features/admin.core.v1/constants/app-constants.ts
@@ -550,7 +550,6 @@ export class AppConstants {
         "groups": "v0.0.0",
         "identityProviders": "v0.0.0",
         "loginAndRegistration": "v1.0.0",
-        "preferenceManagement": "v0.0.0",
         "mcpServers": "v0.0.0",
         "oidcScopes": "v0.0.0",
         "organizations": "v0.0.0",

--- a/features/admin.server-configurations.v1/pages/connector-listing-page.tsx
+++ b/features/admin.server-configurations.v1/pages/connector-listing-page.tsx
@@ -157,6 +157,11 @@ const ConnectorListingPage: FunctionComponent<ConnectorListingPageInterface> = (
                     return false;
                 }
 
+                if (connector.id === ServerConfigurationsConstants.PREFERENCE_MANAGEMENT_CONNECTOR_ID
+                    && (!featureConfig?.consents?.enabled || !hasConsentsReadPermission)) {
+                    return false;
+                }
+
                 if (isSubOrganization() && (connector.id === ServerConfigurationsConstants.SIFT_CONNECTOR_ID ||
                     connector.id === ServerConfigurationsConstants.EMAIL_DOMAIN_DISCOVERY ||
                     connector.id === ServerConfigurationsConstants.ISSUER_USAGE_SCOPE)) {

--- a/modules/core/src/helpers/__mocks__/deployment.config.json
+++ b/modules/core/src/helpers/__mocks__/deployment.config.json
@@ -1321,7 +1321,6 @@
                 "governanceConnectors": "v0.0.0",
                 "groups": "v0.0.0",
                 "identityProviders": "v0.0.0",
-                "preferenceManagement": "v0.0.0",
                 "organizations": "v0.0.0",
                 "roles": "v0.0.0",
                 "smsTemplates": "v0.0.0",


### PR DESCRIPTION
Related issue https://github.com/wso2/product-is/issues/26859

This pull request primarily reorganizes the routing and feature flag configuration for the "Policy Consents" and "Preference Management" modules in the admin console application. The main changes involve restructuring the route definitions to group related pages more logically and removing the `preferenceManagement` feature flag from configuration files, indicating that this flag is no longer required for feature gating. Additionally, connector listing logic now checks for both feature enablement and permission before displaying the preference management connector.

**Routing and navigation restructuring:**

* The "Policy Consents" route and its configuration (including component, icon, and metadata) have been moved to be grouped under the "Preference Management" section, making the routing structure more logical and consistent. [[1]](diffhunk://#diff-e0208e003ed23f24f6c283bcd5cd2e93e9789264e77e3d390ea7137a690c4709L598-R603) [[2]](diffhunk://#diff-e0208e003ed23f24f6c283bcd5cd2e93e9789264e77e3d390ea7137a690c4709L647-R650)
* The "Preference Management" child routes have been updated for improved formatting and clarity, but their functionality remains unchanged.

**Feature flag and configuration cleanup:**

* The `preferenceManagement` feature flag has been removed from `deployment.config.json` and related configuration files, reflecting that this flag is no longer needed for feature gating. [[1]](diffhunk://#diff-e66c115a503827bbd4e1bd6ad04d6ff16ed77f158ae3608fae0f786905382f63L2268) [[2]](diffhunk://#diff-1f0db8ffd77352a4032b41c830b166f7527472f146e105e0f3b9bb346576778aL553) [[3]](diffhunk://#diff-5a0d3816f9df05b2c5de1ac20320ceb026ea9d84d0540bb86e2e0910c0cc89e3L1324)

**Connector listing logic update:**

* The logic for displaying the preference management connector now additionally checks if the consents feature is enabled and if the user has the necessary permissions, ensuring connectors are only shown when appropriate.
