### PR TITLE
Use consent Me API in MyAccount

### DIFF
--- a/.changeset/full-zoos-punch.md
+++ b/.changeset/full-zoos-punch.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/myaccount": patch
+---
+
+Update consent API uri

--- a/apps/myaccount/src/api/consents.ts
+++ b/apps/myaccount/src/api/consents.ts
@@ -36,7 +36,7 @@ import {
     ServiceInterface,
     UpdateReceiptInterface
 } from "../models";
-import { PolicyConsentDetailInterface, PolicyConsentListResponseInterface } from "../models/consents";
+import { PolicyConsentDetailInterface, PolicyConsentSummaryInterface } from "../models/consents";
 import { store } from "../store";
 
 /**
@@ -313,27 +313,25 @@ export const updateConsentedClaims = (
  * Retrieves the list of user consent records from the v2 consents API.
  *
  * @param consentsBaseUrl - Base URL for the v2 consents endpoint.
- * @param subjectId - Username of the subject to filter consents.
  * @param state - Consent state filter (defaults to "ACTIVE").
  * @returns A promise containing the paginated consent list response.
  */
-export const getConsentsBySubject = (
+export const getMeConsents = (
     consentsBaseUrl: string,
-    subjectId: string,
     state: string = "ACTIVE"
-): Promise<PolicyConsentListResponseInterface> => {
+): Promise<PolicyConsentSummaryInterface[]> => {
     const requestConfig: AxiosRequestConfig = {
         headers: {
             "Accept": "application/json",
             "Content-Type": "application/json"
         },
         method: "GET",
-        params: { state, subjectId },
+        params: { state },
         url: consentsBaseUrl
     };
 
     return httpClient(requestConfig)
-        .then((response: HttpResponse<PolicyConsentListResponseInterface>) => {
+        .then((response: HttpResponse<PolicyConsentSummaryInterface[]>) => {
             return response.data;
         })
         .catch((error: HttpError) => {

--- a/apps/myaccount/src/components/policy-consent/policy-consent.tsx
+++ b/apps/myaccount/src/components/policy-consent/policy-consent.tsx
@@ -20,12 +20,11 @@ import {
     ConsentedPurposeInterface,
     PolicyConsentDetailInterface,
     PolicyConsentItemInterface,
-    PolicyConsentListResponseInterface,
     PolicyConsentSummaryInterface
 } from "../../models/consents";
 import {
     getConsentById,
-    getConsentsBySubject,
+    getMeConsents,
     revokeConsentById
 } from "../../api/consents";
 import { IdentifiableComponentInterface } from "@wso2is/core/models";
@@ -60,21 +59,19 @@ export const PolicyConsent: FunctionComponent<PolicyConsentComponentProps> = (
     const [ isPolicyRevokeModalVisible, setPolicyRevokeModalVisible ] = useState<boolean>(false);
     const [ isRevoking, setIsRevoking ] = useState<boolean>(false);
 
-    const userName: string = useSelector((state: AppState) => state?.authenticationInformation?.profileInfo.userName);
     const consentsBaseUrl: string = useSelector(
         (state: AppState) => state?.config?.endpoints?.consentMgtV2?.consents
     );
     const { t } = useTranslation();
 
     const loadPolicyConsents: () => Promise<void> = useCallback(async (): Promise<void> => {
-        if (!userName || !consentsBaseUrl) {
+        if (!consentsBaseUrl) {
             return;
         }
 
         try {
-            const listResponse: PolicyConsentListResponseInterface =
-                await getConsentsBySubject(consentsBaseUrl, userName, "ACTIVE");
-            const summaries: PolicyConsentSummaryInterface[] = listResponse.Consents ?? [];
+            const summaries: PolicyConsentSummaryInterface[] =
+                await getMeConsents(consentsBaseUrl, "ACTIVE") ?? [];
 
             if (summaries.length === 0) {
                 setPolicyConsentItems([]);
@@ -130,7 +127,7 @@ export const PolicyConsent: FunctionComponent<PolicyConsentComponentProps> = (
                 )
             });
         }
-    }, [ userName, consentsBaseUrl, t, onAlertFired ]);
+    }, [ consentsBaseUrl, t, onAlertFired ]);
 
     useEffect(() => {
         loadPolicyConsents();

--- a/apps/myaccount/src/components/preference-management/preference-management-list.tsx
+++ b/apps/myaccount/src/components/preference-management/preference-management-list.tsx
@@ -213,7 +213,7 @@ export const PreferenceManagementList: FunctionComponent<PreferenceManagementLis
                                                                                             .get(item.consentId)
                                                                                             ?.has(element.id)
                                                                                     }
-                                                                                    label={ element.displayName }
+                                                                                    label={ element.displayName || element.name }
                                                                                     onChange={ () =>
                                                                                         onElementToggle(
                                                                                             item.consentId,

--- a/apps/myaccount/src/components/preference-management/preference-management.tsx
+++ b/apps/myaccount/src/components/preference-management/preference-management.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import {
     getConsentById,
-    getConsentsBySubject,
+    getMeConsents,
     postConsent,
     revokeConsentById
 } from "../../api/consents";
@@ -35,7 +35,6 @@ import {
     PreferenceManagementElementInterface,
     PreferenceManagementItemInterface,
     PolicyConsentDetailInterface,
-    PolicyConsentListResponseInterface,
     PolicyConsentSummaryInterface
 } from "../../models/consents";
 import { AppState } from "../../store";
@@ -62,21 +61,19 @@ export const PreferenceManagement: FunctionComponent<PreferenceManagementCompone
     const [ isRevokeModalVisible, setRevokeModalVisible ] = useState<boolean>(false);
     const [ isRevoking, setIsRevoking ] = useState<boolean>(false);
 
-    const userName: string = useSelector((state: AppState) => state?.authenticationInformation?.profileInfo.userName);
     const consentsBaseUrl: string = useSelector(
         (state: AppState) => state?.config?.endpoints?.consentMgtV2?.consents
     );
     const { t } = useTranslation();
 
     const loadPreferenceManagement: () => Promise<void> = useCallback(async (): Promise<void> => {
-        if (!userName || !consentsBaseUrl) {
+        if (!consentsBaseUrl) {
             return;
         }
 
         try {
-            const listResponse: PolicyConsentListResponseInterface =
-                await getConsentsBySubject(consentsBaseUrl, userName, "ACTIVE");
-            const summaries: PolicyConsentSummaryInterface[] = listResponse.Consents ?? [];
+            const summaries: PolicyConsentSummaryInterface[] =
+                await getMeConsents(consentsBaseUrl, "ACTIVE") ?? [];
 
             if (summaries.length === 0) {
                 setConsentItems([]);
@@ -141,7 +138,7 @@ export const PreferenceManagement: FunctionComponent<PreferenceManagementCompone
                 )
             });
         }
-    }, [ userName, consentsBaseUrl, t, onAlertFired ]);
+    }, [ consentsBaseUrl, t, onAlertFired ]);
 
     useEffect(() => {
         loadPreferenceManagement();

--- a/apps/myaccount/src/configs/app.ts
+++ b/apps/myaccount/src/configs/app.ts
@@ -107,7 +107,7 @@ export class Config {
                 }
             },
             consentMgtV2: {
-                consents: `${this.getDeploymentConfig()?.serverHost}/api/identity/consent-mgt/v2.0/consents`
+                consents: `${this.getDeploymentConfig()?.serverHost}/api/users/v1/me/consents`
             },
             federatedAssociations: `${this.getDeploymentConfig()?.serverHost}/api/users/v1/me/federated-associations`,
             fidoEnd: `${this.getDeploymentConfig()?.serverHost}/api/users/v2/me/webauthn/finish-registration`,

--- a/apps/myaccount/src/models/consents.ts
+++ b/apps/myaccount/src/models/consents.ts
@@ -223,15 +223,6 @@ export interface PolicyConsentSummaryInterface {
 }
 
 /**
- * Paginated list response for user consent records.
- */
-export interface PolicyConsentListResponseInterface {
-    Consents: PolicyConsentSummaryInterface[];
-    links?: Array<{ rel: "next" | "previous"; href: string }>;
-    totalResults: number;
-}
-
-/**
  * A data element within a consented purpose.
  */
 interface ConsentedElementInterface {


### PR DESCRIPTION
### Purpose
This pull request updates the consent API endpoint used in the My Account application to align with the latest API structure. The main change is updating the consent management URI to point to the new user-centric endpoint.

API endpoint update:

* Changed the `consentMgtV2.consents` URI in `apps/myaccount/src/configs/app.ts` from `/api/identity/consent-mgt/v2.0/consents` to `/api/users/v1/me/consents` to use the new consent API.
* Added a changeset entry documenting the consent API URI update for the `@wso2is/myaccount` package.

### Related Issues
Related issue https://github.com/wso2/product-is/issues/26859
