### PR TITLE
Fix: Use semantic button element instead of role="button" in ActiveFiltersBar (#27945)

### DIFF
--- a/.changeset/slimy-tools-join.md
+++ b/.changeset/slimy-tools-join.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.workflow-requests.v1": patch
+"@wso2is/console": patch
 ---
 
 Fix accessibility issue by replacing role="button" span with semantic button element in ActiveFiltersBar

--- a/.changeset/slimy-tools-join.md
+++ b/.changeset/slimy-tools-join.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.workflow-requests.v1": patch
+---
+
+Fix accessibility issue by replacing role="button" span with semantic button element in ActiveFiltersBar

--- a/features/admin.workflow-requests.v1/components/active-filters-bar.scss
+++ b/features/admin.workflow-requests.v1/components/active-filters-bar.scss
@@ -102,6 +102,8 @@ $font-size-normal: 12px;
         @include flex-center;
         background: transparent;
         border: none;
+        padding: 0;
+        font: inherit;
         width: 18px;
         height: 18px;
         justify-content: center;

--- a/features/admin.workflow-requests.v1/components/active-filters-bar.tsx
+++ b/features/admin.workflow-requests.v1/components/active-filters-bar.tsx
@@ -56,19 +56,15 @@ const ActiveFiltersBar: React.FC<ActiveFiltersBarProps> = (
                             <span className="filter-value">
                                 { filter.label }
                             </span>
-                            <span
-                                role="button"
-                                tabIndex={ 0 }
+                            <button
+                                type="button"
                                 aria-label={ t("workflowRequests:activeFiltersBar.removeFilter",
                                     { filter: filter.label }) }
                                 onClick={ () => onRemove(filter) }
-                                onKeyPress={ (e: React.KeyboardEvent) => {
-                                    if (e.key === "Enter" || e.key === " ") onRemove(filter);
-                                } }
                                 className="filter-remove-button"
                             >
                                 <Icon name="close" size="small" className="icon" />
-                            </span>
+                            </button>
                         </div>
                     ))
                 ) : (


### PR DESCRIPTION
### Purpose
Replaced a `<span role="button">` with a semantic `<button>` element in the filter remove button within `active-filters-bar.tsx`, as flagged by the React Doctor accessibility check (rule: react-doctor/prefer-tag-over-role).

Changes:
- Replaced `<span role="button" tabIndex={0} onKeyPress={...}>` with `<button type="button">`, removing the now-redundant `tabIndex` and `onKeyPress` handler since native buttons handle keyboard interaction natively.
- Added `padding: 0` and `font: inherit` to `.filter-remove-button` in active-filters-bar.scss to preserve the existing visual appearance after switching from `span` to `button`.

Included a changeset (patch bump for @wso2is/admin.workflow-requests.v1).

### Related Issues
 - fixes https://github.com/wso2/product-is/issues/27945

### Related PRs
- N/A

### Screenshots
**Before (`<span>` tag)**

<img width="1280" height="828" alt="Before" src="https://github.com/user-attachments/assets/051f5265-5b7f-43d3-a96f-33dfc9e9817a" />


**After (`<button type="button">`)** 

<img width="1280" height="828" alt="After" src="https://github.com/user-attachments/assets/c2873a42-d27f-40ac-9b3e-706e3cd4edd3" />


### Technical Changes
- Updated the tag wrapper inside the workflow active filters layout file from `span` to `button`.
- Explicitly applied a `type="button"` attribute to suppress default HTML form submission side effects inside the filter container.
- .filter-remove-button class already had background: transparent and border: none, so I added padding: 0 and font: inherit to neutralize the remaining default <button> styling. This should keep the visual output identical to the "before" state.
