### PR TITLE
Bind Moesif Insights canvas height to the page scroller and refine dashboard templates

### DIFF
--- a/.changeset/moesif-canvas-auto-height.md
+++ b/.changeset/moesif-canvas-auto-height.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.analytics.v1": patch
+---
+
+Bind the Moesif Insights canvas to the console page scroller by sizing the iframe from CANVAS_RESIZE auto-height reports, and improve the dashboard template names and panel layout.

--- a/.changeset/moesif-canvas-auto-height.md
+++ b/.changeset/moesif-canvas-auto-height.md
@@ -1,4 +1,5 @@
 ---
+"@wso2is/console": patch
 "@wso2is/admin.analytics.v1": patch
 ---
 

--- a/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
@@ -2,7 +2,7 @@
   "dashboards": [
     {
       "_id": "6a0d5b2842390139f7ac4a23",
-      "name": "Login",
+      "name": "Authentication",
       "dashboard_ids": [],
       "workspace_ids": [
         [
@@ -16,15 +16,18 @@
         ],
         [
           "6a0da5db04a4ee1e28287918",
-          "6a0db97704a4ee1e282884a8",
+          "6a0db97704a4ee1e282884a8"
+        ],
+        [
           "6a1e9ec27f7e1a2185865c51"
         ]
       ],
-      "parent": "6a0d5af342390139f7ac4a07"
+      "parent": "6a0d5af342390139f7ac4a07",
+      "sort_order": 1
     },
     {
       "_id": "6a0d5b3042390139f7ac4a26",
-      "name": "Registration",
+      "name": "Registrations",
       "dashboard_ids": [],
       "workspace_ids": [
         [
@@ -39,11 +42,12 @@
           "6a1e90519ab5707f95230d63"
         ]
       ],
-      "parent": "6a0d5af342390139f7ac4a07"
+      "parent": "6a0d5af342390139f7ac4a07",
+      "sort_order": 2
     },
     {
       "_id": "6a1ea1475bc7c56efa5ea476",
-      "name": "Token",
+      "name": "Token Issuance",
       "dashboard_ids": [],
       "workspace_ids": [
         [
@@ -59,7 +63,8 @@
           "6a1ea530353c7116a6e54c1e"
         ]
       ],
-      "parent": "6a0d5af342390139f7ac4a07"
+      "parent": "6a0d5af342390139f7ac4a07",
+      "sort_order": 3
     },
     {
       "_id": "6a0d5af342390139f7ac4a07",
@@ -71,20 +76,19 @@
       ],
       "workspace_ids": [
         [
-          "6a1fac5668f9b5457fabcabb",
-          "6a1fac9168f9b5457fabcabc",
-          "6a1face868f9b5457fabcac4",
-          "6a1faccf8507014e56ac4629",
-          "6a1facb78507014e56ac4628"
+          "6a0db96342390139f7ac83e7",
+          "6a1ea2257f7e1a2185865daf",
+          "6a1ea3e67f7e1a2185865dbb",
+          "6a1e8f049ab5707f95230c0a",
+          "6a1e90c39ab5707f95230d67"
         ],
         [
-          "6a1fad0868f9b5457fabcac5",
-          "6a1fad328507014e56ac462e"
-        ],
-        []
+          "6a0db9f004a4ee1e28288627",
+          "6a1e8fa55bc7c56efa5e9e89"
+        ]
       ],
       "parent": null,
-      "sort_order": 2
+      "sort_order": 0
     }
   ],
   "workspaces": [
@@ -184,7 +188,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -281,7 +285,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -373,7 +377,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -457,7 +461,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -515,7 +519,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -1005,7 +1009,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -2211,7 +2215,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -2294,7 +2298,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -2660,7 +2664,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -2751,7 +2755,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {

--- a/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-essentials.json
@@ -95,7 +95,7 @@
     {
       "_id": "6a1fac5668f9b5457fabcabb",
       "type": "events",
-      "name": "Active User Count",
+      "name": "Active Users",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -201,7 +201,7 @@
     {
       "_id": "6a1fac9168f9b5457fabcabc",
       "type": "events",
-      "name": "M2M Token Count",
+      "name": "M2M Tokens",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -298,7 +298,7 @@
     {
       "_id": "6a1face868f9b5457fabcac4",
       "type": "events",
-      "name": "Total Token Count",
+      "name": "Total Tokens",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -390,7 +390,7 @@
     {
       "_id": "6a1faccf8507014e56ac4629",
       "type": "events",
-      "name": "Self Sign-Up Users",
+      "name": "Self Sign-Ups",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -532,7 +532,7 @@
     {
       "_id": "6a1fad0868f9b5457fabcac5",
       "type": "events",
-      "name": "Login Success vs Failures Over Time",
+      "name": "Login Success vs Failure Over Time",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -917,7 +917,7 @@
     {
       "_id": "6a0db96342390139f7ac83e7",
       "type": "events",
-      "name": "Active User Count",
+      "name": "Active Users",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1022,7 +1022,7 @@
     {
       "_id": "6a0db9e042390139f7ac84f6",
       "type": "events",
-      "name": "Login Success vs Failures",
+      "name": "Login Success vs Failure",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1263,7 +1263,7 @@
     {
       "_id": "6a1e9f9e7f7e1a2185865c52",
       "type": "events",
-      "name": "MFA Distribution",
+      "name": "MFA Usage",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1411,7 +1411,7 @@
     {
       "_id": "6a0db9f004a4ee1e28288627",
       "type": "events",
-      "name": "Login Success vs Failures Over Time",
+      "name": "Login Success vs Failure Over Time",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1805,7 +1805,7 @@
     {
       "_id": "6a0da5db04a4ee1e28287918",
       "type": "events",
-      "name": "Logins By Device",
+      "name": "Logins by Device",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1941,7 +1941,7 @@
     {
       "_id": "6a0db97704a4ee1e282884a8",
       "type": "events",
-      "name": "Login By Application",
+      "name": "Logins by Application",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2067,7 +2067,7 @@
     {
       "_id": "6a1e9ec27f7e1a2185865c51",
       "type": "events",
-      "name": "Geo Map",
+      "name": "Logins by Location",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2228,7 +2228,7 @@
     {
       "_id": "6a1e8f049ab5707f95230c0a",
       "type": "events",
-      "name": "Self Sign-Up Users",
+      "name": "Self Sign-Ups",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2311,7 +2311,7 @@
     {
       "_id": "6a1e8e8f9ab5707f95230c08",
       "type": "events",
-      "name": "User Onboarding Method",
+      "name": "Onboarding Methods",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2476,7 +2476,7 @@
     {
       "_id": "6a1e90519ab5707f95230d63",
       "type": "events",
-      "name": "Registrations By Application",
+      "name": "Registrations by Application",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2581,7 +2581,7 @@
     {
       "_id": "6a1ea2257f7e1a2185865daf",
       "type": "events",
-      "name": "M2M Token Count",
+      "name": "M2M Tokens",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2677,7 +2677,7 @@
     {
       "_id": "6a1ea3e67f7e1a2185865dbb",
       "type": "events",
-      "name": "Total Token Count",
+      "name": "Total Tokens",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2768,7 +2768,7 @@
     {
       "_id": "6a1ea464353c7116a6e54aff",
       "type": "events",
-      "name": "Token Distribution By User Type",
+      "name": "Tokens by User Type",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2880,7 +2880,7 @@
     {
       "_id": "6a1ea347353c7116a6e54afd",
       "type": "events",
-      "name": "Token Distribution By Application",
+      "name": "Tokens by Application",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2992,7 +2992,7 @@
     {
       "_id": "6a1ea4bb7f7e1a2185865e3e",
       "type": "events",
-      "name": "Token Distribution By Grant Type",
+      "name": "Tokens by Grant Type",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -3103,7 +3103,7 @@
     {
       "_id": "6a1ea530353c7116a6e54c1e",
       "type": "events",
-      "name": "Token Distribution Over Time",
+      "name": "Tokens Issued Over Time",
       "args": "",
       "es_query": {
         "post_filter": {

--- a/features/admin.analytics.v1/assets/moesif-dashboard-free.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-free.json
@@ -24,7 +24,7 @@
         {
             "_id": "6a1fac5668f9b5457fabcabb",
             "type": "events",
-            "name": "Active User Count",
+            "name": "Active Users",
             "args": "",
             "es_query": {
                 "post_filter": {
@@ -130,7 +130,7 @@
         {
             "_id": "6a1fac9168f9b5457fabcabc",
             "type": "events",
-            "name": "M2M Token Count",
+            "name": "M2M Tokens",
             "args": "",
             "es_query": {
                 "post_filter": {
@@ -227,7 +227,7 @@
         {
             "_id": "6a1fad0868f9b5457fabcac5",
             "type": "events",
-            "name": "Login Success vs Failures Over Time",
+            "name": "Login Success vs Failure Over Time",
             "args": "",
             "es_query": {
                 "post_filter": {

--- a/features/admin.analytics.v1/assets/moesif-dashboard-free.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-free.json
@@ -17,7 +17,7 @@
                 ]
             ],
             "parent": null,
-            "sort_order": 2
+            "sort_order": 0
         }
     ],
     "workspaces": [

--- a/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
@@ -2,7 +2,7 @@
   "dashboards": [
     {
       "_id": "6a0d5b2842390139f7ac4a23",
-      "name": "Login",
+      "name": "Authentication",
       "dashboard_ids": [],
       "workspace_ids": [
         [
@@ -16,15 +16,18 @@
         ],
         [
           "6a0da5db04a4ee1e28287918",
-          "6a0db97704a4ee1e282884a8",
+          "6a0db97704a4ee1e282884a8"
+        ],
+        [
           "6a1e9ec27f7e1a2185865c51"
         ]
       ],
-      "parent": "6a0d5af342390139f7ac4a07"
+      "parent": "6a0d5af342390139f7ac4a07",
+      "sort_order": 1
     },
     {
       "_id": "6a0d5b3042390139f7ac4a26",
-      "name": "Registration",
+      "name": "Registrations",
       "dashboard_ids": [],
       "workspace_ids": [
         [
@@ -39,11 +42,12 @@
           "6a1e90519ab5707f95230d63"
         ]
       ],
-      "parent": "6a0d5af342390139f7ac4a07"
+      "parent": "6a0d5af342390139f7ac4a07",
+      "sort_order": 2
     },
     {
       "_id": "6a1ea1475bc7c56efa5ea476",
-      "name": "Token",
+      "name": "Token Issuance",
       "dashboard_ids": [],
       "workspace_ids": [
         [
@@ -59,7 +63,8 @@
           "6a1ea530353c7116a6e54c1e"
         ]
       ],
-      "parent": "6a0d5af342390139f7ac4a07"
+      "parent": "6a0d5af342390139f7ac4a07",
+      "sort_order": 3
     },
     {
       "_id": "6a0d5af342390139f7ac4a07",
@@ -71,20 +76,19 @@
       ],
       "workspace_ids": [
         [
-          "6a1fac5668f9b5457fabcabb",
-          "6a1fac9168f9b5457fabcabc",
-          "6a1face868f9b5457fabcac4",
-          "6a1faccf8507014e56ac4629",
-          "6a1facb78507014e56ac4628"
+          "6a0db96342390139f7ac83e7",
+          "6a1ea2257f7e1a2185865daf",
+          "6a1ea3e67f7e1a2185865dbb",
+          "6a1e8f049ab5707f95230c0a",
+          "6a1e90c39ab5707f95230d67"
         ],
         [
-          "6a1fad0868f9b5457fabcac5",
-          "6a1fad328507014e56ac462e"
-        ],
-        []
+          "6a0db9f004a4ee1e28288627",
+          "6a1e8fa55bc7c56efa5e9e89"
+        ]
       ],
       "parent": null,
-      "sort_order": 2
+      "sort_order": 0
     }
   ],
   "workspaces": [
@@ -184,7 +188,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -281,7 +285,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -373,7 +377,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -457,7 +461,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -515,7 +519,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -1005,7 +1009,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -2211,7 +2215,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -2294,7 +2298,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -2660,7 +2664,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {
@@ -2751,7 +2755,7 @@
         "hideLegend": true,
         "singleValueSettings": true,
         "trendInidcator": {
-            "isIncreasementGreen": "true"
+          "isIncreasementGreen": "true"
         },
         "metrics": [
           {

--- a/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
+++ b/features/admin.analytics.v1/assets/moesif-dashboard-premium.json
@@ -95,7 +95,7 @@
     {
       "_id": "6a1fac5668f9b5457fabcabb",
       "type": "events",
-      "name": "Active User Count",
+      "name": "Active Users",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -201,7 +201,7 @@
     {
       "_id": "6a1fac9168f9b5457fabcabc",
       "type": "events",
-      "name": "M2M Token Count",
+      "name": "M2M Tokens",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -298,7 +298,7 @@
     {
       "_id": "6a1face868f9b5457fabcac4",
       "type": "events",
-      "name": "Total Token Count",
+      "name": "Total Tokens",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -390,7 +390,7 @@
     {
       "_id": "6a1faccf8507014e56ac4629",
       "type": "events",
-      "name": "Self Sign-Up Users",
+      "name": "Self Sign-Ups",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -532,7 +532,7 @@
     {
       "_id": "6a1fad0868f9b5457fabcac5",
       "type": "events",
-      "name": "Login Success vs Failures Over Time",
+      "name": "Login Success vs Failure Over Time",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -917,7 +917,7 @@
     {
       "_id": "6a0db96342390139f7ac83e7",
       "type": "events",
-      "name": "Active User Count",
+      "name": "Active Users",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1022,7 +1022,7 @@
     {
       "_id": "6a0db9e042390139f7ac84f6",
       "type": "events",
-      "name": "Login Success vs Failures",
+      "name": "Login Success vs Failure",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1263,7 +1263,7 @@
     {
       "_id": "6a1e9f9e7f7e1a2185865c52",
       "type": "events",
-      "name": "MFA Distribution",
+      "name": "MFA Usage",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1411,7 +1411,7 @@
     {
       "_id": "6a0db9f004a4ee1e28288627",
       "type": "events",
-      "name": "Login Success vs Failures Over Time",
+      "name": "Login Success vs Failure Over Time",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1805,7 +1805,7 @@
     {
       "_id": "6a0da5db04a4ee1e28287918",
       "type": "events",
-      "name": "Logins By Device",
+      "name": "Logins by Device",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -1941,7 +1941,7 @@
     {
       "_id": "6a0db97704a4ee1e282884a8",
       "type": "events",
-      "name": "Login By Application",
+      "name": "Logins by Application",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2067,7 +2067,7 @@
     {
       "_id": "6a1e9ec27f7e1a2185865c51",
       "type": "events",
-      "name": "Geo Map",
+      "name": "Logins by Location",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2228,7 +2228,7 @@
     {
       "_id": "6a1e8f049ab5707f95230c0a",
       "type": "events",
-      "name": "Self Sign-Up Users",
+      "name": "Self Sign-Ups",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2311,7 +2311,7 @@
     {
       "_id": "6a1e8e8f9ab5707f95230c08",
       "type": "events",
-      "name": "User Onboarding Method",
+      "name": "Onboarding Methods",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2476,7 +2476,7 @@
     {
       "_id": "6a1e90519ab5707f95230d63",
       "type": "events",
-      "name": "Registrations By Application",
+      "name": "Registrations by Application",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2581,7 +2581,7 @@
     {
       "_id": "6a1ea2257f7e1a2185865daf",
       "type": "events",
-      "name": "M2M Token Count",
+      "name": "M2M Tokens",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2677,7 +2677,7 @@
     {
       "_id": "6a1ea3e67f7e1a2185865dbb",
       "type": "events",
-      "name": "Total Token Count",
+      "name": "Total Tokens",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2768,7 +2768,7 @@
     {
       "_id": "6a1ea464353c7116a6e54aff",
       "type": "events",
-      "name": "Token Distribution By User Type",
+      "name": "Tokens by User Type",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2880,7 +2880,7 @@
     {
       "_id": "6a1ea347353c7116a6e54afd",
       "type": "events",
-      "name": "Token Distribution By Application",
+      "name": "Tokens by Application",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -2992,7 +2992,7 @@
     {
       "_id": "6a1ea4bb7f7e1a2185865e3e",
       "type": "events",
-      "name": "Token Distribution By Grant Type",
+      "name": "Tokens by Grant Type",
       "args": "",
       "es_query": {
         "post_filter": {
@@ -3103,7 +3103,7 @@
     {
       "_id": "6a1ea530353c7116a6e54c1e",
       "type": "events",
-      "name": "Token Distribution Over Time",
+      "name": "Tokens Issued Over Time",
       "args": "",
       "es_query": {
         "post_filter": {

--- a/features/admin.analytics.v1/components/moesif-canvas-iframe.tsx
+++ b/features/admin.analytics.v1/components/moesif-canvas-iframe.tsx
@@ -42,6 +42,7 @@ import { MoesifDashboardInfoInterface } from "../models/moesif-analytics";
 const EMBEDDED_POST_MESSAGE_TYPES: {
     CANVAS_INIT: string;
     CANVAS_READY: string;
+    CANVAS_RESIZE: string;
     ORG_LOAD_FINISHED: string;
     REFRESH_TOKEN: string;
     SCHEMA_GEN_FINISHED: string;
@@ -49,6 +50,7 @@ const EMBEDDED_POST_MESSAGE_TYPES: {
 } = {
     CANVAS_INIT: "CANVAS_INIT",
     CANVAS_READY: "CANVAS_READY",
+    CANVAS_RESIZE: "CANVAS_RESIZE",
     ORG_LOAD_FINISHED: "ORG_LOAD_FINISHED",
     REFRESH_TOKEN: "REFRESH_TOKEN",
     SCHEMA_GEN_FINISHED: "SCHEMA_GEN_FINISHED",
@@ -93,11 +95,9 @@ const ErrorContainer: typeof Box = styled(Box)(() => ({
 const CanvasContainer: typeof Box = styled(Box)(() => ({
     "& iframe": {
         border: "none",
-        height: "100%",
-        minHeight: CANVAS_MIN_HEIGHT,
+        display: "block",
         width: "100%"
     },
-    height: "100%",
     minHeight: CANVAS_MIN_HEIGHT,
     position: "relative",
     width: "100%"
@@ -159,6 +159,7 @@ const MoesifCanvasIframe: FunctionComponent<MoesifCanvasIframePropsInterface> = 
     const [ isIframeDomLoaded, setIsIframeDomLoaded ] = useState<boolean>(false);
     const [ hasAuthCompleted, setHasAuthCompleted ] = useState<boolean>(false);
     const [ isChildReady, setIsChildReady ] = useState<boolean>(false);
+    const [ iframeHeight, setIframeHeight ] = useState<number | null>(null);
 
     const iframeRef: React.MutableRefObject<HTMLIFrameElement | null> = useRef<HTMLIFrameElement | null>(null);
     const isMounted: React.MutableRefObject<boolean> = useRef<boolean>(true);
@@ -223,6 +224,9 @@ const MoesifCanvasIframe: FunctionComponent<MoesifCanvasIframePropsInterface> = 
                 {
                     template,
                     theme: {
+                        // Makes the canvas report its content height via
+                        // CANVAS_RESIZE, which drives the iframe height below.
+                        autoHeight: true,
                         brandColor: theme.palette.primary.main,
                         brandTextColor: theme.palette.primary.main,
                         chartColors: CHART_COLORS,
@@ -290,6 +294,18 @@ const MoesifCanvasIframe: FunctionComponent<MoesifCanvasIframePropsInterface> = 
                     setIsLoading(false);
 
                     break;
+                case EMBEDDED_POST_MESSAGE_TYPES.CANVAS_RESIZE:
+                    // Canvas reports its content height on render and tab changes.
+                    // Size the iframe to it so the page scrolls (no inner scrollbar),
+                    // matching how the rest of the console pages scroll.
+                    if (typeof event.data?.height === "number" && event.data.height > 0) {
+                        // Round up so a fractional reported height can never leave
+                        // the iframe a sub-pixel short of its content (which would
+                        // clip the bottom edge, since inner scrolling is disabled).
+                        setIframeHeight(Math.ceil(event.data.height));
+                    }
+
+                    break;
                 case EMBEDDED_POST_MESSAGE_TYPES.REFRESH_TOKEN:
                     // Iframe requested a token refresh.
                     fetchDashboardInfo();
@@ -337,6 +353,14 @@ const MoesifCanvasIframe: FunctionComponent<MoesifCanvasIframePropsInterface> = 
                     data-componentid={ `${ componentId }-frame` }
                     src={ iframeSrc }
                     title={ t("extensions:develop.moesifAnalytics.dashboard.iframeTitle") }
+                    // The canvas reports its content height via CANVAS_RESIZE and the
+                    // iframe is sized to it, rendering the full content. The iframe
+                    // never scrolls itself — the console page scroller is the only
+                    // scroller, same as the rest of the console pages.
+                    scrolling="no"
+                    style={ {
+                        height: iframeHeight !== null ? `${ iframeHeight }px` : CANVAS_MIN_HEIGHT
+                    } }
                     onLoad={ () => {
                         setIsIframeDomLoaded(true);
                     } }


### PR DESCRIPTION
## Purpose

Make the embedded Moesif Insights canvas scroll like a native console page and polish the dashboard templates.

## Changes

### Canvas iframe (`admin.analytics.v1`)
- Enable `autoHeight` in the `CANVAS_INIT` theme so the embedded canvas reports its content height via `CANVAS_RESIZE` (on render and tab changes).
- Size the iframe to the reported height (`Math.ceil` to avoid sub-pixel clipping) with `scrolling="no"`, so the iframe never shows its own scrollbar and the console page scroller is the only scroller — matching the rest of the console pages.
- 600px placeholder height until the first resize report arrives.
- Remove leftover debug logs.

### Dashboard templates
- Rename dashboards for clarity: **Authentication**, **Registrations**, **Token Issuance**; explicit sort order with **Overview** first.
- Move the Geo Map panel to its own full-width row in the Authentication dashboard.
- Drop an empty trailing row in the Overview dashboard.
- Fix the Free-tier dashboard sort order.

## Related
- Part of the Asgardeo↔Moesif analytics integration.