### PR TITLE
Fix self-registration form value retention on duplicate-username error

### DIFF
--- a/.changeset/quick-spoons-grow.md
+++ b/.changeset/quick-spoons-grow.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix self-registration form fields being cleared on duplicate-username validation error

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-username-request.jsp
@@ -848,7 +848,8 @@
                                 <input
                                     type="email"
                                     id="usernameUserInput"
-                                    value="<%=discoveredUsername != null ? Encode.forHtmlAttribute(discoveredUsername) : ""%>"
+                                    value="<%=discoveredUsername != null ? Encode.forHtmlAttribute(discoveredUsername)
+                                            : (StringUtils.isNotEmpty(emailValue) ? Encode.forHtmlAttribute(emailValue) : "")%>"
                                     name="http://wso2.org/claims/emailaddress"
                                     tabindex="1"
                                     placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "enter.your.email")%>"
@@ -980,8 +981,8 @@
                                             </label>
                                             <input id="firstNameUserInput" type="text" name="http://wso2.org/claims/givenname" class="form-control"
                                                 <% if (firstNamePII.getRequired()) {%> required <%}%>
-                                                <% if (skipSignUpEnableCheck && StringUtils.isNotEmpty(firstNameValue)) { %>
-                                                value="<%= Encode.forHtmlAttribute(firstNameValue)%>" disabled <% } %>
+                                                <% if (skipSignUpEnableCheck && StringUtils.isNotEmpty(firstNameValue)) { %> disabled <% } %>
+                                                <% if (StringUtils.isNotEmpty(firstNameValue)) { %> value="<%= Encode.forHtmlAttribute(firstNameValue)%>"<% } %>
                                                 placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "First.name")%>"/>
                                                 <div class="mt-1" id="firstname-error-msg" hidden="hidden">
                                                     <div class="ui grid">
@@ -1007,8 +1008,8 @@
                                             </label>
                                             <input id="lastNameUserInput" type="text" name="http://wso2.org/claims/lastname" class="form-control"
                                                 <% if (lastNamePII.getRequired()) {%> required <%}%>
-                                                <% if (skipSignUpEnableCheck && StringUtils.isNotEmpty(lastNameValue)) { %>
-                                                value="<%= Encode.forHtmlAttribute(lastNameValue)%>" disabled <% } %>
+                                                <% if (skipSignUpEnableCheck && StringUtils.isNotEmpty(lastNameValue)) { %> disabled <% } %>
+                                                <% if (StringUtils.isNotEmpty(lastNameValue)) { %> value="<%= Encode.forHtmlAttribute(lastNameValue)%>"<% } %>
                                                 placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "Last.name")%>"
                                             />
                                             <div class="mt-1" id="lastname-error-msg" hidden="hidden">
@@ -1112,8 +1113,8 @@
                                                 <% if (claim.getRequired()) { %>
                                                     required
                                                 <% }%>
-                                                <% if(skipSignUpEnableCheck && StringUtils.isNotEmpty(claimValue)) {%>
-                                                    value="<%= Encode.forHtmlAttribute(claimValue)%>" disabled<%}%>
+                                                <% if(skipSignUpEnableCheck && StringUtils.isNotEmpty(claimValue)) {%> disabled<%}%>
+                                                <% if(StringUtils.isNotEmpty(claimValue)) {%> value="<%= Encode.forHtmlAttribute(claimValue)%>"<%}%>
                                             />
                                             <i class="dropdown icon"></i>
                                             <div class="default text">
@@ -1136,8 +1137,8 @@
                                                 <% if (claim.getRequired()) { %>
                                                     required
                                                 <% }%>
-                                                <% if(skipSignUpEnableCheck && StringUtils.isNotEmpty(claimValue)) {%>
-                                                    value="<%= Encode.forHtmlAttribute(claimValue)%>" disabled<%}%>
+                                                <% if(skipSignUpEnableCheck && StringUtils.isNotEmpty(claimValue)) {%> disabled<%}%>
+                                                <% if(StringUtils.isNotEmpty(claimValue)) {%> value="<%= Encode.forHtmlAttribute(claimValue)%>"<%}%>
                                             />
                                             <i class="dropdown icon"></i>
                                             <div class="default text">
@@ -1169,8 +1170,8 @@
                                                             required
                                                         <% } %>
                                                         placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "enter.birth.date")%>"
-                                                    <% if(skipSignUpEnableCheck && StringUtils.isNotEmpty(claimValue)) {%>
-                                                        value="<%= Encode.forHtmlAttribute(claimValue)%>" disabled<%}%>
+                                                    <% if(skipSignUpEnableCheck && StringUtils.isNotEmpty(claimValue)) {%> disabled<%}%>
+                                                    <% if(StringUtils.isNotEmpty(claimValue)) {%> value="<%= Encode.forHtmlAttribute(claimValue)%>"<%}%>
                                                 />
                                             </div>
                                         </div>
@@ -1189,8 +1190,8 @@
                                                     id="mobileNumber"
                                             <% }%>
                                                 placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle, "enter")%> <%=IdentityManagementEndpointUtil.i18nBase64(recoveryResourceBundle, claim.getDisplayName())%>"
-                                                <% if(skipSignUpEnableCheck && StringUtils.isNotEmpty(claimValue)) {%>
-                                                value="<%= Encode.forHtmlAttribute(claimValue)%>" disabled<%}%>
+                                                <% if(skipSignUpEnableCheck && StringUtils.isNotEmpty(claimValue)) {%> disabled<%}%>
+                                                <% if(StringUtils.isNotEmpty(claimValue)) {%> value="<%= Encode.forHtmlAttribute(claimValue)%>"<%}%>
                                             />
                                     <% } %>
                                     <div class="mt-1" id="<%=IdentityManagementEndpointUtil.i18nBase64(recoveryResourceBundle, claimErrorMsg)%>" hidden="hidden">


### PR DESCRIPTION
### Purpose

Fixes the self sign-up form losing all entered values when the submitted username/email is already taken.

Resolves wso2/product-is#22195 for the `self-registration-username-request.jsp` flow.

### Problem

On the self-registration (self sign-up) form, submitting an already-taken username/email shows the duplicate error but clears **all** previously entered fields (email, first/last name, country, locale, DOB, configurable claims). The user has to re-type everything to retry.

### Root cause

In `self-registration-username-request.jsp`, each input coupled its `value="..."` attribute and the `disabled` attribute inside a single `skipSignUpEnableCheck && StringUtils.isNotEmpty(...)` guard. `skipSignUpEnableCheck` is `true` only for JIT provisioning, so on a normal self-registration submit no `value` was ever re-emitted and the form came back empty. The email field separately repopulated only from `discoveredUsername`, which is `null` on a duplicate-username submit, so email cleared too.

The sibling `self-registration-with-verification.jsp` already carries the equivalent fix (#7303); this JSP was missed.

### Changes

Decouple `value` from `disabled` so entered values are retained on a validation error, with JIT behaviour unchanged:

- First name, last name, country, locale, DOB and generic text-claim inputs: `disabled` stays gated on `skipSignUpEnableCheck`; `value=` is now emitted independently whenever the field is non-empty.
- Email field (`#usernameUserInput`): added an `emailValue` fallback so the entered email is retained when `discoveredUsername` is `null`.
- `Encode.forHtmlAttribute` retained on every repopulated value (no new injection surface). Password is intentionally never repopulated.

### Testing

Verified at runtime on a WSO2 IS pack: after a duplicate-username self sign-up error, the email, first name and last name are retained (previously all cleared), the duplicate error is shown, the password field stays blank, and JIT provisioning field disabling is unchanged.

Note: this only handle `self-registration-username-request.jsp` - in legacy flow some scenarios user is redirected to error.jsp instead of showing error in the same page; in those case data will be lost. 