### PR TITLE
Improve trial activation and retrieval flow by moving to a Provider pattern

### DIFF
--- a/.changeset/wild-regions-mate.md
+++ b/.changeset/wild-regions-mate.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.subscription.v1": patch
+"@wso2is/console": patch
+---
+
+Improve trial activation and retrieval flow

--- a/apps/console/src/app.tsx
+++ b/apps/console/src/app.tsx
@@ -46,9 +46,7 @@ import { commonConfig } from "@wso2is/admin.extensions.v1";
 import { featureGateConfig } from "@wso2is/admin.extensions.v1/configs/feature-gate";
 import useGetAllFeatures from "@wso2is/admin.feature-gate.v1/api/use-get-all-features";
 import { useOnboardingStatus } from "@wso2is/admin.onboarding.v1/hooks/use-onboarding-status";
-import { activateTrial } from "@wso2is/admin.subscription.v1/api/activate-trial";
-import { useTrialStatus } from "@wso2is/admin.subscription.v1/hooks/use-trial-status";
-import { TrialStatus } from "@wso2is/admin.subscription.v1/models/trial";
+import TrialProvider from "@wso2is/admin.subscription.v1/providers/trial-provider";
 import { AGENT_USERSTORE_ID } from "@wso2is/admin.userstores.v1/constants/user-store-constants";
 import useUserStores from "@wso2is/admin.userstores.v1/hooks/use-user-stores";
 import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-stores";
@@ -73,7 +71,7 @@ import dayjs from "dayjs";
 import has from "lodash-es/has";
 import isEmpty from "lodash-es/isEmpty";
 import set from "lodash-es/set";
-import React, { ReactElement, Suspense, useEffect, useMemo, useRef, useState } from "react";
+import React, { ReactElement, Suspense, useEffect, useMemo, useState } from "react";
 import { Helmet } from "react-helmet";
 import { Trans } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -205,16 +203,6 @@ const App = ({
 
     const { shouldShowOnboarding, isLoading: isOnboardingStatusLoading } = useOnboardingStatus();
 
-    const {
-        trialStatus,
-        isResolved: isTrialResolved,
-        isLoading: isTrialStatusLoading
-    } = useTrialStatus();
-
-    const isTrialActivationEnabled: boolean =
-        (config?.deployment?.extensions as Record<string, Record<string, unknown>>)
-            ?.trial?.enabled === true;
-
     /**
      * Redirect to onboarding page if user should see onboarding.
      */
@@ -240,35 +228,6 @@ const App = ({
             }
         }
     }, [ shouldShowOnboarding, isOnboardingStatusLoading ]);
-
-    /**
-     * Fire-and-forget trial activation when trial is not yet enabled.
-     */
-    const trialActivationAttempted: React.MutableRefObject<boolean> = useRef<boolean>(false);
-
-    useEffect(() => {
-        if (
-            !isTrialActivationEnabled
-            || isTrialStatusLoading
-            || !isTrialResolved
-            || trialStatus !== TrialStatus.DISABLED
-            || trialActivationAttempted.current
-        ) {
-            return;
-        }
-
-        trialActivationAttempted.current = true;
-
-        activateTrial().catch(() => {
-            // eslint-disable-next-line no-console
-            console.warn("Trial activation is pending.");
-        });
-    }, [
-        isTrialActivationEnabled,
-        isTrialStatusLoading,
-        isTrialResolved,
-        trialStatus
-    ]);
 
     /**
      * Set the deployment configs in redux state.
@@ -517,162 +476,164 @@ const App = ({
                                     features={ featureGateConfigData }
                                     organizationType={ organizationType }
                                 >
-                                    <SessionManagementProvider
-                                        onSessionTimeoutAbort={ handleSessionTimeoutAbort }
-                                        onSessionLogout={ handleSessionLogout }
-                                        onLoginAgain={ handleStayLoggedIn }
-                                        setSessionTimedOut={ handleSessionTimeOut }
-                                        sessionTimedOut={ sessionTimedOut }
-                                        modalOptions={ {
-                                            description: (
-                                                <Trans
-                                                    i18nKey={
-                                                        "console:common.modals.sessionTimeoutModal." +
-                                                        "description"
+                                    <TrialProvider>
+                                        <SessionManagementProvider
+                                            onSessionTimeoutAbort={ handleSessionTimeoutAbort }
+                                            onSessionLogout={ handleSessionLogout }
+                                            onLoginAgain={ handleStayLoggedIn }
+                                            setSessionTimedOut={ handleSessionTimeOut }
+                                            sessionTimedOut={ sessionTimedOut }
+                                            modalOptions={ {
+                                                description: (
+                                                    <Trans
+                                                        i18nKey={
+                                                            "console:common.modals.sessionTimeoutModal." +
+                                                            "description"
+                                                        }
+                                                    >
+                                                        When you click on the <Code>Go back</Code> button, we
+                                                        will try to recover the session if it exists. If you
+                                                        don&apos;t have an active session, you will be
+                                                        redirected to the login page
+                                                    </Trans>
+                                                ),
+                                                headingI18nKey: "console:common.modals.sessionTimeoutModal" +
+                                                    ".heading",
+                                                loginAgainButtonText: (
+                                                    <Trans
+                                                        i18nKey={
+                                                            "console:common.modals" +
+                                                            ".sessionTimeoutModal.loginAgainButton"
+                                                        }>
+                                                        Login again
+                                                    </Trans>
+                                                ),
+                                                primaryButtonText: (
+                                                    <Trans
+                                                        i18nKey={
+                                                            "console:common.modals" +
+                                                            ".sessionTimeoutModal.primaryButton"
+                                                        }>
+                                                        Go back
+                                                    </Trans>
+                                                ),
+                                                secondaryButtonText: (
+                                                    <Trans
+                                                        i18nKey={
+                                                            "console:common.modals" +
+                                                            ".sessionTimeoutModal.secondaryButton"
+                                                        }>
+                                                        Logout
+                                                    </Trans>
+                                                ),
+                                                sessionTimedOutDescription: (
+                                                    <Trans
+                                                        i18nKey={
+                                                            "console:common.modals" +
+                                                            ".sessionTimeoutModal.sessionTimedOutDescription"
+                                                        }>
+                                                        Please log in again to continue from where you left off.
+                                                    </Trans>
+                                                ),
+                                                sessionTimedOutHeadingI18nKey: "console:common.modals" +
+                                                    ".sessionTimeoutModal.sessionTimedOutHeading"
+                                            } }
+                                            type={ SessionTimeoutModalTypes.DEFAULT }
+                                        >
+                                            <>
+                                                <Helmet>
+                                                    <title>{ appTitle }</title>
+                                                    {
+                                                        (window?.themeHash && window?.publicPath && theme)
+                                                            ? (
+                                                                <link
+                                                                    href={
+                                                                        `${
+                                                                            window?.origin
+                                                                        }${
+                                                                            window?.publicPath
+                                                                        }/libs/themes/${
+                                                                            theme
+                                                                        }/theme.${ window?.themeHash }.min.css`
+                                                                    }
+                                                                    rel="stylesheet"
+                                                                    type="text/css"
+                                                                />
+                                                            )
+                                                            : null
                                                     }
-                                                >
-                                                    When you click on the <Code>Go back</Code> button, we
-                                                    will try to recover the session if it exists. If you
-                                                    don&apos;t have an active session, you will be
-                                                    redirected to the login page
-                                                </Trans>
-                                            ),
-                                            headingI18nKey: "console:common.modals.sessionTimeoutModal" +
-                                                ".heading",
-                                            loginAgainButtonText: (
-                                                <Trans
-                                                    i18nKey={
-                                                        "console:common.modals" +
-                                                        ".sessionTimeoutModal.loginAgainButton"
-                                                    }>
-                                                    Login again
-                                                </Trans>
-                                            ),
-                                            primaryButtonText: (
-                                                <Trans
-                                                    i18nKey={
-                                                        "console:common.modals" +
-                                                        ".sessionTimeoutModal.primaryButton"
-                                                    }>
-                                                    Go back
-                                                </Trans>
-                                            ),
-                                            secondaryButtonText: (
-                                                <Trans
-                                                    i18nKey={
-                                                        "console:common.modals" +
-                                                        ".sessionTimeoutModal.secondaryButton"
-                                                    }>
-                                                    Logout
-                                                </Trans>
-                                            ),
-                                            sessionTimedOutDescription: (
-                                                <Trans
-                                                    i18nKey={
-                                                        "console:common.modals" +
-                                                        ".sessionTimeoutModal.sessionTimedOutDescription"
-                                                    }>
-                                                    Please log in again to continue from where you left off.
-                                                </Trans>
-                                            ),
-                                            sessionTimedOutHeadingI18nKey: "console:common.modals" +
-                                                ".sessionTimeoutModal.sessionTimedOutHeading"
-                                        } }
-                                        type={ SessionTimeoutModalTypes.DEFAULT }
-                                    >
-                                        <>
-                                            <Helmet>
-                                                <title>{ appTitle }</title>
-                                                {
-                                                    (window?.themeHash && window?.publicPath && theme)
-                                                        ? (
-                                                            <link
-                                                                href={
-                                                                    `${
-                                                                        window?.origin
-                                                                    }${
-                                                                        window?.publicPath
-                                                                    }/libs/themes/${
-                                                                        theme
-                                                                    }/theme.${ window?.themeHash }.min.css`
-                                                                }
-                                                                rel="stylesheet"
-                                                                type="text/css"
-                                                            />
-                                                        )
-                                                        : null
-                                                }
-                                            </Helmet>
-                                            <NetworkErrorModal
-                                                heading={
-                                                    (<Trans
-                                                        i18nKey={ "common:networkErrorMessage.heading" }
-                                                    >
-                                                        Your session has expired
-                                                    </Trans>)
-                                                }
-                                                description={
-                                                    (<Trans
-                                                        i18nKey={ "common:networkErrorMessage.description" }
-                                                    >
-                                                        Please try signing in again.
-                                                    </Trans>)
-                                                }
-                                                primaryActionText={
-                                                    (<Trans
-                                                        i18nKey={
-                                                            "common:networkErrorMessage.primaryActionText"
-                                                        }
-                                                    >
-                                                        Sign In
-                                                    </Trans>)
-                                                }
-                                                primaryAction={
-                                                    signOut
-                                                }
-                                            />
-                                            <ChunkErrorModal
-                                                heading={
-                                                    (<Trans
-                                                        i18nKey={
-                                                            "common:chunkLoadErrorMessage.heading"
-                                                        }
-                                                    >
-                                                        Something went wrong
-                                                    </Trans>)
-                                                }
-                                                description={
-                                                    (<Trans
-                                                        i18nKey={
-                                                            "common:chunkLoadErrorMessage.description"
-                                                        }
-                                                    >
-                                                        An error occurred when serving the requested
-                                                        application. Please try reloading the app.
-                                                    </Trans>)
-                                                }
-                                                primaryActionText={
-                                                    (<Trans
-                                                        i18nKey={
-                                                            "common:chunkLoadErrorMessage.primaryActionText"
-                                                        }
-                                                    >
-                                                        Reload the App
-                                                    </Trans>)
-                                                }
-                                            />
-                                            <UserStoresProvider>
-                                                <Base
-                                                    onAgentManagementEnableStatusChange={
-                                                        onAgentManagementEnableStatusChange
+                                                </Helmet>
+                                                <NetworkErrorModal
+                                                    heading={
+                                                        (<Trans
+                                                            i18nKey={ "common:networkErrorMessage.heading" }
+                                                        >
+                                                            Your session has expired
+                                                        </Trans>)
                                                     }
-                                                    onCustomerDataServiceStatusChange={
-                                                        onCustomerDataServiceStatusChange
+                                                    description={
+                                                        (<Trans
+                                                            i18nKey={ "common:networkErrorMessage.description" }
+                                                        >
+                                                            Please try signing in again.
+                                                        </Trans>)
+                                                    }
+                                                    primaryActionText={
+                                                        (<Trans
+                                                            i18nKey={
+                                                                "common:networkErrorMessage.primaryActionText"
+                                                            }
+                                                        >
+                                                            Sign In
+                                                        </Trans>)
+                                                    }
+                                                    primaryAction={
+                                                        signOut
                                                     }
                                                 />
-                                            </UserStoresProvider>
-                                        </>
-                                    </SessionManagementProvider>
+                                                <ChunkErrorModal
+                                                    heading={
+                                                        (<Trans
+                                                            i18nKey={
+                                                                "common:chunkLoadErrorMessage.heading"
+                                                            }
+                                                        >
+                                                            Something went wrong
+                                                        </Trans>)
+                                                    }
+                                                    description={
+                                                        (<Trans
+                                                            i18nKey={
+                                                                "common:chunkLoadErrorMessage.description"
+                                                            }
+                                                        >
+                                                            An error occurred when serving the requested
+                                                            application. Please try reloading the app.
+                                                        </Trans>)
+                                                    }
+                                                    primaryActionText={
+                                                        (<Trans
+                                                            i18nKey={
+                                                                "common:chunkLoadErrorMessage.primaryActionText"
+                                                            }
+                                                        >
+                                                            Reload the App
+                                                        </Trans>)
+                                                    }
+                                                />
+                                                <UserStoresProvider>
+                                                    <Base
+                                                        onAgentManagementEnableStatusChange={
+                                                            onAgentManagementEnableStatusChange
+                                                        }
+                                                        onCustomerDataServiceStatusChange={
+                                                            onCustomerDataServiceStatusChange
+                                                        }
+                                                    />
+                                                </UserStoresProvider>
+                                            </>
+                                        </SessionManagementProvider>
+                                    </TrialProvider>
                                 </AccessControlProvider>
                             </MediaContextProvider>
                         </Suspense>

--- a/features/admin.subscription.v1/contexts/trial-context.ts
+++ b/features/admin.subscription.v1/contexts/trial-context.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Context, createContext } from "react";
+
+/**
+ * Props interface of {@link TrialContext}
+ */
+export interface TrialContextPropsInterface {
+    /**
+     * Whether the tenant has an active trial.
+     */
+    tenantHasTrial: boolean;
+    /**
+     * Days remaining in the trial.
+     */
+    daysRemaining: number;
+    /**
+     * Whether the trial resolution is still in progress.
+     */
+    isLoading: boolean;
+}
+
+/**
+ * Context object for managing the Trial context.
+ */
+const TrialContext: Context<TrialContextPropsInterface> =
+    createContext<null | TrialContextPropsInterface>(null);
+
+/**
+ * Display name for the TrialContext.
+ */
+TrialContext.displayName = "TrialContext";
+
+export default TrialContext;

--- a/features/admin.subscription.v1/contexts/trial-context.ts
+++ b/features/admin.subscription.v1/contexts/trial-context.ts
@@ -39,8 +39,8 @@ export interface TrialContextPropsInterface {
 /**
  * Context object for managing the Trial context.
  */
-const TrialContext: Context<TrialContextPropsInterface> =
-    createContext<null | TrialContextPropsInterface>(null);
+const TrialContext: Context<TrialContextPropsInterface | null> =
+    createContext<TrialContextPropsInterface | null>(null);
 
 /**
  * Display name for the TrialContext.

--- a/features/admin.subscription.v1/hooks/__tests__/use-trial-details.test.tsx
+++ b/features/admin.subscription.v1/hooks/__tests__/use-trial-details.test.tsx
@@ -40,11 +40,13 @@ describe("useTrialDetails", () => {
             .spyOn(console, "error")
             .mockImplementation(() => undefined);
 
-        expect(() => render(<Probe />)).toThrow(
-            "useTrialDetails must be used within a TrialProvider"
-        );
-
-        consoleError.mockRestore();
+        try {
+            expect(() => render(<Probe />)).toThrow(
+                "useTrialDetails must be used within a TrialProvider"
+            );
+        } finally {
+            consoleError.mockRestore();
+        }
     });
 
     it("returns the trial state provided via TrialContext", () => {

--- a/features/admin.subscription.v1/hooks/__tests__/use-trial-details.test.tsx
+++ b/features/admin.subscription.v1/hooks/__tests__/use-trial-details.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { render, screen } from "@wso2is/unit-testing/utils";
+import React, { FunctionComponent, ReactElement } from "react";
+import TrialContext, { TrialContextPropsInterface } from "../../contexts/trial-context";
+import { useTrialDetails } from "../use-trial-details";
+import "@testing-library/jest-dom";
+
+const Probe: FunctionComponent = (): ReactElement => {
+    const { tenantHasTrial, daysRemaining, isLoading } = useTrialDetails();
+
+    return (
+        <div data-componentid="use-trial-details-probe">
+            <span>{ `tenantHasTrial:${ tenantHasTrial }` }</span>
+            <span>{ `daysRemaining:${ daysRemaining }` }</span>
+            <span>{ `isLoading:${ isLoading }` }</span>
+        </div>
+    );
+};
+
+describe("useTrialDetails", () => {
+    it("throws when used outside a TrialProvider", () => {
+        const consoleError: jest.SpyInstance = jest
+            .spyOn(console, "error")
+            .mockImplementation(() => undefined);
+
+        expect(() => render(<Probe />)).toThrow(
+            "useTrialDetails must be used within a TrialProvider"
+        );
+
+        consoleError.mockRestore();
+    });
+
+    it("returns the trial state provided via TrialContext", () => {
+        const contextValue: TrialContextPropsInterface = {
+            daysRemaining: 7,
+            isLoading: false,
+            tenantHasTrial: true
+        };
+
+        render(
+            <TrialContext.Provider value={ contextValue }>
+                <Probe />
+            </TrialContext.Provider>
+        );
+
+        expect(screen.getByText("tenantHasTrial:true")).toBeInTheDocument();
+        expect(screen.getByText("daysRemaining:7")).toBeInTheDocument();
+        expect(screen.getByText("isLoading:false")).toBeInTheDocument();
+    });
+});

--- a/features/admin.subscription.v1/hooks/use-trial-details.ts
+++ b/features/admin.subscription.v1/hooks/use-trial-details.ts
@@ -16,72 +16,26 @@
  * under the License.
  */
 
-import { FeatureStatus, useCheckFeatureStatus } from "@wso2is/access-control";
-import { AppState } from "@wso2is/admin.core.v1/store";
-import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
-import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
-import { useMemo } from "react";
-import { useSelector } from "react-redux";
-import { useGetTrialDetails } from "../api/get-trial-details";
+import { useContext } from "react";
+import TrialContext, { TrialContextPropsInterface } from "../contexts/trial-context";
 
 /**
  * Return type for the useTrialDetails hook.
  */
-interface UseTrialDetailsReturn {
-    tenantHasTrial: boolean;
-    daysRemaining: number;
-    isLoading: boolean;
-}
+export type UseTrialDetailsReturn = TrialContextPropsInterface;
 
 /**
- * Hook that fetches trial details from the tenant trial endpoint
- * and derives whether the tenant has an active trial and how many days remain.
+ * Hook that returns the trial state resolved by {@link TrialProvider}:
+ * whether the tenant has an active trial and how many days remain.
  *
  * @returns Trial state and days remaining.
  */
 export const useTrialDetails = (): UseTrialDetailsReturn => {
-    const saasFeatureStatus: FeatureStatus = useCheckFeatureStatus(FeatureGateConstants.SAAS_FEATURES_IDENTIFIER);
-    const { isFirstLevelOrganization } = useGetCurrentOrganizationType();
-    const isFirstLevelOrg: boolean = isFirstLevelOrganization();
+    const context: TrialContextPropsInterface = useContext(TrialContext);
 
-    const isTrialFeatureEnabled: boolean = useSelector(
-        (state: AppState) =>
-            (state.config.deployment.extensions as Record<string, Record<string, unknown>>)
-                ?.trial?.enabled === true
-    );
+    if (context === null) {
+        throw new Error("useTrialDetails must be used within a TrialProvider");
+    }
 
-    const shouldFetch: boolean =
-        saasFeatureStatus !== FeatureStatus.DISABLED &&
-        isTrialFeatureEnabled &&
-        isFirstLevelOrg;
-
-    const {
-        data: trialData,
-        isLoading: isTrialLoading,
-        error
-    } = useGetTrialDetails(shouldFetch);
-
-    const tenantHasTrial: boolean = useMemo((): boolean => {
-        if (!shouldFetch || isTrialLoading) {
-            return false;
-        }
-
-        if (error) {
-            return false;
-        }
-
-        return trialData?.daysRemaining !== undefined && trialData?.daysRemaining !== null;
-    }, [ shouldFetch, isTrialLoading, error, trialData ]);
-
-    const daysRemaining: number = useMemo((): number => {
-        return trialData?.daysRemaining ?? 0;
-    }, [ trialData ]);
-
-    const isLoading: boolean = shouldFetch && isTrialLoading;
-
-    return {
-        daysRemaining,
-        isLoading,
-        tenantHasTrial
-    };
+    return context;
 };

--- a/features/admin.subscription.v1/hooks/use-trial-details.ts
+++ b/features/admin.subscription.v1/hooks/use-trial-details.ts
@@ -22,7 +22,7 @@ import TrialContext, { TrialContextPropsInterface } from "../contexts/trial-cont
 /**
  * Return type for the useTrialDetails hook.
  */
-export type UseTrialDetailsReturn = TrialContextPropsInterface;
+type UseTrialDetailsReturn = TrialContextPropsInterface;
 
 /**
  * Hook that returns the trial state resolved by {@link TrialProvider}:

--- a/features/admin.subscription.v1/hooks/use-trial-details.ts
+++ b/features/admin.subscription.v1/hooks/use-trial-details.ts
@@ -31,7 +31,7 @@ type UseTrialDetailsReturn = TrialContextPropsInterface;
  * @returns Trial state and days remaining.
  */
 export const useTrialDetails = (): UseTrialDetailsReturn => {
-    const context: TrialContextPropsInterface = useContext(TrialContext);
+    const context: TrialContextPropsInterface | null = useContext(TrialContext);
 
     if (context === null) {
         throw new Error("useTrialDetails must be used within a TrialProvider");

--- a/features/admin.subscription.v1/providers/trial-provider.tsx
+++ b/features/admin.subscription.v1/providers/trial-provider.tsx
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { FeatureStatus, useCheckFeatureStatus } from "@wso2is/access-control";
+import { AppState } from "@wso2is/admin.core.v1/store";
+import useGetAllFeatures from "@wso2is/admin.feature-gate.v1/api/use-get-all-features";
+import FeatureGateConstants from "@wso2is/admin.feature-gate.v1/constants/feature-gate-constants";
+import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
+import React, {
+    FunctionComponent,
+    PropsWithChildren,
+    ReactElement,
+    useEffect,
+    useMemo,
+    useRef,
+    useState
+} from "react";
+import { useSelector } from "react-redux";
+import { activateTrial } from "../api/activate-trial";
+import { useGetTrialDetails } from "../api/get-trial-details";
+import useGetTenantTier from "../api/use-get-tenant-tier";
+import TrialContext, { TrialContextPropsInterface } from "../contexts/trial-context";
+import { useTrialStatus } from "../hooks/use-trial-status";
+import { TrialStatus } from "../models/trial";
+
+/**
+ * Props interface for the TrialProvider.
+ */
+type TrialProviderPropsInterface = PropsWithChildren<unknown>;
+
+/**
+ * Provider that owns the trial lifecycle: it checks the user's trial status,
+ * activates the trial when it is not yet enabled, and only then fetches the
+ * tenant trial details. Sequencing the details fetch behind the activation
+ * decision prevents consumers from caching stale "no trial" data.
+ *
+ * @param props - Wrap content/elements.
+ * @returns TrialContext Provider.
+ */
+const TrialProvider: FunctionComponent<TrialProviderPropsInterface> = (
+    props: TrialProviderPropsInterface
+): ReactElement => {
+    const { children } = props;
+
+    const saasFeatureStatus: FeatureStatus = useCheckFeatureStatus(FeatureGateConstants.SAAS_FEATURES_IDENTIFIER);
+    const { isFirstLevelOrganization } = useGetCurrentOrganizationType();
+    const isFirstLevelOrg: boolean = isFirstLevelOrganization();
+
+    const isTrialFeatureEnabled: boolean = useSelector(
+        (state: AppState) =>
+            (state.config.deployment.extensions as Record<string, Record<string, unknown>>)
+                ?.trial?.enabled === true
+    );
+
+    const {
+        trialStatus,
+        isResolved: isTrialStatusResolved,
+        isLoading: isTrialStatusLoading,
+        error: trialStatusError
+    } = useTrialStatus();
+
+    const { mutate: mutateTenantTier } = useGetTenantTier();
+    const { mutate: mutateAllFeatures } = useGetAllFeatures();
+
+    const trialActivationAttempted: React.MutableRefObject<boolean> = useRef<boolean>(false);
+    const [ isActivationAttemptComplete, setIsActivationAttemptComplete ] = useState<boolean>(false);
+
+    /**
+     * Fire-and-forget trial activation when trial is not yet enabled.
+     */
+    useEffect(() => {
+        if (
+            !isTrialFeatureEnabled
+            || isTrialStatusLoading
+            || !isTrialStatusResolved
+            || trialStatus !== TrialStatus.DISABLED
+            || trialActivationAttempted.current
+        ) {
+            return;
+        }
+
+        trialActivationAttempted.current = true;
+
+        activateTrial()
+            .then(() => {
+                // SWR cache is global per key, so these revalidate the
+                // useGetTenantTier/useGetAllFeatures instances elsewhere in the app too.
+                mutateTenantTier();
+                mutateAllFeatures();
+            })
+            .catch(() => {
+                // eslint-disable-next-line no-console
+                console.warn("Trial activation is pending.");
+            })
+            .finally(() => {
+                setIsActivationAttemptComplete(true);
+            });
+    }, [
+        isTrialFeatureEnabled,
+        isTrialStatusLoading,
+        isTrialStatusResolved,
+        trialStatus
+    ]);
+
+    /**
+     * Whether the activation decision is settled, i.e. it is safe to fetch trial
+     * details without racing the activation POST. If the trial status can never
+     * resolve (e.g. the username never reaches the profile state), the gate stays
+     * closed and trial details simply remain hidden for the session.
+     */
+    const isActivationSettled: boolean =
+        !isTrialFeatureEnabled
+        || !isFirstLevelOrg
+        || !!trialStatusError
+        || (isTrialStatusResolved && trialStatus === TrialStatus.ENABLED)
+        || isActivationAttemptComplete;
+
+    const isTrialPipelineEnabled: boolean =
+        saasFeatureStatus !== FeatureStatus.DISABLED &&
+        isTrialFeatureEnabled &&
+        isFirstLevelOrg;
+
+    const shouldFetchDetails: boolean = isTrialPipelineEnabled && isActivationSettled;
+
+    const {
+        data: trialData,
+        isLoading: isTrialDetailsLoading,
+        error: trialDetailsError
+    } = useGetTrialDetails(shouldFetchDetails);
+
+    const tenantHasTrial: boolean = useMemo((): boolean => {
+        if (!shouldFetchDetails || isTrialDetailsLoading) {
+            return false;
+        }
+
+        if (trialDetailsError) {
+            return false;
+        }
+
+        return trialData?.daysRemaining !== undefined && trialData?.daysRemaining !== null;
+    }, [ shouldFetchDetails, isTrialDetailsLoading, trialDetailsError, trialData ]);
+
+    const daysRemaining: number = useMemo((): number => {
+        return trialData?.daysRemaining ?? 0;
+    }, [ trialData ]);
+
+    const isLoading: boolean = isTrialPipelineEnabled && (!isActivationSettled || isTrialDetailsLoading);
+
+    const contextValue: TrialContextPropsInterface = useMemo(
+        (): TrialContextPropsInterface => ({
+            daysRemaining,
+            isLoading,
+            tenantHasTrial
+        }),
+        [ daysRemaining, isLoading, tenantHasTrial ]
+    );
+
+    return (
+        <TrialContext.Provider value={ contextValue }>
+            { children }
+        </TrialContext.Provider>
+    );
+};
+
+export default TrialProvider;

--- a/features/admin.subscription.v1/public-api.ts
+++ b/features/admin.subscription.v1/public-api.ts
@@ -18,5 +18,7 @@
 
 export { default as useGetTenantTier } from "./api/use-get-tenant-tier";
 export { default as useSubscription } from "./hooks/use-subscription";
+export { useTrialDetails } from "./hooks/use-trial-details";
 export { default as SubscriptionProvider } from "./providers/subscription-provider";
+export { default as TrialProvider } from "./providers/trial-provider";
 export * from "./models/tenant-tier";


### PR DESCRIPTION
## Purpose

Refactors the trial activation and retrieval flow to fix two correctness issues and centralize the trial lifecycle in a dedicated provider.

## Background

Previously, the trial activation logic lived directly in `App` (`apps/console/src/app.tsx`), while `useTrialDetails` independently fetched trial details. This caused two problems:

1. **Race condition** — the activation POST and the trial-details GET were not sequenced, so the details request could fire in parallel with (or before) activation completed, letting SWR cache a stale "no trial" response.
2. **Stale tier / feature data** — after activation, the tenant tier and feature-gate caches were never revalidated, so the app continued to show the pre-trial subscription tier and gated-feature set until a full page reload.

## Changes

- **New `TrialProvider`** (`features/admin.subscription.v1/providers/trial-provider.tsx`) — owns the full trial lifecycle: checks trial status, fires the fire-and-forget activation when the trial is not yet enabled, and gates the trial-details fetch behind the activation decision (`isActivationSettled`) so details are never fetched while activation is in flight. **Fixes (1).**
- **Re-fetch tier and feature list after activation** — on successful activation, `mutateTenantTier()` and `mutateAllFeatures()` revalidate the global SWR caches so the subscription tier and gated features reflect the newly activated trial without requiring a page reload. **Fixes (2).**
- **New `TrialContext`** (`features/admin.subscription.v1/contexts/trial-context.ts`) — exposes `tenantHasTrial`, `daysRemaining`, and `isLoading`.
- **`useTrialDetails`** is now a thin context consumer that reads `TrialContext` instead of performing its own fetch; throws if used outside a `TrialProvider`.
- **`app.tsx`** — removed the inline activation effect and `useTrialStatus` wiring; wraps the app tree in `<TrialProvider>`. The remaining diff is re-indentation from the new wrapper.
- Adds `TrialProvider` and `useTrialDetails` to the feature's `public-api.ts`.

## Behavioral notes

- Activation trigger conditions are unchanged (trial extension enabled, status resolved, status `DISABLED`, one attempt per session). Sub-organizations still never resolve a status and never activate.
- Retrieval gating is unchanged (SaaS features not disabled, trial enabled, first-level org) plus the new activation-settled gate.
- Both current consumers — `Header` and `FreeTrialBanner` — render under `<TrialProvider>`, so neither hits the new out-of-provider guard.

## Related Issue

<!-- asgardeo-product issue linked below -->
