### PR TITLE
Fix anchor accessibility warnings in consent components

### DIFF
--- a/.changeset/fix-anchor-accessibility.md
+++ b/.changeset/fix-anchor-accessibility.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.consents.v1": patch
+"@wso2is/admin.flow-builder-core.v1": patch
+---
+
+Fix anchor accessibility warnings in consent components.

--- a/features/admin.consents.v1/components/consent-description-editor.tsx
+++ b/features/admin.consents.v1/components/consent-description-editor.tsx
@@ -654,6 +654,7 @@ export const ConsentDescriptionEditor: FunctionComponent<ConsentDescriptionEdito
                         className="rich-text-link"
                         target={ isValidPolicyUrl ? "_blank" : undefined }
                         rel={ isValidPolicyUrl ? "noopener noreferrer" : undefined }
+                        aria-label={ exampleLinkText }
                     />
                 ] }
             />

--- a/features/admin.consents.v1/components/policy-consent-preview.tsx
+++ b/features/admin.consents.v1/components/policy-consent-preview.tsx
@@ -197,7 +197,10 @@ export const PolicyConsentPreview: FunctionComponent<PolicyConsentPreviewPropsIn
                                             i18nKey="consents:policyConsents.wizard.create.preview.exampleDescription"
                                             values={ { policyName } }
                                             components={ [
-                                                <a className="rich-text-link" />
+                                                <a
+                                                    className="rich-text-link"
+                                                    aria-label={ policyName }
+                                                />
                                             ] }
                                         />
                                         { mandatory && <MandatoryMarker /> }

--- a/features/admin.flow-builder-core.v1/components/resources/elements/adapters/policy-consent-adapter.tsx
+++ b/features/admin.flow-builder-core.v1/components/resources/elements/adapters/policy-consent-adapter.tsx
@@ -199,6 +199,11 @@ const PolicyConsentAdapter: FunctionComponent<PolicyConsentAdapterPropsInterface
                                                             className="rich-text-link"
                                                             target="_blank"
                                                             rel="noopener noreferrer"
+                                                            aria-label={
+                                                                policy.name
+                                                                || i18nLink(i18n.language, policy.policyUrl)
+                                                                || "Policy link"
+                                                            }
                                                         />
                                                     ] }
                                                 />


### PR DESCRIPTION
<!-- Please fill in the pull request template when submitting pull requests. -->

### Purpose

Fixes the React Doctor `anchor-has-content` accessibility warnings in consent-related components.

The affected anchor elements are used inside translated consent description content through `<Trans />`. Since these anchors do not have direct JSX children, this PR adds meaningful `aria-label` values so the anchors have accessible names without changing the visible UI or existing translation behavior.

No visual UI changes are introduced.

### Related Issues

- Fixes wso2/product-is#27871

### Related PRs

- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks

- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)

- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.

### Testing

- Ran `git diff --check`.
- Ran targeted ESLint with `--quiet` for the modified files.

Note: Full `pnpm lint` fails on the current branch due to existing unrelated lint warnings/errors in other modules.