### PR TITLE
Refactor PreIssueAccessTokenActionConfigForm to use useReducer

### DIFF
--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -31,8 +31,7 @@ import { IdentifiableComponentInterface,
 import { FinalForm, FormRenderProps } from "@wso2is/forms";
 import { EmphasizedSegment } from "@wso2is/react-components";
 import { AxiosError } from "axios";
-import React, { FunctionComponent, ReactElement, useEffect, useReducer, useState } from "react";
-import { useTranslation } from "react-i18next";
+import React, { FunctionComponent, ReactElement, useEffect, useReducer } from "react";import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import CommonActionConfigForm from "./common-action-config-form";
 import RuleConfigForm from "./rule-config-form";
@@ -169,16 +168,16 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
      */
     useEffect(() => {
         if (!initialValues?.id) {
-            setIsAuthenticationUpdateFormState(true);
+            dispatch({ type: "SET_AUTH_UPDATE_FORM_STATE", payload: true });
         } else {
-            setAuthenticationType(initialValues.authenticationType as AuthenticationType);
-            setIsAuthenticationUpdateFormState(false);
+            dispatch({ type: "SET_AUTHENTICATION_TYPE", payload: initialValues.authenticationType as AuthenticationType });
+            dispatch({ type: "SET_AUTH_UPDATE_FORM_STATE", payload: false });
         }
     }, [ initialValues ]);
 
     useEffect(() => {
         if (actionData?.rule) {
-            setIsHasRule(true);
+            dispatch({ type: "SET_IS_HAS_RULE", payload: true });
         }
     }, [ actionData ]);
 
@@ -192,14 +191,14 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
     );
 
     const validateForm = (values: ActionConfigFormPropertyInterface):
-        Partial<ActionConfigFormPropertyInterface> => {
+    Partial<ActionConfigFormPropertyInterface> => {
 
-        // Call the utility validate function
-        return validateActionCommonFields(values, {
-            authenticationType: authenticationType,
-            isAuthenticationUpdateFormState: isAuthenticationUpdateFormState,
-            isCreateFormState: isCreateFormState
-        });
+    // Call the utility validate function
+    return validateActionCommonFields(values, {
+        authenticationType: formState.authenticationType,
+        isAuthenticationUpdateFormState: formState.isAuthenticationUpdateFormState,
+        isCreateFormState: isCreateFormState
+    });
     };
 
     const handleSubmit = (
@@ -208,17 +207,17 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
     {
         let payloadRule: RuleWithoutIdInterface | RuleExecuteCollectionWithoutIdInterface | Record<string, never>;
 
-        if (isHasRule) {
-            payloadRule = rule;
+        if (formState.isHasRule) {
+            payloadRule = formState.rule;
         } else {
-            if (!isCreateFormState && !rule) {
+            if (!isCreateFormState && !formState.rule) {
                 payloadRule = {};
             }
         }
 
         const authProperties: Partial<AuthenticationPropertiesInterface> = {};
 
-        if (isAuthenticationUpdateFormState || isCreateFormState) {
+        if (formState.isAuthenticationUpdateFormState || isCreateFormState) {{
             switch (values.authenticationType) {
                 case AuthenticationType.BASIC:
                     authProperties.username = values.usernameAuthProperty;
@@ -272,7 +271,7 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                 ...(payloadRule !== null && { rule: payloadRule })
             };
 
-            setIsSubmitting(true);
+            dispatch({ type: "SET_IS_SUBMITTING", payload: true });
             createAction(actionTypeApiPath, actionValues)
                 .then(() => {
                     handleSuccess(ActionsConstants.CREATE);
@@ -282,19 +281,19 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                     handleError(error, ActionsConstants.CREATE);
                 })
                 .finally(() => {
-                    setIsSubmitting(false);
+                    dispatch({ type: "SET_IS_SUBMITTING", payload: false });
                 });
         } else {
             // Updating the action
             const updatingValues: ActionUpdateInterface = {
-                endpoint: isAuthenticationUpdateFormState ||
+                endpoint: formState.isAuthenticationUpdateFormState ||
                 changedFields?.endpointUri ||
                 changedFields?.allowedHeaders ||
                 changedFields?.allowedParameters
                     ? {
                         allowedHeaders: changedFields?.allowedHeaders ? values.allowedHeaders : undefined,
                         allowedParameters: changedFields?.allowedParameters ? values.allowedParameters : undefined,
-                        authentication: isAuthenticationUpdateFormState ? {
+                        authentication: formState.isAuthenticationUpdateFormState ? {
                             properties: authProperties,
                             type: values.authenticationType as AuthenticationType
                         } : undefined,
@@ -304,18 +303,18 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                 ...(payloadRule !== null && { rule: payloadRule })
             };
 
-            setIsSubmitting(true);
+            dispatch({ type: "SET_IS_SUBMITTING", payload: true });
             updateAction(actionTypeApiPath, initialValues.id, updatingValues)
                 .then(() => {
                     handleSuccess(ActionsConstants.UPDATE);
-                    setIsAuthenticationUpdateFormState(false);
+                    dispatch({ type: "SET_AUTH_UPDATE_FORM_STATE", payload: false });
                     mutateAction();
                 })
                 .catch((error: AxiosError<HttpErrorResponseDataInterface>) => {
                     handleError(error, ActionsConstants.UPDATE);
                 })
                 .finally(() => {
-                    setIsSubmitting(false);
+                    dispatch({ type: "SET_IS_SUBMITTING", payload: false });
                 });
         }
     };
@@ -333,19 +332,19 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                     isCreateFormState={ isCreateFormState }
                     isReadOnly={ isReadOnly }
                     onAuthenticationTypeChange={ (updatedValue: AuthenticationType, change: boolean) => {
-                        setAuthenticationType(updatedValue);
-                        setIsAuthenticationUpdateFormState(change);
+                        dispatch({ type: "SET_AUTHENTICATION_TYPE", payload: updatedValue });
+                        dispatch({ type: "SET_AUTH_UPDATE_FORM_STATE", payload: change });
                     } }
                     showHeadersAndParams={ showHeadersAndParams }
                 />
                 { (RuleExpressionsMetaData && showRuleComponent) && (
                     <RuleConfigForm
                         readonly={ isReadOnly }
-                        rule={ rule }
+                        rule={ formState.rule }
                         ruleActionType={ actionTypeApiPath }
-                        setRule={ setRule }
-                        isHasRule={ isHasRule }
-                        setIsHasRule={ setIsHasRule }
+                        setRule={ (rule: RuleWithoutIdInterface) => dispatch({ type: "SET_RULE", payload: rule }) }
+                        isHasRule={ formState.isHasRule }
+                        setIsHasRule={ (isHasRule: boolean) => dispatch({ type: "SET_IS_HAS_RULE", payload: isHasRule }) }
                         data-componentid={ `${ _componentId }-rule` }
                     />
                 ) }
@@ -381,7 +380,7 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                                             onClick={ handleSubmit }
                                             className={ "button-container" }
                                             data-componentid={ `${ _componentId }-primary-button` }
-                                            loading={ isSubmitting }
+                                            loading={ formState.isSubmitting }
                                             disabled={ isReadOnly }
                                         >
                                             {
@@ -401,5 +400,5 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
         </>
     );
 };
-
+};
 export default PreIssueAccessTokenActionConfigForm;

--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -31,7 +31,7 @@ import { IdentifiableComponentInterface,
 import { FinalForm, FormRenderProps } from "@wso2is/forms";
 import { EmphasizedSegment } from "@wso2is/react-components";
 import { AxiosError } from "axios";
-import React, { FunctionComponent, ReactElement, useEffect, useState } from "react";
+import React, { FunctionComponent, ReactElement, useEffect, useReducer, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import CommonActionConfigForm from "./common-action-config-form";
@@ -83,6 +83,38 @@ interface PreIssueAccessTokenActionConfigFormInterface extends IdentifiableCompo
     versionInfo: ActionVersionInfo;
 }
 
+interface FormStateInterface {
+    isAuthenticationUpdateFormState: boolean;
+    authenticationType: AuthenticationType;
+    isSubmitting: boolean;
+    isHasRule: boolean;
+    rule: RuleWithoutIdInterface;
+}
+
+type FormActionInterface =
+    | { type: "SET_AUTH_UPDATE_FORM_STATE"; payload: boolean }
+    | { type: "SET_AUTHENTICATION_TYPE"; payload: AuthenticationType }
+    | { type: "SET_IS_SUBMITTING"; payload: boolean }
+    | { type: "SET_IS_HAS_RULE"; payload: boolean }
+    | { type: "SET_RULE"; payload: RuleWithoutIdInterface };
+
+const formReducer = (state: FormStateInterface, action: FormActionInterface): FormStateInterface => {
+    switch (action.type) {
+        case "SET_AUTH_UPDATE_FORM_STATE":
+            return { ...state, isAuthenticationUpdateFormState: action.payload };
+        case "SET_AUTHENTICATION_TYPE":
+            return { ...state, authenticationType: action.payload };
+        case "SET_IS_SUBMITTING":
+            return { ...state, isSubmitting: action.payload };
+        case "SET_IS_HAS_RULE":
+            return { ...state, isHasRule: action.payload };
+        case "SET_RULE":
+            return { ...state, rule: action.payload };
+        default:
+            return state;
+    }
+};
+
 const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessTokenActionConfigFormInterface> = ({
     initialValues,
     isLoading,
@@ -94,12 +126,17 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
 
     const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
         (state: AppState) => state.config.ui.features.actions);
-    const [ isAuthenticationUpdateFormState, setIsAuthenticationUpdateFormState ] = useState<boolean>(false);
-    const [ authenticationType, setAuthenticationType ] = useState<AuthenticationType>(null);
-    const [ isSubmitting, setIsSubmitting ] = useState<boolean>(false);
-    const [ isHasRule, setIsHasRule ] = useState<boolean>(false);
-    const [ rule, setRule ] = useState<RuleWithoutIdInterface>(null);
-
+    const [ formState, dispatch ] = useReducer<React.Reducer<FormStateInterface, FormActionInterface>>(
+        formReducer,
+        {
+            isAuthenticationUpdateFormState: false,
+            authenticationType: null,
+            isSubmitting: false,
+            isHasRule: false,
+            rule: null
+        }
+    );
+    
     const { t } = useTranslation();
 
     const handleSuccess: (operation: string) => void = useHandleSuccess();

--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -84,18 +84,18 @@ interface PreIssueAccessTokenActionConfigFormInterface extends IdentifiableCompo
 
 interface FormStateInterface {
     isAuthenticationUpdateFormState: boolean;
-    authenticationType: AuthenticationType;
+    authenticationType: AuthenticationType | null;
     isSubmitting: boolean;
     isHasRule: boolean;
-    rule: RuleWithoutIdInterface;
+    rule: RuleWithoutIdInterface | null;
 }
 
 type FormActionInterface =
     | { type: "SET_AUTH_UPDATE_FORM_STATE"; payload: boolean }
-    | { type: "SET_AUTHENTICATION_TYPE"; payload: AuthenticationType }
+    | { type: "SET_AUTHENTICATION_TYPE"; payload: AuthenticationType | null }
     | { type: "SET_IS_SUBMITTING"; payload: boolean }
     | { type: "SET_IS_HAS_RULE"; payload: boolean }
-    | { type: "SET_RULE"; payload: RuleWithoutIdInterface };
+    | { type: "SET_RULE"; payload: RuleWithoutIdInterface | null };
 
 const formReducer = (state: FormStateInterface, action: FormActionInterface): FormStateInterface => {
     switch (action.type) {
@@ -217,7 +217,7 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
 
         const authProperties: Partial<AuthenticationPropertiesInterface> = {};
 
-        if (formState.isAuthenticationUpdateFormState || isCreateFormState) {{
+        if (formState.isAuthenticationUpdateFormState || isCreateFormState) {
             switch (values.authenticationType) {
                 case AuthenticationType.BASIC:
                     authProperties.username = values.usernameAuthProperty;
@@ -400,5 +400,5 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
         </>
     );
 };
-};
+
 export default PreIssueAccessTokenActionConfigForm;

--- a/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
+++ b/features/admin.actions.v1/components/pre-issue-access-token-action-config-form.tsx
@@ -31,7 +31,8 @@ import { IdentifiableComponentInterface,
 import { FinalForm, FormRenderProps } from "@wso2is/forms";
 import { EmphasizedSegment } from "@wso2is/react-components";
 import { AxiosError } from "axios";
-import React, { FunctionComponent, ReactElement, useEffect, useReducer } from "react";import { useTranslation } from "react-i18next";
+import React, { FunctionComponent, ReactElement, useEffect, useReducer } from "react";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import CommonActionConfigForm from "./common-action-config-form";
 import RuleConfigForm from "./rule-config-form";
@@ -83,10 +84,25 @@ interface PreIssueAccessTokenActionConfigFormInterface extends IdentifiableCompo
 }
 
 interface FormStateInterface {
+    /**
+     * Whether the authentication update form is active.
+     */
     isAuthenticationUpdateFormState: boolean;
+    /**
+     * The current authentication type selected.
+     */
     authenticationType: AuthenticationType | null;
+    /**
+     * Whether the form is currently submitting.
+     */
     isSubmitting: boolean;
+    /**
+     * Whether the action has an associated rule.
+     */
     isHasRule: boolean;
+    /**
+     * The current rule associated with the action.
+     */
     rule: RuleWithoutIdInterface | null;
 }
 
@@ -125,7 +141,7 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
 
     const actionsFeatureConfig: FeatureAccessConfigInterface = useSelector(
         (state: AppState) => state.config.ui.features.actions);
-    const [ formState, dispatch ] = useReducer<React.Reducer<FormStateInterface, FormActionInterface>>(
+    const [ actionFormState, dispatch ] = useReducer<React.Reducer<FormStateInterface, FormActionInterface>>(
         formReducer,
         {
             isAuthenticationUpdateFormState: false,
@@ -193,12 +209,12 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
     const validateForm = (values: ActionConfigFormPropertyInterface):
     Partial<ActionConfigFormPropertyInterface> => {
 
-    // Call the utility validate function
-    return validateActionCommonFields(values, {
-        authenticationType: formState.authenticationType,
-        isAuthenticationUpdateFormState: formState.isAuthenticationUpdateFormState,
-        isCreateFormState: isCreateFormState
-    });
+        // Call the utility validate function
+        return validateActionCommonFields(values, {
+            authenticationType: actionFormState.authenticationType,
+            isAuthenticationUpdateFormState: actionFormState.isAuthenticationUpdateFormState,
+            isCreateFormState: isCreateFormState
+        });
     };
 
     const handleSubmit = (
@@ -207,17 +223,17 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
     {
         let payloadRule: RuleWithoutIdInterface | RuleExecuteCollectionWithoutIdInterface | Record<string, never>;
 
-        if (formState.isHasRule) {
-            payloadRule = formState.rule;
+        if (actionFormState.isHasRule) {
+            payloadRule = actionFormState.rule;
         } else {
-            if (!isCreateFormState && !formState.rule) {
+            if (!isCreateFormState && !actionFormState.rule) {
                 payloadRule = {};
             }
         }
 
         const authProperties: Partial<AuthenticationPropertiesInterface> = {};
 
-        if (formState.isAuthenticationUpdateFormState || isCreateFormState) {
+        if (actionFormState.isAuthenticationUpdateFormState || isCreateFormState) {
             switch (values.authenticationType) {
                 case AuthenticationType.BASIC:
                     authProperties.username = values.usernameAuthProperty;
@@ -286,14 +302,14 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
         } else {
             // Updating the action
             const updatingValues: ActionUpdateInterface = {
-                endpoint: formState.isAuthenticationUpdateFormState ||
+                endpoint: actionFormState.isAuthenticationUpdateFormState ||
                 changedFields?.endpointUri ||
                 changedFields?.allowedHeaders ||
                 changedFields?.allowedParameters
                     ? {
                         allowedHeaders: changedFields?.allowedHeaders ? values.allowedHeaders : undefined,
                         allowedParameters: changedFields?.allowedParameters ? values.allowedParameters : undefined,
-                        authentication: formState.isAuthenticationUpdateFormState ? {
+                        authentication: actionFormState.isAuthenticationUpdateFormState ? {
                             properties: authProperties,
                             type: values.authenticationType as AuthenticationType
                         } : undefined,
@@ -340,10 +356,10 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                 { (RuleExpressionsMetaData && showRuleComponent) && (
                     <RuleConfigForm
                         readonly={ isReadOnly }
-                        rule={ formState.rule }
+                        rule={ actionFormState.rule }
                         ruleActionType={ actionTypeApiPath }
                         setRule={ (rule: RuleWithoutIdInterface) => dispatch({ type: "SET_RULE", payload: rule }) }
-                        isHasRule={ formState.isHasRule }
+                        isHasRule={ actionFormState.isHasRule }
                         setIsHasRule={ (isHasRule: boolean) => dispatch({ type: "SET_IS_HAS_RULE", payload: isHasRule }) }
                         data-componentid={ `${ _componentId }-rule` }
                     />
@@ -380,7 +396,7 @@ const PreIssueAccessTokenActionConfigForm: FunctionComponent<PreIssueAccessToken
                                             onClick={ handleSubmit }
                                             className={ "button-container" }
                                             data-componentid={ `${ _componentId }-primary-button` }
-                                            loading={ formState.isSubmitting }
+                                            loading={ actionFormState.isSubmitting }
                                             disabled={ isReadOnly }
                                         >
                                             {


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose
This PR addresses the react-doctor/prefer-useReducer lint warning in 
`PreIssueAccessTokenActionConfigForm`. The component had 5 separate useState 
calls managing related form state (`isAuthenticationUpdateFormState`, 
`authenticationType`, `isSubmitting`, `isHasRule`, and `rule`). These have been 
refactored into a single useReducer hook with explicit TypeScript interfaces 
for state and actions, improving readability and maintainability.

### Related Issues
- Closes wso2/product-is#27947

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [X] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
