### PR TITLE
Add keyboard event handlers to fix mouse-events-have-key-events accessibility warning

### DIFF
--- a/features/admin.flow-builder-core.v1/components/validation-panel/validation-error-boundary.tsx
+++ b/features/admin.flow-builder-core.v1/components/validation-panel/validation-error-boundary.tsx
@@ -113,6 +113,8 @@ const ValidationErrorBoundary: FunctionComponent<PropsWithChildren<ValidationErr
             data-componentid={ componentId }
             onMouseOver={ () => hasNotification && disableErrorBoundaryOnHover && setActive(true) }
             onMouseOut={ () => hasNotification && disableErrorBoundaryOnHover && setActive(false) }
+            onFocus={ () => hasNotification && disableErrorBoundaryOnHover && setActive(true) }
+            onBlur={ () => hasNotification && disableErrorBoundaryOnHover && setActive(false) }
         >
             { hasNotification && !(active && disableErrorBoundaryOnHover) && (
                 <ExclamationIcon size={ 24 } />

--- a/features/admin.flow-builder-core.v1/components/validation-panel/validation-error-boundary.tsx
+++ b/features/admin.flow-builder-core.v1/components/validation-panel/validation-error-boundary.tsx
@@ -111,6 +111,7 @@ const ValidationErrorBoundary: FunctionComponent<PropsWithChildren<ValidationErr
                 }
             ) }
             data-componentid={ componentId }
+            tabIndex={ hasNotification ? 0 : undefined }
             onMouseOver={ () => hasNotification && disableErrorBoundaryOnHover && setActive(true) }
             onMouseOut={ () => hasNotification && disableErrorBoundaryOnHover && setActive(false) }
             onFocus={ () => hasNotification && disableErrorBoundaryOnHover && setActive(true) }


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
Fix react-doctor/mouse-events-have-key-events accessibility warning by pairing onMouseOver and onMouseOut handlers with their keyboard equivalents onFocus and onBlur in ValidationErrorBoundary.

### Related Issues
<!-- Mention the issue/s related to the pull request. Make sure to only add publicly accessible references. -->
- Closes [#27902](https://github.com/wso2/product-is/issues/27902)

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [N/A] e2e cypress tests locally verified.~~ (for internal contributors)
- [x] Manually ran React Doctor and the warning no longer appears
- [N/A] UX/UI review done on the final implementation.
- [N/A] Documentation provided. (Add links if there are any)
- [N/A] Relevant backend changes deployed and verified
- [N/A] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [N/A] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
- No behavioural change
- No migration impact
- No new configuration introduced