### PR TITLE
Add sp id to recovery v2 api calls.

### DIFF
--- a/.changeset/old-taxis-deny.md
+++ b/.changeset/old-taxis-deny.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add sp id to recovery v2 requests.

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-otp.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery-otp.jsp
@@ -43,6 +43,7 @@
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.RecoveryResponse" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ResendRequest" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.recovery.v2.ResendResponse" %>
+<%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.model.Property" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClient" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.client.PreferenceRetrievalClientException" %>
 <%@ page import="org.wso2.carbon.identity.mgt.endpoint.util.IdentityManagementEndpointConstants" %>
@@ -211,7 +212,18 @@
             RecoveryRequest recoveryRequest = new RecoveryRequest();
             recoveryRequest.setChannelId(channelId);
             recoveryRequest.setRecoveryCode(recoveryCode);
-            RecoveryResponse recoveryResponse = 
+
+            String spId = Encode.forJava(request.getParameter("spId"));
+            if (StringUtils.isNotBlank(spId) && !StringUtils.equalsIgnoreCase(spId, "null")) {
+                List<Property> properties = new ArrayList<>();
+                Property spIdProperty = new Property();
+                spIdProperty.setKey("spId");
+                spIdProperty.setValue(spId);
+                properties.add(spIdProperty);
+                recoveryRequest.setProperties(properties);
+            }
+
+            RecoveryResponse recoveryResponse =
                 recoveryApiV2.recoverPassword(recoveryRequest, tenantDomain, requestHeaders);
             request.setAttribute("resendCode", recoveryResponse.getResendCode());
             request.setAttribute("flowConfirmationCode", recoveryResponse.getFlowConfirmationCode());
@@ -243,7 +255,18 @@
             }
             ResendRequest resendRequest = new ResendRequest();
             resendRequest.setResendCode(resendCode);
-            ResendResponse resendResponse = 
+
+            String spId = Encode.forJava(request.getParameter("spId"));
+            if (StringUtils.isNotBlank(spId) && !StringUtils.equalsIgnoreCase(spId, "null")) {
+                List<Property> properties = new ArrayList<>();
+                Property spIdProperty = new Property();
+                spIdProperty.setKey("spId");
+                spIdProperty.setValue(spId);
+                properties.add(spIdProperty);
+                resendRequest.setProperties(properties);
+            }
+
+            ResendResponse resendResponse =
                 recoveryApiV2.resendPasswordNotification(resendRequest, tenantDomain, requestHeaders);
             
             /** Resend code re-attached to the reqeust to avoid value being missed after the page refresh that
@@ -301,6 +324,8 @@
         request.setAttribute("spId", spId);
         request.getRequestDispatcher("password-reset.jsp").forward(request, response);
     } else if (RecoveryStage.RESET.equalsValue(recoveryStage)) {
+        String spId = Encode.forJava(request.getParameter("spId"));
+        request.setAttribute("spId", spId);
         request.setAttribute("useRecoveryV2API", "true");
         request.getRequestDispatcher("password-reset-complete.jsp").forward(request, response);
     } else {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-recovery.jsp
@@ -103,6 +103,10 @@
 
     try {
         ApplicationDataRetrievalClient applicationDataRetrievalClient = new ApplicationDataRetrievalClient();
+        if (StringUtils.isNotBlank(sp)
+                && (StringUtils.isBlank(spId) || StringUtils.equalsIgnoreCase(spId, "null"))) {
+            spId = applicationDataRetrievalClient.getApplicationID(tenantDomain, Encode.forJava(sp));
+        }
         applicationAccessURLWithoutEncoding = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain,
             Encode.forJava(sp));
         applicationAccessURLWithoutEncoding = IdentityManagementEndpointUtil.replaceUserTenantHintPlaceholder(

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/password-reset-complete.jsp
@@ -175,6 +175,14 @@
             resetRequest.setResetCode(resetCode);
             resetRequest.setFlowConfirmationCode(flowConfirmationCode);
             resetRequest.setPassword(newPassword);
+            if (StringUtils.isNotBlank(spId) && !StringUtils.equalsIgnoreCase(spId, "null")) {
+                List<Property> properties = new ArrayList<>();
+                Property spIdProperty = new Property();
+                spIdProperty.setKey("spId");
+                spIdProperty.setValue(spId);
+                properties.add(spIdProperty);
+                resetRequest.setProperties(properties);
+            }
             ResetResponse resetResponse = recoveryApiV2.resetUserPassword(resetRequest, tenantDomain, requestHeaders);
             if (StringUtils.isBlank(username)) {
                 username = Encode.forJava(request.getParameter("username"));
@@ -200,6 +208,13 @@
             property.setKey("callback");
             property.setValue(URLEncoder.encode(callback, "UTF-8"));
             properties.add(property);
+        }
+
+        if (StringUtils.isNotBlank(spId) && !StringUtils.equalsIgnoreCase(spId, "null")) {
+            Property spIdProperty = new Property();
+            spIdProperty.setKey("spId");
+            spIdProperty.setValue(spId);
+            properties.add(spIdProperty);
         }
 
         Property appIsAccessUrlAvailableProperty = new Property();

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/recovery.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/recovery.jsp
@@ -115,7 +115,8 @@
     String sessionDataKey = request.getParameter("sessionDataKey");
     String confirmationKey = request.getParameter("confirmationKey");
     String callback = request.getParameter("callback");
-    String spId = request.getParameter("spId");
+    String sp = Encode.forJava(request.getParameter("sp"));
+    String spId = Encode.forJava(request.getParameter("spId"));
     String userTenantHint = request.getParameter("t");
     String applicationAccessUrl = "";
 
@@ -132,9 +133,11 @@
     String recoveryOption = request.getParameter("recoveryOption");
 
     try {
-        String sp = Encode.forJava(request.getParameter("sp"));
         if (StringUtils.isNotBlank(sp)) {
             ApplicationDataRetrievalClient applicationDataRetrievalClient = new ApplicationDataRetrievalClient();
+            if (StringUtils.isBlank(spId) || StringUtils.equalsIgnoreCase(spId, "null")) {
+                spId = applicationDataRetrievalClient.getApplicationID(tenantDomain, sp);
+            }
             applicationAccessUrl = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain, sp);
         }
     } catch (Exception e) {
@@ -291,12 +294,21 @@
             }
             
             request.setAttribute("recoveryChannelType", recoveryChannelType);
- 
+
             // Sending the notification if we only found a user.
             if (isUserFound){
                 RecoveryRequest recoveryRequest = new RecoveryRequest();
                 recoveryRequest.setRecoveryCode(recoveryCode);
                 recoveryRequest.setChannelId(recoveryChannelId);
+
+                if (StringUtils.isNotBlank(spId) && !StringUtils.equalsIgnoreCase(spId, "null")) {
+                    List<Property> properties = new ArrayList<>();
+                    Property spIdProperty = new Property();
+                    spIdProperty.setKey("spId");
+                    spIdProperty.setValue(spId);
+                    properties.add(spIdProperty);
+                    recoveryRequest.setProperties(properties);
+                }
 
                 Map<String, String> requestHeaders = new HashedMap();
                 if (request.getParameter("g-recaptcha-response") != null) {

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-process.jsp
@@ -100,7 +100,7 @@
     char[] password = request.getParameter("password") != null ? request.getParameter("password").toCharArray() : null;
     String sessionDataKey = request.getParameter("sessionDataKey");
     String sp = Encode.forJava(request.getParameter("sp"));
-    String spId = "";
+    String spId = Encode.forJava(request.getParameter("spId"));
     String applicationAccessUrl = "";
     JSONObject usernameValidityResponse;
     SelfRegistrationMgtClient selfRegistrationMgtClient = new SelfRegistrationMgtClient();
@@ -124,13 +124,13 @@
             spId = "My_Account";
         } else {
             ApplicationDataRetrievalClient applicationDataRetrievalClient = new ApplicationDataRetrievalClient();
-            spId = applicationDataRetrievalClient.getApplicationID(tenantDomain, sp);
+            if (StringUtils.isBlank(spId) || StringUtils.equalsIgnoreCase(spId, "null")) {
+                spId = applicationDataRetrievalClient.getApplicationID(tenantDomain, sp);
+            }
             applicationAccessUrl = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain, sp);
         }
     } catch (Exception e) {
-        spId = (StringUtils.isBlank(spId) || (request.getParameter("spId") != "null" ))?
-                    Encode.forJava(request.getParameter("spId")) :
-                    "";
+        // Ignored.
     }
 
     Boolean isValidCallBackURL = false;

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification-confirm.jsp
@@ -66,6 +66,7 @@
     String callback = request.getParameter("callback");
     String httpMethod = request.getMethod();
     String sp = Encode.forJava(request.getParameter("sp"));
+    String spId = Encode.forJava(request.getParameter("spId"));
     PreferenceRetrievalClient preferenceRetrievalClient = new PreferenceRetrievalClient();
     Boolean isAutoLoginEnable = preferenceRetrievalClient.checkAutoLoginAfterSelfRegistrationEnabled(tenantDomain);
 
@@ -86,6 +87,9 @@
     try {
         if (StringUtils.isNotBlank(sp)) {
             ApplicationDataRetrievalClient applicationDataRetrievalClient = new ApplicationDataRetrievalClient();
+            if (StringUtils.isBlank(spId) || StringUtils.equalsIgnoreCase(spId, "null")) {
+                spId = applicationDataRetrievalClient.getApplicationID(tenantDomain, sp);
+            }
             applicationAccessUrl = applicationDataRetrievalClient.getApplicationAccessURL(tenantDomain, sp);
         }
     } catch (ApplicationDataRetrievalClientException e) {
@@ -143,6 +147,10 @@
         tenantDomainProperty.setKey(MultitenantConstants.TENANT_DOMAIN);
         tenantDomainProperty.setValue(tenantDomain);
         properties.add(tenantDomainProperty);
+        Property spIdProperty = new Property();
+        spIdProperty.setKey("spId");
+        spIdProperty.setValue(spId);
+        properties.add(spIdProperty);
 
         validationRequest.setCode(confirmationKey);
         validationRequest.setProperties(properties);


### PR DESCRIPTION
Related Issues:

- [x] https://github.com/wso2/product-is/issues/27039

This pull request updates the recovery and self-registration flows in the recovery portal to consistently include the Service Provider ID (`spId`) in all relevant requests and API calls. This ensures that the correct application context is maintained throughout password recovery and self-registration processes. The changes also improve the handling and retrieval of `spId` when it is missing or not provided.

The most important changes are:

**Recovery Flow Enhancements:**

* Added logic to include `spId` as a property in all recovery-related requests (`RecoveryRequest`, `ResendRequest`, and `ResetRequest`) if it is present and valid. This ensures the backend can associate the recovery action with the correct service provider. [[1]](diffhunk://#diff-7c4c8382d87ba9e9554028ce8b3c5e855eaa051dfa0e363364dd1a1b11d7e804R215-R225) [[2]](diffhunk://#diff-7c4c8382d87ba9e9554028ce8b3c5e855eaa051dfa0e363364dd1a1b11d7e804R258-R268) [[3]](diffhunk://#diff-b7deeba01588a720eb014c1bf4d6a87e9062e1615e09e58fcf77f8dc323ab218R178-R185) [[4]](diffhunk://#diff-26b96e62f3f25c273709fc9ae36189367f92b40eb66734610dc33dcffa9368f6R304-R312)
* Improved retrieval of `spId`: If `spId` is missing or "null", it is now fetched using the `ApplicationDataRetrievalClient` based on the provided service provider name (`sp`). [[1]](diffhunk://#diff-26b96e62f3f25c273709fc9ae36189367f92b40eb66734610dc33dcffa9368f6L135-R140) [[2]](diffhunk://#diff-eb336e207f6432f046a37f3a3d8964c3244bb850ae3b13d6b6d6ac5162ea9272R106-R109) [[3]](diffhunk://#diff-1f9e42f5382f4c69d662abb8c11297eaa5b25518ea4d75dd440ae6d2c5804cdeR127-R133) [[4]](diffhunk://#diff-190b76f18bfd1ab02d5e94ced16ed013703fb91bcdfad79603b55944ffa1adbfR90-R92)

**Self-Registration Flow Enhancements:**

* Ensured `spId` is consistently retrieved, encoded, and included in the self-registration and verification confirmation flows, both as a request parameter and as a property in validation requests. [[1]](diffhunk://#diff-1f9e42f5382f4c69d662abb8c11297eaa5b25518ea4d75dd440ae6d2c5804cdeL103-R103) [[2]](diffhunk://#diff-190b76f18bfd1ab02d5e94ced16ed013703fb91bcdfad79603b55944ffa1adbfR69) [[3]](diffhunk://#diff-190b76f18bfd1ab02d5e94ced16ed013703fb91bcdfad79603b55944ffa1adbfR150-R153)

**General Improvements:**

* All usages of `spId` are now properly encoded and checked for validity before being used or sent to backend APIs, reducing the risk of errors or injection issues. [[1]](diffhunk://#diff-26b96e62f3f25c273709fc9ae36189367f92b40eb66734610dc33dcffa9368f6L118-R119) [[2]](diffhunk://#diff-7c4c8382d87ba9e9554028ce8b3c5e855eaa051dfa0e363364dd1a1b11d7e804R327-R328)

**Documentation:**

* Added a changeset documenting that `spId` is now included in recovery v2 requests.