### PR TITLE
Add status flag for consent features

### DIFF
--- a/.changeset/sharp-toys-think.md
+++ b/.changeset/sharp-toys-think.md
@@ -1,0 +1,7 @@
+---
+"@wso2is/console": patch
+"@wso2is/admin.feature-gate.v1": patch
+"@wso2is/admin.server-configurations.v1": patch
+---
+
+Add status flag for consent features

--- a/apps/console/src/public/deployment.config.json
+++ b/apps/console/src/public/deployment.config.json
@@ -1387,6 +1387,14 @@
                     {
                         "feature": "loginAndRegistration.userOnboarding.registrationFlowBuilder",
                         "flag": ""
+                    },
+                    {
+                        "feature": "consents.policyConsents",
+                        "flag": ""
+                    },
+                    {
+                        "feature": "consents.preferenceManagement",
+                        "flag": ""
                     }
                 ],
                 "scopes": {

--- a/features/admin.feature-gate.v1/constants/feature-flag-constants.ts
+++ b/features/admin.feature-gate.v1/constants/feature-flag-constants.ts
@@ -55,6 +55,8 @@ class FeatureFlagConstants {
         CONNECTIONS_CUSTOM_AUTHENTICATOR: "console.connections.templates.customAuthenticator",
         CONNECTIONS_ENTERPRISE: "console.connections.templates.enterprise",
         CONNECTIONS_IDVP: "console.connections.templates.idvp",
+        CONSENTS_POLICY_CONSENTS: "consents.policyConsents",
+        CONSENTS_PREFERENCE_MANAGEMENT: "consents.preferenceManagement",
         CONSOLE_SETTINGS: "console.consoleSettings",
         CUSTOMER_DATA_PROFILES: "customerDataProfiles",
         CUSTOMER_DATA_PROFILES_UNIFICATION_RULES: "customerDataUnificationRules",

--- a/features/admin.server-configurations.v1/utils/governance-connector-utils.ts
+++ b/features/admin.server-configurations.v1/utils/governance-connector-utils.ts
@@ -359,6 +359,7 @@ export class GovernanceConnectorUtils {
                         isCustom: false,
                         name: "policyConsents",
                         route: AppConstants.getPaths().get("POLICY_CONSENTS"),
+                        status: FeatureFlagConstants.FEATURE_FLAG_KEY_MAP.CONSENTS_POLICY_CONSENTS,
                         testId: "policy-consents-card"
                     },
                     {
@@ -372,6 +373,7 @@ export class GovernanceConnectorUtils {
                         isCustom: false,
                         name: "preferenceManagement",
                         route: AppConstants.getPaths().get("PREFERENCE_MANAGEMENT"),
+                        status: FeatureFlagConstants.FEATURE_FLAG_KEY_MAP.CONSENTS_PREFERENCE_MANAGEMENT,
                         testId: "preference-management-card"
                     }
                 ],


### PR DESCRIPTION
This pull request introduces new feature flag support for consent-related features in the application. The main changes add status flags and feature flag constants for "policy consents" and "preference management" features, ensuring they can be toggled via configuration and referenced consistently throughout the codebase.

Feature flag additions for consent features:

* Added new feature flag entries for `consents.policyConsents` and `consents.preferenceManagement` in the deployment configuration (`deployment.config.json`).
* Introduced corresponding constants `CONSENTS_POLICY_CONSENTS` and `CONSENTS_PREFERENCE_MANAGEMENT` in `FeatureFlagConstants` to standardize usage across the codebase (`feature-flag-constants.ts`).

Governance connector updates:

* Updated the governance connector utility to include the new status flags for the "policyConsents" and "preferenceManagement" connectors, referencing the new feature flag constants (`governance-connector-utils.ts`). [[1]](diffhunk://#diff-290aa0700b8b8990aeb289aeb82fa4dd12b9360876d7c1500bad931672db984cR362) [[2]](diffhunk://#diff-290aa0700b8b8990aeb289aeb82fa4dd12b9360876d7c1500bad931672db984cR376)

Documentation:

* Added a changeset documenting the addition of status flags for consent features.

<img width="795" height="260" alt="Screenshot 2026-07-01 at 17 11 33" src="https://github.com/user-attachments/assets/ad05fe38-80b5-4a76-9e5f-5e9594155aea" />
