### PR TITLE
Fix role mapping dropdown menu height in dynamic field

### DIFF
--- a/.changeset/red-rivers-grow.md
+++ b/.changeset/red-rivers-grow.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/theme": patch
+---
+
+Fix role mapping dropdown menu height in dynamic field

--- a/modules/theme/src/themes/default/elements/list.overrides
+++ b/modules/theme/src/themes/default/elements/list.overrides
@@ -382,7 +382,9 @@
                     }
                 }
 
-                & * {
+                > .ui.input,
+                > .ui.input > input,
+                > .ui.dropdown {
                     height: 100%;
                 }
             }


### PR DESCRIPTION
## Purpose

Fix the role mapping dropdown menu height in the dynamic field. The previous `& *` universal selector applied `height: 100%` to every descendant element, which distorted the dropdown menu when it expanded. This tightens the selector to only the direct input/dropdown children so the field controls keep their full height without affecting the expanded menu.

## Verification

![Role mapping dropdown before and after the fix](https://raw.githubusercontent.com/KaveeshaPiumini/identity-apps/verification-assets/role-mapping-dropdown-before-after.png)

## Related issue

- https://github.com/wso2/product-is/issues/27780
