### PR TITLE
Make organization switch breadcrumb trigger keyboard accessible

### DIFF
--- a/.changeset/a11y-org-breadcrumb-tabindex.md
+++ b/.changeset/a11y-org-breadcrumb-tabindex.md
@@ -1,0 +1,6 @@
+---
+"@wso2is/admin.organizations.v1": patch
+---
+
+Make the organization-switch breadcrumb trigger keyboard-accessible (add role="button",
+aria-haspopup, and Enter/Space key handling) to fix a no-noninteractive-tabindex a11y warning.

--- a/features/admin.organizations.v1/components/organization-switch/organization-switch-breadcrumb.tsx
+++ b/features/admin.organizations.v1/components/organization-switch/organization-switch-breadcrumb.tsx
@@ -31,6 +31,7 @@ import { SessionStorageUtils } from "@wso2is/core/utils";
 import { Action, Location } from "history";
 import React, {
     FunctionComponent,
+    KeyboardEvent,
     ReactElement,
     SyntheticEvent,
     useEffect,
@@ -488,10 +489,18 @@ export const OrganizationSwitchBreadcrumb: FunctionComponent<OrganizationSwitchD
                     !isLoading && (
                         <div className="organization-breadcrumb-wrapper">
                             <div
+                                role="button"
+                                aria-haspopup="true"
                                 tabIndex={ 0 }
                                 onBlur={ () => setIsDropDownOpen(false) }
                                 className="organization-breadcrumb"
                                 onClick={ () => setIsDropDownOpen(!isDropDownOpen) }
+                                onKeyDown={ (e: KeyboardEvent<HTMLDivElement>): void => {
+                                    if (e.key === "Enter" || e.key === " ") {
+                                        e.preventDefault();
+                                        e.currentTarget.click();
+                                    }
+                                } }
                             >
                                 <p className="organization-breadcrumb-label">
                                     { organizationType === OrganizationType.SUPER_ORGANIZATION ||


### PR DESCRIPTION
### Purpose

Fix the `jsx-a11y/no-noninteractive-tabindex` accessibility warning (reported by React Doctor) on
the organization-switch breadcrumb trigger in
`features/admin.organizations.v1/components/organization-switch/organization-switch-breadcrumb.tsx`.

The trigger was a non-interactive `<div>` carrying `tabIndex={ 0 }` and an `onClick` handler, but no
interactive `role` and no keyboard handler. As a result it was reachable by Tab yet exposed no role
or keyboard behavior to assistive technology, and was effectively mouse-only (Enter/Space did
nothing once focused).

Rather than simply removing `tabIndex`, which would silence the linter but make the control
unreachable by keyboard (a regression), this PR turns the element into a legitimate dropdown
trigger:

- `role="button"` so the `tabIndex` is justified and screen readers announce it as a control.
- `aria-haspopup="true"` so assistive tech identifies it as a dropdown trigger.
- An `onKeyDown` handler that activates on **Enter**/**Space** via `e.currentTarget.click()`, so
  keyboard activation follows the same event path as a mouse click and reaches the `TenantDropdown`
  that owns the real menu open/close state.

`aria-expanded` is intentionally omitted: the breadcrumb's local `isDropDownOpen` state only drives
the chevron icon and can drift from the actual `TenantDropdown` menu state, so binding
`aria-expanded` to it could announce a stale "expanded" state. This follows the existing keyboard
button pattern in `features/common.workflow-approvals.v1/pages/approvals.tsx`.

*Note*: the repo's ESLint config loads jsx-a11y but doesn't enable its rules, so pnpm lint won't flag this. Reproduced/verified by running the single rule in isolation against the file (0 warnings after the fix).

### Related Issues
- https://github.com/wso2/product-is/issues/27930

### Related PRs
- N/A

### Checklist

- [ ] e2e cypress tests locally verified. (for internal contributers)
- [x] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Relevant backend changes deployed and verified
- [ ] [Unit tests](/docs/testing/UNIT_TESTING.md) provided. (Add links if there are any) <!-- N/A: single-attribute a11y fix; no existing test asserts this markup -->
- [ ] [Integration tests](https://github.com/wso2/product-is/tree/master/modules/integration) provided. (Add links if there are any) <!-- N/A -->

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ ] Ran FindSecurityBugs plugin and verified report <!-- N/A: front-end TSX a11y change, no Java/backend code -->
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets

## Developer Checklist (Mandatory)
- [x] Complete the **Developer Checklist** in the related `product-is` issue to track any behavioral change or migration impact. <!-- No behavioral change beyond enabling keyboard activation of an existing control; no migration impact. -->
