### PR TITLE
[Fix] Remove redundant role attribute from button element to resolve react-doctor/no-redundant-roles warning

### DIFF
--- a/.changeset/fix-no-redundant-roles.md
+++ b/.changeset/fix-no-redundant-roles.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.branding.v1": patch
+---
+
+Remove redundant role attribute from button element to fix react-doctor/no-redundant-roles warning.

--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/basic-auth-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/basic-auth-fragment.tsx
@@ -142,7 +142,6 @@ const BasicAuthFragment: FunctionComponent<BasicAuthFragmentInterface> = (
                             <button
                                 type="submit"
                                 className="ui primary fluid large button"
-                                role="button"
                                 data-testid="login-page-continue-login-button"
                             >
                                 { i18n(CustomTextPreferenceConstants.TEXT_BUNDLE_KEYS.LOGIN.BUTTON, "Sign In") }


### PR DESCRIPTION
### Purpose
Fixes `react-doctor/no-redundant-roles` accessibility warning by removing the 
redundant `role="button"` attribute from a `<button>` element in the branding 
preview sign-in box fragment.

A `<button>` element already has an implicit ARIA role of `"button"` built into 
it by the browser. Adding `role="button"` explicitly is redundant and unnecessary.

**Affected file:**
- `admin.branding.v1/components/preview/sign-in-box/fragments/basic-auth-fragment.tsx` (line 145)

### Related Issues
- Closes wso2/product-is#27934

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

> No behavioural change, migration impact, or new configuration introduced by this fix.