### PR TITLE
Fix URL encoding for claims parameter in self-registration redirect

### DIFF
--- a/.changeset/fix-self-registration-callback-encoding.md
+++ b/.changeset/fix-self-registration-callback-encoding.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Fix the self-registration "Back to sign in" link returning a 400 error by URL-encoding the callback URL's query parameters.

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp
@@ -104,7 +104,7 @@
     boolean skipSignUpEnableCheck = Boolean.parseBoolean(request.getParameter("skipsignupenablecheck"));
     boolean isPasswordProvisionEnabled = Boolean.parseBoolean(request.getParameter("passwordProvisionEnabled"));
     boolean isSaaSApp = Boolean.parseBoolean(request.getParameter("isSaaSApp"));
-    String callback = Encode.forHtmlAttribute(request.getParameter("callback"));
+    String callback = Encode.forHtmlAttribute(IdentityManagementEndpointUtil.encodeURL(request.getParameter("callback")));
     String sp = Encode.forHtmlAttribute(request.getParameter("sp"));
 
     String emailUsernameEnable = application.getInitParameter("EnableEmailUserName");
@@ -192,9 +192,9 @@
      * Validate the back to login URL. If the URL is not valid, set the URL to null.
      */
     if (!StringUtils.isBlank(callback) && !StringUtils.equalsIgnoreCase(callback, "null")) {
-        String encodedCallback = IdentityManagementEndpointUtil.getURLEncodedCallback(callback);
-
-        if (!AuthenticationEndpointUtil.isValidMultiOptionURI(encodedCallback)) {
+        // The callback is already URL-encoded where it is read above, so it can be validated
+        // directly. Re-encoding here would double-encode the query parameters (e.g. %7B -> %257B).
+        if (!AuthenticationEndpointUtil.isValidMultiOptionURI(callback)) {
             callback = null;
         }
     }


### PR DESCRIPTION
## Purpose
Fixes wso2/product-is#23288

The "Back to sign in" link on the self-registration page fails with a 400 error because the `claims` JSON parameter in the callback URL is not URL-encoded.

## Problem
The `callback` parameter was only HTML-encoded using `Encode.forHtmlAttribute()`, which does not handle URL-illegal characters like `{`, `}`, `"`, `:`. These characters remained raw in the query string, causing the server to reject the request with 400 Bad Request.

Example broken URL:
.../authenticationendpoint/login.do?claims={"userinfo":{"email":{"essential":true}}}

## Solution
1. Wrapped `request.getParameter("callback")` with `IdentityManagementEndpointUtil.encodeURL()` before HTML encoding (line 107). This properly percent-encodes query parameter values while preserving the URL structure. This matches the existing pattern already used in `self-registration-username-request.jsp:116`.

2. Removed a now-redundant `IdentityManagementEndpointUtil.getURLEncodedCallback()` call in the callback validation block (lines 194-199). Since the callback is URL-encoded at the point it is read (step 1), re-encoding it there would double-encode the query parameters (e.g. `%7B` -> `%257B`). The already-encoded value is validated directly, which is correct because `AuthenticationEndpointUtil.isValidMultiOptionURI()` validates only the scheme/host/path and ignores the query string.

## Changed File
- `identity-apps-core/apps/recovery-portal/src/main/webapp/self-registration-with-verification.jsp` (callback read at line 107; callback validation at lines 194-199)

## Verification

Tested on a local WSO2 Identity Server (7.1.0) against `self-registration-with-verification.jsp`.

**Before** — the "Back to sign in" link points to `.../login.do?claims={"userinfo":...}` with raw braces; the server rejects it with **HTTP 400**:

https://github.com/user-attachments/assets/390607fc-1df5-4263-9196-7b330d994483



**After** (with this fix) — the link is percent-encoded `.../login.do?claims=%7B%22userinfo%22...` and loads the sign-in page with **HTTP 200**:

https://github.com/user-attachments/assets/0174887d-0cf9-47bf-9a48-28bb4ad65cd0

