### PR TITLE
Add support for configuring link target behavior in Rich Text Editor

### DIFF
--- a/.changeset/goofy-llamas-fix.md
+++ b/.changeset/goofy-llamas-fix.md
@@ -6,4 +6,4 @@
 "@wso2is/i18n": patch
 ---
 
-Fix suggestions
+Add support for configuring link target behavior in Rich Text Editor

--- a/.changeset/goofy-llamas-fix.md
+++ b/.changeset/goofy-llamas-fix.md
@@ -1,0 +1,9 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.flow-builder-core.v1": patch
+"@wso2is/admin.registration-flow-builder.v1": patch
+"@wso2is/identity-apps-core": patch
+"@wso2is/i18n": patch
+---
+
+Fix suggestions

--- a/apps/console/.env.local
+++ b/apps/console/.env.local
@@ -1,8 +1,7 @@
 # ----------------------------------------------------------------------------------
 #  Dev Server Configs
 # ----------------------------------------------------------------------------------
-# change the dev server port to avoid to conflict
-DEV_SERVER_PORT=9002
+DEV_SERVER_PORT=9001
 DEV_SERVER_HOST=localhost
 DISABLE_DEV_SERVER_HOST_CHECK=false
 DISABLE_ESLINT_PLUGIN=false
@@ -12,7 +11,7 @@ ENABLE_ANALYZER=false
 ANALYZER_PORT=8889
 LOG_LEVEL=none
 
-WDS_SOCKET_PORT=9002
+WDS_SOCKET_PORT=9001
 WDS_SOCKET_HOST=localhost
 
 # ----------------------------------------------------------------------------------

--- a/apps/console/.env.local
+++ b/apps/console/.env.local
@@ -1,7 +1,8 @@
 # ----------------------------------------------------------------------------------
 #  Dev Server Configs
 # ----------------------------------------------------------------------------------
-DEV_SERVER_PORT=9001
+# change the dev server port to avoid to conflict
+DEV_SERVER_PORT=9002
 DEV_SERVER_HOST=localhost
 DISABLE_DEV_SERVER_HOST_CHECK=false
 DISABLE_ESLINT_PLUGIN=false
@@ -11,7 +12,7 @@ ENABLE_ANALYZER=false
 ANALYZER_PORT=8889
 LOG_LEVEL=none
 
-WDS_SOCKET_PORT=9001
+WDS_SOCKET_PORT=9002
 WDS_SOCKET_HOST=localhost
 
 # ----------------------------------------------------------------------------------

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -28,6 +28,7 @@ import { PenToSquareIcon } from "@oxygen-ui/react-icons";
 import {
     $getSelection,
     $isRangeSelection,
+    $setSelection,
     BaseSelection,
     CLICK_COMMAND,
     CommandListenerPriority,
@@ -185,14 +186,14 @@ const LinkEditor = (): ReactElement => {
 
             if ($isLinkNode(parent)) {
                 const url: string = parent.getURL();
-                const target:LinkTarget = parent.getTarget() as LinkTarget || "_blank";
+                const target: LinkTarget = (parent.getTarget() ?? "_blank") as LinkTarget;
 
                 setLinkUrl(getPlaceholderUrl(url));
                 setSelectedUrlType(determineUrlType(url));
                 setLinkTarget(target);
             } else if ($isLinkNode(node)) {
                 const url: string = node.getURL();
-                const target:LinkTarget = node.getTarget() as LinkTarget || "_blank";
+                const target: LinkTarget = (node.getTarget() ?? "_blank") as LinkTarget;
 
                 setLinkUrl(getPlaceholderUrl(url));
                 setSelectedUrlType(determineUrlType(url));
@@ -480,28 +481,28 @@ const LinkEditor = (): ReactElement => {
                             } }
                         />
                         {/* Link Target Checkbox - With Description */}
-                        <Box sx={ { alignItems:"center", display: "flex", flexDirection: "row", gap: 0 }}>
+                        <Box sx={ { alignItems: "center", display: "flex", flexDirection: "row", gap: 0 } }>
                             <FormControlLabel
                                 control={
                                     <Checkbox
                                         checked={ linkTarget === "_blank" }
                                         onChange={ (event: React.ChangeEvent<HTMLInputElement>) => {
-                                            const newTarget:LinkTarget =
-                                            event.target.checked ? "_blank" : "_self";
+                                            const newTarget: LinkTarget =
+                                                event.target.checked ? "_blank" : "_self";
 
                                             setLinkTarget(newTarget);
 
                                             if (lastSelection !== null) {
-                                                const currentUrl:string = getCurrentUrl();
+                                                const currentUrl: string = getCurrentUrl();
 
                                                 if (currentUrl !== "") {
                                                     editor.update(() => {
-                                                        const selection:BaseSelection | null = $getSelection();
+                                                        const selection: BaseSelection | null = $getSelection();
 
                                                         if ($isRangeSelection(selection)) {
-                                                            const node:TextNode | ElementNode =
-                                                            getSelectedNode(selection);
-                                                            const linkNode = $isLinkNode(node)
+                                                            const node: TextNode | ElementNode =
+                                                                getSelectedNode(selection);
+                                                            const linkNode: ElementNode = $isLinkNode(node)
                                                                 ? node
                                                                 : node.getParent();
 
@@ -520,10 +521,11 @@ const LinkEditor = (): ReactElement => {
                                 }
                                 label={t("flows:core.elements.richText.linkEditor.linkTargetLabel")}
                             />
-                            <Tooltip title={linkTarget === "_blank"
-                                ? t("flows:core.elements.richText.linkEditor.newTabHint")
-                                : t("flows:core.elements.richText.linkEditor.sameTabHint")
-                            } >
+                            <Tooltip title={
+                                linkTarget === "_blank"
+                                    ? t("flows:core.elements.richText.linkEditor.newTabHint")
+                                    : t("flows:core.elements.richText.linkEditor.sameTabHint")
+                            }>
                                 <span><Hint hint="" /></span>
                             </Tooltip>
 
@@ -535,8 +537,8 @@ const LinkEditor = (): ReactElement => {
                             onClick={ (event: ReactMouseEvent<HTMLButtonElement>) => {
                                 event.preventDefault();
                                 if (lastSelection !== null) {
-                                    editor.update(()=>{
-                                        lastSelection?.clone?.();
+                                    editor.update(() => {
+                                        $setSelection(lastSelection.clone());
                                     });
                                     const currentUrl: string = getCurrentUrl();
 

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -55,9 +55,10 @@ import { useTranslation } from "react-i18next";
 import { getSelectedNode } from "../utils/get-selected-node";
 import "./link-plugin.scss";
 import FormControlLabel from "@oxygen-ui/react/FormControlLabel/FormControlLabel";
-import Checkbox from "semantic-ui-react/dist/commonjs/modules/Checkbox/Checkbox";
+import Checkbox from "@oxygen-ui/react/Checkbox";
 import Hint from "../../../resources/elements/hint";
 import Box from "@oxygen-ui/react/Box/Box";
+import Tooltip from "@oxygen-ui/react/Tooltip";
 
 const LowPriority: CommandListenerPriority = 1;
 const HighPriority: CommandListenerPriority = 3;
@@ -478,16 +479,13 @@ const LinkEditor = (): ReactElement => {
                             } }
                         />
                         {/* Link Target Checkbox - With Description */}
-                        <Box sx={ { display: "flex", flexDirection: "row", gap: 1, alignItems:"flex-start"
+                        <Box sx={ { alignItems:"center", display: "flex", flexDirection: "row", gap: 0
                         } }>
                             <FormControlLabel
-                                sx={ { "& .MuiFormControlLabel-label": { marginLeft: "8px" },
-                                    alignSelf:"flex-start",
-                                    marginLeft: 0 } }
                                 control={
                                     <Checkbox
                                         checked={ linkTarget === "_blank" }
-                                        onChange={ (event: React.FormEvent<HTMLInputElement>) => {
+                                        onChange={ (event: React.ChangeEvent<HTMLInputElement>) => {
                                             const newTarget:"_blank" | "_self" =
                                             event.target.checked ? "_blank" : "_self";
 
@@ -525,8 +523,8 @@ const LinkEditor = (): ReactElement => {
                             <Tooltip title={linkTarget === "_blank"
                                 ? t("flows:core.elements.richText.linkEditor.newTabHint")
                                 : t("flows:core.elements.richText.linkEditor.sameTabHint")
-                            } placement="top">
-                                <Hint></Hint>
+                            } >
+                                <span><Hint></Hint></span>
                             </Tooltip>
 
                         </Box>

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -59,7 +59,8 @@ import Checkbox from "@oxygen-ui/react/Checkbox";
 import Hint from "../../../resources/elements/hint";
 import Box from "@oxygen-ui/react/Box/Box";
 import Tooltip from "@oxygen-ui/react/Tooltip";
-import { LinkTarget } from "lexical/LexicalSelection";
+
+type LinkTarget = "_blank" | "_self";
 
 const LowPriority: CommandListenerPriority = 1;
 const HighPriority: CommandListenerPriority = 3;

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -492,7 +492,7 @@ const LinkEditor = (): ReactElement => {
                                             setLinkTarget(newTarget);
 
                                             if (lastSelection !== null) {
-                                                const currentUrl:any = getCurrentUrl();
+                                                const currentUrl:string = getCurrentUrl();
 
                                                 if (currentUrl !== "") {
                                                     editor.update(() => {
@@ -501,7 +501,7 @@ const LinkEditor = (): ReactElement => {
                                                         if ($isRangeSelection(selection)) {
                                                             const node:TextNode | ElementNode =
                                                             getSelectedNode(selection);
-                                                            const linkNode:any = $isLinkNode(node)
+                                                            const linkNode = $isLinkNode(node)
                                                                 ? node
                                                                 : node.getParent();
 

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -167,7 +167,7 @@ const LinkEditor = (): ReactElement => {
     const [ isEditMode, setEditMode ] = useState(false);
     const [ lastSelection, setLastSelection ] = useState<BaseSelection | null>(null);
     const [ selectedUrlType, setSelectedUrlType ] = useState<string>("CUSTOM");
-    const [ linkTarget, setLinkTarget ] = useState<"_blank" | "_self">("_blank");
+    const [ linkTarget, setLinkTarget ] = useState<LinkTarget>("_blank");
     const { t } = useTranslation();
 
     /**
@@ -183,18 +183,18 @@ const LinkEditor = (): ReactElement => {
 
             if ($isLinkNode(parent)) {
                 const url: string = parent.getURL();
-                const target:string = parent.getTarget() || "_blank";
+                const target:LinkTarget = parent.getTarget() || "_blank";
 
                 setLinkUrl(getPlaceholderUrl(url));
                 setSelectedUrlType(determineUrlType(url));
-                setLinkTarget(target as "_blank" | "_self");
+                setLinkTarget(target);
             } else if ($isLinkNode(node)) {
                 const url: string = node.getURL();
-                const target:string = node.getTarget() || "_blank";
+                const target:LinkTarget = node.getTarget() || "_blank";
 
                 setLinkUrl(getPlaceholderUrl(url));
                 setSelectedUrlType(determineUrlType(url));
-                setLinkTarget(target as "_blank" | "_self");
+                setLinkTarget(target);
             } else {
                 setLinkUrl("");
                 setSelectedUrlType("CUSTOM");
@@ -393,7 +393,6 @@ const LinkEditor = (): ReactElement => {
                                 }
                             }
                         }
-
                     } else {
                         // If no URL, remove the link (same as TOGGLE_LINK_COMMAND with null).
                         editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
@@ -479,14 +478,13 @@ const LinkEditor = (): ReactElement => {
                             } }
                         />
                         {/* Link Target Checkbox - With Description */}
-                        <Box sx={ { alignItems:"center", display: "flex", flexDirection: "row", gap: 0
-                        } }>
+                        <Box sx={ { alignItems:"center", display: "flex", flexDirection: "row", gap: 0 }}>
                             <FormControlLabel
                                 control={
                                     <Checkbox
                                         checked={ linkTarget === "_blank" }
                                         onChange={ (event: React.ChangeEvent<HTMLInputElement>) => {
-                                            const newTarget:"_blank" | "_self" =
+                                            const newTarget:LinkTarget =
                                             event.target.checked ? "_blank" : "_self";
 
                                             setLinkTarget(newTarget);
@@ -524,7 +522,7 @@ const LinkEditor = (): ReactElement => {
                                 ? t("flows:core.elements.richText.linkEditor.newTabHint")
                                 : t("flows:core.elements.richText.linkEditor.sameTabHint")
                             } >
-                                <span><Hint></Hint></span>
+                                <span><Hint hint="" /></span>
                             </Tooltip>
 
                         </Box>

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -59,6 +59,7 @@ import Checkbox from "@oxygen-ui/react/Checkbox";
 import Hint from "../../../resources/elements/hint";
 import Box from "@oxygen-ui/react/Box/Box";
 import Tooltip from "@oxygen-ui/react/Tooltip";
+import { LinkTarget } from "lexical/LexicalSelection";
 
 const LowPriority: CommandListenerPriority = 1;
 const HighPriority: CommandListenerPriority = 3;

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -185,14 +185,14 @@ const LinkEditor = (): ReactElement => {
 
             if ($isLinkNode(parent)) {
                 const url: string = parent.getURL();
-                const target:LinkTarget = parent.getTarget() || "_blank";
+                const target:LinkTarget = parent.getTarget() as LinkTarget || "_blank";
 
                 setLinkUrl(getPlaceholderUrl(url));
                 setSelectedUrlType(determineUrlType(url));
                 setLinkTarget(target);
             } else if ($isLinkNode(node)) {
                 const url: string = node.getURL();
-                const target:LinkTarget = node.getTarget() || "_blank";
+                const target:LinkTarget = node.getTarget() as LinkTarget || "_blank";
 
                 setLinkUrl(getPlaceholderUrl(url));
                 setSelectedUrlType(determineUrlType(url));

--- a/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
+++ b/features/admin.flow-builder-core.v1/components/resource-property-panel/rich-text/helper-plugins/link-plugin.tsx
@@ -54,6 +54,10 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { getSelectedNode } from "../utils/get-selected-node";
 import "./link-plugin.scss";
+import FormControlLabel from "@oxygen-ui/react/FormControlLabel/FormControlLabel";
+import Checkbox from "semantic-ui-react/dist/commonjs/modules/Checkbox/Checkbox";
+import Hint from "../../../resources/elements/hint";
+import Box from "@oxygen-ui/react/Box/Box";
 
 const LowPriority: CommandListenerPriority = 1;
 const HighPriority: CommandListenerPriority = 3;
@@ -162,7 +166,7 @@ const LinkEditor = (): ReactElement => {
     const [ isEditMode, setEditMode ] = useState(false);
     const [ lastSelection, setLastSelection ] = useState<BaseSelection | null>(null);
     const [ selectedUrlType, setSelectedUrlType ] = useState<string>("CUSTOM");
-
+    const [ linkTarget, setLinkTarget ] = useState<"_blank" | "_self">("_blank");
     const { t } = useTranslation();
 
     /**
@@ -178,14 +182,18 @@ const LinkEditor = (): ReactElement => {
 
             if ($isLinkNode(parent)) {
                 const url: string = parent.getURL();
+                const target:string = parent.getTarget() || "_blank";
 
                 setLinkUrl(getPlaceholderUrl(url));
                 setSelectedUrlType(determineUrlType(url));
+                setLinkTarget(target as "_blank" | "_self");
             } else if ($isLinkNode(node)) {
                 const url: string = node.getURL();
+                const target:string = node.getTarget() || "_blank";
 
                 setLinkUrl(getPlaceholderUrl(url));
                 setSelectedUrlType(determineUrlType(url));
+                setLinkTarget(target as "_blank" | "_self");
             } else {
                 setLinkUrl("");
                 setSelectedUrlType("CUSTOM");
@@ -367,9 +375,8 @@ const LinkEditor = (): ReactElement => {
                     if (url) {
                         // First use the default command to handle the link creation/update.
                         editor.dispatchCommand(TOGGLE_LINK_COMMAND, url);
-
                         // Then update the link attributes to include safe properties.
-                        const selection: BaseSelection = $getSelection();
+                        const selection: BaseSelection | null = $getSelection();
 
                         if ($isRangeSelection(selection)) {
                             const node: TextNode | ElementNode = getSelectedNode(selection);
@@ -377,10 +384,15 @@ const LinkEditor = (): ReactElement => {
 
                             if ($isLinkNode(linkNode)) {
                                 // Update the link node with safe attributes.
-                                linkNode.setTarget("_blank");
-                                linkNode.setRel("noopener noreferrer");
+                                linkNode.setTarget(linkTarget);
+                                if(linkTarget === "_blank") {
+                                    linkNode.setRel("noopener noreferrer");
+                                } else {
+                                    linkNode.setRel("");
+                                }
                             }
                         }
+
                     } else {
                         // If no URL, remove the link (same as TOGGLE_LINK_COMMAND with null).
                         editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
@@ -391,7 +403,7 @@ const LinkEditor = (): ReactElement => {
                 HighPriority
             )
         );
-    }, [ editor, updateLinkEditor, isEditMode ]);
+    }, [ editor, updateLinkEditor, isEditMode, linkTarget ]);
 
     /**
      * Updates the link editor position.
@@ -465,6 +477,59 @@ const LinkEditor = (): ReactElement => {
                                 }
                             } }
                         />
+                        {/* Link Target Checkbox - With Description */}
+                        <Box sx={ { display: "flex", flexDirection: "row", gap: 1, alignItems:"flex-start"
+                        } }>
+                            <FormControlLabel
+                                sx={ { "& .MuiFormControlLabel-label": { marginLeft: "8px" },
+                                    alignSelf:"flex-start",
+                                    marginLeft: 0 } }
+                                control={
+                                    <Checkbox
+                                        checked={ linkTarget === "_blank" }
+                                        onChange={ (event: React.FormEvent<HTMLInputElement>) => {
+                                            const newTarget:"_blank" | "_self" =
+                                            event.target.checked ? "_blank" : "_self";
+
+                                            setLinkTarget(newTarget);
+
+                                            if (lastSelection !== null) {
+                                                const currentUrl:any = getCurrentUrl();
+
+                                                if (currentUrl !== "") {
+                                                    editor.update(() => {
+                                                        const selection:BaseSelection | null = $getSelection();
+
+                                                        if ($isRangeSelection(selection)) {
+                                                            const node:TextNode | ElementNode =
+                                                            getSelectedNode(selection);
+                                                            const linkNode:any = $isLinkNode(node)
+                                                                ? node
+                                                                : node.getParent();
+
+                                                            if ($isLinkNode(linkNode)) {
+                                                                linkNode.setTarget(newTarget);
+                                                                linkNode.setRel(newTarget === "_blank"
+                                                                    ? "noopener noreferrer" : "");
+                                                            }
+                                                        }
+                                                    });
+                                                }
+                                            }
+                                        } }
+                                        data-componentid="link-target-checkbox"
+                                    />
+                                }
+                                label={t("flows:core.elements.richText.linkEditor.linkTargetLabel")}
+                            />
+                            <Tooltip title={linkTarget === "_blank"
+                                ? t("flows:core.elements.richText.linkEditor.newTabHint")
+                                : t("flows:core.elements.richText.linkEditor.sameTabHint")
+                            } placement="top">
+                                <Hint></Hint>
+                            </Tooltip>
+
+                        </Box>
                         <Button
                             size="small"
                             variant="outlined"
@@ -472,6 +537,9 @@ const LinkEditor = (): ReactElement => {
                             onClick={ (event: ReactMouseEvent<HTMLButtonElement>) => {
                                 event.preventDefault();
                                 if (lastSelection !== null) {
+                                    editor.update(()=>{
+                                        lastSelection?.clone?.();
+                                    });
                                     const currentUrl: string = getCurrentUrl();
 
                                     if (currentUrl !== "") {

--- a/features/admin.registration-flow-builder.v1/data/templates.json
+++ b/features/admin.registration-flow-builder.v1/data/templates.json
@@ -246,7 +246,8 @@
                                         {
                                             "category": "DISPLAY",
                                             "config": {
-                                                "text": "<p class=\"rich-text-paragraph\"><br></p><p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Already have an account? </span><a href=\"{{application.callbackOrAccessUrl}}\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign in</span></a></p>"
+                                                "text": "<p class=\"rich-text-paragraph\"><br></p><p class=\"rich-text-paragraph\"><span class=\"rich-text-pre-wrap\">Already have an account? </span><a href=\"{{application.callbackOrAccessUrl}}\" class=\"rich-text-link\"><span class=\"rich-text-pre-wrap\">Sign in</span></a></p>",
+                                                "linkTarget": "_self"
                                             },
                                             "id": "{{ID}}",
                                             "type": "RICH_TEXT"

--- a/identity-apps-core/react-ui-core/src/components/adapters/rich-text-field-adapter.js
+++ b/identity-apps-core/react-ui-core/src/components/adapters/rich-text-field-adapter.js
@@ -93,13 +93,31 @@ const RichTextAdapter = ({ component }) => {
 
     // Resolve placeholders in the HTML content before sanitizing.
     const sanitizedHtml = useMemo(() => {
-        const i18nText = resolveElementText(translations, config.text);
-        const resolvedHtml = resolvePlaceholders(i18nText || "");
+    let html = resolveElementText(translations, config.text);
+    html = resolvePlaceholders(html || "");
 
-        return DOMPurify.sanitize(resolvedHtml, {
-            ADD_ATTR: [ "target" ]
+    // If linkTarget is configured, update links to use that target
+    if (config.linkTarget) {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const links = doc.querySelectorAll('a');
+
+        links.forEach(link => {
+            link.setAttribute('target', config.linkTarget);
+            if (config.linkTarget === '_blank') {
+                link.setAttribute('rel', 'noopener noreferrer');
+            } else {
+                link.removeAttribute('rel');
+            }
         });
-    }, [ config.text, contextData ]);
+
+        html = doc.body.innerHTML;
+    }
+
+    return DOMPurify.sanitize(html, {
+        ADD_ATTR: [ "target", "rel" ]
+    });
+}, [ config.text, config.linkTarget, contextData ]);
 
     return (
         <div className="rich-text-content">

--- a/modules/i18n/src/models/namespaces/flows-ns.ts
+++ b/modules/i18n/src/models/namespaces/flows-ns.ts
@@ -64,6 +64,10 @@ export interface flowsNS {
                         termsOfUseUrl: string;
                     };
                     urlTypeLabel: string;
+                    linkTargetLabel: string;
+                    linkTargetHint: string;
+                    newTabHint: string;
+                    sameTabHint: string;
                 };
                 placeholder: string;
             };

--- a/modules/i18n/src/translations/en-US/portals/flows.ts
+++ b/modules/i18n/src/translations/en-US/portals/flows.ts
@@ -46,6 +46,9 @@ export const flows: flowsNS = {
         elements: {
             richText: {
                 linkEditor: {
+                    linkTargetHint: "Allow admin to control whether links open in the same tab or new tab",
+                    linkTargetLabel: "Open link in new tab",
+                    newTabHint: "Link will open in a new browser tab",
                     placeholder: "Enter link URL here...",
                     predefinedUrls: {
                         applicationAccessUrl: "Application Access URL",
@@ -55,11 +58,8 @@ export const flows: flowsNS = {
                         supportEmail: "Contact Support Email",
                         termsOfUseUrl: "Terms of Use URL"
                     },
-                    linkTargetLabel: "Open link in new tab",
-                    linkTargetHint: "Allow admin to control whether links open in the same tab or new tab",
-                    urlTypeLabel: "URL Type",
-                    newTabHint: "Link will open in a new browser tab",
-                    sameTabHint: "Link will open in the same browser tab"
+                    sameTabHint: "Link will open in the same browser tab",
+                    urlTypeLabel: "URL Type"
                 },
                 placeholder: "Enter rich text content here..."
             },

--- a/modules/i18n/src/translations/en-US/portals/flows.ts
+++ b/modules/i18n/src/translations/en-US/portals/flows.ts
@@ -55,7 +55,11 @@ export const flows: flowsNS = {
                         supportEmail: "Contact Support Email",
                         termsOfUseUrl: "Terms of Use URL"
                     },
-                    urlTypeLabel: "URL Type"
+                    linkTargetLabel: "Open link in new tab",
+                    linkTargetHint: "Allow admin to control whether links open in the same tab or new tab",
+                    urlTypeLabel: "URL Type",
+                    newTabHint: "Link will open in a new browser tab",
+                    sameTabHint: "Link will open in the same browser tab"
                 },
                 placeholder: "Enter rich text content here..."
             },


### PR DESCRIPTION
## Purpose

Fixes https://github.com/wso2/product-is/issues/25367

### Problem

In the new self-signup flow, links created through the Rich Text Editor are always configured to open in a new browser tab (`target="_blank"`).

As a result, the Sign In link displayed in the Sign Up page is treated as an external link and opens in a new tab, which differs from the behavior in the old portal where navigation happens in the same tab.

### Solution

This PR enhances the Rich Text Editor link editor by introducing support for configuring the link target.

Changes include:

- Added a checkbox option to control link target behavior.
- Added support for `_blank` and `_self` targets.
- Persist link target configuration in Lexical link nodes.
- Automatically manage the `rel` attribute based on the selected target.
- Added contextual tooltip guidance for the link target option.
- Preserved existing behavior by keeping "Open in new tab" enabled by default.

### Result

Administrators can now decide whether a configured link should:

- Open in the same tab (`_self`)
- Open in a new tab (`_blank`)

This enables self-signup Sign In links to behave consistently with the legacy portal experience.

### Testing

- Verified creating links with "Open in new tab" enabled.
- Verified creating links with "Open in new tab" disabled.
- Verified editing existing links preserves target configuration.
- Verified `rel="noopener noreferrer"` is applied only for `_blank`.
- Verified navigation behavior in self-signup pages.