### PR TITLE
Add dedicated loading state to danger zone revert button

### DIFF
--- a/.changeset/fix-revert-button-loading-state.md
+++ b/.changeset/fix-revert-button-loading-state.md
@@ -1,0 +1,15 @@
+---
+"@wso2is/admin.alternative-login-identifier.v1": patch
+"@wso2is/admin.impersonation.v1": patch
+"@wso2is/admin.saml2-configuration.v1": patch
+"@wso2is/admin.server-configurations.v1": patch
+"@wso2is/admin.session-management.v1": patch
+"@wso2is/admin.username-validation.v1": patch
+"@wso2is/admin.validation.v1": patch
+"@wso2is/admin.wsfed-configuration.v1": patch
+"@wso2is/console": patch
+"@wso2is/myaccount": patch
+"@wso2is/identity-apps-core": patch
+---
+
+Add a dedicated loading state to the danger zone revert button and prevent the revert request from racing with the update request on governance configuration pages.

--- a/features/admin.alternative-login-identifier.v1/pages/alternative-login-identifier-page.tsx
+++ b/features/admin.alternative-login-identifier.v1/pages/alternative-login-identifier-page.tsx
@@ -102,6 +102,7 @@ const AlternativeLoginIdentifierInterface: FunctionComponent<AlternativeLoginIde
     const [ availableClaims, setAvailableClaims ] = useState<ExtendedClaimInterface[]>([]);
     const [ isLoading, setIsLoading ] = useState(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ isReverting, setIsReverting ] = useState<boolean>(false);
     const [ initialFormValues, setInitialFormValues ] = useState<AlternativeLoginIdentifierFormInterface>(undefined);
     const availiableLoginIdentifierAttributes: string[] =
         [
@@ -354,7 +355,7 @@ const AlternativeLoginIdentifierInterface: FunctionComponent<AlternativeLoginIde
     };
 
     const onConfigRevert = () => {
-        setIsSubmitting(true);
+        setIsReverting(true);
         const revertRequest: RevertGovernanceConnectorConfigInterface = {
             properties: connector?.properties?.map((property: ConnectorPropertyInterface) => property.name)
         };
@@ -368,7 +369,7 @@ const AlternativeLoginIdentifierInterface: FunctionComponent<AlternativeLoginIde
                 handleRevertError();
             })
             .finally(() => {
-                setIsSubmitting(false);
+                setIsReverting(false);
             });
     };
 
@@ -710,6 +711,8 @@ const AlternativeLoginIdentifierInterface: FunctionComponent<AlternativeLoginIde
                                         header= { t("governanceConnectors:dangerZone.heading") }
                                         subheader= { t("governanceConnectors:dangerZone.subHeading") }
                                         onActionClick={ () => onConfigRevert() }
+                                        isButtonLoading={ isReverting }
+                                        isButtonDisabled={ isReverting }
                                         data-testid={ `${ componentId }-danger-zone` }
                                     />
                                 </DangerZoneGroup>

--- a/features/admin.impersonation.v1/pages/impersonation-configuration.tsx
+++ b/features/admin.impersonation.v1/pages/impersonation-configuration.tsx
@@ -73,6 +73,7 @@ const ImpersonationConfigurationPage: FunctionComponent<ImpersonationConfigurati
         useState<ImpersonationConfigFormValuesInterface>(undefined);
 
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ isReverting, setIsReverting ] = useState<boolean>(false);
 
     const {
         data: originalImpersonationConfig,
@@ -149,7 +150,7 @@ const ImpersonationConfigurationPage: FunctionComponent<ImpersonationConfigurati
     };
 
     const onConfigRevert = () => {
-        setIsSubmitting(true);
+        setIsReverting(true);
         revertImpersonationConfigurations().then(() => {
             dispatch(
                 addAlert({
@@ -171,7 +172,7 @@ const ImpersonationConfigurationPage: FunctionComponent<ImpersonationConfigurati
                 })
             );
         }).finally(() => {
-            setIsSubmitting(false);
+            setIsReverting(false);
             mutateImpersonationConfig();
         });
     };
@@ -254,6 +255,8 @@ const ImpersonationConfigurationPage: FunctionComponent<ImpersonationConfigurati
                                     header= { t("governanceConnectors:dangerZone.heading") }
                                     subheader= { t("governanceConnectors:dangerZone.subHeading") }
                                     onActionClick={ () => onConfigRevert() }
+                                    isButtonLoading={ isReverting }
+                                    isButtonDisabled={ isReverting }
                                     data-testid={ `${ componentId }-danger-zone` }
                                 />
                             </DangerZoneGroup>

--- a/features/admin.saml2-configuration.v1/pages/saml2-configuration.tsx
+++ b/features/admin.saml2-configuration.v1/pages/saml2-configuration.tsx
@@ -437,6 +437,7 @@ const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInterface>
                                                                 <PrimaryButton
                                                                     size="small"
                                                                     loading={ isSubmitting }
+                                                                    disabled={ isReverting }
                                                                     onClick={ () => {
                                                                         formRef?.current?.triggerSubmit();
                                                                     } }
@@ -468,7 +469,7 @@ const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInterface>
                                         subheader= { t("governanceConnectors:dangerZone.subHeading") }
                                         onActionClick={ () => onConfigRevert() }
                                         isButtonLoading={ isReverting }
-                                        isButtonDisabled={ isReverting }
+                                        isButtonDisabled={ isReverting || isSubmitting }
                                         data-testid={ `${ componentId }-danger-zone` }
                                     />
                                 </DangerZoneGroup>

--- a/features/admin.saml2-configuration.v1/pages/saml2-configuration.tsx
+++ b/features/admin.saml2-configuration.v1/pages/saml2-configuration.tsx
@@ -89,6 +89,7 @@ const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInterface>
     const { t } = useTranslation();
 
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ isReverting, setIsReverting ] = useState<boolean>(false);
     const [ saml2Config , setSaml2Config ] =
         useState<Saml2ConfigFormValuesInterface>(undefined);
     const [ destinationUrls, setDestinationUrls ] = useState<string>("");
@@ -253,7 +254,7 @@ const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInterface>
      * Handle saml2 configuration revert.
      */
     const onConfigRevert = (): void => {
-        setIsSubmitting(true);
+        setIsReverting(true);
 
         revertSaml2Configurations()
             .then(() => {
@@ -261,7 +262,7 @@ const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInterface>
             }).catch(() => {
                 handlerevertError();
             }).finally(() => {
-                setIsSubmitting(false);
+                setIsReverting(false);
                 mutateSaml2Config();
             });
     };
@@ -466,6 +467,8 @@ const Saml2ConfigurationPage: FunctionComponent<Saml2ConfigurationPageInterface>
                                         header= { t("governanceConnectors:dangerZone.heading") }
                                         subheader= { t("governanceConnectors:dangerZone.subHeading") }
                                         onActionClick={ () => onConfigRevert() }
+                                        isButtonLoading={ isReverting }
+                                        isButtonDisabled={ isReverting }
                                         data-testid={ `${ componentId }-danger-zone` }
                                     />
                                 </DangerZoneGroup>

--- a/features/admin.server-configurations.v1/pages/account-disable-page.tsx
+++ b/features/admin.server-configurations.v1/pages/account-disable-page.tsx
@@ -79,6 +79,7 @@ const AccountDisablePage: FC<AccountDisablePageInterface> = (
         ServerConfigurationsConstants.ACCOUNT_DISABLE_CONNECTOR_ID);
 
     const [ isAccountDisableEnabled, setIsAccountDisableEnabled ] = useState<boolean>(false);
+    const [ isReverting, setIsReverting ] = useState<boolean>(false);
 
     useEffect(() => {
         const accountDisableProperty: UpdateGovernanceConnectorConfigPropertyInterface =
@@ -113,6 +114,7 @@ const AccountDisablePage: FC<AccountDisablePageInterface> = (
     }, [ accountDisableFetchRequestError ]);
 
     const onConfigRevert = (): void => {
+        setIsReverting(true);
         const revertData: RevertGovernanceConnectorConfigInterface = {
             properties: [
                 ServerConfigurationsConstants.ACCOUNT_DISABLING_ENABLE
@@ -156,6 +158,7 @@ const AccountDisablePage: FC<AccountDisablePageInterface> = (
                 );
             })
             .finally(() => {
+                setIsReverting(false);
                 mutateAccountDisableFetchRequest();
             }
             );
@@ -318,6 +321,8 @@ const AccountDisablePage: FC<AccountDisablePageInterface> = (
                             header= { t("governanceConnectors:dangerZone.heading") }
                             subheader= { t("governanceConnectors:dangerZone.subHeading") }
                             onActionClick={ () => onConfigRevert() }
+                            isButtonLoading={ isReverting }
+                            isButtonDisabled={ isReverting }
                             data-testid={ `${ componentId }-danger-zone` }
                         />
                     </DangerZoneGroup>

--- a/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
+++ b/features/admin.server-configurations.v1/pages/connector-edit-page.tsx
@@ -112,6 +112,7 @@ const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = (
     const [ connectorId, setConnectorId ] = useState<string>(undefined);
     const [ enableForm, setEnableForm ] = useState<boolean>(false);
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ isReverting, setIsReverting ] = useState<boolean>(false);
     const [ enableBackButton, setEnableBackButton ] = useState<boolean>(true);
 
     const { isSubOrganization } = useGetCurrentOrganizationType();
@@ -330,7 +331,7 @@ const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = (
     };
 
     const onConfigRevert = () => {
-        setIsSubmitting(true);
+        setIsReverting(true);
         const revertRequest: RevertGovernanceConnectorConfigInterface = {
             properties: []
         };
@@ -347,12 +348,13 @@ const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = (
                 handleRevertError();
             })
             .finally(() => {
-                setIsSubmitting(false);
+                setIsReverting(false);
                 loadConnectorDetails();
             });
     };
 
     const onBotDetectionRevert = async () => {
+        setIsReverting(true);
         const ssoPropertiesToRevert: RevertGovernanceConnectorConfigInterface = {
             properties: [
                 serverConfigurationConfig.connectorToggleName[ connector?.name ] ?? connector?.name,
@@ -395,6 +397,7 @@ const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = (
                 handleRevertError();
             })
             .finally(() => {
+                setIsReverting(false);
                 loadConnectorDetails();
             });
     };
@@ -867,6 +870,8 @@ const ConnectorEditPage: FunctionComponent<ConnectorEditPageInterface> = (
                                     onActionClick={ () => connectorId ===
                                         ServerConfigurationsConstants.CAPTCHA_FOR_SSO_LOGIN_CONNECTOR_ID ?
                                         onBotDetectionRevert() : onConfigRevert() }
+                                    isButtonLoading={ isReverting }
+                                    isButtonDisabled={ isReverting }
                                     data-testid={ `${ testId }-${ connectorId }-danger-zone` }
                                 />
                             </DangerZoneGroup>

--- a/features/admin.server-configurations.v1/pages/internal-notification-sending-page.tsx
+++ b/features/admin.server-configurations.v1/pages/internal-notification-sending-page.tsx
@@ -63,6 +63,7 @@ const InternalNotificationSendingPage: FC<InternalNotificationSendingPageInterfa
     const dispatch: Dispatch = useDispatch();
 
     const [ isLoading, setIsLoading ] = useState<boolean>(false);
+    const [ isReverting, setIsReverting ] = useState<boolean>(false);
     const [
         isNotificationInternallyManaged,
         setIsNotificationInternallyManaged
@@ -293,6 +294,7 @@ const InternalNotificationSendingPage: FC<InternalNotificationSendingPageInterfa
     };
 
     const onConfigRevert = async (): Promise<void> => {
+        setIsReverting(true);
         const selfSignupRevertData: RevertGovernanceConnectorConfigInterface = {
             properties: [
                 ServerConfigurationsConstants.SELF_SIGN_UP_NOTIFICATIONS_INTERNALLY_MANAGED
@@ -374,6 +376,8 @@ const InternalNotificationSendingPage: FC<InternalNotificationSendingPageInterfa
                     )
                 })
             );
+        } finally {
+            setIsReverting(false);
         }
     };
 
@@ -501,6 +505,8 @@ const InternalNotificationSendingPage: FC<InternalNotificationSendingPageInterfa
                             header= { t("governanceConnectors:dangerZone.heading") }
                             subheader= { t("governanceConnectors:dangerZone.subHeading") }
                             onActionClick={ () => onConfigRevert() }
+                            isButtonLoading={ isReverting }
+                            isButtonDisabled={ isReverting }
                             data-testid={ `${ componentId }-danger-zone` }
                         />
                     </DangerZoneGroup>

--- a/features/admin.session-management.v1/pages/session-management.tsx
+++ b/features/admin.session-management.v1/pages/session-management.tsx
@@ -67,6 +67,7 @@ const SessionManagementSettingsPage: FunctionComponent<SessionManagementSettings
     const { t } = useTranslation();
 
     const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
+    const [ isReverting, setIsReverting ] = useState<boolean>(false);
     const [ sessionManagementConfig , setSessionManagementConfig ] =
         useState<SessionManagementConfigFormValuesInterface>(undefined);
     const { isSubOrganization } = useGetCurrentOrganizationType();
@@ -255,7 +256,7 @@ const SessionManagementSettingsPage: FunctionComponent<SessionManagementSettings
     };
 
     const onConfigRevert = (): void => {
-        setIsSubmitting(true);
+        setIsReverting(true);
 
         const updateValues: PatchData[] = [
             {
@@ -288,7 +289,7 @@ const SessionManagementSettingsPage: FunctionComponent<SessionManagementSettings
             .catch(() => {
                 handleRevertError();
             }).finally(() => {
-                setIsSubmitting(false);
+                setIsReverting(false);
             });
     };
 
@@ -517,6 +518,8 @@ const SessionManagementSettingsPage: FunctionComponent<SessionManagementSettings
                                         header= { t("governanceConnectors:dangerZone.heading") }
                                         subheader= { t("governanceConnectors:dangerZone.subHeading") }
                                         onActionClick={ () => onConfigRevert() }
+                                        isButtonLoading={ isReverting }
+                                        isButtonDisabled={ isReverting }
                                         data-componentid={ `${ componentId }-danger-zone` }
                                     />
                                 </DangerZoneGroup>

--- a/features/admin.username-validation.v1/pages/username-validation-page.tsx
+++ b/features/admin.username-validation.v1/pages/username-validation-page.tsx
@@ -74,6 +74,7 @@ const UsernameValidationPage: FunctionComponent<UsernameValidationPageInterface>
     const pageContextRef: MutableRefObject<HTMLElement> = useRef(null);
     const { t } = useTranslation();
     const [ isSubmitting, setSubmitting ] = useState<boolean>(false);
+    const [ isReverting, setReverting ] = useState<boolean>(false);
     const [ initialFormValues, setInitialFormValues ] = useState<ValidationFormInterface>(undefined);
     const [ isApplicationRedirect, setApplicationRedirect ] = useState<boolean>(false);
     const [ currentValues, setCurrentValues ] = useState<ValidationFormInterface>(undefined);
@@ -299,7 +300,7 @@ const UsernameValidationPage: FunctionComponent<UsernameValidationPageInterface>
     };
 
     const onConfigRevert = (): void => {
-        setSubmitting(true);
+        setReverting(true);
 
         revertValidationConfigData([ ValidationConfigurationFields.USERNAME ])
             .then(() => {
@@ -310,7 +311,7 @@ const UsernameValidationPage: FunctionComponent<UsernameValidationPageInterface>
                 handleRevertError();
             })
             .finally(() => {
-                setSubmitting(false);
+                setReverting(false);
             });
     };
 
@@ -642,6 +643,8 @@ const UsernameValidationPage: FunctionComponent<UsernameValidationPageInterface>
                                     header= { t("governanceConnectors:dangerZone.heading") }
                                     subheader= { t("governanceConnectors:dangerZone.subHeading") }
                                     onActionClick={ () => onConfigRevert() }
+                                    isButtonLoading={ isReverting }
+                                    isButtonDisabled={ isReverting }
                                     data-componentid={ `${ componentId }-danger-zone` }
                                 />
                             </DangerZoneGroup>

--- a/features/admin.validation.v1/pages/validation-config-edit.tsx
+++ b/features/admin.validation.v1/pages/validation-config-edit.tsx
@@ -492,7 +492,6 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
                 await revertValidationConfigData([ ValidationConfigurationFields.PASSWORD ]);
                 mutateValidationConfigFetchRequest();
             } catch (error) {
-                setReverting(false);
                 isError = true;
                 dispatch(
                     addAlert({
@@ -520,7 +519,6 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
 
                 getLegacyPasswordPolicyProperties();
             } catch (error) {
-                setReverting(false);
                 isError = true;
                 dispatch(
                     addAlert({

--- a/features/admin.validation.v1/pages/validation-config-edit.tsx
+++ b/features/admin.validation.v1/pages/validation-config-edit.tsx
@@ -124,6 +124,7 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
     const maxPasswordLengthLimitLength: number = maxPasswordLengthLimit?.toString()?.length;
 
     const [ isSubmitting, setSubmitting ] = useState<boolean>(false);
+    const [ isReverting, setReverting ] = useState<boolean>(false);
     const [ initialFormValues, setInitialFormValues ] = useState<
         ValidationFormInterface
     >(undefined);
@@ -483,7 +484,7 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
     };
 
     const handleRevertValidationRules = async (): Promise<void> => {
-        setSubmitting(true);
+        setReverting(true);
         let isError: boolean = false;
 
         if (isPasswordInputValidationEnabled) {
@@ -491,7 +492,7 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
                 await revertValidationConfigData([ ValidationConfigurationFields.PASSWORD ]);
                 mutateValidationConfigFetchRequest();
             } catch (error) {
-                setSubmitting(false);
+                setReverting(false);
                 isError = true;
                 dispatch(
                     addAlert({
@@ -519,7 +520,7 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
 
                 getLegacyPasswordPolicyProperties();
             } catch (error) {
-                setSubmitting(false);
+                setReverting(false);
                 isError = true;
                 dispatch(
                     addAlert({
@@ -560,7 +561,7 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
 
             mutatePasswordHistoryCount();
             mutatePasswordExpiry();
-            setSubmitting(false);
+            setReverting(false);
             if (!isError) {
                 dispatch(
                     addAlert({
@@ -575,7 +576,7 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
                 );
             }
         } catch (error) {
-            setSubmitting(false);
+            setReverting(false);
             dispatch(
                 addAlert({
                     description: error?.response?.data?.detail ??
@@ -1906,6 +1907,8 @@ const ValidationConfigEditPage: FunctionComponent<MyAccountSettingsEditPage> = (
                                 header= { t("governanceConnectors:dangerZone.heading") }
                                 subheader= { t("governanceConnectors:dangerZone.subHeading") }
                                 onActionClick={ () => handleRevertValidationRules() }
+                                isButtonLoading={ isReverting }
+                                isButtonDisabled={ isReverting }
                                 data-testid={ `${ componentId }-danger-zone` }
                             />
                         </DangerZoneGroup>

--- a/features/admin.wsfed-configuration.v1/pages/wsfed-configuration.tsx
+++ b/features/admin.wsfed-configuration.v1/pages/wsfed-configuration.tsx
@@ -178,6 +178,10 @@ const WSFederationConfigurationPage: FunctionComponent<WSFederationConfiguration
      * Handle WSFederation form submit.
      */
     const handleSubmit = (value: boolean) => {
+        if (isReverting) {
+            return;
+        }
+
         const data: WSFederationConfigAPIResponseInterface = {
             enableRequestSigning: value
         };
@@ -287,7 +291,7 @@ const WSFederationConfigurationPage: FunctionComponent<WSFederationConfiguration
                                                                 name="enableRequestSigning"
                                                                 label={ t("wsFederationConfig:form." +
                                                                     "enableRequestSigning.label") }
-                                                                readOnly={ isReadOnly }
+                                                                readOnly={ isReadOnly || isReverting }
                                                                 width={ 16 }
                                                                 data-componentid={
                                                                     `${componentId}-enable-request-signing` }

--- a/features/admin.wsfed-configuration.v1/pages/wsfed-configuration.tsx
+++ b/features/admin.wsfed-configuration.v1/pages/wsfed-configuration.tsx
@@ -73,6 +73,7 @@ const WSFederationConfigurationPage: FunctionComponent<WSFederationConfiguration
 
     const [ wsFederationConfig , setWSFederationConfig ] =
         useState<WSFederationConfigFormValuesInterface>(undefined);
+    const [ isReverting, setIsReverting ] = useState<boolean>(false);
 
     const {
         data: originalWSFederationConfig,
@@ -194,11 +195,13 @@ const WSFederationConfigurationPage: FunctionComponent<WSFederationConfiguration
      * Handle WSFederation configuration revert.
      */
     const onConfigRevert = (): void => {
+        setIsReverting(true);
         revertWSFederationConfigurations().then(() => {
             handleRevertSuccess();
         }).catch(() => {
             handleRevertError();
         }).finally(() => {
+            setIsReverting(false);
             mutateWSFederationConfig();
         });
     };
@@ -311,6 +314,8 @@ const WSFederationConfigurationPage: FunctionComponent<WSFederationConfiguration
                                     header= { t("governanceConnectors:dangerZone.heading") }
                                     subheader= { t("governanceConnectors:dangerZone.subHeading") }
                                     onActionClick={ () => onConfigRevert() }
+                                    isButtonLoading={ isReverting }
+                                    isButtonDisabled={ isReverting }
                                     data-testid={ `${ componentId }-danger-zone` }
                                 />
                             </DangerZoneGroup>


### PR DESCRIPTION
## Purpose

This pull request improves the user experience and consistency of the "danger zone" configuration revert actions across multiple admin configuration pages. The main change is the introduction of a dedicated `isReverting` state to manage the loading and disabled states of revert buttons, ensuring clear feedback to users during revert operations. This prevents accidental multiple submissions and provides a more intuitive interface.

**Improvements to revert button behavior:**

* Added a new `isReverting` state to each relevant page/component to track when a configuration revert is in progress, separate from the general `isSubmitting` state. [[1]](diffhunk://#diff-ba0331eff69d95a453f3b34e9d225d118c73d1ac1b6b2ad62a2c46f63d17e283R105) [[2]](diffhunk://#diff-c868930c7bc6065cf5e344298b6c11b093a97c494f59e0d4d569b088b5217c50R76) [[3]](diffhunk://#diff-286381c408371c740458af91a7611bd78f435aa0f5abda2a38dfe88b6d2e7deeR92) [[4]](diffhunk://#diff-284888cff73b4b2124de9ffe320f16f40f7aa053966f1a9163b55d34f568396fR82) [[5]](diffhunk://#diff-1fd1a7fcec9e28b7e2861dc934d9cd5f113a5d9a55799cb91a0ce91c262834acR115) [[6]](diffhunk://#diff-ae86cfc4e4d7559c666b1d0d9e4bc52b52ad3c731802d7ec42580d9050a0c8dbR66) [[7]](diffhunk://#diff-27452d0a9c941606ddc476c8807e268d153a2c86e7acb80f0408c304542cd05dR70) [[8]](diffhunk://#diff-86c052c3c89d93b415fcaffaf69fbd3812012645b968444044927a322a289913R77)
* Updated the `onConfigRevert` (and similar revert handlers) to set `isReverting` to `true` at the start and reset it to `false` after completion, replacing previous usage of `isSubmitting`. [[1]](diffhunk://#diff-ba0331eff69d95a453f3b34e9d225d118c73d1ac1b6b2ad62a2c46f63d17e283L357-R358) [[2]](diffhunk://#diff-ba0331eff69d95a453f3b34e9d225d118c73d1ac1b6b2ad62a2c46f63d17e283L371-R372) [[3]](diffhunk://#diff-c868930c7bc6065cf5e344298b6c11b093a97c494f59e0d4d569b088b5217c50L152-R153) [[4]](diffhunk://#diff-c868930c7bc6065cf5e344298b6c11b093a97c494f59e0d4d569b088b5217c50L174-R175) [[5]](diffhunk://#diff-286381c408371c740458af91a7611bd78f435aa0f5abda2a38dfe88b6d2e7deeL256-R265) [[6]](diffhunk://#diff-286381c408371c740458af91a7611bd78f435aa0f5abda2a38dfe88b6d2e7deeR470-R471) [[7]](diffhunk://#diff-284888cff73b4b2124de9ffe320f16f40f7aa053966f1a9163b55d34f568396fR117) [[8]](diffhunk://#diff-284888cff73b4b2124de9ffe320f16f40f7aa053966f1a9163b55d34f568396fR161) [[9]](diffhunk://#diff-1fd1a7fcec9e28b7e2861dc934d9cd5f113a5d9a55799cb91a0ce91c262834acL333-R334) [[10]](diffhunk://#diff-1fd1a7fcec9e28b7e2861dc934d9cd5f113a5d9a55799cb91a0ce91c262834acL350-R357) [[11]](diffhunk://#diff-1fd1a7fcec9e28b7e2861dc934d9cd5f113a5d9a55799cb91a0ce91c262834acR400) [[12]](diffhunk://#diff-ae86cfc4e4d7559c666b1d0d9e4bc52b52ad3c731802d7ec42580d9050a0c8dbR297) [[13]](diffhunk://#diff-ae86cfc4e4d7559c666b1d0d9e4bc52b52ad3c731802d7ec42580d9050a0c8dbR379-R380) [[14]](diffhunk://#diff-27452d0a9c941606ddc476c8807e268d153a2c86e7acb80f0408c304542cd05dL258-R259) [[15]](diffhunk://#diff-27452d0a9c941606ddc476c8807e268d153a2c86e7acb80f0408c304542cd05dL291-R292) [[16]](diffhunk://#diff-86c052c3c89d93b415fcaffaf69fbd3812012645b968444044927a322a289913L302-R303)

**UI feedback enhancements:**

* Passed `isButtonLoading={isReverting}` and `isButtonDisabled={isReverting}` props to the danger zone action buttons, ensuring the button shows a loading state and is disabled during revert operations. [[1]](diffhunk://#diff-ba0331eff69d95a453f3b34e9d225d118c73d1ac1b6b2ad62a2c46f63d17e283R714-R715) [[2]](diffhunk://#diff-c868930c7bc6065cf5e344298b6c11b093a97c494f59e0d4d569b088b5217c50R258-R259) [[3]](diffhunk://#diff-286381c408371c740458af91a7611bd78f435aa0f5abda2a38dfe88b6d2e7deeR470-R471) [[4]](diffhunk://#diff-284888cff73b4b2124de9ffe320f16f40f7aa053966f1a9163b55d34f568396fR324-R325) [[5]](diffhunk://#diff-1fd1a7fcec9e28b7e2861dc934d9cd5f113a5d9a55799cb91a0ce91c262834acR873-R874) [[6]](diffhunk://#diff-ae86cfc4e4d7559c666b1d0d9e4bc52b52ad3c731802d7ec42580d9050a0c8dbR508-R509) [[7]](diffhunk://#diff-27452d0a9c941606ddc476c8807e268d153a2c86e7acb80f0408c304542cd05dR521-R522)

These changes make the revert process more robust, prevent duplicate requests, and provide better user feedback during configuration reverts.