### PR TITLE
Fix application dropdown in branding page not showing all applications

### DIFF
--- a/.changeset/strong-terms-retire.md
+++ b/.changeset/strong-terms-retire.md
@@ -1,4 +1,5 @@
 ---
+"@wso2is/admin.branding.v1": patch
 "@wso2is/console": patch
 ---
 

--- a/.changeset/strong-terms-retire.md
+++ b/.changeset/strong-terms-retire.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Fix application dropdown in branding page not showing all applications

--- a/features/admin.branding.v1/components/branding-page-layout.tsx
+++ b/features/admin.branding.v1/components/branding-page-layout.tsx
@@ -67,6 +67,7 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
     const [ hasMoreApplications, setHasMoreApplications ] = useState(true);
     const [ appListOffset, setAppListOffset ] = useState<number>(0);
     const [ shouldFetchApplications, setShouldFetchApplications ] = useState<boolean>(true);
+    const [ isApplicationDropdownOpen, setIsApplicationDropdownOpen ] = useState<boolean>(false);
 
     const [ appIdFromQueryParam, setAppIdFromQueryParam ] = useState<string | null>(null);
 
@@ -187,6 +188,55 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
             setHasMoreApplications(false);
         }
     }, [ applicationList ]);
+
+    /**
+     * Proactively loads the next page while the dropdown content does not overflow its
+     * scrollable container. `InfiniteScroll` only fires its `next` callback on a scroll
+     * event, which never happens when the post-filter (non-M2M) options are too few to
+     * overflow the container. Rather than estimating from a fixed item count/height, we
+     * measure the actual container overflow and keep fetching until it can scroll (or no
+     * more pages remain).
+     */
+    useEffect(() => {
+        if (
+            !isApplicationDropdownOpen ||
+            !hasMoreApplications ||
+            shouldFetchApplications ||
+            isApplicationListFetchRequestValidating ||
+            brandingMode !== BrandingModes.APPLICATION
+        ) {
+            return;
+        }
+
+        let frameId: number;
+        let attempts: number = 0;
+
+        // The Autocomplete popup mounts asynchronously, so retry until the scroll
+        // container is available, then measure it. If the content does not overflow, no
+        // scroll event can fire to trigger the next page — load it proactively.
+        const measureAndMaybeFetch = (): void => {
+            const scrollContainer: HTMLElement | null =
+                document.getElementById("autocomplete-scroll-container");
+
+            if (!scrollContainer) {
+                if (attempts++ < 10) {
+                    frameId = requestAnimationFrame(measureAndMaybeFetch);
+                }
+
+                return;
+            }
+
+            if (scrollContainer.scrollHeight <= scrollContainer.clientHeight) {
+                setAppListOffset((prevOffset: number) => prevOffset + 10);
+                setShouldFetchApplications(true);
+            }
+        };
+
+        frameId = requestAnimationFrame(measureAndMaybeFetch);
+
+        return () => cancelAnimationFrame(frameId);
+    }, [ applications, hasMoreApplications, shouldFetchApplications,
+        isApplicationListFetchRequestValidating, brandingMode, isApplicationDropdownOpen ]);
 
     /**
     * Fetch the identity provider id & name when calling the app edit through connected apps
@@ -450,6 +500,8 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                                                     sx={ { width: 190 } }
                                                     readOnly={ isBrandingAppsRedirect }
                                                     clearIcon={ null }
+                                                    onOpen={ () => setIsApplicationDropdownOpen(true) }
+                                                    onClose={ () => setIsApplicationDropdownOpen(false) }
                                                     options={ applications ?? [] }
                                                     value={ applications?.find(
                                                         (app: ApplicationListItemInterface) =>

--- a/features/admin.branding.v1/components/branding-page-layout.tsx
+++ b/features/admin.branding.v1/components/branding-page-layout.tsx
@@ -55,6 +55,24 @@ import "./branding-page-layout.scss";
 
 type BrandingPageLayoutInterface = IdentifiableComponentInterface;
 
+/**
+ * Number of applications fetched per page, and the minimum number of selectable applications
+ * we want loaded before we stop proactively fetching more (see the dropdown prefetch effect below).
+ */
+const APPLICATION_LIST_PAGE_SIZE: number = 10;
+
+/**
+ * Determines whether an application should be selectable in the branding application dropdown,
+ * i.e. not a system app, default app, or M2M app.
+ *
+ * @param application - Application to check.
+ * @returns Whether the application is selectable.
+ */
+const isSelectableApplication = (application: ApplicationListItemInterface): boolean =>
+    !ApplicationManagementConstants.SYSTEM_APPS.includes(application?.name) &&
+    !ApplicationManagementConstants.DEFAULT_APPS.includes(application?.name) &&
+    !(application?.templateId === ApplicationManagementConstants.M2M_APP_TEMPLATE_ID);
+
 const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
     props: BrandingPageLayoutInterface
 ): ReactElement => {
@@ -104,7 +122,7 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
         isLoading: isApplicationListFetchRequestLoading,
         isValidating: isApplicationListFetchRequestValidating,
         error: applicationListFetchRequestError
-    } = useApplicationList("templateId", 10, appListOffset, null,
+    } = useApplicationList("templateId", APPLICATION_LIST_PAGE_SIZE, appListOffset, null,
         brandingMode === BrandingModes.APPLICATION && shouldFetchApplications);
 
     const brandingDisabledFeatures: string[] = useSelector((state: AppState) =>
@@ -190,12 +208,11 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
     }, [ applicationList ]);
 
     /**
-     * Proactively loads the next page while the dropdown content does not overflow its
-     * scrollable container. `InfiniteScroll` only fires its `next` callback on a scroll
-     * event, which never happens when the post-filter (non-M2M) options are too few to
-     * overflow the container. Rather than estimating from a fixed item count/height, we
-     * measure the actual container overflow and keep fetching until it can scroll (or no
-     * more pages remain).
+     * Proactively loads more pages while the dropdown is open and too few selectable
+     * (non-system, non-default, non-M2M) applications have been loaded to overflow the
+     * scrollable listbox. `InfiniteScroll` only fires its `next` callback on a scroll event,
+     * which never happens when M2M apps make up most of a page and too few selectable
+     * options remain to overflow the container.
      */
     useEffect(() => {
         if (
@@ -208,33 +225,12 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
             return;
         }
 
-        let frameId: number;
-        let attempts: number = 0;
+        const selectableApplicationsCount: number = applications.filter(isSelectableApplication).length;
 
-        // The Autocomplete popup mounts asynchronously, so retry until the scroll
-        // container is available, then measure it. If the content does not overflow, no
-        // scroll event can fire to trigger the next page — load it proactively.
-        const measureAndMaybeFetch = (): void => {
-            const scrollContainer: HTMLElement | null =
-                document.getElementById("autocomplete-scroll-container");
-
-            if (!scrollContainer) {
-                if (attempts++ < 10) {
-                    frameId = requestAnimationFrame(measureAndMaybeFetch);
-                }
-
-                return;
-            }
-
-            if (scrollContainer.scrollHeight <= scrollContainer.clientHeight) {
-                setAppListOffset((prevOffset: number) => prevOffset + 10);
-                setShouldFetchApplications(true);
-            }
-        };
-
-        frameId = requestAnimationFrame(measureAndMaybeFetch);
-
-        return () => cancelAnimationFrame(frameId);
+        if (selectableApplicationsCount < APPLICATION_LIST_PAGE_SIZE) {
+            setAppListOffset((prevOffset: number) => prevOffset + APPLICATION_LIST_PAGE_SIZE);
+            setShouldFetchApplications(true);
+        }
     }, [ applications, hasMoreApplications, shouldFetchApplications,
         isApplicationListFetchRequestValidating, brandingMode, isApplicationDropdownOpen ]);
 
@@ -347,7 +343,7 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
     const loadMoreApplications = () => {
         if (!hasMoreApplications) return;
 
-        setAppListOffset((prevOffset: number) => prevOffset + 10);
+        setAppListOffset((prevOffset: number) => prevOffset + APPLICATION_LIST_PAGE_SIZE);
         setShouldFetchApplications(true);
     };
 
@@ -520,14 +516,7 @@ const BrandingPageLayout: FunctionComponent<BrandingPageLayoutInterface> = (
                                                         option.id === value.id
                                                     }
                                                     filterOptions={ (options: ApplicationListItemInterface[]) =>
-                                                        options.filter((application: ApplicationListItemInterface) =>
-                                                            !ApplicationManagementConstants.SYSTEM_APPS.includes(
-                                                                application?.name) &&
-                                                            !ApplicationManagementConstants.DEFAULT_APPS.includes(
-                                                                application?.name) &&
-                                                            !(application?.templateId ===
-                                                                ApplicationManagementConstants.M2M_APP_TEMPLATE_ID)
-                                                        )
+                                                        options.filter(isSelectableApplication)
                                                     }
                                                     ListboxComponent={ customListboxComponent }
                                                     loading={ isApplicationListFetchRequestLoading }


### PR DESCRIPTION
### Purpose

Fixes the application dropdown on the Branding page (`/console/branding`, Application mode) not showing all non-M2M applications when the first page of results is M2M-heavy.

### Related Issue
- https://github.com/wso2/product-is/issues/27768

### Root cause

The dropdown uses `react-infinite-scroll-component`, which fires its `next()` callback only on a scroll event. M2M apps are filtered out client-side, so when the first API page is M2M-heavy (e.g. 7 M2M + 3 OIDC) only a few options remain visible — too few to overflow the 250px listbox. With no overflow there is no scroll, `next()` never fires, and applications on later pages (e.g. SAML apps) are permanently unreachable.

### Solution

Added a `useEffect` that, while the dropdown is open, measures whether the scroll container actually overflows (`scrollHeight <= clientHeight`) once its options are laid out, and proactively loads the next page until the container can scroll or there are no more pages. This measures the real overflow rather than estimating from a fixed item count/height, and gates re-fetching on `shouldFetchApplications`/`isValidating` to avoid duplicate requests.

### Testing

Verified on a tenant seeded with 3 SAML, 7 M2M and 3 OIDC apps (page 1 = 3 OIDC + 7 M2M, page 2 = 5 SAML): the dropdown now auto-loads later pages and shows all OIDC and SAML apps with no manual scroll, while M2M apps remain filtered out.