### PR TITLE
Fix rules-of-hooks violation in getFilePicker

### DIFF
--- a/.changeset/solid-pigs-laugh.md
+++ b/.changeset/solid-pigs-laugh.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.connections.v1": patch
+---
+
+Fix rules-of-hooks violation in getFilePicker

--- a/features/admin.connections.v1/components/edit/forms/helpers/form-fields-helper.tsx
+++ b/features/admin.connections.v1/components/edit/forms/helpers/form-fields-helper.tsx
@@ -592,7 +592,7 @@ const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterface,
                     <Pkcs12FileField
                         onCertificateChange={ (newData: string) =>
                         {
-                            onCertificateChange(data);
+                            onCertificateChange(newData);
                         } }
                     />
                     { propertyMetadata?.description

--- a/features/admin.connections.v1/components/edit/forms/helpers/form-fields-helper.tsx
+++ b/features/admin.connections.v1/components/edit/forms/helpers/form-fields-helper.tsx
@@ -27,7 +27,7 @@ import {
 import { I18n } from "@wso2is/i18n";
 import { CopyInputField, GenericIcon, Hint, P12FileStrategy } from "@wso2is/react-components";
 import { FormValidation } from "@wso2is/validation";
-import React, { ReactElement, useState } from "react";
+import React, { ReactElement } from "react";
 import { Grid } from "semantic-ui-react";
 import { Pkcs12FileField } from "./pkcs12-file-field";
 import { ConnectionUIConstants } from "../../../../constants/connection-ui-constants";
@@ -553,13 +553,13 @@ const getDropDownField = (eachProp: CommonPluggableComponentPropertyInterface,
     );
 };
 
-/* eslint-disable react-hooks/rules-of-hooks */
+
 const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterface,
     propertyMetadata: CommonPluggableComponentMetaPropertyInterface,
     testId?: string,
     onCertificateChange?: ( newFile: string) => void): ReactElement => {
 
-    const [ data, setData ] = useState<string>(eachProp?.value);
+    const data: string = eachProp?.value ?? "";
 
     return (
         <>
@@ -592,7 +592,6 @@ const getFilePicker = (eachProp: CommonPluggableComponentPropertyInterface,
                     <Pkcs12FileField
                         onCertificateChange={ (newData: string) =>
                         {
-                            setData(newData);
                             onCertificateChange(data);
                         } }
                     />


### PR DESCRIPTION
### Purpose
Fixes the react-hooks/rules-of-hooks ESLint violation in getFilePicker function inside form-fields-helper.tsx by replacing the useState hook with a plain variable.

### Related Issues
 - fixes https://github.com/wso2/product-is/issues/27958

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.


https://github.com/user-attachments/assets/b6aa56c1-7ea8-47a3-a276-83c4d0fd1634
