### PR TITLE
Fix/documentation links broken anchors

### DIFF
--- a/.changeset/fix-documentation-links.md
+++ b/.changeset/fix-documentation-links.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.core.v1": patch
+---
+
+Fix broken anchors and outdated paths in Console "Learn More" documentation links

--- a/.changeset/fix-documentation-links.md
+++ b/.changeset/fix-documentation-links.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.core.v1": patch
+"@wso2is/console": patch
 ---
 
 Fix broken anchors and outdated paths in Console "Learn More" documentation links

--- a/features/admin.core.v1/configs/documentation.ts
+++ b/features/admin.core.v1/configs/documentation.ts
@@ -59,26 +59,23 @@ export const DocumentationLinks: DocumentationLinksInterface = {
             addAPIResource: {
                 rbacInfoBox: {
                     learnMore: documentationBaseUrl + "/references/authorization-policies-for-apps/"
-                        + "#role-based-access-control"
                 },
                 requiredAuthorization: {
                     learnMore: documentationBaseUrl + "/guides/api-authorization/"
-                        + "#authorize-the-api-resource-to-an-app"
+                        + "#authorize-apps-to-consume-api-resources"
                 }
             },
-            learnMore: documentationBaseUrl + "/guides/api-authorization/#register-an-api-resource"
+            learnMore: documentationBaseUrl + "/guides/api-authorization/#register-a-business-api"
         },
         applications: {
             apiAuthorization: {
-                learnMore: documentationBaseUrl + "/guides/api-authorization/#authorize-the-api-resource-to-an-app",
+                learnMore: documentationBaseUrl + "/guides/api-authorization/#authorize-apps-to-consume-api-resources",
                 policies: {
                     noPolicy: {
                         learnMore: documentationBaseUrl + "/references/authorization-policies-for-apps/"
-                            + "#no-authorization-policy"
                     },
                     rbac: {
                         learnMore: documentationBaseUrl + "/references/authorization-policies-for-apps/"
-                            + "#role-based-access-control"
                     }
                 }
             },
@@ -98,7 +95,7 @@ export const DocumentationLinks: DocumentationLinksInterface = {
                 },
                 attributeManagement: {
                     manageOIDCScopes: documentationBaseUrl + "/guides/users/attributes/manage-scopes"
-                        + "/#how-to-request-scope-to-request-user-attributes"
+                        + "/#use-scopes-to-request-attributes"
                 },
                 common: {
                     advanced: {
@@ -154,7 +151,7 @@ export const DocumentationLinks: DocumentationLinksInterface = {
                     quickStart: {
                         applicationScopes: {
                             learnMore: documentationBaseUrl + "/guides/authentication/user-attributes/"
-                                + "enable-attributes-for-oidc-app/#application-requests-with-scopes"
+                                + "enable-attributes-for-oidc-app/#application-requests-attributes"
                         },
                         customConfig: {
                             learnMore: documentationBaseUrl + "/guides/authentication/oidc/implement-auth-code"
@@ -170,7 +167,7 @@ export const DocumentationLinks: DocumentationLinksInterface = {
                         version100: {
                             removeUsernameFromIntrospectionRespForAppTokens: {
                                 documentationLink: documentationBaseUrl + "/guides/authentication/oidc"
-                                    + "/token-validation-resource-server/#application-access-token-response"
+                                    + "/token-validation-resource-server/#application-tokens"
                             },
                             useClientIdAsSubClaimOfAppTokens: {
                                 documentationLink: documentationBaseUrl + "/guides/authentication/user-attributes"
@@ -504,7 +501,7 @@ export const DocumentationLinks: DocumentationLinksInterface = {
             },
             userStoreProperties: {
                 learnMore: documentationBaseUrl + "/guides/users/user-stores/configure-a-user-store/"
-                    + "#set-up-the-remote-user-store/"
+                    + "#set-up-the-remote-user-store"
             },
             userStoresList: {
                 learnMore: documentationBaseUrl + "/guides/users/user-stores/"
@@ -515,7 +512,7 @@ export const DocumentationLinks: DocumentationLinksInterface = {
                 learnMore: documentationBaseUrl + "/guides/users/"
             },
             bulkUsers: {
-                learnMore: documentationBaseUrl + "/guides/users/manage-users/#onboard-multiple-user"
+                learnMore: documentationBaseUrl + "/guides/users/onboard-users/#onboard-multiple-users"
             },
             collaboratorAccounts: {
                 adminSettingsLearnMore: documentationBaseUrl


### PR DESCRIPTION

### Purpose
Fixes several broken **"Learn More" documentation links** in the Console. The affected links in `features/admin.core.v1/configs/documentation.ts` pointed to non-existent page anchors or outdated documentation paths, so they either landed on the page without scrolling to the intended section or referenced a fragment/path that no longer exists on the docs site. All targets were verified against the live documentation site.

**Replaced outdated/incorrect anchors and paths:**

| Link key | Before | After |
|----------|--------|-------|
| `develop.apiResources.addAPIResource.requiredAuthorization.learnMore` | `#authorize-the-api-resource-to-an-app` | `#authorize-apps-to-consume-api-resources` |
| `develop.applications.apiAuthorization.learnMore` | `#authorize-the-api-resource-to-an-app` | `#authorize-apps-to-consume-api-resources` |
| `develop.apiResources.learnMore` | `#register-an-api-resource` | `#register-a-business-api` |
| `develop.applications.editApplication.attributeManagement.manageOIDCScopes` | `#how-to-request-scope-to-request-user-attributes` | `#use-scopes-to-request-attributes` |
| `develop.applications.editApplication.oidcApplication.quickStart.applicationScopes.learnMore` | `#application-requests-with-scopes` | `#application-requests-attributes` |
| `develop.applications.editApplication.outdatedApplications.versions.version100.removeUsernameFromIntrospectionRespForAppTokens.documentationLink` | `#application-access-token-response` | `#application-tokens` |
| `manage.userStores.userStoreProperties.learnMore` | `#set-up-the-remote-user-store/` (stray trailing slash) | `#set-up-the-remote-user-store` |
| `manage.users.bulkUsers.learnMore` | `/guides/users/manage-users/#onboard-multiple-user` | `/guides/users/onboard-users/#onboard-multiple-users` |

**Removed fragments with no matching heading on the target page** (links now point to the page root):

- `develop.apiResources.addAPIResource.rbacInfoBox.learnMore` — dropped `#role-based-access-control`
- `develop.applications.apiAuthorization.policies.noPolicy.learnMore` — dropped `#no-authorization-policy`
- `develop.applications.apiAuthorization.policies.rbac.learnMore` — dropped `#role-based-access-control`


### Related Issues
https://github.com/wso2/product-is/issues/28045

### Related PRs
<!-- Mention the related pull requests. Make sure to only add publicly accessible references. -->
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [x] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
