### PR TITLE
Skip protocol template fetch and edit redirect for flow extension connections

### DIFF
--- a/features/admin.connections.v1/components/create/authenticator-create-wizard-factory.tsx
+++ b/features/admin.connections.v1/components/create/authenticator-create-wizard-factory.tsx
@@ -74,6 +74,14 @@ interface AuthenticatorCreateWizardFactoryInterface extends IdentifiableComponen
 }
 
 /**
+ * Connection template Ids created through their own dedicated wizard in ConnectionCreateWizardFactory.
+ * These have no protocol template and don't need the duplicate-name lookup, so both fetches are skipped.
+ */
+const TEMPLATES_WITH_DEDICATED_WIZARD: string[] = [
+    CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.FLOW_EXTENSION
+];
+
+/**
  * Authenticator Create Wizard factory.
  *
  * @param props - Props injected to the component.
@@ -108,6 +116,8 @@ export const AuthenticatorCreateWizardFactory: FC<AuthenticatorCreateWizardFacto
 
     const productName: string = useSelector((state: AppState) => state?.config?.ui?.productName);
 
+    const hasDedicatedWizard: boolean = TEMPLATES_WITH_DEDICATED_WIZARD.includes(type);
+
     const {
         data: connectionsResponse,
         isLoading: isConnectionsFetchRequestLoading,
@@ -117,19 +127,17 @@ export const AuthenticatorCreateWizardFactory: FC<AuthenticatorCreateWizardFacto
         null,
         !selectedTemplate?.idp?.name ? "name sw " + selectedTemplate?.name : "name sw " + selectedTemplate?.idp?.name,
         null,
-        true
+        !hasDedicatedWizard
     );
-
-    // The Flow Extension template has no protocol template to fetch — it is handled by a
-    // dedicated wizard in ConnectionCreateWizardFactory, so skip the template fetch for it.
-    const shouldFetchTemplate: boolean = type !== null
-        && type !== CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.FLOW_EXTENSION;
 
     const {
         data: connectionTemplate,
         isLoading: isConnectionTemplateFetchRequestLoading,
         error: connectionTemplateFetchRequestError
-    } = useGetConnectionTemplate(type === "enterprise-protocols" ? "enterprise-idp" : type, shouldFetchTemplate);
+    } = useGetConnectionTemplate(
+        type === "enterprise-protocols" ? "enterprise-idp" : type,
+        type !== null && !hasDedicatedWizard
+    );
 
     useEffect(() => {
         if (connectionsFetchRequestError) {

--- a/features/admin.connections.v1/pages/connection-edit.tsx
+++ b/features/admin.connections.v1/pages/connection-edit.tsx
@@ -340,7 +340,9 @@ const ConnectionEditPage: FunctionComponent<ConnectionEditPagePropsInterface> = 
             identityProviderTemplate?.id ===
             CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.TWO_FACTOR_CUSTOM_AUTHENTICATOR ||
             identityProviderTemplate?.id ===
-            CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.OUTBOUND_PROVISIONING_CONNECTION
+            CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.OUTBOUND_PROVISIONING_CONNECTION ||
+            identityProviderTemplate?.id ===
+            CommonAuthenticatorConstants.CONNECTION_TEMPLATE_IDS.FLOW_EXTENSION
         ) {
             return;
         }


### PR DESCRIPTION
## Purpose
Flow extension connections are created through their own dedicated wizard in `ConnectionCreateWizardFactory` and have no protocol template. The generic authenticator create wizard was still issuing the protocol template fetch and the duplicate-name lookup for these connections, and the connection edit page was not treating them like the other template-driven connections. This change skips the unnecessary fetches and aligns the edit-page handling for flow extension connections.

## Implementation
- Introduced a `TEMPLATES_WITH_DEDICATED_WIZARD` list in `authenticator-create-wizard-factory.tsx` containing the flow extension template id, and a derived `hasDedicatedWizard` flag.
- Used the flag to skip both the duplicate-name connections lookup and the protocol template fetch for connections with a dedicated wizard, replacing the previous inline `shouldFetchTemplate` check.
- Added the flow extension template id to the early-return condition in `connection-edit.tsx` so it is handled consistently with the other template-driven connections.