### PR TITLE
Show time zone with time in log management UI

### DIFF
--- a/.changeset/log-mgt-timezone-display.md
+++ b/.changeset/log-mgt-timezone-display.md
@@ -1,4 +1,5 @@
 ---
+"@wso2is/console": patch
 "@wso2is/admin.logs.v1": patch
 ---
 

--- a/.changeset/log-mgt-timezone-display.md
+++ b/.changeset/log-mgt-timezone-display.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.logs.v1": patch
+---
+
+Show the time zone alongside the time in the log management UI (e.g. `15:19:16 GMT+05:30`) so timestamps are unambiguous.

--- a/features/admin.logs.v1/utils/datetime-utils.ts
+++ b/features/admin.logs.v1/utils/datetime-utils.ts
@@ -22,12 +22,12 @@ import dayjs from "dayjs";
  * Returns a date-time string in human readable format
  *
  * @param dateString - (string)
- * @returns formatted date time string i.e., "16 Sep, 2022 | 15:19:16"
+ * @returns formatted date time string i.e., "16 Sep, 2022 | 15:19:16 GMT+05:30"
  */
 const formatTimestampToDateTime = (dateString: string): string => {
     if (!dateString) return "N/A";
 
-    return dayjs(dateString).format("DD MMM, YYYY | HH:mm:ss");
+    return dayjs(dateString).format("DD MMM, YYYY | HH:mm:ss [GMT]Z");
 };
 
 /**
@@ -46,12 +46,12 @@ const getDateFromTimestamp = (dateString: string): string => {
  * Returns a time string in human readable format
  *
  * @param dateString - (string)
- * @returns formatted date time string i.e., "15:19:16"
+ * @returns formatted date time string i.e., "15:19:16 GMT+05:30"
  */
 const getTimeFromTimestamp = (dateString: string): string => {
     if (!dateString) return "N/A";
 
-    return dayjs(dateString).format("HH:mm:ss");
+    return dayjs(dateString).format("HH:mm:ss [GMT]Z");
 };
 
 


### PR DESCRIPTION
## Purpose

The log management UI shows the time but not the time zone, which makes timestamps ambiguous.

## Changes

`features/admin.logs.v1/utils/datetime-utils.ts` — append the (local) time zone offset to the formatted time:

- `getTimeFromTimestamp`: `15:19:16` → `15:19:16 GMT+05:30`
- `formatTimestampToDateTime`: `16 Sep, 2022 | 15:19:16` → `16 Sep, 2022 | 15:19:16 GMT+05:30`

These functions back the log-row date/time, the expanded log detail timestamp, and the "last refreshed" time, so the zone now shows consistently across the log management views.

## Notes

- Uses dayjs's core `Z` format token (`[GMT]Z`) — no extra dayjs plugin required.
- The displayed times are rendered in the browser's local time zone (as before); this change just makes that zone explicit. The time-zone *filter* selector is unaffected.