### PR TITLE
fix(framer-motion): replace motion with LazyMotion+m to reduce bundle size (~30kb)

### DIFF
--- a/.changeset/grumpy-readers-wear.md
+++ b/.changeset/grumpy-readers-wear.md
@@ -1,7 +1,7 @@
 ---
 "@wso2is/admin.agents.v1": patch
 "@wso2is/admin.applications.v1": patch
-"@wso2is/admin.branding.ai.v1": patch
+"@wso2is/admin.branding.v1": patch
 "@wso2is/admin.console-settings.v1": patch
 "@wso2is/admin.home.v1": patch
 "@wso2is/admin.users.v1": patch

--- a/.changeset/grumpy-readers-wear.md
+++ b/.changeset/grumpy-readers-wear.md
@@ -1,0 +1,11 @@
+---
+"@wso2is/admin.agents.v1": patch
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.branding.ai.v1": patch
+"@wso2is/admin.console-settings.v1": patch
+"@wso2is/admin.home.v1": patch
+"@wso2is/admin.users.v1": patch
+"@wso2is/common.ai.v1": patch
+---
+
+Replace motion with LazyMotion+m to reduce bundle size (~30kb)

--- a/features/admin.agents.v1/components/edit/share-agent-form.tsx
+++ b/features/admin.agents.v1/components/edit/share-agent-form.tsx
@@ -50,7 +50,7 @@ import {
     Heading,
     Hint
 } from "@wso2is/react-components";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, LazyMotion, domAnimation, m } from "framer-motion";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
     ChangeEvent,
@@ -1485,11 +1485,12 @@ export const ShareAgentForm: FunctionComponent<AgentShareFormPropsInterface> = (
                                 disabled={ readOnly }
                                 data-componentid={ `${ componentId }-share-with-all-orgs-checkbox` }
                             />
+                            <LazyMotion features={ domAnimation }>
                             <AnimatePresence mode="wait">
                                 {
                                     shareType === ShareType.SHARE_ALL
                                     && (
-                                        <motion.div
+                                        <m.div
                                             key="selected-orgs-block"
                                             initial={ { height: 0, opacity: 0 } }
                                             animate={ { height: "auto", opacity: 1 } }
@@ -1510,10 +1511,11 @@ export const ShareAgentForm: FunctionComponent<AgentShareFormPropsInterface> = (
                                                     readOnly={ readOnly }
                                                 />
                                             </div>
-                                        </motion.div>
+                                        </m.div>
                                     )
                                 }
                             </AnimatePresence>
+</LazyMotion>
                             <FormControlLabel
                                 value={ ShareType.SHARE_SELECTED }
                                 label={
@@ -1533,11 +1535,12 @@ export const ShareAgentForm: FunctionComponent<AgentShareFormPropsInterface> = (
                                 disabled={ readOnly || !isOrganizationsAvailable }
                                 data-componentid={ `${ componentId }-share-with-selected-orgs-checkbox` }
                             />
+                            <LazyMotion features={ domAnimation }>
                             <AnimatePresence mode="wait">
                                 {
                                     shareType === ShareType.SHARE_SELECTED
                                     && (
-                                        <motion.div
+                                        <m.div
                                             key="selected-orgs-block"
                                             initial={ { height: 0, opacity: 0 } }
                                             animate={ { height: "auto", opacity: 1 } }
@@ -1595,10 +1598,11 @@ export const ShareAgentForm: FunctionComponent<AgentShareFormPropsInterface> = (
                                                     }
                                                 />
                                             </Grid>
-                                        </motion.div>
+                                        </m.div>
                                     )
                                 }
                             </AnimatePresence>
+</LazyMotion>
                         </RadioGroup>
                     </FormControl>
                 </Grid>

--- a/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
+++ b/features/admin.applications.v1/components/forms/share-application-form-updated.tsx
@@ -52,7 +52,7 @@ import {
     Heading,
     Hint
 } from "@wso2is/react-components";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, LazyMotion, domAnimation, m } from "framer-motion";
 import differenceBy from "lodash-es/differenceBy";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
@@ -1363,11 +1363,12 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
                                 disabled={ readOnly }
                                 data-componentid={ `${ componentId }-share-with-all-orgs-checkbox` }
                             />
+                            <LazyMotion features={ domAnimation }>
                             <AnimatePresence mode="wait">
                                 {
                                     shareType === ShareType.SHARE_ALL
                                     && (
-                                        <motion.div
+                                        <m.div
                                             key="selected-orgs-block"
                                             initial={ { height: 0, opacity: 0 } }
                                             animate={ { height: "auto", opacity: 1 } }
@@ -1472,10 +1473,11 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
                                                         </div>
                                                     )
                                             }
-                                        </motion.div>
+                                        </m.div>
                                     )
                                 }
                             </AnimatePresence>
+</LazyMotion>
                             <FormControlLabel
                                 value={ ShareType.SHARE_SELECTED }
                                 label={
@@ -1495,11 +1497,12 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
                                 disabled={ readOnly || !isOrganizationsAvailable }
                                 data-componentid={ `${ componentId }-share-with-selected-orgs-checkbox` }
                             />
+                            <LazyMotion features={ domAnimation }>
                             <AnimatePresence mode="wait">
                                 {
                                     shareType === ShareType.SHARE_SELECTED
                                     && (
-                                        <motion.div
+                                        <m.div
                                             key="selected-orgs-block"
                                             initial={ { height: 0, opacity: 0 } }
                                             animate={ { height: "auto", opacity: 1 } }
@@ -1571,10 +1574,11 @@ export const ApplicationShareFormUpdated: FunctionComponent<ApplicationShareForm
                                                     }
                                                 />
                                             </Grid>
-                                        </motion.div>
+                                        </m.div>
                                     )
                                 }
                             </AnimatePresence>
+</LazyMotion>
                         </RadioGroup>
                     </FormControl>
                 </Grid>

--- a/features/admin.applications.v1/components/modals/application-share-modal-updated.tsx
+++ b/features/admin.applications.v1/components/modals/application-share-modal-updated.tsx
@@ -38,7 +38,7 @@ import {
     LinkButton,
     PrimaryButton
 } from "@wso2is/react-components";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, LazyMotion, domAnimation, m } from "framer-motion";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
     ChangeEvent,
@@ -313,11 +313,12 @@ export const ApplicationShareModalUpdated: FunctionComponent<ApplicationShareMod
                                 />
                             )
                         }
-                        <AnimatePresence mode="wait">
+                        <LazyMotion features={ domAnimation }>
+                            <AnimatePresence mode="wait">
                             {
                                 shareType === ShareType.SHARE_SELECTED
                                 && (
-                                    <motion.div
+                                    <m.div
                                         key="selected-orgs-block"
                                         initial={ { height: 0, opacity: 0 } }
                                         animate={ { height: "auto", opacity: 1 } }
@@ -336,21 +337,23 @@ export const ApplicationShareModalUpdated: FunctionComponent<ApplicationShareMod
                                                 setRemovedOrgs={ setRemovedOrgIds }
                                             />
                                         </Grid>
-                                    </motion.div>
+                                    </m.div>
                                 )
                             }
                         </AnimatePresence>
+</LazyMotion>
                         <FormControlLabel
                             value={ ShareType.SHARE_ALL }
                             label={ t("organizations:shareApplicationRadio") }
                             control={ <Radio /> }
                             data-componentid={ `${ componentId }-share-with-all-orgs-checkbox` }
                         />
-                        <AnimatePresence mode="wait">
+                        <LazyMotion features={ domAnimation }>
+                            <AnimatePresence mode="wait">
                             {
                                 shareType === ShareType.SHARE_ALL
                                 && (
-                                    <motion.div
+                                    <m.div
                                         key="selected-orgs-block"
                                         initial={ { height: 0, opacity: 0 } }
                                         animate={ { height: "auto", opacity: 1 } }
@@ -391,10 +394,11 @@ export const ApplicationShareModalUpdated: FunctionComponent<ApplicationShareMod
                                                     </Alert>
                                                 )
                                         }
-                                    </motion.div>
+                                    </m.div>
                                 )
                             }
                         </AnimatePresence>
+</LazyMotion>
                     </RadioGroup>
                 </FormControl>
             </Modal.Content>

--- a/features/admin.branding.v1/components/branding-page-layout.tsx
+++ b/features/admin.branding.v1/components/branding-page-layout.tsx
@@ -35,7 +35,7 @@ import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/ho
 import { AlertLevels, FeatureFlagsInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { DocumentationLink, PageLayout, useDocumentation } from "@wso2is/react-components";
-import { AnimatePresence, LayoutGroup, Variants, motion } from "framer-motion";
+import { AnimatePresence, LazyMotion, LayoutGroup, Variants, domAnimation, m } from "framer-motion";
 import React, {
     FunctionComponent, HTMLProps, ReactElement, SyntheticEvent, useEffect, useState
 } from "react";
@@ -342,8 +342,9 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
             title={ (
                 <div className="title-container">
                     <div className="title-container-heading">
-                        <AnimatePresence >
-                            <motion.div
+                        <LazyMotion features={ domAnimation }>
+                        <AnimatePresence>
+                            <m.div
                                 className="content"
                                 key={ resolveBrandingTitle() }
                                 initial="enter"
@@ -370,15 +371,16 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                                         )
                                     }
                                 </h1>
-                            </motion.div>
+                            </m.div>
                         </AnimatePresence>
+</LazyMotion>
                     </div>
                     {
                         !brandingDisabledFeatures.includes(
                             BrandingPreferencesConstants.APP_WISE_BRANDING_FEATURE_TAG) && !appIdFromQueryParam && (
                             <div className="branding-mode-container">
                                 <LayoutGroup>
-                                    <motion.div
+                                    <m.div
                                         initial="enter"
                                         animate="in"
                                         exit="exit"
@@ -429,11 +431,11 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                                                 </ToggleButton>
                                             </ToggleButtonGroup>
                                         </Paper>
-                                    </motion.div>
+                                    </m.div>
                                     {
                                         brandingMode === BrandingModes.APPLICATION &&
                                     !appIdFromQueryParam && (
-                                            <motion.div
+                                            <m.div
                                                 initial="enter"
                                                 animate="in"
                                                 exit="exit"
@@ -496,7 +498,7 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                                                         />
                                                     ) }
                                                 />
-                                            </motion.div>
+                                            </m.div>
                                         ) }
                                 </LayoutGroup>
                             </div>
@@ -506,8 +508,9 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
             ) }
             description={ (
                 <div className="with-label">
-                    <AnimatePresence >
-                        <motion.div
+                    <LazyMotion features={ domAnimation }>
+                        <AnimatePresence>
+                        <m.div
                             className="content"
                             key={ resolveBrandingTitle() }
                             initial="enter"
@@ -525,8 +528,9 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                             >
                                 { t("common:learnMore") }
                             </DocumentationLink>
-                        </motion.div>
+                        </m.div>
                     </AnimatePresence>
+</LazyMotion>
                 </div>
             ) }
             data-componentid={ `${ componentId }-layout` }

--- a/features/admin.console-settings.v1/components/console-shared-access/console-shared-access.tsx
+++ b/features/admin.console-settings.v1/components/console-shared-access/console-shared-access.tsx
@@ -49,7 +49,7 @@ import { AlertLevels,
 } from "@wso2is/core/models";
 import { addAlert } from "@wso2is/core/store";
 import { ContentLoader, EmphasizedSegment, Text } from "@wso2is/react-components";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, LazyMotion, domAnimation, m } from "framer-motion";
 import differenceBy from "lodash-es/differenceBy";
 import isEmpty from "lodash-es/isEmpty";
 import React, { ChangeEvent, FunctionComponent, ReactElement, useEffect, useState } from "react";
@@ -512,11 +512,12 @@ const ConsoleSharedAccess: FunctionComponent<ConsoleSharedAccessPropsInterface> 
                                 disabled={ isReadOnly }
                                 data-componentid={ `${componentId}-share-with-all-orgs-radio-btn` }
                             />
+                            <LazyMotion features={ domAnimation }>
                             <AnimatePresence mode="wait">
                                 {
                                     sharedAccessMode === RoleSharingModes.SELECTED
                                     && (
-                                        <motion.div
+                                        <m.div
                                             key="selected-orgs-block"
                                             initial={ { height: 0, opacity: 0 } }
                                             animate={ { height: "auto", opacity: 1 } }
@@ -530,10 +531,11 @@ const ConsoleSharedAccess: FunctionComponent<ConsoleSharedAccessPropsInterface> 
                                                 onRoleChange={
                                                     updateRoleSelectionForAllOrganizations }
                                             />
-                                        </motion.div>
+                                        </m.div>
                                     )
                                 }
                             </AnimatePresence>
+</LazyMotion>
                             <Alert
                                 severity="info"
                                 className="mt-1 mb-2"

--- a/features/admin.home.v1/components/new-feature-announcement/new-feature-announcement.tsx
+++ b/features/admin.home.v1/components/new-feature-announcement/new-feature-announcement.tsx
@@ -39,7 +39,7 @@ import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { Heading, PrimaryButton, Button as SemanticButton } from "@wso2is/react-components";
 import classNames from "classnames";
 import DOMPurify from "dompurify";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, LazyMotion, domAnimation, m } from "framer-motion";
 import React, { FunctionComponent, ReactElement, useEffect, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { Grid, Modal } from "semantic-ui-react";
@@ -362,8 +362,9 @@ export const FeatureCarousel = () => {
                 width: "100%"
             } }
         >
+            <LazyMotion features={ domAnimation }>
             <AnimatePresence initial={ false } mode="sync">
-                <motion.div
+                <m.div
                     key={ currentIndex }
                     variants={ variants }
                     initial="enter"
@@ -404,8 +405,9 @@ export const FeatureCarousel = () => {
                             featureConfig={ features[currentIndex]?.featureConfig }
                         />
                     ) }
-                </motion.div>
+                </m.div>
             </AnimatePresence>
+</LazyMotion>
 
             { showAgentFeatureAnnouncementModal && (
                 <Modal

--- a/features/admin.users.v1/components/share-user-form.tsx
+++ b/features/admin.users.v1/components/share-user-form.tsx
@@ -50,7 +50,7 @@ import {
     Heading,
     Hint
 } from "@wso2is/react-components";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, LazyMotion, domAnimation, m } from "framer-motion";
 import isEmpty from "lodash-es/isEmpty";
 import React, {
     ChangeEvent,
@@ -1482,11 +1482,12 @@ export const ShareUserForm: FunctionComponent<UserShareFormPropsInterface> = (
                                 disabled={ readOnly }
                                 data-componentid={ `${ componentId }-share-with-all-orgs-checkbox` }
                             />
+                            <LazyMotion features={ domAnimation }>
                             <AnimatePresence mode="wait">
                                 {
                                     shareType === ShareType.SHARE_ALL
                                     && (
-                                        <motion.div
+                                        <m.div
                                             key="selected-orgs-block"
                                             initial={ { height: 0, opacity: 0 } }
                                             animate={ { height: "auto", opacity: 1 } }
@@ -1506,10 +1507,11 @@ export const ShareUserForm: FunctionComponent<UserShareFormPropsInterface> = (
                                                     enableConsoleAdminRole={ enableConsoleAdminRole }
                                                 />
                                             </div>
-                                        </motion.div>
+                                        </m.div>
                                     )
                                 }
                             </AnimatePresence>
+</LazyMotion>
                             <FormControlLabel
                                 value={ ShareType.SHARE_SELECTED }
                                 label={
@@ -1529,11 +1531,12 @@ export const ShareUserForm: FunctionComponent<UserShareFormPropsInterface> = (
                                 disabled={ readOnly || !isOrganizationsAvailable }
                                 data-componentid={ `${ componentId }-share-with-selected-orgs-checkbox` }
                             />
+                            <LazyMotion features={ domAnimation }>
                             <AnimatePresence mode="wait">
                                 {
                                     shareType === ShareType.SHARE_SELECTED
                                     && (
-                                        <motion.div
+                                        <m.div
                                             key="selected-orgs-block"
                                             initial={ { height: 0, opacity: 0 } }
                                             animate={ { height: "auto", opacity: 1 } }
@@ -1591,10 +1594,11 @@ export const ShareUserForm: FunctionComponent<UserShareFormPropsInterface> = (
                                                     }
                                                 />
                                             </Grid>
-                                        </motion.div>
+                                        </m.div>
                                     )
                                 }
                             </AnimatePresence>
+</LazyMotion>
                         </RadioGroup>
                     </FormControl>
                 </Grid>

--- a/features/common.ai.v1/components/ai-banner-tall.tsx
+++ b/features/common.ai.v1/components/ai-banner-tall.tsx
@@ -75,6 +75,7 @@ const AIBannerTall = (props: PropsWithChildren<AIBannerTallProps>): ReactElement
     };
 
     return (
+	<LazyMotion features={ domAnimation }>
         <m.div
             className="ai-banner-motion-container"
             style={ {
@@ -133,6 +134,7 @@ const AIBannerTall = (props: PropsWithChildren<AIBannerTallProps>): ReactElement
                 </Box>
             </Accordion>
         </m.div>
+	</LazyMotion>
     );
 };
 

--- a/features/common.ai.v1/components/ai-banner-tall.tsx
+++ b/features/common.ai.v1/components/ai-banner-tall.tsx
@@ -23,7 +23,7 @@ import Box from "@oxygen-ui/react/Box";
 import Typography from "@oxygen-ui/react/Typography";
 import { ChevronDownIcon }from "@oxygen-ui/react-icons";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
-import { AnimationProps, Variants, motion } from "framer-motion";
+import { AnimationProps, LazyMotion, Variants, domAnimation, m } from "framer-motion";
 import React, { PropsWithChildren, ReactElement, useState } from "react";
 import AIText from "./ai-text";
 import AIBannerBackgroundTall
@@ -75,7 +75,7 @@ const AIBannerTall = (props: PropsWithChildren<AIBannerTallProps>): ReactElement
     };
 
     return (
-        <motion.div
+        <m.div
             className="ai-banner-motion-container"
             style={ {
                 backgroundImage: `url(${ AIBot }), url(${ AIBannerBackgroundTall })`
@@ -132,7 +132,7 @@ const AIBannerTall = (props: PropsWithChildren<AIBannerTallProps>): ReactElement
                     { children }
                 </Box>
             </Accordion>
-        </motion.div>
+        </m.div>
     );
 };
 

--- a/features/common.ai.v1/components/ai-bot-animated-with-bg.tsx
+++ b/features/common.ai.v1/components/ai-bot-animated-with-bg.tsx
@@ -19,7 +19,7 @@
 // Disabling max-line-length for this file as it contains SVGs.
 /* eslint-disable max-len */
 
-import { Variants, motion } from "framer-motion";
+import { LazyMotion, Variants, domAnimation, m } from "framer-motion";
 import React, {
     MutableRefObject,
     PropsWithChildren,
@@ -65,7 +65,7 @@ const AIBotAnimatedWithBackGround = (props: AIBotAnimatedProps): ReactElement =>
     };
 
     return (
-        <>
+        <LazyMotion features={ domAnimation }>
             <svg
                 className="ai-loading-screen-animation"
                 width="728"
@@ -76,7 +76,7 @@ const AIBotAnimatedWithBackGround = (props: AIBotAnimatedProps): ReactElement =>
             >
                 <AIBotBackground />
                 <g id="ai-bot-illustration">
-                    <motion.g
+                    <m.g
                         id="ai-bot-icons"
                         animate="iconAnimation"
                         variants={ variants }
@@ -99,15 +99,15 @@ const AIBotAnimatedWithBackGround = (props: AIBotAnimatedProps): ReactElement =>
                         <AnimatedIcon>
                             <AnimatedCogWheelIcon />
                         </AnimatedIcon>
-                    </motion.g>
-                    <motion.g
+                    </m.g>
+                    <m.g
                         id="ai-bot"
                         animate="botAnimation"
                         variants={ variants }
                     >
                         <AnimatedHead shouldAnimate={ shouldAnimate } />
                         <AnimatedTorso />
-                    </motion.g>
+                    </m.g>
                 </g>
                 <defs>
                     <linearGradient
@@ -222,7 +222,7 @@ const AIBotAnimatedWithBackGround = (props: AIBotAnimatedProps): ReactElement =>
                     </linearGradient>
                 </defs>
             </svg>
-        </>
+        </LazyMotion>
     );
 };
 
@@ -238,7 +238,7 @@ const AIBotBackground = (): ReactElement => {
 
     return (
         <g>
-            <motion.path
+            <m.path
                 opacity="0.06"
                 initial="initial"
                 animate="animate"
@@ -283,7 +283,7 @@ const AnimatedHead = (props: AIBotAnimatedProps): ReactElement => {
     };
 
     return (
-        <motion.g
+        <m.g
             id="bot-head"
             variants={ variants }
         >
@@ -306,7 +306,7 @@ const AnimatedHead = (props: AIBotAnimatedProps): ReactElement => {
                     <AnimatedBotEyes shouldAnimate={ shouldAnimate } />
                 </g>
             </g>
-        </motion.g>
+        </m.g>
     );
 
 };
@@ -379,7 +379,7 @@ const AnimatedBotEyes = (props: AIBotAnimatedProps): ReactElement => {
         <>
             <g ref={ leftEyeRef } id="bot-left-eye">
                 <ellipse id="Ellipse 112" cx="184.719" cy="165.005" rx="9.51965" ry="9.01907" fill="white" />
-                <motion.circle
+                <m.circle
                     cx={ 184.719 + leftPupilPosition.x }
                     cy={ 165.005 + leftPupilPosition.y }
                     r="2"
@@ -395,7 +395,7 @@ const AnimatedBotEyes = (props: AIBotAnimatedProps): ReactElement => {
             </g>
             <g ref={ rightEyeRef } id="bot-right-eye">
                 <ellipse cx="231.817" cy="165.005" rx="9.51965" ry="9.01907" fill="white" />
-                <motion.circle
+                <m.circle
                     cx={ 231.817 + rightPupilPosition.x }
                     cy={ 165.005 + rightPupilPosition.y }
                     r="2"
@@ -467,13 +467,13 @@ const AnimatedIcon = (props: PropsWithChildren): ReactElement=> {
     };
 
     return (
-        <motion.g
+        <m.g
             animate="animate"
             whileHover="grow"
             variants={ variants }
         >
             { children }
-        </motion.g>
+        </m.g>
     );
 };
 

--- a/features/common.ai.v1/components/ai-loading-screen.tsx
+++ b/features/common.ai.v1/components/ai-loading-screen.tsx
@@ -75,7 +75,7 @@ const AILoadingScreen = (props: AILoadingScreenProps): ReactElement => {
 
     return (
         <LazyMotion features={ domAnimation }>
-        <m.div animate="botAnimation">
+        <div>
             <Box
                 className="ai-loading-screen-container"
                 data-componentid={ `${dataComponentId}-container` }
@@ -138,7 +138,7 @@ const AILoadingScreen = (props: AILoadingScreenProps): ReactElement => {
                     </Box>
                 </Box>
             </Box>
-        </m.div>
+        </div>
         </LazyMotion>
     );
 };

--- a/features/common.ai.v1/components/ai-loading-screen.tsx
+++ b/features/common.ai.v1/components/ai-loading-screen.tsx
@@ -24,7 +24,7 @@ import Typography from "@oxygen-ui/react/Typography";
 import { XMarkIcon } from "@oxygen-ui/react-icons";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
-import { Variants, motion } from "framer-motion";
+import { LazyMotion, Variants, domAnimation, m } from "framer-motion";
 import React, { ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import "./ai-loading-screen.scss";
@@ -74,7 +74,8 @@ const AILoadingScreen = (props: AILoadingScreenProps): ReactElement => {
     };
 
     return (
-        <motion.div animate="botAnimation">
+        <LazyMotion features={ domAnimation }>
+        <m.div animate="botAnimation">
             <Box
                 className="ai-loading-screen-container"
                 data-componentid={ `${dataComponentId}-container` }
@@ -100,7 +101,7 @@ const AILoadingScreen = (props: AILoadingScreenProps): ReactElement => {
                         >
                             { t("branding:ai.screens.loading.didYouKnow") }
                         </Typography>
-                        <motion.div
+                        <m.div
                             key={ fact }
                             initial="hidden"
                             animate="visible"
@@ -111,7 +112,7 @@ const AILoadingScreen = (props: AILoadingScreenProps): ReactElement => {
                             <Typography className="ai-loading-screen-sub-heading">
                                 { fact }
                             </Typography>
-                        </motion.div>
+                        </m.div>
                     </Box>
                     <Box sx={ { width: 1 } }>
                         <Box className="ai-loading-screen-loading-container">
@@ -137,7 +138,8 @@ const AILoadingScreen = (props: AILoadingScreenProps): ReactElement => {
                     </Box>
                 </Box>
             </Box>
-        </motion.div>
+        </m.div>
+        </LazyMotion>
     );
 };
 


### PR DESCRIPTION
## Purpose
Fixes the `react-doctor/use-lazy-motion` violation by replacing `motion` 
imports with `LazyMotion` + `m` pattern across 10 components.

## Related Issues
Closes wso2/product-is#27961

## Changes
- `admin.agents.v1/components/edit/share-agent-form.tsx`
- `admin.applications.v1/components/forms/share-application-form-updated.tsx`
- `admin.applications.v1/components/modals/application-share-modal-updated.tsx`
- `admin.branding.v1/components/branding-page-layout.tsx`
- `admin.console-settings.v1/components/console-shared-access/console-shared-access.tsx`
- `admin.home.v1/components/new-feature-announcement/new-feature-announcement.tsx`
- `admin.users.v1/components/share-user-form.tsx`
- `common.ai.v1/components/ai-bot-animated-with-bg.tsx`
- `common.ai.v1/components/ai-banner-tall.tsx`
- `common.ai.v1/components/ai-loading-screen.tsx`

## Checklist
- [✓] No behavioural changes introduced.
- [✓]Existing functionality preserved.
- [✓] Bundle size reduced by ~30kb.
## Testing
 - Manually verified all 10 affected views render and animate as before.