### PR TITLE
Refine free trial banner wording and shrink View Plans button

### DIFF
--- a/.changeset/tidy-trial-banner-wording.md
+++ b/.changeset/tidy-trial-banner-wording.md
@@ -1,0 +1,5 @@
+---
+"@wso2is/admin.subscription.v1": patch
+---
+
+Refine the free trial banner wording and reduce the size of the View Plans button

--- a/.changeset/tidy-trial-banner-wording.md
+++ b/.changeset/tidy-trial-banner-wording.md
@@ -1,5 +1,6 @@
 ---
 "@wso2is/admin.subscription.v1": patch
+"@wso2is/console": patch
 ---
 
 Refine the free trial banner wording and reduce the size of the View Plans button

--- a/features/admin.subscription.v1/components/free-trial-banner.tsx
+++ b/features/admin.subscription.v1/components/free-trial-banner.tsx
@@ -93,32 +93,38 @@ const FreeTrialBanner: FunctionComponent<FreeTrialBannerPropsInterface> = (
                 borderRadius: 1,
                 display: "flex",
                 justifyContent: "space-between",
-                mb: 2,
+                mb: 1,
                 mt: 1,
                 px: 2.5,
-                py: 2
+                py: 1.5
             } }
             data-componentid={ componentId }
         >
             <Typography variant="body1" color="text.secondary">
-                You&apos;re on a free <strong>{ trialTierName } tier</strong> trial with { " " }
+                You&apos;re on the <strong>{ trialTierName }</strong> trial, with { " " }
                 <strong>{ daysRemaining }</strong>{ " " }
                 { daysRemaining === 1 ? "day" : "days" } remaining. { " " }
-                Take this time to try out capabilities not available on the Free plan. { " " }
+                Explore the additional capabilities { trialTierName } unlocks, and { " " }
                 <Link
                     href={ upgradeButtonURL }
                     target="_blank"
                     rel="noreferrer"
                     underline="always"
                 >
-                    Upgrade
+                    upgrade
                 </Link>
-                { " " }whenever you&apos;re ready.
+                { " " }when you&apos;re ready.
             </Typography>
             <Button
                 variant="outlined"
                 size="small"
-                sx={ { ml: 4, mr: 1, whiteSpace: "nowrap" } }
+                sx={ {
+                    ml: 4,
+                    mr: 1,
+                    px: 1.5,
+                    py: 0.25,
+                    whiteSpace: "nowrap"
+                } }
                 onClick={ () => window.open(pricingURL, "_blank", "noopener,noreferrer") }
                 data-componentid={ `${componentId}-view-plans-button` }
             >


### PR DESCRIPTION
## Purpose

Refines the copy shown in the free trial banner and reduces the size of the **View Plans** button.

## Changes

- Update the trial banner message to a concise, single-line format:
  > You're on the **Growth** trial, with **30** days remaining. Explore the additional capabilities Growth unlocks, and upgrade when you're ready.
- Reduce the padding and font size of the **View Plans** button so it sits better alongside the single-line message.
- Tighten the banner's vertical spacing (`mb`/`py`) to match the shorter content.

<img width="1174" height="181" alt="image" src="https://github.com/user-attachments/assets/de3f68c6-18c4-4f6a-b9da-c48c492c181e" />


## Related PRs / Issues
N/A


### Checklist

- [x] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [x] UX/UI review done on the final implementation.
- [x] Documentation provided. (Add links if there are any)
- [x] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any)
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any)

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [x] Ran FindSecurityBugs plugin and verified report
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [ ] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact.
