### PR TITLE
Add customer data feature configs to console deployment config template

### DIFF
--- a/.changeset/quiet-cities-kiss.md
+++ b/.changeset/quiet-cities-kiss.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/console": patch
+---
+
+Add customer data feature configs to console deployment config template

--- a/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
+++ b/apps/console/java/org.wso2.identity.apps.console.server.feature/resources/deployment.config.json.j2
@@ -390,6 +390,154 @@
                 }{% endif %}
             },
             {% endif %}
+            {% if console.customer_data_profile_attributes is defined %}
+            "customerDataProfileAttributes": {
+                "disabledFeatures": [
+                    {% if console.customer_data_profile_attributes.disabled_features is defined %}
+                    {% for feature in console.customer_data_profile_attributes.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {% if console.customer_data_profile_attributes.enabled is defined %} {{ console.customer_data_profile_attributes.enabled }},
+                {% else %} false,
+                {% endif %}
+                "featureFlags": [
+                    {
+                        "feature": "customerDataProfileAttributes",
+                        "flag": ""
+                    }
+                ],
+                "scopes": {
+                    {% if console.customer_data_profile_attributes.scopes is defined %}
+                    {% for operation, scopes in console.customer_data_profile_attributes.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "delete": [],
+                        "feature": [],
+                        "read": [],
+                        "update": []
+                    {% endif %}
+                }
+            },
+            {% endif %}
+            {% if console.customer_data_profiles is defined %}
+            "customerDataProfiles": {
+                "disabledFeatures": [
+                    {% if console.customer_data_profiles.disabled_features is defined %}
+                    {% for feature in console.customer_data_profiles.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {% if console.customer_data_profiles.enabled is defined %} {{ console.customer_data_profiles.enabled }},
+                {% else %} false,
+                {% endif %}
+                "featureFlags": [
+                    {
+                        "feature": "customerDataProfiles",
+                        "flag": ""
+                    }
+                ],
+                "scopes": {
+                    {% if console.customer_data_profiles.scopes is defined %}
+                    {% for operation, scopes in console.customer_data_profiles.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "delete": [],
+                        "feature": [],
+                        "read": [],
+                        "update": []
+                    {% endif %}
+                }
+            },
+            {% endif %}
+            {% if console.customer_data_service is defined %}
+            "customerDataService": {
+                "disabledFeatures": [
+                    {% if console.customer_data_service.disabled_features is defined %}
+                    {% for feature in console.customer_data_service.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {% if console.customer_data_service.enabled is defined %} {{ console.customer_data_service.enabled }},
+                {% else %} false,
+                {% endif %}
+                "featureFlags": [
+                    {
+                        "feature": "customerDataService",
+                        "flag": ""
+                    }
+                ],
+                "scopes": {
+                    {% if console.customer_data_service.scopes is defined %}
+                    {% for operation, scopes in console.customer_data_service.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "delete": [],
+                        "feature": [],
+                        "read": [],
+                        "update": []
+                    {% endif %}
+                }
+            },
+            {% endif %}
+            {% if console.customer_data_unification_rules is defined %}
+            "customerDataUnificationRules": {
+                "disabledFeatures": [
+                    {% if console.customer_data_unification_rules.disabled_features is defined %}
+                    {% for feature in console.customer_data_unification_rules.disabled_features %}
+                    "{{ feature }}"{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% endif %}
+                ],
+                "enabled": {% if console.customer_data_unification_rules.enabled is defined %} {{ console.customer_data_unification_rules.enabled }},
+                {% else %} false,
+                {% endif %}
+                "featureFlags": [
+                    {
+                        "feature": "customerDataUnificationRules",
+                        "flag": ""
+                    }
+                ],
+                "scopes": {
+                    {% if console.customer_data_unification_rules.scopes is defined %}
+                    {% for operation, scopes in console.customer_data_unification_rules.scopes.items() %}
+                    "{{ operation }}": [
+                        {% for scope in scopes %}
+                            "{{ scope }}"{{ "," if not loop.last }}
+                        {% endfor %}
+                    ]{{ "," if not loop.last }}
+                    {% endfor %}
+                    {% else %}
+                        "create": [],
+                        "delete": [],
+                        "feature": [],
+                        "read": [],
+                        "update": []
+                    {% endif %}
+                }
+            },
+            {% endif %}
             {% if console.login_and_registration is defined %}
             "loginAndRegistration": {
                 "disabledFeatures": [


### PR DESCRIPTION
## Purpose

Adds templated feature configuration blocks for the customer data (CDS) console features to the console `deployment.config.json.j2`, which were previously missing under `ui.features`.

## Changes

Adds the following feature blocks under `ui.features`, each guarded by `{% if console.<feature> is defined %}` and following the same templated pattern as existing features (e.g. `actions`, `userStores`):

- `customerDataProfileAttributes`
- `customerDataProfiles`
- `customerDataService`
- `customerDataUnificationRules`

Each block templates `disabledFeatures`, `enabled` (default `false`), and `scopes` from the corresponding `console.customer_data_*` config keys, with empty-array scope defaults consistent with the other feature blocks.

## Related

The default values for these config keys are added in a companion PR to `wso2/carbon-identity-framework`.