### PR TITLE
Fix/rerender lazy state init

### DIFF
--- a/.changeset/fix-rerender-lazy-state-init.md
+++ b/.changeset/fix-rerender-lazy-state-init.md
@@ -1,0 +1,10 @@
+---
+"@wso2is/admin.claims.v1": patch
+"@wso2is/admin.console-settings.v1": patch
+"@wso2is/admin.login-flow-builder.v1": patch
+"@wso2is/admin.logs.v1": patch
+"@wso2is/admin.org-insights.v1": patch
+"@wso2is/admin.tenants.v1": patch
+---
+
+Fix useState lazy initialization to prevent re-running initializer on every render

--- a/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
+++ b/features/admin.claims.v1/components/edit/local-claim/edit-mapped-attributes-local-claims.tsx
@@ -167,7 +167,7 @@ export const EditMappedAttributesLocalClaims: FunctionComponent<EditMappedAttrib
         return property?.value?.split(",") || [];
     };
     const [ excludedUserStores, setExcludedUserStores ] = useState<string[]>(
-        getExcludedStoresFromClaim(claim)
+        () => getExcludedStoresFromClaim(claim)
     );
 
     const getMappedAttributeForUserStore = (userStore: string): string | undefined => {

--- a/features/admin.console-settings.v1/components/console-settings-tabs.tsx
+++ b/features/admin.console-settings.v1/components/console-settings-tabs.tsx
@@ -199,7 +199,7 @@ const ConsoleSettingsTabs: FunctionComponent<ConsoleSettingsTabsInterface> = (
         return activeTabFromUrl ? activeTabFromUrl.value : consoleTabs[0].value;
     };
 
-    const [ activeTab, setActiveTab ] = useState<number>(getActiveTabFromUrl());
+    const [ activeTab, setActiveTab ] = useState<number>(() => getActiveTabFromUrl());
 
     /**
      * Register a hash change listener to update the active tab.

--- a/features/admin.login-flow-builder.v1/providers/authentication-flow-provider.tsx
+++ b/features/admin.login-flow-builder.v1/providers/authentication-flow-provider.tsx
@@ -144,7 +144,7 @@ const AuthenticationFlowProvider = (props: PropsWithChildren<AuthenticationFlowP
     const dispatch: Dispatch = useDispatch();
 
     const [ authenticationSequence, setAuthenticationSequence ] = useState<AuthenticationSequenceInterface>(
-        cloneDeep(application?.authenticationSequence)
+        () => cloneDeep(application?.authenticationSequence)
     );
     const [ isConditionalAuthenticationEnabled, setIsConditionalAuthenticationEnabled ] = useState<boolean>(false);
     const [ filteredAuthenticators, setFilteredAuthenticators ] = useState<{

--- a/features/admin.logs.v1/components/time-range-selector.tsx
+++ b/features/admin.logs.v1/components/time-range-selector.tsx
@@ -54,7 +54,7 @@ const TimeRangeSelectorDropdown = (props: TimeRangeSelectorInterface):ReactEleme
     const [ endTime, setEndTime ] = useState<string>("");
     const [ selectedRange, setSelectedRange ] = useState<number>(0.25);
     const [ prevSelectedRange, setPrevSelectedRange ] = useState<number>(0.25);
-    const [ timeZone, setTimeZone ] = useState<string>(getCurrentTimeZone());
+    const [ timeZone, setTimeZone ] = useState<string>(() => getCurrentTimeZone());
     const [ isTimeRangeDropdownOpen, setIsTimeRangeDropdownOpen ] = useState<boolean | undefined>(
         undefined
     );

--- a/features/admin.org-insights.v1/pages/org-insights.tsx
+++ b/features/admin.org-insights.v1/pages/org-insights.tsx
@@ -33,7 +33,7 @@ import { isM2MInsightsFeatureEnabled } from "../utils/insights";
 const OrgInsightsPage: FunctionComponent = () => {
     const [ duration, setDuration ] = useState<number>(OrgInsightsConstants.DURATION_OPTIONS[0].value);
     const [ filterQuery, setFilterQuery ] = useState<string>("");
-    const [ lastFetchTimestamp, setLastFetchTimestamp ] = useState<string>(dayjs().format("HH:mm:ss"));
+    const [ lastFetchTimestamp, setLastFetchTimestamp ] = useState<string>(() => dayjs().format("HH:mm:ss"));
     const [ selectedActivityType, setSelectedActivityType ] = useState<ActivityType>(ActivityType.LOGIN);
 
     const { t } = useTranslation();

--- a/features/admin.tenants.v1/components/system-settings/system-settings-tabs.tsx
+++ b/features/admin.tenants.v1/components/system-settings/system-settings-tabs.tsx
@@ -113,7 +113,7 @@ const SystemSettingsTabs: FunctionComponent<SystemSettingsTabsInterface> = ({
         return activeTabFromUrl ? activeTabFromUrl.value : tabs[0].value;
     };
 
-    const [ activeTab, setActiveTab ] = useState<number>(getActiveTabFromUrl());
+    const [ activeTab, setActiveTab ] = useState<number>(() => getActiveTabFromUrl());
 
     /**
      * Register a hash change listener to update the active tab.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,16 @@ packages:
   - "features"
   - "features/*"
 
+allowBuilds:
+  '@parcel/watcher': false
+  '@swc/core': false
+  core-js: false
+  core-js-pure: false
+  esbuild: false
+  msw: false
+  nx: false
+  unrs-resolver: false
+
 catalog:
   "@mui/icons-material": "^5.11.16"
   "@mui/lab": "5.0.0-alpha.129"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,16 +5,6 @@ packages:
   - "features"
   - "features/*"
 
-allowBuilds:
-  '@parcel/watcher': false
-  '@swc/core': false
-  core-js: false
-  core-js-pure: false
-  esbuild: false
-  msw: false
-  nx: false
-  unrs-resolver: false
-
 catalog:
   "@mui/icons-material": "^5.11.16"
   "@mui/lab": "5.0.0-alpha.129"


### PR DESCRIPTION

### Purpose

Fix performance issue where useState initial values were being re-evaluated on every render instead of only once on mount. closes https://github.com/wso2/product-is/issues/27955#event-27020045813

React evaluates a plain expression passed to useState(expr) on every render (the result is discarded after the first render, but the computation still runs). Wrapping it as useState(() => expr) changes to a lazy initializer pattern ensuring the function is called only once during component mount.

Fixed in 6 files:

admin.claims.v1 — getExcludedStoresFromClaim(claim) (array computation from claim data)
admin.console-settings.v1 — getActiveTabFromUrl() (URL parsing)
admin.login-flow-builder.v1 — cloneDeep(application?.authenticationSequence) (deep object clone)
admin.logs.v1 — getCurrentTimeZone() (timezone lookup)
admin.org-insights.v1 — dayjs().format("HH:mm:ss") (date formatting)
admin.tenants.v1 — getActiveTabFromUrl() (URL parsing)

### Related Issues

- N/A

### Related PRs

- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
- Behavioral change? No. This is a pure performance fix. Initialization logic is unchanged; only when it runs changes (mount only vs. every render). No visible difference to users.
- Migration impact? No.
- New configuration? No.
