### PR TITLE
Fix double submit issue by adding 10s delay before rendering click here.

### DIFF
--- a/.changeset/afraid-horses-call.md
+++ b/.changeset/afraid-horses-call.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Hide the click_here url for 10s.

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/oauth_response.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/oauth_response.jsp
@@ -506,9 +506,25 @@
     <% if (overrideStylesheet != null) { %>
     <link rel="stylesheet" href="<%= StringEscapeUtils.escapeHtml4(overrideStylesheet) %>">
     <% } %>
+
+    <script type="text/javascript">
+        var submitted = false;
+        function submitOAuthResponse() {
+            if (!submitted) {
+                submitted = true;
+                document.getElementById('oauth-response').submit();
+                // If still on this page after 10 seconds, the submission likely
+                // failed. Show the "Click here" fallback so the user can retry.
+                setTimeout(function() {
+                    submitted = false;
+                    document.getElementById('fallback-submit').style.display = 'inline';
+                }, 10000);
+            }
+        }
+    </script>
 </head>
 
-<body class="login-portal layout recovery-layout" onload="javascript:document.getElementById('oauth-response').submit()" data-page="<%= request.getAttribute("pageName") %>">
+<body class="login-portal layout recovery-layout" onload="javascript:submitOAuthResponse()" data-page="<%= request.getAttribute("pageName") %>">
     <div class="page-wrapper">
         <main class="center-segment registration-loader">
             <div class="ui container aligned middle aligned text-center">
@@ -544,9 +560,9 @@
                         </div>
                     <% } %>
                 </div>
-                <p class="message-description">
+                <p class="message-description" id="fallback-submit" style="display:none;">
                     <a class="primary-color-btn button"
-                        href="javascript:document.getElementById('oauth-response').submit()">
+                        href="javascript:submitOAuthResponse()">
                         <%=AuthenticationEndpointUtil.i18n(resourceBundle, "click.here")%>
                     </a>
                     <%=AuthenticationEndpointUtil.i18n(resourceBundle, "if.you.have.been.waiting.for.too.long")%>
@@ -554,6 +570,13 @@
                 <form id="oauth-response" method="post" action="${redirectURI}">
                 <% String params = (String) request.getAttribute("params"); %>
                 <%= params %>
+                <noscript>
+                    <p class="message-description">
+                        <input type="submit" class="ui button primary-color-btn"
+                            value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "click.here")%>" />
+                        <%=AuthenticationEndpointUtil.i18n(resourceBundle, "if.you.have.been.waiting.for.too.long")%>
+                    </p>
+                </noscript>
                 </form>
             </div>
         </main>


### PR DESCRIPTION
Related Issues:

- [x] https://github.com/wso2/product-is/issues/27268

This pull request improves the user experience during OAuth response handling by hiding the "Click here" fallback link for 10 seconds, only displaying it if automatic form submission fails. This prevents users from prematurely clicking the fallback and provides a cleaner interface. Additionally, a noscript fallback is added for users with JavaScript disabled.

**OAuth Response UI/UX Improvements:**

* Added JavaScript logic in `oauth_response.jsp` to hide the "Click here" fallback link for 10 seconds after attempting automatic form submission, displaying it only if the submission does not succeed within that time. [[1]](diffhunk://#diff-547a4d873d25876e1492cbf7a129911b0d4cb90d7340248ae2bcee612607477bR509-R527) [[2]](diffhunk://#diff-547a4d873d25876e1492cbf7a129911b0d4cb90d7340248ae2bcee612607477bL547-R579)
* Modified the fallback link to use the new JavaScript function for resubmission, and initially hide it with inline CSS.
* Added a `<noscript>` block to provide a manual submission option for users without JavaScript enabled.

**Changelog:**

* Added a changeset entry describing the patch to hide the "click_here" URL for 10 seconds. (.changeset/afraid-horses-call.md)