### PR TITLE
Replace inline array defaults with module-level constants for memoization optimization

### DIFF
--- a/.changeset/cozy-showers-start.md
+++ b/.changeset/cozy-showers-start.md
@@ -1,0 +1,9 @@
+---
+"@wso2is/admin.approval-workflows.v1": patch
+"@wso2is/admin.flow-builder-core.v1": patch
+"@wso2is/admin.policy-administration.v1": patch
+"@wso2is/admin.rules.v1": patch
+"@wso2is/admin.webhooks.v1": patch
+---
+
+Replace inline array default props with module-level constants to prevent unnecessary re-renders

--- a/.changeset/cozy-showers-start.md
+++ b/.changeset/cozy-showers-start.md
@@ -4,6 +4,8 @@
 "@wso2is/admin.policy-administration.v1": patch
 "@wso2is/admin.rules.v1": patch
 "@wso2is/admin.webhooks.v1": patch
+"@wso2is/core": patch
+"@wso2is/console": patch
 ---
 
 Replace inline array default props with module-level constants to prevent unnecessary re-renders

--- a/features/admin.approval-workflows.v1/components/rules/workflow-condition-value-input.tsx
+++ b/features/admin.approval-workflows.v1/components/rules/workflow-condition-value-input.tsx
@@ -33,6 +33,8 @@ import WorkflowConditionTextInput from "./workflow-condition-text-input";
 import WorkflowResourceListSelect from "./workflow-resource-list-select";
 import { APPROVAL_WORKFLOW_RULE_FIELDS } from "../../constants/approval-workflow-constants";
 
+const EMPTY_STRING_ARRAY: string[] = [];
+
 /**
  * Props interface of {@link WorkflowConditionValueInput}
  */
@@ -66,8 +68,8 @@ const WorkflowConditionValueInput: FunctionComponent<WorkflowConditionValueInput
     expressionValue: _expressionValue,
     metaValue,
     setIsResourceMissing,
-    hiddenResources: _hiddenResources = [],
-    hiddenValues: _hiddenValues = [],
+    hiddenResources: _hiddenResources = EMPTY_STRING_ARRAY,
+    hiddenValues: _hiddenValues = EMPTY_STRING_ARRAY,
     readonly: isReadonly,
     showValidationError = false
 }: WorkflowConditionValueInputPropsInterface) => {

--- a/features/admin.approval-workflows.v1/components/rules/workflow-condition-value-input.tsx
+++ b/features/admin.approval-workflows.v1/components/rules/workflow-condition-value-input.tsx
@@ -26,14 +26,13 @@ import {
     ListDataInterface
 } from "@wso2is/admin.rules.v1/models/meta";
 import { ExpressionFieldTypes } from "@wso2is/admin.rules.v1/models/rules";
+import { EMPTY_ARRAY } from "@wso2is/core/constants";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, { Dispatch, FunctionComponent } from "react";
 import RoleAudienceValueSelector from "./role-audience-value-selector";
 import WorkflowConditionTextInput from "./workflow-condition-text-input";
 import WorkflowResourceListSelect from "./workflow-resource-list-select";
 import { APPROVAL_WORKFLOW_RULE_FIELDS } from "../../constants/approval-workflow-constants";
-
-const EMPTY_STRING_ARRAY: string[] = [];
 
 /**
  * Props interface of {@link WorkflowConditionValueInput}
@@ -68,8 +67,8 @@ const WorkflowConditionValueInput: FunctionComponent<WorkflowConditionValueInput
     expressionValue: _expressionValue,
     metaValue,
     setIsResourceMissing,
-    hiddenResources: _hiddenResources = EMPTY_STRING_ARRAY,
-    hiddenValues: _hiddenValues = EMPTY_STRING_ARRAY,
+    hiddenResources: _hiddenResources = EMPTY_ARRAY,
+    hiddenValues: _hiddenValues = EMPTY_ARRAY,
     readonly: isReadonly,
     showValidationError = false
 }: WorkflowConditionValueInputPropsInterface) => {

--- a/features/admin.approval-workflows.v1/components/rules/workflow-resource-autocomplete.tsx
+++ b/features/admin.approval-workflows.v1/components/rules/workflow-resource-autocomplete.tsx
@@ -44,6 +44,8 @@ import AutoCompleteRenderOption from "./auto-complete-render-option";
 import useGetWorkflowResources from "../../hooks/use-get-workflow-resources";
 import { normalizeResourceResponse, processResourceItems } from "../../utils/resource-utils";
 
+const EMPTY_STRING_ARRAY: string[] = [];
+
 /**
  * Value input autocomplete options interface.
  */
@@ -93,7 +95,7 @@ const WorkflowResourceAutocomplete: FunctionComponent<WorkflowResourceAutocomple
     conditionId: _conditionId,
     expressionId: _expressionId,
     shouldFetch,
-    hiddenResources: _hiddenResources = [],
+    hiddenResources: _hiddenResources = EMPTY_STRING_ARRAY,
     showClearFilter = false,
     readonly: isReadonly,
     showValidationError = false

--- a/features/admin.approval-workflows.v1/components/rules/workflow-resource-autocomplete.tsx
+++ b/features/admin.approval-workflows.v1/components/rules/workflow-resource-autocomplete.tsx
@@ -28,6 +28,7 @@ import { AppState } from "@wso2is/admin.core.v1/store";
 import useRulesContext from "@wso2is/admin.rules.v1/hooks/use-rules-context";
 import { ResourceInterface } from "@wso2is/admin.rules.v1/models/resource";
 import { ExpressionFieldTypes } from "@wso2is/admin.rules.v1/models/rules";
+import { EMPTY_ARRAY } from "@wso2is/core/constants";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import debounce from "lodash-es/debounce";
 import React, {
@@ -43,8 +44,6 @@ import { useSelector } from "react-redux";
 import AutoCompleteRenderOption from "./auto-complete-render-option";
 import useGetWorkflowResources from "../../hooks/use-get-workflow-resources";
 import { normalizeResourceResponse, processResourceItems } from "../../utils/resource-utils";
-
-const EMPTY_STRING_ARRAY: string[] = [];
 
 /**
  * Value input autocomplete options interface.
@@ -95,7 +94,7 @@ const WorkflowResourceAutocomplete: FunctionComponent<WorkflowResourceAutocomple
     conditionId: _conditionId,
     expressionId: _expressionId,
     shouldFetch,
-    hiddenResources: _hiddenResources = EMPTY_STRING_ARRAY,
+    hiddenResources: _hiddenResources = EMPTY_ARRAY,
     showClearFilter = false,
     readonly: isReadonly,
     showValidationError = false

--- a/features/admin.approval-workflows.v1/components/rules/workflow-resource-list-select.tsx
+++ b/features/admin.approval-workflows.v1/components/rules/workflow-resource-list-select.tsx
@@ -25,6 +25,7 @@ import useRulesContext from "@wso2is/admin.rules.v1/hooks/use-rules-context";
 import { ConditionExpressionMetaInterface } from "@wso2is/admin.rules.v1/models/meta";
 import { ResourceInterface } from "@wso2is/admin.rules.v1/models/resource";
 import { ExpressionFieldTypes } from "@wso2is/admin.rules.v1/models/rules";
+import { EMPTY_ARRAY } from "@wso2is/core/constants";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import React, {
     Dispatch,
@@ -39,8 +40,6 @@ import AutoCompleteRenderOption from "./auto-complete-render-option";
 import WorkflowResourceAutocomplete from "./workflow-resource-autocomplete";
 import useGetWorkflowResources from "../../hooks/use-get-workflow-resources";
 import { normalizeResourceResponse, processResourceItems } from "../../utils/resource-utils";
-
-const EMPTY_STRING_ARRAY: string[] = [];
 
 /**
  * Props interface of {@link WorkflowResourceListSelect}
@@ -76,7 +75,7 @@ const WorkflowResourceListSelect: FunctionComponent<WorkflowResourceListSelectPr
     findMetaValuesAgainst,
     initialResourcesLoadUrl,
     filterBaseResourcesUrl,
-    hiddenResources: _hiddenResources = EMPTY_STRING_ARRAY,
+    hiddenResources: _hiddenResources = EMPTY_ARRAY,
     readonly: isReadonly,
     showValidationError = false
 }: WorkflowResourceListSelectPropsInterface) => {

--- a/features/admin.approval-workflows.v1/components/rules/workflow-resource-list-select.tsx
+++ b/features/admin.approval-workflows.v1/components/rules/workflow-resource-list-select.tsx
@@ -40,6 +40,8 @@ import WorkflowResourceAutocomplete from "./workflow-resource-autocomplete";
 import useGetWorkflowResources from "../../hooks/use-get-workflow-resources";
 import { normalizeResourceResponse, processResourceItems } from "../../utils/resource-utils";
 
+const EMPTY_STRING_ARRAY: string[] = [];
+
 /**
  * Props interface of {@link WorkflowResourceListSelect}
  */
@@ -74,7 +76,7 @@ const WorkflowResourceListSelect: FunctionComponent<WorkflowResourceListSelectPr
     findMetaValuesAgainst,
     initialResourcesLoadUrl,
     filterBaseResourcesUrl,
-    hiddenResources: _hiddenResources = [],
+    hiddenResources: _hiddenResources = EMPTY_STRING_ARRAY,
     readonly: isReadonly,
     showValidationError = false
 }: WorkflowResourceListSelectPropsInterface) => {

--- a/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
+++ b/features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
@@ -59,6 +59,9 @@ import ElementPropertiesPanel from "../resource-property-panel/resource-property
 import ValidationPanel from "../validation-panel/validation-panel";
 import VersionHistoryPanel from "../version-history-panel/version-history-panel";
 
+const EMPTY_NODES: Node[] = [];
+const EMPTY_EDGES: Edge[] = [];
+
 /**
  * Props interface of {@link DecoratedVisualFlow}
  */
@@ -91,8 +94,8 @@ const DecoratedVisualFlow: FunctionComponent<DecoratedVisualFlowPropsInterface> 
     "data-componentid": componentId = "authentication-flow-visual-editor",
     aiGeneratedFlow,
     resources,
-    initialNodes = [],
-    initialEdges = [],
+    initialNodes = EMPTY_NODES,
+    initialEdges = EMPTY_EDGES,
     setNodes,
     setEdges,
     edges,

--- a/features/admin.policy-administration.v1/components/policy-list.tsx
+++ b/features/admin.policy-administration.v1/components/policy-list.tsx
@@ -31,6 +31,8 @@ import PolicyListNode from "./policy-list-node";
 import { PolicyInterface } from "../models/policies";
 import "./policy-list.scss";
 
+const EMPTY_POLICIES: PolicyInterface[] = [];
+
 interface PolicyListProps extends IdentifiableComponentInterface {
     onDrop?: (containerId: string) => void;
     policies?: PolicyInterface[]; // Use PolicyInterface[]
@@ -66,7 +68,7 @@ interface PolicyListProps extends IdentifiableComponentInterface {
 
 export const PolicyList: React.FunctionComponent<PolicyListProps> = ({
     onDrop,
-    policies = [],
+    policies = EMPTY_POLICIES,
     deleteActivePolicy,
     deleteInactivePolicy,
     activatePolicy,

--- a/features/admin.policy-administration.v1/components/policy-list.tsx
+++ b/features/admin.policy-administration.v1/components/policy-list.tsx
@@ -18,6 +18,7 @@
 
 import { DroppableContainer, GetDragItemProps, useDnD  } from "@oxygen-ui/react/dnd";
 import { getEmptyPlaceholderIllustrations } from "@wso2is/admin.core.v1/configs/ui";
+import { EMPTY_ARRAY } from "@wso2is/core/constants";
 import {
     IdentifiableComponentInterface
 } from "@wso2is/core/models";
@@ -30,8 +31,6 @@ import PolicyListDraggableNode from "./policy-list-draggable-node";
 import PolicyListNode from "./policy-list-node";
 import { PolicyInterface } from "../models/policies";
 import "./policy-list.scss";
-
-const EMPTY_POLICIES: PolicyInterface[] = [];
 
 interface PolicyListProps extends IdentifiableComponentInterface {
     onDrop?: (containerId: string) => void;
@@ -68,7 +67,7 @@ interface PolicyListProps extends IdentifiableComponentInterface {
 
 export const PolicyList: React.FunctionComponent<PolicyListProps> = ({
     onDrop,
-    policies = EMPTY_POLICIES,
+    policies = EMPTY_ARRAY,
     deleteActivePolicy,
     deleteInactivePolicy,
     activatePolicy,

--- a/features/admin.rules.v1/components/rule-conditions.tsx
+++ b/features/admin.rules.v1/components/rule-conditions.tsx
@@ -57,7 +57,7 @@ import {
     RuleInterface
 } from "../models/rules";
 import "./rule-conditions.scss";
-
+const EMPTY_STRING_ARRAY: string[] = [];
 /**
  * Value input autocomplete options interface.
  */
@@ -210,7 +210,7 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         conditionId,
         expressionId,
         shouldFetch,
-        hiddenResources = []
+        hiddenResources = EMPTY_STRING_ARRAY
     }: ValueInputAutocompleteProps) => {
 
         const [ inputValue, setInputValue ] = useState<string>(null);

--- a/features/admin.rules.v1/components/rule-conditions.tsx
+++ b/features/admin.rules.v1/components/rule-conditions.tsx
@@ -57,7 +57,9 @@ import {
     RuleInterface
 } from "../models/rules";
 import "./rule-conditions.scss";
+
 const EMPTY_STRING_ARRAY: string[] = [];
+
 /**
  * Value input autocomplete options interface.
  */

--- a/features/admin.rules.v1/components/rule-conditions.tsx
+++ b/features/admin.rules.v1/components/rule-conditions.tsx
@@ -403,7 +403,7 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         findMetaValuesAgainst,
         initialResourcesLoadUrl,
         filterBaseResourcesUrl,
-        hiddenResources = []
+        hiddenResources = EMPTY_STRING_ARRAY
     }: ResourceListSelectProps) => {
 
         const [ resourceDetails, setResourceDetails ] = useState<ResourceInterface>(null);
@@ -666,8 +666,8 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         expressionValue,
         metaValue,
         setIsResourceMissing,
-        hiddenResources = [],
-        hiddenValues = []
+        hiddenResources = EMPTY_STRING_ARRAY,
+        hiddenValues = EMPTY_STRING_ARRAY
     }: ConditionValueInputProps) => {
 
         if (metaValue?.inputType === "input" || null) {
@@ -780,9 +780,9 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         index,
         isConditionLast,
         isConditionExpressionRemovable,
-        hiddenConditions = [],
-        hiddenResources = [],
-        hiddenValues = []
+        hiddenConditions = EMPTY_STRING_ARRAY,
+        hiddenResources = EMPTY_STRING_ARRAY,
+        hiddenValues = EMPTY_STRING_ARRAY
     }: RuleExpressionComponentProps) => {
 
         const [ isResourceMissing, setIsResourceMissing ] = useState<boolean>(false);

--- a/features/admin.rules.v1/components/rule-conditions.tsx
+++ b/features/admin.rules.v1/components/rule-conditions.tsx
@@ -32,6 +32,7 @@ import MenuItem from "@oxygen-ui/react/MenuItem";
 import Select, { SelectChangeEvent } from "@oxygen-ui/react/Select";
 import TextField from "@oxygen-ui/react/TextField";
 import { MinusIcon, PlusIcon, TrashIcon } from "@oxygen-ui/react-icons";
+import { EMPTY_ARRAY } from "@wso2is/core/constants";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { Code } from "@wso2is/react-components";
 import debounce from "lodash-es/debounce";
@@ -57,8 +58,6 @@ import {
     RuleInterface
 } from "../models/rules";
 import "./rule-conditions.scss";
-
-const EMPTY_STRING_ARRAY: string[] = [];
 
 /**
  * Value input autocomplete options interface.
@@ -212,7 +211,7 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         conditionId,
         expressionId,
         shouldFetch,
-        hiddenResources = EMPTY_STRING_ARRAY
+        hiddenResources = EMPTY_ARRAY
     }: ValueInputAutocompleteProps) => {
 
         const [ inputValue, setInputValue ] = useState<string>(null);
@@ -405,7 +404,7 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         findMetaValuesAgainst,
         initialResourcesLoadUrl,
         filterBaseResourcesUrl,
-        hiddenResources = EMPTY_STRING_ARRAY
+        hiddenResources = EMPTY_ARRAY
     }: ResourceListSelectProps) => {
 
         const [ resourceDetails, setResourceDetails ] = useState<ResourceInterface>(null);
@@ -668,8 +667,8 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         expressionValue,
         metaValue,
         setIsResourceMissing,
-        hiddenResources = EMPTY_STRING_ARRAY,
-        hiddenValues = EMPTY_STRING_ARRAY
+        hiddenResources = EMPTY_ARRAY,
+        hiddenValues = EMPTY_ARRAY
     }: ConditionValueInputProps) => {
 
         if (metaValue?.inputType === "input" || null) {
@@ -782,9 +781,9 @@ const RuleConditions: FunctionComponent<RulesComponentPropsInterface> = ({
         index,
         isConditionLast,
         isConditionExpressionRemovable,
-        hiddenConditions = EMPTY_STRING_ARRAY,
-        hiddenResources = EMPTY_STRING_ARRAY,
-        hiddenValues = EMPTY_STRING_ARRAY
+        hiddenConditions = EMPTY_ARRAY,
+        hiddenResources = EMPTY_ARRAY,
+        hiddenValues = EMPTY_ARRAY
     }: RuleExpressionComponentProps) => {
 
         const [ isResourceMissing, setIsResourceMissing ] = useState<boolean>(false);

--- a/features/admin.webhooks.v1/components/webhook-channel-config-form.tsx
+++ b/features/admin.webhooks.v1/components/webhook-channel-config-form.tsx
@@ -27,6 +27,8 @@ import { Icon } from "semantic-ui-react";
 import { WebhookChannelConfigInterface } from "../models/event-profile";
 import { ChannelStatus, WebhookChannelSubscriptionInterface } from "../models/webhooks";
 
+const EMPTY_CHANNEL_SUBSCRIPTIONS: WebhookChannelSubscriptionInterface[] = [];
+
 interface WebhookChannelConfigFormInterface extends IdentifiableComponentInterface {
     /**
      * Specifies the channel configurations for the form.
@@ -45,7 +47,7 @@ interface WebhookChannelConfigFormInterface extends IdentifiableComponentInterfa
 const WebhookChannelConfigForm: FunctionComponent<WebhookChannelConfigFormInterface> = ({
     channelConfigs,
     isReadOnly,
-    channelSubscriptions = [],
+    channelSubscriptions = EMPTY_CHANNEL_SUBSCRIPTIONS,
     ["data-componentid"]: _componentId = "webhook-channel-config-form"
 }: WebhookChannelConfigFormInterface): ReactElement => {
     const defaultChannels: WebhookChannelConfigInterface[] = channelConfigs;

--- a/features/admin.webhooks.v1/components/webhook-channel-config-form.tsx
+++ b/features/admin.webhooks.v1/components/webhook-channel-config-form.tsx
@@ -18,6 +18,7 @@
 
 import "./webhook-channel-config-form.scss";
 import { Box, FormGroup, Grid, Typography } from "@mui/material";
+import { EMPTY_ARRAY } from "@wso2is/core/constants";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
 import { FinalFormField } from "@wso2is/forms";
 import CheckboxAdapter from "@wso2is/forms/src/components/adapters/checkbox-field-adapter";
@@ -26,8 +27,6 @@ import { useTranslation } from "react-i18next";
 import { Icon } from "semantic-ui-react";
 import { WebhookChannelConfigInterface } from "../models/event-profile";
 import { ChannelStatus, WebhookChannelSubscriptionInterface } from "../models/webhooks";
-
-const EMPTY_CHANNEL_SUBSCRIPTIONS: WebhookChannelSubscriptionInterface[] = [];
 
 interface WebhookChannelConfigFormInterface extends IdentifiableComponentInterface {
     /**
@@ -47,7 +46,7 @@ interface WebhookChannelConfigFormInterface extends IdentifiableComponentInterfa
 const WebhookChannelConfigForm: FunctionComponent<WebhookChannelConfigFormInterface> = ({
     channelConfigs,
     isReadOnly,
-    channelSubscriptions = EMPTY_CHANNEL_SUBSCRIPTIONS,
+    channelSubscriptions = EMPTY_ARRAY,
     ["data-componentid"]: _componentId = "webhook-channel-config-form"
 }: WebhookChannelConfigFormInterface): ReactElement => {
     const defaultChannels: WebhookChannelConfigInterface[] = channelConfigs;

--- a/modules/core/src/constants/common-constants.ts
+++ b/modules/core/src/constants/common-constants.ts
@@ -17,6 +17,13 @@
  */
 
 /**
+ * A frozen empty array assignable to any typed array prop default.
+ * Use this instead of inline `= []` to avoid creating a new array reference on every render,
+ * which would defeat React.memo and useMemo optimizations.
+ */
+export const EMPTY_ARRAY: never[] = Object.freeze([]) as unknown as never[];
+
+/**
  * Class containing common constants which can be used across several applications.
  */
 export class CommonConstants {


### PR DESCRIPTION
### Purpose

Fix inline array default prop references that create new array objects on every render, defeating memoization. Replaces 20 occurrences of inline `= []` prop defaults with module-level constants typed to the correct array type across 7 files in 5 feature packages.

fixes https://github.com/wso2/product-is/issues/27956


**Files modified:**

- features/admin.rules.v1/components/rule-conditions.tsx
- features/admin.approval-workflows.v1/components/rules/workflow-condition-value-input.tsx
- features/admin.approval-workflows.v1/components/rules/workflow-resource-autocomplete.tsx
- features/admin.approval-workflows.v1/components/rules/workflow-resource-list-select.tsx
- features/admin.flow-builder-core.v1/components/visual-flow/decorated-visual-flow.tsx
- features/admin.policy-administration.v1/components/policy-list.tsx
- features/admin.webhooks.v1/components/webhook-channel-config-form.tss


### Related PRs
- N/A

### Checklist

- [x] Manual test round performed and verified.


### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)

[Behavioural Change] No, this is a pure performance refactor. Component output and behavior are identical. Only the memory reference of default array props changed, which is invisible to users.

[Migration Impact] No, no API changes, no data changes, no breaking changes.

[New Configuration] No, no new props, config keys, or deployment configuration changes.
