### PR TITLE
Fix flow builder stale state

### DIFF
--- a/.changeset/dull-moose-wink.md
+++ b/.changeset/dull-moose-wink.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.ask-password-flow-builder.v1": patch
+"@wso2is/admin.password-recovery-flow-builder.v1": patch
+"@wso2is/admin.registration-flow-builder.v1": patch
+---
+
+Fix flow builder showing stale flow state after publishing. Publishing now revalidates the cached flow, so returning to the builder reflects the latest saved changes.

--- a/.changeset/honest-lines-raise.md
+++ b/.changeset/honest-lines-raise.md
@@ -1,4 +1,5 @@
 ---
+"@wso2is/console": patch
 "@wso2is/admin.ask-password-flow-builder.v1": patch
 "@wso2is/admin.password-recovery-flow-builder.v1": patch
 "@wso2is/admin.registration-flow-builder.v1": patch

--- a/features/admin.ask-password-flow-builder.v1/providers/ask-password-flow-builder-provider.tsx
+++ b/features/admin.ask-password-flow-builder.v1/providers/ask-password-flow-builder-provider.tsx
@@ -110,7 +110,7 @@ const FlowContextWrapper: FC<AskPasswordFlowBuilderProviderProps> = ({
     const { t } = useTranslation();
     const { toObject } = useReactFlow();
     const { data: supportedAttributes } = useGetSupportedProfileAttributes();
-    const { flowCompletionConfigs } = useAuthenticationFlowBuilderCore();
+    const { flowCompletionConfigs, setRefetchFlow } = useAuthenticationFlowBuilderCore();
     const {
         data: isNewAskPasswordPortalEnabled,
         mutate: mutateNewAskPasswordPortalEnabledRequest
@@ -312,6 +312,8 @@ const FlowContextWrapper: FC<AskPasswordFlowBuilderProviderProps> = ({
                     message: "Flow Updated Successfully"
                 })
             );
+
+            setRefetchFlow(true);
 
             return true;
         } catch (error) {

--- a/features/admin.password-recovery-flow-builder.v1/providers/password-recovery-flow-builder-provider.tsx
+++ b/features/admin.password-recovery-flow-builder.v1/providers/password-recovery-flow-builder-provider.tsx
@@ -105,7 +105,7 @@ const FlowContextWrapper: FC<PasswordRecoveryFlowBuilderProviderProps> = ({
     const dispatch: Dispatch = useDispatch();
     const { t } = useTranslation();
     const { toObject } = useReactFlow();
-    const { flowCompletionConfigs } = useAuthenticationFlowBuilderCore();
+    const { flowCompletionConfigs, setRefetchFlow } = useAuthenticationFlowBuilderCore();
     const { metadata } = useAuthenticationFlowBuilderCore();
     const {
         data: isNewPasswordRecoveryPortalEnabled,
@@ -197,6 +197,8 @@ const FlowContextWrapper: FC<PasswordRecoveryFlowBuilderProviderProps> = ({
                     message: "Flow Updated Successfully"
                 })
             );
+
+            setRefetchFlow(true);
 
             return true;
         } catch (error) {

--- a/features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx
+++ b/features/admin.registration-flow-builder.v1/providers/registration-flow-builder-provider.tsx
@@ -93,7 +93,7 @@ const FlowContextWrapper: FC<RegistrationFlowBuilderProviderProps> = ({
 
     const { toObject } = useReactFlow();
     const { data: supportedAttributes } = useGetSupportedProfileAttributes();
-    const { flowCompletionConfigs } = useAuthenticationFlowBuilderCore();
+    const { flowCompletionConfigs, setRefetchFlow } = useAuthenticationFlowBuilderCore();
 
     const [ selectedAttributes, setSelectedAttributes ] = useState<{ [key: string]: Attribute[] }>({});
     const [ isPublishing, setIsPublishing ] = useState<boolean>(false);
@@ -134,6 +134,8 @@ const FlowContextWrapper: FC<RegistrationFlowBuilderProviderProps> = ({
                     message: t("flows:registrationFlow.notifications.updateRegistrationFlow.success.message")
                 })
             );
+
+            setRefetchFlow(true);
 
             return true;
         } catch (error) {


### PR DESCRIPTION
### Purpose
- Fixes a stale-state bug in the visual Flow Builder where, after publishing a flow, navigating away and returning showed the previous (pre-change) state rather than the just-saved flow. The change only became visible on a second return to the builder.

### Related Issue
- https://github.com/wso2/product-is/issues/28032

### Approach
- After a successful publish, trigger the existing `setRefetchFlow(true)` flag, which revalidates the cached flow GET so the builder always reflects the latest saved state on the next mount. 