### PR TITLE
fix: replace javascript: URL with button element in password recovery multi-option fragment

### DIFF
--- a/features/admin.branding.v1/components/preview/sign-in-box/fragments/password-recovery/password-recovery-multi-option-fragment.tsx
+++ b/features/admin.branding.v1/components/preview/sign-in-box/fragments/password-recovery/password-recovery-multi-option-fragment.tsx
@@ -107,9 +107,13 @@ const PasswordRecoveryMultiOptionFragment: FunctionComponent<PasswordRecoveryMul
                         </button>
                     </div>
                     <div className="mt-1 align-center">
-                        <a href="javascript:goBack()" className="ui button secondary large fluid">
+                        <button
+                            type="button"
+                            id="subButton"
+                            className="ui secondary fluid large button"
+                        >
                             Cancel
-                        </a>
+                        </button>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
### Purpose
   Replaces `<a href="javascript:goBack()">` with a `<button type="button">` element in the password recovery multi-option
   preview fragment. React 19 blocks `javascript:` URLs as a security measure (jsx-no-script-url). Pattern matches existing
   sibling fragments in the same directory.

   ### Related Issues
   - wso2/product-is#27899

   ### Related PRs
   - N/A

   ### Checklist
   - [ ] e2e cypress tests locally verified.
   - [x] Manual test round performed and verified.
   - [ ] UX/UI review done on the final implementation.
   - [ ] Documentation provided.
   - [ ] Relevant backend changes deployed and verified
   - [ ] Unit tests provided.
   - [ ] Integration tests provided.

   ### Security checks
   - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
   - [ ] Ran FindSecurityBugs plugin and verified report
   - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

   ## Developer Checklist (Mandatory)
   - [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration
   impact.