### PR TITLE
[Fix] Replace array sort with reduce to find longest match, avoiding O(n log n) sort

### DIFF
--- a/.changeset/fix-js-min-max-loop.md
+++ b/.changeset/fix-js-min-max-loop.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.core.v1": patch
+---
+
+Replace array sort with reduce to find the longest consecutive character match, avoiding unnecessary O(n log n) sort.

--- a/features/admin.core.v1/utils/user-store-utils.ts
+++ b/features/admin.core.v1/utils/user-store-utils.ts
@@ -150,11 +150,9 @@ export class SharedUserStoreUtils {
         // Repetitive character check.
         if(passwordConfig.consecutiveCharacterValidatorEnabled &&
             inputValue.match(consecutiveChrPattern)) {
-            const long: string = inputValue.match(consecutiveChrPattern).sort(
-                function(a: string, b: string) {
-                    return b.length - a.length;
-                }
-            ) [0];
+            const long: string = inputValue.match(consecutiveChrPattern).reduce(
+                (a: string, b: string) => (a.length >= b.length ? a : b)
+            );
 
             if (long.length > Number(passwordConfig.maxConsecutiveCharacters)) {
                 return false;


### PR DESCRIPTION
### Purpose
Fixes `react-doctor/js-min-max-loop` performance warning by replacing an 
unnecessary array sort with `reduce` to find the longest consecutive character 
match.

Previously, the code sorted the entire array of regex matches by length just 
to grab the first (longest) element — an `O(n log n)` operation. This is now 
replaced with `reduce`, which finds the longest match in a single `O(n)` pass.

**Affected file:**
- `admin.core.v1/utils/user-store-utils.ts` (line 153)

### Related Issues
- Closes wso2/product-is#27892

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

> No behavioural change, migration impact, or new configuration introduced by this fix.
