### PR TITLE
Derive default token type label from issuer class

### DIFF
--- a/.changeset/funky-forks-send.md
+++ b/.changeset/funky-forks-send.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.applications.v1": patch
+"@wso2is/admin.core.v1": patch
+"@wso2is/i18n": patch
+---
+
+Derive default token type label from issuer class

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -230,6 +230,9 @@
         {% if console.ui.identity_provider_template_loading_strategy is defined %}
         "identityProviderTemplateLoadingStrategy": "{{ console.ui.identity_provider_template_loading_strategy }}",
         {% endif %}
+        {% if oauth.extensions.token_generator is defined %}
+        "defaultTokenIssuerClass": "{{ oauth.extensions.token_generator }}",
+        {% endif %}
         "appLogoPath": "{{ console.ui.app_logo_path }}",
         "appWhiteLogoPath": "{{ console.ui.app_white_logo_path }}",
         "emailTemplates": {

--- a/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
+++ b/features/admin.applications.v1/components/forms/inbound-oidc-form.tsx
@@ -985,6 +985,9 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
             case "jwt":
                 return t("applications:forms.inboundOIDC.sections" +
                     ".accessToken.fields.type.valueDescriptions.jwt");
+            case "opaque":
+                return t("applications:forms.inboundOIDC.sections" +
+                    ".accessToken.fields.type.valueDescriptions.opaque");
             case "dpop":
                 return t("applications:forms.inboundOIDC.sections" +
                     ".accessToken.fields.bindingType.valueDescriptions.dpop");
@@ -1128,11 +1131,21 @@ export const InboundOIDCForm: FunctionComponent<InboundOIDCFormPropsInterface> =
         if (metadataProp) {
             metadataProp.options.map((ele: string) => {
                 if ((ele === "Default") && !isBinding) {
+                    const issuerClass: string = config?.ui?.defaultTokenIssuerClass;
+                    let defaultTokenTypeLabel: string = "Default";
+                    let defaultTokenTypeHint: string | undefined = undefined;
+
+                    if (!issuerClass
+                        || issuerClass === ApplicationManagementConstants.DEFAULT_OPAQUE_TOKEN_ISSUER_CLASS) {
+                        defaultTokenTypeLabel = "Opaque";
+                        defaultTokenTypeHint = getMetadataHints("opaque");
+                    }
+
                     allowedList.push({
                         hint: {
-                            content: getMetadataHints(ele)
+                            content: defaultTokenTypeHint
                         },
-                        label: "Opaque",
+                        label: defaultTokenTypeLabel,
                         value: ele
                     });
                 // Cookie binding was hidden from the UI for SPAs & Traditional OIDC with

--- a/features/admin.applications.v1/constants/application-management.ts
+++ b/features/admin.applications.v1/constants/application-management.ts
@@ -225,6 +225,12 @@ export class ApplicationManagementConstants {
     public static readonly HYBRID_FLOW_RESPONSE_TYPE: string = "hybridFlowResponseType";
 
     /**
+     * Fully-qualified class name for the built-in default token issuer.
+     */
+    public static readonly DEFAULT_OPAQUE_TOKEN_ISSUER_CLASS: string =
+        "org.wso2.carbon.identity.oauth2.token.OauthTokenIssuerImpl";
+
+    /**
      * List of available grant types.
      */
     public static readonly AVAILABLE_GRANT_TYPES: string[] = [

--- a/features/admin.core.v1/configs/app.ts
+++ b/features/admin.core.v1/configs/app.ts
@@ -447,6 +447,7 @@ export class Config {
             cookiePolicyUrl: window[ "AppUtils" ]?.getConfig()?.ui?.cookiePolicyUrl,
             customContent: window[ "AppUtils" ]?.getConfig()?.ui?.customContent ??
                 UIConstants.DEFAULT_CUSTOM_CONTENT_CONFIGS,
+            defaultTokenIssuerClass: window[ "AppUtils" ]?.getConfig()?.ui?.defaultTokenIssuerClass,
             disableEmailTemplateForFreeTier: window[ "AppUtils" ]?.getConfig()?.ui?.disableEmailTemplateForFreeTier,
             emailTemplates: {
                 defaultLogoUrl: window[ "AppUtils" ]?.getConfig()?.ui?.emailTemplates?.defaultLogoUrl,

--- a/features/admin.core.v1/models/config.ts
+++ b/features/admin.core.v1/models/config.ts
@@ -497,6 +497,10 @@ export interface UIConfigInterface extends CommonUIConfigInterface<FeatureConfig
      */
     googleOneTapEnabledTenants?: string[];
     /**
+     * Fully-qualified class name of the default token issuer.
+     */
+    defaultTokenIssuerClass?: string;
+    /**
      * API resource management UI configurations.
      */
     apiResourceManagement?: APIResourceManagementUIConfigInterface;

--- a/modules/i18n/src/models/namespaces/applications-ns.ts
+++ b/modules/i18n/src/models/namespaces/applications-ns.ts
@@ -1635,6 +1635,7 @@ export interface ApplicationsNS {
                             valueDescriptions: {
                                 default: string;
                                 jwt: string;
+                                opaque: string;
                             };
                         };
                         revokeToken: {

--- a/modules/i18n/src/translations/en-US/portals/applications.ts
+++ b/modules/i18n/src/translations/en-US/portals/applications.ts
@@ -1939,7 +1939,8 @@ export const applications: ApplicationsNS = {
                             label: "Token type",
                             valueDescriptions: {
                                 "default": "Issue an opaque UUID as a token.",
-                                "jwt": "Issue a self-contained JWT token."
+                                "jwt": "Issue a self-contained JWT token.",
+                                "opaque": "Issue an opaque UUID as a token."
                             }
                         },
                         validateBinding: {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                            
                                                                                                                                                                                                                   
  - The "Default" token type option in the application token type selector had a hardcoded "Opaque" label (and an always-opaque hint), regardless of the actual configured default token issuer.
  - The frontend now derives the label and hint from the issuer class:                                                                                                                                               
    - OauthTokenIssuerImpl or unset → Opaque (with opaque hint)                                                                                                                                                                          
    - Any other class → Default (no hint)                                                                                                                                                                     
  - Added a dedicated valueDescriptions.opaque i18n key so the Opaque custom token type option also carries the correct hint.

## Related Issue
- https://github.com/wso2/product-is/issues/27215