### PR TITLE
Add user existence and account status messages in Dutch localization

### DIFF
--- a/.changeset/eleven-parrots-shave.md
+++ b/.changeset/eleven-parrots-shave.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/identity-apps-core": patch
+---
+
+Add missing Dutch (nl_NL) translations for user existence and account status messages

--- a/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_nl_NL.properties
+++ b/identity-apps-core/apps/accounts/src/main/resources/org/wso2/carbon/identity/application/accounts/endpoint/i18n/Resources_nl_NL.properties
@@ -152,3 +152,17 @@ password.reset.error.unexpected.description=Er is een onverwachte fout opgetrede
 flow.execution.success.redirect.message=U wordt over
 flow.execution.success.redirect.seconds.singular=seconde automatisch teruggestuurd naar de toepassing
 flow.execution.success.redirect.seconds.plural=seconden automatisch teruggestuurd naar de toepassing
+
+# User existence messages
+user.not.found=Gebruiker bestaat niet.
+
+# User account status messages
+account.locked=Uw account is vergrendeld.
+account.locked.admin.initiated=Uw account is vergrendeld. Neem contact op met uw systeembeheerder.
+account.locked.idle=Uw account is vergrendeld wegens inactiviteit.
+account.locked.max.attempts=Uw account is tijdelijk vergrendeld wegens te veel mislukte aanmeldpogingen.
+account.locked.pending.self.registration=Uw account is vergrendeld wegens onvolledige registratie.
+account.locked.pending.email.verification=Uw account is vergrendeld wegens openstaande e-mailverificatie.
+account.locked.pending.ask.password=Uw account is vergrendeld wegens openstaande wachtwoordinstelling.
+account.locked.pending.admin.forced.password.reset=Uw account is vergrendeld wegens een verplichte wachtwoordreset.
+account.disabled=Uw account is uitgeschakeld.


### PR DESCRIPTION
### Purpose
This pull request adds new Dutch translations for various user account status and existence messages to improve the localization of password recovery notifications.

### Related PRs
- https://github.com/wso2/identity-apps/pull/10332

**Localization improvements:**

* Added Dutch translations for user existence messages, such as when a user is not found.
* Added Dutch translations for different user account status messages.