### PR TITLE
[Fix] Rename LOGO_IMAGE to LogoImage to resolve react-doctor/jsx-pascal-case warning

### DIFF
--- a/.changeset/fix-jsx-pascal-case.md
+++ b/.changeset/fix-jsx-pascal-case.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.core.v1": patch
+---
+
+Rename LOGO_IMAGE component to LogoImage to follow JSX PascalCase naming convention.

--- a/features/admin.core.v1/components/header.tsx
+++ b/features/admin.core.v1/components/header.tsx
@@ -548,7 +548,7 @@ const Header: FunctionComponent<HeaderPropsInterface> = ({
         return accountAppURL;
     };
 
-    const LOGO_IMAGE = () => {
+    const LogoImage = () => {
         return (
             <Image
                 src={ resolveAppLogoFilePath(

--- a/features/admin.core.v1/components/header.tsx
+++ b/features/admin.core.v1/components/header.tsx
@@ -630,8 +630,8 @@ const Header: FunctionComponent<HeaderPropsInterface> = ({
                 className={ isSAASDeployment ? "is-header saas-header" : "is-header" }
                 brand={ {
                     logo: {
-                        desktop: <LOGO_IMAGE />,
-                        mobile: <LOGO_IMAGE />
+                        desktop: <LogoImage />,
+                        mobile: <LogoImage />
                     },
                     onClick: () =>
                         hasGettingStartedViewPermission &&


### PR DESCRIPTION
### Purpose
Fixes `react-doctor/jsx-pascal-case` architecture warning by renaming the 
`LOGO_IMAGE` component to `LogoImage` in the header component.

JSX component names must be in PascalCase so React can distinguish them from 
native HTML elements. `LOGO_IMAGE` (SCREAMING_SNAKE_CASE) violates this convention 
and is renamed to `LogoImage` at both the definition and its two usages.

**Affected file:**
- `admin.core.v1/components/header.tsx` (lines 632, 633)

### Related Issues
- Closes wso2/product-is#27900

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

> No behavioural change, migration impact, or new configuration introduced by this fix.