### PR TITLE
Resolve mobile keyboard OTP autofill truncation in segmented inputs

### DIFF
--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/backup-code.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/backup-code.jsp
@@ -37,6 +37,7 @@
 
 <%
     request.getSession().invalidate();
+    int otpLength = 6;
     String errorMessage = AuthenticationEndpointUtil.i18n(resourceBundle,"error.retry");
     String authenticationFailed = "false";
     if (Boolean.parseBoolean(request.getParameter(Constants.AUTH_FAILURE))) {
@@ -105,9 +106,19 @@
             // Handle form submission via a single guarded path.
             $(document).ready(function(){
                 $('#backupCodeForm').on('submit', function (e) {
-                    e.preventDefault();
-                    handleSubmit();
-                    return false;
+                    if (isBackupCodeSubmitting) {
+                        e.preventDefault();
+                        return false;
+                    }
+                    var backupInput = document.getElementById('backupOTPInput');
+                    var backupCodeField = document.getElementById('BackupCode');
+                    if (backupInput && backupCodeField) backupCodeField.value = backupInput.value;
+                    isBackupCodeSubmitting = true;
+                    $('#subButton').attr('disabled', true);
+                    $('#subButton').addClass('loading');
+                    trackEvent("authentication-portal-backup-code-click-continue", {
+                        "tenant": insightsTenantIdentifier != "null" ? insightsTenantIdentifier : ""
+                    });
                 });
             });
         </script>
@@ -163,74 +174,24 @@
                                 <input hidden type="text"  id="BackupCode" name="BackupCode" class="form-control">
                             </div>
 
-                            <div class="equal width fields">
+                            <div class="equal width fields segmented-otp-field">
+                                <input
+                                    type="text"
+                                    id="backupOTPInput"
+                                    class="segmented-otp-input"
+                                    maxlength="<%= otpLength %>"
+                                    autocomplete="one-time-code"
+                                    autocorrect="off"
+                                    autocapitalize="off"
+                                    spellcheck="false"
+                                    autofocus
+                                    aria-label="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "enter.backup.code")%>"
+                                >
+                                <% for (int i = 1; i <= otpLength; i++) { %>
                                 <div class="field mt-5">
-                                    <input
-                                        class="text-center p-1 pb-3 pt-3"
-                                        id="pincode-1"
-                                        name="pincode-1"
-                                        tabindex="1"
-                                        placeholder="·"
-                                        maxlength="1"
-                                        onkeyup="movetoNext(this, 'pincode-2', null)"
-                                        autocomplete="off"
-                                        autofocus>
+                                    <div class="text-center p-1 pb-3 pt-3" id="pincode-<%=i%>" aria-hidden="true">·</div>
                                 </div>
-                                <div class="field mt-5">
-                                    <input
-                                        class="text-center p-1 pb-3 pt-3"
-                                        id="pincode-2"
-                                        name="pincode-2"
-                                        onkeyup="movetoNext(this, 'pincode-3', 'pincode-1')"
-                                        tabindex="2"
-                                        placeholder="·"
-                                        maxlength="1"
-                                        autocomplete="off">
-                                </div>
-                                <div class="field mt-5">
-                                    <input
-                                        class="text-center p-1 pb-3 pt-3"
-                                        id="pincode-3"
-                                        name="pincode-3"
-                                        tabindex="3"
-                                        placeholder="·"
-                                        maxlength="1"
-                                        onkeyup="movetoNext(this, 'pincode-4', 'pincode-2')"
-                                        autocomplete="off">
-                                </div>
-                                <div class="field mt-5">
-                                    <input
-                                        class="text-center p-1 pb-3 pt-3"
-                                        id="pincode-4"
-                                        name="pincode-4"
-                                        tabindex="4"
-                                        placeholder="·"
-                                        maxlength="1"
-                                        onkeyup="movetoNext(this, 'pincode-5', 'pincode-3')"
-                                        autocomplete="off">
-                                </div>
-                                <div class="field mt-5">
-                                    <input
-                                        class="text-center p-1 pb-3 pt-3"
-                                        id="pincode-5"
-                                        name="pincode-5"
-                                        tabindex="5"
-                                        placeholder="·"
-                                        maxlength="1"
-                                        onkeyup="movetoNext(this, 'pincode-6', 'pincode-4')"
-                                        autocomplete="off">
-                                </div>
-                                <div class="field mt-5">
-                                    <input
-                                        class="text-center p-1 pb-3 pt-3"
-                                        id="pincode-6"
-                                        name="pincode-6"
-                                        tabindex="6"
-                                        placeholder="·"
-                                        maxlength="1"
-                                        onkeyup="movetoNext(this, null, 'pincode-5')"
-                                        autocomplete="off">
-                                </div>
+                                <% } %>
                             </div>
 
                             <input id="sessionDataKey" type="hidden" name="sessionDataKey"
@@ -296,70 +257,62 @@
 
         <script type="text/javascript">
             var insightsTenantIdentifier = "<%=userTenant%>";
-            function movetoNext(current, nextFieldID, previousID) {
-                var key = event.keyCode || event.charCode;
-                if (nextFieldID != null && current.value.length >= current.maxLength) {
-                    document.getElementById(nextFieldID).focus();
-                }
-                if( key == 8 || key == 46 ) {
-                    if ( previousID != null) {
-                        document.getElementById(previousID).focus();
-                    }
+
+            function updateBackupDigitBoxes(value) {
+                for (var i = 1; i <= <%= otpLength %>; i++) {
+                    var box = document.getElementById('pincode-' + i);
+                    if (box) box.textContent = (value.length >= i) ? value[i - 1] : '·';
                 }
             }
-            function handleSubmit() {
-                if (isBackupCodeSubmitting) {
-                    return false;
-                }
 
-                var pin1 = document.getElementById("pincode-1").value;
-                var pin2 = document.getElementById("pincode-2").value;
-                var pin3 = document.getElementById("pincode-3").value;
-                var pin4 = document.getElementById("pincode-4").value;
-                var pin5 = document.getElementById("pincode-5").value;
-                var pin6 = document.getElementById("pincode-6").value;
-                var token = pin1 + pin2 + pin3 + pin4 + pin5 + pin6;
-                document.getElementById('BackupCode').value = token;
-                var isValidToken = pin1 !== "" && pin2 !== "" && pin3 !== "" && pin4 !== "" && pin5 !== "" && pin6 !== "";
-                if (isValidToken) {
-                    isBackupCodeSubmitting = true;
-                    $('#subButton').attr('disabled', true);
-                    $('#subButton').addClass('loading');
-                    trackEvent("authentication-portal-backup-code-click-continue", {
-                        "tenant": insightsTenantIdentifier != "null" ? insightsTenantIdentifier : ""
-                    });
-                    document.getElementById("backupCodeForm").submit();
-                }
+            var backupInput = document.getElementById('backupOTPInput');
+            var backupCodeField = document.getElementById('BackupCode');
+            var submitBtn = document.getElementById('subButton');
 
-                return false;
+            function updateBackupCursor(value) {
+                for (var i = 1; i <= <%= otpLength %>; i++) {
+                    var box = document.getElementById('pincode-' + i);
+                    if (box) box.classList.remove('active-pincode');
+                }
+                if (value.length < <%= otpLength %>) {
+                    var activeBox = document.getElementById('pincode-' + (value.length + 1));
+                    if (activeBox) activeBox.classList.add('active-pincode');
+                }
             }
-            // Handle paste events
+
             function handlePaste(e) {
-                var clipboardData, value;
-                // Stop data actually being pasted into element
-                e.stopPropagation();
                 e.preventDefault();
-                // Get pasted data via clipboard API
-                clipboardData = e.clipboardData || window.clipboardData;
-                value = clipboardData.getData('Text');
-                const reg = new RegExp(/^\d+$/);
-                if (reg.test(value)) {
-                    for (n = 0; n < 6; ++n) {
-                        $("#pincode-" + (n+1)).val(value[n]);
-                        $("#pincode-" + (n+1)).focus();
-                    }
-                }
+                var pasted = (e.clipboardData || window.clipboardData).getData('Text').replace(/\s/g, '');
+                if (!/^\d+$/.test(pasted)) return;
+                backupInput.value = pasted.slice(0, <%= otpLength %>);
+                backupInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
             }
-            document.getElementById('pincode-1').addEventListener('paste', handlePaste);
-            $('#subButton').attr('disabled', true);
-            $('#pincode-6').on('keyup', function() {
-                if ($('#pincode-1').val() != '' && $('#pincode-2').val() != ''
-                && $('#pincode-3').val() != '' && $('#pincode-4').val() != '' && $('#pincode-5').val() != ''  && $('#pincode-6').val() != '') {
-                    $('#subButton').attr('disabled', false);
-                } else {
-                    $('#subButton').attr('disabled', true);
-                }
-            });
+
+            function handleInput() {
+                var sanitized = backupInput.value.replace(/\s/g, '');
+                if (sanitized !== backupInput.value) backupInput.value = sanitized;
+                backupCodeField.value = sanitized;
+                updateBackupDigitBoxes(sanitized);
+                updateBackupCursor(sanitized);
+                submitBtn.disabled = sanitized.length !== <%= otpLength %>;
+            }
+
+            if (backupInput) {
+                document.addEventListener('selectionchange', function () {
+                    if (document.activeElement === backupInput) {
+                        backupInput.selectionStart = backupInput.selectionEnd = backupInput.value.length;
+                    }
+                });
+                backupInput.addEventListener('copy', function (e) { e.preventDefault(); });
+                backupInput.addEventListener('cut', function (e) { e.preventDefault(); });
+                backupInput.addEventListener('focus', function () { updateBackupCursor(this.value); });
+                backupInput.addEventListener('blur', function () { updateBackupCursor('x'.repeat(<%= otpLength %>)); });
+                backupInput.addEventListener('paste', handlePaste);
+                backupInput.addEventListener('input', handleInput);
+                updateBackupCursor(backupInput.value);
+            }
+
+            submitBtn.disabled = true;
         </script>
     </body>
 </html>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/emailOtp.jsp
@@ -199,7 +199,7 @@
                                     type="text"
                                     id='OTPCode'
                                     name="OTPCode"
-                                    c size='30'
+                                    size='30'
                                     autocomplete="off"
                                     aria-describedby="OTPDescription"/>
                                 <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/smsOtp.jsp
@@ -211,47 +211,35 @@
                                 <% } %>
 
                                 <% if (authenticators.equals(LOCAL_SMS_OTP_AUTHENTICATOR_ID) && otpLength <= 6) { %>
-                                    <div class="sms-otp-fields equal width fields">
+                                    <div class="sms-otp-fields equal width fields segmented-otp-field">
                                         <input
-                                            hidden
                                             type="text"
                                             id="OTPCode"
                                             name="OTPcode"
-                                            class="form-control"
-                                            placeholder="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "verification.code")%>"
+                                            class="segmented-otp-input"
+                                            maxlength="<%=otpLength%>"
+                                            autocomplete="one-time-code"
+                                            autocorrect="off"
+                                            autocapitalize="off"
+                                            spellcheck="false"
+                                            inputmode="<%= isOnlyNumeric ? "numeric" : "text" %>"
+                                            autofocus
+                                            aria-label="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "verification.code")%>"
                                         >
-                                        <% for (int index = 1; index <= otpLength;) {
-                                            String previousStringIndex = null;
-                                            if (index != 1) {
-                                                previousStringIndex = "pincode-" + (index - 1);
-                                            }
-                                            String currentStringIndex = "pincode-" + index;
-                                            index++;
-                                            String nextStringIndex = null;
-                                            if (index != (otpLength + 1)) {
-                                                nextStringIndex = "pincode-" + index;
-                                            }
-                                        %>
-                                            <div class="field mt-5">
-                                                <input
-                                                    class="text-center p-1 pb-3 pt-3"
-                                                    id=<%= currentStringIndex %>
-                                                    name=<%= currentStringIndex %>
-                                                    onkeyup="movetoNext(this, '<%= nextStringIndex %>', '<%= previousStringIndex %>')"
-                                                    tabindex="1"
-                                                    placeholder="·"
-                                                    autofocus
-                                                    maxlength="1"
-                                                    autocomplete="off"
-                                                    type="text"
-                                                    inputmode=<%= isOnlyNumeric ? "numeric" : "text" %>
-                                                >
-                                            </div>
+                                        <% for (int index = 1; index <= otpLength; index++) { %>
+                                        <div class="field mt-5">
+                                            <div class="text-center p-1 pb-3 pt-3" id="pincode-<%=index%>" aria-hidden="true">·</div>
+                                        </div>
                                         <% } %>
                                     </div>
                                 <% } else { %>
                                     <div class="ui fluid icon input addon-wrapper">
-                                        <input type="text" id='OTPCode' name="OTPcode" size='30' autocomplete="off"/>
+                                        <input type="text" id='OTPCode' name="OTPcode" size='30'
+                                            autocomplete="one-time-code"
+                                            autocorrect="off"
+                                            autocapitalize="off"
+                                            spellcheck="false"
+                                            inputmode="<%= isOnlyNumeric ? "numeric" : "text" %>"/>
                                         <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
                                     </div>
                                 <% } %>
@@ -288,8 +276,9 @@
                                 <div class="buttons">
                                     <% if (authenticators.equals(LOCAL_SMS_OTP_AUTHENTICATOR_ID) && otpLength <= 6) { %>
                                         <div>
-                                            <input type="button"
+                                            <input type="submit"
                                                 id="subButton"
+                                                disabled
                                                 value="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "authenticate")%>"
                                                 class="ui primary fluid large button" />
                                         </div>
@@ -396,52 +385,83 @@
             var insightsTenantIdentifier = "<%=userTenant%>";
             var otpLength = "<%=otpLength%>";
 
-            function movetoNext(current, nextFieldID, previousID) {
-                var key = event.keyCode || event.charCode;
-                if(key == 8 || key == 46) {
-                    if (previousID != null && previousID != 'null') {
-                        document.getElementById(previousID).focus();
-                    }
-                } else {
-                    if (nextFieldID != null && nextFieldID != 'null' && current.value.length >= current.maxLength) {
-                        document.getElementById(nextFieldID).focus();
+            (function() {
+                var OTPInput = document.getElementById('OTPCode');
+                if (!OTPInput || !OTPInput.classList.contains('segmented-otp-input')) return;
+                var submitBtn = document.getElementById('subButton');
+                var otpLen = parseInt(otpLength);
+                var isOnlyNumeric = <%= isOnlyNumeric %>;
+
+                function updateDigitBoxes(value) {
+                    for (var i = 1; i <= otpLen; i++) {
+                        var box = document.getElementById('pincode-' + i);
+                        if (box) box.textContent = (value.length >= i) ? value[i - 1] : '·';
                     }
                 }
-            }
 
+                function updateCursor(value) {
+                    for (var i = 1; i <= otpLen; i++) {
+                        var box = document.getElementById('pincode-' + i);
+                        if (box) box.classList.remove('active-pincode');
+                    }
+                    if (value.length < otpLen) {
+                        var activeBox = document.getElementById('pincode-' + (value.length + 1));
+                        if (activeBox) activeBox.classList.add('active-pincode');
+                    }
+                }
+
+                function handlePaste(e) {
+                    e.preventDefault();
+                    var pasted = (e.clipboardData || window.clipboardData).getData('Text').replace(/\s/g, '');
+                    var isValid = isOnlyNumeric ? /^\d+$/.test(pasted) : pasted.length > 0;
+                    if (!isValid) return;
+                    OTPInput.value = pasted.slice(0, otpLen);
+                    OTPInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
+                }
+
+                function handleKeypress(e) {
+                    if (!isOnlyNumeric) return;
+                    var char = String.fromCharCode(e.which);
+                    if (!/\d/.test(char)) e.preventDefault();
+                }
+
+                function handleInput() {
+                    var sanitized = isOnlyNumeric ? OTPInput.value.replace(/\D/g, '') : OTPInput.value.replace(/\s/g, '');
+                    if (sanitized !== OTPInput.value) OTPInput.value = sanitized;
+                    updateDigitBoxes(sanitized);
+                    updateCursor(sanitized);
+                    if (submitBtn) submitBtn.disabled = sanitized.length !== otpLen;
+                }
+
+                document.addEventListener('selectionchange', function () {
+                    if (document.activeElement === OTPInput) {
+                        OTPInput.selectionStart = OTPInput.selectionEnd = OTPInput.value.length;
+                    }
+                });
+                OTPInput.addEventListener('copy', function (e) { e.preventDefault(); });
+                OTPInput.addEventListener('cut', function (e) { e.preventDefault(); });
+                OTPInput.addEventListener('focus', function () { updateCursor(this.value); });
+                OTPInput.addEventListener('blur', function () { updateCursor(Array(otpLen + 1).join('x')); });
+                OTPInput.addEventListener('keypress', handleKeypress);
+                OTPInput.addEventListener('paste', handlePaste);
+                OTPInput.addEventListener('input', handleInput);
+                updateCursor(OTPInput.value);
+            })();
+
+            // Shim retained so reCaptcha data-callback="sub" continues to submit the form
+            // when captcha is solved (segmented + reCaptcha-enabled case).
             function sub() {
-
-                var token = null;
-                var hasNullDigit = false;
-
-                for(var i = 1; i <= otpLength; i++){
-                    var currentDigit = document.getElementById("pincode-"+i).value;
-                    if(!currentDigit || currentDigit == null || currentDigit == 'null') {
-                        hasNullDigit = true;
-                        break;
-                    }
-                    if(i === 1) {
-                        token = currentDigit;
-                    } else {
-                        token += currentDigit;
-                    }
-                }
-
-                document.getElementById('OTPCode').value = token;
-
-                if (!hasNullDigit) {
-                    trackEvent("authentication-portal-sms-otp-click-continue", {
-                        "tenant": insightsTenantIdentifier != "null" ? insightsTenantIdentifier : ""
-                    });
-                    // Disable during the initial submission to prevent double submissions.
-                    document.getElementById("subButton").disabled = true;
-                    document.getElementById("codeForm").submit();
-                }
-
+                var OTPInput = document.getElementById('OTPCode');
+                if (!OTPInput || OTPInput.value.length < parseInt(otpLength)) return;
+                trackEvent("authentication-portal-sms-otp-click-continue", {
+                    "tenant": insightsTenantIdentifier != "null" ? insightsTenantIdentifier : ""
+                });
+                document.getElementById("subButton").disabled = true;
+                document.getElementById("codeForm").submit();
             }
 
             function submitForm() {
-                
+
                 var insightsTenantIdentifier = "<%=userTenant%>";
                 var code = document.getElementById("OTPCode").value;
                 if (code == "") {
@@ -458,60 +478,6 @@
                         });
                         $('#codeForm').submit();
                     }
-                }
-            }
-
-            // Handle paste events
-    	    function handlePaste(e) {
-     	        var clipboardData, value;
-
-                // Stop data get being pasted into element
-                e.stopPropagation();
-                e.preventDefault();
-
-                // Get pasted data via clipboard API
-                clipboardData = e.clipboardData || window.clipboardData;
-                value = clipboardData.getData('Text').trim();
-                
-                var isValid = true;
-                var firstInput = document.getElementById('pincode-1');
-                var isOnlyNumeric = firstInput && firstInput.getAttribute('inputmode') === 'numeric';
-                
-                if (isOnlyNumeric) {
-                    isValid = /^\d+$/.test(value);
-                } else {
-                    isValid = value.length > 0;
-                }
-                
-                if (isValid) {
-                    value = value.substring(0, otpLength);
-                    
-                    for (let n = 0; n < value.length && n < otpLength; ++n) {
-                        $("#pincode-" + (n+1)).val(value[n]);
-                    }
-                    
-                    if (value.length < otpLength) {
-                        $("#pincode-" + (value.length + 1)).focus();
-                    } else {
-                        $("#pincode-" + otpLength).focus();
-                        var hasNullDigit = false;
-                        for (let i = 1; i <= otpLength; i++) {
-                            if (!$("#pincode-" + i).val()) {
-                                hasNullDigit = true;
-                                break;
-                            }
-                        }
-                        
-                        if (!hasNullDigit) {
-                            document.getElementById("subButton").disabled = false;
-                        }
-                    }
-                }
-            }
-
-            for (let i = 1; i <= otpLength; i++) {
-                if (document.getElementById('pincode-' + i)) {
-                    document.getElementById('pincode-' + i).addEventListener('paste', handlePaste);
                 }
             }
 

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/sms_otp_verify.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/sms_otp_verify.jsp
@@ -1,5 +1,5 @@
 <%--
-~ Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+~ Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
 ~
 ~ WSO2 LLC. licenses this file to you under the Apache License,
 ~ Version 2.0 (the "License"); you may not use this file except
@@ -206,7 +206,11 @@
                             </label>
 
                             <div class="ui fluid icon input addon-wrapper">
-                                <input type="text" id='OTPCode' name="OTPcode" size='30'/>
+                                <input type="text" id='OTPCode' name="OTPcode" size='30'
+                                    autocomplete="one-time-code"
+                                    autocorrect="off"
+                                    autocapitalize="off"
+                                    spellcheck="false"/>
                                 <i id="password-eye" class="eye icon right-align password-toggle slash" onclick="showOTPCode()"></i>
                             </div>
                         </div>
@@ -263,41 +267,6 @@
 
         <script type="text/javascript">
             var insightsTenantIdentifier = "<%=userTenant%>";
-
-            function movetoNext(current, nextFieldID, previousID) {
-                var key = event.keyCode || event.charCode;
-                if(key == 8 || key == 46) {
-                    if (previousID != null && previousID != 'null') {
-                        document.getElementById(previousID).focus();
-                    }
-                } else {
-                    if (nextFieldID != null && nextFieldID != 'null' && current.value.length >= current.maxLength) {
-                        document.getElementById(nextFieldID).focus();
-                    }
-                }
-            }
-
-            // Handle paste events
-    	    function handlePaste(e) {
-     	        var clipboardData, value;
-
-                // Stop data get being pasted into element
-                e.stopPropagation();
-                e.preventDefault();
-
-                // Get pasted data via clipboard API
-                clipboardData = e.clipboardData || window.clipboardData;
-                value = clipboardData.getData('Text');
-                const reg = new RegExp(/^\d+$/);
-                if (reg.test(value)) {
-                    for (n = 0; n < 6; ++n) {
-                        $("#pincode-" + (n+1)).val(value[n]);
-                        $("#pincode-" + (n+1)).focus();
-                    }
-                }
-            }
-
-           document.getElementById('pincode-1') ? document.getElementById('pincode-1').addEventListener('paste', handlePaste) : null;
 
             $(document).ready(function () {
                 $.fn.preventDoubleSubmission = function() {

--- a/identity-apps-core/apps/authentication-portal/src/main/webapp/totp.jsp
+++ b/identity-apps-core/apps/authentication-portal/src/main/webapp/totp.jsp
@@ -46,6 +46,7 @@
 
 <%
     request.getSession().invalidate();
+    int otpLength = 6;
     String queryString = request.getQueryString();
     Map<String, String> idpAuthenticatorMapping = null;
     if (request.getAttribute(Constants.IDP_AUTHENTICATOR_MAP) != null) {
@@ -121,9 +122,19 @@
             // Handle form submission through a single guarded path.
             $(document).ready(function(){
                 $('#totpForm').on('submit', function (e) {
-                    e.preventDefault();
-                    handleSubmit();
-                    return false;
+                    if (isTOTPSubmitting) {
+                        e.preventDefault();
+                        return false;
+                    }
+                    var totpInput = document.getElementById('totpOTPInput');
+                    var tokenField = document.getElementById('token');
+                    if (totpInput && tokenField) tokenField.value = totpInput.value;
+                    isTOTPSubmitting = true;
+                    $('#subButton').attr('disabled', true);
+                    $('#subButton').addClass('loading');
+                    trackEvent("authentication-portal-totp-click-continue", {
+                        "tenant": insightsTenantIdentifier != "null" ? insightsTenantIdentifier : ""
+                    });
                 });
             });
         </script>
@@ -185,86 +196,25 @@
                                 <input hidden type="text"  id="token" name="token" class="form-control" placeholder="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "verification.code")%>">
                             </div>
 
-                            <div class="equal width fields">
-                                    <div class="field mt-5">
-                                        <input
-                                            class="text-center p-1 pb-3 pt-3"
-                                            id="pincode-1"
-                                            name="pincode-1"
-                                            tabindex="1"
-                                            placeholder="·"
-                                            maxlength="1"
-                                            onkeyup="movetoNext(this, 'pincode-2', null)"
-                                            autocomplete="off"
-                                            type="text"
-                                            inputmode="numeric"
-                                            autofocus>
-                                    </div>
-                                    <div class="field mt-5">
-                                        <input
-                                            class="text-center p-1 pb-3 pt-3"
-                                            id="pincode-2"
-                                            name="pincode-2"
-                                            tabindex="2"
-                                            placeholder="·"
-                                            maxlength="1"
-                                            onkeyup="movetoNext(this, 'pincode-3', 'pincode-1')"
-                                            autocomplete="off"
-                                            type="text"
-                                            inputmode="numeric">
-                                    </div>
-                                    <div class="field mt-5">
-                                        <input
-                                            class="text-center p-1 pb-3 pt-3"
-                                            id="pincode-3"
-                                            name="pincode-3"
-                                            tabindex="3"
-                                            placeholder="·"
-                                            maxlength="1"
-                                            onkeyup="movetoNext(this, 'pincode-4', 'pincode-2')"
-                                            autocomplete="off"
-                                            type="text"
-                                            inputmode="numeric">
-                                    </div>
-                                    <div class="field mt-5">
-                                        <input
-                                            class="text-center p-1 pb-3 pt-3"
-                                            id="pincode-4"
-                                            name="pincode-4"
-                                            tabindex="4"
-                                            placeholder="·"
-                                            maxlength="1"
-                                            onkeyup="movetoNext(this, 'pincode-5', 'pincode-3')"
-                                            autocomplete="off"
-                                            type="text"
-                                            inputmode="numeric">
-                                    </div>
-                                    <div class="field mt-5">
-                                        <input
-                                            class="text-center p-1 pb-3 pt-3"
-                                            id="pincode-5"
-                                            name="pincode-5"
-                                            tabindex="5"
-                                            placeholder="·"
-                                            maxlength="1"
-                                            onkeyup="movetoNext(this, 'pincode-6', 'pincode-4')"
-                                            autocomplete="off"
-                                            type="text"
-                                            inputmode="numeric">
-                                    </div>
-                                    <div class="field mt-5">
-                                        <input
-                                            class="text-center p-1 pb-3 pt-3"
-                                            id="pincode-6"
-                                            name="pincode-6"
-                                            tabindex="6"
-                                            placeholder="·"
-                                            maxlength="1"
-                                            onkeyup="movetoNext(this, null, 'pincode-5')"
-                                            autocomplete="off"
-                                            type="text"
-                                            inputmode="numeric">
-                                    </div>
+                            <div class="equal width fields segmented-otp-field">
+                                <input
+                                    type="text"
+                                    id="totpOTPInput"
+                                    class="segmented-otp-input"
+                                    maxlength="<%= otpLength %>"
+                                    autocomplete="one-time-code"
+                                    autocorrect="off"
+                                    autocapitalize="off"
+                                    spellcheck="false"
+                                    inputmode="numeric"
+                                    autofocus
+                                    aria-label="<%=AuthenticationEndpointUtil.i18n(resourceBundle, "verification.code")%>"
+                                >
+                                <% for (int i = 1; i <= otpLength; i++) { %>
+                                <div class="field mt-5">
+                                    <div class="text-center p-1 pb-3 pt-3" id="pincode-<%=i%>" aria-hidden="true">·</div>
+                                </div>
+                                <% } %>
                             </div>
 
                             <input id="sessionDataKey" type="hidden" name="sessionDataKey"
@@ -360,82 +310,68 @@
 
         <script type="text/javascript">
             var insightsTenantIdentifier = "<%=userTenant%>";
-            function movetoNext(current, nextFieldID, previousID) {
-                var key = event.keyCode || event.charCode;
-                if (nextFieldID != null && current.value.length >= current.maxLength) {
-                    document.getElementById(nextFieldID).focus();
-                }
-                if( key == 8 || key == 46 ) {
-                    if ( previousID != null) {
-                        document.getElementById(previousID).focus();
-                    }
+
+            function updateTotpDigitBoxes(value) {
+                for (var i = 1; i <= <%= otpLength %>; i++) {
+                    var box = document.getElementById('pincode-' + i);
+                    if (box) box.textContent = (value.length >= i) ? value[i - 1] : '·';
                 }
             }
-            function handleSubmit() {
-                if (isTOTPSubmitting) {
-                    return false;
-                }
 
-                var pin1 = document.getElementById("pincode-1").value;
-                var pin2 = document.getElementById("pincode-2").value;
-                var pin3 = document.getElementById("pincode-3").value;
-                var pin4 = document.getElementById("pincode-4").value;
-                var pin5 = document.getElementById("pincode-5").value;
-                var pin6 = document.getElementById("pincode-6").value;
-                var token = pin1 + pin2 + pin3 + pin4 + pin5 + pin6;
-                document.getElementById('token').value = token;
-                var isValidToken = pin1 !== "" && pin2 !== "" && pin3 !== "" && pin4 !== "" && pin5 !== "" && pin6 !== "";
-                if (isValidToken) {
-                    isTOTPSubmitting = true;
-                    $('#subButton').attr('disabled', true);
-                    $('#subButton').addClass('loading');
-                    trackEvent("authentication-portal-totp-click-continue", {
-                        "tenant": insightsTenantIdentifier != "null" ? insightsTenantIdentifier : ""
-                    });
-                    document.getElementById("totpForm").submit();
-                }
+            var totpInput = document.getElementById('totpOTPInput');
+            var tokenField = document.getElementById('token');
+            var submitBtn = document.getElementById('subButton');
 
-                return false;
+            function updateTotpCursor(value) {
+                for (var i = 1; i <= <%= otpLength %>; i++) {
+                    var box = document.getElementById('pincode-' + i);
+                    if (box) box.classList.remove('active-pincode');
+                }
+                if (value.length < <%= otpLength %>) {
+                    var activeBox = document.getElementById('pincode-' + (value.length + 1));
+                    if (activeBox) activeBox.classList.add('active-pincode');
+                }
             }
-            // Handle paste events
+
             function handlePaste(e) {
-                var clipboardData, value;
-                // Stop data actually being pasted into element
-                e.stopPropagation();
                 e.preventDefault();
-                // Get pasted data via clipboard API
-                clipboardData = e.clipboardData || window.clipboardData;
-                value = clipboardData.getData('Text').trim();
-                const reg = new RegExp(/^\d+$/);
-                if (reg.test(value)) {
-                    value = value.substring(0, 6);
-
-                    for (let n = 0; n < value.length && n < 6; ++n) {
-                        $("#pincode-" + (n+1)).val(value[n]);
-                    }
-
-                    if (value.length < 6) {
-                        $("#pincode-" + (value.length + 1)).focus();
-                    } else {
-                        $("#pincode-6").focus();
-                        $('#subButton').attr('disabled', false);
-                    }
-                }
+                var pasted = (e.clipboardData || window.clipboardData).getData('Text').replace(/\s/g, '');
+                if (!/^\d+$/.test(pasted)) return;
+                totpInput.value = pasted.slice(0, <%= otpLength %>);
+                totpInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
             }
 
-            // Add paste event listener to all input fields
-            for (let i = 1; i <= 6; i++) {
-                document.getElementById('pincode-' + i).addEventListener('paste', handlePaste);
+            function handleKeypress(e) {
+                var char = String.fromCharCode(e.which);
+                if (!/\d/.test(char)) e.preventDefault();
             }
-            $('#subButton').attr('disabled', true);
-            $('#pincode-6').on('keyup', function() {
-                if ($('#pincode-1').val() != '' && $('#pincode-2').val() != ''
-                && $('#pincode-3').val() != '' && $('#pincode-4').val() != '' && $('#pincode-5').val() != ''  && $('#pincode-6').val() != '') {
-                    $('#subButton').attr('disabled', false);
-                } else {
-                    $('#subButton').attr('disabled', true);
-                }
-            });
+
+            function handleInput() {
+                var sanitized = totpInput.value.replace(/\D/g, '');
+                if (sanitized !== totpInput.value) totpInput.value = sanitized;
+                tokenField.value = sanitized;
+                updateTotpDigitBoxes(sanitized);
+                updateTotpCursor(sanitized);
+                submitBtn.disabled = sanitized.length !== <%= otpLength %>;
+            }
+
+            if (totpInput) {
+                document.addEventListener('selectionchange', function () {
+                    if (document.activeElement === totpInput) {
+                        totpInput.selectionStart = totpInput.selectionEnd = totpInput.value.length;
+                    }
+                });
+                totpInput.addEventListener('copy', function (e) { e.preventDefault(); });
+                totpInput.addEventListener('cut', function (e) { e.preventDefault(); });
+                totpInput.addEventListener('focus', function () { updateTotpCursor(this.value); });
+                totpInput.addEventListener('blur', function () { updateTotpCursor('x'.repeat(<%= otpLength %>)); });
+                totpInput.addEventListener('keypress', handleKeypress);
+                totpInput.addEventListener('paste', handlePaste);
+                totpInput.addEventListener('input', handleInput);
+                updateTotpCursor(totpInput.value);
+            }
+
+            submitBtn.disabled = true;
         </script>
     </body>
 </html>

--- a/identity-apps-core/apps/recovery-portal/src/main/webapp/sms-and-email-otp.jsp
+++ b/identity-apps-core/apps/recovery-portal/src/main/webapp/sms-and-email-otp.jsp
@@ -1,5 +1,5 @@
 <%--
-~ Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com).
+~ Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com).
 ~
 ~ WSO2 LLC. licenses this file to you under the Apache License,
 ~ Version 2.0 (the "License"); you may not use this file except
@@ -181,7 +181,7 @@
                     %>
                     <div id="alertDiv"></div>
                     <div class="segment-form">
-                        <form class="ui large form" id="codeForm" name="codeForm"
+                        <form class="ui large form otp-form" id="codeForm" name="codeForm"
                             action="passwordrecoveryotp.do" method="POST">
                             <%
                                 String loginFailed = request.getParameter("authFailure");
@@ -204,42 +204,26 @@
                                 </label>
 
                                 <% if (otpLength <= 6) { %>
-                                    <div class="sms-otp-fields equal width fields">
+                                    <div class="sms-otp-fields equal width fields segmented-otp-field">
                                         <input
-                                            hidden
                                             type="text"
                                             id="OTPCode"
                                             name="OTPcode"
-                                            class="form-control"
+                                            class="segmented-otp-input"
+                                            maxlength="<%=otpLength%>"
+                                            autocomplete="one-time-code"
+                                            autocorrect="off"
+                                            autocapitalize="off"
+                                            spellcheck="false"
+                                            autofocus
                                             data-testid="recovery-otp-page-segmented-otp-input"
-                                            placeholder="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
+                                            aria-label="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                                                 "verification.code")%>"
                                         >
-                                        <% for (int index = 1; index <= otpLength;) {
-                                            String previousStringIndex = null;
-                                            if (index != 1) {
-                                                previousStringIndex = "pincode-" + (index - 1);
-                                            }
-                                            String currentStringIndex = "pincode-" + index;
-                                            index++;
-                                            String nextStringIndex = null;
-                                            if (index != (otpLength + 1)) {
-                                                nextStringIndex = "pincode-" + index;
-                                            }
-                                        %>
-                                            <div class="field mt-5">
-                                                <input
-                                                    class="text-center pl-0 pr-0 pt-3 pb-3"
-                                                    id=<%= currentStringIndex %>
-                                                    name=<%= currentStringIndex %>
-                                                    onkeyup="movetoNext(this, '<%= nextStringIndex %>',
-                                                        '<%= previousStringIndex %>')"
-                                                    tabindex="1"
-                                                    placeholder="·"
-                                                    autofocus
-                                                    maxlength="1"
-                                                >
-                                            </div>
+                                        <% for (int index = 1; index <= otpLength; index++) { %>
+                                        <div class="field mt-5">
+                                            <div class="text-center p-1 pb-3 pt-3" id="pincode-<%=index%>" aria-hidden="true">·</div>
+                                        </div>
                                         <% } %>
                                     </div>
                                 <% } else { %>
@@ -249,6 +233,10 @@
                                             id='OTPCode'
                                             name="OTPcode"
                                             size='30'
+                                            autocomplete="one-time-code"
+                                            autocorrect="off"
+                                            autocapitalize="off"
+                                            spellcheck="false"
                                             data-testid="recovery-otp-page-non-segmented-otp-input"
                                         />
                                         <i id="password-eye" class="eye icon right-align password-toggle slash"
@@ -314,9 +302,9 @@
                                 <div class="buttons">
                                     <% if (otpLength <= 6) { %>
                                         <div>
-                                            <input type="button"
+                                            <input type="submit"
                                                 id="subButton"
-                                                onclick="sub(); return false;"
+                                                disabled
                                                 value="<%=IdentityManagementEndpointUtil.i18n(recoveryResourceBundle,
                                                     "sms.otp.submit.button")%>"
                                                 class="ui primary fluid large button" />
@@ -394,69 +382,59 @@
             var insightsTenantIdentifier = "<%=userTenant%>";
             var otpLength = "<%=otpLength%>";
 
-            function movetoNext(current, nextFieldID, previousID) {
-                var key = event.keyCode || event.charCode;
-                if(key == 8 || key == 46) {
-                    if (previousID != null && previousID != 'null') {
-                        document.getElementById(previousID).focus();
-                    }
-                } else {
-                    if (nextFieldID != null && nextFieldID != 'null' && current.value.length >= current.maxLength) {
-                        document.getElementById(nextFieldID).focus();
-                    }
-                }
-            }
+            (function() {
+                var OTPInput = document.getElementById('OTPCode');
+                if (!OTPInput || !OTPInput.classList.contains('segmented-otp-input')) return;
+                var submitBtn = document.getElementById('subButton');
+                var otpLen = parseInt(otpLength);
 
-            function sub() {
-
-                var token = null;
-                var hasNullDigit = false;
-
-                for(var i = 1; i <= otpLength; i++){
-                    var currentDigit = document.getElementById("pincode-"+i).value;
-                    if(!currentDigit || currentDigit == null || currentDigit == 'null') {
-                        hasNullDigit = true;
-                        break;
-                    }
-                    if(i === 1) {
-                        token = currentDigit;
-                    } else {
-                        token += currentDigit;
+                function updateDigitBoxes(value) {
+                    for (var i = 1; i <= otpLen; i++) {
+                        var box = document.getElementById('pincode-' + i);
+                        if (box) box.textContent = (value.length >= i) ? value[i - 1] : '·';
                     }
                 }
 
-                document.getElementById('OTPCode').value = token;
-
-                if (!hasNullDigit) {
-                    // Disable during the initial submission to prevent double submissions.
-                    document.getElementById("subButton").disabled = true;
-                    document.getElementById("codeForm").submit();
-                }
-
-            }
-
-            // Handle paste events
-            function handlePaste(e) {
-                var clipboardData, value;
-
-                // Stop data get being pasted into element
-                e.stopPropagation();
-                e.preventDefault();
-
-                // Get pasted data via clipboard API
-                clipboardData = e.clipboardData || window.clipboardData;
-                value = clipboardData.getData('Text');
-                const reg = new RegExp(/^[a-zA-Z0-9_]+$/);
-                if (reg.test(value)) {
-                    for (n = 0; n < 6; ++n) {
-                        $("#pincode-" + (n+1)).val(value[n]);
-                        $("#pincode-" + (n+1)).focus();
+                function updateCursor(value) {
+                    for (var i = 1; i <= otpLen; i++) {
+                        var box = document.getElementById('pincode-' + i);
+                        if (box) box.classList.remove('active-pincode');
+                    }
+                    if (value.length < otpLen) {
+                        var activeBox = document.getElementById('pincode-' + (value.length + 1));
+                        if (activeBox) activeBox.classList.add('active-pincode');
                     }
                 }
-            }
 
-            document.getElementById('pincode-1') ? document.getElementById('pincode-1')
-                .addEventListener('paste', handlePaste) : null;
+                function handlePaste(e) {
+                    e.preventDefault();
+                    var pasted = (e.clipboardData || window.clipboardData).getData('Text').replace(/\s/g, '');
+                    if (!/^[a-zA-Z0-9_]+$/.test(pasted)) return;
+                    OTPInput.value = pasted.slice(0, otpLen);
+                    OTPInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
+                }
+
+                function handleInput() {
+                    var sanitized = OTPInput.value.replace(/\s/g, '');
+                    if (sanitized !== OTPInput.value) OTPInput.value = sanitized;
+                    updateDigitBoxes(sanitized);
+                    updateCursor(sanitized);
+                    if (submitBtn) submitBtn.disabled = sanitized.length !== otpLen;
+                }
+
+                document.addEventListener('selectionchange', function () {
+                    if (document.activeElement === OTPInput) {
+                        OTPInput.selectionStart = OTPInput.selectionEnd = OTPInput.value.length;
+                    }
+                });
+                OTPInput.addEventListener('copy', function (e) { e.preventDefault(); });
+                OTPInput.addEventListener('cut', function (e) { e.preventDefault(); });
+                OTPInput.addEventListener('focus', function () { updateCursor(this.value); });
+                OTPInput.addEventListener('blur', function () { updateCursor(Array(otpLen + 1).join('x')); });
+                OTPInput.addEventListener('paste', handlePaste);
+                OTPInput.addEventListener('input', handleInput);
+                updateCursor(OTPInput.value);
+            })();
 
             $(document).ready(function () {
                 $.fn.preventDoubleSubmission = function() {

--- a/modules/theme/src/theme-core/definitions/apps/login-portal.less
+++ b/modules/theme/src/theme-core/definitions/apps/login-portal.less
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2019-2023, WSO2 Inc. (http://www.wso2.org).
+ * Copyright (c) 2019-2026, WSO2 Inc. (http://www.wso2.org).
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -248,6 +248,63 @@
                 @media screen and (min-width: 500px) {
                     flex-wrap: nowrap;
                 }
+            }
+        }
+
+        /* Segmented OTP Field */
+        .segmented-otp-field {
+            position: relative;
+
+            > input.segmented-otp-input {
+                position: absolute !important;
+                top: 0 !important;
+                left: 0 !important;
+                right: 0 !important;
+                bottom: 0 !important;
+                color: transparent !important;
+                background: transparent !important;
+                border: none !important;
+                outline: none !important;
+                caret-color: transparent !important;
+                z-index: 2;
+                padding: 0 !important;
+                margin: 0 !important;
+                font-size: 16px;
+                cursor: default;
+                user-select: none;
+                -webkit-user-select: none;
+                -webkit-touch-callout: none;
+            }
+
+            div[id^="pincode-"] {
+                position: relative;
+                border: 1px solid var(--asg-input-field-base-border-color, rgba(34, 36, 38, .15));
+                border-radius: var(--asg-input-field-base-border-radius, 8px);
+                background: var(--asg-input-field-base-background-color, #fff);
+                font-size: 1em;
+                line-height: 1.21428571em;
+                color: var(--asg-input-field-base-text-color, rgba(0, 0, 0, .87));
+
+                &.active-pincode {
+                    border-color: var(--asg-colors-primary-main, #FF7300);
+
+                    &::after {
+                        content: '';
+                        position: absolute;
+                        left: 50%;
+                        top: 50%;
+                        transform: translate(-50%, -50%);
+                        width: 1px;
+                        height: 1em;
+                        background-color: var(--asg-input-field-base-text-color, rgba(0, 0, 0, .87));
+                        animation: otpCursorBlink 1s step-end infinite;
+                    }
+                }
+            }
+
+            @keyframes otpCursorBlink {
+                0%, 100% { opacity: 1; }
+                50% { opacity: 0; }
             }
         }
 


### PR DESCRIPTION
### Problem

  The following issues were reported on the OTP authentication screens:

  - **Mobile keyboard OTP autofill truncates to single digit** — When the OS autofill is used to enter the OTP code, only the first digit box with a single character is populated instead of
  filling all boxes.
  - **Submit button remained disabled** — After typing all digits without tapping the keyboard's return/enter key, the authenticate button stayed disabled and the user could not proceed.

  ### Fix

  An invisible overlay `<input>` is placed over the segmented digit box row. It carries `autocomplete="one-time-code"` so the OS autofill banner targets it correctly, and JavaScript relays its
  value into the visual boxes in real time.

  Key changes across `totp.jsp`, `backup-code.jsp`, `smsOtp.jsp`, and `sms-and-email-otp.jsp`:

  - Added a transparent full-width overlay input with `autocomplete="one-time-code", autocorrect="off", autocapitalize="off", spellcheck="false"`
  - `handlePaste` — intercepts paste events, strips whitespace, and populates the overlay input, triggering the input event chain
  - `handleInput` — syncs the overlay value to the hidden form field, updates digit boxes and cursor indicator, and enables/disables the submit button
  - Cursor blink animation on the active digit box to indicate focus position
  - Overlay CSS (`.segmented-otp-field`, `.segmented-otp-input`, `div[id^="pincode-"]`, `.active-pincode`, `@keyframes otpCursorBlink`) added to `modules/theme/src/theme-core/definitions/apps/login-portal.less`, with `!important` on critical positioning/transparency rules to prevent branding stylesheet overrides.
  - For `sms-and-email-otp.jsp`, the form element now also carries the `otp-form` class so the segmented digit boxes don't wrap on mobile (mirrors the structure already present on
  `backup-code.jsp` and `totp.jsp`).

  For `sms_otp_verify.jsp`, which uses a plain text input (no segmented boxes), `autocomplete="one-time-code", autocorrect="off", autocapitalize="off", and spellcheck="false"` were added to enable browser/OS autofill suggestions and suppress unwanted text correction on mobile. The dead `movetoNext` / `handlePaste` functions referencing non-existent `pincode-*` elements were removed.

  For `emailOtp.jsp`, a stray `c` HTML attribute on the `<input>` (`c size='30'`) was removed.

  ### Behaviour Change

Field | Before | After
-- | -- | --
TOTP input | Accepted alphanumeric characters | Numeric only (enforced via keypress handler and inputmode="numeric")

The TOTP change aligns the input with RFC 6238, which defines TOTP codes as numeric. SMS OTP and backup codes remain unchanged in their character-set acceptance.

### Before the fix 

- Backup code

https://github.com/user-attachments/assets/746e68aa-8cb3-450c-bee0-52929cfa7002


- TOTP

https://github.com/user-attachments/assets/b73d4b88-49be-4881-bbce-4ff5be2712f6


- SMS OTP

https://github.com/user-attachments/assets/0744c240-c896-4e15-a2ae-1eeda4d3db8f



- Legacy password recovery - Email OTP

https://github.com/user-attachments/assets/9df665db-0940-4876-ad4c-ea1ed69e28b2


- Legacy Password recovery - SMS OTP


https://github.com/user-attachments/assets/965ab50d-6f71-45b5-ada7-6513816a86d9

### After the fix 

- Backup code

https://github.com/user-attachments/assets/96a2af9b-afdf-41dd-8842-213c194c72a6



- TOTP

https://github.com/user-attachments/assets/b4b10543-3fd9-4962-b65f-131b4a4eaebf




- SMS OTP (Numeric, OTP length <= 6)

https://github.com/user-attachments/assets/e384ba11-b059-49d1-bfed-2a5272ed009e



- SMS OTP (Alpha Numeric, OTP length > 6)

https://github.com/user-attachments/assets/1a1bbe3e-d652-42d0-a3df-de883d9096f3



- SMS OTP (OTP length > 6)

https://github.com/user-attachments/assets/e10db7e7-ff23-421f-a051-25de834f1b50

- Email OTP

https://github.com/user-attachments/assets/ecdaf835-e97f-438e-a8ee-9294b7dc6957



- Legacy password recovery - Email OTP

https://github.com/user-attachments/assets/2c42e132-48f4-47ec-b154-168029d9a0bf



- Legacy Password recovery - SMS OTP

https://github.com/user-attachments/assets/f44ebdbf-b824-4704-9c4d-fdcae979c146




### Related Issue

- https://github.com/wso2/product-is/issues/24933