### PR TITLE
fix(admin.core.v1): split ModalWithSidePanel sub-components into separate files

### DIFF
--- a/.changeset/thirty-zebras-tap.md
+++ b/.changeset/thirty-zebras-tap.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.core.v1": patch
+---
+
+split ModelWithSidePanel sub-components into separate files to fix react-doctor/no-multi-comp violation

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-actions.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-actions.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
+
+interface ComponentsPropsInterface {
+    className?: string;
+}
+
+/**
+ * The actions of a panel.
+ *
+ * @param {PropsWithChildren<ComponentsPropsInterface>} props - Props to be injected into the component.
+ * @return {ReactElement} The actions section.
+ */
+export const ModalWithSidePanelActions: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
+    props: PropsWithChildren<ComponentsPropsInterface>
+): ReactElement => {
+    return (
+        <>
+            <div className={ `modal-actions ${ props?.className ?? "" }` }>{ props?.children }</div>
+        </>
+    );
+};

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-content.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-content.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
+
+interface ComponentsPropsInterface {
+    className?: string;
+}
+
+/**
+ * The content of a panel.
+ *
+ * @param {PropsWithChildren<ComponentsPropsInterface>} props - Props to be injected into the component.
+ * @return {ReactElement} The content section.
+ */
+export const ModalWithSidePanelContent: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
+    props: PropsWithChildren<ComponentsPropsInterface>
+): ReactElement => {
+    return <div className={ `modal-content ${ props?.className ?? "" }` }>{ props?.children }</div>;
+};

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-content.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-content.tsx
@@ -18,9 +18,7 @@
 
 import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
 
-interface ComponentsPropsInterface {
-    className?: string;
-}
+import { ComponentsPropsInterface } from "./modal-with-side-panel-types";
 
 /**
  * The content of a panel.

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-header.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-header.tsx
@@ -18,10 +18,7 @@
 
 import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
 
-interface ComponentsPropsInterface {
-    className?: string;
-}
-
+import { ComponentsPropsInterface } from "./modal-with-side-panel-types";
 /**
  * The header of a panel.
  *
@@ -32,8 +29,6 @@ export const ModalWithSidePanelHeader: FunctionComponent<PropsWithChildren<Compo
     props: PropsWithChildren<ComponentsPropsInterface>
 ): ReactElement => {
     return (
-        <>
-            <div className={ `modal-header ${ props?.className ?? "" }` }>{ props?.children }</div>
-        </>
+    	<div className={ `modal-header ${ props?.className ?? "" }` }>{ props?.children }</div>
     );
 };

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-header.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-header.tsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
+
+interface ComponentsPropsInterface {
+    className?: string;
+}
+
+/**
+ * The header of a panel.
+ *
+ * @param {PropsWithChildren<ComponentsPropsInterface>} props - Props to be injected into the component.
+ * @return {ReactElement} The header.
+ */
+export const ModalWithSidePanelHeader: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
+    props: PropsWithChildren<ComponentsPropsInterface>
+): ReactElement => {
+    return (
+        <>
+            <div className={ `modal-header ${ props?.className ?? "" }` }>{ props?.children }</div>
+        </>
+    );
+};

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-main-panel.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-main-panel.tsx
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
+
+interface ComponentsPropsInterface {
+    className?: string;
+}
+
+/**
+ * The main panel of the modal.
+ *
+ * @param {PropsWithChildren<ComponentsPropsInterface>} props - Props to be injected into the component.
+ * @return {ReactElement} The main panel.
+ */
+export const ModalWithSidePanelMainPanel: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
+    props: PropsWithChildren<ComponentsPropsInterface>
+): ReactElement => {
+    return <div className={ `main-panel ${ props?.className ?? "" }` }>{ props?.children }</div>;
+};

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-main-panel.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-main-panel.tsx
@@ -18,9 +18,7 @@
 
 import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
 
-interface ComponentsPropsInterface {
-    className?: string;
-}
+import { ComponentsPropsInterface } from "./modal-with-side-panel-types";
 
 /**
  * The main panel of the modal.

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-side-panel.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-side-panel.tsx
@@ -20,9 +20,7 @@ import { GenericIcon } from "@wso2is/react-components";
 import React, { FunctionComponent, PropsWithChildren, ReactElement, useState } from "react";
 import { getHelpPanelActionIcons } from "../../configs/ui";
 
-interface ComponentsPropsInterface {
-    className?: string;
-}
+import { ComponentsPropsInterface } from "./modal-with-side-panel-types";
 
 /**
  * The side panel of the modal.
@@ -33,7 +31,7 @@ interface ComponentsPropsInterface {
 export const ModalWithSidePanelSidePanel: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
     props: PropsWithChildren<ComponentsPropsInterface>
 ): ReactElement => {
-    const [ sidePanelOpen, setSidePanelOpen ] = useState(true);
+    const [ sidePanelOpen, setSidePanelOpen ] = useState<boolean>(true);
 
     return (
         <div className={ `side-panel ${ props?.className ?? "" } ${ !sidePanelOpen ? "closed" : "" }` }>

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-side-panel.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-side-panel.tsx
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com). All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { GenericIcon } from "@wso2is/react-components";
+import React, { FunctionComponent, PropsWithChildren, ReactElement, useState } from "react";
+import { getHelpPanelActionIcons } from "../../configs/ui";
+
+interface ComponentsPropsInterface {
+    className?: string;
+}
+
+/**
+ * The side panel of the modal.
+ *
+ * @param {PropsWithChildren<ComponentsPropsInterface>} props - Props to be injected into the component.
+ * @return {ReactElement} The side panel.
+ */
+export const ModalWithSidePanelSidePanel: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
+    props: PropsWithChildren<ComponentsPropsInterface>
+): ReactElement => {
+    const [ sidePanelOpen, setSidePanelOpen ] = useState(true);
+
+    return (
+        <div className={ `side-panel ${ props?.className ?? "" } ${ !sidePanelOpen ? "closed" : "" }` }>
+            <div className={ `side-panel-content ${ sidePanelOpen ? "visible" : "hidden" }` }>
+                { props?.children }
+            </div>
+            <div className={ `toggle-button-column ${ !sidePanelOpen ? "closed" : "" }` }>
+                <div
+                    className="toggle-button"
+                    onClick={ () => {
+                        setSidePanelOpen(!sidePanelOpen);
+                    } }
+                >
+                    <GenericIcon
+                        hoverable={ true }
+                        hoverType="circular"
+                        background={ false }
+                        transparent={ true }
+                        link={ true }
+                        icon={
+                            sidePanelOpen
+                                ? getHelpPanelActionIcons().caretLeft
+                                : getHelpPanelActionIcons().caretRight
+                        }
+                    />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/features/admin.core.v1/components/modals/modal-with-side-panel-types.ts
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel-types.ts
@@ -16,21 +16,9 @@
  * under the License.
  */
 
-import React, { FunctionComponent, PropsWithChildren, ReactElement } from "react";
-
-import { ComponentsPropsInterface } from "./modal-with-side-panel-types";
-
-
 /**
- * The actions of a panel.
- *
- * @param {PropsWithChildren<ComponentsPropsInterface>} props - Props to be injected into the component.
- * @return {ReactElement} The actions section.
+ * Shared props interface for ModalWithSidePanel sub-components.
  */
-export const ModalWithSidePanelActions: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
-    props: PropsWithChildren<ComponentsPropsInterface>
-): ReactElement => {
-    return (
-    	<div className={ `modal-actions ${ props?.className ?? "" }` }>{ props?.children }</div>
-    );
-};
+export interface ComponentsPropsInterface {
+    className?: string;
+}

--- a/features/admin.core.v1/components/modals/modal-with-side-panel.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel.tsx
@@ -24,9 +24,7 @@ import { ModalWithSidePanelHeader } from "./modal-with-side-panel-header";
 import { ModalWithSidePanelMainPanel } from "./modal-with-side-panel-main-panel";
 import { ModalWithSidePanelSidePanel } from "./modal-with-side-panel-side-panel";
 
-interface ComponentsPropsInterface {
-    className?: string;
-}
+import { ComponentsPropsInterface } from "./modal-with-side-panel-types";
 
 interface ModalWithSidePanelSubComponentsInterface {
     MainPanel: typeof ModalWithSidePanelMainPanel;

--- a/features/admin.core.v1/components/modals/modal-with-side-panel.tsx
+++ b/features/admin.core.v1/components/modals/modal-with-side-panel.tsx
@@ -16,14 +16,18 @@
  * under the License.
  */
 
-import { GenericIcon } from "@wso2is/react-components";
-import React, { FunctionComponent, PropsWithChildren, ReactElement, useState } from "react";
+import React, { FunctionComponent, ReactElement } from "react";
 import { Modal, ModalProps } from "semantic-ui-react";
-import { getHelpPanelActionIcons } from "../../configs/ui";
+import { ModalWithSidePanelActions } from "./modal-with-side-panel-actions";
+import { ModalWithSidePanelContent } from "./modal-with-side-panel-content";
+import { ModalWithSidePanelHeader } from "./modal-with-side-panel-header";
+import { ModalWithSidePanelMainPanel } from "./modal-with-side-panel-main-panel";
+import { ModalWithSidePanelSidePanel } from "./modal-with-side-panel-side-panel";
 
-/**
- * Model of the sub components  of the `ModalWithSidePanel` component.
- */
+interface ComponentsPropsInterface {
+    className?: string;
+}
+
 interface ModalWithSidePanelSubComponentsInterface {
     MainPanel: typeof ModalWithSidePanelMainPanel;
     SidePanel: typeof ModalWithSidePanelSidePanel;
@@ -33,21 +37,15 @@ interface ModalWithSidePanelSubComponentsInterface {
 }
 
 /**
- * Proptypes of the components belonging to modal with side panel.
- */
-interface ComponentsPropsInterface {
-    className?: string;
-}
-
-/**
  * The root component that encapsulates all the sub components.
  *
- * @param {ModalProps & ComponentsPropsInterface} props Props to be injected into the component.
- *
+ * @param {ModalProps & ComponentsPropsInterface} props - Props to be injected into the component.
  * @return {ReactElement} A modal with a side panel.
  */
 export const ModalWithSidePanel: FunctionComponent<ModalProps & ComponentsPropsInterface> &
-    ModalWithSidePanelSubComponentsInterface = (props: ModalProps & ComponentsPropsInterface): ReactElement => {
+    ModalWithSidePanelSubComponentsInterface = (
+        props: ModalProps & ComponentsPropsInterface
+    ): ReactElement => {
         return (
             <Modal { ...props } className={ `modal-with-side-panel ${ props.className ?? "" }` }>
                 <div className="panels">{ props?.children }</div>
@@ -55,109 +53,6 @@ export const ModalWithSidePanel: FunctionComponent<ModalProps & ComponentsPropsI
         );
     };
 
-/**
- * The header of a panel.
- *
- * @param {PropsWithChildren<ComponentsPropsInterface>} props Props to be injected into the component.
- *
- * @return {ReactElement} The header.
- */
-const ModalWithSidePanelHeader: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
-    props: PropsWithChildren<ComponentsPropsInterface>
-): ReactElement => {
-    return (
-        <>
-            <div className={ `modal-header ${ props?.className ?? "" }` }>{ props?.children }</div>
-        </>
-    );
-};
-
-/**
- * The content of a panel.
- *
- * @param {PropsWithChildren<ComponentsPropsInterface>} props Props to be injected into the component.
- *
- * @return {ReactElement} The content section.
- */
-const ModalWithSidePanelContent: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
-    props: PropsWithChildren<ComponentsPropsInterface>
-): ReactElement => {
-    return <div className={ `modal-content ${ props?.className ?? "" }` }>{ props?.children }</div>;
-};
-
-/**
- * The actions of a panel.
- *
- * @param {PropsWithChildren<ComponentsPropsInterface>} props Props to be injected into the component.
- *
- * @return {ReactElement} The actions section.
- */
-const ModalWithSidePanelActions: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
-    props: PropsWithChildren<ComponentsPropsInterface>
-): ReactElement => {
-    return (
-        <>
-            <div className={ `modal-actions ${ props?.className ?? "" }` }>{ props?.children }</div>
-        </>
-    );
-};
-
-/**
- * The main panel of the modal.
- *
- * @param {PropsWithChildren<ComponentsPropsInterface>} props Props to be injected into the component.
- *
- * @return {ReactElement} The main panel.
- */
-const ModalWithSidePanelMainPanel: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
-    props: PropsWithChildren<ComponentsPropsInterface>
-): ReactElement => {
-    return <div className={ `main-panel ${ props?.className ?? "" }` }>{ props?.children }</div>;
-};
-
-/**
- * The side panel of the modal.
- *
- * @param {PropsWithChildren<ComponentsPropsInterface>} props Props to be injected into the component.
- *
- * @return {ReactElement} The side panel.
- */
-const ModalWithSidePanelSidePanel: FunctionComponent<PropsWithChildren<ComponentsPropsInterface>> = (
-    props: PropsWithChildren<ComponentsPropsInterface>
-): ReactElement => {
-    const [ sidePanelOpen, setSidePanelOpen ] = useState(true);
-
-    return (
-        <div className={ `side-panel ${ props?.className ?? "" } ${ !sidePanelOpen ? "closed" : "" }` }>
-            <div className={ `side-panel-content ${ sidePanelOpen ? "visible" : "hidden" }` }>{ props?.children }</div>
-            <div className={ `toggle-button-column ${ !sidePanelOpen ? "closed" : "" }` }>
-                <div
-                    className="toggle-button"
-                    onClick={ () => {
-                        setSidePanelOpen(!sidePanelOpen);
-                    } }
-                >
-                    <GenericIcon
-                        hoverable={ true }
-                        hoverType="circular"
-                        background={ false }
-                        transparent={ true }
-                        link={ true }
-                        icon={
-                            sidePanelOpen
-                                ? getHelpPanelActionIcons().caretLeft
-                                : getHelpPanelActionIcons().caretRight
-                        }
-                    />
-                </div>
-            </div>
-        </div>
-    );
-};
-
-/**
- * Attaches with sub components to the `ModalWithSidePanel` component.
- */
 ModalWithSidePanel.MainPanel = ModalWithSidePanelMainPanel;
 ModalWithSidePanel.SidePanel = ModalWithSidePanelSidePanel;
 ModalWithSidePanel.Header = ModalWithSidePanelHeader;


### PR DESCRIPTION
## Purpose
Fixes react-doctor/no-multi-comp violation by extracting secondary components 
from modal-with-side-panel.tsx into their own dedicated files.

## Related Issues
Closes wso2/product-is#27926

## Changes
- Extracted `ModalWithSidePanelHeader` → `modal-with-side-panel-header.tsx`
- Extracted `ModalWithSidePanelContent` → `modal-with-side-panel-content.tsx`
- Extracted `ModalWithSidePanelActions` → `modal-with-side-panel-actions.tsx`
- Extracted `ModalWithSidePanelMainPanel` → `modal-with-side-panel-main-panel.tsx`
- Extracted `ModalWithSidePanelSidePanel` → `modal-with-side-panel-side-panel.tsx`
- Updated `modal-with-side-panel.tsx` to import from the new files

## Checklist
- [ ] No behavioural changes introduced
- [ ] Existing functionality preserved