### PR TITLE
Add provider-level OTP delivery failure notifications for Email OTP and SMS OTP

### DIFF
--- a/.changeset/thick-wolves-scream.md
+++ b/.changeset/thick-wolves-scream.md
@@ -1,0 +1,8 @@
+---
+"@wso2is/console": minor
+"@wso2is/admin.identity-providers.v1": minor
+"@wso2is/identity-apps-core": minor
+"@wso2is/i18n": patch
+---
+
+Add provider-level OTP delivery failure notifications for Email OTP and SMS OTP

--- a/features/admin.identity-providers.v1/components/forms/authenticators/email-otp-authenticator-form.tsx
+++ b/features/admin.identity-providers.v1/components/forms/authenticators/email-otp-authenticator-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2021-2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2021-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -107,6 +107,10 @@ interface EmailOTPAuthenticatorFormInitialValuesInterface {
      * Time duration to block resend attempts
      */
     EmailOTP_ResendBlockDuration: number;
+    /**
+     * Whether to propagate OTP delivery failures to the user's login page.
+     */
+    EmailOTP_NotifyEmailSendingFailure: boolean;
 }
 
 /**
@@ -133,6 +137,10 @@ interface EmailOTPAuthenticatorFormFieldsInterface {
      * Time duration to block resend attempts
      */
     EmailOTP_ResendBlockDuration: CommonAuthenticatorFormFieldInterface;
+    /**
+     * Whether to propagate OTP delivery failures to the user's login page.
+     */
+    EmailOTP_NotifyEmailSendingFailure: CommonAuthenticatorFormFieldInterface;
 }
 
 /**
@@ -159,7 +167,10 @@ interface EmailOTPAuthenticatorFormErrorValidationsInterface {
      * Time duration to block resend attempts
      */
     EmailOTP_ResendBlockDuration: string;
-
+    /**
+     * Whether to propagate OTP delivery failures to the user's login page.
+     */
+    EmailOTP_NotifyEmailSendingFailure: string;
 }
 
 const FORM_ID: string = "email-otp-authenticator-form";
@@ -302,6 +313,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
 
         const errors: EmailOTPAuthenticatorFormErrorValidationsInterface = {
             EmailOTP_ExpiryTime: undefined,
+            EmailOTP_NotifyEmailSendingFailure: undefined,
             EmailOTP_OTPLength: undefined,
             EmailOTP_ResendAttemptsCount: undefined,
             EmailOTP_ResendBlockDuration: undefined,
@@ -615,6 +627,19 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                     }
                 </Label>
             </Field.Input>
+            <Field.Checkbox
+                ariaLabel="Notify users on OTP delivery failure"
+                name="EmailOTP_NotifyEmailSendingFailure"
+                label={
+                    t("authenticationProvider:forms.authenticatorSettings" +
+                        ".emailOTP.notifyEmailSendingFailure.label")
+                }
+                hint={ t("authenticationProvider:forms.authenticatorSettings" +
+                    ".emailOTP.notifyEmailSendingFailure.hint") }
+                readOnly={ readOnly }
+                width={ 12 }
+                data-testid={ `${ testId }-show-failure-reason` }
+            />
             <Field.Button
                 form={ FORM_ID }
                 size="small"

--- a/features/admin.identity-providers.v1/components/forms/authenticators/email-otp-authenticator-form.tsx
+++ b/features/admin.identity-providers.v1/components/forms/authenticators/email-otp-authenticator-form.tsx
@@ -638,7 +638,7 @@ export const EmailOTPAuthenticatorForm: FunctionComponent<EmailOTPAuthenticatorF
                     ".emailOTP.notifyEmailSendingFailure.hint") }
                 readOnly={ readOnly }
                 width={ 12 }
-                data-testid={ `${ testId }-show-failure-reason` }
+                data-componentid={ `${ testId }-show-failure-reason` }
             />
             <Field.Button
                 form={ FORM_ID }

--- a/features/admin.identity-providers.v1/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/features/admin.identity-providers.v1/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -650,7 +650,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                     ".smsOTP.notifySmsSendingFailure.hint") }
                 readOnly={ readOnly }
                 width={ 12 }
-                data-testid={ `${ testId }-show-failure-reason` }
+                data-componentid={ `${ testId }-show-failure-reason` }
             />
             <Field.Button
                 form={ FORM_ID }

--- a/features/admin.identity-providers.v1/components/forms/authenticators/sms-otp-authenticator-form.tsx
+++ b/features/admin.identity-providers.v1/components/forms/authenticators/sms-otp-authenticator-form.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022-2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2022-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -104,6 +104,10 @@ interface SMSOTPAuthenticatorFormInitialValuesInterface {
      * Resend block time in minutes
      */
     SmsOTP_ResendBlockDuration: number;
+    /**
+     * Whether to propagate OTP delivery failures to the user's login page.
+     */
+    SmsOTP_NotifySmsSendingFailure: boolean;
 }
 
 /**
@@ -130,6 +134,10 @@ interface SMSOTPAuthenticatorFormFieldsInterface {
      * Resend block time field
      */
     SmsOTP_ResendBlockDuration: CommonAuthenticatorFormFieldInterface;
+    /**
+     * Whether to propagate OTP delivery failures to the user's login page.
+     */
+    SmsOTP_NotifySmsSendingFailure: CommonAuthenticatorFormFieldInterface;
 }
 
 /**
@@ -156,6 +164,10 @@ interface SMSOTPAuthenticatorFormErrorValidationsInterface {
      * Resend block time field
      */
     SmsOTP_ResendBlockDuration: string;
+    /**
+     * Whether to propagate OTP delivery failures to the user's login page.
+     */
+    SmsOTP_NotifySmsSendingFailure: string;
 }
 
 const FORM_ID: string = "sms-otp-authenticator-form";
@@ -297,6 +309,7 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
 
         const errors: SMSOTPAuthenticatorFormErrorValidationsInterface = {
             SmsOTP_ExpiryTime: undefined,
+            SmsOTP_NotifySmsSendingFailure: undefined,
             SmsOTP_OTPLength: undefined,
             SmsOTP_OtpRegex_UseNumericChars: undefined,
             SmsOTP_ResendAttemptsCount: undefined,
@@ -626,6 +639,19 @@ export const SMSOTPAuthenticatorForm: FunctionComponent<SMSOTPAuthenticatorFormP
                     }
                 </Label>
             </Field.Input>
+            <Field.Checkbox
+                ariaLabel="Notify users on OTP delivery failure"
+                name="SmsOTP_NotifySmsSendingFailure"
+                label={
+                    t("authenticationProvider:forms.authenticatorSettings" +
+                        ".smsOTP.notifySmsSendingFailure.label")
+                }
+                hint={ t("authenticationProvider:forms.authenticatorSettings" +
+                    ".smsOTP.notifySmsSendingFailure.hint") }
+                readOnly={ readOnly }
+                width={ 12 }
+                data-testid={ `${ testId }-show-failure-reason` }
+            />
             <Field.Button
                 form={ FORM_ID }
                 size="small"

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources.properties
@@ -791,3 +791,37 @@ policy.consent.section.updated.title=Updated policies
 policy.consent.button.confirm=Confirm and Continue
 policy.consent.button.decline=Decline
 policy.consent.mandatory=This is a mandatory policy
+
+# Email notification error codes.
+error.email.notification.EP-65001=Your email could not be sent due to a mail server issue. Please try again or contact support if the problem persists.
+error.email.notification.EP-65002=Your email could not be sent because no recipient address was provided. Please try again.
+error.email.notification.EP-65003=Your email could not be sent because the recipient address contains unsupported characters. Please check the email address and try again.
+error.email.notification.EP-65004=Your email could not be sent because the mail server could not verify the sender. Please contact your administrator.
+error.email.notification.EP-65005=Your email could not be sent because the recipient address was not accepted by the mail server. Please verify the email address and try again.
+error.email.notification.EP-65006=The email service is not ready. Please contact your administrator.
+error.email.notification.EP-65007=The email could not be delivered because access was denied. Please contact your administrator.
+error.email.notification.EP-65008=The email could not be delivered because the configured account does not have the required permissions. Please contact your administrator.
+error.email.notification.EP-65009=The email could not be delivered because the email service did not accept the request. Please contact your administrator.
+error.email.notification.EP-65010=The email could not be delivered because the email service is receiving too many requests. Please try again in a few moments.
+error.email.notification.EP-65011=The email could not be delivered because the email service encountered an unexpected error. Please try again or contact support.
+error.email.notification.EP-65012=The email could not be delivered because the email service is temporarily unavailable. Please try again in a few moments.
+error.email.notification.EP-65013=The email could not be delivered because a connection to the email service could not be established. Please try again or contact support.
+error.email.notification.EP-65014=The email could not be delivered because the service authentication failed. Please contact your administrator.
+error.email.notification.EP-65015=The notification could not be delivered due to an unexpected error. Please try again or contact support.
+error.email.notification.EP-65016=The email could not be delivered because the email service is temporarily suspended due to repeated failures. Please try again later or contact support.
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=The SMS could not be sent because authentication with the SMS service failed. Please contact your administrator.
+error.sms.notification.SP-65002=The SMS could not be sent because the account does not have the required permissions. Please contact your administrator.
+error.sms.notification.SP-65003=The SMS could not be sent because the SMS service did not accept the request. Please contact your administrator.
+error.sms.notification.SP-65004=The SMS could not be sent because the SMS service is temporarily busy. Please try again in a few moments.
+error.sms.notification.SP-65005=The SMS could not be sent because the SMS service encountered an unexpected error. Please try again or contact support.
+error.sms.notification.SP-65006=The SMS could not be sent due to an unexpected error. Please try again or contact your administrator.
+error.sms.notification.SP-65007=The SMS could not be delivered. Please try again or contact your administrator.
+error.sms.notification.SP-65008=The SMS could not be sent because the SMS service is not configured correctly. Please contact your administrator.
+error.sms.notification.SP-65009=The SMS could not be sent because the SMS service cannot be reached. Please contact your administrator.
+error.sms.notification.SP-65010=The SMS could not be sent because the messaging account has been suspended. Please contact your administrator.
+error.sms.notification.SP-65011=The SMS could not be sent because the account limit has been reached. Please contact your administrator.
+error.sms.notification.SP-65012=The SMS could not be delivered. The recipient's number may be switched off, out of coverage, or not a mobile number. Please check the number and try again.
+error.sms.notification.SP-65013=The SMS was blocked by the mobile carrier. This can happen due to content filtering or sender restrictions. Please contact your administrator.
+error.sms.notification.SP-65014=The SMS could not be delivered because the recipient's number is not permitted. Please contact your administrator.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_de_DE.properties
@@ -694,3 +694,37 @@ policy.consent.section.updated.title=Aktualisierte Richtlinien
 policy.consent.button.confirm=Bestätigen und fortfahren
 policy.consent.button.decline=Ablehnen
 policy.consent.mandatory=Dies ist eine obligatorische Richtlinie
+
+# Email notification error codes.
+error.email.notification.EP-65001=Ihre E-Mail konnte aufgrund eines Mailserver-Problems nicht gesendet werden. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support, falls das Problem weiterhin besteht.
+error.email.notification.EP-65002=Ihre E-Mail konnte nicht gesendet werden, da keine Empfängeradresse angegeben wurde. Bitte versuchen Sie es erneut.
+error.email.notification.EP-65003=Ihre E-Mail konnte nicht gesendet werden, da die Empfängeradresse nicht unterstützte Zeichen enthält. Bitte überprüfen Sie die E-Mail-Adresse und versuchen Sie es erneut.
+error.email.notification.EP-65004=Ihre E-Mail konnte nicht gesendet werden, da der Mailserver den Absender nicht verifizieren konnte. Bitte wenden Sie sich an Ihren Administrator.
+error.email.notification.EP-65005=Ihre E-Mail konnte nicht gesendet werden, da die Empfängeradresse vom Mailserver nicht akzeptiert wurde. Bitte überprüfen Sie die E-Mail-Adresse und versuchen Sie es erneut.
+error.email.notification.EP-65006=Der E-Mail-Dienst ist nicht bereit. Bitte wenden Sie sich an Ihren Administrator.
+error.email.notification.EP-65007=Die E-Mail konnte nicht zugestellt werden, da der Zugriff verweigert wurde. Bitte wenden Sie sich an Ihren Administrator.
+error.email.notification.EP-65008=Die E-Mail konnte nicht zugestellt werden, da das konfigurierte Konto nicht über die erforderlichen Berechtigungen verfügt. Bitte wenden Sie sich an Ihren Administrator.
+error.email.notification.EP-65009=Die E-Mail konnte nicht zugestellt werden, da der E-Mail-Dienst die Anfrage nicht akzeptiert hat. Bitte wenden Sie sich an Ihren Administrator.
+error.email.notification.EP-65010=Die E-Mail konnte nicht zugestellt werden, da der E-Mail-Dienst zu viele Anfragen erhält. Bitte versuchen Sie es in einigen Momenten erneut.
+error.email.notification.EP-65011=Die E-Mail konnte nicht zugestellt werden, da der E-Mail-Dienst auf einen unerwarteten Fehler gestoßen ist. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support.
+error.email.notification.EP-65012=Die E-Mail konnte nicht zugestellt werden, da der E-Mail-Dienst vorübergehend nicht verfügbar ist. Bitte versuchen Sie es in einigen Momenten erneut.
+error.email.notification.EP-65013=Die E-Mail konnte nicht zugestellt werden, da keine Verbindung zum E-Mail-Dienst hergestellt werden konnte. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support.
+error.email.notification.EP-65014=Die E-Mail konnte nicht zugestellt werden, da die Dienstauthentifizierung fehlgeschlagen ist. Bitte wenden Sie sich an Ihren Administrator.
+error.email.notification.EP-65015=Die Benachrichtigung konnte aufgrund eines unerwarteten Fehlers nicht zugestellt werden. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support.
+error.email.notification.EP-65016=Die E-Mail konnte nicht zugestellt werden, da der E-Mail-Dienst aufgrund wiederholter Fehler vorübergehend gesperrt ist. Bitte versuchen Sie es später erneut oder wenden Sie sich an den Support.
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=Die SMS konnte nicht gesendet werden, da die Authentifizierung mit dem SMS-Dienst fehlgeschlagen ist. Bitte wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65002=Die SMS konnte nicht gesendet werden, da das Konto nicht über die erforderlichen Berechtigungen verfügt. Bitte wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65003=Die SMS konnte nicht gesendet werden, da der SMS-Dienst die Anfrage nicht akzeptiert hat. Bitte wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65004=Die SMS konnte nicht gesendet werden, da der SMS-Dienst vorübergehend ausgelastet ist. Bitte versuchen Sie es in einigen Momenten erneut.
+error.sms.notification.SP-65005=Die SMS konnte nicht gesendet werden, da der SMS-Dienst auf einen unerwarteten Fehler gestoßen ist. Bitte versuchen Sie es erneut oder wenden Sie sich an den Support.
+error.sms.notification.SP-65006=Die SMS konnte aufgrund eines unerwarteten Fehlers nicht gesendet werden. Bitte versuchen Sie es erneut oder wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65007=Die SMS konnte nicht zugestellt werden. Bitte versuchen Sie es erneut oder wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65008=Die SMS konnte nicht gesendet werden, da der SMS-Dienst nicht korrekt konfiguriert ist. Bitte wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65009=Die SMS konnte nicht gesendet werden, da der SMS-Dienst nicht erreichbar ist. Bitte wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65010=Die SMS konnte nicht gesendet werden, da das Messaging-Konto gesperrt wurde. Bitte wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65011=Die SMS konnte nicht gesendet werden, da das Kontolimit erreicht wurde. Bitte wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65012=Die SMS konnte nicht zugestellt werden. Die Nummer des Empfängers ist möglicherweise ausgeschaltet, außerhalb der Reichweite oder keine Mobilnummer. Bitte überprüfen Sie die Nummer und versuchen Sie es erneut.
+error.sms.notification.SP-65013=Die SMS wurde vom Mobilfunkanbieter blockiert. Dies kann aufgrund von Inhaltsfilterung oder Absenderbeschränkungen passieren. Bitte wenden Sie sich an Ihren Administrator.
+error.sms.notification.SP-65014=Die SMS konnte nicht zugestellt werden, da die Nummer des Empfängers nicht zulässig ist. Bitte wenden Sie sich an Ihren Administrator.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_es_ES.properties
@@ -695,3 +695,37 @@ policy.consent.section.updated.title=Políticas actualizadas
 policy.consent.button.confirm=Confirmar y continuar
 policy.consent.button.decline=Rechazar
 policy.consent.mandatory=Esta es una política obligatoria
+
+# Email notification error codes.
+error.email.notification.EP-65001=Su correo electrónico no pudo enviarse debido a un problema con el servidor de correo. Por favor, inténtelo de nuevo o contacte con el soporte si el problema persiste.
+error.email.notification.EP-65002=Su correo electrónico no pudo enviarse porque no se proporcionó ninguna dirección de destinatario. Por favor, inténtelo de nuevo.
+error.email.notification.EP-65003=Su correo electrónico no pudo enviarse porque la dirección del destinatario contiene caracteres no compatibles. Por favor, verifique la dirección de correo electrónico e inténtelo de nuevo.
+error.email.notification.EP-65004=Su correo electrónico no pudo enviarse porque el servidor de correo no pudo verificar al remitente. Por favor, contacte con su administrador.
+error.email.notification.EP-65005=Su correo electrónico no pudo enviarse porque el servidor de correo no aceptó la dirección del destinatario. Por favor, verifique la dirección de correo electrónico e inténtelo de nuevo.
+error.email.notification.EP-65006=El servicio de correo electrónico no está listo. Por favor, contacte con su administrador.
+error.email.notification.EP-65007=El correo electrónico no pudo entregarse porque se denegó el acceso. Por favor, contacte con su administrador.
+error.email.notification.EP-65008=El correo electrónico no pudo entregarse porque la cuenta configurada no tiene los permisos necesarios. Por favor, contacte con su administrador.
+error.email.notification.EP-65009=El correo electrónico no pudo entregarse porque el servicio de correo electrónico no aceptó la solicitud. Por favor, contacte con su administrador.
+error.email.notification.EP-65010=El correo electrónico no pudo entregarse porque el servicio de correo electrónico está recibiendo demasiadas solicitudes. Por favor, inténtelo de nuevo en unos momentos.
+error.email.notification.EP-65011=El correo electrónico no pudo entregarse porque el servicio de correo electrónico encontró un error inesperado. Por favor, inténtelo de nuevo o contacte con el soporte.
+error.email.notification.EP-65012=El correo electrónico no pudo entregarse porque el servicio de correo electrónico no está disponible temporalmente. Por favor, inténtelo de nuevo en unos momentos.
+error.email.notification.EP-65013=El correo electrónico no pudo entregarse porque no se pudo establecer una conexión con el servicio de correo electrónico. Por favor, inténtelo de nuevo o contacte con el soporte.
+error.email.notification.EP-65014=El correo electrónico no pudo entregarse porque falló la autenticación del servicio. Por favor, contacte con su administrador.
+error.email.notification.EP-65015=La notificación no pudo entregarse debido a un error inesperado. Por favor, inténtelo de nuevo o contacte con el soporte.
+error.email.notification.EP-65016=El correo electrónico no pudo entregarse porque el servicio de correo electrónico está temporalmente suspendido debido a fallos repetidos. Por favor, inténtelo de nuevo más tarde o contacte con el soporte.
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=El SMS no pudo enviarse porque la autenticación con el servicio de SMS falló. Por favor, contacte con su administrador.
+error.sms.notification.SP-65002=El SMS no pudo enviarse porque la cuenta no tiene los permisos necesarios. Por favor, contacte con su administrador.
+error.sms.notification.SP-65003=El SMS no pudo enviarse porque el servicio de SMS no aceptó la solicitud. Por favor, contacte con su administrador.
+error.sms.notification.SP-65004=El SMS no pudo enviarse porque el servicio de SMS está temporalmente ocupado. Por favor, inténtelo de nuevo en unos momentos.
+error.sms.notification.SP-65005=El SMS no pudo enviarse porque el servicio de SMS encontró un error inesperado. Por favor, inténtelo de nuevo o contacte con el soporte.
+error.sms.notification.SP-65006=El SMS no pudo enviarse debido a un error inesperado. Por favor, inténtelo de nuevo o contacte con su administrador.
+error.sms.notification.SP-65007=El SMS no pudo entregarse. Por favor, inténtelo de nuevo o contacte con su administrador.
+error.sms.notification.SP-65008=El SMS no pudo enviarse porque el servicio de SMS no está configurado correctamente. Por favor, contacte con su administrador.
+error.sms.notification.SP-65009=El SMS no pudo enviarse porque el servicio de SMS no puede ser alcanzado. Por favor, contacte con su administrador.
+error.sms.notification.SP-65010=El SMS no pudo enviarse porque la cuenta de mensajería ha sido suspendida. Por favor, contacte con su administrador.
+error.sms.notification.SP-65011=El SMS no pudo enviarse porque se ha alcanzado el límite de la cuenta. Por favor, contacte con su administrador.
+error.sms.notification.SP-65012=El SMS no pudo entregarse. El número del destinatario puede estar apagado, fuera de cobertura o no ser un número de móvil. Por favor, compruebe el número e inténtelo de nuevo.
+error.sms.notification.SP-65013=El SMS fue bloqueado por el operador móvil. Esto puede ocurrir por filtrado de contenido o restricciones del remitente. Por favor, contacte con su administrador.
+error.sms.notification.SP-65014=El SMS no pudo entregarse porque el número del destinatario no está permitido. Por favor, contacte con su administrador.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_fr_FR.properties
@@ -696,3 +696,37 @@ policy.consent.section.updated.title=Politiques mises à jour
 policy.consent.button.confirm=Confirmer et continuer
 policy.consent.button.decline=Refuser
 policy.consent.mandatory=Ceci est une politique obligatoire
+
+# Email notification error codes.
+error.email.notification.EP-65001=Votre e-mail n'a pas pu être envoyé en raison d'un problème avec le serveur de messagerie. Veuillez réessayer ou contacter le support si le problème persiste.
+error.email.notification.EP-65002=Votre e-mail n'a pas pu être envoyé car aucune adresse de destinataire n'a été fournie. Veuillez réessayer.
+error.email.notification.EP-65003=Votre e-mail n'a pas pu être envoyé car l'adresse du destinataire contient des caractères non pris en charge. Veuillez vérifier l'adresse e-mail et réessayer.
+error.email.notification.EP-65004=Votre e-mail n'a pas pu être envoyé car le serveur de messagerie n'a pas pu vérifier l'expéditeur. Veuillez contacter votre administrateur.
+error.email.notification.EP-65005=Votre e-mail n'a pas pu être envoyé car l'adresse du destinataire n'a pas été acceptée par le serveur de messagerie. Veuillez vérifier l'adresse e-mail et réessayer.
+error.email.notification.EP-65006=Le service de messagerie n'est pas prêt. Veuillez contacter votre administrateur.
+error.email.notification.EP-65007=L'e-mail n'a pas pu être livré car l'accès a été refusé. Veuillez contacter votre administrateur.
+error.email.notification.EP-65008=L'e-mail n'a pas pu être livré car le compte configuré ne dispose pas des autorisations requises. Veuillez contacter votre administrateur.
+error.email.notification.EP-65009=L'e-mail n'a pas pu être livré car le service de messagerie n'a pas accepté la demande. Veuillez contacter votre administrateur.
+error.email.notification.EP-65010=L'e-mail n'a pas pu être livré car le service de messagerie reçoit trop de demandes. Veuillez réessayer dans quelques instants.
+error.email.notification.EP-65011=L'e-mail n'a pas pu être livré car le service de messagerie a rencontré une erreur inattendue. Veuillez réessayer ou contacter le support.
+error.email.notification.EP-65012=L'e-mail n'a pas pu être livré car le service de messagerie est temporairement indisponible. Veuillez réessayer dans quelques instants.
+error.email.notification.EP-65013=L'e-mail n'a pas pu être livré car une connexion au service de messagerie n'a pas pu être établie. Veuillez réessayer ou contacter le support.
+error.email.notification.EP-65014=L'e-mail n'a pas pu être livré car l'authentification du service a échoué. Veuillez contacter votre administrateur.
+error.email.notification.EP-65015=La notification n'a pas pu être livrée en raison d'une erreur inattendue. Veuillez réessayer ou contacter le support.
+error.email.notification.EP-65016=L'e-mail n'a pas pu être livré car le service de messagerie est temporairement suspendu en raison de défaillances répétées. Veuillez réessayer plus tard ou contacter le support.
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=Le SMS n'a pas pu être envoyé car l'authentification auprès du service SMS a échoué. Veuillez contacter votre administrateur.
+error.sms.notification.SP-65002=Le SMS n'a pas pu être envoyé car le compte ne dispose pas des autorisations requises. Veuillez contacter votre administrateur.
+error.sms.notification.SP-65003=Le SMS n'a pas pu être envoyé car le service SMS n'a pas accepté la demande. Veuillez contacter votre administrateur.
+error.sms.notification.SP-65004=Le SMS n'a pas pu être envoyé car le service SMS est temporairement occupé. Veuillez réessayer dans quelques instants.
+error.sms.notification.SP-65005=Le SMS n'a pas pu être envoyé car le service SMS a rencontré une erreur inattendue. Veuillez réessayer ou contacter le support.
+error.sms.notification.SP-65006=Le SMS n'a pas pu être envoyé en raison d'une erreur inattendue. Veuillez réessayer ou contacter votre administrateur.
+error.sms.notification.SP-65007=Le SMS n'a pas pu être livré. Veuillez réessayer ou contacter votre administrateur.
+error.sms.notification.SP-65008=Le SMS n'a pas pu être envoyé car le service SMS n'est pas configuré correctement. Veuillez contacter votre administrateur.
+error.sms.notification.SP-65009=Le SMS n'a pas pu être envoyé car le service SMS est inaccessible. Veuillez contacter votre administrateur.
+error.sms.notification.SP-65010=Le SMS n'a pas pu être envoyé car le compte de messagerie a été suspendu. Veuillez contacter votre administrateur.
+error.sms.notification.SP-65011=Le SMS n'a pas pu être envoyé car la limite du compte a été atteinte. Veuillez contacter votre administrateur.
+error.sms.notification.SP-65012=Le SMS n'a pas pu être livré. Le numéro du destinataire est peut-être éteint, hors de portée ou n'est pas un numéro de mobile. Veuillez vérifier le numéro et réessayer.
+error.sms.notification.SP-65013=Le SMS a été bloqué par l'opérateur mobile. Cela peut arriver en raison du filtrage de contenu ou de restrictions d'expéditeur. Veuillez contacter votre administrateur.
+error.sms.notification.SP-65014=Le SMS n'a pas pu être livré car le numéro du destinataire n'est pas autorisé. Veuillez contacter votre administrateur.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_ja_JP.properties
@@ -694,3 +694,37 @@ policy.consent.section.updated.title=更新されたポリシー
 policy.consent.button.confirm=確認して続行
 policy.consent.button.decline=拒否
 policy.consent.mandatory=これは必須ポリシーです
+
+# Email notification error codes.
+error.email.notification.EP-65001=メールサーバーの問題により、メールを送信できませんでした。もう一度お試しいただくか、問題が解決しない場合はサポートにご連絡ください。
+error.email.notification.EP-65002=受信者のアドレスが指定されていないため、メールを送信できませんでした。もう一度お試しください。
+error.email.notification.EP-65003=受信者のアドレスにサポートされていない文字が含まれているため、メールを送信できませんでした。メールアドレスを確認してもう一度お試しください。
+error.email.notification.EP-65004=メールサーバーが送信者を確認できなかったため、メールを送信できませんでした。管理者にお問い合わせください。
+error.email.notification.EP-65005=受信者のアドレスがメールサーバーに受け入れられなかったため、メールを送信できませんでした。メールアドレスを確認してもう一度お試しください。
+error.email.notification.EP-65006=メールサービスの準備ができていません。管理者にお問い合わせください。
+error.email.notification.EP-65007=アクセスが拒否されたため、メールを配信できませんでした。管理者にお問い合わせください。
+error.email.notification.EP-65008=設定されたアカウントに必要な権限がないため、メールを配信できませんでした。管理者にお問い合わせください。
+error.email.notification.EP-65009=メールサービスがリクエストを受け入れなかったため、メールを配信できませんでした。管理者にお問い合わせください。
+error.email.notification.EP-65010=メールサービスへのリクエストが多すぎるため、メールを配信できませんでした。しばらくしてからもう一度お試しください。
+error.email.notification.EP-65011=メールサービスで予期しないエラーが発生したため、メールを配信できませんでした。もう一度お試しいただくか、サポートにご連絡ください。
+error.email.notification.EP-65012=メールサービスが一時的に利用できないため、メールを配信できませんでした。しばらくしてからもう一度お試しください。
+error.email.notification.EP-65013=メールサービスへの接続を確立できなかったため、メールを配信できませんでした。もう一度お試しいただくか、サポートにご連絡ください。
+error.email.notification.EP-65014=サービス認証に失敗したため、メールを配信できませんでした。管理者にお問い合わせください。
+error.email.notification.EP-65015=予期しないエラーが発生したため、通知を配信できませんでした。もう一度お試しいただくか、サポートにご連絡ください。
+error.email.notification.EP-65016=繰り返しの失敗によりメールサービスが一時的に停止されているため、メールを配信できませんでした。後でもう一度お試しいただくか、サポートにご連絡ください。
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=SMSサービスへの認証に失敗したため、SMSを送信できませんでした。管理者にお問い合わせください。
+error.sms.notification.SP-65002=アカウントに必要な権限がないため、SMSを送信できませんでした。管理者にお問い合わせください。
+error.sms.notification.SP-65003=SMSサービスがリクエストを受け入れなかったため、SMSを送信できませんでした。管理者にお問い合わせください。
+error.sms.notification.SP-65004=SMSサービスが一時的に混雑しているため、SMSを送信できませんでした。しばらくしてからもう一度お試しください。
+error.sms.notification.SP-65005=SMSサービスで予期しないエラーが発生したため、SMSを送信できませんでした。もう一度お試しいただくか、サポートにご連絡ください。
+error.sms.notification.SP-65006=予期しないエラーが発生したため、SMSを送信できませんでした。もう一度お試しいただくか、管理者にお問い合わせください。
+error.sms.notification.SP-65007=SMSを配信できませんでした。もう一度お試しいただくか、管理者にお問い合わせください。
+error.sms.notification.SP-65008=SMSサービスが正しく設定されていないため、SMSを送信できませんでした。管理者にお問い合わせください。
+error.sms.notification.SP-65009=SMSサービスに到達できないため、SMSを送信できませんでした。管理者にお問い合わせください。
+error.sms.notification.SP-65010=メッセージングアカウントが停止されているため、SMSを送信できませんでした。管理者にお問い合わせください。
+error.sms.notification.SP-65011=アカウントの上限に達したため、SMSを送信できませんでした。管理者にお問い合わせください。
+error.sms.notification.SP-65012=SMSを配信できませんでした。受信者の番号がオフになっているか、圏外か、携帯電話番号でない可能性があります。番号を確認してもう一度お試しください。
+error.sms.notification.SP-65013=SMSが携帯キャリアによってブロックされました。コンテンツフィルタリングや送信者制限が原因の可能性があります。管理者にお問い合わせください。
+error.sms.notification.SP-65014=受信者の番号が許可されていないため、SMSを配信できませんでした。管理者にお問い合わせください。

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_nl_NL.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_nl_NL.properties
@@ -780,3 +780,37 @@ invalid.tenant.domain={{tenantDomain}} is een ongeldig tenantdomein
 tenant.domain.validation.error=Fout opgetreden bij het valideren van tenantdomein {{tenantDomain}}
 tenant.domain.null=Kan geen verzoek doen aan dit pad.
 contact.site.administrator=Neem contact op met de sitebeheerder als het probleem aanhoudt.
+
+# Email notification error codes.
+error.email.notification.EP-65001=Uw e-mail kon niet worden verzonden vanwege een probleem met de mailserver. Probeer het opnieuw of neem contact op met de ondersteuning als het probleem aanhoudt.
+error.email.notification.EP-65002=Uw e-mail kon niet worden verzonden omdat er geen ontvangersadres was opgegeven. Probeer het opnieuw.
+error.email.notification.EP-65003=Uw e-mail kon niet worden verzonden omdat het ontvangersadres niet-ondersteunde tekens bevat. Controleer het e-mailadres en probeer het opnieuw.
+error.email.notification.EP-65004=Uw e-mail kon niet worden verzonden omdat de mailserver de afzender niet kon verifiëren. Neem contact op met uw beheerder.
+error.email.notification.EP-65005=Uw e-mail kon niet worden verzonden omdat het ontvangersadres niet werd geaccepteerd door de mailserver. Controleer het e-mailadres en probeer het opnieuw.
+error.email.notification.EP-65006=De e-mailservice is niet gereed. Neem contact op met uw beheerder.
+error.email.notification.EP-65007=De e-mail kon niet worden afgeleverd omdat de toegang werd geweigerd. Neem contact op met uw beheerder.
+error.email.notification.EP-65008=De e-mail kon niet worden afgeleverd omdat het geconfigureerde account niet over de vereiste machtigingen beschikt. Neem contact op met uw beheerder.
+error.email.notification.EP-65009=De e-mail kon niet worden afgeleverd omdat de e-mailservice het verzoek niet accepteerde. Neem contact op met uw beheerder.
+error.email.notification.EP-65010=De e-mail kon niet worden afgeleverd omdat de e-mailservice te veel verzoeken ontvangt. Probeer het over enkele ogenblikken opnieuw.
+error.email.notification.EP-65011=De e-mail kon niet worden afgeleverd omdat de e-mailservice een onverwachte fout heeft ondervonden. Probeer het opnieuw of neem contact op met de ondersteuning.
+error.email.notification.EP-65012=De e-mail kon niet worden afgeleverd omdat de e-mailservice tijdelijk niet beschikbaar is. Probeer het over enkele ogenblikken opnieuw.
+error.email.notification.EP-65013=De e-mail kon niet worden afgeleverd omdat er geen verbinding met de e-mailservice kon worden gemaakt. Probeer het opnieuw of neem contact op met de ondersteuning.
+error.email.notification.EP-65014=De e-mail kon niet worden afgeleverd omdat de serviceauthenticatie is mislukt. Neem contact op met uw beheerder.
+error.email.notification.EP-65015=De melding kon niet worden afgeleverd vanwege een onverwachte fout. Probeer het opnieuw of neem contact op met de ondersteuning.
+error.email.notification.EP-65016=De e-mail kon niet worden afgeleverd omdat de e-mailservice tijdelijk is opgeschort vanwege herhaalde fouten. Probeer het later opnieuw of neem contact op met de ondersteuning.
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=Het sms-bericht kon niet worden verzonden omdat de authenticatie met de sms-service is mislukt. Neem contact op met uw beheerder.
+error.sms.notification.SP-65002=Het sms-bericht kon niet worden verzonden omdat het account niet over de vereiste machtigingen beschikt. Neem contact op met uw beheerder.
+error.sms.notification.SP-65003=Het sms-bericht kon niet worden verzonden omdat de sms-service het verzoek niet heeft geaccepteerd. Neem contact op met uw beheerder.
+error.sms.notification.SP-65004=Het sms-bericht kon niet worden verzonden omdat de sms-service tijdelijk bezet is. Probeer het over enkele ogenblikken opnieuw.
+error.sms.notification.SP-65005=Het sms-bericht kon niet worden verzonden omdat de sms-service een onverwachte fout heeft ondervonden. Probeer het opnieuw of neem contact op met de ondersteuning.
+error.sms.notification.SP-65006=Het sms-bericht kon niet worden verzonden vanwege een onverwachte fout. Probeer het opnieuw of neem contact op met uw beheerder.
+error.sms.notification.SP-65007=Het sms-bericht kon niet worden afgeleverd. Probeer het opnieuw of neem contact op met uw beheerder.
+error.sms.notification.SP-65008=Het sms-bericht kon niet worden verzonden omdat de sms-service niet correct is geconfigureerd. Neem contact op met uw beheerder.
+error.sms.notification.SP-65009=Het sms-bericht kon niet worden verzonden omdat de sms-service niet bereikbaar is. Neem contact op met uw beheerder.
+error.sms.notification.SP-65010=Het sms-bericht kon niet worden verzonden omdat het berichtenaccount is opgeschort. Neem contact op met uw beheerder.
+error.sms.notification.SP-65011=Het sms-bericht kon niet worden verzonden omdat de accountlimiet is bereikt. Neem contact op met uw beheerder.
+error.sms.notification.SP-65012=Het sms-bericht kon niet worden afgeleverd. Het nummer van de ontvanger is mogelijk uitgeschakeld, buiten bereik of geen mobiel nummer. Controleer het nummer en probeer het opnieuw.
+error.sms.notification.SP-65013=Het sms-bericht is geblokkeerd door de mobiele provider. Dit kan gebeuren door inhoudsfiltering of beperkingen van de afzender. Neem contact op met uw beheerder.
+error.sms.notification.SP-65014=Het sms-bericht kon niet worden afgeleverd omdat het nummer van de ontvanger niet is toegestaan. Neem contact op met uw beheerder.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_BR.properties
@@ -692,3 +692,37 @@ policy.consent.section.updated.title=Políticas atualizadas
 policy.consent.button.confirm=Confirmar e continuar
 policy.consent.button.decline=Recusar
 policy.consent.mandatory=Esta é uma política obrigatória
+
+# Email notification error codes.
+error.email.notification.EP-65001=Seu e-mail não pôde ser enviado devido a um problema no servidor de e-mail. Tente novamente ou entre em contato com o suporte se o problema persistir.
+error.email.notification.EP-65002=Seu e-mail não pôde ser enviado porque nenhum endereço de destinatário foi fornecido. Tente novamente.
+error.email.notification.EP-65003=Seu e-mail não pôde ser enviado porque o endereço do destinatário contém caracteres não suportados. Verifique o endereço de e-mail e tente novamente.
+error.email.notification.EP-65004=Seu e-mail não pôde ser enviado porque o servidor de e-mail não pôde verificar o remetente. Entre em contato com seu administrador.
+error.email.notification.EP-65005=Seu e-mail não pôde ser enviado porque o endereço do destinatário não foi aceito pelo servidor de e-mail. Verifique o endereço de e-mail e tente novamente.
+error.email.notification.EP-65006=O serviço de e-mail não está pronto. Entre em contato com seu administrador.
+error.email.notification.EP-65007=O e-mail não pôde ser entregue porque o acesso foi negado. Entre em contato com seu administrador.
+error.email.notification.EP-65008=O e-mail não pôde ser entregue porque a conta configurada não tem as permissões necessárias. Entre em contato com seu administrador.
+error.email.notification.EP-65009=O e-mail não pôde ser entregue porque o serviço de e-mail não aceitou a solicitação. Entre em contato com seu administrador.
+error.email.notification.EP-65010=O e-mail não pôde ser entregue porque o serviço de e-mail está recebendo muitas solicitações. Tente novamente em alguns momentos.
+error.email.notification.EP-65011=O e-mail não pôde ser entregue porque o serviço de e-mail encontrou um erro inesperado. Tente novamente ou entre em contato com o suporte.
+error.email.notification.EP-65012=O e-mail não pôde ser entregue porque o serviço de e-mail está temporariamente indisponível. Tente novamente em alguns momentos.
+error.email.notification.EP-65013=O e-mail não pôde ser entregue porque não foi possível estabelecer uma conexão com o serviço de e-mail. Tente novamente ou entre em contato com o suporte.
+error.email.notification.EP-65014=O e-mail não pôde ser entregue porque a autenticação do serviço falhou. Entre em contato com seu administrador.
+error.email.notification.EP-65015=A notificação não pôde ser entregue devido a um erro inesperado. Tente novamente ou entre em contato com o suporte.
+error.email.notification.EP-65016=O e-mail não pôde ser entregue porque o serviço de e-mail está temporariamente suspenso devido a falhas repetidas. Tente novamente mais tarde ou entre em contato com o suporte.
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=O SMS não pôde ser enviado porque a autenticação com o serviço de SMS falhou. Entre em contato com seu administrador.
+error.sms.notification.SP-65002=O SMS não pôde ser enviado porque a conta não tem as permissões necessárias. Entre em contato com seu administrador.
+error.sms.notification.SP-65003=O SMS não pôde ser enviado porque o serviço de SMS não aceitou a solicitação. Entre em contato com seu administrador.
+error.sms.notification.SP-65004=O SMS não pôde ser enviado porque o serviço de SMS está temporariamente ocupado. Tente novamente em alguns momentos.
+error.sms.notification.SP-65005=O SMS não pôde ser enviado porque o serviço de SMS encontrou um erro inesperado. Tente novamente ou entre em contato com o suporte.
+error.sms.notification.SP-65006=O SMS não pôde ser enviado devido a um erro inesperado. Tente novamente ou entre em contato com seu administrador.
+error.sms.notification.SP-65007=O SMS não pôde ser entregue. Tente novamente ou entre em contato com seu administrador.
+error.sms.notification.SP-65008=O SMS não pôde ser enviado porque o serviço de SMS não está configurado corretamente. Entre em contato com seu administrador.
+error.sms.notification.SP-65009=O SMS não pôde ser enviado porque o serviço de SMS não pode ser alcançado. Entre em contato com seu administrador.
+error.sms.notification.SP-65010=O SMS não pôde ser enviado porque a conta de mensagens foi suspensa. Entre em contato com seu administrador.
+error.sms.notification.SP-65011=O SMS não pôde ser enviado porque o limite da conta foi atingido. Entre em contato com seu administrador.
+error.sms.notification.SP-65012=O SMS não pôde ser entregue. O número do destinatário pode estar desligado, fora de cobertura ou não ser um número de celular. Verifique o número e tente novamente.
+error.sms.notification.SP-65013=O SMS foi bloqueado pela operadora. Isso pode ocorrer devido a filtragem de conteúdo ou restrições do remetente. Entre em contato com seu administrador.
+error.sms.notification.SP-65014=O SMS não pôde ser entregue porque o número do destinatário não é permitido. Entre em contato com seu administrador.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_pt_PT.properties
@@ -695,3 +695,37 @@ policy.consent.section.updated.title=Políticas atualizadas
 policy.consent.button.confirm=Confirmar e continuar
 policy.consent.button.decline=Recusar
 policy.consent.mandatory=Esta é uma política obrigatória
+
+# Email notification error codes.
+error.email.notification.EP-65001=O seu e-mail não pôde ser enviado devido a um problema no servidor de e-mail. Por favor, tente novamente ou contacte o suporte se o problema persistir.
+error.email.notification.EP-65002=O seu e-mail não pôde ser enviado porque não foi fornecido nenhum endereço de destinatário. Por favor, tente novamente.
+error.email.notification.EP-65003=O seu e-mail não pôde ser enviado porque o endereço do destinatário contém caracteres não suportados. Por favor, verifique o endereço de e-mail e tente novamente.
+error.email.notification.EP-65004=O seu e-mail não pôde ser enviado porque o servidor de e-mail não pôde verificar o remetente. Por favor, contacte o seu administrador.
+error.email.notification.EP-65005=O seu e-mail não pôde ser enviado porque o endereço do destinatário não foi aceite pelo servidor de e-mail. Por favor, verifique o endereço de e-mail e tente novamente.
+error.email.notification.EP-65006=O serviço de e-mail não está pronto. Por favor, contacte o seu administrador.
+error.email.notification.EP-65007=O e-mail não pôde ser entregue porque o acesso foi negado. Por favor, contacte o seu administrador.
+error.email.notification.EP-65008=O e-mail não pôde ser entregue porque a conta configurada não tem as permissões necessárias. Por favor, contacte o seu administrador.
+error.email.notification.EP-65009=O e-mail não pôde ser entregue porque o serviço de e-mail não aceitou o pedido. Por favor, contacte o seu administrador.
+error.email.notification.EP-65010=O e-mail não pôde ser entregue porque o serviço de e-mail está a receber demasiados pedidos. Por favor, tente novamente dentro de alguns momentos.
+error.email.notification.EP-65011=O e-mail não pôde ser entregue porque o serviço de e-mail encontrou um erro inesperado. Por favor, tente novamente ou contacte o suporte.
+error.email.notification.EP-65012=O e-mail não pôde ser entregue porque o serviço de e-mail está temporariamente indisponível. Por favor, tente novamente dentro de alguns momentos.
+error.email.notification.EP-65013=O e-mail não pôde ser entregue porque não foi possível estabelecer uma ligação ao serviço de e-mail. Por favor, tente novamente ou contacte o suporte.
+error.email.notification.EP-65014=O e-mail não pôde ser entregue porque a autenticação do serviço falhou. Por favor, contacte o seu administrador.
+error.email.notification.EP-65015=A notificação não pôde ser entregue devido a um erro inesperado. Por favor, tente novamente ou contacte o suporte.
+error.email.notification.EP-65016=O e-mail não pôde ser entregue porque o serviço de e-mail está temporariamente suspenso devido a falhas repetidas. Por favor, tente novamente mais tarde ou contacte o suporte.
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=O SMS não pôde ser enviado porque a autenticação com o serviço de SMS falhou. Por favor, contacte o seu administrador.
+error.sms.notification.SP-65002=O SMS não pôde ser enviado porque a conta não tem as permissões necessárias. Por favor, contacte o seu administrador.
+error.sms.notification.SP-65003=O SMS não pôde ser enviado porque o serviço de SMS não aceitou o pedido. Por favor, contacte o seu administrador.
+error.sms.notification.SP-65004=O SMS não pôde ser enviado porque o serviço de SMS está temporariamente ocupado. Por favor, tente novamente dentro de alguns momentos.
+error.sms.notification.SP-65005=O SMS não pôde ser enviado porque o serviço de SMS encontrou um erro inesperado. Por favor, tente novamente ou contacte o suporte.
+error.sms.notification.SP-65006=O SMS não pôde ser enviado devido a um erro inesperado. Por favor, tente novamente ou contacte o seu administrador.
+error.sms.notification.SP-65007=O SMS não pôde ser entregue. Por favor, tente novamente ou contacte o seu administrador.
+error.sms.notification.SP-65008=O SMS não pôde ser enviado porque o serviço de SMS não está configurado corretamente. Por favor, contacte o seu administrador.
+error.sms.notification.SP-65009=O SMS não pôde ser enviado porque o serviço de SMS não pode ser alcançado. Por favor, contacte o seu administrador.
+error.sms.notification.SP-65010=O SMS não pôde ser enviado porque a conta de mensagens foi suspensa. Por favor, contacte o seu administrador.
+error.sms.notification.SP-65011=O SMS não pôde ser enviado porque o limite da conta foi atingido. Por favor, contacte o seu administrador.
+error.sms.notification.SP-65012=O SMS não pôde ser entregue. O número do destinatário pode estar desligado, fora de cobertura ou não ser um número de telemóvel. Por favor, verifique o número e tente novamente.
+error.sms.notification.SP-65013=O SMS foi bloqueado pela operadora móvel. Isto pode ocorrer devido a filtragem de conteúdo ou restrições do remetente. Por favor, contacte o seu administrador.
+error.sms.notification.SP-65014=O SMS não pôde ser entregue porque o número do destinatário não é permitido. Por favor, contacte o seu administrador.

--- a/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
+++ b/identity-apps-core/apps/authentication-portal/src/main/resources/org/wso2/carbon/identity/application/authentication/endpoint/i18n/Resources_zh_CN.properties
@@ -694,3 +694,37 @@ policy.consent.section.updated.title=已更新的政策
 policy.consent.button.confirm=确认并继续
 policy.consent.button.decline=拒绝
 policy.consent.mandatory=这是一项强制性政策
+
+# Email notification error codes.
+error.email.notification.EP-65001=由于邮件服务器问题，您的电子邮件无法发送。请重试，如果问题仍然存在，请联系支持。
+error.email.notification.EP-65002=由于未提供收件人地址，您的电子邮件无法发送。请重试。
+error.email.notification.EP-65003=由于收件人地址包含不支持的字符，您的电子邮件无法发送。请检查电子邮件地址并重试。
+error.email.notification.EP-65004=由于邮件服务器无法验证发件人，您的电子邮件无法发送。请联系您的管理员。
+error.email.notification.EP-65005=由于收件人地址未被邮件服务器接受，您的电子邮件无法发送。请验证电子邮件地址并重试。
+error.email.notification.EP-65006=电子邮件服务尚未就绪。请联系您的管理员。
+error.email.notification.EP-65007=由于访问被拒绝，电子邮件无法投递。请联系您的管理员。
+error.email.notification.EP-65008=由于配置的账户没有所需权限，电子邮件无法投递。请联系您的管理员。
+error.email.notification.EP-65009=由于电子邮件服务不接受该请求，电子邮件无法投递。请联系您的管理员。
+error.email.notification.EP-65010=由于电子邮件服务接收到太多请求，电子邮件无法投递。请稍后重试。
+error.email.notification.EP-65011=由于电子邮件服务遇到意外错误，电子邮件无法投递。请重试或联系支持。
+error.email.notification.EP-65012=由于电子邮件服务暂时不可用，电子邮件无法投递。请稍后重试。
+error.email.notification.EP-65013=由于无法与电子邮件服务建立连接，电子邮件无法投递。请重试或联系支持。
+error.email.notification.EP-65014=由于服务认证失败，电子邮件无法投递。请联系您的管理员。
+error.email.notification.EP-65015=由于意外错误，通知无法投递。请重试或联系支持。
+error.email.notification.EP-65016=由于反复失败，电子邮件服务暂时停止，电子邮件无法投递。请稍后重试或联系支持。
+
+# SMS notification error codes.
+error.sms.notification.SP-65001=由于与短信服务的身份验证失败，短信无法发送。请联系您的管理员。
+error.sms.notification.SP-65002=由于账户没有所需权限，短信无法发送。请联系您的管理员。
+error.sms.notification.SP-65003=由于短信服务不接受该请求，短信无法发送。请联系您的管理员。
+error.sms.notification.SP-65004=由于短信服务暂时繁忙，短信无法发送。请稍后重试。
+error.sms.notification.SP-65005=由于短信服务遇到意外错误，短信无法发送。请重试或联系支持。
+error.sms.notification.SP-65006=由于意外错误，短信无法发送。请重试或联系您的管理员。
+error.sms.notification.SP-65007=短信无法投递。请重试或联系您的管理员。
+error.sms.notification.SP-65008=由于短信服务配置不正确，短信无法发送。请联系您的管理员。
+error.sms.notification.SP-65009=由于无法到达短信服务，短信无法发送。请联系您的管理员。
+error.sms.notification.SP-65010=由于消息账户已被暂停，短信无法发送。请联系您的管理员。
+error.sms.notification.SP-65011=由于账户限额已达到，短信无法发送。请联系您的管理员。
+error.sms.notification.SP-65012=短信无法投递。收件人的号码可能已关机、不在服务区或不是手机号码。请检查号码并重试。
+error.sms.notification.SP-65013=短信被移动运营商拦截。这可能是由于内容过滤或发件人限制造成的。请联系您的管理员。
+error.sms.notification.SP-65014=由于收件人的号码不被允许，短信无法投递。请联系您的管理员。

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -52,7 +52,14 @@
     if (Boolean.parseBoolean(request.getParameter(Constants.AUTH_FAILURE))) {
         authenticationFailed = "true";
 
-        if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
+        String errorCode = request.getParameter("errorCode");
+        if (StringUtils.isNotBlank(errorCode)) {
+            String errorCodeKey = "error.email.notification." + errorCode;
+            String errorCodeMsg = AuthenticationEndpointUtil.i18n(resourceBundle, errorCodeKey);
+            if (!errorCodeMsg.equalsIgnoreCase(errorCodeKey)) {
+                errorMessage = errorCodeMsg;
+            }
+        } else if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
             String error = request.getParameter(Constants.AUTH_FAILURE_MSG);
 
             if (error.equalsIgnoreCase("authentication.fail.message")) {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
@@ -79,7 +79,14 @@
     if (Boolean.parseBoolean(request.getParameter(Constants.AUTH_FAILURE))) {
         authenticationFailed = "true";
 
-        if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
+        String errorCode = request.getParameter("errorCode");
+        if (StringUtils.isNotBlank(errorCode)) {
+            String errorCodeKey = "error.sms.notification." + errorCode;
+            String errorCodeMsg = AuthenticationEndpointUtil.i18n(resourceBundle, errorCodeKey);
+            if (!errorCodeMsg.equalsIgnoreCase(errorCodeKey)) {
+                errorMessage = errorCodeMsg;
+            }
+        } else if (request.getParameter(Constants.AUTH_FAILURE_MSG) != null) {
             String error = request.getParameter(Constants.AUTH_FAILURE_MSG);
 
             if (error.equalsIgnoreCase("authentication.fail.message")) {

--- a/modules/i18n/src/models/namespaces/authentication-provider-ns.ts
+++ b/modules/i18n/src/models/namespaces/authentication-provider-ns.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -314,6 +314,13 @@ export interface AuthenticationProviderNS {
                         required: string;
                     };
                 };
+                notifyEmailSendingFailure: {
+                    hint: string;
+                    label: string;
+                    validations: {
+                        required: string;
+                    };
+                };
             };
             smsOTP: {
                 hint: string;
@@ -374,7 +381,13 @@ export interface AuthenticationProviderNS {
                         range: string;
                     };
                 };
-
+                notifySmsSendingFailure: {
+                    hint: string;
+                    label: string;
+                    validations: {
+                        required: string;
+                    };
+                };
             };
             push: {
                 hint: string;

--- a/modules/i18n/src/translations/en-US/portals/authentication-provider.ts
+++ b/modules/i18n/src/translations/en-US/portals/authentication-provider.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import { AuthenticationProviderNS } from "../../../models";
 /**
  * NOTES: No need to care about the max-len for this file since it's easier to
@@ -332,6 +333,13 @@ export const authenticationProvider:AuthenticationProviderNS = {
                     label: "Use alphanumeric characters for OTP",
                     validations: {
                         required: "Use alphanumeric characters for OTP is a required field."
+                    }
+                },
+                notifyEmailSendingFailure: {
+                    hint: "Notify users when OTP delivery fails, instead of proceeding silently.",
+                    label: "Notify users on OTP delivery failure",
+                    validations: {
+                        required: "Notify users on OTP delivery failure is a required field."
                     }
                 }
             },
@@ -889,6 +897,13 @@ export const authenticationProvider:AuthenticationProviderNS = {
                     label: "Use only numeric characters for OTP",
                     validations: {
                         required: "Use only numeric characters for OTP token is a required field."
+                    }
+                },
+                notifySmsSendingFailure: {
+                    hint: "Notify users when OTP delivery fails, instead of proceeding silently.",
+                    label: "Notify users on OTP delivery failure",
+                    validations: {
+                        required: "Notify users on OTP delivery failure is a required field."
                     }
                 }
             },


### PR DESCRIPTION
## Purpose

Adds support for surfacing provider-level OTP delivery failures to users during Email OTP and SMS OTP authentication flows.

Previously, when the OTP delivery failed (e.g., due to a mail server issue or SMS provider error), the authentication portal would show a generic failure message or proceed silently. This change allows administrators to enable user-facing notifications with specific, descriptive error messages based on the error code returned by the provider.

## Changes

### Admin Console
- Added a new **"Notify users on OTP delivery failure"** checkbox to the Email OTP authenticator settings (`EmailOTP_NotifyEmailSendingFailure`) and SMS OTP authenticator settings (`SmsOTP_NotifySmsSendingFailure`).
- When enabled, users will see a descriptive error message on the login page if OTP delivery fails, rather than a silent continuation or generic error.

### Authentication Portal
- Updated `emailOtp.jsp` and `smsOtp.jsp` to check for an `errorCode` request parameter on authentication failure.
- Error codes are resolved to locale-specific messages via i18n keys (`error.email.notification.<code>` / `error.sms.notification.<code>`).
- Falls back to the existing `AUTH_FAILURE_MSG` handling if no error code is present.

### i18n
- Added 16 email notification error codes (EP-65001 – EP-65016) and 14 SMS notification error codes (SP-65001 – SP-65014) across all supported locales.
- Added `notifyEmailSendingFailure` and `notifySmsSendingFailure` translation keys to the admin console authentication provider namespace.

## Related Issue
- https://github.com/wso2/product-is/issues/28017