### PR TITLE
Add support for new tenant tiers (FreeV2, PYG, PYG-Trial)

### DIFF
--- a/.changeset/happy-goats-drop.md
+++ b/.changeset/happy-goats-drop.md
@@ -1,0 +1,10 @@
+---
+"@wso2is/admin.console-settings.v1": patch
+"@wso2is/admin.subscription.v1": patch
+"@wso2is/admin.analytics.v1": patch
+"@wso2is/admin.core.v1": patch
+"@wso2is/admin.home.v1": patch
+"@wso2is/console": patch
+---
+
+Add support for the new `FreeV2`, `PYG` and `PYG-Trial` tenant tiers. All existing `Free` tier behaviors now also apply to `FreeV2`, while `PYG` and `PYG-Trial` are treated as paid tiers.

--- a/features/admin.analytics.v1/constants/moesif-dashboard-constants.ts
+++ b/features/admin.analytics.v1/constants/moesif-dashboard-constants.ts
@@ -34,18 +34,22 @@ export class MoesifDashboardConstants {
     /**
      * Canvas template per subscription tier.
      *
-     * - Free            — minimal set aligned with the legacy Org Insights page
+     * - Free / FreeV2   — minimal set aligned with the legacy Org Insights page
      *                     (active users, login success vs failures, registrations, M2M tokens).
      * - Essentials      — the standard dashboard set (Overview, Login, Registration, Token).
      * - Professional /
-     *   Enterprise      — extended dashboard set (currently identical to Essentials;
+     *   Enterprise /
+     *   PYG / PYG-Trial — extended dashboard set (currently identical to Essentials;
      *                     kept as a separate file so it can diverge without code changes).
      */
     public static readonly TEMPLATES: Record<TenantTier, Record<string, unknown>> = {
         [ TenantTier.ENTERPRISE ]: premiumDashboardTemplate,
         [ TenantTier.ESSENTIALS ]: essentialsDashboardTemplate,
         [ TenantTier.FREE ]: freeDashboardTemplate,
-        [ TenantTier.PROFESSIONAL ]: premiumDashboardTemplate
+        [ TenantTier.FREE_V2 ]: freeDashboardTemplate,
+        [ TenantTier.PROFESSIONAL ]: premiumDashboardTemplate,
+        [ TenantTier.PYG ]: premiumDashboardTemplate,
+        [ TenantTier.PYG_TRIAL ]: premiumDashboardTemplate
     };
 
     /**

--- a/features/admin.console-settings.v1/components/console-settings-tabs.tsx
+++ b/features/admin.console-settings.v1/components/console-settings-tabs.tsx
@@ -22,7 +22,7 @@ import Tabs from "@oxygen-ui/react/Tabs";
 import { AppState } from "@wso2is/admin.core.v1/store";
 import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/hooks/use-get-organization-type";
 import useSubscription, { UseSubscriptionInterface } from "@wso2is/admin.subscription.v1/hooks/use-subscription";
-import { TenantTier } from "@wso2is/admin.subscription.v1/models/tenant-tier";
+import { isFreeTier } from "@wso2is/admin.subscription.v1/models/tenant-tier";
 import { FeatureAccessConfigInterface, IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, { FunctionComponent, ReactElement, SyntheticEvent, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -171,7 +171,7 @@ const ConsoleSettingsTabs: FunctionComponent<ConsoleSettingsTabsInterface> = (
                     pane: <ConsoleSharedAccess isFeatureLocked={ isFeatureLocked } />,
                     value: ConsoleSettingsTabIDs.SHARED_ACCESS
                 },
-                !(isSubOrganization() || isEnterpriseLoginDisabled || tierName === TenantTier.FREE) && {
+                !(isSubOrganization() || isEnterpriseLoginDisabled || isFreeTier(tierName)) && {
                     className: "console-enterprise-login",
                     "data-componentid": `${componentId}-tab-enterprise-login`,
                     "data-tabid": ConsoleSettingsModes.ENTERPRISE_LOGIN,

--- a/features/admin.core.v1/components/header.tsx
+++ b/features/admin.core.v1/components/header.tsx
@@ -51,7 +51,7 @@ import { useGetCurrentOrganizationType } from "@wso2is/admin.organizations.v1/ho
 import useOrganizations from "@wso2is/admin.organizations.v1/hooks/use-organizations";
 import useSubscription, { UseSubscriptionInterface } from "@wso2is/admin.subscription.v1/hooks/use-subscription";
 import { useTrialDetails } from "@wso2is/admin.subscription.v1/hooks/use-trial-details";
-import { TenantTier } from "@wso2is/admin.subscription.v1/models/tenant-tier";
+import { isFreeTier } from "@wso2is/admin.subscription.v1/models/tenant-tier";
 import useRuntimeConfig from "@wso2is/common.ui.v1/hooks/use-runtime-config";
 import { resolveAppLogoFilePath } from "@wso2is/core/helpers";
 import { IdentifiableComponentInterface, ProfileInfoInterface } from "@wso2is/core/models";
@@ -487,7 +487,7 @@ const Header: FunctionComponent<HeaderPropsInterface> = ({
                 </Menu>
             </>
         ),
-        (tierName === TenantTier.FREE || tenantHasTrial) &&
+        (isFreeTier(tierName) || tenantHasTrial) &&
             billingPortalURL &&
             !isPrivilegedUser &&
             window["AppUtils"].getConfig().extensions.upgradeButtonEnabled && (

--- a/features/admin.home.v1/components/new-feature-announcement/new-feature-announcement.tsx
+++ b/features/admin.home.v1/components/new-feature-announcement/new-feature-announcement.tsx
@@ -31,7 +31,7 @@ import FeatureFlagLabel from "@wso2is/admin.feature-gate.v1/components/feature-f
 import FeatureFlagConstants from "@wso2is/admin.feature-gate.v1/constants/feature-flag-constants";
 import useFeatureGate from "@wso2is/admin.feature-gate.v1/hooks/use-feature-gate";
 import useSubscription, { UseSubscriptionInterface } from "@wso2is/admin.subscription.v1/hooks/use-subscription";
-import { TenantTier } from "@wso2is/admin.subscription.v1/models/tenant-tier";
+import { isFreeTier } from "@wso2is/admin.subscription.v1/models/tenant-tier";
 import { AGENT_USERSTORE } from "@wso2is/admin.userstores.v1/constants/user-store-constants";
 import useUserStores from "@wso2is/admin.userstores.v1/hooks/use-user-stores";
 import { UserStoreListItem } from "@wso2is/admin.userstores.v1/models/user-stores";
@@ -308,7 +308,7 @@ export const FeatureCarousel = () => {
                 if (isAgentManagementFeatureEnabledForOrganization) {
                     setShowAgentFeatureAnnouncementModal(true);
                 } else {
-                    const url: string = tierName === TenantTier.FREE
+                    const url: string = isFreeTier(tierName)
                         ? `mailto:${supportEmail}`
                         : window["AppUtils"].getConfig().extensions.getHelp.helpCenterURL;
 

--- a/features/admin.subscription.v1/models/tenant-tier.ts
+++ b/features/admin.subscription.v1/models/tenant-tier.ts
@@ -22,7 +22,20 @@ export interface TenantTierRequestResponse {
 
 export enum TenantTier {
     FREE = "Free",
+    FREE_V2 = "FreeV2",
     ESSENTIALS = "Essentials",
     PROFESSIONAL = "Professional",
-    ENTERPRISE = "Enterprise"
+    ENTERPRISE = "Enterprise",
+    PYG = "PYG",
+    PYG_TRIAL = "PYG-Trial"
 }
+
+/**
+ * Whether the given tier should receive Free-tier behavior.
+ * Both `Free` and `FreeV2` are treated as free tiers.
+ *
+ * @param tierName - The tenant's subscription tier.
+ * @returns `true` when the tier is a free tier.
+ */
+export const isFreeTier = (tierName: TenantTier): boolean =>
+    tierName === TenantTier.FREE || tierName === TenantTier.FREE_V2;


### PR DESCRIPTION
## Purpose

The backend now returns three new subscription tier names — `FreeV2`, `PYG` and `PYG-Trial`. This PR add support for the new `FreeV2`, `PYG` and `PYG-Trial` tenant tiers. All existing `Free` tier behaviors now also apply to `FreeV2`, while `PYG` and `PYG-Trial` are treated as paid tiers.

## Changes

- Added `FREE_V2`, `PYG` and `PYG_TRIAL` members to the `TenantTier` enum.
- Introduced an exported `isFreeTier()` helper that treats both `Free` and `FreeV2` as free tiers.
- Replaced the four `tierName === TenantTier.FREE` comparisons with `isFreeTier(tierName)` so that **all existing `Free` tier behaviors now also apply to `FreeV2`**:
  - Upgrade button in the header
  - Hidden Enterprise Login tab in console settings
  - Contact-us (mailto) link for the AI agents feature
  - Minimal free analytics dashboard
- `PYG` and `PYG-Trial` are treated as **paid tiers** (none of the Free restrictions apply) and use the **premium** Moesif analytics dashboard.
- Completed the `Record<TenantTier, ...>` Moesif template map so it remains exhaustive.

## Related Issues

N/A