### PR TITLE
fix: add explicit type attribute to button elements

### DIFF
--- a/.changeset/fix-button-has-type.md
+++ b/.changeset/fix-button-has-type.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/admin.branding.v1": patch
+"@wso2is/admin.flow-builder-core.v1": patch
+"@wso2is/admin.users.v1": patch
+---
+
+Add explicit type attribute to button elements to fix react-doctor/button-has-type warnings.

--- a/.changeset/fix-button-has-type.md
+++ b/.changeset/fix-button-has-type.md
@@ -2,6 +2,7 @@
 "@wso2is/admin.branding.v1": patch
 "@wso2is/admin.flow-builder-core.v1": patch
 "@wso2is/admin.users.v1": patch
+"@wso2is/console": patch
 ---
 
 Add explicit type attribute to button elements to fix react-doctor/button-has-type warnings.

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx
@@ -57,7 +57,7 @@ const EmailLinkExpiryFragment: FunctionComponent<EmailLinkExpiryFragmentInterfac
             >
                 <Placeholder.Image />
             </Placeholder>
-            <button className="ui primary button mb-2">Go Back</button>
+            <button type="button" className="ui primary button mb-2">Go Back</button>
         </div>
     );
 };

--- a/features/admin.flow-builder-core.v1/components/dnd/action.tsx
+++ b/features/admin.flow-builder-core.v1/components/dnd/action.tsx
@@ -61,6 +61,7 @@ const Action: ForwardRefExoticComponent<ActionProps> = forwardRef<HTMLButtonElem
         ref: ForwardedRef<HTMLButtonElement>
     ): ReactElement => (
         <button
+            type="button"
             ref={ ref }
             className={ classNames("flow-builder-dnd-action", className) }
             style={

--- a/features/admin.users.v1/components/wizard/steps/add-user-basic/add-user-basic.tsx
+++ b/features/admin.users.v1/components/wizard/steps/add-user-basic/add-user-basic.tsx
@@ -1367,6 +1367,7 @@ export const AddUserBasic: React.FunctionComponent<AddUserBasicProps> = ({
                         </Grid>
                         { /** This hidden button is used to submit the form programmatically */ }
                         <button
+                            type="button"
                             ref={ submitButtonRef }
                             onClick={ () => onSubmitClick(hasValidationErrors) }
                             hidden

--- a/features/admin.users.v1/components/wizard/steps/add-user-basic/add-user-basic.tsx
+++ b/features/admin.users.v1/components/wizard/steps/add-user-basic/add-user-basic.tsx
@@ -1367,7 +1367,7 @@ export const AddUserBasic: React.FunctionComponent<AddUserBasicProps> = ({
                         </Grid>
                         { /** This hidden button is used to submit the form programmatically */ }
                         <button
-                            type="button"
+                            type="submit"
                             ref={ submitButtonRef }
                             onClick={ () => onSubmitClick(hasValidationErrors) }
                             hidden


### PR DESCRIPTION
### Purpose
Fixes `react-doctor/button-has-type` lint warnings by adding an explicit 
`type="button"` attribute to three `<button>` elements that were missing it.

Without an explicit `type`, buttons inside forms default to `type="submit"` 
in HTML, which can cause unintended form submissions. This change makes the 
intent explicit and resolves the correctness warnings flagged by React Doctor.

**Affected files:**
- `admin.branding.v1/components/preview/sign-in-box/fragments/email-link-expiry-fragment.tsx` (line 60)
- `admin.flow-builder-core.v1/components/dnd/action.tsx` (line 63)
- `admin.users.v1/components/wizard/steps/add-user-basic/add-user-basic.tsx` (line 1369)

### Related Issues
- Closes  wso2/product-is#27877

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track 
any behavioral change or migration impact.

> No behavioural change, migration impact, or new configuration introduced by this fix.